### PR TITLE
[codex] Fix time clock employee name resolution

### DIFF
--- a/client/src/__tests__/inOutBoardHighlight.component.test.tsx
+++ b/client/src/__tests__/inOutBoardHighlight.component.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@/lib/editPunchHandler', () => ({
 const ALICE: {
   employee: {
     id: number;
+    epochEmployeeId?: number | null;
     firstName: string;
     lastName: string;
     employeeNumber: string | null;
@@ -54,6 +55,7 @@ const ALICE: {
 } = {
   employee: {
     id: 7,
+    epochEmployeeId: 20,
     firstName: 'Alice',
     lastName: 'Nguyen',
     employeeNumber: 'E007',
@@ -71,6 +73,7 @@ const ALICE: {
 const BOB: typeof ALICE = {
   employee: {
     id: 12,
+    epochEmployeeId: 31,
     firstName: 'Bob',
     lastName: 'Kastner',
     employeeNumber: 'E012',
@@ -250,5 +253,46 @@ describe('In/Out Board — row highlight on punch_recorded', () => {
     });
 
     expect(aliceRow.className).toContain('bg-green-100');
+  });
+
+  it('resolves punch review employee names from canonical employee ids', async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/timekeeping/punches')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            {
+              id: 101,
+              sessionId: 101,
+              employeeId: 20,
+              type: 'clock_in',
+              punchedAt: new Date('2026-05-05T13:00:00.000Z').toISOString(),
+              source: 'PORTAL',
+              isEdited: false,
+              editNote: null,
+              costCode: null,
+              note: null,
+              hasMissingClockOut: false,
+            },
+          ]),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    });
+
+    await act(async () => {
+      await renderPage();
+    });
+
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByRole('tab', { name: /^punch review$/i }));
+    });
+
+    expect(await screen.findByText('Alice Nguyen')).toBeInTheDocument();
+    expect(screen.queryByText('Employee #20')).not.toBeInTheDocument();
   });
 });

--- a/client/src/pages/timekeeping/TimeClockAdminPage.tsx
+++ b/client/src/pages/timekeeping/TimeClockAdminPage.tsx
@@ -693,9 +693,19 @@ export default function TimeClockAdminPage() {
   });
   const myPermSet = new Set(myPermissions?.permissions ?? []);
 
