### PR TITLE
[codex] Add parts request project budget metadata

### DIFF
--- a/client/src/components/inventory/PartsRequestsCard.tsx
+++ b/client/src/components/inventory/PartsRequestsCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plus, Edit, Trash2, Calendar, User, Package } from 'lucide-react';
+import { Plus, Edit, Trash2, Calendar, User, Package, Factory, FolderOpen } from 'lucide-react';
 import toast from 'react-hot-toast';
 import type { PartsRequest } from '@shared/schema';
 
@@ -29,6 +29,8 @@ interface PartsRequestFormData {
   partNumber: string;
   partName: string;
   requestedBy: string;
+  productionLine: string;
+  projectId: string;
   department: string;
   quantity: string;
   urgency: string;
@@ -39,6 +41,28 @@ interface PartsRequestFormData {
   expectedDelivery: string;
   notes: string;
 }
+
+interface ProjectOption {
+  id: string;
+  projectCode: string;
+  projectName: string;
+  status?: string;
+}
+
+interface DepartmentOption {
+  id: number;
+  name: string;
+}
+
+type PartsRequestWithProject = PartsRequest & {
+  project?: {
+    id: string | null;
+    projectCode: string | null;
+    projectName: string | null;
+  };
+};
+
+const NONE_VALUE = '__none__';
 
 export default function PartsRequestsCard() {
   const queryClient = useQueryClient();
@@ -52,6 +76,8 @@ export default function PartsRequestsCard() {
     partNumber: '',
     partName: '',
     requestedBy: '',
+    productionLine: '',
+    projectId: '',
     department: '',
     quantity: '',
     urgency: 'MEDIUM',
@@ -64,9 +90,19 @@ export default function PartsRequestsCard() {
   });
 
   // Load parts requests
-  const { data: requests = [], isLoading } = useQuery<PartsRequest[]>({
+  const { data: requests = [], isLoading } = useQuery<PartsRequestWithProject[]>({
     queryKey: ['/api/inventory/parts-requests'],
     queryFn: () => apiRequest('/api/inventory/parts-requests'),
+  });
+
+  const { data: projects = [] } = useQuery<ProjectOption[]>({
+    queryKey: ['/api/projects'],
+    queryFn: () => apiRequest('/api/projects'),
+  });
+
+  const { data: departments = [] } = useQuery<DepartmentOption[]>({
+    queryKey: ['/api/inventory/departments'],
+    queryFn: () => apiRequest('/api/inventory/departments'),
   });
 
   // Group requests by department
@@ -150,6 +186,8 @@ export default function PartsRequestsCard() {
       partNumber: '',
       partName: '',
       requestedBy: '',
+      productionLine: '',
+      projectId: '',
       department: '',
       quantity: '',
       urgency: 'MEDIUM',
@@ -190,6 +228,8 @@ export default function PartsRequestsCard() {
       partNumber: formData.partNumber,
       partName: formData.partName,
       requestedBy: formData.requestedBy,
+      productionLine: formData.productionLine || null,
+      projectId: formData.projectId || null,
       department: formData.department || null,
       quantity: parseInt(formData.quantity),
       urgency: formData.urgency,
@@ -216,6 +256,8 @@ export default function PartsRequestsCard() {
       partNumber: request.partNumber,
       partName: request.partName,
       requestedBy: request.requestedBy,
+      productionLine: request.productionLine || '',
+      projectId: request.projectId || '',
       department: request.department || '',
       quantity: request.quantity.toString(),
       urgency: request.urgency,
@@ -311,14 +353,68 @@ export default function PartsRequestsCard() {
           />
         </div>
         <div>
+          <Label htmlFor="productionLine">Production Line</Label>
+          <Select
+            value={formData.productionLine || NONE_VALUE}
+            onValueChange={(value) =>
+              handleSelectChange('productionLine', value === NONE_VALUE ? '' : value)
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Optional line" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE_VALUE}>No line selected</SelectItem>
+              <SelectItem value="P1">P1</SelectItem>
+              <SelectItem value="P2">P2</SelectItem>
+              <SelectItem value="P3">P3</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="projectId">Project</Label>
+          <Select
+            value={formData.projectId || NONE_VALUE}
+            onValueChange={(value) =>
+              handleSelectChange('projectId', value === NONE_VALUE ? '' : value)
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Optional project" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE_VALUE}>No project selected</SelectItem>
+              {projects.map((project) => (
+                <SelectItem key={project.id} value={project.id}>
+                  {project.projectCode} - {project.projectName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
           <Label htmlFor="department">Department</Label>
-          <Input
-            id="department"
-            name="department"
-            value={formData.department}
-            onChange={handleChange}
-            placeholder="Enter department"
-          />
+          <Select
+            value={formData.department || NONE_VALUE}
+            onValueChange={(value) =>
+              handleSelectChange('department', value === NONE_VALUE ? '' : value)
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Optional department" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE_VALUE}>No department selected</SelectItem>
+              {departments.map((department) => (
+                <SelectItem key={department.id} value={department.name}>
+                  {department.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 
@@ -398,7 +494,7 @@ export default function PartsRequestsCard() {
       </div>
 
       <div>
-        <Label htmlFor="expectedDelivery">Expected Delivery</Label>
+        <Label htmlFor="expectedDelivery">Estimated Arrival</Label>
         <Input
           id="expectedDelivery"
           name="expectedDelivery"
@@ -555,6 +651,23 @@ export default function PartsRequestsCard() {
                           <span>{request.requestedBy}</span>
                         </div>
 
+                        {(request.productionLine || request.project) && (
+                          <div className="flex flex-wrap gap-2">
+                            {request.productionLine && (
+                              <span className="inline-flex items-center gap-1 text-xs text-gray-600 bg-gray-50 px-2 py-1 rounded">
+                                <Factory className="h-3 w-3" />
+                                {request.productionLine}
+                              </span>
+                            )}
+                            {request.project && (
+                              <span className="inline-flex items-center gap-1 text-xs text-gray-600 bg-gray-50 px-2 py-1 rounded">
+                                <FolderOpen className="h-3 w-3" />
+                                {request.project.projectCode} - {request.project.projectName}
+                              </span>
+                            )}
+                          </div>
+                        )}
+
                         <div className="flex items-center gap-2">
                           <Package className="h-4 w-4 text-gray-400" />
                           <span>Qty: {request.quantity}</span>
@@ -577,7 +690,7 @@ export default function PartsRequestsCard() {
                           <div className="flex items-center gap-2">
                             <Calendar className="h-4 w-4 text-gray-400" />
                             <span>
-                              Expected:{' '}
+                              ETA:{' '}
                               {new Date(
                                 request.expectedDelivery
                               ).toLocaleDateString()}

--- a/client/src/components/inventory/PartsRequestsCard.tsx
+++ b/client/src/components/inventory/PartsRequestsCard.tsx
@@ -1,14 +1,39 @@
 import React, { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plus, Edit, Trash2, Calendar, User, Package, Factory, FolderOpen } from 'lucide-react';
+import {
+  Plus,
+  Edit,
+  Trash2,
+  Calendar,
+  User,
+  Package,
+  Factory,
+  FolderOpen,
+  Check,
+  ChevronsUpDown,
+} from 'lucide-react';
 import toast from 'react-hot-toast';
-import type { PartsRequest } from '@shared/schema';
+import type { InventoryItem, PartsRequest } from '@shared/schema';
 
 import { apiRequest } from '@/lib/queryClient';
+import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
@@ -26,6 +51,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 
 interface PartsRequestFormData {
+  agPartNumber: string;
   partNumber: string;
   partName: string;
   requestedBy: string;
@@ -68,11 +94,13 @@ export default function PartsRequestsCard() {
   const queryClient = useQueryClient();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const [isPartSelectOpen, setIsPartSelectOpen] = useState(false);
   const [editingRequest, setEditingRequest] = useState<PartsRequest | null>(
     null
   );
 
   const [formData, setFormData] = useState<PartsRequestFormData>({
+    agPartNumber: '',
     partNumber: '',
     partName: '',
     requestedBy: '',
@@ -104,6 +132,29 @@ export default function PartsRequestsCard() {
     queryKey: ['/api/inventory/departments'],
     queryFn: () => apiRequest('/api/inventory/departments'),
   });
+
+  const { data: inventoryItems = [], isLoading: isLoadingInventory } = useQuery<InventoryItem[]>({
+    queryKey: ['/api/inventory'],
+    queryFn: () => apiRequest('/api/inventory'),
+  });
+
+  const activeInventoryItems = useMemo(
+    () =>
+      inventoryItems
+        .filter((item) => item.isActive !== false)
+        .sort((a, b) =>
+          String(a.agPartNumber || '').localeCompare(String(b.agPartNumber || ''))
+        ),
+    [inventoryItems]
+  );
+
+  const selectedInventoryItem = useMemo(
+    () =>
+      activeInventoryItems.find(
+        (item) => item.agPartNumber === formData.agPartNumber
+      ),
+    [activeInventoryItems, formData.agPartNumber]
+  );
 
   // Group requests by department
   const requestsByDepartment = useMemo(() => {
@@ -183,6 +234,7 @@ export default function PartsRequestsCard() {
 
   const resetForm = () => {
     setFormData({
+      agPartNumber: '',
       partNumber: '',
       partName: '',
       requestedBy: '',
@@ -211,6 +263,21 @@ export default function PartsRequestsCard() {
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleInventoryItemSelect = (item: InventoryItem) => {
+    setFormData((prev) => ({
+      ...prev,
+      agPartNumber: item.agPartNumber,
+      partNumber: item.agPartNumber,
+      partName: item.name,
+      supplier: item.source || prev.supplier,
+      estimatedCost:
+        item.costPer !== null && item.costPer !== undefined
+          ? String(item.costPer)
+          : prev.estimatedCost,
+    }));
+    setIsPartSelectOpen(false);
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -225,6 +292,7 @@ export default function PartsRequestsCard() {
     }
 
     const submitData = {
+      agPartNumber: formData.agPartNumber,
       partNumber: formData.partNumber,
       partName: formData.partName,
       requestedBy: formData.requestedBy,
@@ -253,6 +321,7 @@ export default function PartsRequestsCard() {
   const handleEdit = (request: PartsRequest) => {
     setEditingRequest(request);
     setFormData({
+      agPartNumber: request.agPartNumber || '',
       partNumber: request.partNumber,
       partName: request.partName,
       requestedBy: request.requestedBy,
@@ -315,29 +384,77 @@ export default function PartsRequestsCard() {
 
   const FormContent = () => (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor="partNumber">Part Number *</Label>
-          <Input
-            id="partNumber"
-            name="partNumber"
-            value={formData.partNumber}
-            onChange={handleChange}
-            placeholder="Enter part number"
-            required
-          />
-        </div>
-        <div>
-          <Label htmlFor="partName">Part Name *</Label>
-          <Input
-            id="partName"
-            name="partName"
-            value={formData.partName}
-            onChange={handleChange}
-            placeholder="Enter part name"
-            required
-          />
-        </div>
+      <div>
+        <Label htmlFor="inventoryItem">Inventory Part *</Label>
+        <Popover open={isPartSelectOpen} onOpenChange={setIsPartSelectOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              id="inventoryItem"
+              type="button"
+              variant="outline"
+              role="combobox"
+              aria-expanded={isPartSelectOpen}
+              className={cn(
+                'w-full justify-between',
+                !formData.agPartNumber && 'text-muted-foreground'
+              )}
+              disabled={isLoadingInventory}
+            >
+              {selectedInventoryItem
+                ? `${selectedInventoryItem.agPartNumber} - ${selectedInventoryItem.name}`
+                : formData.partNumber && formData.partName
+                  ? `${formData.partNumber} - ${formData.partName}`
+                  : isLoadingInventory
+                    ? 'Loading inventory...'
+                    : 'Search inventory by part number or name...'}
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Type part number or name..." />
+              <CommandList>
+                <CommandEmpty>No inventory items found.</CommandEmpty>
+                <CommandGroup>
+                  {activeInventoryItems.map((item) => (
+                    <CommandItem
+                      key={item.id}
+                      value={`${item.agPartNumber} ${item.name} ${item.source || ''}`}
+                      onSelect={() => handleInventoryItemSelect(item)}
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4',
+                          item.agPartNumber === formData.agPartNumber
+                            ? 'opacity-100'
+                            : 'opacity-0'
+                        )}
+                      />
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-mono text-sm font-medium">
+                            {item.agPartNumber}
+                          </span>
+                          <span className="truncate">{item.name}</span>
+                        </div>
+                        {item.source && (
+                          <div className="text-xs text-muted-foreground">
+                            Vendor: {item.source}
+                          </div>
+                        )}
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+        {formData.partNumber && formData.partName && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Selected part: {formData.partNumber} - {formData.partName}
+          </p>
+        )}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -994,7 +994,7 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
                   <TableRow key={`${row.inventoryItemId}-${idx}`}>
                     <TableCell>
                       <Badge className={MATERIAL_STATUS_COLORS[row.status] ?? 'bg-gray-100 text-gray-600'}>
-                        {row.status.replace('_', ' ')}
+                        {row.status.replace(/_/g, ' ')}
                       </Badge>
                     </TableCell>
                     <TableCell className="font-mono text-sm font-medium">{row.itemCode || '—'}</TableCell>

--- a/migrations/0108_parts_request_project_line_budget.sql
+++ b/migrations/0108_parts_request_project_line_budget.sql
@@ -1,0 +1,9 @@
+ALTER TABLE parts_requests
+  ADD COLUMN IF NOT EXISTS production_line TEXT,
+  ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES projects(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS parts_requests_project_id_idx
+  ON parts_requests(project_id);
+
+CREATE INDEX IF NOT EXISTS parts_requests_production_line_idx
+  ON parts_requests(production_line);

--- a/server/index.ts
+++ b/server/index.ts
@@ -465,6 +465,7 @@ async function initializeBackgroundServices() {
           '0104_improvement_notes.sql',
           '0106_employee_payroll_item_attachments.sql',
           '0107_accounting_expense_attachments.sql',
+          '0108_parts_request_project_line_budget.sql',
           'investigation_308_order_duplication.sql',
         ];
         const criticalMigrations = new Set([

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -802,6 +802,8 @@ export const partsRequests = pgTable('parts_requests', {
   partNumber: text('part_number').notNull(), // Part number (can be AG part or external)
   partName: text('part_name').notNull(),
   requestedBy: text('requested_by').notNull(),
+  productionLine: text('production_line'), // Optional P1/P2/P3 line requested for this part
+  projectId: uuid('project_id').references((): AnyPgColumn => projects.id, { onDelete: 'set null' }),
   department: text('department'), // Department name (legacy text field)
   departmentId: integer('department_id').references(() => inventoryDepartments.id, { onDelete: 'set null' }), // FK to inventory_departments
   quantity: integer('quantity').notNull(),
@@ -2944,6 +2946,8 @@ export const insertPartsRequestSchema = createInsertSchema(partsRequests)
     partNumber: z.string().min(1, 'Part number is required'),
     partName: z.string().min(1, 'Part name is required'),
     requestedBy: z.string().min(1, 'Requested by is required'),
+    productionLine: z.enum(['P1', 'P2', 'P3']).optional().nullable(),
+    projectId: z.string().uuid().optional().nullable(),
     department: z.string().optional().nullable(),
     departmentId: z.number().optional().nullable(),
     quantity: z.number().positive('Quantity must be positive'),

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -1075,8 +1075,8 @@ router.put('/parts-requests/:id', async (req: Request, res: Response) => {
       const validTransitions: Record<string, string[]> = {
         'APPROVED': ['PENDING'],
         'REJECTED': ['PENDING', 'CANCEL_REQUESTED'],
-        'ORDERED': ['APPROVED'],
-        'ORDERED_PARTIAL': ['APPROVED'],
+        'ORDERED': ['PENDING', 'APPROVED'],
+        'ORDERED_PARTIAL': ['PENDING', 'APPROVED'],
         'RECEIVED': ['ORDERED', 'ORDERED_PARTIAL', 'RECEIVED_PARTIAL'],
         'RECEIVED_PARTIAL': ['ORDERED', 'ORDERED_PARTIAL'],
         'DELIVERED_TO_DEPT': ['RECEIVED', 'RECEIVED_PARTIAL'],
@@ -1097,6 +1097,15 @@ router.put('/parts-requests/:id', async (req: Request, res: Response) => {
             error: `Cannot change status to '${updates.status}' from '${existingRequest.status}'. Valid source statuses: ${allowedFromStatuses.join(', ')}.`
           });
         }
+      }
+
+      if (updates.status === 'ORDERED' || updates.status === 'ORDERED_PARTIAL') {
+        updates.orderDate = updates.orderDate ?? new Date();
+      }
+
+      if (updates.status === 'REJECTED') {
+        updates.rejectedAt = updates.rejectedAt ?? new Date();
+        updates.rejectionReason = updates.rejectionReason ?? updates.notes ?? null;
       }
     }
     

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -127,6 +127,14 @@ interface MaterialItemRow {
   status: string;
 }
 
+const ORDERED_PARTS_REQUEST_STATUSES = [
+  'ORDERED',
+  'ORDERED_PARTIAL',
+  'RECEIVED',
+  'RECEIVED_PARTIAL',
+  'DELIVERED_TO_DEPT',
+];
+
 // GET /api/pm-dashboard/managers — distinct PMs who own at least one active project
 router.get('/managers', h(async (_req, res) => {
   const result = await pool.query<{ id: number; name: string }>(`
@@ -261,6 +269,14 @@ router.get('/:projectId/summary', h(async (req, res) => {
     )
   `, [projectId]);
 
+  const partsRequestMaterialRes = await pool.query<{ committedMaterialCost: string }>(`
+    SELECT COALESCE(SUM(quantity * COALESCE(estimated_cost, 0)), 0) AS "committedMaterialCost"
+    FROM parts_requests
+    WHERE project_id = $1
+      AND is_active = true
+      AND status = ANY($2::text[])
+  `, [projectId, ORDERED_PARTS_REQUEST_STATUSES]);
+
   // Quantity-based production percent
   const qtyProgressRes = await pool.query<{ totalRequired: string; totalCompleted: string }>(`
     SELECT
@@ -291,10 +307,12 @@ router.get('/:projectId/summary', h(async (req, res) => {
   const actualLaborHours = parseFloat(laborActualRes[0].actualLaborHours) || 0;
   const laborRemainingHours = budgetedLaborHours - actualLaborHours;
 
-  const committedMaterialCost = parseFloat(materialRes[0].committedMaterialCost) || 0;
+  const committedMaterialCost =
+    (parseFloat(materialRes[0].committedMaterialCost) || 0) +
+    (parseFloat(partsRequestMaterialRes[0]?.committedMaterialCost) || 0);
   const consumedMaterialCost = parseFloat(consumedRes[0].consumedMaterialCost) || 0;
   const plannedMaterialCost = parseFloat(materialRes[0].plannedMaterialCost) || 0;
-  const remainingMaterialBudget = plannedMaterialCost - consumedMaterialCost;
+  const remainingMaterialBudget = plannedMaterialCost - committedMaterialCost - consumedMaterialCost;
 
   res.json({
     ...projRes[0],
@@ -727,7 +745,7 @@ router.get('/:projectId/materials', h(async (req, res) => {
 
   const summaryRes = await pool.query<MaterialSummaryRow>(`
     SELECT
-      COALESCE(committed_sub.committed, 0) AS "committedCost",
+      COALESCE(committed_sub.committed, 0) + COALESCE(parts_request_sub.committed, 0) AS "committedCost",
       COALESCE(consumed_sub.consumed, 0) AS "consumedCost"
     FROM (
       SELECT SUM(mlr.quantity_reserved * COALESCE(ii.unit_cost, 0)) AS committed
@@ -746,8 +764,15 @@ router.get('/:projectId/materials', h(async (req, res) => {
       WHERE tmc.traveler_id IN (
         SELECT id FROM travelers WHERE project_id = $1
       )
-    ) consumed_sub
-  `, [projectId]);
+    ) consumed_sub,
+    (
+      SELECT SUM(quantity * COALESCE(estimated_cost, 0)) AS committed
+      FROM parts_requests
+      WHERE project_id = $1
+        AND is_active = true
+        AND status = ANY($2::text[])
+    ) parts_request_sub
+  `, [projectId, ORDERED_PARTS_REQUEST_STATUSES]);
 
   const rowsRes = await pool.query<MaterialItemRow>(`
     SELECT
@@ -800,6 +825,37 @@ router.get('/:projectId/materials', h(async (req, res) => {
       ii.ag_part_number ASC
   `, [projectId]);
 
+  const partsRequestRowsRes = await pool.query<MaterialItemRow>(`
+    SELECT
+      ('PR-' || pr.id::text) AS "inventoryItemId",
+      pr.part_number AS "itemCode",
+      pr.part_name AS "itemName",
+      NULL::text AS "lotNumber",
+      NULL::text AS "internalControlNumber",
+      pr.quantity::numeric AS "qtyRequired",
+      CASE
+        WHEN pr.status IN ('ORDERED', 'ORDERED_PARTIAL') THEN pr.quantity::numeric
+        ELSE 0::numeric
+      END AS "qtyAllocated",
+      CASE
+        WHEN pr.status IN ('RECEIVED', 'RECEIVED_PARTIAL', 'DELIVERED_TO_DEPT') THEN pr.quantity::numeric
+        ELSE 0::numeric
+      END AS "qtyIssued",
+      COALESCE(pr.estimated_cost, 0)::numeric AS "unitCost",
+      (pr.quantity * COALESCE(pr.estimated_cost, 0))::numeric AS "committedCost",
+      CASE
+        WHEN pr.status IN ('RECEIVED', 'RECEIVED_PARTIAL', 'DELIVERED_TO_DEPT')
+          THEN (pr.quantity * COALESCE(pr.estimated_cost, 0))::numeric
+        ELSE 0::numeric
+      END AS "consumedCost",
+      ('PART_REQUEST_' || pr.status) AS "status"
+    FROM parts_requests pr
+    WHERE pr.project_id = $1
+      AND pr.is_active = true
+      AND pr.status = ANY($2::text[])
+    ORDER BY pr.request_date DESC
+  `, [projectId, ORDERED_PARTS_REQUEST_STATUSES]);
+
   const committedCost = parseFloat(summaryRes[0]?.committedCost) || 0;
   const consumedCost = parseFloat(summaryRes[0]?.consumedCost) || 0;
 
@@ -808,9 +864,9 @@ router.get('/:projectId/materials', h(async (req, res) => {
       plannedCost: 0,
       committedCost,
       consumedCost,
-      remainingCost: committedCost - consumedCost,
+      remainingCost: 0 - committedCost - consumedCost,
     },
-    rows: rowsRes,
+    rows: [...rowsRes, ...partsRequestRowsRes],
   });
 }));
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -6848,9 +6848,12 @@ export class DatabaseStorage implements IStorage {
         invSource: inventoryItems.source,
         invVendorId: inventoryItems.vendorId,
         invUsageUnit: inventoryItems.usageUnit,
+        projectCode: projects.projectCode,
+        projectName: projects.projectName,
       })
       .from(partsRequests)
       .leftJoin(inventoryItems, eq(inventoryItems.agPartNumber, partsRequests.agPartNumber))
+      .leftJoin(projects, eq(projects.id, partsRequests.projectId))
       .where(eq(partsRequests.isActive, true))
       .orderBy(desc(partsRequests.requestDate));
 
@@ -6863,6 +6866,11 @@ export class DatabaseStorage implements IStorage {
         source: r.invSource,
         vendorId: r.invVendorId,
         usageUnit: r.invUsageUnit,
+      } : undefined,
+      project: r.projectCode ? {
+        id: r.request.projectId,
+        projectCode: r.projectCode,
+        projectName: r.projectName,
       } : undefined,
     }));
   }
@@ -6954,10 +6962,13 @@ export class DatabaseStorage implements IStorage {
         request: partsRequests,
         inventoryItem: inventoryItems,
         department: departments,
+        projectCode: projects.projectCode,
+        projectName: projects.projectName,
       })
       .from(partsRequests)
       .leftJoin(inventoryItems, eq(partsRequests.agPartNumber, inventoryItems.agPartNumber))
       .leftJoin(departments, eq(partsRequests.departmentId, departments.id))
+      .leftJoin(projects, eq(projects.id, partsRequests.projectId))
       .where(and(
         or(
           eq(partsRequests.status, 'PENDING'),
@@ -6972,6 +6983,11 @@ export class DatabaseStorage implements IStorage {
       ...r.request,
       inventoryItem: r.inventoryItem,
       department: r.department,
+      project: r.projectCode ? {
+        id: r.request.projectId,
+        projectCode: r.projectCode,
+        projectName: r.projectName,
+      } : undefined,
     }));
   }
 


### PR DESCRIPTION
## Summary

- Adds optional production line and project association fields to parts requests, including a migration and schema validation.
- Updates the parts request UI so requesters can optionally choose P1/P2/P3, a project, and a department while still submitting a basic request with only the required part details.
- Enriches parts request queues with project metadata and lets managers set ETA/order/deny responses through the existing edit/status flow.
- Includes project-linked ordered/received parts requests in the PM material budget projection so purchased parts reduce remaining material budget and appear in the material table.

## Notes

- Existing unrelated local files were left out of this PR: `PRODUCTION_STOCK_MODELS.sql` and `receiving-traceability-preview.html`.
- This may overlap with other active branches if they touch parts requests, inventory receiving/ordering, PM material budgets, WAD material visibility, or project procurement accounting.

## Validation

- `git diff --check -- client/src/components/inventory/PartsRequestsCard.tsx client/src/pages/PMControlCenterPage.tsx server/index.ts server/schema.ts server/storage.ts server/src/routes/inventory.ts server/src/routes/pmDashboard.ts migrations/0108_parts_request_project_line_budget.sql`
- `npm run check` could not run because `npm` is not available on PATH and this checkout has no `node_modules`.