### PR TITLE
[codex] Add My Score History to EDRI

### DIFF
--- a/client/src/components/EdriSubNav.tsx
+++ b/client/src/components/EdriSubNav.tsx
@@ -17,7 +17,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Heatmap',          path: '/admin/edri/heatmap',            icon: BarChart3     },
   { label: 'Red Flags',        path: '/admin/edri/red-flags',          icon: AlertOctagon  },
   { label: 'Remediation',      path: '/admin/edri/remediation',        icon: Wrench        },
-  { label: 'History',          path: '/admin/edri/history',            icon: Clock         },
+  { label: 'My Score History', path: '/admin/edri/history',            icon: Clock         },
 ];
 
 export default function EdriSubNav() {

--- a/client/src/pages/admin/EdriDashboard.tsx
+++ b/client/src/pages/admin/EdriDashboard.tsx
@@ -551,7 +551,7 @@ export default function EdriDashboard() {
           )}
         </div>
         <div className="flex items-center gap-3 flex-wrap">
-          <Button variant="outline" asChild><Link href="/admin/edri/history">Score History</Link></Button>
+          <Button variant="outline" asChild><Link href="/admin/edri/history">My Score History</Link></Button>
           {(session?.role === 'ADMIN' || session?.role === 'OWNER') && (
             <Button
               variant="outline"
@@ -1060,7 +1060,7 @@ export default function EdriDashboard() {
               <Link href="/admin/edri/history">
                 <div className="group hover:bg-muted rounded-md p-2 cursor-pointer transition-colors">
                   <Activity className="h-5 w-5 mx-auto text-muted-foreground group-hover:text-foreground" />
-                  <p className="text-xs mt-1 text-muted-foreground group-hover:text-foreground">History</p>
+                  <p className="text-xs mt-1 text-muted-foreground group-hover:text-foreground">My Score History</p>
                 </div>
               </Link>
               <Link href="/admin/edri/executive-matrix">

--- a/client/src/pages/admin/EdriHistory.tsx
+++ b/client/src/pages/admin/EdriHistory.tsx
@@ -61,7 +61,7 @@ export default function EdriHistory() {
       <EdriSubNav />
 
       <div>
-        <h1 className="text-3xl font-bold">Score History</h1>
+        <h1 className="text-3xl font-bold">My Score History</h1>
         <p className="text-muted-foreground">Historical trend of EDRI composite and domain scores</p>
       </div>
 


### PR DESCRIPTION
## Summary

- Renames the EDRI history navigation item to "My Score History".
- Updates the /admin/edri dashboard entry points and the history page heading to match.

## Validation

- Reviewed the scoped diff.
- Attempted `npx tsc --noEmit --pretty false`, but this checkout tried to fetch `tsc` from npm and failed under restricted permissions.
- Attempted `npm run check -- --pretty false`, but `tsc` is not available on PATH in this checkout.