### PR TITLE
[codex] Add PTO 14-day summary card

### DIFF
--- a/client/src/components/admin/SystemHealthWidget.tsx
+++ b/client/src/components/admin/SystemHealthWidget.tsx
@@ -22,14 +22,29 @@ function formatTime(iso: string) {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 }
 
+function normalizeIntegrityStatus(data?: Partial<IntegrityStatus>): IntegrityStatus | undefined {
+  if (!data) return undefined;
+
+  return {
+    healthy: data.healthy ?? true,
+    criticalCount: data.criticalCount ?? 0,
+    warningCount: data.warningCount ?? 0,
+    infoCount: data.infoCount ?? 0,
+    affectedDepartments: Array.isArray(data.affectedDepartments) ? data.affectedDepartments : [],
+    lastCheckTime: data.lastCheckTime ?? null,
+    history: Array.isArray(data.history) ? data.history : [],
+  };
+}
+
 export default function SystemHealthWidget({ variant = 'default' }: Props) {
-  const { data, isLoading } = useQuery<IntegrityStatus>({
+  const { data: integrityStatus, isLoading } = useQuery<Partial<IntegrityStatus>>({
     queryKey: ['/api/admin/queue-integrity/status'],
     queryFn: () => apiRequest('/api/admin/queue-integrity/status'),
     refetchInterval: 5 * 60 * 1000,
     retry: false,
   });
 
+  const data = normalizeIntegrityStatus(integrityStatus);
   const isPremium = variant === 'premium';
 
   if (isPremium) {

--- a/client/src/pages/PTOCommandCenter.tsx
+++ b/client/src/pages/PTOCommandCenter.tsx
@@ -103,6 +103,7 @@ function SummaryCards({ data }: { data: any }) {
     { label: "Denied/Cancelled", value: data.deniedCancelled, icon: XCircle, color: "text-red-600" },
     { label: "On PTO Today", value: data.onPtoToday, icon: CalendarDays, color: "text-orange-600" },
     { label: "Upcoming 7 Days", value: data.upcoming7Days, icon: ArrowRight, color: "text-cyan-600" },
+    { label: "Upcoming 14 Days", value: data.upcoming14Days, icon: CalendarDays, color: "text-teal-600" },
   ];
 
   return (

--- a/server/src/routes/timekeeping/ptoCommandCenter.ts
+++ b/server/src/routes/timekeeping/ptoCommandCenter.ts
@@ -101,6 +101,9 @@ router.get(
     const in7Days = new Date();
     in7Days.setDate(in7Days.getDate() + 7);
     const in7DaysStr = in7Days.toISOString().slice(0, 10);
+    const in14Days = new Date();
+    in14Days.setDate(in14Days.getDate() + 14);
+    const in14DaysStr = in14Days.toISOString().slice(0, 10);
 
     const { rows } = await pool.query(`
       WITH status_counts AS (
@@ -112,11 +115,12 @@ router.get(
           COUNT(*) FILTER (WHERE status = 'approved' AND updated_at >= NOW() - INTERVAL '14 days') AS approved_this_period,
           COUNT(*) FILTER (WHERE status IN ('rejected','denied','cancelled')) AS denied_cancelled,
           COUNT(*) FILTER (WHERE status = 'approved' AND start_date <= $1 AND end_date >= $1) AS on_pto_today,
-          COUNT(*) FILTER (WHERE status = 'approved' AND start_date <= $2 AND end_date >= $1 AND start_date > $1) AS upcoming_7_days
+          COUNT(*) FILTER (WHERE status = 'approved' AND start_date <= $2 AND end_date >= $1 AND start_date > $1) AS upcoming_7_days,
+          COUNT(*) FILTER (WHERE status = 'approved' AND start_date <= $3 AND end_date >= $1 AND start_date > $1) AS upcoming_14_days
         FROM timekeeping.time_off_requests
       )
       SELECT * FROM status_counts
-    `, [today, in7DaysStr]);
+    `, [today, in7DaysStr, in14DaysStr]);
 
     const summary = rows[0] || {};
     res.json({
@@ -128,6 +132,7 @@ router.get(
       deniedCancelled: Number(summary.denied_cancelled || 0),
       onPtoToday: Number(summary.on_pto_today || 0),
       upcoming7Days: Number(summary.upcoming_7_days || 0),
+      upcoming14Days: Number(summary.upcoming_14_days || 0),
       callerCapabilities: callerCaps,
       isAdmin,
     });


### PR DESCRIPTION
## Summary

- Add an Upcoming 14 Days summary card to the PTO Command Center overview.
- Extend the PTO command center summary API to return `upcoming14Days`.
- Harden the admin dashboard queue integrity widget against missing or partial health payloads.

## Validation

- Confirmed Vite serves the updated local frontend files.
- Reviewed the scoped Git diff before commit.
- Full TypeScript check was attempted locally earlier, but the repo-wide run exceeded the 2 minute timeout.