### PR TITLE
Add vendor PO line project traceability

### DIFF
--- a/client/src/components/inventory/VendorPOItemSelector.tsx
+++ b/client/src/components/inventory/VendorPOItemSelector.tsx
@@ -67,7 +67,34 @@ type VendorPOItem = {
   lineTotal: number;
   notes?: string;
   customerPoId?: number;
+  projectId?: string | null;
+  productionWorkOrderId?: string | null;
+  chargeCodeId?: number | null;
   otherIdentifier?: string;
+  customerPo?: {
+    id: number;
+    poNumber: string;
+    customerName?: string;
+    status?: string;
+  };
+  project?: {
+    id: string;
+    projectCode: string;
+    projectName: string;
+  };
+  productionWorkOrder?: {
+    id: string;
+    workOrderNumber: string;
+    projectId: string;
+    partNumber?: string;
+    status?: string;
+  };
+  chargeCode?: {
+    id: number;
+    code: string;
+    description?: string | null;
+    type?: string;
+  };
 };
 
 type P2PurchaseOrder = {
@@ -76,6 +103,32 @@ type P2PurchaseOrder = {
   customerId: string;
   customerName: string;
   status: string;
+};
+
+type Project = {
+  id: string;
+  projectCode: string;
+  projectName: string;
+  status?: string;
+};
+
+type ProductionWorkOrder = {
+  id: string;
+  workOrderNumber: string;
+  projectId: string;
+  projectCode?: string;
+  projectName?: string;
+  partNumber?: string;
+  status: string;
+  defaultChargeCodeId?: number | null;
+};
+
+type ChargeCode = {
+  id: number;
+  code: string;
+  description?: string | null;
+  active?: boolean;
+  type?: string;
 };
 
 type VendorPart = {
@@ -115,6 +168,9 @@ type NewItemState = {
   quantity: number;
   unitPrice: number;
   customerPoId?: number | null;
+  projectId?: string | null;
+  productionWorkOrderId?: string | null;
+  chargeCodeId?: number | null;
   otherIdentifier: string;
   notes: string;
 };
@@ -218,11 +274,19 @@ export default function VendorPOItemSelector({
     quantity: 0,
     unitPrice: 0,
     customerPoId: undefined,
+    projectId: undefined,
+    productionWorkOrderId: undefined,
+    chargeCodeId: undefined,
     otherIdentifier: '',
     notes: '',
   });
   const [editingItemId, setEditingItemId] = useState<number | null>(null);
-  const [editedItem, setEditedItem] = useState<Partial<VendorPOItem> & { customerPoId?: number | null }>({});
+  const [editedItem, setEditedItem] = useState<Partial<VendorPOItem> & {
+    customerPoId?: number | null;
+    projectId?: string | null;
+    productionWorkOrderId?: string | null;
+    chargeCodeId?: number | null;
+  }>({});
 
   const { data: items = [], isLoading } = useQuery<VendorPOItem[]>({
     queryKey: ['/api/vendor-pos', vendorPoId, 'items'],
@@ -235,14 +299,37 @@ export default function VendorPOItemSelector({
     enabled: !!vendorId,
   });
 
+  const isP2Purchase = String(productionLine || '').toUpperCase() === 'P2';
+
   const { data: p2PurchaseOrders = [] } = useQuery<P2PurchaseOrder[]>({
     queryKey: ['/api/p2-purchase-orders-bypass'],
   });
 
-  const isP2Purchase = String(productionLine || '').toUpperCase() === 'P2';
+  const { data: traceabilityOptions } = useQuery<{
+    projects: Project[];
+    productionWorkOrders: ProductionWorkOrder[];
+    chargeCodes: ChargeCode[];
+  }>({
+    queryKey: ['/api/vendor-pos/traceability-options'],
+  });
+
+  const projects = traceabilityOptions?.projects ?? [];
+  const productionWorkOrders = traceabilityOptions?.productionWorkOrders ?? [];
+  const chargeCodes = traceabilityOptions?.chargeCodes ?? [];
+
   const isP2ComplianceComplete = complianceStatus === 'Reviewed';
   const customerPoAllocationDisabled = isP2Purchase && !isP2ComplianceComplete;
-  const newLineCustomerPoDisabled = isP2Purchase;
+  const projectAllocationDisabled = isP2Purchase && !isP2ComplianceComplete;
+
+  const filteredWorkOrders = useMemo(() => {
+    if (!newItem.projectId) return productionWorkOrders;
+    return productionWorkOrders.filter((wo) => wo.projectId === newItem.projectId);
+  }, [newItem.projectId, productionWorkOrders]);
+
+  const editFilteredWorkOrders = useMemo(() => {
+    if (!editedItem.projectId) return productionWorkOrders;
+    return productionWorkOrders.filter((wo) => wo.projectId === editedItem.projectId);
+  }, [editedItem.projectId, productionWorkOrders]);
 
   const hasUnitConversion = useMemo(() => {
     return selectedInventoryItem?.vendorUnit && 
@@ -314,6 +401,9 @@ export default function VendorPOItemSelector({
             quantity: 0,
             unitPrice: 0,
             customerPoId: prev.customerPoId,
+            projectId: prev.projectId,
+            productionWorkOrderId: prev.productionWorkOrderId,
+            chargeCodeId: prev.chargeCodeId,
             otherIdentifier: prev.otherIdentifier,
             notes: prev.notes,
           }));
@@ -331,6 +421,9 @@ export default function VendorPOItemSelector({
             quantity: selectedPart.minimumOrderQty || 1,
             unitPrice: selectedPart.unitPrice || 0,
             customerPoId: prev.customerPoId,
+            projectId: prev.projectId,
+            productionWorkOrderId: prev.productionWorkOrderId,
+            chargeCodeId: prev.chargeCodeId,
             otherIdentifier: prev.otherIdentifier,
             notes: prev.notes,
           }));
@@ -350,6 +443,9 @@ export default function VendorPOItemSelector({
           quantity: selectedPart.minimumOrderQty || 1,
           unitPrice: selectedPart.unitPrice || 0,
           customerPoId: prev.customerPoId,
+          projectId: prev.projectId,
+          productionWorkOrderId: prev.productionWorkOrderId,
+          chargeCodeId: prev.chargeCodeId,
           otherIdentifier: prev.otherIdentifier,
           notes: prev.notes,
         }));
@@ -374,8 +470,8 @@ export default function VendorPOItemSelector({
         onTotalChange(calculateTotal());
       }
     },
-    onError: () => {
-      toast.error('Failed to add item');
+    onError: (error: any) => {
+      toast.error(error?.message || 'Failed to add item');
     },
   });
 
@@ -414,8 +510,8 @@ export default function VendorPOItemSelector({
         onTotalChange(calculateTotal());
       }
     },
-    onError: () => {
-      toast.error('Failed to update item');
+    onError: (error: any) => {
+      toast.error(error?.message || 'Failed to update item');
     },
   });
 
@@ -435,6 +531,9 @@ export default function VendorPOItemSelector({
       quantity: 0,
       unitPrice: 0,
       customerPoId: undefined,
+      projectId: undefined,
+      productionWorkOrderId: undefined,
+      chargeCodeId: undefined,
       otherIdentifier: '',
       notes: '',
     });
@@ -443,8 +542,13 @@ export default function VendorPOItemSelector({
   };
 
   const handleAddItem = () => {
-    if (newLineCustomerPoDisabled && newItem.customerPoId) {
-      toast.error('Add the P2 line item first, complete compliance review, then allocate it to a customer PO');
+    if (projectAllocationDisabled && (newItem.customerPoId || newItem.projectId || newItem.productionWorkOrderId)) {
+      toast.error('Complete compliance review before linking this P2 purchase to a customer PO, project, or WAD');
+      return;
+    }
+
+    if (isP2Purchase && !newItem.customerPoId && !newItem.projectId && !newItem.productionWorkOrderId && !newItem.chargeCodeId) {
+      toast.error('P2 line items need at least one traceability link: customer PO, project, WAD/work order, or charge code');
       return;
     }
 
@@ -473,6 +577,9 @@ export default function VendorPOItemSelector({
         unitPrice: calculatedVendorValues.vendorUnitPrice,
         lineTotal: lineTotal,
         customerPoId: newItem.customerPoId || null,
+        projectId: newItem.projectId || null,
+        productionWorkOrderId: newItem.productionWorkOrderId || null,
+        chargeCodeId: newItem.chargeCodeId || null,
         otherIdentifier: newItem.otherIdentifier || null,
         notes: newItem.notes || null,
       };
@@ -490,6 +597,9 @@ export default function VendorPOItemSelector({
         vendorUnit: newItem.vendorUnit || null,
         lineTotal: newItem.quantity * newItem.unitPrice,
         customerPoId: newItem.customerPoId || null,
+        projectId: newItem.projectId || null,
+        productionWorkOrderId: newItem.productionWorkOrderId || null,
+        chargeCodeId: newItem.chargeCodeId || null,
         otherIdentifier: newItem.otherIdentifier || null,
         notes: newItem.notes || null,
       };
@@ -507,6 +617,9 @@ export default function VendorPOItemSelector({
       unitPrice: item.unitPrice,
       notes: item.notes,
       customerPoId: item.customerPoId,
+      projectId: item.projectId,
+      productionWorkOrderId: item.productionWorkOrderId,
+      chargeCodeId: item.chargeCodeId,
       otherIdentifier: item.otherIdentifier,
     });
   };
@@ -515,8 +628,18 @@ export default function VendorPOItemSelector({
     const originalItem = items.find(item => item.id === itemId);
     if (!originalItem) return;
 
-    if (customerPoAllocationDisabled && editedItem.customerPoId) {
-      toast.error('Complete compliance review before allocating this P2 purchase to a customer PO');
+    const nextProjectId = 'projectId' in editedItem ? editedItem.projectId : originalItem.projectId;
+    const nextProductionWorkOrderId = 'productionWorkOrderId' in editedItem ? editedItem.productionWorkOrderId : originalItem.productionWorkOrderId;
+    const nextChargeCodeId = 'chargeCodeId' in editedItem ? editedItem.chargeCodeId : originalItem.chargeCodeId;
+    const nextCustomerPoId = 'customerPoId' in editedItem ? editedItem.customerPoId : originalItem.customerPoId;
+
+    if (projectAllocationDisabled && (nextCustomerPoId || nextProjectId || nextProductionWorkOrderId)) {
+      toast.error('Complete compliance review before linking this P2 purchase to a customer PO, project, or WAD');
+      return;
+    }
+
+    if (isP2Purchase && !nextCustomerPoId && !nextProjectId && !nextProductionWorkOrderId && !nextChargeCodeId) {
+      toast.error('P2 line items need at least one traceability link: customer PO, project, WAD/work order, or charge code');
       return;
     }
     
@@ -526,7 +649,10 @@ export default function VendorPOItemSelector({
       quantity: editedItem.quantity ?? originalItem.quantity,
       unitPrice: editedItem.unitPrice ?? originalItem.unitPrice,
       notes: editedItem.notes ?? originalItem.notes,
-      customerPoId: 'customerPoId' in editedItem ? editedItem.customerPoId : originalItem.customerPoId,
+      customerPoId: nextCustomerPoId,
+      projectId: nextProjectId,
+      productionWorkOrderId: nextProductionWorkOrderId,
+      chargeCodeId: nextChargeCodeId,
       otherIdentifier: 'otherIdentifier' in editedItem ? editedItem.otherIdentifier : originalItem.otherIdentifier,
     };
     
@@ -715,13 +841,13 @@ export default function VendorPOItemSelector({
             <div className="flex items-center gap-2 mb-3">
               <span className="font-medium text-purple-800 dark:text-purple-200 text-sm">📋 Internal Tracking (not shown on vendor PO)</span>
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
               <div>
                 <Label htmlFor="customerPo">Customer PO</Label>
                 <Select 
                   value={newItem.customerPoId?.toString() || 'none'} 
                   onValueChange={(value) => setNewItem({ ...newItem, customerPoId: value && value !== 'none' ? parseInt(value) : undefined })}
-                  disabled={newLineCustomerPoDisabled}
+                  disabled={customerPoAllocationDisabled}
                 >
                   <SelectTrigger data-testid="select-customer-po">
                     <SelectValue placeholder="Select customer PO (optional)..." />
@@ -738,10 +864,79 @@ export default function VendorPOItemSelector({
                 <p className="text-xs text-purple-600 dark:text-purple-400 mt-1">
                   {customerPoAllocationDisabled
                     ? 'P2 project allocation unlocks after compliance review is complete'
-                    : newLineCustomerPoDisabled
-                      ? 'Add the P2 line first, then allocate after compliance review'
                     : 'Link this purchase to a customer order'}
                 </p>
+              </div>
+              <div>
+                <Label htmlFor="project">Project</Label>
+                <Select
+                  value={newItem.projectId || 'none'}
+                  onValueChange={(value) => setNewItem({
+                    ...newItem,
+                    projectId: value !== 'none' ? value : undefined,
+                    productionWorkOrderId: undefined,
+                  })}
+                  disabled={projectAllocationDisabled}
+                >
+                  <SelectTrigger data-testid="select-project">
+                    <SelectValue placeholder="Select project..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None</SelectItem>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.projectCode} - {project.projectName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="workOrder">WAD / Work Order</Label>
+                <Select
+                  value={newItem.productionWorkOrderId || 'none'}
+                  onValueChange={(value) => {
+                    const selected = productionWorkOrders.find((wo) => wo.id === value);
+                    setNewItem({
+                      ...newItem,
+                      productionWorkOrderId: value !== 'none' ? value : undefined,
+                      projectId: selected?.projectId || newItem.projectId,
+                      chargeCodeId: selected?.defaultChargeCodeId || newItem.chargeCodeId,
+                    });
+                  }}
+                  disabled={projectAllocationDisabled}
+                >
+                  <SelectTrigger data-testid="select-production-work-order">
+                    <SelectValue placeholder="Select WAD..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None</SelectItem>
+                    {filteredWorkOrders.map((wo) => (
+                      <SelectItem key={wo.id} value={wo.id}>
+                        {wo.workOrderNumber} - {wo.partNumber || 'No part'}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="chargeCode">Charge Code</Label>
+                <Select
+                  value={newItem.chargeCodeId?.toString() || 'none'}
+                  onValueChange={(value) => setNewItem({ ...newItem, chargeCodeId: value !== 'none' ? parseInt(value) : undefined })}
+                >
+                  <SelectTrigger data-testid="select-charge-code">
+                    <SelectValue placeholder="Select charge code..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None</SelectItem>
+                    {chargeCodes.map((code) => (
+                      <SelectItem key={code.id} value={code.id.toString()}>
+                        {code.code}{code.description ? ` - ${code.description}` : ''}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div>
                 <Label htmlFor="otherIdentifier">Other Identifier</Label>
@@ -791,6 +986,9 @@ export default function VendorPOItemSelector({
               <TableHead>Qty (Vendor)</TableHead>
               <TableHead>Unit Price</TableHead>
               <TableHead>Line Total</TableHead>
+              <TableHead className="text-purple-600">Project</TableHead>
+              <TableHead className="text-purple-600">WAD / WO</TableHead>
+              <TableHead className="text-purple-600">Charge Code</TableHead>
               <TableHead className="text-purple-600">Customer PO</TableHead>
               <TableHead className="text-purple-600">Other ID</TableHead>
               <TableHead>Notes</TableHead>
@@ -866,9 +1064,89 @@ export default function VendorPOItemSelector({
                   </TableCell>
                   <TableCell className="text-purple-600">
                     {isEditing ? (
+                      <Select
+                        value={editedItem.projectId || 'none'}
+                        onValueChange={(value) => setEditedItem({
+                          ...editedItem,
+                          projectId: value !== 'none' ? value : null,
+                          productionWorkOrderId: null,
+                        })}
+                        disabled={projectAllocationDisabled}
+                      >
+                        <SelectTrigger className="w-36" data-testid={`select-edit-project-${item.id}`}>
+                          <SelectValue placeholder="None" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">None</SelectItem>
+                          {projects.map((project) => (
+                            <SelectItem key={project.id} value={project.id}>
+                              {project.projectCode}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      item.project?.projectCode || projects.find(project => project.id === item.projectId)?.projectCode || '-'
+                    )}
+                  </TableCell>
+                  <TableCell className="text-purple-600">
+                    {isEditing ? (
+                      <Select
+                        value={editedItem.productionWorkOrderId || 'none'}
+                        onValueChange={(value) => {
+                          const selected = productionWorkOrders.find((wo) => wo.id === value);
+                          setEditedItem({
+                            ...editedItem,
+                            productionWorkOrderId: value !== 'none' ? value : null,
+                            projectId: selected?.projectId || editedItem.projectId,
+                            chargeCodeId: selected?.defaultChargeCodeId || editedItem.chargeCodeId,
+                          });
+                        }}
+                        disabled={projectAllocationDisabled}
+                      >
+                        <SelectTrigger className="w-36" data-testid={`select-edit-production-work-order-${item.id}`}>
+                          <SelectValue placeholder="None" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">None</SelectItem>
+                          {editFilteredWorkOrders.map((wo) => (
+                            <SelectItem key={wo.id} value={wo.id}>
+                              {wo.workOrderNumber}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      item.productionWorkOrder?.workOrderNumber || productionWorkOrders.find(wo => wo.id === item.productionWorkOrderId)?.workOrderNumber || '-'
+                    )}
+                  </TableCell>
+                  <TableCell className="text-purple-600">
+                    {isEditing ? (
+                      <Select
+                        value={editedItem.chargeCodeId?.toString() || 'none'}
+                        onValueChange={(value) => setEditedItem({ ...editedItem, chargeCodeId: value !== 'none' ? parseInt(value) : null })}
+                      >
+                        <SelectTrigger className="w-36" data-testid={`select-edit-charge-code-${item.id}`}>
+                          <SelectValue placeholder="None" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">None</SelectItem>
+                          {chargeCodes.map((code) => (
+                            <SelectItem key={code.id} value={code.id.toString()}>
+                              {code.code}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      item.chargeCode?.code || chargeCodes.find(code => code.id === item.chargeCodeId)?.code || '-'
+                    )}
+                  </TableCell>
+                  <TableCell className="text-purple-600">
+                    {isEditing ? (
                       <Select 
                         value={editedItem.customerPoId?.toString() || 'none'} 
-                        onValueChange={(value) => setEditedItem({ ...editedItem, customerPoId: value && value !== 'none' ? parseInt(value) : null as unknown as undefined })}
+                        onValueChange={(value) => setEditedItem({ ...editedItem, customerPoId: value && value !== 'none' ? parseInt(value) : null })}
                         disabled={customerPoAllocationDisabled}
                       >
                         <SelectTrigger className="w-32" data-testid={`select-edit-customer-po-${item.id}`}>
@@ -884,9 +1162,11 @@ export default function VendorPOItemSelector({
                         </SelectContent>
                       </Select>
                     ) : (
-                      item.customerPoId ? 
-                        p2PurchaseOrders.find(po => po.id === item.customerPoId)?.poNumber || '-' 
+                      item.customerPo?.poNumber ||
+                      (item.customerPoId ?
+                        p2PurchaseOrders.find(po => po.id === item.customerPoId)?.poNumber || '-'
                         : '-'
+                      )
                     )}
                   </TableCell>
                   <TableCell className="text-purple-600">

--- a/migrations/0117_vendor_po_line_project_traceability.sql
+++ b/migrations/0117_vendor_po_line_project_traceability.sql
@@ -1,0 +1,17 @@
+-- Task #173: procurement-to-project traceability for vendor PO line items.
+-- Adds optional cost-objective links so every related procurement line can point
+-- to the P2 project, WAD/work order, and charge code it supports.
+
+ALTER TABLE vendor_po_items
+  ADD COLUMN IF NOT EXISTS project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS charge_code_id integer REFERENCES charge_codes(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS vendor_po_items_project_id_idx
+  ON vendor_po_items(project_id);
+
+CREATE INDEX IF NOT EXISTS vendor_po_items_production_work_order_id_idx
+  ON vendor_po_items(production_work_order_id);
+
+CREATE INDEX IF NOT EXISTS vendor_po_items_charge_code_id_idx
+  ON vendor_po_items(charge_code_id);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -3872,6 +3872,12 @@ export const vendorPOItems = pgTable('vendor_po_items', {
   notes: text('notes'),
   customerPoId: integer('customer_po_id')
     .references(() => p2PurchaseOrders.id), // Optional link to customer PO (internal tracking only)
+  projectId: uuid('project_id')
+    .references((): AnyPgColumn => projects.id, { onDelete: 'set null' }), // Optional project traceability
+  productionWorkOrderId: uuid('production_work_order_id')
+    .references((): AnyPgColumn => productionWorkOrders.id, { onDelete: 'set null' }), // Optional WAD/work order traceability
+  chargeCodeId: integer('charge_code_id')
+    .references((): AnyPgColumn => chargeCodes.id, { onDelete: 'set null' }), // Optional cost objective traceability
   otherIdentifier: text('other_identifier'), // Optional identifier when no customer PO (internal tracking only)
   historicalAvgPrice: real('historical_avg_price'),
   priceVariancePercent: real('price_variance_percent'),

--- a/server/src/routes/vendorPOs.ts
+++ b/server/src/routes/vendorPOs.ts
@@ -40,8 +40,22 @@ async function getVendorPOComplianceBlockers(vendorPoId: number): Promise<string
   return blockers;
 }
 
-async function requireP2ComplianceBeforeProjectAllocation(vendorPoId: number, customerPoId: unknown) {
-  if (customerPoId === undefined || customerPoId === null) return;
+function hasTraceabilityLink(data: Record<string, unknown>): boolean {
+  return ['customerPoId', 'projectId', 'productionWorkOrderId', 'chargeCodeId'].some((key) => {
+    const value = data[key];
+    return value !== undefined && value !== null && String(value).trim() !== '';
+  });
+}
+
+async function requireP2ComplianceBeforeProjectAllocation(
+  vendorPoId: number,
+  traceability: { customerPoId?: unknown; projectId?: unknown; productionWorkOrderId?: unknown }
+) {
+  const hasProjectAllocation =
+    traceability.customerPoId !== undefined && traceability.customerPoId !== null ||
+    traceability.projectId !== undefined && traceability.projectId !== null ||
+    traceability.productionWorkOrderId !== undefined && traceability.productionWorkOrderId !== null;
+  if (!hasProjectAllocation) return;
   const vendorPO = await storage.getVendorPO(vendorPoId);
   if (!vendorPO) {
     const error: any = new Error('Vendor PO not found');
@@ -55,6 +69,20 @@ async function requireP2ComplianceBeforeProjectAllocation(vendorPoId: number, cu
     const error: any = new Error(`Cannot allocate P2 vendor purchase to a project. Reason(s): ${blockers.join('; ')}.`);
     error.status = 422;
     error.blockingReasons = blockers;
+    throw error;
+  }
+}
+
+async function requireP2LineTraceability(vendorPoId: number, data: Record<string, unknown>) {
+  const vendorPO = await storage.getVendorPO(vendorPoId);
+  if (!isP2ProductionLine(vendorPO?.productionLine)) return;
+
+  if (!hasTraceabilityLink(data)) {
+    const error: any = new Error(
+      'P2 vendor PO lines must include at least one traceability link: customer PO, project, WAD/work order, or charge code.'
+    );
+    error.status = 422;
+    error.blockingReasons = [error.message];
     throw error;
   }
 }
@@ -610,6 +638,22 @@ router.put('/compliance-effective-date', async (req: Request, res: Response) => 
   }
 });
 
+// GET /api/vendor-pos/traceability-options - Options for line-level project/WAD/charge-code links
+router.get('/traceability-options', async (_req: Request, res: Response) => {
+  try {
+    const [projects, productionWorkOrders, chargeCodes] = await Promise.all([
+      storage.getAllProjects(),
+      storage.getAllProductionWorkOrders(),
+      storage.listChargeCodes(true),
+    ]);
+
+    res.json({ projects, productionWorkOrders, chargeCodes });
+  } catch (error) {
+    console.error('Get vendor PO traceability options error:', error);
+    res.status(500).json({ error: 'Failed to retrieve traceability options' });
+  }
+});
+
 // GET /api/vendor-pos/:id - Get a single vendor PO
 router.get('/:id', async (req: Request, res: Response) => {
   try {
@@ -881,7 +925,8 @@ router.post('/:id/items', async (req: Request, res: Response) => {
       { changedField: 'lineItems', action: 'added' },
     );
 
-    await requireP2ComplianceBeforeProjectAllocation(vendorPoId, data.customerPoId);
+    await requireP2LineTraceability(vendorPoId, data as Record<string, unknown>);
+    await requireP2ComplianceBeforeProjectAllocation(vendorPoId, data);
 
     const item = await storage.createVendorPOItem(data);
     res.status(201).json(item);
@@ -927,14 +972,20 @@ router.put('/items/:itemId', async (req: Request, res: Response) => {
       : undefined;
 
     if (oldItem) {
-      const finalCustomerPoId = data.customerPoId !== undefined ? data.customerPoId : oldItem.customerPoId;
-      await requireP2ComplianceBeforeProjectAllocation(oldItem.vendorPoId, finalCustomerPoId);
+      const finalTraceability = {
+        customerPoId: data.customerPoId !== undefined ? data.customerPoId : oldItem.customerPoId,
+        projectId: data.projectId !== undefined ? data.projectId : oldItem.projectId,
+        productionWorkOrderId: data.productionWorkOrderId !== undefined ? data.productionWorkOrderId : oldItem.productionWorkOrderId,
+        chargeCodeId: data.chargeCodeId !== undefined ? data.chargeCodeId : oldItem.chargeCodeId,
+      };
+      await requireP2LineTraceability(oldItem.vendorPoId, finalTraceability);
+      await requireP2ComplianceBeforeProjectAllocation(oldItem.vendorPoId, finalTraceability);
 
-      if (changedField && finalCustomerPoId != null) {
+      if (changedField && hasTraceabilityLink(finalTraceability)) {
         const vendorPO = await storage.getVendorPO(oldItem.vendorPoId);
         if (isP2ProductionLine(vendorPO?.productionLine)) {
           const error: any = new Error(
-            `Cannot keep a P2 line allocated to a project while changing ${changedField.label}. Clear the project allocation, save the material change, complete compliance review, then allocate it again.`
+            `Cannot keep a P2 line linked to project traceability while changing ${changedField.label}. Clear the traceability links, save the material change, complete compliance review, then allocate it again.`
           );
           error.status = 422;
           error.blockingReasons = [error.message];

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -9919,6 +9919,10 @@ export class DatabaseStorage implements IStorage {
         inventoryItems,
         eq(vendorPOItems.agPartNumber, inventoryItems.agPartNumber)
       )
+      .leftJoin(projects, eq(projects.id, vendorPOItems.projectId))
+      .leftJoin(productionWorkOrders, eq(productionWorkOrders.id, vendorPOItems.productionWorkOrderId))
+      .leftJoin(chargeCodes, eq(chargeCodes.id, vendorPOItems.chargeCodeId))
+      .leftJoin(p2PurchaseOrders, eq(p2PurchaseOrders.id, vendorPOItems.customerPoId))
       .where(eq(vendorPOItems.vendorPoId, vendorPoId))
       .orderBy(vendorPOItems.lineNumber);
     
@@ -9937,6 +9941,30 @@ export class DatabaseStorage implements IStorage {
         consumptionRate: row.inventory_items?.consumptionRate,
         usageUnit: row.inventory_items?.usageUnit,
         purchaseUnitLabel: row.inventory_items?.purchaseUnitLabel,
+        project: row.projects ? {
+          id: row.projects.id,
+          projectCode: row.projects.projectCode,
+          projectName: row.projects.projectName,
+        } : undefined,
+        productionWorkOrder: row.production_work_orders ? {
+          id: row.production_work_orders.id,
+          workOrderNumber: row.production_work_orders.workOrderNumber,
+          projectId: row.production_work_orders.projectId,
+          partNumber: row.production_work_orders.partNumber,
+          status: row.production_work_orders.status,
+        } : undefined,
+        chargeCode: row.charge_codes ? {
+          id: row.charge_codes.id,
+          code: row.charge_codes.code,
+          description: row.charge_codes.description,
+          type: row.charge_codes.type,
+        } : undefined,
+        customerPo: row.p2_purchase_orders ? {
+          id: row.p2_purchase_orders.id,
+          poNumber: row.p2_purchase_orders.poNumber,
+          customerName: row.p2_purchase_orders.customerName,
+          status: row.p2_purchase_orders.status,
+        } : undefined,
       };
       return formatDates(flat as Record<string, unknown>, VENDOR_PO_ITEM_DATE_COLUMNS) as typeof flat;
     });


### PR DESCRIPTION
## Summary
- Add project, WAD/work order, and charge-code links to vendor PO line items with a migration and schema fields.
- Return joined traceability labels from vendor PO item reads, plus a vendor PO traceability-options endpoint for the line-item UI.
- Add line-item controls/display for customer PO, project, WAD/work order, charge code, and other identifier; enforce at least one traceability link on P2 vendor PO lines.

## Validation
- `git diff --check -- client/src/components/inventory/VendorPOItemSelector.tsx server/schema.ts server/storage.ts server/src/routes/vendorPOs.ts migrations/0117_vendor_po_line_project_traceability.sql`

## Notes
- Local typecheck/build could not be run because this worktree has no `npm`, `pnpm`, `yarn`, or `node_modules` available.
- `PRODUCTION_STOCK_MODELS.sql` was already dirty in the worktree and was intentionally left out of this commit.