### PR TITLE
Add P1 or P2 selection to non-conforming item entries

### DIFF
--- a/.replit
+++ b/.replit
@@ -53,6 +53,10 @@ localPort = 33381
 externalPort = 3003
 
 [[ports]]
+localPort = 34869
+externalPort = 8000
+
+[[ports]]
 localPort = 35553
 externalPort = 3002
 

--- a/client/src/pages/NonConformingItemsPage.tsx
+++ b/client/src/pages/NonConformingItemsPage.tsx
@@ -17,6 +17,7 @@ import { format } from 'date-fns';
 type NonConformingItem = {
   id: number;
   date: string;
+  p1OrP2: string;
   customer: string;
   sku: string;
   qty: number;
@@ -33,6 +34,7 @@ type NonConformingItem = {
 
 type FormData = {
   date: string;
+  p1OrP2: string;
   customer: string;
   sku: string;
   qty: number;
@@ -47,6 +49,7 @@ type FormData = {
 
 const initialFormData: FormData = {
   date: new Date().toISOString().split('T')[0],
+  p1OrP2: 'P1',
   customer: '',
   sku: '',
   qty: 1,
@@ -168,6 +171,7 @@ export default function NonConformingItemsPage() {
     setEditingItem(item);
     setFormData({
       date: item.date,
+      p1OrP2: item.p1OrP2,
       customer: item.customer,
       sku: item.sku,
       qty: item.qty,
@@ -227,6 +231,23 @@ export default function NonConformingItemsPage() {
                       required
                       data-testid="input-date"
                     />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="p1OrP2">P1 or P2 *</Label>
+                    <Select
+                      value={formData.p1OrP2}
+                      onValueChange={(value) => setFormData(prev => ({ ...prev, p1OrP2: value }))}
+                      required
+                    >
+                      <SelectTrigger id="p1OrP2" data-testid="select-p1-or-p2">
+                        <SelectValue placeholder="Select P1 or P2" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="P1">P1</SelectItem>
+                        <SelectItem value="P2">P2</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
 
                   <div className="space-y-2">
@@ -416,6 +437,7 @@ export default function NonConformingItemsPage() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>Date</TableHead>
+                    <TableHead>P1/P2</TableHead>
                     <TableHead>Customer</TableHead>
                     <TableHead>SKU</TableHead>
                     <TableHead>Qty</TableHead>
@@ -434,6 +456,7 @@ export default function NonConformingItemsPage() {
                       <TableCell data-testid={`text-date-${item.id}`}>
                         {format(new Date(item.date), 'MM/dd/yyyy')}
                       </TableCell>
+                      <TableCell data-testid={`text-p1-or-p2-${item.id}`}>{item.p1OrP2}</TableCell>
                       <TableCell data-testid={`text-customer-${item.id}`}>{item.customer}</TableCell>
                       <TableCell data-testid={`text-sku-${item.id}`}>{item.sku}</TableCell>
                       <TableCell data-testid={`text-qty-${item.id}`}>{item.qty}</TableCell>

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -4491,6 +4491,7 @@ export type VendorScore = typeof vendorScores.$inferSelect;
 export const nonConformingItems = pgTable("non_conforming_items", {
   id: serial("id").primaryKey(),
   date: date("date").notNull(),
+  p1OrP2: text("p1_or_p2").notNull(),
   customer: text("customer").notNull(),
   sku: text("sku").notNull(),
   qty: integer("qty").notNull().default(1),
@@ -4511,6 +4512,7 @@ export const insertNonConformingItemSchema = createInsertSchema(nonConformingIte
   updatedAt: true,
 }).extend({
   date: z.coerce.date(),
+  p1OrP2: z.enum(["P1", "P2"], { required_error: "P1 or P2 selection is required" }),
   customer: z.string().min(1, "Customer is required"),
   sku: z.string().min(1, "SKU is required"),
   qty: z.number().min(1, "Quantity must be at least 1"),


### PR DESCRIPTION
Update the NonConformingItemsPage component to include a new 'p1OrP2' field in the form and data model. This involves modifying the client-side form elements, table display, and server-side schema validation using Zod for 'P1' or 'P2' enum.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 5e3126ce-8735-43ff-8264-f312ac1ca82c
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/8384f9fc-1778-4293-94b0-251b75c1c0e8/5e3126ce-8735-43ff-8264-f312ac1ca82c/xduKfsR