### PR TITLE
[codex] Add quote reconciliation release gates

### DIFF
--- a/client/src/components/P2POManager.tsx
+++ b/client/src/components/P2POManager.tsx
@@ -54,6 +54,9 @@ import {
   FolderOpen,
   Search,
   Eye,
+  AlertTriangle,
+  CheckCircle,
+  RefreshCw,
 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { apiRequest } from '@/lib/queryClient';
@@ -110,6 +113,19 @@ interface P2PurchaseOrder
   updatedAt: string;
 }
 
+interface QuotePoReconciliation {
+  id: string;
+  p2_purchase_order_id: number;
+  status: 'MATCH' | 'MISMATCH' | string;
+  revision_mismatch: boolean;
+  pricing_mismatch: boolean;
+  clause_mismatch: boolean;
+  schedule_mismatch: boolean;
+  quantity_mismatch: boolean;
+  mismatch_summary?: Record<string, any> | null;
+  checked_at: string;
+}
+
 interface P2POManagerProps {
   onManageItems?: (poId: number, poNumber: string) => void;
   selectedPOIds?: number[];
@@ -137,6 +153,17 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
   const { data: allQuotes = [] } = useQuery<Quote[]>({
     queryKey: ['/api/quotes'],
   });
+
+  const { data: quoteReconciliations = [] } = useQuery<QuotePoReconciliation[]>({
+    queryKey: ['/api/p2/quote-po-reconciliations/latest'],
+  });
+
+  const reconciliationByPoId = new Map(
+    quoteReconciliations.map((reconciliation) => [
+      reconciliation.p2_purchase_order_id,
+      reconciliation,
+    ])
+  );
 
   const sentQuotes = allQuotes.filter((quote) => quote.status === 'SENT');
 
@@ -327,6 +354,29 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
     },
   });
 
