### PR TITLE
[codex] Enforce inventory status controls

### DIFF
--- a/server/__tests__/inventoryControls.test.ts
+++ b/server/__tests__/inventoryControls.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MATERIAL_TRACEABILITY_REQUIREMENTS,
+  validateInventoryStatusAction,
+} from '../src/constants/inventoryControls';
+
+describe('inventory status action controls', () => {
+  it('makes quarantined material view-only except disposition changes', () => {
+    expect(validateInventoryStatusAction('QUARANTINE', 'view')).toEqual({ ok: true });
+    expect(validateInventoryStatusAction('QUARANTINE', 'status_change')).toEqual({ ok: true });
+    expect(validateInventoryStatusAction('QUARANTINE', 'move')).toMatchObject({
+      ok: false,
+      code: 'ACTION_BLOCKED',
+    });
+  });
+
+  it('limits rejected material to scrap or MRB', () => {
+    expect(validateInventoryStatusAction('REJECTED', 'scrap')).toEqual({ ok: true });
+    expect(validateInventoryStatusAction('REJECTED', 'mrb')).toEqual({ ok: true });
+    expect(validateInventoryStatusAction('REJECTED', 'reserve')).toMatchObject({
+      ok: false,
+      code: 'ACTION_BLOCKED',
+    });
+  });
+
+  it('blocks all non-view actions for scrapped material', () => {
+    expect(validateInventoryStatusAction('SCRAPPED', 'view')).toEqual({ ok: true });
+    expect(validateInventoryStatusAction('SCRAPPED', 'move')).toMatchObject({
+      ok: false,
+      code: 'ACTION_BLOCKED',
+    });
+  });
+
+  it('prevents expired material from allocation-style actions', () => {
+    expect(validateInventoryStatusAction('EXPIRED', 'reserve')).toMatchObject({
+      ok: false,
+      code: 'ACTION_BLOCKED',
+    });
+    expect(validateInventoryStatusAction('EXPIRED', 'consume')).toMatchObject({
+      ok: false,
+      code: 'ACTION_BLOCKED',
+    });
+    expect(validateInventoryStatusAction('EXPIRED', 'scrap')).toEqual({ ok: true });
+  });
+
+  it('requires approval for held material actions', () => {
+    expect(validateInventoryStatusAction('HOLD', 'view')).toEqual({ ok: true });
+    expect(validateInventoryStatusAction('HOLD', 'move')).toMatchObject({
+      ok: false,
+      code: 'APPROVAL_REQUIRED',
+    });
+    expect(validateInventoryStatusAction('HOLD', 'move', 'approval-123')).toEqual({ ok: true });
+  });
+});
+
+describe('material traceability requirements', () => {
+  it('formalizes required evidence by department', () => {
+    expect(MATERIAL_TRACEABILITY_REQUIREMENTS).toEqual([
+      { department: 'Layup', requiredTraceability: ['ICN', 'lot', 'expiration', 'out-time'] },
+      { department: 'CNC', requiredTraceability: ['serial'] },
+      { department: 'Finish', requiredTraceability: ['batch number'] },
+      { department: 'QC', requiredTraceability: ['cert package'] },
+    ]);
+  });
+});