-  const employeeMap = (employees ?? []).reduce<Record<number, EmployeeRecord>>((m, e) => {
+  const employeeByTimekeepingId = (employees ?? []).reduce<Record<number, EmployeeRecord>>((m, e) => {
     m[e.id] = e; return m;
   }, {});
+  const employeeByEpochId = (employees ?? []).reduce<Record<number, EmployeeRecord>>((m, e) => {
+    if (e.epochEmployeeId != null) m[e.epochEmployeeId] = e;
+    return m;
+  }, {});
+  const employeeName = (employee: EmployeeRecord | undefined, fallbackId: number | string): string =>
+    employee ? `${employee.firstName} ${employee.lastName}` : `Employee #${fallbackId}`;
+  const employeeNameFromTimekeepingId = (employeeId: number): string =>
+    employeeName(employeeByTimekeepingId[employeeId], employeeId);
+  const employeeNameFromEpochId = (employeeId: number): string =>
+    employeeName(employeeByEpochId[employeeId], employeeId);
 
   const {
     data: unapprovedGroups,
@@ -1676,9 +1686,7 @@ export default function TimeClockAdminPage() {
               <FileText className="h-4 w-4 shrink-0 text-blue-500" />
               <span className="flex-1 min-w-0">
                 <span className="font-medium">
-                  {employeeMap[pinnedTs.employeeId]
-                    ? `${employeeMap[pinnedTs.employeeId].firstName} ${employeeMap[pinnedTs.employeeId].lastName}`
-                    : `Employee #${pinnedTs.employeeId}`}
+                  {employeeNameFromTimekeepingId(pinnedTs.employeeId)}
                 </span>
                 {' '}— {pinnedTs.periodStart} to {pinnedTs.periodEnd}
                 {' '}<StatusBadge status={pinnedTs.status} />
@@ -1766,10 +1774,7 @@ export default function TimeClockAdminPage() {
                   </TableHeader>
                   <TableBody>
                     {timesheets.map(ts => {
-                      const emp = employeeMap[ts.employeeId];
-                      const empName = emp
-                        ? `${emp.firstName} ${emp.lastName}`
-                        : `Employee #${ts.employeeId}`;
+                      const empName = employeeNameFromTimekeepingId(ts.employeeId);
                       const isHighlighted = ts.id === highlightedTsId;
                       return (
                         <Fragment key={ts.id}>
@@ -2125,10 +2130,7 @@ export default function TimeClockAdminPage() {
                   </TableHeader>
                   <TableBody>
                     {punches.map(p => {
-                      const emp = employeeMap[p.employeeId];
-                      const empName = emp
-                        ? `${emp.firstName} ${emp.lastName}`
-                        : `Employee #${p.employeeId}`;
+                      const empName = employeeNameFromEpochId(p.employeeId);
                       return (
                         <TableRow key={`${p.sessionId}-${p.type}`} className={p.hasMissingClockOut ? 'bg-amber-50/60 dark:bg-amber-900/10' : p.isEdited ? 'bg-yellow-50/40 dark:bg-yellow-900/10' : undefined}>
                           <TableCell className="font-medium">{empName}</TableCell>
@@ -2956,7 +2958,7 @@ export default function TimeClockAdminPage() {
                 </SelectTrigger>
                 <SelectContent>
                   {(employees ?? []).map(e => (
-                    <SelectItem key={e.id} value={String(e.id)}>
+                    <SelectItem key={e.epochEmployeeId ?? e.id} value={String(e.epochEmployeeId ?? e.employeeNumber ?? e.id)}>
                       {e.firstName} {e.lastName}
                       {e.employeeNumber ? ` (${e.employeeNumber})` : ''}
                     </SelectItem>
@@ -3470,7 +3472,7 @@ export default function TimeClockAdminPage() {
             </p>
             {deletePunchTarget && (
               <div className="rounded-md bg-muted p-3 text-sm space-y-1">
-                <div><span className="font-medium">Employee:</span> {(() => { const e = employeeMap[deletePunchTarget.employeeId]; return e ? `${e.firstName} ${e.lastName}` : `Employee #${deletePunchTarget.employeeId}`; })()}</div>
+                <div><span className="font-medium">Employee:</span> {employeeNameFromEpochId(deletePunchTarget.employeeId)}</div>
                 <div><span className="font-medium">Session ID:</span> {deletePunchTarget.sessionId}</div>
                 <div><span className="font-medium">Event:</span> {deletePunchTarget.type === 'clock_in' ? 'Clock-In' : deletePunchTarget.type === 'clock_out' ? 'Clock-Out' : deletePunchTarget.type}</div>
                 <div><span className="font-medium">Time:</span> {new Date(deletePunchTarget.punchedAt).toLocaleString()}</div>
@@ -3732,8 +3734,7 @@ export default function TimeClockAdminPage() {
         timesheetLabel={
           auditTrailTs
             ? (() => {
-                const emp = employeeMap[auditTrailTs.employeeId];
-                const name = emp ? `${emp.firstName} ${emp.lastName}` : `Employee #${auditTrailTs.employeeId}`;
+                const name = employeeNameFromTimekeepingId(auditTrailTs.employeeId);
                 return `${name} · ${auditTrailTs.periodStart} – ${auditTrailTs.periodEnd}`;
               })()
             : undefined


### PR DESCRIPTION
## Summary

- Resolve Time Clock Admin employee display names using the correct employee-id namespace for each view.
- Keep timesheet rows mapped by timekeeping employee id, while punch rows and punch dialogs resolve by canonical `public.employees.id`.
- Submit canonical employee ids from the Add Punch dialog so new admin-created punch records do not recreate the mismatch.
- Add a regression test covering punch rows whose canonical id differs from the timekeeping row id.

## Root Cause

`/api/timekeeping/employees` exposes `id` as the timekeeping employee row id and `epochEmployeeId` as the canonical employee id. Punch review rows use canonical ids from `punch_ledger`, but the UI was looking them up in a map keyed only by timekeeping id, causing rows like `Employee #20` when the ids diverged.

## Validation

- `git diff --check -- client/src/pages/timekeeping/TimeClockAdminPage.tsx client/src/__tests__/inOutBoardHighlight.component.test.tsx` passed.
- Attempted the focused Vitest component test, but this checkout has no local `node_modules`, and running Vitest through the sibling dependency tree failed because esbuild worker spawning is blocked in this sandbox (`spawn EPERM`).
- Attempted TypeScript check through the sibling dependency tree; it could not resolve this checkout's package dependencies cleanly without a local install and produced broad unrelated module-resolution errors.