### PR TITLE
[codex] Tune order entry console for industrial style

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -85,7 +85,7 @@
   }
 }
 
-/* Toggleable /order-entry hardware-console pilot */
+/* Toggleable /order-entry professional industrial console pilot */
 .order-entry-shell {
   transition:
     background 180ms ease,
@@ -95,15 +95,15 @@
 .order-entry-console {
   max-width: none;
   min-height: calc(100vh - 24px);
-  border-radius: 18px;
+  border-radius: 12px;
   background:
-    radial-gradient(circle at 18px 18px, rgba(255, 255, 255, 0.7) 0 1px, transparent 1.4px) 0 0 / 12px 12px,
-    linear-gradient(135deg, #e9e7e1 0%, #c9c7bf 47%, #f5f4ee 100%);
-  color: #1d1d1b;
+    linear-gradient(90deg, rgba(255, 255, 255, 0.18) 0 1px, transparent 1px 14px),
+    linear-gradient(135deg, #e9e9e5 0%, #c9cbc5 43%, #f4f4ef 100%);
+  color: #171b1d;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.9),
-    inset 0 -2px 8px rgba(88, 83, 72, 0.22),
-    0 20px 60px rgba(25, 23, 20, 0.18);
+    inset 0 -2px 8px rgba(52, 59, 61, 0.16),
+    0 18px 52px rgba(22, 27, 29, 0.18);
 }
 
 .order-entry-console .order-console-toggle {
@@ -115,72 +115,73 @@
   padding: 7px 10px 7px 12px;
   border: 1px solid rgba(72, 68, 60, 0.38);
   border-radius: 999px;
-  background: linear-gradient(180deg, #f3f1ea 0%, #c9c6bd 100%);
+  background: linear-gradient(180deg, #f5f5f2 0%, #c8ccc8 100%);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.9),
-    inset 0 -1px 2px rgba(51, 48, 43, 0.2),
-    0 9px 20px rgba(36, 32, 28, 0.18);
+    inset 0 -1px 2px rgba(43, 49, 51, 0.18),
+    0 8px 18px rgba(29, 34, 36, 0.16);
 }
 
 .order-entry-console .order-console-toggle button[role='switch'][data-state='checked'] {
-  background: linear-gradient(90deg, #ef3b12 0%, #ff6b1a 100%);
+  background: linear-gradient(90deg, #1d6f84 0%, #2aa8b8 100%);
   box-shadow:
     inset 0 1px 4px rgba(255, 255, 255, 0.36),
-    0 0 18px rgba(255, 82, 26, 0.36);
+    0 0 16px rgba(42, 168, 184, 0.32);
 }
 
 .order-entry-console .bg-card.text-card-foreground {
   overflow: hidden;
-  border: 1px solid rgba(63, 60, 55, 0.45);
-  border-radius: 8px;
+  border: 1px solid rgba(73, 78, 78, 0.4);
+  border-radius: 7px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(222, 219, 209, 0.92)),
-    #dedbd1;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(222, 224, 219, 0.94)),
+    #e0e2dd;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.82),
-    inset 0 -1px 3px rgba(73, 68, 61, 0.18),
-    0 14px 28px rgba(35, 31, 27, 0.18);
+    inset 0 1px 0 rgba(255, 255, 255, 0.86),
+    inset 0 -1px 3px rgba(48, 55, 57, 0.14),
+    0 12px 24px rgba(30, 35, 36, 0.16);
 }
 
 .order-entry-console .bg-card.text-card-foreground > div:first-child {
-  border-bottom: 1px solid rgba(80, 74, 66, 0.34);
+  border-bottom: 1px solid rgba(79, 86, 86, 0.26);
   background:
-    linear-gradient(90deg, rgba(255, 255, 255, 0.5), rgba(203, 199, 187, 0.34)),
-    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.035) 0 1px, transparent 1px 14px);
+    linear-gradient(90deg, rgba(255, 255, 255, 0.52), rgba(201, 205, 201, 0.28)),
+    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.025) 0 1px, transparent 1px 18px);
 }
 
 .order-entry-console .order-console-module {
   margin-top: 16px;
   padding: 10px;
-  border: 1px solid rgba(47, 45, 40, 0.46);
-  border-radius: 8px;
+  border: 1px solid rgba(46, 54, 56, 0.42);
+  border-radius: 7px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.22), rgba(91, 86, 76, 0.12)),
-    rgba(210, 207, 196, 0.78);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(74, 84, 86, 0.1)),
+    rgba(211, 215, 210, 0.8);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.66),
-    inset 0 -1px 2px rgba(51, 47, 40, 0.18);
+    inset 0 -1px 2px rgba(45, 52, 54, 0.16);
 }
 
 .order-entry-console .order-console-display {
   padding: 13px;
-  border: 1px solid rgba(255, 255, 255, 0.11);
-  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 5px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.07), transparent 42%),
-    #121412;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 45%),
+    linear-gradient(90deg, rgba(83, 104, 110, 0.14) 0 1px, transparent 1px 12px),
+    #121718;
   box-shadow:
