### PR TITLE
Add project FAR flowdown from purchase review

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -269,6 +269,18 @@ interface ProjectWorkOrder {
   description: string | null;
 }
 
+interface ProjectFarFlowdown {
+  id: number;
+  clauseNumber: string;
+  title: string;
+  description: string | null;
+  applicable: boolean;
+  reasoning: string;
+  status: string;
+  purchaseReviewChecklistId: number | null;
+  updatedAt: string;
+}
+
 const STEP_CONFIG: Record<string, { label: string; route: string; icon: typeof FileText }> = {
   rfq_risk_assessment: { label: 'RFQ Risk Assessment', route: '/rfq-risk-assessment', icon: FileText },
   quote: { label: 'Quote', route: '/p2-quote-form', icon: FileText },
@@ -437,6 +449,12 @@ export default function ProjectDetailPage() {
     queryKey: ['/api/projects', id, 'p2-gate-status'],
     queryFn: () => fetch(`/api/projects/${id}/p2-gate-status`).then(r => r.json()),
     enabled: !!id && !!project && ['po_received', 'p2_release', 'purchase_review'].includes(project.currentStage || ''),
+  });
+
+  const { data: projectFarFlowdowns = [] } = useQuery<ProjectFarFlowdown[]>({
+    queryKey: ['/api/far-flowdown-clauses/project', id],
+    queryFn: () => fetch(`/api/far-flowdown-clauses/project/${id}`).then(r => r.json()),
+    enabled: !!id,
   });
 
   const releaseToP2Mutation = useMutation({
@@ -1480,7 +1498,7 @@ export default function ProjectDetailPage() {
                 title: 'Purchase Review Checklist',
                 description: 'Verify PO terms, pricing, and contract requirements before authorizing work.',
                 step: purchaseStep,
-                route: `/purchase-review-checklist${project.customerId ? `?customerId=${encodeURIComponent(project.customerId)}` : ''}`,
+                route: `/purchase-review-checklist?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`,
                 icon: <ListChecks className="h-5 w-5 text-blue-600" />,
                 gateLabel: 'Complete before WAD',
               },
@@ -1556,6 +1574,57 @@ export default function ProjectDetailPage() {
               </div>
             );
           })()}
