### PR TITLE
Add parts request PO approval workflow

### DIFF
--- a/client/src/components/inventory/PartsRequestOwnerApprovals.tsx
+++ b/client/src/components/inventory/PartsRequestOwnerApprovals.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CheckCircle2, ClipboardCheck, XCircle } from 'lucide-react';
+import toast from 'react-hot-toast';
+import type { PartsRequest } from '@shared/schema';
+
+import { apiRequest } from '@/lib/queryClient';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type PartsRequestApproval = PartsRequest & {
+  project?: {
+    projectCode?: string | null;
+    projectName?: string | null;
+  };
+  approvalHistory?: Array<Record<string, unknown>> | null;
+};
+
+interface PartsRequestOwnerApprovalsProps {
+  userName?: string;
+  compact?: boolean;
+}
+
+export default function PartsRequestOwnerApprovals({
+  userName,
+  compact = false,
+}: PartsRequestOwnerApprovalsProps) {
+  const queryClient = useQueryClient();
+  const [signatureById, setSignatureById] = useState<Record<number, string>>({});
+  const [notesById, setNotesById] = useState<Record<number, string>>({});
+
+  const { data: requests = [], isLoading } = useQuery<PartsRequestApproval[]>({
+    queryKey: ['/api/inventory/parts-requests/owner-approvals'],
+    queryFn: () => apiRequest('/api/inventory/parts-requests/owner-approvals'),
+  });
+
+  const totalPendingValue = useMemo(
+    () =>
+      requests.reduce(
+        (sum, request) => sum + Number(request.estimatedCost || 0),
+        0
+      ),
+    [requests]
+  );
+
+  const approvalMutation = useMutation({
+    mutationFn: ({
+      id,
+      decision,
+      digitalSignature,
+      notes,
+    }: {
+      id: number;
+      decision: 'APPROVED' | 'REJECTED';
+      digitalSignature: string;
+      notes?: string;
+    }) =>
+      apiRequest(`/api/inventory/parts-requests/${id}/approve`, {
+        method: 'POST',
+        body: {
+          decision,
+          approvedBy: userName,
+          digitalSignature,
+          notes,
+        },
+      }),
+    onSuccess: () => {
+      toast.success('Parts request approval recorded');
+      queryClient.invalidateQueries({ queryKey: ['/api/inventory/parts-requests/owner-approvals'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/inventory/parts-requests'] });
+    },
+    onError: (error: Error) => toast.error(error.message || 'Failed to record approval'),
+  });
+
+  const submitDecision = (request: PartsRequestApproval, decision: 'APPROVED' | 'REJECTED') => {
+    const signature = signatureById[request.id]?.trim();
+    if (!signature) {
+      toast.error('Digital signature is required');
+      return;
+    }
+
+    approvalMutation.mutate({
+      id: request.id,
+      decision,
+      digitalSignature: signature,
+      notes: notesById[request.id]?.trim() || undefined,
+    });
+  };
+
+  return (
+    <Card className={compact ? 'border-amber-200 bg-amber-50/50' : ''}>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ClipboardCheck className="h-5 w-5 text-amber-600" />
+            Parts Request Approvals
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">{requests.length} pending</Badge>
+            {requests.length > 0 && (
+              <Badge className="bg-amber-100 text-amber-900">
+                ${totalPendingValue.toFixed(2)}
+              </Badge>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {isLoading ? (
+          <div className="text-sm text-muted-foreground">Loading owner approvals...</div>
+        ) : requests.length === 0 ? (
+          <div className="text-sm text-muted-foreground">No parts requests need owner approval.</div>
+        ) : (
+          requests.map((request) => {
+            const totalCost = Number(request.estimatedCost || 0);
+            const lastApprovalEvent =
+              request.approvalHistory && request.approvalHistory.length > 0
+                ? request.approvalHistory[request.approvalHistory.length - 1]
+                : undefined;
+            return (
+              <div key={request.id} className="rounded-md border bg-white p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="font-medium">{request.partName}</div>
+                    <div className="text-sm text-muted-foreground">
+                      {request.partNumber} | Qty {request.quantity} | Requested by {request.requestedBy}
+                    </div>
+                    {request.project && (
+                      <div className="text-sm text-muted-foreground">
+                        {request.project.projectCode} - {request.project.projectName}
+                      </div>
+                    )}
+                  </div>
+                  <Badge className="bg-amber-100 text-amber-900">
+                    ${totalCost.toFixed(2)}
+                  </Badge>
+                </div>
+
+                {lastApprovalEvent?.notes && (
+                  <div className="mt-3 rounded bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                    {String(lastApprovalEvent.notes)}
+                  </div>
+                )}
+
+                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <div>
+                    <Label htmlFor={`signature-${request.id}`}>Digital Signature</Label>
+                    <Input
+                      id={`signature-${request.id}`}
+                      value={signatureById[request.id] || ''}
+                      onChange={(event) =>
+                        setSignatureById((prev) => ({
+                          ...prev,
+                          [request.id]: event.target.value,
+                        }))
+                      }
+                      placeholder={userName || 'Type your name'}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor={`approval-notes-${request.id}`}>Approval Notes</Label>
+                    <Textarea
+                      id={`approval-notes-${request.id}`}
+                      value={notesById[request.id] || ''}
+                      onChange={(event) =>
+                        setNotesById((prev) => ({
+                          ...prev,
+                          [request.id]: event.target.value,
+                        }))
+                      }
+                      rows={1}
+                      placeholder="Optional"
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-3 flex flex-wrap justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => submitDecision(request, 'REJECTED')}
+                    disabled={approvalMutation.isPending}
+                  >
+                    <XCircle className="mr-2 h-4 w-4" />
+                    Reject
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => submitDecision(request, 'APPROVED')}
+                    disabled={approvalMutation.isPending}
+                  >
+                    <CheckCircle2 className="mr-2 h-4 w-4" />
+                    Approve
+                  </Button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/inventory/PartsRequestsCard.tsx
+++ b/client/src/components/inventory/PartsRequestsCard.tsx
@@ -66,6 +66,7 @@ interface PartsRequestFormData {
   status: string;
   expectedDelivery: string;
   notes: string;
+  approvalSignature: string;
 }
 
 interface ProjectOption {
@@ -115,6 +116,7 @@ export default function PartsRequestsCard() {
     status: 'PENDING',
     expectedDelivery: '',
     notes: '',
+    approvalSignature: '',
   });
 
   // Load parts requests
@@ -251,6 +253,7 @@ export default function PartsRequestsCard() {
       status: 'PENDING',
       expectedDelivery: '',
       notes: '',
+      approvalSignature: '',
     });
   };
 
@@ -309,6 +312,14 @@ export default function PartsRequestsCard() {
         : null;
       submitData.expectedDelivery = formData.expectedDelivery || null;
       submitData.notes = formData.notes || null;
+      if (formData.status === 'APPROVED') {
+        if (!formData.approvalSignature.trim()) {
+          toast.error('Digital approval signature is required to approve a request');
+          return;
+        }
+        submitData.approvedBy = formData.approvalSignature.trim();
+        submitData.digitalApprovalSignature = `Inventory manager approval: ${formData.approvalSignature.trim()}`;
+      }
     }
 
     if (editingRequest) {
@@ -340,6 +351,7 @@ export default function PartsRequestsCard() {
         ? new Date(request.expectedDelivery).toISOString().split('T')[0]
         : '',
       notes: request.notes || '',
+      approvalSignature: '',
     });
     setIsEditOpen(true);
   };
@@ -354,6 +366,8 @@ export default function PartsRequestsCard() {
     switch (status) {
       case 'PENDING':
         return 'bg-yellow-100 text-yellow-800';
+      case 'PENDING_OWNER_APPROVAL':
+        return 'bg-amber-100 text-amber-900';
       case 'APPROVED':
         return 'bg-green-100 text-green-800';
       case 'ORDERED':
@@ -576,6 +590,9 @@ export default function PartsRequestsCard() {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="PENDING">Pending</SelectItem>
+                  <SelectItem value="PENDING_OWNER_APPROVAL" disabled>
+                    Pending Owner Approval
+                  </SelectItem>
                   <SelectItem value="APPROVED">Approved</SelectItem>
                   <SelectItem value="ORDERED">Ordered</SelectItem>
                   <SelectItem value="RECEIVED">Received</SelectItem>
@@ -617,6 +634,22 @@ export default function PartsRequestsCard() {
               onChange={handleChange}
             />
           </div>
+
+          {formData.status === 'APPROVED' && (
+            <div>
+              <Label htmlFor="approvalSignature">Digital Approval Signature</Label>
+              <Input
+                id="approvalSignature"
+                name="approvalSignature"
+                value={formData.approvalSignature}
+                onChange={handleChange}
+                placeholder="Type inventory manager name"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Requests over $1,000 will move to owner approval after this review.
+              </p>
+            </div>
+          )}
         </>
       )}
 
@@ -754,7 +787,9 @@ export default function PartsRequestsCard() {
 
                       <div className="flex items-center gap-2">
                         <Badge className={getStatusBadgeColor(request.status)}>
-                          {request.status}
+                          {request.status === 'PENDING_OWNER_APPROVAL'
+                            ? 'OWNER APPROVAL'
+                            : request.status}
                         </Badge>
                         <Badge
                           className={getUrgencyBadgeColor(request.urgency)}
@@ -803,6 +838,34 @@ export default function PartsRequestsCard() {
                             </span>
                           </div>
                         )}
+
+                        {request.approvalStatus && (
+                          <div className="text-xs text-gray-600 bg-blue-50 p-2 rounded">
+                            Approval: {request.approvalStatus}
+                            {request.approvalRequiredRole === 'OWNER'
+                              ? ' - owner required'
+                              : ''}
+                            {request.approvedDate
+                              ? ` - ${new Date(request.approvedDate).toLocaleString()}`
+                              : ''}
+                          </div>
+                        )}
+
+                        {Array.isArray(request.approvalHistory) &&
+                          request.approvalHistory.length > 0 && (
+                            <div className="text-xs text-gray-600 bg-gray-50 p-2 rounded space-y-1">
+                              <div className="font-medium text-gray-700">Approval History</div>
+                              {request.approvalHistory.slice(-3).map((event, index) => (
+                                <div key={`${request.id}-approval-${index}`}>
+                                  {String(event.event || 'APPROVAL')} by{' '}
+                                  {String(event.actor || 'System')}
+                                  {event.occurredAt
+                                    ? ` - ${new Date(String(event.occurredAt)).toLocaleString()}`
+                                    : ''}
+                                </div>
+                              ))}
+                            </div>
+                          )}
 
                         {request.expectedDelivery && (
                           <div className="flex items-center gap-2">

--- a/client/src/pages/GLENNTestDashboard.tsx
+++ b/client/src/pages/GLENNTestDashboard.tsx
@@ -50,6 +50,7 @@ import WeeklyShippingWidget from '@/components/WeeklyShippingWidget';
 import WatchRuleCards from '@/components/WatchRuleCards';
 import MyTasksControlCenter from '@/components/MyTasksControlCenter';
 import SystemHealthWidget from '@/components/admin/SystemHealthWidget';
+import PartsRequestOwnerApprovals from '@/components/inventory/PartsRequestOwnerApprovals';
 
 export default function GLENNTestDashboard() {
   const [isPremiumMode, setIsPremiumMode] = useState(() => {
@@ -172,6 +173,10 @@ export default function GLENNTestDashboard() {
               <span>On target</span>
             </div>
           </div>
+        </div>
+
+        <div className="mb-8">
+          <PartsRequestOwnerApprovals userName={currentUser?.username} />
         </div>
 
         {/* Main Grid */}
@@ -680,6 +685,8 @@ function LightModeDashboard({
           </div>
         </div>
       )}
+
+      <PartsRequestOwnerApprovals userName={currentUser?.username} />
 
       {/* My Tasks Control Center */}
       {isUserLoading ? (

--- a/migrations/0116_parts_request_po_approvals.sql
+++ b/migrations/0116_parts_request_po_approvals.sql
@@ -1,0 +1,24 @@
+ALTER TABLE parts_requests
+  ADD COLUMN IF NOT EXISTS approval_required_role text DEFAULT 'INVENTORY_MANAGER',
+  ADD COLUMN IF NOT EXISTS approval_status text DEFAULT 'PENDING',
+  ADD COLUMN IF NOT EXISTS owner_approved_by text,
+  ADD COLUMN IF NOT EXISTS owner_approved_at timestamp,
+  ADD COLUMN IF NOT EXISTS digital_approval_signature text,
+  ADD COLUMN IF NOT EXISTS approval_history jsonb DEFAULT '[]'::jsonb;
+
+UPDATE parts_requests
+SET
+  approval_required_role = COALESCE(approval_required_role, 'INVENTORY_MANAGER'),
+  approval_status = COALESCE(
+    approval_status,
+    CASE
+      WHEN status = 'APPROVED' THEN 'APPROVED'
+      WHEN status = 'REJECTED' THEN 'REJECTED'
+      ELSE 'PENDING'
+    END
+  ),
+  approval_history = COALESCE(approval_history, '[]'::jsonb)
+WHERE
+  approval_required_role IS NULL
+  OR approval_status IS NULL
+  OR approval_history IS NULL;

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -818,6 +818,12 @@ export const partsRequests = pgTable('parts_requests', {
   estimatedCost: real('estimated_cost'),
   reason: text('reason'), // Why the part is needed
   status: text('status').default('PENDING').notNull(), // PENDING, APPROVED, ORDERED, RECEIVED, DELIVERED_TO_DEPT, REJECTED
+  approvalRequiredRole: text('approval_required_role').default('INVENTORY_MANAGER'), // INVENTORY_MANAGER, OWNER
+  approvalStatus: text('approval_status').default('PENDING'), // PENDING, OWNER_PENDING, APPROVED, REJECTED
+  ownerApprovedBy: text('owner_approved_by'),
+  ownerApprovedAt: timestamp('owner_approved_at'),
+  digitalApprovalSignature: text('digital_approval_signature'),
+  approvalHistory: jsonb('approval_history').$type<Array<Record<string, unknown>>>().default(sql`'[]'::jsonb`),
   requestDate: timestamp('request_date').defaultNow().notNull(),
   approvedBy: text('approved_by'),
   approvedDate: timestamp('approved_date'),
@@ -2967,8 +2973,14 @@ export const insertPartsRequestSchema = createInsertSchema(partsRequests)
     estimatedCost: z.number().min(0).optional().nullable(),
     reason: z.string().optional().nullable(),
     status: z
-      .enum(['PENDING', 'APPROVED', 'ORDERED', 'ORDERED_PARTIAL', 'RECEIVED', 'RECEIVED_PARTIAL', 'DELIVERED_TO_DEPT', 'REJECTED', 'CANCEL_REQUESTED', 'CANCELED'])
+      .enum(['PENDING', 'PENDING_OWNER_APPROVAL', 'APPROVED', 'ORDERED', 'ORDERED_PARTIAL', 'RECEIVED', 'RECEIVED_PARTIAL', 'DELIVERED_TO_DEPT', 'REJECTED', 'CANCEL_REQUESTED', 'CANCELED'])
       .default('PENDING'),
+    approvalRequiredRole: z.enum(['INVENTORY_MANAGER', 'OWNER']).default('INVENTORY_MANAGER').optional(),
+    approvalStatus: z.enum(['PENDING', 'OWNER_PENDING', 'APPROVED', 'REJECTED']).default('PENDING').optional(),
+    ownerApprovedBy: z.string().optional().nullable(),
+    ownerApprovedAt: z.coerce.date().optional().nullable(),
+    digitalApprovalSignature: z.string().optional().nullable(),
+    approvalHistory: z.array(z.record(z.unknown())).optional().nullable(),
     approvedBy: z.string().optional().nullable(),
     approvedDate: z.coerce.date().optional().nullable(),
     orderDate: z.coerce.date().optional().nullable(),

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -1003,6 +1003,41 @@ router.get('/parts-requests', async (req: Request, res: Response) => {
   }
 });
 
+const OWNER_APPROVAL_THRESHOLD = 1000;
+
+function getPartsRequestTotalCost(request: { estimatedCost?: number | null }) {
+  return Number(request.estimatedCost || 0);
+}
+
+function appendApprovalHistory(
+  request: { approvalHistory?: Array<Record<string, unknown>> | null },
+  entry: Record<string, unknown>
+) {
+  const existing = Array.isArray(request.approvalHistory) ? request.approvalHistory : [];
+  return [...existing, { ...entry, occurredAt: new Date().toISOString() }];
+}
+
+function getApprovalActor(req: Request, fallback?: string | null) {
+  return req.user?.username || fallback?.trim() || 'Unknown approver';
+}
+
+router.get('/parts-requests/owner-approvals', async (_req: Request, res: Response) => {
+  try {
+    const requests = await storage.getAllPartsRequests();
+    res.json(
+      requests.filter(
+        (request) =>
+          request.isActive !== false &&
+          request.status === 'PENDING_OWNER_APPROVAL' &&
+          request.approvalStatus === 'OWNER_PENDING'
+      )
+    );
+  } catch (error) {
+    console.error('Get owner approval parts requests error:', error);
+    res.status(500).json({ error: 'Failed to fetch owner approval requests' });
+  }
+});
+
 // Resolve a free-text source string to a vendors.id via case-insensitive name match.
 // Future improvement: replace with inventory_items.source_vendor_id (FK) once schema migration is done.
 async function resolveSourceVendorId(sourceText: string | null | undefined, db: any): Promise<number | null> {
@@ -1021,6 +1056,20 @@ async function resolveSourceVendorId(sourceText: string | null | undefined, db: 
 router.post('/parts-requests', async (req: Request, res: Response) => {
   try {
     const requestData = insertPartsRequestSchema.parse(req.body);
+    const now = new Date();
+    requestData.status = 'PENDING';
+    requestData.approvalStatus = 'PENDING';
+    requestData.approvalRequiredRole = 'INVENTORY_MANAGER';
+    requestData.approvalHistory = [
+      {
+        event: 'REQUEST_CREATED',
+        actor: requestData.requestedBy,
+        fromStatus: null,
+        toStatus: 'PENDING',
+        notes: 'Parts request submitted for inventory manager review.',
+        occurredAt: now.toISOString(),
+      },
+    ];
 
     if (requestData.agPartNumber) {
       const { inventoryItems } = await import('../../schema');
@@ -1064,16 +1113,96 @@ router.post('/parts-requests', async (req: Request, res: Response) => {
   }
 });
 
+router.post('/parts-requests/:id/approve', async (req: Request, res: Response) => {
+  try {
+    const requestId = parseInt(req.params.id);
+    const {
+      approvedBy,
+      digitalSignature,
+      notes,
+      decision = 'APPROVED',
+    } = req.body as {
+      approvedBy?: string;
+      digitalSignature?: string;
+      notes?: string;
+      decision?: 'APPROVED' | 'REJECTED';
+    };
+
+    const existingRequest = await storage.getPartsRequest(requestId);
+    if (!existingRequest) {
+      return res.status(404).json({ error: 'Request not found' });
+    }
+
+    if (existingRequest.status !== 'PENDING_OWNER_APPROVAL') {
+      return res.status(400).json({ error: `Request is not waiting on owner approval. Current status: ${existingRequest.status}` });
+    }
+
+    const actor = getApprovalActor(req, approvedBy);
+    const now = new Date();
+    const isApproved = decision !== 'REJECTED';
+    const nextStatus = isApproved ? 'APPROVED' : 'REJECTED';
+    const signature = digitalSignature || `${actor} digital approval ${now.toISOString()}`;
+    const approvalHistory = appendApprovalHistory(existingRequest, {
+      event: isApproved ? 'OWNER_APPROVED' : 'OWNER_REJECTED',
+      actor,
+      fromStatus: existingRequest.status,
+      toStatus: nextStatus,
+      approvalLevel: 'OWNER',
+      digitalSignature: signature,
+      notes: notes || null,
+      totalCost: getPartsRequestTotalCost(existingRequest),
+    });
+
+    const updatedRequest = await storage.updatePartsRequest(requestId, {
+      status: nextStatus,
+      approvalStatus: isApproved ? 'APPROVED' : 'REJECTED',
+      approvedBy: isApproved ? actor : existingRequest.approvedBy,
+      approvedDate: isApproved ? now : existingRequest.approvedDate,
+      ownerApprovedBy: isApproved ? actor : existingRequest.ownerApprovedBy,
+      ownerApprovedAt: isApproved ? now : existingRequest.ownerApprovedAt,
+      digitalApprovalSignature: signature,
+      rejectionReason: isApproved ? existingRequest.rejectionReason : notes || existingRequest.rejectionReason,
+      rejectedBy: isApproved ? existingRequest.rejectedBy : actor,
+      rejectedAt: isApproved ? existingRequest.rejectedAt : now,
+      notes: notes ?? existingRequest.notes,
+      approvalHistory,
+      updatedAt: now,
+    } as any);
+
+    const { partsRequestStatusHistory } = await import('../../schema');
+    await db.insert(partsRequestStatusHistory).values({
+      partsRequestId: requestId,
+      fromStatus: existingRequest.status,
+      toStatus: nextStatus,
+      changedBy: actor,
+      reason: isApproved ? 'Owner digital approval completed.' : notes || 'Owner rejected approval request.',
+    });
+
+    res.json(updatedRequest);
+  } catch (error) {
+    console.error('Approve owner parts request error:', error);
+    if (error instanceof Error) {
+      return res.status(400).json({ error: error.message });
+    }
+    res.status(500).json({ error: 'Failed to approve parts request' });
+  }
+});
+
 router.put('/parts-requests/:id', async (req: Request, res: Response) => {
   try {
     const requestId = parseInt(req.params.id);
     const updates = insertPartsRequestSchema.partial().parse(req.body);
+    const existingRequest = await storage.getPartsRequest(requestId);
+    if (!existingRequest) {
+      return res.status(404).json({ error: 'Request not found' });
+    }
     
     // Enforce status transition rules: PENDING → APPROVED → ORDERED → RECEIVED → DELIVERED_TO_DEPT
     // Also allows PENDING → REJECTED
     if (updates.status) {
       const validTransitions: Record<string, string[]> = {
-        'APPROVED': ['PENDING'],
+        'PENDING_OWNER_APPROVAL': ['PENDING'],
+        'APPROVED': ['PENDING', 'PENDING_OWNER_APPROVAL'],
         'REJECTED': ['PENDING', 'CANCEL_REQUESTED'],
         'ORDERED': ['PENDING', 'APPROVED'],
         'ORDERED_PARTIAL': ['PENDING', 'APPROVED'],
@@ -1085,12 +1214,6 @@ router.put('/parts-requests/:id', async (req: Request, res: Response) => {
       };
       
       if (validTransitions[updates.status]) {
-        // Get current status
-        const existingRequest = await storage.getPartsRequest(requestId);
-        if (!existingRequest) {
-          return res.status(404).json({ error: 'Request not found' });
-        }
-        
         const allowedFromStatuses = validTransitions[updates.status];
         if (!allowedFromStatuses.includes(existingRequest.status)) {
           return res.status(400).json({ 
@@ -1107,6 +1230,35 @@ router.put('/parts-requests/:id', async (req: Request, res: Response) => {
         updates.rejectedAt = updates.rejectedAt ?? new Date();
         updates.rejectionReason = updates.rejectionReason ?? updates.notes ?? null;
       }
+    }
+
+    if (updates.status === 'APPROVED') {
+      const effectiveRequest = { ...existingRequest, ...updates };
+      const totalCost = getPartsRequestTotalCost(effectiveRequest);
+      const actor = getApprovalActor(req, updates.approvedBy ?? null);
+      const now = new Date();
+      const needsOwnerApproval = totalCost > OWNER_APPROVAL_THRESHOLD;
+      const nextStatus = needsOwnerApproval ? 'PENDING_OWNER_APPROVAL' : 'APPROVED';
+      const signature = updates.digitalApprovalSignature || `${actor} digital approval ${now.toISOString()}`;
+
+      updates.approvalRequiredRole = needsOwnerApproval ? 'OWNER' : 'INVENTORY_MANAGER';
+      updates.approvalStatus = needsOwnerApproval ? 'OWNER_PENDING' : 'APPROVED';
+      updates.status = nextStatus;
+      updates.approvedBy = needsOwnerApproval ? existingRequest.approvedBy : actor;
+      updates.approvedDate = needsOwnerApproval ? existingRequest.approvedDate : now;
+      updates.digitalApprovalSignature = needsOwnerApproval ? existingRequest.digitalApprovalSignature : signature;
+      updates.approvalHistory = appendApprovalHistory(existingRequest, {
+        event: needsOwnerApproval ? 'OWNER_APPROVAL_REQUESTED' : 'INVENTORY_MANAGER_APPROVED',
+        actor,
+        fromStatus: existingRequest.status,
+        toStatus: nextStatus,
+        approvalLevel: needsOwnerApproval ? 'OWNER' : 'INVENTORY_MANAGER',
+        digitalSignature: needsOwnerApproval ? null : signature,
+        notes: needsOwnerApproval
+          ? `Total cost $${totalCost.toFixed(2)} exceeds the $${OWNER_APPROVAL_THRESHOLD.toFixed(2)} inventory manager approval limit.`
+          : updates.notes ?? null,
+        totalCost,
+      });
     }
     
     const updatedRequest = await storage.updatePartsRequest(requestId, updates);


### PR DESCRIPTION
## Summary
- add parts-request approval routing fields, migration, and owner approval endpoint
- route inventory manager approvals over $1,000 into a pending owner approval state
- add digital signature capture, timestamps, and approval history display on parts requests and the owner dashboard

## Validation
- `git diff --cached --check`
- Full TypeScript check not run: this worktree has no `node_modules` and no `npm` command available locally.