### PR TITLE
[codex] Add improvement notes prototype

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { Toaster } from '@/components/ui/toaster';
 import Navigation from './components/Navigation';
 import OfflineIndicator from './components/OfflineIndicator';
 import MessageNotificationPopup from './components/MessageNotificationPopup';
+import ImprovementNoteCapture from './components/ImprovementNoteCapture';
 import { useWebSocketNotifications } from './hooks/useWebSocketNotifications';
 import NotFound from './pages/not-found';
 import AccessDenied from './pages/AccessDenied';
@@ -318,6 +319,7 @@ import UrgentOrdersReport from './pages/UrgentOrdersReport';
 import OTDReport from './pages/OTDReport';
 import OrderHeatMap from './pages/OrderHeatMap';
 import QuickNotesPage from './pages/QuickNotesPage';
+import ImprovementNotesDashboard from './pages/ImprovementNotesDashboard';
 import RFQListPage from './pages/RFQListPage';
 import RFQBuilderPage from './pages/RFQBuilderPage';
 import SystemAuditsPage from './pages/SystemAuditsPage';
@@ -580,6 +582,7 @@ function App() {
                   <Route path="/otd-report" component={OTDReport} />
                   <Route path="/order-heat-map" component={OrderHeatMap} />
                   <Route path="/quick-notes" component={QuickNotesPage} />
+                  <Route path="/improvement-notes" component={ImprovementNotesDashboard} />
                   <Route path="/estimating" component={RFQListPage} />
                   <Route path="/rfq-builder" component={RFQBuilderPage} />
                   <Route path="/rfq-builder/:id" component={RFQBuilderPage} />
@@ -1355,6 +1358,7 @@ function App() {
             <WebSocketNotifications />
             <SessionAwareMessageNotificationPopup />
             <SessionExpiryListener />
+            <ImprovementNoteCapture />
           </Router>
         </DeploymentAuthWrapper>
       </QueryClientProvider>

--- a/client/src/components/ImprovementNoteCapture.tsx
+++ b/client/src/components/ImprovementNoteCapture.tsx
@@ -1,0 +1,220 @@
+import { useMemo, useState } from 'react';
+import { Link, useLocation } from 'wouter';
+import { ClipboardList, Lightbulb, MessageSquarePlus, X } from 'lucide-react';
+import {
+  makeImprovementNoteId,
+  notePriorities,
+  noteTypes,
+  roleOptions,
+  saveImprovementNote,
+  workflowOptions,
+  type ImprovementNotePriority,
+  type ImprovementNoteType,
+} from '@/lib/improvementNotes';
+
+export default function ImprovementNoteCapture() {
+  const [location] = useLocation();
+  const [open, setOpen] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [title, setTitle] = useState('');
+  const [details, setDetails] = useState('');
+  const [role, setRole] = useState('Inventory Manager');
+  const [workflow, setWorkflow] = useState('PO creation');
+  const [type, setType] = useState<ImprovementNoteType>('pain-point');
+  const [priority, setPriority] = useState<ImprovementNotePriority>('medium');
+
+  const context = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return { pageTitle: 'EPOCH', pagePath: location, pageUrl: location };
+    }
+
+    return {
+      pageTitle: document.title || 'EPOCH',
+      pagePath: window.location.pathname,
+      pageUrl: window.location.href,
+    };
+  }, [location, open]);
+
+  const resetForm = () => {
+    setTitle('');
+    setDetails('');
+    setRole('Inventory Manager');
+    setWorkflow('PO creation');
+    setType('pain-point');
+    setPriority('medium');
+  };
+
+  const submitNote = () => {
+    const now = new Date().toISOString();
+    saveImprovementNote({
+      id: makeImprovementNoteId(),
+      title: title.trim() || `${workflow} improvement`,
+      details: details.trim(),
+      role,
+      workflow,
+      type,
+      priority,
+      status: 'new',
+      pagePath: context.pagePath,
+      pageTitle: context.pageTitle,
+      pageUrl: context.pageUrl,
+      createdAt: now,
+      updatedAt: now,
+      source: 'context-capture',
+    });
+    resetForm();
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2500);
+  };
+
+  return (
+    <>
+      <div className="fixed bottom-5 right-5 z-50 flex items-center gap-3">
+        {saved && (
+          <div className="rounded-md border border-emerald-200 bg-white px-3 py-2 text-sm font-medium text-emerald-700 shadow-lg">
+            Note captured
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="inline-flex h-12 items-center gap-2 rounded-full bg-slate-950 px-4 text-sm font-semibold text-white shadow-xl shadow-slate-900/20 transition hover:bg-slate-800"
+          title="Capture an improvement note for this page"
+        >
+          <MessageSquarePlus className="h-5 w-5" />
+          Add note
+        </button>
+      </div>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-end justify-end bg-slate-950/30 p-4 backdrop-blur-sm sm:p-6">
+          <div className="w-full max-w-xl overflow-hidden rounded-lg border border-slate-200 bg-white shadow-2xl">
+            <div className="flex items-start justify-between border-b border-slate-200 px-5 py-4">
+              <div>
+                <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-cyan-700">
+                  <Lightbulb className="h-4 w-4" />
+                  Context-aware improvement note
+                </div>
+                <h2 className="mt-1 text-xl font-bold text-slate-950">Capture what would help</h2>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-md p-2 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+                title="Close"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="space-y-4 px-5 py-5">
+              <div className="rounded-md border border-cyan-100 bg-cyan-50 px-3 py-2 text-sm text-cyan-950">
+                Capturing this page: <span className="font-semibold">{context.pagePath}</span>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="space-y-1 text-sm font-medium text-slate-700">
+                  Role
+                  <select
+                    value={role}
+                    onChange={event => setRole(event.target.value)}
+                    className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                  >
+                    {roleOptions.map(option => (
+                      <option key={option}>{option}</option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="space-y-1 text-sm font-medium text-slate-700">
+                  Workflow
+                  <select
+                    value={workflow}
+                    onChange={event => setWorkflow(event.target.value)}
+                    className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                  >
+                    {workflowOptions.map(option => (
+                      <option key={option}>{option}</option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="space-y-1 text-sm font-medium text-slate-700">
+                  Note type
+                  <select
+                    value={type}
+                    onChange={event => setType(event.target.value as ImprovementNoteType)}
+                    className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                  >
+                    {noteTypes.map(option => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="space-y-1 text-sm font-medium text-slate-700">
+                  Priority
+                  <select
+                    value={priority}
+                    onChange={event => setPriority(event.target.value as ImprovementNotePriority)}
+                    className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                  >
+                    {notePriorities.map(option => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <label className="space-y-1 text-sm font-medium text-slate-700">
+                Short title
+                <input
+                  value={title}
+                  onChange={event => setTitle(event.target.value)}
+                  placeholder="Example: Need item history while creating PO"
+                  className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                />
+              </label>
+
+              <label className="space-y-1 text-sm font-medium text-slate-700">
+                What happened or what would help?
+                <textarea
+                  value={details}
+                  onChange={event => setDetails(event.target.value)}
+                  placeholder="Write it the way she says it. The page, role, workflow, and timestamp are captured automatically."
+                  rows={5}
+                  className="w-full resize-none rounded-md border border-slate-300 px-3 py-2 text-sm"
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 bg-slate-50 px-5 py-4">
+              <Link href="/improvement-notes">
+                <a className="inline-flex items-center gap-2 text-sm font-semibold text-slate-700 hover:text-slate-950">
+                  <ClipboardList className="h-4 w-4" />
+                  View dashboard
+                </a>
+              </Link>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={submitNote}
+                  className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-semibold text-white hover:bg-cyan-700"
+                >
+                  Save note
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/client/src/lib/improvementNotes.ts
+++ b/client/src/lib/improvementNotes.ts
@@ -1,0 +1,116 @@
+export type ImprovementNoteStatus = 'new' | 'reviewed' | 'planned' | 'built';
+
+export type ImprovementNoteType =
+  | 'pain-point'
+  | 'missing-info'
+  | 'repeated-task'
+  | 'bug'
+  | 'idea';
+
+export type ImprovementNotePriority = 'low' | 'medium' | 'high';
+
+export interface ImprovementNote {
+  id: string;
+  title: string;
+  details: string;
+  role: string;
+  workflow: string;
+  type: ImprovementNoteType;
+  priority: ImprovementNotePriority;
+  status: ImprovementNoteStatus;
+  pagePath: string;
+  pageTitle: string;
+  pageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  source: 'context-capture' | 'dashboard';
+}
+
+export const IMPROVEMENT_NOTES_STORAGE_KEY = 'epoch.improvementNotes.v1';
+
+export const noteTypes: { value: ImprovementNoteType; label: string }[] = [
+  { value: 'pain-point', label: 'Pain point' },
+  { value: 'missing-info', label: 'Missing info' },
+  { value: 'repeated-task', label: 'Repeated task' },
+  { value: 'bug', label: 'Bug' },
+  { value: 'idea', label: 'Idea' },
+];
+
+export const notePriorities: { value: ImprovementNotePriority; label: string }[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+export const noteStatuses: { value: ImprovementNoteStatus; label: string }[] = [
+  { value: 'new', label: 'New' },
+  { value: 'reviewed', label: 'Reviewed' },
+  { value: 'planned', label: 'Planned' },
+  { value: 'built', label: 'Built' },
+];
+
+export const roleOptions = [
+  'Inventory Manager',
+  'CSR',
+  'Production Manager',
+  'Owner',
+  'Accounting',
+  'Quality',
+  'Shipping',
+  'Other',
+];
+
+export const workflowOptions = [
+  'PO creation',
+  'Inventory lookup',
+  'Receiving',
+  'Customer order',
+  'Production movement',
+  'Scheduling',
+  'Invoicing',
+  'Audit evidence',
+  'Other',
+];
+
+export function makeImprovementNoteId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `note-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function readImprovementNotes(): ImprovementNote[] {
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const raw = window.localStorage.getItem(IMPROVEMENT_NOTES_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeImprovementNotes(notes: ImprovementNote[]) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(IMPROVEMENT_NOTES_STORAGE_KEY, JSON.stringify(notes));
+}
+
+export function saveImprovementNote(note: ImprovementNote) {
+  const notes = readImprovementNotes();
+  const next = [note, ...notes.filter(existing => existing.id !== note.id)];
+  writeImprovementNotes(next);
+  window.dispatchEvent(new CustomEvent('epoch:improvement-notes-updated'));
+}
+
+export function updateImprovementNote(noteId: string, patch: Partial<ImprovementNote>) {
+  const notes = readImprovementNotes();
+  const now = new Date().toISOString();
+  const next = notes.map(note =>
+    note.id === noteId ? { ...note, ...patch, updatedAt: now } : note
+  );
+  writeImprovementNotes(next);
+  window.dispatchEvent(new CustomEvent('epoch:improvement-notes-updated'));
+}

--- a/client/src/pages/ImprovementNotesDashboard.tsx
+++ b/client/src/pages/ImprovementNotesDashboard.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowUpRight, ClipboardList, Download, Filter, Lightbulb, Search } from 'lucide-react';
+import {
+  noteStatuses,
+  readImprovementNotes,
+  updateImprovementNote,
+  type ImprovementNote,
+  type ImprovementNoteStatus,
+} from '@/lib/improvementNotes';
+
+const priorityStyles: Record<string, string> = {
+  high: 'border-rose-200 bg-rose-50 text-rose-700',
+  medium: 'border-amber-200 bg-amber-50 text-amber-700',
+  low: 'border-slate-200 bg-slate-50 text-slate-600',
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value));
+}
+
+export default function ImprovementNotesDashboard() {
+  const [notes, setNotes] = useState<ImprovementNote[]>(() => readImprovementNotes());
+  const [query, setQuery] = useState('');
+  const [roleFilter, setRoleFilter] = useState('all');
+  const [workflowFilter, setWorkflowFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('all');
+
+  useEffect(() => {
+    const refresh = () => setNotes(readImprovementNotes());
+    window.addEventListener('storage', refresh);
+    window.addEventListener('epoch:improvement-notes-updated', refresh);
+    return () => {
+      window.removeEventListener('storage', refresh);
+      window.removeEventListener('epoch:improvement-notes-updated', refresh);
+    };
+  }, []);
+
+  const roles = useMemo(() => Array.from(new Set(notes.map(note => note.role))).sort(), [notes]);
+  const workflows = useMemo(() => Array.from(new Set(notes.map(note => note.workflow))).sort(), [notes]);
+
+  const filteredNotes = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return notes.filter(note => {
+      const matchesSearch = !needle || [
+        note.title,
+        note.details,
+        note.role,
+        note.workflow,
+        note.pagePath,
+      ].some(value => value.toLowerCase().includes(needle));
+
+      return (
+        matchesSearch &&
+        (roleFilter === 'all' || note.role === roleFilter) &&
+        (workflowFilter === 'all' || note.workflow === workflowFilter) &&
+        (statusFilter === 'all' || note.status === statusFilter)
+      );
+    });
+  }, [notes, query, roleFilter, statusFilter, workflowFilter]);
+
+  const stats = useMemo(() => {
+    return {
+      total: notes.length,
+      high: notes.filter(note => note.priority === 'high').length,
+      new: notes.filter(note => note.status === 'new').length,
+      workflows: workflows.length,
+    };
+  }, [notes, workflows.length]);
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(notes, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `epoch-improvement-notes-${new Date().toISOString().slice(0, 10)}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="border-b border-slate-200 bg-white">
+        <div className="mx-auto max-w-7xl px-6 py-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-cyan-700">
+                <Lightbulb className="h-4 w-4" />
+                Workflow improvement capture
+              </div>
+              <h1 className="mt-2 text-3xl font-bold text-slate-950">Improvement Notes Dashboard</h1>
+              <p className="mt-2 max-w-3xl text-slate-600">
+                Centralized notes from live screens, organized by role, workflow, priority, and status.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={exportJson}
+              className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+            >
+              <Download className="h-4 w-4" />
+              Export notes
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <main className="mx-auto max-w-7xl px-6 py-6">
+        <div className="grid gap-4 md:grid-cols-4">
+          <div className="rounded-lg border border-slate-200 bg-white p-4">
+            <div className="text-sm font-medium text-slate-500">Total notes</div>
+            <div className="mt-2 text-3xl font-bold text-slate-950">{stats.total}</div>
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white p-4">
+            <div className="text-sm font-medium text-slate-500">New</div>
+            <div className="mt-2 text-3xl font-bold text-cyan-700">{stats.new}</div>
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white p-4">
+            <div className="text-sm font-medium text-slate-500">High priority</div>
+            <div className="mt-2 text-3xl font-bold text-rose-600">{stats.high}</div>
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white p-4">
+            <div className="text-sm font-medium text-slate-500">Workflows touched</div>
+            <div className="mt-2 text-3xl font-bold text-slate-950">{stats.workflows}</div>
+          </div>
+        </div>
+
+        <div className="mt-6 rounded-lg border border-slate-200 bg-white p-4">
+          <div className="grid gap-3 lg:grid-cols-[1fr_180px_200px_160px]">
+            <label className="relative block">
+              <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
+              <input
+                value={query}
+                onChange={event => setQuery(event.target.value)}
+                placeholder="Search notes, pages, people, workflows"
+                className="w-full rounded-md border border-slate-300 py-2 pl-9 pr-3 text-sm"
+              />
+            </label>
+
+            <select
+              value={roleFilter}
+              onChange={event => setRoleFilter(event.target.value)}
+              className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="all">All roles</option>
+              {roles.map(role => (
+                <option key={role}>{role}</option>
+              ))}
+            </select>
+
+            <select
+              value={workflowFilter}
+              onChange={event => setWorkflowFilter(event.target.value)}
+              className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="all">All workflows</option>
+              {workflows.map(workflow => (
+                <option key={workflow}>{workflow}</option>
+              ))}
+            </select>
+
+            <select
+              value={statusFilter}
+              onChange={event => setStatusFilter(event.target.value)}
+              className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="all">All statuses</option>
+              {noteStatuses.map(status => (
+                <option key={status.value} value={status.value}>{status.label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4">
+          {filteredNotes.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-slate-300 bg-white px-6 py-14 text-center">
+              <ClipboardList className="mx-auto h-10 w-10 text-slate-400" />
+              <h2 className="mt-4 text-lg font-bold text-slate-900">No notes captured yet</h2>
+              <p className="mt-2 text-sm text-slate-600">
+                Use the Add note button on any workflow page to capture role, workflow, page, and timestamp automatically.
+              </p>
+            </div>
+          ) : filteredNotes.map(note => (
+            <article key={note.id} className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={`rounded-full border px-2.5 py-1 text-xs font-bold uppercase ${priorityStyles[note.priority]}`}>
+                      {note.priority}
+                    </span>
+                    <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-600">
+                      {note.role}
+                    </span>
+                    <span className="rounded-full border border-cyan-100 bg-cyan-50 px-2.5 py-1 text-xs font-semibold text-cyan-700">
+                      {note.workflow}
+                    </span>
+                  </div>
+                  <h2 className="mt-3 text-xl font-bold text-slate-950">{note.title}</h2>
+                  {note.details && (
+                    <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{note.details}</p>
+                  )}
+                  <div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-slate-500">
+                    <span>{formatDate(note.createdAt)}</span>
+                    <span>{note.pagePath}</span>
+                    <a href={note.pageUrl} className="inline-flex items-center gap-1 font-semibold text-cyan-700 hover:text-cyan-900">
+                      Open source page
+                      <ArrowUpRight className="h-3.5 w-3.5" />
+                    </a>
+                  </div>
+                </div>
+
+                <label className="flex items-center gap-2 text-sm font-medium text-slate-700">
+                  <Filter className="h-4 w-4 text-slate-400" />
+                  <select
+                    value={note.status}
+                    onChange={event => updateImprovementNote(note.id, { status: event.target.value as ImprovementNoteStatus })}
+                    className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm"
+                  >
+                    {noteStatuses.map(status => (
+                      <option key={status.value} value={status.value}>{status.label}</option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            </article>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed
- Added a browser-local improvement notes model backed by `localStorage`.
- Added a floating context-aware `Add note` capture component that records the current page URL/path/title plus role, workflow, type, priority, and note details.
- Added an `/improvement-notes` dashboard with filtering, status updates, summary counts, source-page links, and JSON export.
- Wired the capture component and dashboard route into `client/src/App.tsx`.

## Impact
This creates a lightweight prototype for collecting workflow improvement requests from live dashboard/application screens. It is intentionally not a production ticketing backend yet; notes stay in browser storage until we add database persistence, assignment, comments, notifications, and audit/status history.

## Validation
- Ran `git diff --cached --check` successfully.
- Could not run the TypeScript check in this clean worktree because this environment does not have `npm`/`npx` available and the worktree has no local dependency install.

## Scope note
The branch was created from latest `origin/main`. I staged only the four improvement-notes files and left unrelated local SQL/marketing changes out of the commit.