+  const reconcileQuoteMutation = useMutation({
+    mutationFn: (poId: number) =>
+      apiRequest(`/api/p2-purchase-orders/${poId}/reconcile-quote`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+      }),
+    onSuccess: (_data, poId) => {
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/quote-po-reconciliations/latest'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2-purchase-orders-bypass'] });
+      toast({
+        title: 'Quote reconciliation updated',
+        description: `PO ${poId} was checked against its source quote snapshot.`,
+      });
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Quote reconciliation failed',
+        description: error.message || 'Failed to reconcile this PO against its source quote.',
+        variant: 'destructive',
+      });
+    },
+  });
+
   const handleGenerateProductionOrders = (po: P2PurchaseOrder) => {
     if (
       confirm(
@@ -508,6 +558,17 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
       default:
         return 'outline';
     }
+  };
+
+  const getMismatchFlags = (reconciliation?: QuotePoReconciliation | null) => {
+    if (!reconciliation) return [];
+    return [
+      reconciliation.revision_mismatch && 'Revision',
+      reconciliation.pricing_mismatch && 'Pricing',
+      reconciliation.clause_mismatch && 'Clauses',
+      reconciliation.schedule_mismatch && 'Schedule',
+      reconciliation.quantity_mismatch && 'Quantity',
+    ].filter(Boolean) as string[];
   };
 
   const baseFilteredPOs = selectedPOIds.length > 0
@@ -911,7 +972,11 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
             </CardContent>
           </Card>
         ) : (
-          sortedPurchaseOrders.map((po) => (
+          sortedPurchaseOrders.map((po) => {
+            const quoteReconciliation = reconciliationByPoId.get(po.id);
+            const mismatchFlags = getMismatchFlags(quoteReconciliation);
+
+            return (
             <Card key={po.id}>
               <CardHeader>
                 <div className="flex justify-between items-start">
@@ -933,6 +998,23 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
                       <Badge variant="outline" className="border-amber-500 text-amber-600 dark:text-amber-400 flex items-center gap-1">
                         <Lock className="h-3 w-3" />
                         Locked
+                      </Badge>
+                    )}
+                    {po.sourceQuoteId && quoteReconciliation?.status === 'MATCH' && (
+                      <Badge variant="outline" className="border-green-500 text-green-700 dark:text-green-400 flex items-center gap-1">
+                        <CheckCircle className="h-3 w-3" />
+                        Quote Match
+                      </Badge>
+                    )}
+                    {po.sourceQuoteId && quoteReconciliation?.status === 'MISMATCH' && (
+                      <Badge variant="destructive" className="flex items-center gap-1">
+                        <AlertTriangle className="h-3 w-3" />
+                        Quote Mismatch
+                      </Badge>
+                    )}
+                    {po.sourceQuoteId && !quoteReconciliation && (
+                      <Badge variant="outline" className="border-yellow-500 text-yellow-700 dark:text-yellow-400">
+                        Reconcile Needed
                       </Badge>
                     )}
                   </div>
@@ -964,6 +1046,48 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
                     <span>Project: <span className="font-medium text-foreground">{po.projectName}</span></span>
                   </div>
                 )}
+                {po.sourceQuoteId && (
+                  <div className={`mb-4 rounded-md border p-3 text-sm ${
+                    quoteReconciliation?.status === 'MISMATCH'
+                      ? 'border-red-200 bg-red-50 text-red-900 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-200'
+                      : !quoteReconciliation
+                      ? 'border-yellow-200 bg-yellow-50 text-yellow-900 dark:border-yellow-900/50 dark:bg-yellow-950/20 dark:text-yellow-200'
+                      : 'border-green-200 bg-green-50 text-green-900 dark:border-green-900/50 dark:bg-green-950/20 dark:text-green-200'
+                  }`}>
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex items-center gap-2 font-medium">
+                        {quoteReconciliation?.status === 'MISMATCH' || !quoteReconciliation ? (
+                          <AlertTriangle className="h-4 w-4" />
+                        ) : (
+                          <CheckCircle className="h-4 w-4" />
+                        )}
+                        Quote Snapshot Reconciliation
+                      </div>
+                      {quoteReconciliation?.checked_at && (
+                        <span className="text-xs opacity-75">
+                          Checked {format(new Date(quoteReconciliation.checked_at), 'MMM d, yyyy h:mm a')}
+                      </span>
+                      )}
+                    </div>
+                    {!quoteReconciliation ? (
+                      <p className="mt-1 text-xs opacity-80">
+                        Run reconciliation to compare revision, pricing, clauses, schedule, and quantity against the latest sent quote snapshot.
+                      </p>
+                    ) : mismatchFlags.length > 0 ? (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {mismatchFlags.map((flag) => (
+                          <Badge key={flag} variant="destructive" className="text-xs">
+                            {flag} mismatch
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="mt-1 text-xs opacity-80">
+                        Revision, pricing, clauses, schedule, and quantity are aligned with the latest sent quote snapshot.
+                      </p>
+                    )}
+                  </div>
+                )}
                 {po.notes && (
                   <p className="text-sm text-muted-foreground mb-4">
                     {po.notes}
@@ -988,6 +1112,19 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
                     <Eye className="h-4 w-4 mr-2" />
                     Preview PO
                   </Button>
+                  {po.sourceQuoteId && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => reconcileQuoteMutation.mutate(po.id)}
+                      disabled={reconcileQuoteMutation.isPending}
+                      data-testid={`button-reconcile-quote-${po.id}`}
+                      title="Re-check revision, pricing, clauses, schedule, and quantity against the sent quote snapshot"
+                    >
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      Reconcile Quote
+                    </Button>
+                  )}
                   {po.status === 'OPEN' && (
                     <>
                       <Button
@@ -1074,7 +1211,8 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
                 </div>
               </CardContent>
             </Card>
-          ))
+            );
+          })
         )}
       </div>
     </div>

