### PR TITLE
Add immutable inventory transaction ledger

### DIFF
--- a/migrations/0109_inventory_transaction_ledger.sql
+++ b/migrations/0109_inventory_transaction_ledger.sql
@@ -1,0 +1,100 @@
+CREATE TYPE inventory_ledger_transaction_type AS ENUM (
+  'RECEIVE',
+  'ISSUE',
+  'RETURN',
+  'TRANSFER',
+  'MOVE',
+  'RESERVE',
+  'UNRESERVE',
+  'CONSUME',
+  'ADJUST',
+  'SCRAP',
+  'SPLIT',
+  'MERGE',
+  'COUNT_ADJUSTMENT',
+  'STATUS_CHANGE',
+  'QUARANTINE',
+  'RELEASE',
+  'EXPIRE',
+  'REVERSAL'
+);
+
+CREATE SEQUENCE inventory_transaction_ledger_number_seq;
+
+CREATE TABLE inventory_transaction_ledger (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  transaction_number text NOT NULL UNIQUE DEFAULT (
+    'ITL-' ||
+    to_char(now(), 'YYYYMMDD') ||
+    '-' ||
+    lpad(nextval('inventory_transaction_ledger_number_seq')::text, 8, '0')
+  ),
+  transaction_type inventory_ledger_transaction_type NOT NULL,
+  inventory_item_id integer NOT NULL REFERENCES inventory_items(id),
+  ag_part_number text NOT NULL REFERENCES inventory_items(ag_part_number),
+  lot_id uuid REFERENCES material_lots(id),
+  location_id text,
+  quantity_delta numeric(14,4) NOT NULL,
+  quantity_before numeric(14,4) NOT NULL,
+  quantity_after numeric(14,4) NOT NULL,
+  unit_of_measure text NOT NULL DEFAULT 'EA',
+  status_before text,
+  status_after text,
+  performed_by_user_id integer REFERENCES users(id),
+  performed_by_display_name text NOT NULL,
+  approved_by_user_id integer REFERENCES users(id),
+  approved_by_display_name text,
+  approval_id uuid,
+  project_id uuid REFERENCES projects(id),
+  production_work_order_id uuid REFERENCES production_work_orders(id),
+  traveler_id varchar(255) REFERENCES travelers(id),
+  traveler_step_id varchar(255) REFERENCES traveler_steps(id),
+  charge_code_id integer REFERENCES charge_codes(id),
+  reason_code text,
+  notes text,
+  digital_signature_id uuid,
+  source_module text NOT NULL,
+  source_record_id text,
+  event_hash text NOT NULL,
+  reversed_transaction_id uuid REFERENCES inventory_transaction_ledger(id),
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT inventory_transaction_ledger_quantity_math_ck
+    CHECK (quantity_after = quantity_before + quantity_delta),
+  CONSTRAINT inventory_transaction_ledger_reversal_link_ck
+    CHECK (
+      (transaction_type = 'REVERSAL' AND reversed_transaction_id IS NOT NULL)
+      OR
+      (transaction_type <> 'REVERSAL')
+    )
+);
+
+CREATE INDEX itl_transaction_type_idx ON inventory_transaction_ledger(transaction_type);
+CREATE INDEX itl_inventory_item_idx ON inventory_transaction_ledger(inventory_item_id);
+CREATE INDEX itl_ag_part_number_idx ON inventory_transaction_ledger(ag_part_number);
+CREATE INDEX itl_lot_idx ON inventory_transaction_ledger(lot_id);
+CREATE INDEX itl_location_idx ON inventory_transaction_ledger(location_id);
+CREATE INDEX itl_project_idx ON inventory_transaction_ledger(project_id);
+CREATE INDEX itl_work_order_idx ON inventory_transaction_ledger(production_work_order_id);
+CREATE INDEX itl_traveler_idx ON inventory_transaction_ledger(traveler_id);
+CREATE INDEX itl_charge_code_idx ON inventory_transaction_ledger(charge_code_id);
+CREATE INDEX itl_source_idx ON inventory_transaction_ledger(source_module, source_record_id);
+CREATE INDEX itl_reversed_transaction_idx ON inventory_transaction_ledger(reversed_transaction_id);
+CREATE INDEX itl_created_at_idx ON inventory_transaction_ledger(created_at);
+
+CREATE OR REPLACE FUNCTION prevent_inventory_ledger_modification()
+RETURNS trigger AS $$
+BEGIN
+  RAISE EXCEPTION 'Inventory transaction ledger entries are immutable';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER inventory_transaction_ledger_no_update
+BEFORE UPDATE ON inventory_transaction_ledger
+FOR EACH ROW
+EXECUTE FUNCTION prevent_inventory_ledger_modification();
+
+CREATE TRIGGER inventory_transaction_ledger_no_delete
+BEFORE DELETE ON inventory_transaction_ledger
+FOR EACH ROW
+EXECUTE FUNCTION prevent_inventory_ledger_modification();

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -3683,6 +3683,79 @@ export const inventoryTransactions = pgTable('inventory_transactions', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
 });
 
