### PR TITLE
Add contract PO review flowdown foundation

### DIFF
--- a/migrations/0127_contract_po_review_flowdown.sql
+++ b/migrations/0127_contract_po_review_flowdown.sql
@@ -1,0 +1,280 @@
+-- Section 3: Contract / PO review foundation.
+-- Idempotent: safe to run on environments where this branch was partially applied.
+
+CREATE TABLE IF NOT EXISTS contract_review_checklist_templates (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  description text,
+  version integer NOT NULL DEFAULT 1,
+  review_areas text[] NOT NULL DEFAULT ARRAY['engineering','quality','procurement','scheduling','finance']::text[],
+  checklist_items jsonb NOT NULL DEFAULT '[]'::jsonb,
+  applicability_rule jsonb,
+  status text NOT NULL DEFAULT 'draft',
+  is_active boolean NOT NULL DEFAULT true,
+  created_by_user_id integer,
+  created_by_display_name text,
+  created_at timestamp NOT NULL DEFAULT NOW(),
+  updated_at timestamp NOT NULL DEFAULT NOW(),
+  UNIQUE(name, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_review_templates_active
+  ON contract_review_checklist_templates(is_active);
+
+CREATE TABLE IF NOT EXISTS contract_clauses (
+  id serial PRIMARY KEY,
+  clause_number text NOT NULL UNIQUE,
+  title text NOT NULL,
+  description text,
+  clause_type text NOT NULL DEFAULT 'CUSTOMER',
+  source text NOT NULL DEFAULT 'contract_review',
+  default_flow_targets text[] NOT NULL DEFAULT ARRAY['po','traveler','qc','supplier_po','cert_package']::text[],
+  is_active boolean NOT NULL DEFAULT true,
+  effective_date timestamp,
+  retired_at timestamp,
+  created_at timestamp NOT NULL DEFAULT NOW(),
+  updated_at timestamp NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_clauses_active
+  ON contract_clauses(is_active);
+
+CREATE INDEX IF NOT EXISTS idx_contract_clauses_type
+  ON contract_clauses(clause_type);
+
+CREATE TABLE IF NOT EXISTS clause_templates (
+  id serial PRIMARY KEY,
+  checklist_template_id integer NOT NULL REFERENCES contract_review_checklist_templates(id) ON DELETE CASCADE,
+  contract_clause_id integer NOT NULL REFERENCES contract_clauses(id) ON DELETE CASCADE,
+  review_area text NOT NULL,
+  requirement_text text NOT NULL,
+  required_artifacts text[] NOT NULL DEFAULT ARRAY[]::text[],
+  flow_targets text[] NOT NULL DEFAULT ARRAY['po','traveler','qc','supplier_po','cert_package']::text[],
+  applicability_rule jsonb,
+  required boolean NOT NULL DEFAULT true,
+  created_at timestamp NOT NULL DEFAULT NOW(),
+  updated_at timestamp NOT NULL DEFAULT NOW(),
+  UNIQUE(checklist_template_id, contract_clause_id, review_area),
+  CHECK (review_area IN ('engineering','quality','procurement','scheduling','finance'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_clause_templates_template_id
+  ON clause_templates(checklist_template_id);
+
+CREATE INDEX IF NOT EXISTS idx_clause_templates_clause_id
+  ON clause_templates(contract_clause_id);
+
+CREATE TABLE IF NOT EXISTS contract_review_checklist_instances (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  checklist_template_id integer NOT NULL REFERENCES contract_review_checklist_templates(id) ON DELETE RESTRICT,
+  project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
+  purchase_review_checklist_id integer REFERENCES purchase_review_checklists(id) ON DELETE SET NULL,
+  p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
+  vendor_po_id integer REFERENCES vendor_pos(id) ON DELETE SET NULL,
+  traveler_id varchar(255) REFERENCES travelers(id) ON DELETE SET NULL,
+  status text NOT NULL DEFAULT 'draft',
+  review_area_status jsonb NOT NULL DEFAULT '{}'::jsonb,
+  responses jsonb NOT NULL DEFAULT '{}'::jsonb,
+  missing_review_areas text[] NOT NULL DEFAULT ARRAY[]::text[],
+  created_by_user_id integer,
+  created_by_display_name text,
+  submitted_at timestamp,
+  approved_at timestamp,
+  created_at timestamp NOT NULL DEFAULT NOW(),
+  updated_at timestamp NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_review_instances_project_id
+  ON contract_review_checklist_instances(project_id);
+
+CREATE INDEX IF NOT EXISTS idx_contract_review_instances_template_id
+  ON contract_review_checklist_instances(checklist_template_id);
+
+CREATE INDEX IF NOT EXISTS idx_contract_review_instances_vendor_po_id
+  ON contract_review_checklist_instances(vendor_po_id);
+
+CREATE TABLE IF NOT EXISTS flowed_requirements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  contract_review_instance_id uuid REFERENCES contract_review_checklist_instances(id) ON DELETE CASCADE,
+  contract_clause_id integer NOT NULL REFERENCES contract_clauses(id) ON DELETE RESTRICT,
+  clause_template_id integer REFERENCES clause_templates(id) ON DELETE SET NULL,
+  target_type text NOT NULL,
+  target_id text NOT NULL,
+  requirement_text text NOT NULL,
+  required_artifacts text[] NOT NULL DEFAULT ARRAY[]::text[],
+  status text NOT NULL DEFAULT 'open',
+  source text NOT NULL DEFAULT 'contract_review',
+  flowed_at timestamp NOT NULL DEFAULT NOW(),
+  satisfied_at timestamp,
+  satisfied_by_user_id integer,
+  satisfied_by_display_name text,
+  evidence jsonb,
+  created_at timestamp NOT NULL DEFAULT NOW(),
+  updated_at timestamp NOT NULL DEFAULT NOW(),
+  UNIQUE(contract_review_instance_id, contract_clause_id, target_type, target_id),
+  CHECK (target_type IN ('po','traveler','qc','supplier_po','cert_package'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_flowed_requirements_target
+  ON flowed_requirements(target_type, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_flowed_requirements_instance_id
+  ON flowed_requirements(contract_review_instance_id);
+
+CREATE INDEX IF NOT EXISTS idx_flowed_requirements_clause_id
+  ON flowed_requirements(contract_clause_id);
+
+INSERT INTO contract_review_checklist_templates (
+  name,
+  description,
+  version,
+  review_areas,
+  checklist_items,
+  status,
+  is_active
+)
+VALUES (
+  'Section 3 Contract / PO Review',
+  'Baseline cross-functional contract and PO review template for engineering, quality, procurement, scheduling, and finance.',
+  1,
+  ARRAY['engineering','quality','procurement','scheduling','finance']::text[],
+  '[
+    {"area":"engineering","label":"Confirm technical data, drawings, specs, and manufacturability requirements."},
+    {"area":"quality","label":"Confirm inspection, acceptance, certification, and flowed quality requirements."},
+    {"area":"procurement","label":"Confirm supplier PO flowdowns, debarment, sourcing, and purchasing controls."},
+    {"area":"scheduling","label":"Confirm delivery, DPAS, lead-time, and traveler schedule constraints."},
+    {"area":"finance","label":"Confirm pricing, funding, billing, tax, and contract accounting implications."}
+  ]'::jsonb,
+  'approved',
+  true
+)
+ON CONFLICT (name, version) DO NOTHING;
+
+INSERT INTO contract_clauses (
+  clause_number,
+  title,
+  description,
+  clause_type,
+  source,
+  default_flow_targets
+)
+VALUES
+  (
+    'EPOCH-CR-ENG-001',
+    'Engineering Technical Data Flowdown',
+    'Engineering must confirm drawings, specifications, revision levels, customer technical data, and manufacturability constraints before release.',
+    'INTERNAL',
+    'section_3_contract_review',
+    ARRAY['po','traveler']::text[]
+  ),
+  (
+    'EPOCH-CR-QUAL-001',
+    'Quality and Acceptance Requirement Flowdown',
+    'Quality must confirm inspection plans, acceptance criteria, special process controls, and customer quality clauses before work release.',
+    'QUALITY',
+    'section_3_contract_review',
+    ARRAY['traveler','qc','cert_package']::text[]
+  ),
+  (
+    'EPOCH-CR-PROC-001',
+    'Procurement Supplier Flowdown',
+    'Procurement must flow applicable customer, FAR/DFARS, quality, packaging, and certification requirements to supplier purchase orders.',
+    'INTERNAL',
+    'section_3_contract_review',
+    ARRAY['supplier_po']::text[]
+  ),
+  (
+    'EPOCH-CR-SCHED-001',
+    'Schedule and Priority Flowdown',
+    'Scheduling must confirm required delivery dates, DPAS or customer priority constraints, lead times, and traveler schedule risk.',
+    'INTERNAL',
+    'section_3_contract_review',
+    ARRAY['po','traveler']::text[]
+  ),
+  (
+    'EPOCH-CR-FIN-001',
+    'Finance Contract Accounting Review',
+    'Finance must confirm pricing, billing, tax, funding, payment terms, and contract accounting treatment before release.',
+    'INTERNAL',
+    'section_3_contract_review',
+    ARRAY['po','cert_package']::text[]
+  )
+ON CONFLICT (clause_number) DO NOTHING;
+
+WITH base_template AS (
+  SELECT id
+  FROM contract_review_checklist_templates
+  WHERE name = 'Section 3 Contract / PO Review'
+    AND version = 1
+  LIMIT 1
+),
+seed_rows AS (
+  SELECT
+    base_template.id AS checklist_template_id,
+    contract_clauses.id AS contract_clause_id,
+    seed.review_area,
+    seed.requirement_text,
+    seed.required_artifacts,
+    seed.flow_targets
+  FROM base_template
+  JOIN (
+    VALUES
+      (
+        'EPOCH-CR-ENG-001',
+        'engineering',
+        'Flow confirmed engineering requirements into the customer PO record and traveler execution package.',
+        ARRAY['approved drawing/spec revision','engineering review signoff']::text[],
+        ARRAY['po','traveler']::text[]
+      ),
+      (
+        'EPOCH-CR-QUAL-001',
+        'quality',
+        'Flow confirmed inspection, acceptance, and quality clauses into traveler QC tasks and the final cert package.',
+        ARRAY['inspection plan','acceptance criteria','quality signoff']::text[],
+        ARRAY['traveler','qc','cert_package']::text[]
+      ),
+      (
+        'EPOCH-CR-PROC-001',
+        'procurement',
+        'Flow customer and government contract requirements into supplier purchase order terms and required supplier evidence.',
+        ARRAY['supplier PO terms','supplier certification evidence']::text[],
+        ARRAY['supplier_po']::text[]
+      ),
+      (
+        'EPOCH-CR-SCHED-001',
+        'scheduling',
+        'Flow due date, DPAS, and schedule-risk requirements into the PO and traveler planning record.',
+        ARRAY['schedule review','delivery commitment']::text[],
+        ARRAY['po','traveler']::text[]
+      ),
+      (
+        'EPOCH-CR-FIN-001',
+        'finance',
+        'Flow pricing, payment, billing, and contract-accounting requirements into PO and cert-package closeout evidence.',
+        ARRAY['finance review','billing terms confirmation']::text[],
+        ARRAY['po','cert_package']::text[]
+      )
+  ) AS seed(clause_number, review_area, requirement_text, required_artifacts, flow_targets)
+    ON true
+  JOIN contract_clauses
+    ON contract_clauses.clause_number = seed.clause_number
+)
+INSERT INTO clause_templates (
+  checklist_template_id,
+  contract_clause_id,
+  review_area,
+  requirement_text,
+  required_artifacts,
+  flow_targets,
+  required
+)
+SELECT
+  checklist_template_id,
+  contract_clause_id,
+  review_area,
+  requirement_text,
+  required_artifacts,
+  flow_targets,
+  true
+FROM seed_rows
+ON CONFLICT (checklist_template_id, contract_clause_id, review_area) DO NOTHING;

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -18027,6 +18027,110 @@ export const projectFarFlowdowns = pgTable('project_far_flowdowns', {
   checklistIdx: index('idx_project_far_flowdowns_checklist_id').on(t.purchaseReviewChecklistId),
 }));
 
+export const contractReviewChecklistTemplates = pgTable('contract_review_checklist_templates', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  description: text('description'),
+  version: integer('version').notNull().default(1),
+  reviewAreas: text('review_areas').array().notNull().default(sql`ARRAY['engineering','quality','procurement','scheduling','finance']::text[]`),
+  checklistItems: jsonb('checklist_items').$type<Array<Record<string, unknown>>>().notNull().default(sql`'[]'::jsonb`),
+  applicabilityRule: jsonb('applicability_rule').$type<Record<string, unknown> | null>(),
+  status: text('status').notNull().default('draft'),
+  isActive: boolean('is_active').notNull().default(true),
+  createdByUserId: integer('created_by_user_id'),
+  createdByDisplayName: text('created_by_display_name'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  activeIdx: index('idx_contract_review_templates_active').on(t.isActive),
+  nameVersionUnique: unique().on(t.name, t.version),
+}));
+
+export const contractClauses = pgTable('contract_clauses', {
+  id: serial('id').primaryKey(),
+  clauseNumber: text('clause_number').notNull().unique(),
+  title: text('title').notNull(),
+  description: text('description'),
+  clauseType: text('clause_type').notNull().default('CUSTOMER'), // FAR | DFARS | CUSTOMER | QUALITY | INTERNAL
+  source: text('source').notNull().default('contract_review'),
+  defaultFlowTargets: text('default_flow_targets').array().notNull().default(sql`ARRAY['po','traveler','qc','supplier_po','cert_package']::text[]`),
+  isActive: boolean('is_active').notNull().default(true),
+  effectiveDate: timestamp('effective_date'),
+  retiredAt: timestamp('retired_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  activeIdx: index('idx_contract_clauses_active').on(t.isActive),
+  typeIdx: index('idx_contract_clauses_type').on(t.clauseType),
+}));
+
+export const clauseTemplates = pgTable('clause_templates', {
+  id: serial('id').primaryKey(),
+  checklistTemplateId: integer('checklist_template_id').notNull().references(() => contractReviewChecklistTemplates.id, { onDelete: 'cascade' }),
+  contractClauseId: integer('contract_clause_id').notNull().references(() => contractClauses.id, { onDelete: 'cascade' }),
+  reviewArea: text('review_area').notNull(),
+  requirementText: text('requirement_text').notNull(),
+  requiredArtifacts: text('required_artifacts').array().notNull().default(sql`ARRAY[]::text[]`),
+  flowTargets: text('flow_targets').array().notNull().default(sql`ARRAY['po','traveler','qc','supplier_po','cert_package']::text[]`),
+  applicabilityRule: jsonb('applicability_rule').$type<Record<string, unknown> | null>(),
+  required: boolean('required').notNull().default(true),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  templateClauseUnique: unique().on(t.checklistTemplateId, t.contractClauseId, t.reviewArea),
+  templateIdx: index('idx_clause_templates_template_id').on(t.checklistTemplateId),
+  clauseIdx: index('idx_clause_templates_clause_id').on(t.contractClauseId),
+}));
+
+export const contractReviewChecklistInstances = pgTable('contract_review_checklist_instances', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  checklistTemplateId: integer('checklist_template_id').notNull().references(() => contractReviewChecklistTemplates.id, { onDelete: 'restrict' }),
+  projectId: uuid('project_id').references(() => projects.id, { onDelete: 'set null' }),
+  purchaseReviewChecklistId: integer('purchase_review_checklist_id').references(() => purchaseReviewChecklists.id, { onDelete: 'set null' }),
+  p2PurchaseOrderId: integer('p2_purchase_order_id').references(() => p2PurchaseOrders.id, { onDelete: 'set null' }),
+  vendorPoId: integer('vendor_po_id').references(() => vendorPOs.id, { onDelete: 'set null' }),
+  travelerId: varchar('traveler_id', { length: 255 }).references(() => travelers.id, { onDelete: 'set null' }),
+  status: text('status').notNull().default('draft'),
+  reviewAreaStatus: jsonb('review_area_status').$type<Record<string, unknown>>().notNull().default(sql`'{}'::jsonb`),
+  responses: jsonb('responses').$type<Record<string, unknown>>().notNull().default(sql`'{}'::jsonb`),
+  missingReviewAreas: text('missing_review_areas').array().notNull().default(sql`ARRAY[]::text[]`),
+  createdByUserId: integer('created_by_user_id'),
+  createdByDisplayName: text('created_by_display_name'),
+  submittedAt: timestamp('submitted_at'),
+  approvedAt: timestamp('approved_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  projectIdx: index('idx_contract_review_instances_project_id').on(t.projectId),
+  templateIdx: index('idx_contract_review_instances_template_id').on(t.checklistTemplateId),
+  vendorPoIdx: index('idx_contract_review_instances_vendor_po_id').on(t.vendorPoId),
+}));
+
+export const flowedRequirements = pgTable('flowed_requirements', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  contractReviewInstanceId: uuid('contract_review_instance_id').references(() => contractReviewChecklistInstances.id, { onDelete: 'cascade' }),
+  contractClauseId: integer('contract_clause_id').notNull().references(() => contractClauses.id, { onDelete: 'restrict' }),
+  clauseTemplateId: integer('clause_template_id').references(() => clauseTemplates.id, { onDelete: 'set null' }),
+  targetType: text('target_type').notNull(), // po | traveler | qc | supplier_po | cert_package
+  targetId: text('target_id').notNull(),
+  requirementText: text('requirement_text').notNull(),
+  requiredArtifacts: text('required_artifacts').array().notNull().default(sql`ARRAY[]::text[]`),
+  status: text('status').notNull().default('open'),
+  source: text('source').notNull().default('contract_review'),
+  flowedAt: timestamp('flowed_at').defaultNow().notNull(),
+  satisfiedAt: timestamp('satisfied_at'),
+  satisfiedByUserId: integer('satisfied_by_user_id'),
+  satisfiedByDisplayName: text('satisfied_by_display_name'),
+  evidence: jsonb('evidence').$type<Record<string, unknown> | null>(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (t) => ({
+  targetIdx: index('idx_flowed_requirements_target').on(t.targetType, t.targetId),
+  instanceIdx: index('idx_flowed_requirements_instance_id').on(t.contractReviewInstanceId),
+  clauseIdx: index('idx_flowed_requirements_clause_id').on(t.contractClauseId),
+  targetClauseUnique: unique().on(t.contractReviewInstanceId, t.contractClauseId, t.targetType, t.targetId),
+}));
+
 export const vendorDebarmentChecks = pgTable('vendor_debarment_checks', {
   id: serial('id').primaryKey(),
   vendorId: integer('vendor_id').notNull().references(() => vendors.id),
@@ -18078,6 +18182,43 @@ export const insertFarFlowdownClauseSchema = createInsertSchema(farFlowdownClaus
   title: z.string().min(1),
 });
 
+export const REQUIRED_CONTRACT_REVIEW_AREAS = ['engineering', 'quality', 'procurement', 'scheduling', 'finance'] as const;
+
+export const insertContractReviewChecklistTemplateSchema = createInsertSchema(contractReviewChecklistTemplates).omit({
+  id: true, createdAt: true, updatedAt: true,
+}).extend({
+  name: z.string().min(1),
+  reviewAreas: z.array(z.string()).default([...REQUIRED_CONTRACT_REVIEW_AREAS]),
+});
+
+export const insertContractClauseSchema = createInsertSchema(contractClauses).omit({
+  id: true, createdAt: true, updatedAt: true,
+}).extend({
+  clauseNumber: z.string().min(1),
+  title: z.string().min(1),
+});
+
+export const insertClauseTemplateSchema = createInsertSchema(clauseTemplates).omit({
+  id: true, createdAt: true, updatedAt: true,
+}).extend({
+  reviewArea: z.enum(REQUIRED_CONTRACT_REVIEW_AREAS),
+  requirementText: z.string().min(5),
+});
+
+export const insertContractReviewChecklistInstanceSchema = createInsertSchema(contractReviewChecklistInstances).omit({
+  id: true, createdAt: true, updatedAt: true, submittedAt: true, approvedAt: true,
+}).extend({
+  checklistTemplateId: z.number().int().positive(),
+});
+
+export const insertFlowedRequirementSchema = createInsertSchema(flowedRequirements).omit({
+  id: true, flowedAt: true, createdAt: true, updatedAt: true,
+}).extend({
+  targetType: z.enum(['po', 'traveler', 'qc', 'supplier_po', 'cert_package']),
+  targetId: z.string().min(1),
+  requirementText: z.string().min(5),
+});
+
 export const insertVendorDebarmentCheckSchema = createInsertSchema(vendorDebarmentChecks).omit({
   id: true, checkedAt: true,
 }).extend({
@@ -18097,6 +18238,16 @@ export type FarFlowdownClause = typeof farFlowdownClauses.$inferSelect;
 export type InsertFarFlowdownClause = z.infer<typeof insertFarFlowdownClauseSchema>;
 export type VendorPoFarFlowdown = typeof vendorPoFarFlowdowns.$inferSelect;
 export type ProjectFarFlowdown = typeof projectFarFlowdowns.$inferSelect;
+export type ContractReviewChecklistTemplate = typeof contractReviewChecklistTemplates.$inferSelect;
+export type InsertContractReviewChecklistTemplate = z.infer<typeof insertContractReviewChecklistTemplateSchema>;
+export type ContractClause = typeof contractClauses.$inferSelect;
+export type InsertContractClause = z.infer<typeof insertContractClauseSchema>;
+export type ClauseTemplate = typeof clauseTemplates.$inferSelect;
+export type InsertClauseTemplate = z.infer<typeof insertClauseTemplateSchema>;
+export type ContractReviewChecklistInstance = typeof contractReviewChecklistInstances.$inferSelect;
+export type InsertContractReviewChecklistInstance = z.infer<typeof insertContractReviewChecklistInstanceSchema>;
+export type FlowedRequirement = typeof flowedRequirements.$inferSelect;
+export type InsertFlowedRequirement = z.infer<typeof insertFlowedRequirementSchema>;
 export type VendorDebarmentCheck = typeof vendorDebarmentChecks.$inferSelect;
 export type InsertVendorDebarmentCheck = z.infer<typeof insertVendorDebarmentCheckSchema>;
 export type ProcurementSettings = typeof procurementSettings.$inferSelect;

--- a/server/src/routes/contractReview.ts
+++ b/server/src/routes/contractReview.ts
@@ -1,0 +1,348 @@
+import { Router, Request, Response } from 'express';
+import { and, desc, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../../db';
+import {
+  REQUIRED_CONTRACT_REVIEW_AREAS,
+  clauseTemplates,
+  contractClauses,
+  contractReviewChecklistInstances,
+  contractReviewChecklistTemplates,
+  flowedRequirements,
+  insertClauseTemplateSchema,
+  insertContractClauseSchema,
+  insertContractReviewChecklistTemplateSchema,
+} from '../../schema';
+import { requirePermission } from '../../middleware/requirePermission';
+
+const router = Router();
+
+const targetTypeSchema = z.enum(['po', 'traveler', 'qc', 'supplier_po', 'cert_package']);
+
+const instanceCreateSchema = z.object({
+  checklistTemplateId: z.number().int().positive(),
+  projectId: z.string().uuid().optional().nullable(),
+  purchaseReviewChecklistId: z.number().int().positive().optional().nullable(),
+  p2PurchaseOrderId: z.number().int().positive().optional().nullable(),
+  vendorPoId: z.number().int().positive().optional().nullable(),
+  travelerId: z.string().min(1).optional().nullable(),
+  status: z.enum(['draft', 'in_review', 'submitted', 'approved']).default('in_review'),
+  reviewAreaStatus: z.record(z.string(), z.unknown()).optional(),
+  responses: z.record(z.string(), z.unknown()).optional(),
+  targetIds: z.object({
+    po: z.string().min(1).optional(),
+    traveler: z.string().min(1).optional(),
+    qc: z.string().min(1).optional(),
+    supplier_po: z.string().min(1).optional(),
+    cert_package: z.string().min(1).optional(),
+  }).optional(),
+});
+
+const requirementStatusSchema = z.object({
+  status: z.enum(['open', 'satisfied', 'waived', 'not_applicable']),
+  evidence: z.record(z.string(), z.unknown()).optional().nullable(),
+});
+
+function displayName(req: Request): string | null {
+  const user = (req as any).user;
+  return user?.displayName ?? user?.fullName ?? user?.username ?? user?.email ?? (user?.id ? `user:${user.id}` : null);
+}
+
+function userId(req: Request): number | null {
+  const raw = (req as any).user?.id;
+  if (typeof raw === 'number') return raw;
+  if (raw == null) return null;
+  const parsed = Number.parseInt(String(raw), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeAreas(areas: string[]): string[] {
+  return areas.map((area) => area.trim().toLowerCase()).filter(Boolean);
+}
+
+function missingRequiredAreas(areas: string[]): string[] {
+  const present = new Set(normalizeAreas(areas));
+  return REQUIRED_CONTRACT_REVIEW_AREAS.filter((area) => !present.has(area));
+}
+
+function targetMapFromBody(body: z.infer<typeof instanceCreateSchema>): Map<string, string> {
+  const targets = new Map<string, string>();
+  if (body.p2PurchaseOrderId) targets.set('po', String(body.p2PurchaseOrderId));
+  if (body.vendorPoId) targets.set('supplier_po', String(body.vendorPoId));
+  if (body.travelerId) {
+    targets.set('traveler', body.travelerId);
+    targets.set('qc', body.travelerId);
+  }
+  if (body.p2PurchaseOrderId) targets.set('cert_package', String(body.p2PurchaseOrderId));
+  else if (body.travelerId) targets.set('cert_package', body.travelerId);
+
+  for (const [targetType, targetId] of Object.entries(body.targetIds ?? {})) {
+    if (targetId) targets.set(targetType, targetId);
+  }
+  return targets;
+}
+
+async function loadTemplateClauseRows(templateId: number) {
+  return db
+    .select({
+      clauseTemplateId: clauseTemplates.id,
+      contractClauseId: contractClauses.id,
+      clauseNumber: contractClauses.clauseNumber,
+      title: contractClauses.title,
+      reviewArea: clauseTemplates.reviewArea,
+      requirementText: clauseTemplates.requirementText,
+      requiredArtifacts: clauseTemplates.requiredArtifacts,
+      flowTargets: clauseTemplates.flowTargets,
+      defaultFlowTargets: contractClauses.defaultFlowTargets,
+    })
+    .from(clauseTemplates)
+    .innerJoin(contractClauses, eq(clauseTemplates.contractClauseId, contractClauses.id))
+    .where(and(
+      eq(clauseTemplates.checklistTemplateId, templateId),
+      eq(contractClauses.isActive, true),
+    ))
+    .orderBy(contractClauses.clauseNumber);
+}
+
+router.get('/templates', requirePermission('purchasing.view_requisitions'), async (_req: Request, res: Response) => {
+  const templates = await db
+    .select()
+    .from(contractReviewChecklistTemplates)
+    .where(eq(contractReviewChecklistTemplates.isActive, true))
+    .orderBy(desc(contractReviewChecklistTemplates.updatedAt));
+  res.json(templates);
+});
+
+router.post('/templates', requirePermission('purchasing.admin_chain'), async (req: Request, res: Response) => {
+  try {
+    const body = z.object({
+      template: insertContractReviewChecklistTemplateSchema,
+      clauseTemplates: z.array(insertClauseTemplateSchema.omit({ checklistTemplateId: true })).optional(),
+    }).parse(req.body);
+
+    const missing = missingRequiredAreas(body.template.reviewAreas);
+    if (missing.length > 0) {
+      return res.status(400).json({
+        error: 'Contract review template is missing required review areas',
+        requiredAreas: REQUIRED_CONTRACT_REVIEW_AREAS,
+        missingAreas: missing,
+      });
+    }
+
+    const [created] = await db.transaction(async (tx) => {
+      const [template] = await tx.insert(contractReviewChecklistTemplates).values({
+        ...body.template,
+        createdByUserId: userId(req),
+        createdByDisplayName: displayName(req),
+      }).returning();
+
+      for (const clauseTemplate of body.clauseTemplates ?? []) {
+        await tx.insert(clauseTemplates).values({
+          ...clauseTemplate,
+          checklistTemplateId: template.id,
+        });
+      }
+      return [template];
+    });
+
+    res.status(201).json(created);
+  } catch (err: any) {
+    if (err instanceof z.ZodError) return res.status(400).json({ error: 'Validation failed', issues: err.errors });
+    res.status(500).json({ error: err.message ?? 'Failed to create contract review template' });
+  }
+});
+
+router.get('/templates/:id/clauses', requirePermission('purchasing.view_requisitions'), async (req: Request, res: Response) => {
+  const templateId = Number.parseInt(req.params.id, 10);
+  if (!Number.isFinite(templateId)) return res.status(400).json({ error: 'Invalid template ID' });
+  res.json(await loadTemplateClauseRows(templateId));
+});
+
+router.get('/clauses', requirePermission('purchasing.view_requisitions'), async (_req: Request, res: Response) => {
+  const clauses = await db
+    .select()
+    .from(contractClauses)
+    .where(eq(contractClauses.isActive, true))
+    .orderBy(contractClauses.clauseNumber);
+  res.json(clauses);
+});
+
+router.post('/clauses', requirePermission('purchasing.admin_chain'), async (req: Request, res: Response) => {
+  try {
+    const parsed = insertContractClauseSchema.parse(req.body);
+    const [created] = await db.insert(contractClauses).values(parsed).returning();
+    res.status(201).json(created);
+  } catch (err: any) {
+    if (err instanceof z.ZodError) return res.status(400).json({ error: 'Validation failed', issues: err.errors });
+    res.status(500).json({ error: err.message ?? 'Failed to create contract clause' });
+  }
+});
+
+router.post('/templates/:id/clause-templates', requirePermission('purchasing.admin_chain'), async (req: Request, res: Response) => {
+  try {
+    const templateId = Number.parseInt(req.params.id, 10);
+    if (!Number.isFinite(templateId)) return res.status(400).json({ error: 'Invalid template ID' });
+
+    const parsed = insertClauseTemplateSchema.parse({
+      ...req.body,
+      checklistTemplateId: templateId,
+    });
+    const [created] = await db.insert(clauseTemplates).values(parsed).returning();
+    res.status(201).json(created);
+  } catch (err: any) {
+    if (err instanceof z.ZodError) return res.status(400).json({ error: 'Validation failed', issues: err.errors });
+    res.status(500).json({ error: err.message ?? 'Failed to create clause template' });
+  }
+});
+
+router.get('/instances/:id', requirePermission('purchasing.view_requisitions'), async (req: Request, res: Response) => {
+  const id = req.params.id;
+  const [instance] = await db
+    .select()
+    .from(contractReviewChecklistInstances)
+    .where(eq(contractReviewChecklistInstances.id, id))
+    .limit(1);
+  if (!instance) return res.status(404).json({ error: 'Contract review instance not found' });
+
+  const requirements = await db
+    .select()
+    .from(flowedRequirements)
+    .where(eq(flowedRequirements.contractReviewInstanceId, id))
+    .orderBy(flowedRequirements.targetType);
+  res.json({ instance, requirements });
+});
+
+router.post('/instances', requirePermission('purchasing.manage_pos'), async (req: Request, res: Response) => {
+  try {
+    const body = instanceCreateSchema.parse(req.body);
+    const [template] = await db
+      .select()
+      .from(contractReviewChecklistTemplates)
+      .where(eq(contractReviewChecklistTemplates.id, body.checklistTemplateId))
+      .limit(1);
+
+    if (!template || !template.isActive) {
+      return res.status(404).json({ error: 'Active contract review template not found' });
+    }
+
+    const missing = missingRequiredAreas(template.reviewAreas);
+    if (missing.length > 0) {
+      return res.status(409).json({
+        error: 'Contract review template is not ready for use',
+        requiredAreas: REQUIRED_CONTRACT_REVIEW_AREAS,
+        missingAreas: missing,
+      });
+    }
+
+    const targetIds = targetMapFromBody(body);
+    const templateClauses = await loadTemplateClauseRows(body.checklistTemplateId);
+    const actorId = userId(req);
+    const actorName = displayName(req);
+
+    const result = await db.transaction(async (tx) => {
+      const reviewAreaStatus = body.reviewAreaStatus ?? Object.fromEntries(
+        REQUIRED_CONTRACT_REVIEW_AREAS.map((area) => [area, { status: 'pending' }]),
+      );
+
+      const [instance] = await tx.insert(contractReviewChecklistInstances).values({
+        checklistTemplateId: body.checklistTemplateId,
+        projectId: body.projectId ?? null,
+        purchaseReviewChecklistId: body.purchaseReviewChecklistId ?? null,
+        p2PurchaseOrderId: body.p2PurchaseOrderId ?? null,
+        vendorPoId: body.vendorPoId ?? null,
+        travelerId: body.travelerId ?? null,
+        status: body.status,
+        reviewAreaStatus,
+        responses: body.responses ?? {},
+        missingReviewAreas: [],
+        createdByUserId: actorId,
+        createdByDisplayName: actorName,
+        submittedAt: body.status === 'submitted' || body.status === 'approved' ? new Date() : null,
+        approvedAt: body.status === 'approved' ? new Date() : null,
+      }).returning();
+
+      const flowed = [];
+      for (const clause of templateClauses) {
+        const requestedTargets = clause.flowTargets?.length
+          ? clause.flowTargets
+          : clause.defaultFlowTargets ?? [];
+
+        for (const targetType of requestedTargets) {
+          const targetId = targetIds.get(targetType);
+          if (!targetId) continue;
+          const [requirement] = await tx.insert(flowedRequirements).values({
+            contractReviewInstanceId: instance.id,
+            contractClauseId: clause.contractClauseId,
+            clauseTemplateId: clause.clauseTemplateId,
+            targetType,
+            targetId,
+            requirementText: clause.requirementText,
+            requiredArtifacts: clause.requiredArtifacts ?? [],
+            status: 'open',
+            source: 'contract_review',
+          }).onConflictDoNothing().returning();
+          if (requirement) flowed.push(requirement);
+        }
+      }
+
+      return { instance, flowedRequirements: flowed };
+    });
+
+    res.status(201).json({
+      ...result,
+      targetSummary: Object.fromEntries(targetIds),
+    });
+  } catch (err: any) {
+    if (err instanceof z.ZodError) return res.status(400).json({ error: 'Validation failed', issues: err.errors });
+    res.status(500).json({ error: err.message ?? 'Failed to create contract review instance' });
+  }
+});
+
+router.get('/requirements', requirePermission('purchasing.view_requisitions'), async (req: Request, res: Response) => {
+  const parsed = z.object({
+    targetType: targetTypeSchema,
+    targetId: z.string().min(1),
+  }).safeParse(req.query);
+
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'targetType and targetId are required', issues: parsed.error.errors });
+  }
+
+  const rows = await db
+    .select()
+    .from(flowedRequirements)
+    .where(and(
+      eq(flowedRequirements.targetType, parsed.data.targetType),
+      eq(flowedRequirements.targetId, parsed.data.targetId),
+    ))
+    .orderBy(desc(flowedRequirements.flowedAt));
+  res.json(rows);
+});
+
+router.patch('/requirements/:id/status', requirePermission('purchasing.manage_pos'), async (req: Request, res: Response) => {
+  try {
+    const id = req.params.id;
+    const body = requirementStatusSchema.parse(req.body);
+    const satisfied = body.status === 'satisfied';
+    const [updated] = await db
+      .update(flowedRequirements)
+      .set({
+        status: body.status,
+        evidence: body.evidence ?? null,
+        satisfiedAt: satisfied ? new Date() : null,
+        satisfiedByUserId: satisfied ? userId(req) : null,
+        satisfiedByDisplayName: satisfied ? displayName(req) : null,
+        updatedAt: new Date(),
+      })
+      .where(eq(flowedRequirements.id, id))
+      .returning();
+
+    if (!updated) return res.status(404).json({ error: 'Flowed requirement not found' });
+    res.json(updated);
+  } catch (err: any) {
+    if (err instanceof z.ZodError) return res.status(400).json({ error: 'Validation failed', issues: err.errors });
+    res.status(500).json({ error: err.message ?? 'Failed to update flowed requirement' });
+  }
+});
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -232,6 +232,7 @@ import chargeCodesRoutes from './chargeCodes';
 import purchaseRequisitionsRoutes from './purchaseRequisitions';
 import farFlowdownClausesRoutes from './farFlowdownClauses';
 import vendorDebarmentChecksRoutes from './vendorDebarmentChecks';
+import contractReviewRoutes from './contractReview';
 import continuityRoutes from './continuity';
 import proteusLabsRoutes from './proteusLabs';
 import devSeedPunchesRoutes from './timekeeping/devSeedPunches';
@@ -791,6 +792,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   app.use('/api/purchase-requisitions', purchaseRequisitionsRoutes);
   app.use('/api/far-flowdown-clauses', farFlowdownClausesRoutes);
   app.use('/api/vendor-debarment-checks', vendorDebarmentChecksRoutes);
+  app.use('/api/contract-review', contractReviewRoutes);
 
   // Quote management routes
   app.use(quotesRoutes);


### PR DESCRIPTION
## Summary
- Adds configurable contract review checklist templates and instances with required engineering, quality, procurement, scheduling, and finance review areas.
- Adds formal `contract_clauses`, `clause_templates`, and `flowed_requirements` data structures with an idempotent Section 3 seed migration.
- Adds `/api/contract-review` endpoints to manage templates/clauses, create checklist instances, automatically flow clause requirements to PO, traveler, QC, supplier PO, and cert-package targets, and update flowed requirement status.

## Validation
- `git diff --cached --check`
- TypeScript/build validation not run locally: this worktree has no `npm`, `npx`, `pnpm`, `tsc`, or `node_modules` available.