### PR TITLE
[codex] Make DCAA readiness nav light blue

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -2631,8 +2631,8 @@ export default function Navigation() {
               <Button
                 variant={location.startsWith('/admin/edri') ? 'default' : 'ghost'}
                 className={cn(
-                  'flex items-center gap-2 text-sm',
-                  location.startsWith('/admin/edri') && 'bg-primary text-white'
+                  'flex items-center gap-2 text-sm text-sky-500 hover:bg-sky-50 hover:text-sky-600',
+                  location.startsWith('/admin/edri') && 'bg-sky-400 text-white hover:bg-sky-500 hover:text-white'
                 )}
                 onClick={() => { closeAllDropdowns(); setLocation('/admin/edri'); }}
               >


### PR DESCRIPTION
## What changed
- Updated the DCAA Readiness navigation button to use a light blue color treatment.
- Scoped the change to the `/admin/edri` navigation entry rendered from the admin dashboard/navigation UI.

## Impact
- DCAA Readiness now visually distinguishes itself with light blue inactive and active states.
- Neighboring readiness links are unchanged.

## Validation
- Ran `git diff --check -- client/src/components/Navigation.tsx` successfully.
- Full TypeScript validation was not run because this checkout does not have local dependencies installed and `npx` attempted to reach the npm registry from the restricted environment.