+
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <CardTitle className="flex items-center gap-2">
+                    <ShieldCheck className="h-5 w-5 text-blue-600" />
+                    FAR Flowdown
+                  </CardTitle>
+                  <CardDescription>
+                    Contract clauses captured from the purchase review checklist and carried on this project.
+                  </CardDescription>
+                </div>
+                <Badge variant="outline">{projectFarFlowdowns.length} clause{projectFarFlowdowns.length === 1 ? '' : 's'}</Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {projectFarFlowdowns.length === 0 ? (
+                <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                  No FAR flowdowns have been captured yet. Open the Purchase Review Checklist for this project to record clause numbers and flowdown notes.
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {projectFarFlowdowns.map((flowdown) => (
+                    <div key={flowdown.id} className="rounded-md border p-3">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="font-medium">
+                          {flowdown.clauseNumber} - {flowdown.title}
+                        </div>
+                        <Badge className={flowdown.status === 'open' ? 'bg-blue-100 text-blue-800' : 'bg-green-100 text-green-800'}>
+                          {flowdown.status}
+                        </Badge>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">{flowdown.reasoning}</p>
+                      {flowdown.purchaseReviewChecklistId && (
+                        <Button
+                          variant="link"
+                          size="sm"
+                          className="mt-2 h-auto p-0"
+                          onClick={() => setLocation(`/purchase-review-checklist?id=${flowdown.purchaseReviewChecklistId}&projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`)}
+                        >
+                          <ExternalLink className="mr-1 h-3 w-3" />
+                          Open source checklist
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
           <Card>
             <CardHeader>
@@ -1645,9 +1714,11 @@ export default function ProjectDetailPage() {
                                   onClick={() => {
                                     if (!config?.route) return;
                                     const CUSTOMER_ID_STEPS = ['rfq_risk_assessment', 'quote', 'purchase_review_checklist'];
-                                    const route = CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
-                                      ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
-                                      : config.route;
+                                    const route = step.stepType === 'purchase_review_checklist'
+                                      ? `${config.route}?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`
+                                      : CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
+                                        ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
+                                        : config.route;
                                     setLocation(route);
                                   }}
                                   data-testid={`button-open-${step.stepType}`}
@@ -1712,9 +1783,11 @@ export default function ProjectDetailPage() {
                                   onClick={() => {
                                     if (!config?.route) return;
                                     const CUSTOMER_ID_STEPS = ['rfq_risk_assessment', 'quote', 'purchase_review_checklist'];
-                                    const route = CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
-                                      ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
-                                      : config.route;
+                                    const route = step.stepType === 'purchase_review_checklist'
+                                      ? `${config.route}?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`
+                                      : CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
+                                        ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
+                                        : config.route;
                                     setLocation(route);
                                   }}
                                   data-testid={`button-view-${step.stepType}`}
@@ -1810,9 +1883,11 @@ export default function ProjectDetailPage() {
                                     startStepMutation.mutate(step.id);
                                     if (config?.route) {
                                       const CUSTOMER_ID_STEPS = ['rfq_risk_assessment', 'quote', 'purchase_review_checklist'];
-                                      const route = CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
-                                        ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
-                                        : config.route;
+                                      const route = step.stepType === 'purchase_review_checklist'
+                                        ? `${config.route}?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`
+                                        : CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
+                                          ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
+                                          : config.route;
                                       setLocation(route);
                                     }
                                   }}

--- a/client/src/pages/PurchaseReviewChecklist.tsx
+++ b/client/src/pages/PurchaseReviewChecklist.tsx
@@ -64,6 +64,7 @@ export default function PurchaseReviewChecklist() {
   const [location, setLocation] = useLocation();
   const search = useSearch();
   const urlCustomerId = new URLSearchParams(search).get('customerId') ?? '';
+  const urlProjectId = new URLSearchParams(search).get('projectId') ?? '';
   const autoFilledRef = useRef(false);
   const [submissionId, setSubmissionId] = useState<string | null>(null);
   const [isLoadingSubmission, setIsLoadingSubmission] = useState(false);
@@ -234,6 +235,9 @@ export default function PurchaseReviewChecklist() {
     certifications: [] as string[],
     retentionRequirements: '',
     dpasRating: '',
+    farFlowdownClauseNumbers: '',
+    farFlowdownNotes: '',
+    projectId: urlProjectId,
 
     // Reviewers
     reviewerName: '',
@@ -260,7 +264,7 @@ export default function PurchaseReviewChecklist() {
             
             // Load form data
             if (submission.formData) {
-              setFormData(submission.formData);
+              setFormData((prev) => ({ ...prev, ...submission.formData }));
             }
             
             toast({
@@ -289,6 +293,12 @@ export default function PurchaseReviewChecklist() {
     
     loadSubmission();
   }, []);
+
+  useEffect(() => {
+    if (urlProjectId) {
+      setFormData((prev) => ({ ...prev, projectId: urlProjectId }));
+    }
+  }, [urlProjectId]);
 
   // Auto-fill customer when customerId is provided via URL param
   useEffect(() => {
@@ -1854,6 +1864,34 @@ export default function PurchaseReviewChecklist() {
                   <Label htmlFor="dpas-na">N/A</Label>
                 </div>
               </div>
+            </div>
+
+            <div>
+              <Label htmlFor="farFlowdownClauseNumbers">
+                FAR/DFARS Clauses to Flow Down
+              </Label>
+              <Textarea
+                id="farFlowdownClauseNumbers"
+                value={formData.farFlowdownClauseNumbers}
+                onChange={(e) =>
+                  handleInputChange('farFlowdownClauseNumbers', e.target.value)
+                }
+                rows={3}
+                placeholder="Example: FAR 52.204-21, DFARS 252.204-7012"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="farFlowdownNotes">FAR Flowdown Notes</Label>
+              <Textarea
+                id="farFlowdownNotes"
+                value={formData.farFlowdownNotes}
+                onChange={(e) =>
+                  handleInputChange('farFlowdownNotes', e.target.value)
+                }
+                rows={3}
+                placeholder="Capture contract-specific flowdown reasoning, subcontractor handling, or project constraints."
+              />
             </div>
           </CardContent>
         </Card>

--- a/migrations/0120_project_far_flowdowns.sql
+++ b/migrations/0120_project_far_flowdowns.sql
@@ -1,0 +1,24 @@
+-- Project-level FAR/DFARS flowdown continuity from purchase review checklist.
+-- Idempotent: safe on environments where the table or indexes already exist.
+
+CREATE TABLE IF NOT EXISTS project_far_flowdowns (
+  id serial PRIMARY KEY,
+  project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  purchase_review_checklist_id integer REFERENCES purchase_review_checklists(id) ON DELETE SET NULL,
+  clause_id integer NOT NULL REFERENCES far_flowdown_clauses(id),
+  applicable boolean NOT NULL DEFAULT true,
+  reasoning text NOT NULL,
+  source text NOT NULL DEFAULT 'purchase_review_checklist',
+  status text NOT NULL DEFAULT 'open',
+  recorded_by_user_id integer,
+  recorded_by_display_name text,
+  created_at timestamp NOT NULL DEFAULT NOW(),
+  updated_at timestamp NOT NULL DEFAULT NOW(),
+  UNIQUE(project_id, clause_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_far_flowdowns_project_id
+  ON project_far_flowdowns(project_id);
+
+CREATE INDEX IF NOT EXISTS idx_project_far_flowdowns_checklist_id
+  ON project_far_flowdowns(purchase_review_checklist_id);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -17559,6 +17559,25 @@ export const vendorPoFarFlowdowns = pgTable('vendor_po_far_flowdowns', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
 }, (t) => ({ uniq: unique().on(t.vendorPoId, t.clauseId) }));
 
+export const projectFarFlowdowns = pgTable('project_far_flowdowns', {
+  id: serial('id').primaryKey(),
+  projectId: uuid('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  purchaseReviewChecklistId: integer('purchase_review_checklist_id').references(() => purchaseReviewChecklists.id, { onDelete: 'set null' }),
+  clauseId: integer('clause_id').notNull().references(() => farFlowdownClauses.id),
+  applicable: boolean('applicable').notNull().default(true),
+  reasoning: text('reasoning').notNull(),
+  source: text('source').notNull().default('purchase_review_checklist'),
+  status: text('status').notNull().default('open'),
+  recordedByUserId: integer('recorded_by_user_id'),
+  recordedByDisplayName: text('recorded_by_display_name'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  uniq: unique().on(t.projectId, t.clauseId),
+  projectIdx: index('idx_project_far_flowdowns_project_id').on(t.projectId),
+  checklistIdx: index('idx_project_far_flowdowns_checklist_id').on(t.purchaseReviewChecklistId),
+}));
+
 export const vendorDebarmentChecks = pgTable('vendor_debarment_checks', {
   id: serial('id').primaryKey(),
   vendorId: integer('vendor_id').notNull().references(() => vendors.id),
@@ -17628,6 +17647,7 @@ export type PurchaseRequisitionApprovalChain = typeof purchaseRequisitionApprova
 export type FarFlowdownClause = typeof farFlowdownClauses.$inferSelect;
 export type InsertFarFlowdownClause = z.infer<typeof insertFarFlowdownClauseSchema>;
 export type VendorPoFarFlowdown = typeof vendorPoFarFlowdowns.$inferSelect;
+export type ProjectFarFlowdown = typeof projectFarFlowdowns.$inferSelect;
 export type VendorDebarmentCheck = typeof vendorDebarmentChecks.$inferSelect;
 export type InsertVendorDebarmentCheck = z.infer<typeof insertVendorDebarmentCheckSchema>;
 export type ProcurementSettings = typeof procurementSettings.$inferSelect;

--- a/server/src/routes/farFlowdownClauses.ts
+++ b/server/src/routes/farFlowdownClauses.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { db } from '../../db';
 import {
   farFlowdownClauses,
+  projectFarFlowdowns,
   vendorPoFarFlowdowns,
   insertFarFlowdownClauseSchema,
 } from '../../schema';
@@ -54,6 +55,33 @@ router.delete('/:id', requirePermission('purchasing.admin_chain'), async (req, r
     .set({ isActive: false, updatedAt: new Date() })
     .where(eq(farFlowdownClauses.id, parseInt(req.params.id)));
   res.json({ ok: true });
+});
+
+// PER-PROJECT flowdown continuity from purchase review checklist
+router.get('/project/:projectId', requirePermission('purchasing.view_requisitions'), async (req, res) => {
+  const projectId = req.params.projectId;
+  const rows = await db
+    .select({
+      id: projectFarFlowdowns.id,
+      projectId: projectFarFlowdowns.projectId,
+      purchaseReviewChecklistId: projectFarFlowdowns.purchaseReviewChecklistId,
+      clauseId: projectFarFlowdowns.clauseId,
+      applicable: projectFarFlowdowns.applicable,
+      reasoning: projectFarFlowdowns.reasoning,
+      source: projectFarFlowdowns.source,
+      status: projectFarFlowdowns.status,
+      recordedByDisplayName: projectFarFlowdowns.recordedByDisplayName,
+      createdAt: projectFarFlowdowns.createdAt,
+      updatedAt: projectFarFlowdowns.updatedAt,
+      clauseNumber: farFlowdownClauses.clauseNumber,
+      title: farFlowdownClauses.title,
+      description: farFlowdownClauses.description,
+    })
+    .from(projectFarFlowdowns)
+    .innerJoin(farFlowdownClauses, eq(projectFarFlowdowns.clauseId, farFlowdownClauses.id))
+    .where(eq(projectFarFlowdowns.projectId, projectId))
+    .orderBy(farFlowdownClauses.clauseNumber);
+  res.json(rows);
 });
 
 // PER-PO flowdown selections (read + bulk upsert)

--- a/server/src/routes/forms.ts
+++ b/server/src/routes/forms.ts
@@ -4,11 +4,143 @@ import {
   insertFormSubmissionSchema,
   insertPurchaseReviewChecklistSchema,
   insertManufacturersCertificateSchema,
+  farFlowdownClauses,
+  projectFarFlowdowns,
 } from '@shared/schema';
+import { and, eq } from 'drizzle-orm';
 
 import { storage } from '../../storage';
+import { db } from '../../db';
 
 const router = Router();
+
+function splitClauseNumbers(value: unknown): string[] {
+  if (!value) return [];
+  return String(value)
+    .split(/[\n,;]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function hasMeaningfulValue(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some((item) => hasMeaningfulValue(item));
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return normalized !== '' && normalized !== 'n/a' && normalized !== 'na' && normalized !== 'none';
+}
+
+async function ensureFlowdownClause(clauseNumber: string) {
+  const [existing] = await db
+    .select()
+    .from(farFlowdownClauses)
+    .where(eq(farFlowdownClauses.clauseNumber, clauseNumber))
+    .limit(1);
+  if (existing) return existing;
+
+  const [created] = await db
+    .insert(farFlowdownClauses)
+    .values({
+      clauseNumber,
+      title: `Manual FAR/DFARS clause ${clauseNumber}`,
+      description: 'Captured from the purchase review checklist for project flowdown continuity.',
+      defaultApplicable: false,
+      isActive: true,
+    })
+    .returning();
+  return created;
+}
+
+async function syncProjectFarFlowdownsFromChecklist(checklist: any) {
+  const formData = checklist?.formData ?? {};
+  const projectId = formData.projectId || formData.project_id;
+  if (!projectId) return;
+
+  const explicitClauseNumbers = splitClauseNumbers(formData.farFlowdownClauseNumbers);
+  const clauses = explicitClauseNumbers.length > 0
+    ? await Promise.all(explicitClauseNumbers.map(ensureFlowdownClause))
+    : await db
+        .select()
+        .from(farFlowdownClauses)
+        .where(eq(farFlowdownClauses.isActive, true));
+
+  const sourceSignals = [
+    hasMeaningfulValue(formData.farFlowdownNotes) && 'purchase review FAR/DFARS notes',
+    hasMeaningfulValue(formData.retentionRequirements) && 'record retention requirements',
+    hasMeaningfulValue(formData.dpasRating) && 'DPAS rating',
+    hasMeaningfulValue(formData.certifications) && 'certification requirements',
+    hasMeaningfulValue(formData.qualityRequirements) && 'quality requirements',
+    hasMeaningfulValue(formData.acceptanceRejectionCriteria) && 'acceptance criteria',
+  ].filter(Boolean);
+
+  const selectedClauses = clauses.filter((clause: any) => {
+    if (explicitClauseNumbers.length > 0) return true;
+    return clause.defaultApplicable;
+  });
+
+  for (const clause of selectedClauses) {
+    const reasoning = [
+      explicitClauseNumbers.length > 0
+        ? 'Clause listed on purchase review checklist.'
+        : 'Project contract requirements captured in purchase review checklist.',
+      sourceSignals.length > 0 ? `Signals: ${sourceSignals.join(', ')}.` : '',
+      formData.farFlowdownNotes ? `Notes: ${formData.farFlowdownNotes}` : '',
+    ].filter(Boolean).join(' ');
+
+    const existing = await db
+      .select()
+      .from(projectFarFlowdowns)
+      .where(and(
+        eq(projectFarFlowdowns.projectId, projectId),
+        eq(projectFarFlowdowns.clauseId, clause.id),
+      ))
+      .limit(1);
+
+    const values = {
+      projectId,
+      purchaseReviewChecklistId: checklist.id,
+      clauseId: clause.id,
+      applicable: true,
+      reasoning,
+      source: 'purchase_review_checklist',
+      status: 'open',
+      recordedByDisplayName: checklist.createdBy ?? null,
+      updatedAt: new Date(),
+    };
+
+    if (existing.length > 0) {
+      await db.update(projectFarFlowdowns)
+        .set(values)
+        .where(eq(projectFarFlowdowns.id, existing[0].id));
+    } else {
+      await db.insert(projectFarFlowdowns).values(values);
+    }
+  }
+
+  const steps = await storage.getProjectSteps(projectId);
+  const purchaseReviewStep = steps.find((step: any) => step.stepType === 'purchase_review_checklist');
+  if (purchaseReviewStep) {
+    const shouldComplete = checklist.status === 'SUBMITTED' || checklist.status === 'APPROVED';
+    await storage.updateProjectStep(purchaseReviewStep.id, {
+      linkedPurchaseReviewId: checklist.id,
+      ...(shouldComplete ? {
+        status: 'completed',
+        completedAt: new Date(),
+      } : {}),
+      notes: selectedClauses.length > 0
+        ? `FAR flowdown captured from purchase review checklist #${checklist.id}.`
+        : purchaseReviewStep.notes,
+    } as any);
+  }
+
+  if (selectedClauses.length > 0) {
+    await storage.createProjectActivityLog({
+      projectId,
+      activityType: 'far_flowdown_synced',
+      stepType: 'purchase_review_checklist' as any,
+      description: `FAR flowdown synced from purchase review checklist #${checklist.id} (${selectedClauses.length} clause${selectedClauses.length === 1 ? '' : 's'})`,
+      performedByDisplayName: checklist.createdBy ?? null,
+    } as any);
+  }
+}
 
 // Enhanced Forms Management
 router.get('/enhanced', async (req: Request, res: Response) => {
@@ -147,6 +279,7 @@ router.post(
       const checklistData = insertPurchaseReviewChecklistSchema.parse(req.body);
       const newChecklist =
         await storage.createPurchaseReviewChecklist(checklistData);
+      await syncProjectFarFlowdownsFromChecklist(newChecklist);
       res.status(201).json(newChecklist);
     } catch (error) {
       console.error('Create purchase review checklist error:', error);
@@ -170,6 +303,7 @@ router.put(
         id,
         updates
       );
+      await syncProjectFarFlowdownsFromChecklist(updatedChecklist);
       res.json(updatedChecklist);
     } catch (error) {
       console.error('Update purchase review checklist error:', error);


### PR DESCRIPTION
## Summary
- Adds persistent project-level FAR/DFARS flowdown records tied to purchase review checklists.
- Syncs clauses and checklist linkage when a purchase review checklist is saved or submitted with a projectId.
- Passes projectId from project workflow actions into the purchase review checklist and shows captured FAR flowdowns on the project detail workflow view.

## Validation
- `git diff --cached --check` passed before commit.
- Could not run `npm run check` locally because `npm` is not installed/available in this shell.