-    inset 0 0 0 1px rgba(0, 0, 0, 0.72),
-    inset 0 2px 18px rgba(0, 0, 0, 0.72),
-    0 1px 0 rgba(255, 255, 255, 0.5);
+    inset 0 0 0 1px rgba(0, 0, 0, 0.68),
+    inset 0 2px 16px rgba(0, 0, 0, 0.66),
+    0 1px 0 rgba(255, 255, 255, 0.56);
 }
 
 .order-entry-console .order-console-display div {
   position: relative;
   min-height: 54px;
   padding: 8px 10px 8px 20px;
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.035);
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .order-entry-console .order-console-display div::before {
@@ -191,13 +192,13 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #ff3b10;
-  box-shadow: 0 0 10px rgba(255, 61, 16, 0.85);
+  background: #36c2cd;
+  box-shadow: 0 0 10px rgba(54, 194, 205, 0.72);
 }
 
 .order-entry-console .order-console-display span {
   display: block;
-  color: #aeb7b3;
+  color: #a8b8b9;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0;
@@ -206,12 +207,12 @@
 .order-entry-console .order-console-display strong {
   display: block;
   margin-top: 4px;
-  color: #f2f5f1;
+  color: #f1f6f5;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: clamp(15px, 1.6vw, 24px);
   font-weight: 700;
   line-height: 1.05;
-  text-shadow: 0 0 9px rgba(255, 72, 24, 0.35);
+  text-shadow: 0 0 8px rgba(54, 194, 205, 0.22);
 }
 
 .order-entry-console .order-console-workflow {
@@ -227,12 +228,12 @@
   gap: 8px;
   min-width: 0;
   padding: 8px 9px;
-  border: 1px solid rgba(55, 51, 44, 0.32);
-  border-radius: 5px;
-  background: linear-gradient(180deg, #ebe8df 0%, #cac6bb 100%);
+  border: 1px solid rgba(56, 64, 65, 0.28);
+  border-radius: 4px;
+  background: linear-gradient(180deg, #eef0ec 0%, #c9cec9 100%);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.74),
-    0 2px 7px rgba(43, 38, 32, 0.12);
+    0 2px 7px rgba(35, 42, 43, 0.1);
 }
 
 .order-entry-console .order-console-workflow-item > span {
@@ -240,24 +241,24 @@
   height: 9px;
   flex: 0 0 auto;
   border-radius: 999px;
-  background: #6f6b62;
+  background: #697173;
   box-shadow:
     inset 0 1px 1px rgba(255, 255, 255, 0.5),
     0 0 0 transparent;
 }
 
 .order-entry-console .order-console-workflow-item.is-active > span {
-  background: #ff4318;
+  background: #39b27f;
   box-shadow:
     inset 0 1px 1px rgba(255, 255, 255, 0.54),
-    0 0 10px rgba(255, 67, 24, 0.72);
+    0 0 9px rgba(57, 178, 127, 0.62);
 }
 
 .order-entry-console .order-console-workflow-item.is-warning > span {
-  background: #ffb21a;
+  background: #d79a24;
   box-shadow:
     inset 0 1px 1px rgba(255, 255, 255, 0.6),
-    0 0 10px rgba(255, 178, 26, 0.72);
+    0 0 9px rgba(215, 154, 36, 0.62);
 }
 
 .order-entry-console .order-console-workflow-item div {
@@ -273,7 +274,7 @@
 }
 
 .order-entry-console .order-console-workflow-item strong {
-  color: #25231f;
+  color: #1f2526;
   font-size: 11px;
   font-weight: 800;
   line-height: 1.15;
@@ -281,45 +282,45 @@
 }
 
 .order-entry-console .order-console-workflow-item small {
-  color: #615b51;
+  color: #586263;
   font-size: 11px;
   line-height: 1.25;
 }
 
 .order-entry-console label,
 .order-entry-console .font-medium {
-  color: #25231f;
+  color: #1f2526;
 }
 
 .order-entry-console input,
 .order-entry-console textarea,
 .order-entry-console button[role='combobox'],
 .order-entry-console .flex-1.flex.items-center.h-10 {
-  border-color: rgba(65, 61, 55, 0.38);
-  border-radius: 6px;
+  border-color: rgba(66, 73, 73, 0.34);
+  border-radius: 4px;
   background:
-    linear-gradient(180deg, #f8f7f2 0%, #e2dfd4 100%);
+    linear-gradient(180deg, #f8f8f5 0%, #e0e3de 100%);
   box-shadow:
     inset 0 1px 3px rgba(255, 255, 255, 0.85),
-    inset 0 -1px 2px rgba(55, 51, 45, 0.12);
+    inset 0 -1px 2px rgba(45, 52, 53, 0.1);
 }
 
 .order-entry-console input:focus,
 .order-entry-console textarea:focus,
 .order-entry-console button[role='combobox']:focus {
-  border-color: #ff5a1f;
+  border-color: #238ea2;
   box-shadow:
     inset 0 1px 3px rgba(255, 255, 255, 0.82),
-    0 0 0 2px rgba(255, 86, 31, 0.2),
-    0 0 16px rgba(255, 86, 31, 0.16);
+    0 0 0 2px rgba(35, 142, 162, 0.18),
+    0 0 14px rgba(35, 142, 162, 0.14);
 }
 
 .order-entry-console button:not([role='switch']):not([role='combobox']) {
-  border-radius: 5px;
+  border-radius: 4px;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.44),
-    inset 0 -2px 3px rgba(0, 0, 0, 0.22),
-    0 5px 12px rgba(39, 34, 29, 0.18);
+    inset 0 -2px 3px rgba(0, 0, 0, 0.18),
+    0 4px 10px rgba(31, 38, 39, 0.14);
 }
 
 .order-entry-console button:not([role='switch']):not([role='combobox']):active {
@@ -331,20 +332,20 @@
 
 .order-entry-console button.bg-primary,
 .order-entry-console button[class*='bg-primary'] {
-  border: 1px solid #a8300f;
-  background: linear-gradient(180deg, #ff6b28 0%, #e73712 58%, #b51f0b 100%);
+  border: 1px solid #1b5d6d;
+  background: linear-gradient(180deg, #2c9aae 0%, #1f7588 58%, #174f61 100%);
   color: white;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.34);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .order-entry-console .text-blue-600,
 .order-entry-console .text-green-600 {
-  color: #e83b12;
+  color: #146f80;
 }
 
 .order-entry-console .border-b,
 .order-entry-console .border-t {
-  border-color: rgba(79, 74, 65, 0.3);
+  border-color: rgba(76, 84, 84, 0.26);
 }
 
 .order-entry-console .bg-blue-50,
@@ -353,16 +354,16 @@
 .order-entry-console .bg-orange-50,
 .order-entry-console .bg-gray-50,
 .order-entry-console .bg-green-50 {
-  border-color: rgba(83, 76, 66, 0.28);
+  border-color: rgba(76, 84, 84, 0.24);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(216, 212, 201, 0.62)),
-    #e4e0d6;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(215, 219, 214, 0.62)),
+    #e4e6e1;
 }
 
 .order-entry-console .text-muted-foreground,
 .order-entry-console .text-gray-500,
 .order-entry-console .text-gray-600 {
-  color: #5d574d;
+  color: #576263;
 }
 
 .order-entry-console .order-console-workbench .space-y-4 > .grid,
@@ -382,22 +383,22 @@
 .order-entry-console .order-console-summary-card > div:first-child {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.1), transparent 52%),
-    #171915;
+    #151b1d;
 }
 
 .order-entry-console .order-console-summary-card > div:first-child h3,
 .order-entry-console .order-console-summary-card > div:first-child [class*='CardTitle'] {
-  color: #f3f3ef;
+  color: #f3f6f4;
 }
 
 .order-entry-console .order-console-summary-card .order-summary-total {
   margin: -2px -2px 12px;
   padding: 14px 12px 16px;
-  border: 1px solid rgba(20, 21, 19, 0.78);
-  border-radius: 6px;
+  border: 1px solid rgba(19, 24, 25, 0.76);
+  border-radius: 5px;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.06), transparent 48%),
-    #141714;
+    #121819;
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.06),
     inset 0 2px 18px rgba(0, 0, 0, 0.66);
@@ -406,45 +407,45 @@
 .order-entry-console .order-console-summary-card .order-summary-total span {
   color: #f1f4ef;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  text-shadow: 0 0 9px rgba(255, 65, 24, 0.24);
+  text-shadow: 0 0 8px rgba(54, 194, 205, 0.2);
 }
 
 .order-entry-console .order-console-summary-card .order-summary-total .text-muted-foreground span,
 .order-entry-console .order-console-summary-card .order-summary-total .text-muted-foreground {
-  color: #aeb7b0;
+  color: #a8b8b9;
   font-family: inherit;
   text-shadow: none;
 }
 
 .order-entry-console .order-console-summary-card .order-console-actions {
   padding: 10px;
-  border: 1px solid rgba(58, 53, 46, 0.38);
-  border-radius: 8px;
+  border: 1px solid rgba(59, 67, 67, 0.34);
+  border-radius: 6px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(174, 168, 154, 0.42)),
-    #cbc6ba;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(176, 184, 179, 0.42)),
+    #cbd0ca;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.7),
-    0 8px 20px rgba(35, 31, 27, 0.14);
+    0 8px 20px rgba(32, 38, 39, 0.12);
 }
 
 .order-entry-console .order-console-summary-card .order-console-actions button {
   min-height: 44px;
-  border: 1px solid rgba(60, 55, 48, 0.44);
+  border: 1px solid rgba(61, 69, 69, 0.42);
   font-weight: 800;
   text-transform: uppercase;
 }
 
 .order-entry-console .order-console-summary-card .order-console-actions button:last-child {
-  border-color: #9f2c0d;
+  border-color: #1c6877;
   background:
-    radial-gradient(circle at 30% 18%, rgba(255, 255, 255, 0.38), transparent 26%),
-    linear-gradient(180deg, #ff7030 0%, #eb3d13 56%, #ab1f08 100%);
+    radial-gradient(circle at 30% 18%, rgba(255, 255, 255, 0.34), transparent 26%),
+    linear-gradient(180deg, #31a7b8 0%, #237c8d 56%, #185567 100%);
   color: #fff;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.42),
-    inset 0 -3px 5px rgba(80, 7, 0, 0.34),
-    0 8px 16px rgba(205, 49, 14, 0.24);
+    inset 0 -3px 5px rgba(3, 39, 48, 0.28),
+    0 8px 16px rgba(35, 124, 141, 0.22);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

Tunes the existing `/order-entry` Console Mode toward a more professional industrial control-console style.

## Changes

- Shifts the console palette from warm/orange hardware toward cooler brushed steel and graphite.
- Uses teal/green status accents for active/ready states and amber only for warning/review states.
- Reduces glow intensity and button drama for a more operational ERP feel.
- Keeps the normal `/order-entry` mode untouched and preserves the existing Console Mode layout.

## Validation

- `git diff --check` passed for `client/src/index.css`.
- Full local app validation is still blocked by the checkout dependency/install state.