--- a/migrations/0127_quote_contract_snapshot_release_gates.sql
+++ b/migrations/0127_quote_contract_snapshot_release_gates.sql
@@ -1,0 +1,4 @@
+-- Section 2 quoting contracts: snapshot clause payloads and release-gate support.
+
+ALTER TABLE quote_snapshots
+  ADD COLUMN IF NOT EXISTS contractual_clauses JSONB;

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -9964,6 +9964,7 @@ export const quoteSnapshots = pgTable('quote_snapshots', {
   leadTimes: jsonb('lead_times').$type<Record<string, unknown> | unknown[] | null>(),
   exclusions: jsonb('exclusions').$type<Record<string, unknown> | unknown[] | null>(),
   certRequirements: jsonb('cert_requirements').$type<Record<string, unknown> | unknown[] | null>(),
+  contractualClauses: jsonb('contractual_clauses').$type<Record<string, unknown> | unknown[] | null>(),
   sourceData: jsonb('source_data').$type<Record<string, unknown> | null>(),
   sentAt: timestamp('sent_at').defaultNow().notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3702,6 +3702,17 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     }
   });
 
+  app.get('/api/p2/quote-po-reconciliations/latest', async (_req, res) => {
+    try {
+      const { getLatestQuotePoReconciliations } = await import('../services/quoteContractService');
+      const reconciliations = await getLatestQuotePoReconciliations();
+      res.json(reconciliations);
+    } catch (error) {
+      console.error('Get latest P2 quote reconciliations error:', error);
+      res.status(500).json({ error: 'Failed to fetch latest quote reconciliations' });
+    }
+  });
+
   app.get('/api/p2-purchase-orders/:id/quote-reconciliation', async (req, res) => {
     try {
       const poId = parseInt(req.params.id, 10);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -7,6 +7,7 @@ import { createEmployeeIdentitySnapshot } from '../../identity/userIdentity';
 import { validateProjectClosing, deriveClosingStatus } from '../lib/projectClosingValidation';
 import { ensureProjectHasWAD } from '../lib/wadHelper';
 import { resolveCustomersIntegerId } from '../lib/customerResolver';
+import { getQuoteContractReviewGate } from '../services/quoteContractService';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
@@ -602,6 +603,7 @@ router.post('/', async (req, res) => {
     
     const validatedData = validationResult.data;
     const { quoteId, customerNameSnapshot, ...projectFields } = validatedData;
+
     const nextCode = await storage.getNextProjectCode();
 
     // Resolve the integer FK to the master customers table from the text customerId.
@@ -1062,7 +1064,7 @@ router.patch('/:projectId/steps/:stepId/reopen', async (req, res) => {
 });
 
 // POST /api/projects/:id/release-to-p2 — P2 Release Gate endpoint
-// Three-way gate: PO Review + WAD + Preproduction must all pass
+// Release gate: PO Review + Contract Review + WAD + Preproduction must all pass
 // First call (pre-gate) → sets stage to p2_release and PO to ready_for_p2_release
 // Second call (staged) → sets stage to production and PO to in_production
 // Repeated calls once in production → 409 (idempotent-safe)
@@ -1119,8 +1121,12 @@ router.post('/:id/release-to-p2', async (req, res) => {
     const workOrders = await storage.getWorkOrdersByProject(id);
     const wadPassed = workOrders.some(wo => WAD_APPROVED_STATUSES.includes(wo.status));
 
+    const quoteStep = steps.find(s => s.stepType === 'quote');
+    const contractReviewGate = await getQuoteContractReviewGate(quoteStep?.linkedQuoteId ?? null, id);
+
     const gates = [
       { key: 'po_review', label: 'PO Review', passed: poReviewPassed },
+      contractReviewGate,
       { key: 'wad', label: 'WAD (Work Authorization Document)', passed: wadPassed },
       { key: 'preproduction', label: 'Preproduction', passed: preproductionPassed },
     ];
@@ -1217,8 +1223,12 @@ router.get('/:id/p2-gate-status', async (req, res) => {
     const workOrders = await storage.getWorkOrdersByProject(id);
     const wadPassed = workOrders.some(wo => WAD_APPROVED_STATUSES.includes(wo.status));
 
+    const quoteStep = steps.find(s => s.stepType === 'quote');
+    const contractReviewGate = await getQuoteContractReviewGate(quoteStep?.linkedQuoteId ?? null, id);
+
     const gates = [
       { key: 'po_review', label: 'PO Review', passed: poReviewPassed },
+      contractReviewGate,
       { key: 'wad', label: 'WAD (Work Authorization Document)', passed: wadPassed },
       { key: 'preproduction', label: 'Preproduction', passed: preproductionPassed },
     ];

--- a/server/src/routes/quotes.ts
+++ b/server/src/routes/quotes.ts
@@ -509,7 +509,7 @@ router.post('/api/quotes/save', async (req: Request, res: Response) => {
 // Submit quote (change status to SENT and send email)
 router.post('/api/quotes/submit', async (req: Request, res: Response) => {
   try {
-    const { id, revisionLabel, exclusions, certRequirements } = req.body;
+    const { id, revisionLabel, exclusions, certRequirements, contractualClauses } = req.body;
 
     if (!id) {
       return res.status(400).json({ error: 'Quote ID is required' });
@@ -561,6 +561,7 @@ router.post('/api/quotes/submit', async (req: Request, res: Response) => {
       revisionLabel,
       exclusions,
       certRequirements,
+      contractualClauses,
     });
 
     res.json({

--- a/server/src/services/quoteContractService.ts
+++ b/server/src/services/quoteContractService.ts
@@ -19,6 +19,32 @@ function normalizeText(value: unknown): string {
   return String(value ?? '').trim().toLowerCase();
 }
 
+function hasMeaningfulValue(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasMeaningfulValue);
+  if (value && typeof value === 'object') return Object.values(value).some(hasMeaningfulValue);
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return normalized !== '' && normalized !== 'n/a' && normalized !== 'na' && normalized !== 'none';
+}
+
+function arrayPayload(value: unknown): unknown[] {
+  if (!hasMeaningfulValue(value)) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function uniqueText(values: unknown[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const text = String(value ?? '').trim();
+    if (!text) continue;
+    const key = text.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(text);
+  }
+  return result;
+}
+
 function sameDate(a: unknown, b: unknown): boolean {
   if (!a || !b) return !a && !b;
   const ad = new Date(String(a));
@@ -34,6 +60,29 @@ function extractRevision(...values: unknown[]): string | null {
     if (match?.[1]) return match[1].toUpperCase();
   }
   return null;
+}
+
+function extractClauseNumbers(...values: unknown[]): string[] {
+  const clauses: string[] = [];
+  for (const value of values) {
+    const text = JSON.stringify(value ?? '');
+    const matches = text.match(/\b(?:FAR|DFARS)\s+\d{1,3}\.\d{3}(?:-\d+)?\b/gi) ?? [];
+    clauses.push(...matches.map((match) => match.replace(/\s+/g, ' ').toUpperCase()));
+  }
+  return uniqueText(clauses);
+}
+
+function buildSnapshotPayloadChecks(payload: Record<string, unknown>) {
+  const checks = Object.entries(payload).map(([key, value]) => ({
+    key,
+    present: hasMeaningfulValue(value),
+    count: Array.isArray(value) ? value.length : hasMeaningfulValue(value) ? 1 : 0,
+  }));
+  return {
+    complete: checks.every((check) => check.present),
+    missing: checks.filter((check) => !check.present).map((check) => check.key),
+    checks,
+  };
 }
 
 async function nextRevisionNumber(quoteId: string): Promise<number> {
@@ -113,6 +162,7 @@ export async function createQuoteSnapshot(
     revisionLabel?: string | null;
     exclusions?: unknown;
     certRequirements?: unknown;
+    contractualClauses?: unknown;
     sentAt?: Date;
   } = {},
 ) {
@@ -145,6 +195,28 @@ export async function createQuoteSnapshot(
     estimating.rfq?.revision ||
     `R${revisionNumber}`;
   const sentAt = options.sentAt ?? new Date();
+  const leadTimes = {
+    pricingSnapshots: estimating.pricingSnapshots.map((snap) => ({
+      rfqPartId: snap.rfq_part_id,
+      quantityBreakId: snap.quantity_break_id,
+      leadTimeDays: snap.lead_time_days,
+    })),
+    quantityBreaks: estimating.quantityBreaks,
+  };
+  const exclusions = arrayPayload(options.exclusions);
+  const certRequirements = arrayPayload(options.certRequirements ?? estimating.complianceFlags);
+  const contractualClauses = uniqueText([
+    ...arrayPayload(options.contractualClauses),
+    ...extractClauseNumbers(quote.notes, options.exclusions, options.certRequirements, estimating.complianceFlags, estimating.rfq),
+  ]);
+  const payloadChecks = buildSnapshotPayloadChecks({
+    bomAssumptions: estimating.bomLines,
+    laborAssumptions: estimating.processRows,
+    leadTimes,
+    exclusions,
+    certRequirements,
+    contractualClauses,
+  });
 
   const snapshot = firstRow<any>(
     await pool.query(
@@ -152,12 +224,12 @@ export async function createQuoteSnapshot(
         quote_id, quote_number, revision_number, revision_label, status_at_snapshot,
         customer_id, customer_name, customers_integer_id, description, total_amount,
         valid_until, quoted_by, notes, bom_assumptions, labor_assumptions,
-        lead_times, exclusions, cert_requirements, source_data, sent_at
+        lead_times, exclusions, cert_requirements, contractual_clauses, source_data, sent_at
        ) VALUES (
         $1, $2, $3, $4, $5,
         $6, $7, $8, $9, $10,
         $11, $12, $13, $14::jsonb, $15::jsonb,
-        $16::jsonb, $17::jsonb, $18::jsonb, $19::jsonb, $20
+        $16::jsonb, $17::jsonb, $18::jsonb, $19::jsonb, $20::jsonb, $21
        )
        RETURNING *`,
       [
@@ -176,17 +248,11 @@ export async function createQuoteSnapshot(
         quote.notes ?? null,
         JSON.stringify(estimating.bomLines),
         JSON.stringify(estimating.processRows),
-        JSON.stringify({
-          pricingSnapshots: estimating.pricingSnapshots.map((snap) => ({
-            rfqPartId: snap.rfq_part_id,
-            quantityBreakId: snap.quantity_break_id,
-            leadTimeDays: snap.lead_time_days,
-          })),
-          quantityBreaks: estimating.quantityBreaks,
-        }),
-        JSON.stringify(options.exclusions ?? []),
-        JSON.stringify(options.certRequirements ?? estimating.complianceFlags),
-        JSON.stringify({ estimatingRfq: estimating.rfq }),
+        JSON.stringify(leadTimes),
+        JSON.stringify(exclusions),
+        JSON.stringify(certRequirements),
+        JSON.stringify(contractualClauses),
+        JSON.stringify({ estimatingRfq: estimating.rfq, payloadChecks }),
         sentAt,
       ],
     ),
@@ -235,6 +301,62 @@ export async function createQuoteSnapshot(
   }
 
   return snapshot;
+}
+
+export async function getQuoteContractReviewGate(quoteId: string | null | undefined, projectId?: string | null) {
+  if (!quoteId && !projectId) {
+    return {
+      key: 'contract_review',
+      label: 'Contract Review',
+      passed: false,
+      status: 'missing_link',
+      message: 'No source quote or project link is available for contract review.',
+    };
+  }
+
+  const snapshot = quoteId ? await latestSnapshot(quoteId) : null;
+  const params: unknown[] = [];
+  const predicates: string[] = [];
+  if (quoteId) {
+    params.push(quoteId);
+    predicates.push(`form_data->>'quoteId' = $${params.length}`);
+    predicates.push(`form_data->>'quote_id' = $${params.length}`);
+  }
+  if (projectId) {
+    params.push(projectId);
+    predicates.push(`form_data->>'projectId' = $${params.length}`);
+    predicates.push(`form_data->>'project_id' = $${params.length}`);
+  }
+
+  const review = predicates.length > 0
+    ? firstRow<any>(
+        await pool.query(
+          `SELECT id, status, form_data, updated_at
+           FROM purchase_review_checklists
+           WHERE ${predicates.map((predicate) => `(${predicate})`).join(' OR ')}
+           ORDER BY updated_at DESC, created_at DESC
+           LIMIT 1`,
+          params,
+        ),
+      )
+    : null;
+  const reviewApproved = normalizeText(review?.status) === 'approved';
+
+  return {
+    key: 'contract_review',
+    label: 'Contract Review',
+    passed: Boolean(snapshot && reviewApproved),
+    status: !snapshot ? 'missing_snapshot' : reviewApproved ? 'approved' : review ? 'review_not_approved' : 'missing_review',
+    quoteSnapshotId: snapshot?.id ?? null,
+    quoteRevision: snapshot?.revision_label ?? null,
+    purchaseReviewChecklistId: review?.id ?? null,
+    purchaseReviewStatus: review?.status ?? null,
+    message: !snapshot
+      ? 'A sent quote snapshot is required before project release.'
+      : reviewApproved
+        ? 'Contract review is approved for the quote snapshot.'
+        : 'Purchase review checklist must be approved before project release.',
+  };
 }
 
 export async function reconcileCustomerPoToQuote(poId: number) {
@@ -301,14 +423,16 @@ export async function reconcileCustomerPoToQuote(poId: number) {
       : false;
 
   const snapshotCerts = JSON.stringify(snapshot.cert_requirements ?? []);
+  const snapshotClauses = JSON.stringify(snapshot.contractual_clauses ?? []);
   const poClauseText = normalizeText(`${po.notes ?? ''} ${poItems.map((item) => `${item.specifications ?? ''} ${item.notes ?? ''}`).join(' ')}`);
   const clauseMismatch =
-    snapshotCerts !== '[]' &&
-    snapshotCerts !== 'null' &&
+    ((snapshotCerts !== '[]' && snapshotCerts !== 'null') || (snapshotClauses !== '[]' && snapshotClauses !== 'null')) &&
     !poClauseText.includes('cert') &&
     !poClauseText.includes('coc') &&
     !poClauseText.includes('sds') &&
-    !poClauseText.includes('tds');
+    !poClauseText.includes('tds') &&
+    !poClauseText.includes('far') &&
+    !poClauseText.includes('dfars');
 
   const status =
     revisionMismatch || pricingMismatch || clauseMismatch || scheduleMismatch || quantityMismatch
@@ -320,7 +444,7 @@ export async function reconcileCustomerPoToQuote(poId: number) {
     pricing: { quoteTotal, poTotal, mismatch: pricingMismatch },
     revision: { quoteRevision: snapshot.revision_label, poRevisions: poRevisionCandidates, mismatch: revisionMismatch },
     schedule: { quoteValidUntil: snapshot.valid_until, poExpectedDelivery: po.expected_delivery, mismatch: scheduleMismatch },
-    clauses: { requiredCerts: snapshot.cert_requirements ?? [], mismatch: clauseMismatch },
+    clauses: { requiredCerts: snapshot.cert_requirements ?? [], contractualClauses: snapshot.contractual_clauses ?? [], mismatch: clauseMismatch },
   };
 
   return firstRow<any>(
@@ -361,6 +485,16 @@ export async function getLatestQuotePoReconciliation(poId: number) {
        ORDER BY checked_at DESC, created_at DESC
        LIMIT 1`,
       [poId],
+    ),
+  );
+}
+
+export async function getLatestQuotePoReconciliations() {
+  return rowsFrom<any>(
+    await pool.query(
+      `SELECT DISTINCT ON (p2_purchase_order_id) *
+       FROM quote_po_reconciliations
+       ORDER BY p2_purchase_order_id, checked_at DESC, created_at DESC`,
     ),
   );
 }


### PR DESCRIPTION
## Summary
- Expand sent quote snapshots with contractual clause payload capture and payload completeness checks for BOM assumptions, labor assumptions, lead times, exclusions, cert requirements, and clauses.
- Add latest quote-to-PO reconciliation API support and surface revision, pricing, clause, schedule, and quantity mismatch flags in the P2 PO manager UI.
- Add contract review as an explicit P2 release gate by requiring an approved purchase review checklist tied to the quote/project before project release.

## Validation
- `git diff --cached --check`
- `git diff --check origin/main..HEAD`

## Notes
- Local build/test was not run because this checkout has no `npm` and no `node_modules` available in the environment.
- Overlap risk: this builds directly on the quote snapshot and PO reconciliation foundation already present on `origin/main`; branch was rebased onto latest `origin/main` before push.