### PR TITLE
Add P2 compliance gate for vendor POs

### DIFF
--- a/client/src/components/inventory/VendorPOItemSelector.tsx
+++ b/client/src/components/inventory/VendorPOItemSelector.tsx
@@ -45,6 +45,8 @@ type VendorPOItemSelectorProps = {
   vendorPoId: number;
   vendorId: number;
   poNumber: string;
+  productionLine?: string | null;
+  complianceStatus?: string | null;
   onTotalChange?: (total: number) => void;
 };
 
@@ -194,7 +196,14 @@ function UnitPriceDisplay({ item }: { item: VendorPOItem }) {
   );
 }
 
-export default function VendorPOItemSelector({ vendorPoId, vendorId, poNumber, onTotalChange }: VendorPOItemSelectorProps) {
+export default function VendorPOItemSelector({
+  vendorPoId,
+  vendorId,
+  poNumber,
+  productionLine,
+  complianceStatus,
+  onTotalChange,
+}: VendorPOItemSelectorProps) {
   const queryClient = useQueryClient();
   const [selectedPartId, setSelectedPartId] = useState<string>('');
   const [selectedInventoryItem, setSelectedInventoryItem] = useState<InventoryItem | null>(null);
@@ -229,6 +238,11 @@ export default function VendorPOItemSelector({ vendorPoId, vendorId, poNumber, o
   const { data: p2PurchaseOrders = [] } = useQuery<P2PurchaseOrder[]>({
     queryKey: ['/api/p2-purchase-orders-bypass'],
   });
+
+  const isP2Purchase = String(productionLine || '').toUpperCase() === 'P2';
+  const isP2ComplianceComplete = complianceStatus === 'Reviewed';
+  const customerPoAllocationDisabled = isP2Purchase && !isP2ComplianceComplete;
+  const newLineCustomerPoDisabled = isP2Purchase;
 
   const hasUnitConversion = useMemo(() => {
     return selectedInventoryItem?.vendorUnit && 
@@ -429,6 +443,11 @@ export default function VendorPOItemSelector({ vendorPoId, vendorId, poNumber, o
   };
 
   const handleAddItem = () => {
+    if (newLineCustomerPoDisabled && newItem.customerPoId) {
+      toast.error('Add the P2 line item first, complete compliance review, then allocate it to a customer PO');
+      return;
+    }
+
     if (!newItem.description && !newItem.agPartNumber) {
       toast.error('Please provide either AG Part# or description');
       return;
@@ -495,6 +514,11 @@ export default function VendorPOItemSelector({ vendorPoId, vendorId, poNumber, o
   const handleSaveEdit = (itemId: number) => {
     const originalItem = items.find(item => item.id === itemId);
     if (!originalItem) return;
+
+    if (customerPoAllocationDisabled && editedItem.customerPoId) {
+      toast.error('Complete compliance review before allocating this P2 purchase to a customer PO');
+      return;
+    }
     
     const updatedData = {
       agPartNumber: editedItem.agPartNumber ?? originalItem.agPartNumber,
@@ -697,6 +721,7 @@ export default function VendorPOItemSelector({ vendorPoId, vendorId, poNumber, o
                 <Select 
                   value={newItem.customerPoId?.toString() || 'none'} 
                   onValueChange={(value) => setNewItem({ ...newItem, customerPoId: value && value !== 'none' ? parseInt(value) : undefined })}
+                  disabled={newLineCustomerPoDisabled}
                 >
                   <SelectTrigger data-testid="select-customer-po">
                     <SelectValue placeholder="Select customer PO (optional)..." />
@@ -710,7 +735,13 @@ export default function VendorPOItemSelector({ vendorPoId, vendorId, poNumber, o
                     ))}
                   </SelectContent>
                 </Select>
-                <p className="text-xs text-purple-600 dark:text-purple-400 mt-1">Link this purchase to a customer order</p>
+                <p className="text-xs text-purple-600 dark:text-purple-400 mt-1">
+                  {customerPoAllocationDisabled
+                    ? 'P2 project allocation unlocks after compliance review is complete'
+                    : newLineCustomerPoDisabled
+                      ? 'Add the P2 line first, then allocate after compliance review'
+                    : 'Link this purchase to a customer order'}
+                </p>
               </div>
               <div>
                 <Label htmlFor="otherIdentifier">Other Identifier</Label>
@@ -838,6 +869,7 @@ export default function VendorPOItemSelector({ vendorPoId, vendorId, poNumber, o
                       <Select 
                         value={editedItem.customerPoId?.toString() || 'none'} 
                         onValueChange={(value) => setEditedItem({ ...editedItem, customerPoId: value && value !== 'none' ? parseInt(value) : null as unknown as undefined })}
+                        disabled={customerPoAllocationDisabled}
                       >
                         <SelectTrigger className="w-32" data-testid={`select-edit-customer-po-${item.id}`}>
                           <SelectValue placeholder="None" />

--- a/client/src/components/inventory/VendorPOManager.tsx
+++ b/client/src/components/inventory/VendorPOManager.tsx
@@ -192,7 +192,7 @@ type VendorPO = {
   poNumber: string | null;
   vendorId: number;
   vendorName?: string; // From join
-  productionLine?: 'P1' | 'P2' | 'GENERAL' | string | null;
+  productionLine?: 'P1' | 'P2' | 'GENERAL' | 'R_AND_D' | string | null;
   status:
     | 'Draft'
     | 'RFQ Sent'
@@ -276,12 +276,23 @@ type VendorPOItem = {
 
 type CreateVendorPOData = {
   vendorId: number;
-  productionLine?: 'P1' | 'P2' | 'GENERAL';
+  productionLine?: 'P1' | 'P2' | 'GENERAL' | 'R_AND_D';
   expectedDeliveryDate?: string;
   shipVia?: string;
   notes?: string;
   externalPoNumber?: string;
 };
+
+function formatProductionLineLabel(value?: string | null): string {
+  switch (value) {
+    case 'GENERAL':
+      return 'General / Stock';
+    case 'R_AND_D':
+      return 'R&D';
+    default:
+      return value || '';
+  }
+}
 
 // Vendor PO line items display component
 function VendorPOItemsDisplay({ vendorPoId }: { vendorPoId: number }) {
@@ -751,7 +762,7 @@ function VendorPOCard({
                 </span>
                 {vendorPo.productionLine && (
                   <Badge variant="outline" className="text-xs">
-                    {vendorPo.productionLine === 'GENERAL' ? 'General / Stock' : vendorPo.productionLine}
+                    {formatProductionLineLabel(vendorPo.productionLine)}
                   </Badge>
                 )}
               </div>
@@ -1020,11 +1031,17 @@ function VendorPOForm({
             <SelectItem value="GENERAL">General / Stock</SelectItem>
             <SelectItem value="P1">P1</SelectItem>
             <SelectItem value="P2">P2</SelectItem>
+            <SelectItem value="R_AND_D">R&D</SelectItem>
           </SelectContent>
         </Select>
         {formData.productionLine === 'P2' && (
           <p className="mt-1 text-xs text-amber-700">
             P2 purchases require a completed compliance review before project allocation.
+          </p>
+        )}
+        {formData.productionLine === 'R_AND_D' && (
+          <p className="mt-1 text-xs text-emerald-700">
+            R&D purchases can push through project allocation without the P2 compliance hold.
           </p>
         )}
       </div>

--- a/client/src/components/inventory/VendorPOManager.tsx
+++ b/client/src/components/inventory/VendorPOManager.tsx
@@ -192,6 +192,7 @@ type VendorPO = {
   poNumber: string | null;
   vendorId: number;
   vendorName?: string; // From join
+  productionLine?: 'P1' | 'P2' | 'GENERAL' | string | null;
   status:
     | 'Draft'
     | 'RFQ Sent'
@@ -275,6 +276,7 @@ type VendorPOItem = {
 
 type CreateVendorPOData = {
   vendorId: number;
+  productionLine?: 'P1' | 'P2' | 'GENERAL';
   expectedDeliveryDate?: string;
   shipVia?: string;
   notes?: string;
@@ -742,9 +744,16 @@ function VendorPOCard({
               className="mt-1"
               data-testid={`text-vendor-name-${vendorPo.id}`}
             >
-              <div className="flex items-center gap-1">
-                <Building2 className="w-4 h-4" />
-                {vendorPo.vendorName || 'Unknown Vendor'}
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="inline-flex items-center gap-1">
+                  <Building2 className="w-4 h-4" />
+                  {vendorPo.vendorName || 'Unknown Vendor'}
+                </span>
+                {vendorPo.productionLine && (
+                  <Badge variant="outline" className="text-xs">
+                    {vendorPo.productionLine === 'GENERAL' ? 'General / Stock' : vendorPo.productionLine}
+                  </Badge>
+                )}
               </div>
             </CardDescription>
             <div className="mt-3">
@@ -916,6 +925,7 @@ function VendorPOForm({
 }) {
   const [formData, setFormData] = useState<CreateVendorPOData>({
     vendorId: vendorPo?.vendorId || 0,
+    productionLine: (vendorPo?.productionLine as CreateVendorPOData['productionLine']) || undefined,
     expectedDeliveryDate: vendorPo?.expectedDeliveryDate || '',
     shipVia: vendorPo?.shipVia || '',
     notes: vendorPo?.notes || '',
@@ -943,6 +953,10 @@ function VendorPOForm({
 
     if (formData.vendorId === 0) {
       toast.error('Please select a vendor');
+      return;
+    }
+    if (!formData.productionLine) {
+      toast.error('Please select the production line for this purchase');
       return;
     }
 
@@ -988,6 +1002,31 @@ function VendorPOForm({
             ))}
           </SelectContent>
         </Select>
+      </div>
+
+      <div>
+        <Label htmlFor="productionLine">Production Line *</Label>
+        <Select
+          value={formData.productionLine}
+          onValueChange={(value) =>
+            setFormData({ ...formData, productionLine: value as CreateVendorPOData['productionLine'] })
+          }
+          data-testid="select-production-line"
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select production line..." />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="GENERAL">General / Stock</SelectItem>
+            <SelectItem value="P1">P1</SelectItem>
+            <SelectItem value="P2">P2</SelectItem>
+          </SelectContent>
+        </Select>
+        {formData.productionLine === 'P2' && (
+          <p className="mt-1 text-xs text-amber-700">
+            P2 purchases require a completed compliance review before project allocation.
+          </p>
+        )}
       </div>
 
       <div>
@@ -3933,6 +3972,8 @@ export default function VendorPOManager({ preSelectedPoId }: { preSelectedPoId?:
               vendorPoId={selectedVendorPO.id}
               vendorId={selectedVendorPO.vendorId}
               poNumber={selectedVendorPO.poNumber || `Draft #${selectedVendorPO.id}`}
+              productionLine={selectedVendorPO.productionLine}
+              complianceStatus={selectedVendorPO.complianceStatus}
               onTotalChange={(total: number) => {
                 queryClient.invalidateQueries({
                   queryKey: ['/api/vendor-pos'],

--- a/migrations/0115_vendor_pos_production_line.sql
+++ b/migrations/0115_vendor_pos_production_line.sql
@@ -1,0 +1,7 @@
+ALTER TABLE vendor_pos
+  ADD COLUMN IF NOT EXISTS production_line TEXT;
+
+UPDATE vendor_pos
+   SET production_line = 'GENERAL'
+ WHERE production_line IS NULL;
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -3368,6 +3368,15 @@ async function initializeBackgroundServices() {
         console.warn('⚠️ vendor_pos rfq_outcome_notes migration:', vpoNotesErr.message);
       }
 
+      // Ensure production_line exists for P1/P2 purchasing allocation gates.
+      try {
+        const { sql: sqlVpoProductionLine } = await import('drizzle-orm');
+        await db.execute(sqlVpoProductionLine`ALTER TABLE vendor_pos ADD COLUMN IF NOT EXISTS production_line TEXT`);
+        console.log('✅ Ensured vendor_pos has production_line column');
+      } catch (vpoProductionLineErr: any) {
+        console.warn('⚠️ vendor_pos production_line migration:', vpoProductionLineErr.message);
+      }
+
       // Ensure Task #83 purchasing-control columns exist on vendor_pos.
       // Some Replit deployments run boot-time schema repair without replaying
       // every migration against the selected production database; without these

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -3796,7 +3796,7 @@ export const vendorPOs = pgTable('vendor_pos', {
   vendorId: integer('vendor_id')
     .references(() => vendors.id)
     .notNull(),
-  productionLine: text('production_line'), // P1 | P2 | GENERAL; P2 requires compliance review before project allocation
+  productionLine: text('production_line'), // P1 | P2 | GENERAL | R_AND_D; P2 requires compliance review before project allocation
   status: text('status').notNull().default('Draft'), // Draft, RFQ Sent, Quote Received, Declined, Expired, Sent, Partially Received, Fully Received, Cancelled
   orderDate: date('order_date'),
   expectedDeliveryDate: date('expected_delivery_date'),
@@ -4395,7 +4395,7 @@ export const insertVendorPOSchema = createInsertSchema(vendorPOs)
   .extend({
     poNumber: z.string().nullable().optional(),
     vendorId: z.number().int().positive('Vendor ID is required'),
-    productionLine: z.enum(['P1', 'P2', 'GENERAL'], {
+    productionLine: z.enum(['P1', 'P2', 'GENERAL', 'R_AND_D'], {
       required_error: 'Production line is required',
     }),
     status: z.enum(['Draft', 'RFQ Sent', 'Quote Received', 'Declined', 'Expired', 'Sent', 'Partially Received', 'Fully Received', 'Cancelled']).default('Draft'),

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -3796,6 +3796,7 @@ export const vendorPOs = pgTable('vendor_pos', {
   vendorId: integer('vendor_id')
     .references(() => vendors.id)
     .notNull(),
+  productionLine: text('production_line'), // P1 | P2 | GENERAL; P2 requires compliance review before project allocation
   status: text('status').notNull().default('Draft'), // Draft, RFQ Sent, Quote Received, Declined, Expired, Sent, Partially Received, Fully Received, Cancelled
   orderDate: date('order_date'),
   expectedDeliveryDate: date('expected_delivery_date'),
@@ -4394,6 +4395,9 @@ export const insertVendorPOSchema = createInsertSchema(vendorPOs)
   .extend({
     poNumber: z.string().nullable().optional(),
     vendorId: z.number().int().positive('Vendor ID is required'),
+    productionLine: z.enum(['P1', 'P2', 'GENERAL'], {
+      required_error: 'Production line is required',
+    }),
     status: z.enum(['Draft', 'RFQ Sent', 'Quote Received', 'Declined', 'Expired', 'Sent', 'Partially Received', 'Fully Received', 'Cancelled']).default('Draft'),
     orderDate: z.string().optional().nullable(),
     expectedDeliveryDate: z.string().optional().nullable(),

--- a/server/src/routes/vendorPOs.ts
+++ b/server/src/routes/vendorPOs.ts
@@ -18,6 +18,47 @@ import { sql } from 'drizzle-orm';
 
 const router = Router();
 
+function isP2ProductionLine(value: unknown): boolean {
+  return String(value ?? '').trim().toUpperCase() === 'P2';
+}
+
+async function getVendorPOComplianceBlockers(vendorPoId: number): Promise<string[]> {
+  const review = await storage.getVendorPOComplianceReview(vendorPoId);
+  if (!review) {
+    return ['P2 purchase requires a completed compliance review before it can be allocated to a project'];
+  }
+
+  const blockers: string[] = [];
+  if (review.reviewStatus === 'requires_attention') {
+    blockers.push('Compliance review requires attention because the PO changed after review');
+  } else if (review.reviewStatus !== 'reviewed') {
+    blockers.push(`Compliance review status is "${review.reviewStatus}" and must be "reviewed"`);
+  }
+  if (!review.secondPartyComplete) blockers.push('Second-party approval is not complete');
+  if (!review.vendorApproved) blockers.push('Vendor is not approved');
+  if (!review.reviewNotes?.trim()) blockers.push('Compliance justification is missing');
+  return blockers;
+}
+
+async function requireP2ComplianceBeforeProjectAllocation(vendorPoId: number, customerPoId: unknown) {
+  if (customerPoId === undefined || customerPoId === null) return;
+  const vendorPO = await storage.getVendorPO(vendorPoId);
+  if (!vendorPO) {
+    const error: any = new Error('Vendor PO not found');
+    error.status = 404;
+    throw error;
+  }
+  if (!isP2ProductionLine(vendorPO.productionLine)) return;
+
+  const blockers = await getVendorPOComplianceBlockers(vendorPoId);
+  if (blockers.length > 0) {
+    const error: any = new Error(`Cannot allocate P2 vendor purchase to a project. Reason(s): ${blockers.join('; ')}.`);
+    error.status = 422;
+    error.blockingReasons = blockers;
+    throw error;
+  }
+}
+
 /**
  * Build the set of allowed recipient emails for a vendor:
  * primary email, additionalEmail, and all active vendor_contact emails.
@@ -684,6 +725,14 @@ router.put('/:id', requirePermission('purchasing.manage_pos'), async (req: Reque
         newValue: data.vendorId,
       });
     }
+    if ((data as any).productionLine !== undefined && (data as any).productionLine !== existingPO.productionLine) {
+      const actorId = (req as any).user?.id as number | undefined;
+      await storage.invalidateVendorPoComplianceReview(id, 'Production line changed after compliance review', actorId, {
+        changedField: 'productionLine',
+        previousValue: existingPO.productionLine,
+        newValue: (data as any).productionLine,
+      });
+    }
 
     const vendorPO = await storage.updateVendorPO(id, data);
 
@@ -825,10 +874,19 @@ router.post('/:id/items', async (req: Request, res: Response) => {
       { changedField: 'lineItems', action: 'added' },
     );
 
+    await requireP2ComplianceBeforeProjectAllocation(vendorPoId, data.customerPoId);
+
     const item = await storage.createVendorPOItem(data);
     res.status(201).json(item);
   } catch (error) {
     console.error('Create vendor PO item error:', error);
+    if ((error as any)?.status) {
+      return res.status((error as any).status).json({
+        error: (error as Error).message,
+        complianceBlocked: (error as any).status === 422,
+        blockingReasons: (error as any).blockingReasons ?? undefined,
+      });
+    }
     if (error instanceof z.ZodError) {
       return res
         .status(400)
@@ -849,19 +907,38 @@ router.put('/items/:itemId', async (req: Request, res: Response) => {
     // Fetch old item to compare material fields before updating.
     const oldItem = await storage.getVendorPOItemById(itemId);
     const data = insertVendorPOItemSchema.partial().parse(req.body);
+    const materialFields: Array<{ key: string; label: string }> = [
+      { key: 'quantity', label: 'quantity' },
+      { key: 'unitPrice', label: 'unit price' },
+      { key: 'purchaseQty', label: 'purchase quantity' },
+      { key: 'purchaseUnitPrice', label: 'purchase unit price' },
+    ];
+    const changedField = oldItem
+      ? materialFields.find(
+          (f) => data[f.key as keyof typeof data] !== undefined && Number(data[f.key as keyof typeof data]) !== Number(oldItem[f.key])
+        )
+      : undefined;
+
+    if (oldItem) {
+      const finalCustomerPoId = data.customerPoId !== undefined ? data.customerPoId : oldItem.customerPoId;
+      await requireP2ComplianceBeforeProjectAllocation(oldItem.vendorPoId, finalCustomerPoId);
+
+      if (changedField && finalCustomerPoId != null) {
+        const vendorPO = await storage.getVendorPO(oldItem.vendorPoId);
+        if (isP2ProductionLine(vendorPO?.productionLine)) {
+          const error: any = new Error(
+            `Cannot keep a P2 line allocated to a project while changing ${changedField.label}. Clear the project allocation, save the material change, complete compliance review, then allocate it again.`
+          );
+          error.status = 422;
+          error.blockingReasons = [error.message];
+          throw error;
+        }
+      }
+    }
 
     // Invalidate compliance review BEFORE updating the item so that if invalidation
     // fails the item mutation never commits (fail-safe).
     if (oldItem) {
-      const materialFields: Array<{ key: string; label: string }> = [
-        { key: 'quantity', label: 'quantity' },
-        { key: 'unitPrice', label: 'unit price' },
-        { key: 'purchaseQty', label: 'purchase quantity' },
-        { key: 'purchaseUnitPrice', label: 'purchase unit price' },
-      ];
-      const changedField = materialFields.find(
-        (f) => data[f.key as keyof typeof data] !== undefined && Number(data[f.key as keyof typeof data]) !== Number(oldItem[f.key])
-      );
       if (changedField) {
         const actorId = (req as any).user?.id as number | undefined;
         await storage.invalidateVendorPoComplianceReview(
@@ -882,6 +959,13 @@ router.put('/items/:itemId', async (req: Request, res: Response) => {
     res.json(item);
   } catch (error) {
     console.error('Update vendor PO item error:', error);
+    if ((error as any)?.status) {
+      return res.status((error as any).status).json({
+        error: (error as Error).message,
+        complianceBlocked: (error as any).status === 422,
+        blockingReasons: (error as any).blockingReasons ?? undefined,
+      });
+    }
     if (error instanceof z.ZodError) {
       return res
         .status(400)

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -9346,6 +9346,7 @@ export class DatabaseStorage implements IStorage {
           externalPoNumber: vendorPOs.externalPoNumber,
           vendorId: vendorPOs.vendorId,
           vendorName: vendors.name,
+          productionLine: vendorPOs.productionLine,
           status: vendorPOs.status,
           orderDate: vendorPOs.orderDate,
           expectedDeliveryDate: vendorPOs.expectedDeliveryDate,
@@ -9501,6 +9502,7 @@ export class DatabaseStorage implements IStorage {
         externalPoNumber: vendorPOs.externalPoNumber,
         vendorId: vendorPOs.vendorId,
         vendorName: vendors.name,
+        productionLine: vendorPOs.productionLine,
         status: vendorPOs.status,
         orderDate: vendorPOs.orderDate,
         expectedDeliveryDate: vendorPOs.expectedDeliveryDate,
@@ -9821,6 +9823,7 @@ export class DatabaseStorage implements IStorage {
       const revisionData = {
         poNumber: newPONumber,
         vendorId: originalPO.vendorId,
+        productionLine: originalPO.productionLine,
         status: 'Draft' as const,
         orderDate: originalPO.orderDate,
         expectedDeliveryDate: originalPO.expectedDeliveryDate,


### PR DESCRIPTION
## Summary
- add a production line field to vendor purchase orders with migration and boot-time column repair
- require the production line on vendor PO create/edit and show P2 compliance guidance in the UI
- add an R&D production-line option that can push through allocation without the P2 compliance hold
- block P2 customer/project allocation until compliance review is complete, with server-side enforcement on line item create/update

## Validation
- git diff --check
- npm run check could not run locally because npm is not installed in this environment

## Notes
- Unrelated local file left untouched/uncommitted: PRODUCTION_STOCK_MODELS.sql