### PR TITLE
[codex] Add WAD approval controls

### DIFF
--- a/client/src/components/wad/WADWizard.tsx
+++ b/client/src/components/wad/WADWizard.tsx
@@ -50,11 +50,10 @@ const DOCUMENT_CHECKLIST_ITEMS = [
 
 const REQUIRED_APPROVAL_ROLES = [
   { key: 'project_manager', label: 'Project Manager' },
-  { key: 'production_manager', label: 'Production Manager' },
+  { key: 'engineering', label: 'Engineering' },
   { key: 'quality', label: 'Quality' },
-  { key: 'finance', label: 'Finance / Accounting' },
-  { key: 'engineering', label: 'Engineering (optional)', optional: true },
-  { key: 'compliance', label: 'Compliance / Export Control (optional)', optional: true },
+  { key: 'operations', label: 'Operations' },
+  { key: 'executive', label: 'Executive' },
 ];
 
 const RISK_TYPES = ['Technical', 'Schedule', 'Material', 'Quality', 'Tooling', 'Supplier'];
@@ -111,6 +110,59 @@ interface ApprovalRecord {
   timestamp: string;
 }
 
+type WadExceptionType = 'overrun' | 'charge_code_override' | 'late_release_exception';
+
+interface ApprovalRequestRecord {
+  id: string;
+  type: WadExceptionType;
+  status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  reason: string;
+  requestedByName: string;
+  requestedAt: string;
+  resolvedByName?: string | null;
+  resolvedAt?: string | null;
+}
+
+interface RevisionHistoryRecord {
+  revision: number;
+  action: string;
+  role?: string;
+  actorName?: string;
+  comments?: string | null;
+  timestamp: string;
+}
+
+interface WadControlStatus {
+  labor: {
+    usedHours: number;
+    budgetHours: number | null;
+    plannedHours: number;
+    projectedHours: number;
+    percentUsed: number | null;
+    projectedPercentUsed: number | null;
+    projectedOverrun: boolean;
+    status: string;
+  };
+  material: {
+    usedSpend: number;
+    spendCap: number | null;
+    percentUsed: number | null;
+    projectedOverrun: boolean;
+  };
+  outsideProcessing: {
+    usedSpend: number;
+    spendCap: number | null;
+    percentUsed: number | null;
+    projectedOverrun: boolean;
+  };
+  exceptions: {
+    chargeCodeOverride: boolean;
+    lateRelease: boolean;
+    requiredRequests: WadExceptionType[];
+    missingRequests: WadExceptionType[];
+  };
+}
+
 interface WizardData {
   step1?: {
     projectNumber: string;
@@ -141,6 +193,10 @@ interface WizardData {
     outTimeTracking: boolean;
     customerSuppliedMaterial: boolean;
     certsRequired: boolean;
+    materialSpendCap: number;
+    outsideProcessingCap: number;
+    materialOverrunRule: 'REQUIRE_APPROVAL' | 'HARD_STOP';
+    outsideProcessingRule: 'REQUIRE_APPROVAL' | 'HARD_STOP';
     notes: string;
   };
   step6?: {
@@ -183,6 +239,10 @@ interface WizardData {
   };
   step10?: { documents: DocItem[] };
   approvals?: ApprovalRecord[];
+  approvalRequests?: ApprovalRequestRecord[];
+  currentRevision?: number;
+  revisionStatus?: 'DRAFT' | 'IN_REVIEW' | 'IN_REVISION' | 'NEEDS_REVISION' | 'APPROVED';
+  revisionHistory?: RevisionHistoryRecord[];
   __seedMeta?: {
     seededAt: string;
     sources: {
@@ -228,7 +288,7 @@ export default function WADWizard({ wadId, onClose }: WADWizardProps) {
   const [data, setData] = useState<WizardData>({});
   const [saving, setSaving] = useState(false);
 
-  const { data: wizardCtx, isLoading } = useQuery<{ wad: any; project: any; po: any }>({
+  const { data: wizardCtx, isLoading } = useQuery<{ wad: any; project: any; po: any; controlStatus?: WadControlStatus }>({
     queryKey: ['/api/work-orders/production', wadId, 'wizard'],
     queryFn: async () => {
       const res = await fetch(`/api/work-orders/production/${wadId}/wizard`);
@@ -276,6 +336,22 @@ export default function WADWizard({ wadId, onClose }: WADWizardProps) {
     },
     onError: (err: Error) => {
       toast({ title: 'Approval failed', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const exceptionRequestMutation = useMutation({
+    mutationFn: async (payload: { type: WadExceptionType; action: 'REQUEST' | 'APPROVE' | 'REJECT'; reason: string }) => {
+      return apiRequest(`/api/work-orders/production/${wadId}/approval-requests`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/work-orders/production', wadId, 'wizard'] });
+      toast({ title: 'Approval request recorded' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Request failed', description: err.message, variant: 'destructive' });
     },
   });
 
@@ -363,7 +439,7 @@ export default function WADWizard({ wadId, onClose }: WADWizardProps) {
         break;
       }
       case 11: {
-        const required = ['project_manager', 'production_manager', 'quality', 'finance'];
+        const required = REQUIRED_APPROVAL_ROLES.map((role) => role.key);
         const approved = new Set(
           (d.approvals ?? []).filter((a) => a.decision === 'APPROVED').map((a) => a.role)
         );
@@ -383,6 +459,7 @@ export default function WADWizard({ wadId, onClose }: WADWizardProps) {
   const wad = wizardCtx?.wad;
   const project = wizardCtx?.project;
   const po = wizardCtx?.po;
+  const controlStatus = wizardCtx?.controlStatus;
   const wadStatus = wad?.wadStatus ?? 'DRAFT';
   const approvals: ApprovalRecord[] = (data.approvals ?? []) as ApprovalRecord[];
   const isBackfill = project?.currentStage === 'production';
@@ -688,17 +765,22 @@ export default function WADWizard({ wadId, onClose }: WADWizardProps) {
               data={data}
               wad={wad}
               approvals={approvals}
+              controlStatus={controlStatus}
+              approvalRequests={data.approvalRequests ?? []}
+              revisionHistory={data.revisionHistory ?? []}
+              exceptionRequestMutation={exceptionRequestMutation}
               onApprove={async () => {
                 // Persist the latest wizardData. The actual APPROVED transition happens
-                // server-side in POST /wizard/approve once all four required slots are
+                // server-side in POST /wizard/approve once all required slots are
                 // signed (Step 11). PATCH is intentionally not allowed to set APPROVED.
                 await saveMutation.mutateAsync({ wizardData: data });
-                const allFour = approvals.filter((a) => a.decision === 'APPROVED').length >= 4;
+                const allRequired = REQUIRED_APPROVAL_ROLES
+                  .every((role) => approvals.some((a) => a.role === role.key && a.decision === 'APPROVED'));
                 toast({
-                  title: allFour ? 'WAD Approved' : 'Final review saved',
-                  description: allFour
+                  title: allRequired ? 'WAD approvals complete' : 'Final review saved',
+                  description: allRequired
                     ? 'All required approvals are recorded — WAD has been promoted to APPROVED on the server.'
-                    : 'Collect all four required slot approvals on Step 11 to promote this WAD to APPROVED.',
+                    : 'Collect PM, engineering, quality, operations, and executive approvals on Step 11.',
                 });
                 queryClient.invalidateQueries({ queryKey: ['/api/work-orders', wadId] });
               }}
@@ -1214,6 +1296,10 @@ function Step5MaterialAuth({ data, onChange }: {
     outTimeTracking: false,
     customerSuppliedMaterial: false,
     certsRequired: false,
+    materialSpendCap: 0,
+    outsideProcessingCap: 0,
+    materialOverrunRule: 'REQUIRE_APPROVAL',
+    outsideProcessingRule: 'REQUIRE_APPROVAL',
     notes: '',
     ...(data ?? {}),
   };
@@ -1232,6 +1318,50 @@ function Step5MaterialAuth({ data, onChange }: {
         <BoolField label="Out-Time Tracking" value={base.outTimeTracking} onChange={v => set('outTimeTracking', v)} />
         <BoolField label="Customer-Supplied Material" value={base.customerSuppliedMaterial} onChange={v => set('customerSuppliedMaterial', v)} />
         <BoolField label="Certs Required" value={base.certsRequired} onChange={v => set('certsRequired', v)} />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <Label className="text-xs">Material Spend Cap</Label>
+          <Input
+            type="number"
+            min={0}
+            step={100}
+            value={base.materialSpendCap}
+            onChange={e => set('materialSpendCap', parseFloat(e.target.value) || 0)}
+            className="h-8 text-sm"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs">Material Cap Rule</Label>
+          <Select value={base.materialOverrunRule} onValueChange={v => set('materialOverrunRule', v)}>
+            <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="REQUIRE_APPROVAL">Require Approval</SelectItem>
+              <SelectItem value="HARD_STOP">Hard Stop</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs">Outside Processing Cap</Label>
+          <Input
+            type="number"
+            min={0}
+            step={100}
+            value={base.outsideProcessingCap}
+            onChange={e => set('outsideProcessingCap', parseFloat(e.target.value) || 0)}
+            className="h-8 text-sm"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs">Outside Processing Rule</Label>
+          <Select value={base.outsideProcessingRule} onValueChange={v => set('outsideProcessingRule', v)}>
+            <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="REQUIRE_APPROVAL">Require Approval</SelectItem>
+              <SelectItem value="HARD_STOP">Hard Stop</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
       <div className="space-y-1">
         <Label>Notes</Label>
@@ -1624,7 +1754,7 @@ function Step11Approvals({ approvals, wadId, approveMutation }: {
   return (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
-        Collect required approvals from each role. Project Manager, Production Manager, Quality, and Finance are required. Engineering and Compliance are optional.
+        Collect the WAD approval matrix: PM, engineering, quality, operations, and executive. Rejections keep the WAD in revision until the next saved change resets the signature cycle.
       </p>
       <div className="space-y-3">
         {REQUIRED_APPROVAL_ROLES.map(role => {
@@ -1697,20 +1827,25 @@ function Step11Approvals({ approvals, wadId, approveMutation }: {
 }
 
 // ─── Step 12: Final Review ────────────────────────────────────────────────────
-function Step12FinalReview({ data, wad, approvals, onApprove, isSaving }: {
+function Step12FinalReview({ data, wad, approvals, controlStatus, approvalRequests, revisionHistory, exceptionRequestMutation, onApprove, isSaving }: {
   data: WizardData;
   wad: any;
   approvals: ApprovalRecord[];
+  controlStatus?: WadControlStatus;
+  approvalRequests: ApprovalRequestRecord[];
+  revisionHistory: RevisionHistoryRecord[];
+  exceptionRequestMutation: any;
   onApprove: () => Promise<void>;
   isSaving: boolean;
 }) {
   const { toast } = useToast();
   const [approving, setApproving] = useState(false);
 
-  const requiredRoles = ['project_manager', 'production_manager', 'quality', 'finance'];
+  const requiredRoles = REQUIRED_APPROVAL_ROLES.map((role) => role.key);
   const allRequiredApproved = requiredRoles.every(r =>
     approvals.some(a => a.role === r && a.decision === 'APPROVED')
   );
+  const missingExceptionRequests = controlStatus?.exceptions.missingRequests ?? [];
 
   const docsComplete = (data.step10?.documents ?? []).every(d => d.status !== 'PENDING');
   const poReviewGate = data.step1?.poReviewApproved ?? false;
@@ -1723,9 +1858,18 @@ function Step12FinalReview({ data, wad, approvals, onApprove, isSaving }: {
     { label: 'Charge Codes Assigned', ok: chargeCodesDefined },
     { label: 'Documents Resolved', ok: docsComplete },
     { label: 'All Required Approvals Collected', ok: allRequiredApproved },
+    { label: 'Exception Requests Resolved', ok: missingExceptionRequests.length === 0 },
   ];
 
   const allGatesPassed = gates.every(g => g.ok);
+  const exceptionLabels: Record<WadExceptionType, string> = {
+    overrun: 'Overrun',
+    charge_code_override: 'Charge-code override',
+    late_release_exception: 'Late release',
+  };
+  const formatPct = (value: number | null | undefined) => value == null ? 'N/A' : `${value}%`;
+  const formatMoney = (value: number | null | undefined) =>
+    value == null ? 'N/A' : new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
 
   const handleApprove = async () => {
     if (!allGatesPassed) {
@@ -1752,6 +1896,97 @@ function Step12FinalReview({ data, wad, approvals, onApprove, isSaving }: {
           </div>
         ))}
       </div>
+      <Separator />
+      {controlStatus && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <Card className="p-3">
+            <p className="text-xs text-muted-foreground">Labor Hours</p>
+            <p className="text-sm font-medium">{controlStatus.labor.usedHours} / {controlStatus.labor.budgetHours ?? 'N/A'} used</p>
+            <p className={controlStatus.labor.projectedOverrun ? 'text-xs text-red-600' : 'text-xs text-muted-foreground'}>
+              {formatPct(controlStatus.labor.percentUsed)} used, {formatPct(controlStatus.labor.projectedPercentUsed)} projected
+            </p>
+          </Card>
+          <Card className="p-3">
+            <p className="text-xs text-muted-foreground">Material Spend</p>
+            <p className="text-sm font-medium">{formatMoney(controlStatus.material.usedSpend)} / {formatMoney(controlStatus.material.spendCap)}</p>
+            <p className={controlStatus.material.projectedOverrun ? 'text-xs text-red-600' : 'text-xs text-muted-foreground'}>
+              {formatPct(controlStatus.material.percentUsed)} used
+            </p>
+          </Card>
+          <Card className="p-3">
+            <p className="text-xs text-muted-foreground">Outside Processing</p>
+            <p className="text-sm font-medium">{formatMoney(controlStatus.outsideProcessing.usedSpend)} / {formatMoney(controlStatus.outsideProcessing.spendCap)}</p>
+            <p className={controlStatus.outsideProcessing.projectedOverrun ? 'text-xs text-red-600' : 'text-xs text-muted-foreground'}>
+              {formatPct(controlStatus.outsideProcessing.percentUsed)} used
+            </p>
+          </Card>
+        </div>
+      )}
+      {missingExceptionRequests.length > 0 && (
+        <Alert className="border-amber-300 bg-amber-50">
+          <AlertTriangle className="h-4 w-4 text-amber-700" />
+          <AlertDescription className="text-amber-900">
+            {missingExceptionRequests.map(type => exceptionLabels[type]).join(', ')} approval request required before release.
+            <div className="flex flex-wrap gap-2 mt-2">
+              {missingExceptionRequests.map(type => (
+                <Button
+                  key={type}
+                  size="sm"
+                  variant="outline"
+                  onClick={() => exceptionRequestMutation.mutate({ type, action: 'REQUEST', reason: `${exceptionLabels[type]} exception requested from WAD final review` })}
+                  disabled={exceptionRequestMutation.isPending}
+                >
+                  Request {exceptionLabels[type]}
+                </Button>
+              ))}
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+      {approvalRequests.length > 0 && (
+        <div className="space-y-2">
+          <p className="font-medium text-sm">Approval Requests</p>
+          {approvalRequests.slice(-5).map(req => (
+            <div key={req.id} className="flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-xs">
+              <span>{exceptionLabels[req.type]} - {req.reason}</span>
+              <div className="flex items-center gap-2">
+                <Badge variant={req.status === 'APPROVED' ? 'default' : 'outline'}>{req.status}</Badge>
+                {req.status === 'PENDING' && (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => exceptionRequestMutation.mutate({ type: req.type, action: 'APPROVE', reason: `Approved: ${req.reason}` })}
+                      disabled={exceptionRequestMutation.isPending}
+                    >
+                      Approve
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => exceptionRequestMutation.mutate({ type: req.type, action: 'REJECT', reason: `Rejected: ${req.reason}` })}
+                      disabled={exceptionRequestMutation.isPending}
+                    >
+                      Reject
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {revisionHistory.length > 0 && (
+        <div className="space-y-2">
+          <p className="font-medium text-sm">Revision History</p>
+          {revisionHistory.slice(-4).map((event, idx) => (
+            <div key={`${event.timestamp}-${idx}`} className="rounded-md border px-3 py-2 text-xs text-muted-foreground">
+              Rev {event.revision}: {event.action.replaceAll('_', ' ')}{event.role ? ` (${event.role})` : ''} by {event.actorName ?? 'system'}
+              {event.comments ? ` - ${event.comments}` : ''}
+            </div>
+          ))}
+        </div>
+      )}
       <Separator />
       <div className="grid grid-cols-2 gap-4 text-sm">
         <div>

--- a/server/src/routes/workOrders.ts
+++ b/server/src/routes/workOrders.ts
@@ -14,6 +14,7 @@ import {
   projects,
   p2PurchaseOrders,
   p2PurchaseOrderItems,
+  vendorPOItems,
   insertWorkOrderSchema,
   insertWorkOrderPartSchema,
   insertWorkOrderAttachmentSchema,
@@ -64,6 +65,138 @@ function requireSupervisorOrAdmin(req: Request, res: Response, next: NextFunctio
     return res.status(403).json({ error: 'Supervisor or admin access required to approve labor overruns' });
   }
   next();
+}
+
+const WAD_APPROVAL_MATRIX = [
+  { key: 'project_manager', label: 'Project Manager', allowedRoles: ['PROJECT_MANAGER', 'ADMIN', 'OWNER'] },
+  { key: 'engineering', label: 'Engineering', allowedRoles: ['ENGINEERING', 'ADMIN', 'OWNER'] },
+  { key: 'quality', label: 'Quality', allowedRoles: ['QUALITY', 'QC', 'MANAGER', 'ADMIN', 'OWNER'] },
+  { key: 'operations', label: 'Operations', allowedRoles: ['OPERATIONS', 'PRODUCTION_MANAGER', 'MANAGER', 'SUPERVISOR', 'ADMIN', 'OWNER'] },
+  { key: 'executive', label: 'Executive', allowedRoles: ['EXECUTIVE', 'OWNER', 'ADMIN'] },
+] as const;
+
+type WadApprovalSlot = typeof WAD_APPROVAL_MATRIX[number]['key'];
+const WAD_APPROVAL_SLOTS: WadApprovalSlot[] = WAD_APPROVAL_MATRIX.map((slot) => slot.key);
+const WAD_SLOT_ALLOWED_ROLES: Record<WadApprovalSlot, ReadonlyArray<string>> =
+  Object.fromEntries(WAD_APPROVAL_MATRIX.map((slot) => [slot.key, slot.allowedRoles])) as Record<WadApprovalSlot, ReadonlyArray<string>>;
+
+const WAD_LEGACY_SLOT_ALIASES: Record<string, WadApprovalSlot> = {
+  production_manager: 'operations',
+  finance: 'executive',
+  compliance: 'executive',
+};
+
+const WAD_EXCEPTION_TYPES = ['overrun', 'charge_code_override', 'late_release_exception'] as const;
+type WadExceptionType = typeof WAD_EXCEPTION_TYPES[number];
+
+function normalizeWadApprovalRole(role: string | undefined | null): WadApprovalSlot | null {
+  if (!role) return null;
+  const normalized = role.trim().toLowerCase();
+  if ((WAD_APPROVAL_SLOTS as readonly string[]).includes(normalized)) return normalized as WadApprovalSlot;
+  return WAD_LEGACY_SLOT_ALIASES[normalized] ?? null;
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function percent(numerator: number, denominator: number | null): number | null {
+  if (denominator == null || denominator <= 0) return null;
+  return Math.round((numerator / denominator) * 10000) / 100;
+}
+
+function hasApprovedExceptionRequest(wizardData: Record<string, unknown>, type: WadExceptionType): boolean {
+  const requests = Array.isArray(wizardData.approvalRequests) ? wizardData.approvalRequests : [];
+  return requests.some((req) => {
+    const r = req as { type?: string; status?: string };
+    return r.type === type && r.status === 'APPROVED';
+  });
+}
+
+function getWadRevisionNumber(wizardData: Record<string, unknown>): number {
+  const value = toNumber(wizardData.currentRevision);
+  return value != null && value > 0 ? value : 1;
+}
+
+async function calculateWadControlStatus(wad: typeof productionWorkOrders.$inferSelect, wizardData: Record<string, unknown>) {
+  const step4 = (wizardData.step4 as { chargeCodes?: Array<{ budgetedHours?: number; operatorOverrideAllowed?: boolean }> } | undefined) ?? {};
+  const step5 = (wizardData.step5 as { materialSpendCap?: number; outsideProcessingCap?: number } | undefined) ?? {};
+  const step8 = (wizardData.step8 as { authorizedStartDate?: string; requiredCompletionDate?: string } | undefined) ?? {};
+
+  const laborStatus = await evaluateWorkOrderLaborStatus(wad.id, undefined);
+  const plannedLaborHours = (step4.chargeCodes ?? []).reduce((sum, row) => sum + (toNumber(row.budgetedHours) ?? 0), 0);
+  const laborCap = toNumber(wad.totalBudgetHours) ?? (plannedLaborHours > 0 ? plannedLaborHours : null);
+  const laborUsedHours = laborStatus.totalHours;
+  const laborProjectedHours = Math.max(laborUsedHours, plannedLaborHours);
+
+  const [materialRow] = await db
+    .select({
+      total: sql<number>`COALESCE(SUM(${vendorPOItems.lineTotal}), 0)`,
+    })
+    .from(vendorPOItems)
+    .where(eq(vendorPOItems.productionWorkOrderId, wad.id));
+
+  const [outsideRow] = await db
+    .select({
+      total: sql<number>`COALESCE(SUM(${vendorPOItems.lineTotal}), 0)`,
+    })
+    .from(vendorPOItems)
+    .where(and(
+      eq(vendorPOItems.productionWorkOrderId, wad.id),
+      sql`(
+        LOWER(COALESCE(${vendorPOItems.description}, '')) LIKE '%outside%'
+        OR LOWER(COALESCE(${vendorPOItems.description}, '')) LIKE '%subcontract%'
+        OR LOWER(COALESCE(${vendorPOItems.description}, '')) LIKE '%special process%'
+      )`,
+    ));
+
+  const materialSpendCap = toNumber(step5.materialSpendCap);
+  const materialSpendUsed = toNumber(materialRow?.total) ?? 0;
+  const outsideProcessingCap = toNumber(step5.outsideProcessingCap);
+  const outsideProcessingUsed = toNumber(outsideRow?.total) ?? 0;
+
+  const hasChargeCodeOverride = (step4.chargeCodes ?? []).some((row) => row.operatorOverrideAllowed);
+  const lateRelease = Boolean(step8.requiredCompletionDate && new Date(step8.requiredCompletionDate) < new Date() && wad.wadStatus !== 'APPROVED');
+
+  const requiredExceptionRequests: WadExceptionType[] = [];
+  if ((laborCap != null && laborProjectedHours > laborCap) || (materialSpendCap != null && materialSpendUsed > materialSpendCap) || (outsideProcessingCap != null && outsideProcessingUsed > outsideProcessingCap)) {
+    requiredExceptionRequests.push('overrun');
+  }
+  if (hasChargeCodeOverride) requiredExceptionRequests.push('charge_code_override');
+  if (lateRelease) requiredExceptionRequests.push('late_release_exception');
+
+  return {
+    labor: {
+      usedHours: laborUsedHours,
+      budgetHours: laborCap,
+      plannedHours: plannedLaborHours,
+      projectedHours: laborProjectedHours,
+      percentUsed: percent(laborUsedHours, laborCap),
+      projectedPercentUsed: percent(laborProjectedHours, laborCap),
+      projectedOverrun: laborCap != null && laborProjectedHours > laborCap,
+      status: laborStatus.status,
+    },
+    material: {
+      usedSpend: materialSpendUsed,
+      spendCap: materialSpendCap,
+      percentUsed: percent(materialSpendUsed, materialSpendCap),
+      projectedOverrun: materialSpendCap != null && materialSpendUsed > materialSpendCap,
+    },
+    outsideProcessing: {
+      usedSpend: outsideProcessingUsed,
+      spendCap: outsideProcessingCap,
+      percentUsed: percent(outsideProcessingUsed, outsideProcessingCap),
+      projectedOverrun: outsideProcessingCap != null && outsideProcessingUsed > outsideProcessingCap,
+    },
+    exceptions: {
+      chargeCodeOverride: hasChargeCodeOverride,
+      lateRelease,
+      requiredRequests: Array.from(new Set(requiredExceptionRequests)),
+      missingRequests: Array.from(new Set(requiredExceptionRequests)).filter((type) => !hasApprovedExceptionRequest(wizardData, type)),
+    },
+  };
 }
 
 // ==================== WORK ORDERS (MAINTENANCE EVENTS) ====================
@@ -2217,7 +2350,25 @@ router.get('/production/:id/wizard', async (req: Request, res: Response) => {
       po = poRow ?? null;
     }
 
-    return res.json({ wad, project: project ?? null, po });
+    const wizardData = (wad.wizardData as Record<string, unknown> | null) ?? {};
+    const controlStatus = await calculateWadControlStatus(wad, wizardData);
+
+    return res.json({
+      wad: {
+        ...wad,
+        wizardData: {
+          currentRevision: 1,
+          revisionStatus: 'DRAFT',
+          revisionHistory: [],
+          approvalRequests: [],
+          ...wizardData,
+        },
+      },
+      project: project ?? null,
+      po,
+      controlStatus,
+      approvalMatrix: WAD_APPROVAL_MATRIX.map(({ key, label }) => ({ key, label })),
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error('[WAD Wizard] GET error:', err);
@@ -2265,12 +2416,34 @@ router.patch(
       // "last edited by … on …" without needing a separate column.
       const sessionDisplayName = sessionUser.displayName ?? sessionUser.username ?? `user:${sessionUser.id ?? 'unknown'}`;
       const editedAt = new Date().toISOString();
+      const existingWizardData = (wad.wizardData as Record<string, unknown> | null) ?? {};
       const existingMeta =
-        ((wad.wizardData as Record<string, unknown> | null)?.__meta as Record<string, unknown> | undefined) ?? {};
+        (existingWizardData.__meta as Record<string, unknown> | undefined) ?? {};
+      const existingRevisionStatus = typeof existingWizardData.revisionStatus === 'string' ? existingWizardData.revisionStatus : 'DRAFT';
+      const existingRevisionHistory = Array.isArray(existingWizardData.revisionHistory) ? existingWizardData.revisionHistory : [];
+      const nextRevision = existingRevisionStatus === 'NEEDS_REVISION'
+        ? getWadRevisionNumber(existingWizardData) + 1
+        : getWadRevisionNumber(existingWizardData);
+      const revisionHistory = existingRevisionStatus === 'NEEDS_REVISION'
+        ? [
+            ...existingRevisionHistory,
+            {
+              revision: nextRevision,
+              action: 'REVISION_STARTED',
+              actorId: sessionUser.id ?? null,
+              actorName: sessionDisplayName,
+              timestamp: editedAt,
+            },
+          ]
+        : existingRevisionHistory;
 
       const mergedWizardData: Record<string, unknown> = {
-        ...(wad.wizardData as Record<string, unknown> ?? {}),
+        ...existingWizardData,
         ...(wizardData ?? {}),
+        currentRevision: nextRevision,
+        revisionStatus: existingRevisionStatus === 'NEEDS_REVISION' ? 'IN_REVISION' : existingRevisionStatus,
+        revisionHistory,
+        approvals: existingRevisionStatus === 'NEEDS_REVISION' ? [] : existingWizardData.approvals,
         __meta: {
           ...existingMeta,
           lastEditedBy: sessionDisplayName,
@@ -2285,6 +2458,8 @@ router.patch(
       };
       if (wadStatus === 'DRAFT' || wadStatus === 'PENDING_APPROVAL') {
         updatePayload.wadStatus = wadStatus;
+      } else if (existingRevisionStatus === 'NEEDS_REVISION') {
+        updatePayload.wadStatus = 'DRAFT';
       }
 
       const [updated] = await db
@@ -2302,26 +2477,111 @@ router.patch(
   },
 );
 
+router.get('/production/:id/control-status', authenticateToken, requirePermission('work_orders.release'), async (req: Request, res: Response) => {
+  const { id } = req.params;
+  if (!WAD_UUID_RE.test(id)) return res.status(400).json({ error: 'Invalid WAD ID format' });
+  try {
+    const [wad] = await db.select().from(productionWorkOrders).where(eq(productionWorkOrders.id, id)).limit(1);
+    if (!wad) return res.status(404).json({ error: 'WAD not found' });
+    const wizardData = (wad.wizardData as Record<string, unknown> | null) ?? {};
+    return res.json(await calculateWadControlStatus(wad, wizardData));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[WAD Wizard] control status error:', err);
+    return res.status(500).json({ error: 'Failed to calculate WAD control status', message: msg });
+  }
+});
+
+const wadApprovalRequestBodySchema = z.object({
+  type: z.enum(WAD_EXCEPTION_TYPES),
+  action: z.enum(['REQUEST', 'APPROVE', 'REJECT']).default('REQUEST'),
+  reason: z.string().min(1, 'reason is required'),
+});
+
+router.post('/production/:id/approval-requests', authenticateToken, requirePermission('work_orders.release'), async (req: Request, res: Response) => {
+  const { id } = req.params;
+  if (!WAD_UUID_RE.test(id)) return res.status(400).json({ error: 'Invalid WAD ID format' });
+
+  const sessionUser = (req as Request & { user?: { id?: number | string | null; username?: string | null; displayName?: string | null; role?: string | null } }).user;
+  if (!sessionUser) return res.status(401).json({ error: 'Authentication required' });
+
+  const parsed = wadApprovalRequestBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten() });
+  }
+
+  try {
+    const [wad] = await db.select().from(productionWorkOrders).where(eq(productionWorkOrders.id, id)).limit(1);
+    if (!wad) return res.status(404).json({ error: 'WAD not found' });
+
+    const sessionRole = (sessionUser.role ?? '').toUpperCase();
+    const canResolve = sessionRole === 'ADMIN' || sessionRole === 'OWNER' || sessionRole === 'EXECUTIVE' || sessionRole === 'PROJECT_MANAGER';
+    if (parsed.data.action !== 'REQUEST' && !canResolve) {
+      return res.status(403).json({ error: 'Only PM, executive, admin, or owner roles may resolve WAD exception approval requests.' });
+    }
+
+    const sessionUserIdRaw = sessionUser.id;
+    const sessionUserIdNumber = typeof sessionUserIdRaw === 'number'
+      ? sessionUserIdRaw
+      : (sessionUserIdRaw != null ? Number.parseInt(String(sessionUserIdRaw), 10) || null : null);
+    const sessionDisplayName = sessionUser.displayName ?? sessionUser.username ?? `user:${sessionUserIdRaw ?? 'unknown'}`;
+    const now = new Date().toISOString();
+
+    const existingData = (wad.wizardData as Record<string, unknown> | null) ?? {};
+    const existingRequests = Array.isArray(existingData.approvalRequests) ? existingData.approvalRequests : [];
+    const nextRequest = {
+      id: `wad-ex-${Date.now().toString(36)}`,
+      type: parsed.data.type,
+      status: parsed.data.action === 'APPROVE' ? 'APPROVED' : parsed.data.action === 'REJECT' ? 'REJECTED' : 'PENDING',
+      reason: parsed.data.reason,
+      requestedById: sessionUserIdNumber,
+      requestedByName: sessionDisplayName,
+      requestedAt: now,
+      resolvedById: parsed.data.action === 'REQUEST' ? null : sessionUserIdNumber,
+      resolvedByName: parsed.data.action === 'REQUEST' ? null : sessionDisplayName,
+      resolvedAt: parsed.data.action === 'REQUEST' ? null : now,
+    };
+
+    const updatedWizardData = {
+      ...existingData,
+      approvalRequests: [...existingRequests, nextRequest],
+    };
+
+    const [updated] = await db
+      .update(productionWorkOrders)
+      .set({ wizardData: updatedWizardData, updatedAt: new Date() })
+      .where(eq(productionWorkOrders.id, id))
+      .returning();
+
+    await recordAuditEvent({
+      eventType: `WAD_EXCEPTION_${nextRequest.status}`,
+      subjectType: 'production_work_order',
+      subjectId: id,
+      sourceService: 'workOrders.router',
+      actor: { id: sessionUserIdNumber, username: sessionDisplayName, role: sessionRole || null },
+      reason: parsed.data.reason,
+      payload: {
+        workOrderNumber: wad.workOrderNumber,
+        projectId: wad.projectId,
+        request: nextRequest,
+      },
+    }).catch((e: Error) => console.warn('[AuditLedger] WAD exception request ledger write failed:', e?.message));
+
+    return res.status(201).json({ wad: updated, request: nextRequest });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[WAD Wizard] approval request error:', err);
+    return res.status(500).json({ error: 'Failed to record WAD approval request', message: msg });
+  }
+});
+
 // POST /production/:id/wizard/approve — record an approval role decision.
 // Auth: an authenticated session is required, plus the work_orders.release capability
 // (the same gate used for the P2 release flow this approval implicitly satisfies).
 // Identity (userId / displayName / system role) is taken from req.user — never the body —
 // so an attacker cannot spoof the approver. The body's `role` field selects which WAD
-// approval slot is being filled (project_manager / production_manager / quality / finance);
+// approval slot is being filled (PM / engineering / quality / operations / executive);
 // the user must hold the system-level capability to fill it, enforced via the slot policy.
-const WAD_APPROVAL_SLOTS = ['project_manager', 'production_manager', 'quality', 'finance', 'engineering', 'compliance'] as const;
-type WadApprovalSlot = typeof WAD_APPROVAL_SLOTS[number];
-
-// Map each WAD slot to the system roles permitted to fill it. ADMIN/OWNER bypass via
-// requirePermission's superuser short-circuit, so they can always sign every slot.
-const WAD_SLOT_ALLOWED_ROLES: Record<WadApprovalSlot, ReadonlyArray<string>> = {
-  project_manager: ['PROJECT_MANAGER', 'ADMIN', 'OWNER'],
-  production_manager: ['PRODUCTION_MANAGER', 'MANAGER', 'SUPERVISOR', 'ADMIN', 'OWNER'],
-  quality: ['QUALITY', 'QC', 'MANAGER', 'ADMIN', 'OWNER'],
-  finance: ['FINANCE', 'ACCOUNTING', 'ADMIN', 'OWNER'],
-  engineering: ['ENGINEERING', 'ADMIN', 'OWNER'],
-  compliance: ['COMPLIANCE', 'ADMIN', 'OWNER'],
-};
 
 router.post(
   '/production/:id/wizard/approve',
@@ -2339,11 +2599,11 @@ router.post(
       if (!wad) return res.status(404).json({ error: 'WAD not found' });
 
       const body = req.body as { role?: string; decision?: 'APPROVED' | 'REJECTED'; comments?: string };
-      const role = body.role as WadApprovalSlot | undefined;
+      const role = normalizeWadApprovalRole(body.role);
       const decision = body.decision;
       const comments = body.comments ?? null;
 
-      if (!role || !WAD_APPROVAL_SLOTS.includes(role)) {
+      if (!role) {
         return res.status(400).json({ error: `role must be one of: ${WAD_APPROVAL_SLOTS.join(', ')}` });
       }
       if (decision !== 'APPROVED' && decision !== 'REJECTED') {
@@ -2373,6 +2633,8 @@ router.post(
         role?: string; userId?: number | string | null; displayName?: string; decision?: string;
         comments?: string | null; timestamp?: string;
       }>;
+      const existingRevisionHistory = Array.isArray(existingData.revisionHistory) ? existingData.revisionHistory : [];
+      const currentRevision = getWadRevisionNumber(existingData);
 
       const newApproval = {
         role,
@@ -2384,24 +2646,44 @@ router.post(
       };
 
       const updatedApprovals = [
-        ...existingApprovals.filter((a) => a.role !== role),
+        ...existingApprovals.filter((a) => normalizeWadApprovalRole(a.role) !== role),
         newApproval,
       ];
 
-      const updatedWizardData = { ...existingData, approvals: updatedApprovals };
+      const revisionEvent = {
+        revision: currentRevision,
+        action: decision === 'APPROVED' ? 'APPROVAL_RECORDED' : 'REJECTION_RECORDED',
+        role,
+        actorId: sessionUserIdNumber,
+        actorName: sessionDisplayName,
+        comments,
+        timestamp: newApproval.timestamp,
+      };
 
-      // Determine required roles for full approval (the four required slots).
-      const requiredRoles: WadApprovalSlot[] = ['project_manager', 'production_manager', 'quality', 'finance'];
+      const updatedWizardData = {
+        ...existingData,
+        currentRevision,
+        revisionStatus: decision === 'REJECTED' ? 'NEEDS_REVISION' : existingData.revisionStatus ?? 'IN_REVIEW',
+        approvals: updatedApprovals,
+        revisionHistory: [...existingRevisionHistory, revisionEvent],
+      };
+
+      // Determine required roles for full approval (PM, engineering, quality, operations, executive).
+      const requiredRoles: WadApprovalSlot[] = [...WAD_APPROVAL_SLOTS];
       const allApproved = requiredRoles.every((r) =>
-        updatedApprovals.some((a) => a.role === r && a.decision === 'APPROVED')
+        updatedApprovals.some((a) => normalizeWadApprovalRole(a.role) === r && a.decision === 'APPROVED')
       );
 
-      const newWadStatus = allApproved ? 'APPROVED' : wad.wadStatus;
+      const controlStatus = await calculateWadControlStatus(wad, updatedWizardData);
+      const missingExceptionRequests = controlStatus.exceptions.missingRequests;
+      const releaseApproved = allApproved && missingExceptionRequests.length === 0;
+
+      const newWadStatus = releaseApproved ? 'APPROVED' : (decision === 'REJECTED' ? 'DRAFT' : wad.wadStatus);
 
       // Detect backfill: WAD reaching APPROVED while project is already in production.
       let isBackfill = false;
       let projectStage: string | null = null;
-      if (allApproved && wad.projectId) {
+      if (releaseApproved && wad.projectId) {
         const [p] = await db.select({ currentStage: projects.currentStage })
           .from(projects).where(eq(projects.id, wad.projectId)).limit(1);
         projectStage = p?.currentStage ?? null;
@@ -2419,7 +2701,7 @@ router.post(
       // approval so the project's WAD gate flips ✓ regardless of where the PWO
       // sat before approval (e.g. PLANNED, READY, IN_PROGRESS for backfill).
       const TERMINAL_STATUSES = new Set(['COMPLETE', 'COMPLETED', 'CANCELLED', 'CANCELED', 'CLOSED']);
-      if (allApproved && wad.status !== 'RELEASED' && !TERMINAL_STATUSES.has(wad.status)) {
+      if (releaseApproved && wad.status !== 'RELEASED' && !TERMINAL_STATUSES.has(wad.status)) {
         updateSet.status = 'RELEASED';
       }
 
@@ -2435,10 +2717,29 @@ router.post(
         action: decision === 'APPROVED' ? 'WAD_APPROVAL_RECORDED' : 'WAD_REJECTION_RECORDED',
         actor: { id: sessionUserIdNumber ?? 0, username: sessionDisplayName },
         reason: comments ?? undefined,
-        meta: { role, decision, allApproved, backfill: isBackfill, sessionRole },
+        meta: { role, decision, allApproved: releaseApproved, matrixApproved: allApproved, missingExceptionRequests, backfill: isBackfill, sessionRole },
       }).catch((e: Error) => console.warn('[Audit] WAD approval log failed:', e?.message));
 
-      if (allApproved) {
+      await recordAuditEvent({
+        eventType: decision === 'APPROVED' ? 'WAD_APPROVAL_SLOT_APPROVED' : 'WAD_APPROVAL_SLOT_REJECTED',
+        subjectType: 'production_work_order',
+        subjectId: id,
+        sourceService: 'workOrders.router',
+        actor: { id: sessionUserIdNumber, username: sessionDisplayName, role: sessionRole || null },
+        reason: comments,
+        payload: {
+          projectId: wad.projectId,
+          workOrderNumber: wad.workOrderNumber,
+          role,
+          decision,
+          revision: currentRevision,
+          revisionStatus: updatedWizardData.revisionStatus,
+          matrixApproved: allApproved,
+          missingExceptionRequests,
+        },
+      }).catch((e: Error) => console.warn('[AuditLedger] WAD approval slot ledger write failed:', e?.message));
+
+      if (releaseApproved) {
         await recordAuditEvent({
           eventType: isBackfill ? 'WAD_BACKFILL_APPROVED' : 'WAD_APPROVED',
           subjectType: 'production_work_order',
@@ -2462,7 +2763,7 @@ router.post(
         }).catch((e: Error) => console.warn('[AuditLedger] WAD approval ledger write failed:', e?.message));
       }
 
-      return res.json({ wad: updated, allApproved, backfill: isBackfill });
+      return res.json({ wad: updated, allApproved: releaseApproved, matrixApproved: allApproved, missingRequests: missingExceptionRequests, backfill: isBackfill });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error('[WAD Wizard] approve error:', err);


### PR DESCRIPTION
## Summary
- Adds the required WAD approval matrix for PM, engineering, quality, operations, and executive approvals.
- Preserves WAD revision history and moves rejected WADs into a revision workflow before approvals can be reset.
- Adds server-derived WAD control status for labor hours, material spend, outside processing caps, projected overrun, charge-code override, and late-release exception gates.
- Adds WAD exception approval requests for overrun, charge-code override, and late-release releases, with audit-ledger events.
- Surfaces control meters, exception requests, and revision history in the WAD wizard final review.

## Validation
- `git diff --check`
- `git diff --cached --check`

## Notes
- Local TypeScript/build validation could not run because this checkout has no `npm`, `npx`, `tsc`, or `node_modules` available in the shell.