+export const inventoryLedgerTransactionTypeEnum = pgEnum('inventory_ledger_transaction_type', [
+  'RECEIVE',
+  'ISSUE',
+  'RETURN',
+  'TRANSFER',
+  'MOVE',
+  'RESERVE',
+  'UNRESERVE',
+  'CONSUME',
+  'ADJUST',
+  'SCRAP',
+  'SPLIT',
+  'MERGE',
+  'COUNT_ADJUSTMENT',
+  'STATUS_CHANGE',
+  'QUARANTINE',
+  'RELEASE',
+  'EXPIRE',
+  'REVERSAL',
+]);
+
+export const inventoryTransactionLedger = pgTable('inventory_transaction_ledger', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  transactionNumber: text('transaction_number').notNull().unique(),
+  transactionType: inventoryLedgerTransactionTypeEnum('transaction_type').notNull(),
+  inventoryItemId: integer('inventory_item_id')
+    .references(() => inventoryItems.id)
+    .notNull(),
+  agPartNumber: text('ag_part_number')
+    .references(() => inventoryItems.agPartNumber)
+    .notNull(),
+  lotId: uuid('lot_id').references(() => materialLots.id),
+  locationId: text('location_id'),
+  quantityDelta: numeric('quantity_delta', { precision: 14, scale: 4 }).notNull(),
+  quantityBefore: numeric('quantity_before', { precision: 14, scale: 4 }).notNull(),
+  quantityAfter: numeric('quantity_after', { precision: 14, scale: 4 }).notNull(),
+  unitOfMeasure: text('unit_of_measure').default('EA').notNull(),
+  statusBefore: text('status_before'),
+  statusAfter: text('status_after'),
+  performedByUserId: integer('performed_by_user_id').references(() => users.id),
+  performedByDisplayName: text('performed_by_display_name').notNull(),
+  approvedByUserId: integer('approved_by_user_id').references(() => users.id),
+  approvedByDisplayName: text('approved_by_display_name'),
+  approvalId: uuid('approval_id'),
+  projectId: uuid('project_id').references(() => projects.id),
+  productionWorkOrderId: uuid('production_work_order_id').references(() => productionWorkOrders.id),
+  travelerId: varchar('traveler_id', { length: 255 }).references(() => travelers.id),
+  travelerStepId: varchar('traveler_step_id', { length: 255 }).references(() => travelerSteps.id),
+  chargeCodeId: integer('charge_code_id').references(() => chargeCodes.id),
+  reasonCode: text('reason_code'),
+  notes: text('notes'),
+  digitalSignatureId: uuid('digital_signature_id'),
+  sourceModule: text('source_module').notNull(),
+  sourceRecordId: text('source_record_id'),
+  eventHash: text('event_hash').notNull(),
+  reversedTransactionId: uuid('reversed_transaction_id'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  transactionTypeIdx: index('itl_transaction_type_idx').on(table.transactionType),
+  inventoryItemIdx: index('itl_inventory_item_idx').on(table.inventoryItemId),
+  agPartNumberIdx: index('itl_ag_part_number_idx').on(table.agPartNumber),
+  lotIdx: index('itl_lot_idx').on(table.lotId),
+  locationIdx: index('itl_location_idx').on(table.locationId),
+  projectIdx: index('itl_project_idx').on(table.projectId),
+  workOrderIdx: index('itl_work_order_idx').on(table.productionWorkOrderId),
+  travelerIdx: index('itl_traveler_idx').on(table.travelerId),
+  chargeCodeIdx: index('itl_charge_code_idx').on(table.chargeCodeId),
+  sourceIdx: index('itl_source_idx').on(table.sourceModule, table.sourceRecordId),
+  reversedTransactionIdx: index('itl_reversed_transaction_idx').on(table.reversedTransactionId),
+  createdAtIdx: index('itl_created_at_idx').on(table.createdAt),
+}));
+
 // Vendor Parts - Links parts to vendors with pricing and lead times
 export const vendorParts = pgTable('vendor_parts', {
   id: serial('id').primaryKey(),
@@ -4192,6 +4265,46 @@ export const insertInventoryTransactionSchema = createInsertSchema(inventoryTran
   });
 export type InsertInventoryTransaction = z.infer<typeof insertInventoryTransactionSchema>;
 export type InventoryTransaction = typeof inventoryTransactions.$inferSelect;
+
+export const insertInventoryTransactionLedgerSchema = createInsertSchema(inventoryTransactionLedger)
+  .omit({
+    id: true,
+    transactionNumber: true,
+    eventHash: true,
+    createdAt: true,
+  })
+  .extend({
+    transactionType: z.enum([
+      'RECEIVE',
+      'ISSUE',
+      'RETURN',
+      'TRANSFER',
+      'MOVE',
+      'RESERVE',
+      'UNRESERVE',
+      'CONSUME',
+      'ADJUST',
+      'SCRAP',
+      'SPLIT',
+      'MERGE',
+      'COUNT_ADJUSTMENT',
+      'STATUS_CHANGE',
+      'QUARANTINE',
+      'RELEASE',
+      'EXPIRE',
+      'REVERSAL',
+    ]),
+    inventoryItemId: z.number().int().positive(),
+    agPartNumber: z.string().min(1, 'Part number is required'),
+    quantityDelta: z.union([z.string(), z.number()]),
+    quantityBefore: z.union([z.string(), z.number()]),
+    quantityAfter: z.union([z.string(), z.number()]),
+    unitOfMeasure: z.string().min(1).default('EA'),
+    performedByDisplayName: z.string().min(1, 'Performed by is required'),
+    sourceModule: z.string().min(1, 'Source module is required'),
+  });
+export type InsertInventoryTransactionLedger = z.infer<typeof insertInventoryTransactionLedgerSchema>;
+export type InventoryTransactionLedger = typeof inventoryTransactionLedger.$inferSelect;
 
 export const insertVendorPartSchema = createInsertSchema(vendorParts)
   .omit({

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -136,6 +136,7 @@ import modelAnalyticsRoutes from './modelAnalytics';
 import aqlSamplingRoutes from './aqlSampling';
 import auditRoutes from './audit';
 import auditLedgerRoutes from './auditLedger';
+import inventoryTransactionLedgerRoutes from './inventoryTransactionLedger';
 import { auditService } from '../services/auditService';
 import mediaRoutes from './media';
 import voiceNotesRoutes from './voiceNotes';
@@ -822,6 +823,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   // Audit System routes
   app.use('/api/audit', auditRoutes);
   app.use('/api/audit-ledger', auditLedgerRoutes);
+  app.use('/api/inventory-transaction-ledger', inventoryTransactionLedgerRoutes);
 
   // Media Library routes
   app.use('/api/media', mediaRoutes);

--- a/server/src/routes/inventoryTransactionLedger.ts
+++ b/server/src/routes/inventoryTransactionLedger.ts
@@ -1,0 +1,83 @@
+import { Router, type Request, type Response } from 'express';
+import { requireAdminOrOwner } from '../../middleware/auth';
+import {
+  listInventoryLedgerEntries,
+  recordInventoryLedgerEntry,
+  reverseInventoryLedgerEntry,
+  verifyInventoryLedgerHashes,
+} from '../services/inventoryTransactionLedgerService';
+
+const router = Router();
+
+router.use(requireAdminOrOwner);
+
+function currentUser(req: Request): { id?: number; username?: string } {
+  return (req.user ?? {}) as { id?: number; username?: string };
+}
+
+router.get('/', async (req: Request, res: Response) => {
+  try {
+    const limit = typeof req.query.limit === 'string' ? Number(req.query.limit) : undefined;
+    res.json(await listInventoryLedgerEntries({
+      agPartNumber: typeof req.query.agPartNumber === 'string' ? req.query.agPartNumber : undefined,
+      lotId: typeof req.query.lotId === 'string' ? req.query.lotId : undefined,
+      sourceModule: typeof req.query.sourceModule === 'string' ? req.query.sourceModule : undefined,
+      limit,
+    }));
+  } catch (error) {
+    console.error('[inventory-transaction-ledger] list failed', error);
+    res.status(500).json({ error: 'Failed to list inventory ledger entries' });
+  }
+});
+
+router.post('/verify', async (req: Request, res: Response) => {
+  try {
+    const limit = typeof req.body?.limit === 'number' ? req.body.limit : undefined;
+    res.json(await verifyInventoryLedgerHashes({ limit }));
+  } catch (error) {
+    console.error('[inventory-transaction-ledger] verify failed', error);
+    res.status(500).json({ error: 'Failed to verify inventory ledger hashes' });
+  }
+});
+
+router.post('/', async (req: Request, res: Response) => {
+  try {
+    const user = currentUser(req);
+    const entry = await recordInventoryLedgerEntry({
+      ...req.body,
+      performedByUserId: req.body?.performedByUserId ?? user.id ?? null,
+      performedByDisplayName:
+        req.body?.performedByDisplayName ??
+        user.username ??
+        'system',
+    });
+    res.status(201).json(entry);
+  } catch (error: any) {
+    console.error('[inventory-transaction-ledger] insert failed', error);
+    res.status(400).json({ error: error.message ?? 'Failed to record inventory ledger entry' });
+  }
+});
+
+router.post('/:id/reversal', async (req: Request, res: Response) => {
+  try {
+    const user = currentUser(req);
+    const entry = await reverseInventoryLedgerEntry({
+      transactionId: req.params.id,
+      performedByDisplayName:
+        req.body?.performedByDisplayName ??
+        user.username ??
+        'system',
+      reasonCode: req.body?.reasonCode ?? 'REVERSAL',
+      notes: req.body?.notes ?? null,
+      approvedByUserId: req.body?.approvedByUserId ?? null,
+      approvedByDisplayName: req.body?.approvedByDisplayName ?? null,
+      digitalSignatureId: req.body?.digitalSignatureId ?? null,
+    });
+    res.status(201).json(entry);
+  } catch (error: any) {
+    console.error('[inventory-transaction-ledger] reversal failed', error);
+    res.status(400).json({ error: error.message ?? 'Failed to reverse inventory ledger entry' });
+  }
+});
+
+export default router;

--- a/server/src/routes/materialLots.ts
+++ b/server/src/routes/materialLots.ts
@@ -23,6 +23,7 @@ import { db } from '../../db';
 import { eq, sql, and, like } from 'drizzle-orm';
 import { backfillPacketFromQueue } from '../lib/packetResolution';
 import { evaluateQueueReadiness } from '../services/queueReadinessService';
+import { recordInventoryLedgerEntry } from '../services/inventoryTransactionLedgerService';
 
 const router = Router();
 
@@ -1323,6 +1324,31 @@ router.post('/consume', async (req: Request, res: Response) => {
           .update(inventoryBalances)
           .set({ quantityOnHand: newOnHand, quantityAllocated: newAllocated, quantityAvailable: newAvailable, updatedAt: new Date() })
           .where(eq(inventoryBalances.id, balance.id));
+
+        await recordInventoryLedgerEntry({
+          transactionType: 'CONSUME',
+          inventoryItemId: lot.inventoryItemId,
+          agPartNumber: lot.materialPartNumber,
+          lotId: lot.id,
+          locationId: balance.locationId,
+          quantityDelta: newOnHand - balance.quantityOnHand,
+          quantityBefore: balance.quantityOnHand,
+          quantityAfter: newOnHand,
+          unitOfMeasure: lot.unitOfMeasure,
+          statusBefore: lot.status,
+          statusAfter: newStatus,
+          performedByDisplayName: validatedData.scannedBy,
+          travelerId: validatedData.travelerId ?? null,
+          travelerStepId: validatedData.travelerStepId ?? null,
+          reasonCode: 'TRAVELER_CONSUMPTION',
+          sourceModule: 'material-lots',
+          sourceRecordId: consumption.id,
+          metadata: {
+            fulfilledReservationId,
+            reservationUpdatedId,
+            receivedUnitId: resolvedRuId,
+          },
+        }, tx);
       }
 
       return { consumption, fulfilledReservationId, reservationUpdatedId };

--- a/server/src/services/inventoryAllocationService.ts
+++ b/server/src/services/inventoryAllocationService.ts
@@ -2,6 +2,7 @@ import { db } from '../../db';
 import { inventoryBalances, inventoryTransactions, allocationRequirements } from '../../schema';
 import { eq, and, sql } from 'drizzle-orm';
 import { evaluateQueueReadiness } from './queueReadinessService';
+import { recordInventoryBalanceLedgerChange } from './inventoryTransactionLedgerService';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -139,6 +140,24 @@ export async function allocateInventory(
       notes: notes ?? null,
       transactionDate: new Date(),
     });
+
+    await recordInventoryBalanceLedgerChange({
+      agPartNumber,
+      transactionType: 'RESERVE',
+      locationId,
+      quantityDelta: (updated.quantityAvailable ?? 0) - (row.quantityAvailable ?? 0),
+      quantityBefore: row.quantityAvailable ?? 0,
+      quantityAfter: updated.quantityAvailable ?? 0,
+      performedBy,
+      referenceType,
+      referenceId,
+      notes,
+      metadata: {
+        requirementId: requirementId ?? null,
+        queueId: queueId ?? null,
+        quantityBasis: 'available',
+      },
+    }, runner);
 
     return {
       allocated: toAllocate,
@@ -280,6 +299,22 @@ export async function deallocateInventory(
       transactionDate: new Date(),
     });
 
+    await recordInventoryBalanceLedgerChange({
+      agPartNumber,
+      transactionType: 'UNRESERVE',
+      locationId,
+      quantityDelta: (updated.quantityAvailable ?? 0) - (row.quantityAvailable ?? 0),
+      quantityBefore: row.quantityAvailable ?? 0,
+      quantityAfter: updated.quantityAvailable ?? 0,
+      performedBy,
+      referenceType,
+      referenceId,
+      notes,
+      metadata: {
+        quantityBasis: 'available',
+      },
+    }, tx);
+
     return {
       allocated: quantity,
       remaining: 0,
@@ -374,6 +409,22 @@ export async function consumeAllocatedInventory(
       notes: notes ?? null,
       transactionDate: new Date(),
     });
+
+    await recordInventoryBalanceLedgerChange({
+      agPartNumber,
+      transactionType: 'CONSUME',
+      locationId,
+      quantityDelta: updated.quantityOnHand - row.quantityOnHand,
+      quantityBefore: row.quantityOnHand,
+      quantityAfter: updated.quantityOnHand,
+      performedBy,
+      referenceType,
+      referenceId,
+      notes,
+      metadata: {
+        quantityBasis: 'on_hand',
+      },
+    }, tx);
 
     return {
       allocated: quantity,

--- a/server/src/services/inventoryEventService.ts
+++ b/server/src/services/inventoryEventService.ts
@@ -1,6 +1,12 @@
 import { db } from '../../db';
 import { inventoryItems, inventoryTransactions, inventoryBalances } from '../../schema';
 import { eq, and, sql } from 'drizzle-orm';
+import {
+  recordInventoryBalanceLedgerChange,
+  type InventoryLedgerTransactionType,
+} from './inventoryTransactionLedgerService';
+
+type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 export const RECEIVING_LOCATION = 'RECEIVING';
 export const MAIN_WAREHOUSE_LOCATION = 'WAREHOUSE-MAIN';
@@ -31,6 +37,28 @@ export interface InventoryEventParams {
   transactionDate?: Date;
 }
 
+function toLedgerTransactionType(eventType: InventoryEventType): InventoryLedgerTransactionType {
+  switch (eventType) {
+    case 'receipt':
+    case 'receipt_pending':
+      return 'RECEIVE';
+    case 'putaway':
+      return 'MOVE';
+    case 'consumption':
+      return 'CONSUME';
+    case 'transfer':
+      return 'TRANSFER';
+    case 'adjustment':
+      return 'ADJUST';
+    case 'return':
+      return 'RETURN';
+    case 'issue':
+      return 'ISSUE';
+    default:
+      return 'ADJUST';
+  }
+}
+
 export async function createInventoryEvent(params: InventoryEventParams): Promise<void> {
   const {
     agPartNumber,
@@ -59,7 +87,8 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     );
   }
 
-  const [item] = await db
+  await db.transaction(async (tx) => {
+  const [item] = await tx
     .select({ agPartNumber: inventoryItems.agPartNumber })
     .from(inventoryItems)
     .where(eq(inventoryItems.agPartNumber, agPartNumber));
@@ -71,7 +100,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
   const totalCost =
     costPerUnit != null ? String((costPerUnit * Math.abs(quantity)).toFixed(2)) : null;
 
-  await db.insert(inventoryTransactions).values({
+  await tx.insert(inventoryTransactions).values({
     agPartNumber,
     transactionType: eventType,
     quantity,
@@ -101,31 +130,120 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
 
   if (eventType === 'transfer') {
     if (fromLocation) {
-      await upsertBalance(agPartNumber, fromLocation, -Math.abs(quantity));
+      const change = await upsertBalance(agPartNumber, fromLocation, -Math.abs(quantity), tx);
+      await recordInventoryBalanceLedgerChange({
+        agPartNumber,
+        transactionType: 'TRANSFER',
+        locationId: fromLocation,
+        quantityDelta: change.delta,
+        quantityBefore: change.before,
+        quantityAfter: change.after,
+        unitOfMeasure,
+        performedBy,
+        referenceType,
+        referenceId,
+        notes,
+        metadata,
+      }, tx);
     }
     if (toLocation) {
-      await upsertBalance(agPartNumber, toLocation, Math.abs(quantity));
+      const change = await upsertBalance(agPartNumber, toLocation, Math.abs(quantity), tx);
+      await recordInventoryBalanceLedgerChange({
+        agPartNumber,
+        transactionType: 'TRANSFER',
+        locationId: toLocation,
+        quantityDelta: change.delta,
+        quantityBefore: change.before,
+        quantityAfter: change.after,
+        unitOfMeasure,
+        performedBy,
+        referenceType,
+        referenceId,
+        notes,
+        metadata,
+      }, tx);
     }
     return;
   }
 
   if (eventType === 'receipt' || eventType === 'putaway' || eventType === 'adjustment') {
     const location = toLocation || fromLocation || MAIN_WAREHOUSE_LOCATION;
-    await upsertBalance(agPartNumber, location, quantity);
+    const change = await upsertBalance(agPartNumber, location, quantity, tx);
+    await recordInventoryBalanceLedgerChange({
+      agPartNumber,
+      transactionType: toLedgerTransactionType(eventType),
+      locationId: location,
+      quantityDelta: change.delta,
+      quantityBefore: change.before,
+      quantityAfter: change.after,
+      unitOfMeasure,
+      performedBy,
+      referenceType,
+      referenceId,
+      notes,
+      metadata,
+    }, tx);
+
+    if (eventType === 'putaway' && fromLocation && fromLocation !== location) {
+      const sourceChange = await upsertBalance(agPartNumber, fromLocation, -Math.abs(quantity), tx);
+      await recordInventoryBalanceLedgerChange({
+        agPartNumber,
+        transactionType: 'MOVE',
+        locationId: fromLocation,
+        quantityDelta: sourceChange.delta,
+        quantityBefore: sourceChange.before,
+        quantityAfter: sourceChange.after,
+        unitOfMeasure,
+        performedBy,
+        referenceType,
+        referenceId,
+        notes,
+        metadata,
+      }, tx);
+    }
     return;
   }
 
   if (eventType === 'consumption' || eventType === 'issue') {
     const location = fromLocation || MAIN_WAREHOUSE_LOCATION;
-    await upsertBalance(agPartNumber, location, -Math.abs(quantity));
+    const change = await upsertBalance(agPartNumber, location, -Math.abs(quantity), tx);
+    await recordInventoryBalanceLedgerChange({
+      agPartNumber,
+      transactionType: toLedgerTransactionType(eventType),
+      locationId: location,
+      quantityDelta: change.delta,
+      quantityBefore: change.before,
+      quantityAfter: change.after,
+      unitOfMeasure,
+      performedBy,
+      referenceType,
+      referenceId,
+      notes,
+      metadata,
+    }, tx);
     return;
   }
 
   if (eventType === 'return') {
     const location = toLocation || MAIN_WAREHOUSE_LOCATION;
-    await upsertBalance(agPartNumber, location, Math.abs(quantity));
+    const change = await upsertBalance(agPartNumber, location, Math.abs(quantity), tx);
+    await recordInventoryBalanceLedgerChange({
+      agPartNumber,
+      transactionType: 'RETURN',
+      locationId: location,
+      quantityDelta: change.delta,
+      quantityBefore: change.before,
+      quantityAfter: change.after,
+      unitOfMeasure,
+      performedBy,
+      referenceType,
+      referenceId,
+      notes,
+      metadata,
+    }, tx);
     return;
   }
+  });
 }
 
 export async function putAwayInventory(params: {
@@ -152,16 +270,16 @@ export async function putAwayInventory(params: {
     referenceId,
   });
 
-  await upsertBalance(agPartNumber, fromLocation, -Math.abs(quantity));
 }
 
 async function upsertBalance(
   agPartNumber: string,
   locationId: string,
-  delta: number
-): Promise<void> {
-  const [existing] = await db
-    .select({ id: inventoryBalances.id })
+  delta: number,
+  runner: DbTransaction | typeof db = db,
+): Promise<{ before: number; delta: number; after: number }> {
+  const [existing] = await runner
+    .select({ id: inventoryBalances.id, quantityOnHand: inventoryBalances.quantityOnHand })
     .from(inventoryBalances)
     .where(
       and(
@@ -171,7 +289,9 @@ async function upsertBalance(
     );
 
   if (existing) {
-    await db
+    const before = existing.quantityOnHand;
+    const after = Math.max(0, before + delta);
+    await runner
       .update(inventoryBalances)
       .set({
         quantityOnHand: sql`GREATEST(0, ${inventoryBalances.quantityOnHand} + ${delta})`,
@@ -179,14 +299,16 @@ async function upsertBalance(
         updatedAt: new Date(),
       })
       .where(eq(inventoryBalances.id, existing.id));
+    return { before, delta: after - before, after };
   } else {
     const onHand = Math.max(0, delta);
-    await db.insert(inventoryBalances).values({
+    await runner.insert(inventoryBalances).values({
       agPartNumber,
       locationId,
       quantityOnHand: onHand,
       quantityAllocated: 0,
       quantityAvailable: onHand,
     });
+    return { before: 0, delta: onHand, after: onHand };
   }
 }

--- a/server/src/services/inventoryTransactionLedgerService.ts
+++ b/server/src/services/inventoryTransactionLedgerService.ts
@@ -1,0 +1,381 @@
+import crypto from 'crypto';
+import { asc, desc, eq, sql } from 'drizzle-orm';
+import { db } from '../../db';
+import {
+  inventoryBalances,
+  inventoryItems,
+  inventoryTransactionLedger,
+  type InventoryTransactionLedger,
+} from '../../schema';
+import { canonicalize } from './auditLedgerService';
+
+type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+type LedgerTx = Pick<DbTransaction, 'insert' | 'select' | 'execute'>;
+
+export type InventoryLedgerTransactionType =
+  | 'RECEIVE'
+  | 'ISSUE'
+  | 'RETURN'
+  | 'TRANSFER'
+  | 'MOVE'
+  | 'RESERVE'
+  | 'UNRESERVE'
+  | 'CONSUME'
+  | 'ADJUST'
+  | 'SCRAP'
+  | 'SPLIT'
+  | 'MERGE'
+  | 'COUNT_ADJUSTMENT'
+  | 'STATUS_CHANGE'
+  | 'QUARANTINE'
+  | 'RELEASE'
+  | 'EXPIRE'
+  | 'REVERSAL';
+
+export type InventoryLedgerEntryInput = {
+  transactionType: InventoryLedgerTransactionType;
+  inventoryItemId: number;
+  agPartNumber: string;
+  lotId?: string | null;
+  locationId?: string | null;
+  quantityDelta: number | string;
+  quantityBefore: number | string;
+  quantityAfter: number | string;
+  unitOfMeasure?: string | null;
+  statusBefore?: string | null;
+  statusAfter?: string | null;
+  performedByUserId?: number | null;
+  performedByDisplayName: string;
+  approvedByUserId?: number | null;
+  approvedByDisplayName?: string | null;
+  approvalId?: string | null;
+  projectId?: string | null;
+  productionWorkOrderId?: string | null;
+  travelerId?: string | null;
+  travelerStepId?: string | null;
+  chargeCodeId?: number | null;
+  reasonCode?: string | null;
+  notes?: string | null;
+  digitalSignatureId?: string | null;
+  sourceModule: string;
+  sourceRecordId?: string | number | null;
+  reversedTransactionId?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type InventoryLedgerBalanceChangeInput = {
+  agPartNumber: string;
+  transactionType: InventoryLedgerTransactionType;
+  locationId?: string | null;
+  quantityDelta: number;
+  quantityBefore: number;
+  quantityAfter: number;
+  unitOfMeasure?: string | null;
+  performedBy?: string | null;
+  referenceType?: string | null;
+  referenceId?: string | number | null;
+  notes?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+function sha256Hex(input: string): string {
+  return crypto.createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+function toLedgerNumeric(value: number | string): string {
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numericValue)) {
+    throw new Error(`INVENTORY LEDGER: invalid numeric value ${value}`);
+  }
+  return numericValue.toFixed(4);
+}
+
+function assertQuantityMath(input: Pick<InventoryLedgerEntryInput, 'quantityBefore' | 'quantityDelta' | 'quantityAfter'>): void {
+  const before = Number(input.quantityBefore);
+  const delta = Number(input.quantityDelta);
+  const after = Number(input.quantityAfter);
+
+  if (!Number.isFinite(before) || !Number.isFinite(delta) || !Number.isFinite(after)) {
+    throw new Error('INVENTORY LEDGER: quantity values must be finite numbers');
+  }
+
+  if (Math.abs(before + delta - after) > 0.0001) {
+    throw new Error(
+      `INVENTORY LEDGER: quantity math mismatch. before=${before} delta=${delta} after=${after}`,
+    );
+  }
+}
+
+function transactionNumber(): string {
+  const stamp = new Date().toISOString().replace(/[-:TZ.]/g, '').slice(0, 14);
+  const suffix = crypto.randomBytes(3).toString('hex').toUpperCase();
+  return `ITL-${stamp}-${suffix}`;
+}
+
+function eventHash(input: InventoryLedgerEntryInput, txNumber: string): string {
+  return sha256Hex(canonicalize({
+    transactionNumber: txNumber,
+    transactionType: input.transactionType,
+    inventoryItemId: input.inventoryItemId,
+    agPartNumber: input.agPartNumber,
+    lotId: input.lotId ?? null,
+    locationId: input.locationId ?? null,
+    quantityDelta: toLedgerNumeric(input.quantityDelta),
+    quantityBefore: toLedgerNumeric(input.quantityBefore),
+    quantityAfter: toLedgerNumeric(input.quantityAfter),
+    unitOfMeasure: input.unitOfMeasure ?? 'EA',
+    statusBefore: input.statusBefore ?? null,
+    statusAfter: input.statusAfter ?? null,
+    performedByUserId: input.performedByUserId ?? null,
+    performedByDisplayName: input.performedByDisplayName,
+    sourceModule: input.sourceModule,
+    sourceRecordId: input.sourceRecordId != null ? String(input.sourceRecordId) : null,
+    reversedTransactionId: input.reversedTransactionId ?? null,
+  }));
+}
+
+export async function recordInventoryLedgerEntry(
+  input: InventoryLedgerEntryInput,
+  tx?: LedgerTx,
+): Promise<InventoryTransactionLedger> {
+  if (!input.performedByDisplayName) {
+    throw new Error('INVENTORY LEDGER: performedByDisplayName required');
+  }
+  if (!input.sourceModule) {
+    throw new Error('INVENTORY LEDGER: sourceModule required');
+  }
+  if (input.transactionType === 'REVERSAL' && !input.reversedTransactionId) {
+    throw new Error('INVENTORY LEDGER: reversal entries must link reversedTransactionId');
+  }
+  assertQuantityMath(input);
+
+  const runner = tx ?? db;
+  const txNumber = transactionNumber();
+  const hash = eventHash(input, txNumber);
+
+  const [inserted] = await runner
+    .insert(inventoryTransactionLedger)
+    .values({
+      transactionNumber: txNumber,
+      transactionType: input.transactionType,
+      inventoryItemId: input.inventoryItemId,
+      agPartNumber: input.agPartNumber,
+      lotId: input.lotId ?? null,
+      locationId: input.locationId ?? null,
+      quantityDelta: toLedgerNumeric(input.quantityDelta),
+      quantityBefore: toLedgerNumeric(input.quantityBefore),
+      quantityAfter: toLedgerNumeric(input.quantityAfter),
+      unitOfMeasure: input.unitOfMeasure ?? 'EA',
+      statusBefore: input.statusBefore ?? null,
+      statusAfter: input.statusAfter ?? null,
+      performedByUserId: input.performedByUserId ?? null,
+      performedByDisplayName: input.performedByDisplayName,
+      approvedByUserId: input.approvedByUserId ?? null,
+      approvedByDisplayName: input.approvedByDisplayName ?? null,
+      approvalId: input.approvalId ?? null,
+      projectId: input.projectId ?? null,
+      productionWorkOrderId: input.productionWorkOrderId ?? null,
+      travelerId: input.travelerId ?? null,
+      travelerStepId: input.travelerStepId ?? null,
+      chargeCodeId: input.chargeCodeId ?? null,
+      reasonCode: input.reasonCode ?? null,
+      notes: input.notes ?? null,
+      digitalSignatureId: input.digitalSignatureId ?? null,
+      sourceModule: input.sourceModule,
+      sourceRecordId: input.sourceRecordId != null ? String(input.sourceRecordId) : null,
+      eventHash: hash,
+      reversedTransactionId: input.reversedTransactionId ?? null,
+      metadata: input.metadata ?? null,
+    })
+    .returning();
+
+  if (!inserted) {
+    throw new Error('INVENTORY LEDGER: insert returned no row');
+  }
+
+  return inserted;
+}
+
+export async function recordInventoryBalanceLedgerChange(
+  input: InventoryLedgerBalanceChangeInput,
+  tx?: LedgerTx,
+): Promise<InventoryTransactionLedger> {
+  const runner = tx ?? db;
+  const [item] = await runner
+    .select({
+      id: inventoryItems.id,
+      agPartNumber: inventoryItems.agPartNumber,
+      usageUnit: inventoryItems.usageUnit,
+      purchaseUnit: inventoryItems.purchaseUnit,
+    })
+    .from(inventoryItems)
+    .where(eq(inventoryItems.agPartNumber, input.agPartNumber));
+
+  if (!item) {
+    throw new Error(`INVENTORY LEDGER: part number ${input.agPartNumber} not found`);
+  }
+
+  return recordInventoryLedgerEntry({
+    transactionType: input.transactionType,
+    inventoryItemId: item.id,
+    agPartNumber: item.agPartNumber,
+    locationId: input.locationId ?? null,
+    quantityDelta: input.quantityDelta,
+    quantityBefore: input.quantityBefore,
+    quantityAfter: input.quantityAfter,
+    unitOfMeasure: input.unitOfMeasure ?? item.usageUnit ?? item.purchaseUnit ?? 'EA',
+    performedByDisplayName: input.performedBy ?? 'system',
+    reasonCode: input.referenceType ?? null,
+    notes: input.notes ?? null,
+    sourceModule: 'inventory',
+    sourceRecordId: input.referenceId ?? null,
+    metadata: input.metadata ?? null,
+  }, tx);
+}
+
+export async function reverseInventoryLedgerEntry(params: {
+  transactionId: string;
+  performedByDisplayName: string;
+  reasonCode: string;
+  notes?: string | null;
+  approvedByUserId?: number | null;
+  approvedByDisplayName?: string | null;
+  digitalSignatureId?: string | null;
+}): Promise<InventoryTransactionLedger> {
+  return db.transaction(async (tx) => {
+    const [original] = await tx
+      .select()
+      .from(inventoryTransactionLedger)
+      .where(eq(inventoryTransactionLedger.id, params.transactionId))
+      .for('update');
+
+    if (!original) {
+      throw new Error(`INVENTORY LEDGER: transaction ${params.transactionId} not found`);
+    }
+    if (original.transactionType === 'REVERSAL') {
+      throw new Error('INVENTORY LEDGER: reversal entries cannot be reversed directly');
+    }
+
+    const [existingReversal] = await tx
+      .select({ id: inventoryTransactionLedger.id })
+      .from(inventoryTransactionLedger)
+      .where(eq(inventoryTransactionLedger.reversedTransactionId, original.id))
+      .limit(1);
+
+    if (existingReversal) {
+      throw new Error(`INVENTORY LEDGER: transaction ${params.transactionId} already has a reversal`);
+    }
+
+    const [balance] = await tx
+      .select({
+        quantityOnHand: inventoryBalances.quantityOnHand,
+      })
+      .from(inventoryBalances)
+      .where(sql`${inventoryBalances.agPartNumber} = ${original.agPartNumber} AND ${inventoryBalances.locationId} IS NOT DISTINCT FROM ${original.locationId}`)
+      .limit(1);
+
+    const currentQuantity = balance?.quantityOnHand ?? Number(original.quantityAfter);
+    const reversalDelta = -Number(original.quantityDelta);
+
+    return recordInventoryLedgerEntry({
+      transactionType: 'REVERSAL',
+      inventoryItemId: original.inventoryItemId,
+      agPartNumber: original.agPartNumber,
+      lotId: original.lotId,
+      locationId: original.locationId,
+      quantityDelta: reversalDelta,
+      quantityBefore: currentQuantity,
+      quantityAfter: currentQuantity + reversalDelta,
+      unitOfMeasure: original.unitOfMeasure,
+      statusBefore: original.statusAfter,
+      statusAfter: original.statusBefore,
+      performedByDisplayName: params.performedByDisplayName,
+      approvedByUserId: params.approvedByUserId ?? null,
+      approvedByDisplayName: params.approvedByDisplayName ?? null,
+      reasonCode: params.reasonCode,
+      notes: params.notes ?? `Reversal of ${original.transactionNumber}`,
+      digitalSignatureId: params.digitalSignatureId ?? null,
+      sourceModule: 'inventory-ledger-reversal',
+      sourceRecordId: original.id,
+      reversedTransactionId: original.id,
+      metadata: {
+        originalTransactionNumber: original.transactionNumber,
+        originalEventHash: original.eventHash,
+      },
+    }, tx);
+  });
+}
+
+export async function listInventoryLedgerEntries(params: {
+  agPartNumber?: string;
+  lotId?: string;
+  sourceModule?: string;
+  limit?: number;
+} = {}): Promise<InventoryTransactionLedger[]> {
+  const limit = Math.min(Math.max(params.limit ?? 100, 1), 500);
+  const conditions = [];
+  if (params.agPartNumber) {
+    conditions.push(eq(inventoryTransactionLedger.agPartNumber, params.agPartNumber));
+  }
+  if (params.lotId) {
+    conditions.push(eq(inventoryTransactionLedger.lotId, params.lotId));
+  }
+  if (params.sourceModule) {
+    conditions.push(eq(inventoryTransactionLedger.sourceModule, params.sourceModule));
+  }
+
+  return db
+    .select()
+    .from(inventoryTransactionLedger)
+    .where(conditions.length ? sql.join(conditions, sql` AND `) : sql`TRUE`)
+    .orderBy(desc(inventoryTransactionLedger.createdAt), asc(inventoryTransactionLedger.transactionNumber))
+    .limit(limit);
+}
+
+export async function verifyInventoryLedgerHashes(params: {
+  limit?: number;
+} = {}): Promise<{
+  checked: number;
+  mismatches: Array<{ id: string; transactionNumber: string; expectedHash: string; actualHash: string }>;
+}> {
+  const limit = Math.min(Math.max(params.limit ?? 500, 1), 5000);
+  const rows = await db
+    .select()
+    .from(inventoryTransactionLedger)
+    .orderBy(asc(inventoryTransactionLedger.createdAt), asc(inventoryTransactionLedger.transactionNumber))
+    .limit(limit);
+
+  const mismatches = rows
+    .map((row) => {
+      const expectedHash = eventHash({
+        transactionType: row.transactionType,
+        inventoryItemId: row.inventoryItemId,
+        agPartNumber: row.agPartNumber,
+        lotId: row.lotId,
+        locationId: row.locationId,
+        quantityDelta: row.quantityDelta,
+        quantityBefore: row.quantityBefore,
+        quantityAfter: row.quantityAfter,
+        unitOfMeasure: row.unitOfMeasure,
+        statusBefore: row.statusBefore,
+        statusAfter: row.statusAfter,
+        performedByUserId: row.performedByUserId,
+        performedByDisplayName: row.performedByDisplayName,
+        sourceModule: row.sourceModule,
+        sourceRecordId: row.sourceRecordId,
+        reversedTransactionId: row.reversedTransactionId,
+      }, row.transactionNumber);
+
+      return expectedHash === row.eventHash
+        ? null
+        : {
+            id: row.id,
+            transactionNumber: row.transactionNumber,
+            expectedHash,
+            actualHash: row.eventHash,
+          };
+    })
+    .filter((row): row is { id: string; transactionNumber: string; expectedHash: string; actualHash: string } => Boolean(row));
+
+  return { checked: rows.length, mismatches };
+}


### PR DESCRIPTION
## Summary
- Adds `inventory_transaction_ledger` with append-only transaction types, before/after quantities, lot/project/work-order/traveler/charge-code linkage, event hashes, and reversal linkage.
- Adds database immutability triggers that block UPDATE and DELETE on ledger rows.
- Adds an admin-only `/api/inventory-transaction-ledger` API for listing, inserting controlled entries, creating reversals, and verifying event hashes.
- Dual-writes current inventory event, allocation, and traveler material consumption paths into the immutable ledger inside the relevant transaction boundaries.

## Verification
- `git diff --check` passed.
- `npm run check` could not run in this desktop session because `npm` is not available on PATH and this checkout has no local `node_modules`.

## Notes
- Existing unrelated local files were left out of this commit: `PRODUCTION_STOCK_MODELS.sql`, `parts-request-project-preview.html`, and `receiving-traceability-preview.html`.