--- a/server/__tests__/traceabilityRoutes.test.ts
+++ b/server/__tests__/traceabilityRoutes.test.ts
@@ -145,6 +145,19 @@ describe('Material Traceability HTTP routes (Task #147)', () => {
   // /search — 400 validation + 200 happy path for each of the 8 keys
   // ─────────────────────────────────────────────────────────────────────
 
+  it('GET /requirements returns the department traceability matrix', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/api/traceability/requirements');
+    expect(res.status).toBe(200);
+    expect(res.body.requirements).toEqual([
+      { department: 'Layup', requiredTraceability: ['ICN', 'lot', 'expiration', 'out-time'] },
+      { department: 'CNC', requiredTraceability: ['serial'] },
+      { department: 'Finish', requiredTraceability: ['batch number'] },
+      { department: 'QC', requiredTraceability: ['cert package'] },
+    ]);
+    expect(res.body.generatedAt).toBeDefined();
+  });
+
   it('GET /search rejects an unknown key with 400', async () => {
     const app = await makeApp();
     const res = await request(app).get('/api/traceability/search?key=bogusKey&value=x');

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -5375,7 +5375,7 @@ export const materialLots = pgTable('material_lots', {
   storageRequirements: text('storage_requirements'), // Temperature, humidity requirements
   
   // Status tracking
-  status: text('status').default('RECEIVED').notNull(), // RECEIVED | QUARANTINE | ACCEPTED | REJECTED | EXPIRED | ISSUED | CONSUMED | SCRAPPED
+  status: text('status').default('RECEIVED').notNull(), // RECEIVED | QUARANTINE | ACCEPTED | REJECTED | EXPIRED | ISSUED | CONSUMED | SCRAPPED | HOLD
   
   // Out-time tracking (for prepregs/time-sensitive materials)
   totalOutTimeMinutes: integer('total_out_time_minutes').default(0),
@@ -5418,7 +5418,7 @@ export const materialLotTransactions = pgTable('material_lot_transactions', {
   internalControlNumber: text('internal_control_number').notNull(), // Denormalized for queries
   
   // Transaction type
-  transactionType: text('transaction_type').notNull(), // RECEIVE | MOVE | ISSUE | ADJUST | SCRAP | RETURN | SPLIT | OUT_START | OUT_END | ACCEPT | REJECT | QUARANTINE
+  transactionType: text('transaction_type').notNull(), // RECEIVE | MOVE | ISSUE | ADJUST | SCRAP | RETURN | SPLIT | OUT_START | OUT_END | ACCEPT | REJECT | QUARANTINE | EXPIRE | HOLD
   
   // Quantity change
   qtyBefore: numeric('qty_before'),
@@ -6858,7 +6858,7 @@ export const insertMaterialLotSchema = createInsertSchema(materialLots)
     manufactureDate: z.coerce.date().optional().nullable(),
     storageLocation: z.string().optional().nullable(),
     storageRequirements: z.string().optional().nullable(),
-    status: z.enum(['RECEIVED', 'QUARANTINE', 'ACCEPTED', 'REJECTED', 'EXPIRED', 'ISSUED', 'CONSUMED', 'SCRAPPED']).default('RECEIVED'),
+    status: z.enum(['RECEIVED', 'QUARANTINE', 'ACCEPTED', 'REJECTED', 'EXPIRED', 'ISSUED', 'CONSUMED', 'SCRAPPED', 'HOLD']).default('RECEIVED'),
     totalOutTimeMinutes: z.number().int().default(0),
     maxOutTimeMinutes: z.number().int().optional().nullable(),
     currentlyOutOfStorage: z.boolean().default(false),
@@ -6886,7 +6886,7 @@ export const insertMaterialLotTransactionSchema = createInsertSchema(materialLot
   .extend({
     materialLotId: z.string().uuid('Invalid material lot ID'),
     internalControlNumber: z.string().min(1, 'ICN is required'),
-    transactionType: z.enum(['RECEIVE', 'MOVE', 'ISSUE', 'ADJUST', 'SCRAP', 'RETURN', 'SPLIT', 'OUT_START', 'OUT_END', 'ACCEPT', 'REJECT', 'QUARANTINE']),
+    transactionType: z.enum(['RECEIVE', 'MOVE', 'ISSUE', 'ADJUST', 'SCRAP', 'RETURN', 'SPLIT', 'OUT_START', 'OUT_END', 'ACCEPT', 'REJECT', 'QUARANTINE', 'EXPIRE', 'HOLD']),
     qtyBefore: z.string().optional().nullable(),
     qtyChange: z.string().optional().nullable(),
     qtyAfter: z.string().optional().nullable(),

--- a/server/src/constants/inventoryControls.ts
+++ b/server/src/constants/inventoryControls.ts
@@ -1,0 +1,108 @@
+export const CONTROLLED_INVENTORY_STATUSES = [
+  'QUARANTINE',
+  'REJECTED',
+  'SCRAPPED',
+  'EXPIRED',
+  'HOLD',
+] as const;
+
+export type ControlledInventoryStatus = typeof CONTROLLED_INVENTORY_STATUSES[number];
+
+export type InventoryStatusAction =
+  | 'view'
+  | 'move'
+  | 'issue'
+  | 'return'
+  | 'reserve'
+  | 'consume'
+  | 'scrap'
+  | 'mrb'
+  | 'split'
+  | 'adjust'
+  | 'status_change';
+
+export const INVENTORY_STATUS_ACTION_POLICY: Record<
+  ControlledInventoryStatus,
+  {
+    allowedActions: InventoryStatusAction[];
+    requiresApproval?: boolean;
+    auditRule: string;
+  }
+> = {
+  QUARANTINE: {
+    allowedActions: ['view', 'status_change'],
+    auditRule: 'Quarantined material is view-only until Quality changes disposition.',
+  },
+  REJECTED: {
+    allowedActions: ['view', 'scrap', 'mrb'],
+    auditRule: 'Rejected material can only move through scrap or MRB disposition.',
+  },
+  SCRAPPED: {
+    allowedActions: ['view'],
+    auditRule: 'Scrapped material is final and cannot move or be allocated.',
+  },
+  EXPIRED: {
+    allowedActions: ['view', 'move', 'return', 'scrap', 'mrb', 'adjust', 'status_change'],
+    auditRule: 'Expired material cannot be allocated, reserved, issued, or consumed.',
+  },
+  HOLD: {
+    allowedActions: ['view', 'move', 'issue', 'return', 'reserve', 'consume', 'scrap', 'mrb', 'split', 'adjust', 'status_change'],
+    requiresApproval: true,
+    auditRule: 'Held material requires an approval reference for every non-view action.',
+  },
+};
+
+export function normalizeInventoryStatus(status: unknown): string {
+  return String(status ?? '').trim().toUpperCase();
+}
+
+export function isControlledInventoryStatus(status: unknown): status is ControlledInventoryStatus {
+  return (CONTROLLED_INVENTORY_STATUSES as readonly string[]).includes(normalizeInventoryStatus(status));
+}
+
+export function getInventoryStatusPolicy(status: unknown) {
+  const normalized = normalizeInventoryStatus(status);
+  return isControlledInventoryStatus(normalized)
+    ? INVENTORY_STATUS_ACTION_POLICY[normalized]
+    : null;
+}
+
+export function validateInventoryStatusAction(
+  status: unknown,
+  action: InventoryStatusAction,
+  approvalReference?: unknown,
+): { ok: true } | { ok: false; code: 'ACTION_BLOCKED' | 'APPROVAL_REQUIRED'; message: string } {
+  const normalized = normalizeInventoryStatus(status);
+  const policy = getInventoryStatusPolicy(normalized);
+  if (!policy) return { ok: true };
+
+  if (!policy.allowedActions.includes(action)) {
+    return {
+      ok: false,
+      code: 'ACTION_BLOCKED',
+      message: `${action} is not allowed while inventory status is ${normalized}. ${policy.auditRule}`,
+    };
+  }
+
+  if (policy.requiresApproval && action !== 'view' && !approvalReference) {
+    return {
+      ok: false,
+      code: 'APPROVAL_REQUIRED',
+      message: `${normalized} inventory requires an approval reference before ${action}.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export type TraceabilityField = 'ICN' | 'lot' | 'expiration' | 'out-time' | 'serial' | 'batch number' | 'cert package';
+
+export const MATERIAL_TRACEABILITY_REQUIREMENTS: Array<{
+  department: string;
+  requiredTraceability: TraceabilityField[];
+}> = [
+  { department: 'Layup', requiredTraceability: ['ICN', 'lot', 'expiration', 'out-time'] },
+  { department: 'CNC', requiredTraceability: ['serial'] },
+  { department: 'Finish', requiredTraceability: ['batch number'] },
+  { department: 'QC', requiredTraceability: ['cert package'] },
+];

--- a/server/src/routes/materialLots.ts
+++ b/server/src/routes/materialLots.ts
@@ -24,14 +24,48 @@ import { eq, sql, and, like } from 'drizzle-orm';
 import { backfillPacketFromQueue } from '../lib/packetResolution';
 import { evaluateQueueReadiness } from '../services/queueReadinessService';
 import { recordInventoryLedgerEntry } from '../services/inventoryTransactionLedgerService';
+import {
+  type InventoryStatusAction,
+  validateInventoryStatusAction,
+} from '../constants/inventoryControls';
 
 const router = Router();
 
-type TransactionType = 'RECEIVE' | 'MOVE' | 'ISSUE' | 'ADJUST' | 'SCRAP' | 'RETURN' | 'SPLIT' | 'OUT_START' | 'OUT_END' | 'ACCEPT' | 'REJECT' | 'QUARANTINE';
-type MaterialLotStatus = 'RECEIVED' | 'ACCEPTED' | 'ISSUED' | 'EXPIRED' | 'QUARANTINE' | 'REJECTED' | 'CONSUMED' | 'SCRAPPED';
+type TransactionType = 'RECEIVE' | 'MOVE' | 'ISSUE' | 'ADJUST' | 'SCRAP' | 'RETURN' | 'SPLIT' | 'OUT_START' | 'OUT_END' | 'ACCEPT' | 'REJECT' | 'QUARANTINE' | 'EXPIRE' | 'HOLD';
+type MaterialLotStatus = 'RECEIVED' | 'ACCEPTED' | 'ISSUED' | 'EXPIRED' | 'QUARANTINE' | 'REJECTED' | 'CONSUMED' | 'SCRAPPED' | 'HOLD';
+
+const STATUS_TRANSACTION_TYPE: Partial<Record<MaterialLotStatus, TransactionType>> = {
+  ACCEPTED: 'ACCEPT',
+  REJECTED: 'REJECT',
+  QUARANTINE: 'QUARANTINE',
+  ISSUED: 'ISSUE',
+  EXPIRED: 'EXPIRE',
+  HOLD: 'HOLD',
+};
 
 function createTransaction(data: Omit<InsertMaterialLotTransaction, 'wasOverride'> & { wasOverride?: boolean }): InsertMaterialLotTransaction {
   return { ...data, wasOverride: data.wasOverride ?? false };
+}
+
+function getApprovalReference(req: Request): unknown {
+  return req.body?.approvalId ?? req.body?.approvedBy ?? req.body?.approvalReference;
+}
+
+function blockedInventoryActionResponse(
+  req: Request,
+  res: Response,
+  lot: { status: string },
+  action: InventoryStatusAction
+): boolean {
+  const validation = validateInventoryStatusAction(lot.status, action, getApprovalReference(req));
+  if (validation.ok) return false;
+  res.status(validation.code === 'APPROVAL_REQUIRED' ? 403 : 409).json({
+    error: validation.code,
+    message: validation.message,
+    status: lot.status,
+    action,
+  });
+  return true;
 }
 
 router.use((req: Request, res: Response, next: NextFunction) => {
@@ -740,10 +774,12 @@ router.post('/:id/status', async (req: Request, res: Response) => {
     }
 
     const validTransitions: Record<string, string[]> = {
-      'RECEIVED': ['QUARANTINE', 'ACCEPTED', 'REJECTED'],
-      'QUARANTINE': ['ACCEPTED', 'REJECTED'],
-      'ACCEPTED': ['ISSUED', 'QUARANTINE', 'REJECTED'],
-      'ISSUED': ['ACCEPTED', 'CONSUMED', 'QUARANTINE'],
+      'RECEIVED': ['QUARANTINE', 'ACCEPTED', 'REJECTED', 'HOLD'],
+      'QUARANTINE': ['ACCEPTED', 'REJECTED', 'HOLD'],
+      'ACCEPTED': ['ISSUED', 'QUARANTINE', 'REJECTED', 'HOLD', 'EXPIRED'],
+      'ISSUED': ['ACCEPTED', 'CONSUMED', 'QUARANTINE', 'HOLD', 'EXPIRED'],
+      'HOLD': ['ACCEPTED', 'ISSUED', 'QUARANTINE', 'REJECTED', 'EXPIRED'],
+      'REJECTED': ['QUARANTINE'],
     };
 
     if (!validTransitions[lot.status]?.includes(newStatus)) {
@@ -752,6 +788,12 @@ router.post('/:id/status', async (req: Request, res: Response) => {
         message: `Cannot transition from ${lot.status} to ${newStatus}`,
       });
     }
+
+    const statusAction = lot.status === 'REJECTED' && newStatus === 'QUARANTINE'
+      ? 'mrb'
+      : 'status_change';
+    if (blockedInventoryActionResponse(req, res, lot, statusAction)) return;
+    if (newStatus === 'HOLD' && blockedInventoryActionResponse(req, res, { status: 'HOLD' }, 'status_change')) return;
 
     const updateData: Record<string, any> = { status: newStatus };
     
@@ -766,7 +808,7 @@ router.post('/:id/status', async (req: Request, res: Response) => {
     await storage.createMaterialLotTransaction(createTransaction({
       materialLotId: id,
       internalControlNumber: lot.internalControlNumber,
-      transactionType: newStatus as TransactionType,
+      transactionType: STATUS_TRANSACTION_TYPE[newStatus as MaterialLotStatus] ?? 'ADJUST',
       qtyBefore: lot.remainingQty,
       qtyAfter: lot.remainingQty,
       performedBy,
@@ -787,6 +829,10 @@ router.post('/:id/move', async (req: Request, res: Response) => {
     const { id } = req.params;
     const { toLocation, performedBy, notes } = req.body;
 
+    const lot = await storage.getMaterialLot(id);
+    if (!lot) return res.status(404).json({ error: 'Material lot not found' });
+    if (blockedInventoryActionResponse(req, res, lot, 'move')) return;
+
     const updatedLot = await storage.moveMaterialLot(id, { toLocation, performedBy, notes });
     res.json(updatedLot);
   } catch (error: any) {
@@ -801,6 +847,10 @@ router.post('/:id/issue', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const { performedBy, toLocation, notes } = req.body;
+
+    const lot = await storage.getMaterialLot(id);
+    if (!lot) return res.status(404).json({ error: 'Material lot not found' });
+    if (blockedInventoryActionResponse(req, res, lot, 'issue')) return;
 
     const updatedLot = await storage.issueMaterialLot(id, { performedBy, toLocation, notes });
     res.json(updatedLot);
@@ -836,6 +886,7 @@ router.post('/:id/return', async (req: Request, res: Response) => {
     if (!lot) {
       return res.status(404).json({ error: 'Material lot not found' });
     }
+    if (blockedInventoryActionResponse(req, res, lot, 'return')) return;
 
     const blockedStatuses: MaterialLotStatus[] = ['SCRAPPED', 'CONSUMED'];
     if (blockedStatuses.includes(lot.status as MaterialLotStatus)) {
@@ -884,6 +935,7 @@ router.post('/:id/scrap', async (req: Request, res: Response) => {
     if (!lot) {
       return res.status(404).json({ error: 'Material lot not found' });
     }
+    if (blockedInventoryActionResponse(req, res, lot, 'scrap')) return;
 
     const remaining = parseFloat(lot.remainingQty);
 
@@ -940,6 +992,7 @@ router.post('/:id/adjust', async (req: Request, res: Response) => {
     if (!lot) {
       return res.status(404).json({ error: 'Material lot not found' });
     }
+    if (blockedInventoryActionResponse(req, res, lot, 'adjust')) return;
 
     const remaining = parseFloat(lot.remainingQty);
     if (remaining + delta < 0 && !allowNegative) {
@@ -975,6 +1028,7 @@ router.post('/:id/split', async (req: Request, res: Response) => {
     if (!parentLot) {
       return res.status(404).json({ error: 'Material lot not found' });
     }
+    if (blockedInventoryActionResponse(req, res, parentLot, 'split')) return;
 
     const parentRemaining = parseFloat(parentLot.remainingQty);
     const splitAmount = parseFloat(splitQty);
@@ -1009,7 +1063,7 @@ router.post('/:id/split', async (req: Request, res: Response) => {
       manufactureDate: parentLot.manufactureDate,
       storageLocation: newLocation || parentLot.storageLocation,
       storageRequirements: parentLot.storageRequirements,
-      status: parentLot.status as 'RECEIVED' | 'ACCEPTED' | 'ISSUED' | 'EXPIRED' | 'QUARANTINE' | 'REJECTED' | 'CONSUMED' | 'SCRAPPED',
+      status: parentLot.status as MaterialLotStatus,
       totalOutTimeMinutes: parentLot.totalOutTimeMinutes ?? 0,
       maxOutTimeMinutes: parentLot.maxOutTimeMinutes,
       currentlyOutOfStorage: parentLot.currentlyOutOfStorage ?? false,
@@ -1104,9 +1158,10 @@ router.post('/consume', async (req: Request, res: Response) => {
     if (!lot) {
       return res.status(404).json({ error: 'Material lot not found' });
     }
+    if (blockedInventoryActionResponse(req, res, lot, 'consume')) return;
 
     // ── Guard 1: Lot status ────────────────────────────────────────────────────
-    const blockedStatuses: MaterialLotStatus[] = ['QUARANTINE', 'REJECTED', 'EXPIRED'];
+    const blockedStatuses: MaterialLotStatus[] = ['QUARANTINE', 'REJECTED', 'EXPIRED', 'SCRAPPED', 'HOLD'];
     if (blockedStatuses.includes(lot.status as MaterialLotStatus)) {
       return res.status(400).json({
         error: 'LOT_NOT_USABLE',
@@ -1436,6 +1491,7 @@ router.post('/:lotId/reserve', async (req: Request, res: Response) => {
     const { lotId } = req.params;
     const lot = await storage.getMaterialLot(lotId);
     if (!lot) return res.status(404).json({ error: 'Material lot not found' });
+    if (blockedInventoryActionResponse(req, res, lot, 'reserve')) return;
 
     if (lot.status !== 'ACCEPTED' && lot.status !== 'ISSUED') {
       return res.status(409).json({

--- a/server/src/routes/traceability.ts
+++ b/server/src/routes/traceability.ts
@@ -31,11 +31,19 @@ import {
   type TraceabilitySearchInput,
   type TraceabilitySearchKey,
 } from '../services/traceabilityService';
+import { MATERIAL_TRACEABILITY_REQUIREMENTS } from '../constants/inventoryControls';
 
 const router = Router();
 
 router.use(authenticateToken);
 router.use(requirePermission('inventory.traceability.view'));
+
+router.get('/requirements', (_req: Request, res: Response) => {
+  res.json({
+    requirements: MATERIAL_TRACEABILITY_REQUIREMENTS,
+    generatedAt: new Date().toISOString(),
+  });
+});
 
 function isAllowedKey(key: unknown): key is TraceabilitySearchKey {
   return typeof key === 'string' && (TRACEABILITY_SEARCH_KEYS as readonly string[]).includes(key);


### PR DESCRIPTION
## Summary

- Adds a shared inventory control policy for QUARANTINE, REJECTED, SCRAPPED, EXPIRED, and HOLD material statuses.
- Enforces the policy on material lot movement, issue, return, scrap, adjustment, split, consumption, reservation, and status-disposition routes.
- Adds the formal department traceability matrix through `/api/traceability/requirements` and covers it with focused tests.

## Validation

- `git diff --check -- server/src/constants/inventoryControls.ts server/src/routes/materialLots.ts server/src/routes/traceability.ts server/schema.ts server/__tests__/inventoryControls.test.ts server/__tests__/traceabilityRoutes.test.ts`
- Could not run Vitest or TypeScript checks in this environment: project `node_modules` is missing, `npm` is not available, and direct `node.exe` execution is blocked.

## Scope / overlap

This was done in a separate worktree and branch. Likely overlap areas are the existing `codex/immutable-inventory-ledger` and `codex/receiving-traceability-disposition` branches because they touch inventory ledger/disposition behavior, so this PR intentionally stays limited to status-action policy and traceability requirements.