### PR TITLE
Add Section 5 engineering control revision and ECO framework

### DIFF
--- a/migrations/0128_engineering_control_revision_eco.sql
+++ b/migrations/0128_engineering_control_revision_eco.sql
@@ -1,0 +1,140 @@
+-- Section 5 Engineering Control: reusable revision, effectivity, and ECO framework.
+
+DO $$ BEGIN
+  CREATE TYPE engineering_controlled_artifact_type AS ENUM (
+    'BOM',
+    'ROUTING',
+    'TRAVELER_TEMPLATE',
+    'WORK_INSTRUCTION',
+    'SPEC',
+    'QC_FORM'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE engineering_release_state AS ENUM (
+    'draft',
+    'review',
+    'approved',
+    'released',
+    'obsolete'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE engineering_eco_status AS ENUM (
+    'draft',
+    'impact_review',
+    'approval',
+    'approved',
+    'rejected',
+    'implemented',
+    'released',
+    'closed'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS engineering_controlled_revisions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  artifact_type engineering_controlled_artifact_type NOT NULL,
+  artifact_id TEXT NOT NULL,
+  artifact_number TEXT,
+  title TEXT NOT NULL,
+  revision TEXT NOT NULL,
+  release_state engineering_release_state NOT NULL DEFAULT 'draft',
+  description TEXT,
+  source_module TEXT,
+  source_version_id TEXT,
+  change_summary TEXT,
+  effectivity_serial_start TEXT,
+  effectivity_serial_end TEXT,
+  effectivity_start_date DATE,
+  effectivity_end_date DATE,
+  effectivity_customer_id TEXT,
+  effectivity_customer_name TEXT,
+  effectivity_project_id UUID,
+  effectivity_project_number TEXT,
+  created_by TEXT NOT NULL DEFAULT 'system',
+  reviewed_by TEXT,
+  reviewed_at TIMESTAMPTZ,
+  approved_by TEXT,
+  approved_at TIMESTAMPTZ,
+  released_by TEXT,
+  released_at TIMESTAMPTZ,
+  obsolete_by TEXT,
+  obsolete_at TIMESTAMPTZ,
+  release_notes TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT ecr_artifact_revision_unique UNIQUE (artifact_type, artifact_id, revision)
+);
+
+CREATE INDEX IF NOT EXISTS ecr_artifact_idx
+  ON engineering_controlled_revisions (artifact_type, artifact_id);
+CREATE INDEX IF NOT EXISTS ecr_release_state_idx
+  ON engineering_controlled_revisions (release_state);
+CREATE INDEX IF NOT EXISTS ecr_effectivity_date_idx
+  ON engineering_controlled_revisions (effectivity_start_date, effectivity_end_date);
+CREATE INDEX IF NOT EXISTS ecr_effectivity_customer_idx
+  ON engineering_controlled_revisions (effectivity_customer_id);
+CREATE INDEX IF NOT EXISTS ecr_effectivity_project_idx
+  ON engineering_controlled_revisions (effectivity_project_id);
+
+CREATE TABLE IF NOT EXISTS engineering_change_orders (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  eco_number TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  change_description TEXT NOT NULL,
+  status engineering_eco_status NOT NULL DEFAULT 'draft',
+  requested_by TEXT NOT NULL DEFAULT 'system',
+  requested_at TIMESTAMPTZ DEFAULT NOW(),
+  impact_review JSONB NOT NULL DEFAULT '{}'::jsonb,
+  impact_reviewed_by TEXT,
+  impact_reviewed_at TIMESTAMPTZ,
+  approval_plan JSONB NOT NULL DEFAULT '{}'::jsonb,
+  approved_by TEXT,
+  approved_at TIMESTAMPTZ,
+  rejected_by TEXT,
+  rejected_at TIMESTAMPTZ,
+  rejection_reason TEXT,
+  implementation_date DATE,
+  implemented_by TEXT,
+  implemented_at TIMESTAMPTZ,
+  release_linkage JSONB NOT NULL DEFAULT '{}'::jsonb,
+  released_by TEXT,
+  released_at TIMESTAMPTZ,
+  closed_by TEXT,
+  closed_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS eco_status_idx
+  ON engineering_change_orders (status);
+CREATE INDEX IF NOT EXISTS eco_implementation_date_idx
+  ON engineering_change_orders (implementation_date);
+
+CREATE TABLE IF NOT EXISTS engineering_eco_revision_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  eco_id UUID NOT NULL REFERENCES engineering_change_orders(id) ON DELETE CASCADE,
+  revision_id UUID NOT NULL REFERENCES engineering_controlled_revisions(id) ON DELETE CASCADE,
+  link_type TEXT NOT NULL DEFAULT 'release',
+  notes TEXT,
+  created_by TEXT NOT NULL DEFAULT 'system',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT eco_revision_links_unique UNIQUE (eco_id, revision_id, link_type)
+);
+
+CREATE INDEX IF NOT EXISTS eco_revision_links_eco_idx
+  ON engineering_eco_revision_links (eco_id);
+CREATE INDEX IF NOT EXISTS eco_revision_links_revision_idx
+  ON engineering_eco_revision_links (revision_id);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -17790,6 +17790,184 @@ export type ProductionControlTemplate = typeof productionControlTemplates.$infer
 export type InsertProductionControlTemplate = z.infer<typeof insertProductionControlTemplateSchema>;
 
 // ---------------------------------------------------------------------------
+// Engineering Control - reusable revision, effectivity, and ECO framework
+// ---------------------------------------------------------------------------
+
+export const engineeringControlledArtifactTypeEnum = pgEnum('engineering_controlled_artifact_type', [
+  'BOM',
+  'ROUTING',
+  'TRAVELER_TEMPLATE',
+  'WORK_INSTRUCTION',
+  'SPEC',
+  'QC_FORM',
+]);
+
+export const engineeringReleaseStateEnum = pgEnum('engineering_release_state', [
+  'draft',
+  'review',
+  'approved',
+  'released',
+  'obsolete',
+]);
+
+export const engineeringEcoStatusEnum = pgEnum('engineering_eco_status', [
+  'draft',
+  'impact_review',
+  'approval',
+  'approved',
+  'rejected',
+  'implemented',
+  'released',
+  'closed',
+]);
+
+export const engineeringControlledRevisions = pgTable('engineering_controlled_revisions', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  artifactType: engineeringControlledArtifactTypeEnum('artifact_type').notNull(),
+  artifactId: text('artifact_id').notNull(),
+  artifactNumber: text('artifact_number'),
+  title: text('title').notNull(),
+  revision: text('revision').notNull(),
+  releaseState: engineeringReleaseStateEnum('release_state').notNull().default('draft'),
+  description: text('description'),
+  sourceModule: text('source_module'),
+  sourceVersionId: text('source_version_id'),
+  changeSummary: text('change_summary'),
+  effectivitySerialStart: text('effectivity_serial_start'),
+  effectivitySerialEnd: text('effectivity_serial_end'),
+  effectivityStartDate: date('effectivity_start_date'),
+  effectivityEndDate: date('effectivity_end_date'),
+  effectivityCustomerId: text('effectivity_customer_id'),
+  effectivityCustomerName: text('effectivity_customer_name'),
+  effectivityProjectId: uuid('effectivity_project_id'),
+  effectivityProjectNumber: text('effectivity_project_number'),
+  createdBy: text('created_by').notNull().default('system'),
+  reviewedBy: text('reviewed_by'),
+  reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
+  approvedBy: text('approved_by'),
+  approvedAt: timestamp('approved_at', { withTimezone: true }),
+  releasedBy: text('released_by'),
+  releasedAt: timestamp('released_at', { withTimezone: true }),
+  obsoleteBy: text('obsolete_by'),
+  obsoleteAt: timestamp('obsolete_at', { withTimezone: true }),
+  releaseNotes: text('release_notes'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  createdAt: timestamp('created_at', { withTimezone: true }).default(sql`now()`),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).default(sql`now()`),
+}, (table) => ({
+  artifactIdx: index('ecr_artifact_idx').on(table.artifactType, table.artifactId),
+  releaseStateIdx: index('ecr_release_state_idx').on(table.releaseState),
+  effectivityDateIdx: index('ecr_effectivity_date_idx').on(table.effectivityStartDate, table.effectivityEndDate),
+  effectivityCustomerIdx: index('ecr_effectivity_customer_idx').on(table.effectivityCustomerId),
+  effectivityProjectIdx: index('ecr_effectivity_project_idx').on(table.effectivityProjectId),
+  revisionUniqueIdx: uniqueIndex('ecr_artifact_revision_unique').on(table.artifactType, table.artifactId, table.revision),
+}));
+
+export const engineeringChangeOrders = pgTable('engineering_change_orders', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  ecoNumber: text('eco_number').notNull().unique(),
+  title: text('title').notNull(),
+  reason: text('reason').notNull(),
+  changeDescription: text('change_description').notNull(),
+  status: engineeringEcoStatusEnum('status').notNull().default('draft'),
+  requestedBy: text('requested_by').notNull().default('system'),
+  requestedAt: timestamp('requested_at', { withTimezone: true }).default(sql`now()`),
+  impactReview: jsonb('impact_review').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  impactReviewedBy: text('impact_reviewed_by'),
+  impactReviewedAt: timestamp('impact_reviewed_at', { withTimezone: true }),
+  approvalPlan: jsonb('approval_plan').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  approvedBy: text('approved_by'),
+  approvedAt: timestamp('approved_at', { withTimezone: true }),
+  rejectedBy: text('rejected_by'),
+  rejectedAt: timestamp('rejected_at', { withTimezone: true }),
+  rejectionReason: text('rejection_reason'),
+  implementationDate: date('implementation_date'),
+  implementedBy: text('implemented_by'),
+  implementedAt: timestamp('implemented_at', { withTimezone: true }),
+  releaseLinkage: jsonb('release_linkage').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  releasedBy: text('released_by'),
+  releasedAt: timestamp('released_at', { withTimezone: true }),
+  closedBy: text('closed_by'),
+  closedAt: timestamp('closed_at', { withTimezone: true }),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  createdAt: timestamp('created_at', { withTimezone: true }).default(sql`now()`),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).default(sql`now()`),
+}, (table) => ({
+  statusIdx: index('eco_status_idx').on(table.status),
+  implementationDateIdx: index('eco_implementation_date_idx').on(table.implementationDate),
+}));
+
+export const engineeringEcoRevisionLinks = pgTable('engineering_eco_revision_links', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  ecoId: uuid('eco_id').notNull().references(() => engineeringChangeOrders.id, { onDelete: 'cascade' }),
+  revisionId: uuid('revision_id').notNull().references(() => engineeringControlledRevisions.id, { onDelete: 'cascade' }),
+  linkType: text('link_type').notNull().default('release'),
+  notes: text('notes'),
+  createdBy: text('created_by').notNull().default('system'),
+  createdAt: timestamp('created_at', { withTimezone: true }).default(sql`now()`),
+}, (table) => ({
+  ecoIdx: index('eco_revision_links_eco_idx').on(table.ecoId),
+  revisionIdx: index('eco_revision_links_revision_idx').on(table.revisionId),
+  ecoRevisionUniqueIdx: uniqueIndex('eco_revision_links_unique').on(table.ecoId, table.revisionId, table.linkType),
+}));
+
+export const insertEngineeringControlledRevisionSchema = createInsertSchema(engineeringControlledRevisions).omit({
+  id: true,
+  reviewedAt: true,
+  approvedAt: true,
+  releasedAt: true,
+  obsoleteAt: true,
+  createdAt: true,
+  updatedAt: true,
+}).extend({
+  artifactType: z.enum(['BOM', 'ROUTING', 'TRAVELER_TEMPLATE', 'WORK_INSTRUCTION', 'SPEC', 'QC_FORM']),
+  artifactId: z.string().min(1),
+  title: z.string().min(1),
+  revision: z.string().min(1),
+  releaseState: z.enum(['draft', 'review', 'approved', 'released', 'obsolete']).default('draft'),
+  metadata: z.record(z.unknown()).optional().nullable(),
+});
+
+export const insertEngineeringChangeOrderSchema = createInsertSchema(engineeringChangeOrders).omit({
+  id: true,
+  requestedAt: true,
+  impactReviewedAt: true,
+  approvedAt: true,
+  rejectedAt: true,
+  implementedAt: true,
+  releasedAt: true,
+  closedAt: true,
+  createdAt: true,
+  updatedAt: true,
+}).extend({
+  ecoNumber: z.string().min(1),
+  title: z.string().min(1),
+  reason: z.string().min(1),
+  changeDescription: z.string().min(1),
+  status: z.enum(['draft', 'impact_review', 'approval', 'approved', 'rejected', 'implemented', 'released', 'closed']).default('draft'),
+  impactReview: z.record(z.unknown()).optional().nullable(),
+  approvalPlan: z.record(z.unknown()).optional().nullable(),
+  releaseLinkage: z.record(z.unknown()).optional().nullable(),
+  metadata: z.record(z.unknown()).optional().nullable(),
+});
+
+export const insertEngineeringEcoRevisionLinkSchema = createInsertSchema(engineeringEcoRevisionLinks).omit({
+  id: true,
+  createdAt: true,
+}).extend({
+  ecoId: z.string().uuid(),
+  revisionId: z.string().uuid(),
+  linkType: z.string().min(1).default('release'),
+});
+
+export type EngineeringControlledRevision = typeof engineeringControlledRevisions.$inferSelect;
+export type InsertEngineeringControlledRevision = z.infer<typeof insertEngineeringControlledRevisionSchema>;
+export type EngineeringChangeOrder = typeof engineeringChangeOrders.$inferSelect;
+export type InsertEngineeringChangeOrder = z.infer<typeof insertEngineeringChangeOrderSchema>;
+export type EngineeringEcoRevisionLink = typeof engineeringEcoRevisionLinks.$inferSelect;
+export type InsertEngineeringEcoRevisionLink = z.infer<typeof insertEngineeringEcoRevisionLinkSchema>;
+
+// ---------------------------------------------------------------------------
 // WAD Production Controls — persisted controls + provision record per WAD
 // ---------------------------------------------------------------------------
 

--- a/server/src/routes/engineeringControl.ts
+++ b/server/src/routes/engineeringControl.ts
@@ -1,0 +1,541 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { and, desc, eq } from 'drizzle-orm';
+import { db } from '../../db';
+import { authenticateToken } from '../../middleware/auth';
+import {
+  engineeringControlledRevisions,
+  engineeringChangeOrders,
+  engineeringEcoRevisionLinks,
+  insertEngineeringControlledRevisionSchema,
+  insertEngineeringChangeOrderSchema,
+  insertEngineeringEcoRevisionLinkSchema,
+} from '../../schema';
+
+const router = Router();
+
+const releaseStates = ['draft', 'review', 'approved', 'released', 'obsolete'] as const;
+const ecoStatuses = ['draft', 'impact_review', 'approval', 'approved', 'rejected', 'implemented', 'released', 'closed'] as const;
+
+const listRevisionQuerySchema = z.object({
+  artifactType: z.enum(['BOM', 'ROUTING', 'TRAVELER_TEMPLATE', 'WORK_INSTRUCTION', 'SPEC', 'QC_FORM']).optional(),
+  artifactId: z.string().optional(),
+  releaseState: z.enum(releaseStates).optional(),
+  customerId: z.string().optional(),
+  projectId: z.string().uuid().optional(),
+});
+
+const effectiveRevisionQuerySchema = z.object({
+  artifactType: z.enum(['BOM', 'ROUTING', 'TRAVELER_TEMPLATE', 'WORK_INSTRUCTION', 'SPEC', 'QC_FORM']),
+  artifactId: z.string().optional(),
+  serialNumber: z.string().optional(),
+  effectiveDate: z.string().optional(),
+  customerId: z.string().optional(),
+  projectId: z.string().uuid().optional(),
+});
+
+const listEcoQuerySchema = z.object({
+  status: z.enum(ecoStatuses).optional(),
+});
+
+const transitionRevisionSchema = z.object({
+  releaseState: z.enum(releaseStates),
+  actor: z.string().optional(),
+  releaseNotes: z.string().optional(),
+  ecoId: z.string().uuid().optional(),
+});
+
+const updateRevisionSchema = insertEngineeringControlledRevisionSchema.partial().omit({
+  artifactType: true,
+  artifactId: true,
+  revision: true,
+});
+
+const impactReviewSchema = z.object({
+  impactReview: z.record(z.unknown()),
+  actor: z.string().optional(),
+  approvalPlan: z.record(z.unknown()).optional(),
+});
+
+const approvalSchema = z.object({
+  actor: z.string().optional(),
+  approvalPlan: z.record(z.unknown()).optional(),
+});
+
+const rejectionSchema = z.object({
+  actor: z.string().optional(),
+  rejectionReason: z.string().min(1),
+});
+
+const implementationSchema = z.object({
+  actor: z.string().optional(),
+  implementationDate: z.string().min(1),
+  releaseLinkage: z.record(z.unknown()).optional(),
+});
+
+const ecoReleaseSchema = z.object({
+  actor: z.string().optional(),
+  releaseLinkage: z.record(z.unknown()).optional(),
+});
+
+function actorFromRequest(req: Request, override?: string): string {
+  if (override) return override;
+  const user = (req as any).user;
+  return user?.username || user?.email || user?.displayName || 'system';
+}
+
+function transitionAllowed(current: string, next: string): boolean {
+  if (next === 'obsolete') return current !== 'obsolete';
+  if (current === 'obsolete') return false;
+  if (current === next) return true;
+  const order: Record<string, number> = {
+    draft: 0,
+    review: 1,
+    approved: 2,
+    released: 3,
+  };
+  return order[next] === order[current] + 1;
+}
+
+function buildRevisionFilters(query: z.infer<typeof listRevisionQuerySchema>) {
+  const filters = [];
+  if (query.artifactType) filters.push(eq(engineeringControlledRevisions.artifactType, query.artifactType));
+  if (query.artifactId) filters.push(eq(engineeringControlledRevisions.artifactId, query.artifactId));
+  if (query.releaseState) filters.push(eq(engineeringControlledRevisions.releaseState, query.releaseState));
+  if (query.customerId) filters.push(eq(engineeringControlledRevisions.effectivityCustomerId, query.customerId));
+  if (query.projectId) filters.push(eq(engineeringControlledRevisions.effectivityProjectId, query.projectId));
+  return filters.length ? and(...filters) : undefined;
+}
+
+function dateWithinRange(candidateDate: string, start?: string | null, end?: string | null): boolean {
+  const value = candidateDate.slice(0, 10);
+  return (!start || value >= String(start).slice(0, 10)) && (!end || value <= String(end).slice(0, 10));
+}
+
+function serialWithinRange(serial: string | undefined, start?: string | null, end?: string | null): boolean {
+  if (!start && !end) return true;
+  if (!serial) return false;
+  return (!start || serial >= start) && (!end || serial <= end);
+}
+
+router.get('/revisions', async (req: Request, res: Response) => {
+  try {
+    const parsed = listRevisionQuerySchema.safeParse(req.query);
+    if (!parsed.success) return res.status(400).json({ error: 'Invalid filters', details: parsed.error.issues });
+
+    const rows = await db
+      .select()
+      .from(engineeringControlledRevisions)
+      .where(buildRevisionFilters(parsed.data))
+      .orderBy(desc(engineeringControlledRevisions.createdAt));
+
+    return res.json(rows);
+  } catch (error) {
+    console.error('[EngineeringControl] list revisions error:', error);
+    return res.status(500).json({ error: 'Failed to fetch engineering revisions' });
+  }
+});
+
+router.get('/revisions/effective', async (req: Request, res: Response) => {
+  try {
+    const parsed = effectiveRevisionQuerySchema.safeParse(req.query);
+    if (!parsed.success) return res.status(400).json({ error: 'Invalid filters', details: parsed.error.issues });
+
+    const filters = [
+      eq(engineeringControlledRevisions.artifactType, parsed.data.artifactType),
+      eq(engineeringControlledRevisions.releaseState, 'released' as const),
+    ];
+    if (parsed.data.artifactId) {
+      filters.push(eq(engineeringControlledRevisions.artifactId, parsed.data.artifactId));
+    }
+
+    const rows = await db
+      .select()
+      .from(engineeringControlledRevisions)
+      .where(and(...filters))
+      .orderBy(desc(engineeringControlledRevisions.releasedAt));
+
+    const effectiveDate = parsed.data.effectiveDate ?? new Date().toISOString().slice(0, 10);
+    const matches = rows.filter((row) => {
+      const customerMatch = !row.effectivityCustomerId || row.effectivityCustomerId === parsed.data.customerId;
+      const projectMatch = !row.effectivityProjectId || row.effectivityProjectId === parsed.data.projectId;
+      const dateMatch = dateWithinRange(effectiveDate, row.effectivityStartDate, row.effectivityEndDate);
+      const serialMatch = serialWithinRange(parsed.data.serialNumber, row.effectivitySerialStart, row.effectivitySerialEnd);
+      return customerMatch && projectMatch && dateMatch && serialMatch;
+    });
+
+    return res.json({ effectiveDate, matches });
+  } catch (error) {
+    console.error('[EngineeringControl] resolve effectivity error:', error);
+    return res.status(500).json({ error: 'Failed to resolve effective engineering revisions' });
+  }
+});
+
+router.get('/revisions/:id', async (req: Request, res: Response) => {
+  try {
+    const [revision] = await db
+      .select()
+      .from(engineeringControlledRevisions)
+      .where(eq(engineeringControlledRevisions.id, req.params.id))
+      .limit(1);
+    if (!revision) return res.status(404).json({ error: 'Engineering revision not found' });
+    return res.json(revision);
+  } catch (error) {
+    console.error('[EngineeringControl] get revision error:', error);
+    return res.status(500).json({ error: 'Failed to fetch engineering revision' });
+  }
+});
+
+router.post('/revisions', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = insertEngineeringControlledRevisionSchema.safeParse({
+      ...req.body,
+      createdBy: actorFromRequest(req, req.body?.createdBy),
+    });
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [created] = await db.insert(engineeringControlledRevisions).values(parsed.data).returning();
+    return res.status(201).json(created);
+  } catch (error: any) {
+    console.error('[EngineeringControl] create revision error:', error);
+    return res.status(500).json({ error: 'Failed to create engineering revision', detail: error?.message });
+  }
+});
+
+router.patch('/revisions/:id', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const [existing] = await db
+      .select()
+      .from(engineeringControlledRevisions)
+      .where(eq(engineeringControlledRevisions.id, req.params.id))
+      .limit(1);
+    if (!existing) return res.status(404).json({ error: 'Engineering revision not found' });
+    if (!['draft', 'review'].includes(existing.releaseState)) {
+      return res.status(400).json({ error: 'Only draft or review revisions can be edited directly. Use an ECO for released content.' });
+    }
+
+    const parsed = updateRevisionSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [updated] = await db
+      .update(engineeringControlledRevisions)
+      .set({ ...parsed.data, updatedAt: new Date() })
+      .where(eq(engineeringControlledRevisions.id, req.params.id))
+      .returning();
+    return res.json(updated);
+  } catch (error: any) {
+    console.error('[EngineeringControl] update revision error:', error);
+    return res.status(500).json({ error: 'Failed to update engineering revision', detail: error?.message });
+  }
+});
+
+router.post('/revisions/:id/transition', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = transitionRevisionSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [existing] = await db
+      .select()
+      .from(engineeringControlledRevisions)
+      .where(eq(engineeringControlledRevisions.id, req.params.id))
+      .limit(1);
+    if (!existing) return res.status(404).json({ error: 'Engineering revision not found' });
+    if (!transitionAllowed(existing.releaseState, parsed.data.releaseState)) {
+      return res.status(400).json({ error: `Cannot transition revision from ${existing.releaseState} to ${parsed.data.releaseState}` });
+    }
+
+    if (parsed.data.ecoId) {
+      const [eco] = await db
+        .select()
+        .from(engineeringChangeOrders)
+        .where(eq(engineeringChangeOrders.id, parsed.data.ecoId))
+        .limit(1);
+      if (!eco) return res.status(404).json({ error: 'Linked ECO not found' });
+      if (parsed.data.releaseState === 'released' && !['approved', 'implemented', 'released'].includes(eco.status)) {
+        return res.status(400).json({ error: 'Revision release requires an approved, implemented, or released ECO.' });
+      }
+    }
+
+    const actor = actorFromRequest(req, parsed.data.actor);
+    const now = new Date();
+    const updates: Record<string, unknown> = {
+      releaseState: parsed.data.releaseState,
+      updatedAt: now,
+    };
+    if (parsed.data.releaseNotes !== undefined) updates.releaseNotes = parsed.data.releaseNotes;
+    if (parsed.data.releaseState === 'review') {
+      updates.reviewedBy = actor;
+      updates.reviewedAt = now;
+    }
+    if (parsed.data.releaseState === 'approved') {
+      updates.approvedBy = actor;
+      updates.approvedAt = now;
+    }
+    if (parsed.data.releaseState === 'released') {
+      updates.releasedBy = actor;
+      updates.releasedAt = now;
+    }
+    if (parsed.data.releaseState === 'obsolete') {
+      updates.obsoleteBy = actor;
+      updates.obsoleteAt = now;
+    }
+
+    const [updated] = await db
+      .update(engineeringControlledRevisions)
+      .set(updates)
+      .where(eq(engineeringControlledRevisions.id, req.params.id))
+      .returning();
+
+    if (parsed.data.ecoId) {
+      await db
+        .insert(engineeringEcoRevisionLinks)
+        .values({
+          ecoId: parsed.data.ecoId,
+          revisionId: updated.id,
+          linkType: parsed.data.releaseState === 'released' ? 'release' : parsed.data.releaseState,
+          createdBy: actor,
+        })
+        .onConflictDoNothing();
+    }
+
+    return res.json(updated);
+  } catch (error: any) {
+    console.error('[EngineeringControl] transition revision error:', error);
+    return res.status(500).json({ error: 'Failed to transition engineering revision', detail: error?.message });
+  }
+});
+
+router.get('/ecos', async (req: Request, res: Response) => {
+  try {
+    const parsed = listEcoQuerySchema.safeParse(req.query);
+    if (!parsed.success) return res.status(400).json({ error: 'Invalid filters', details: parsed.error.issues });
+
+    const rows = await db
+      .select()
+      .from(engineeringChangeOrders)
+      .where(parsed.data.status ? eq(engineeringChangeOrders.status, parsed.data.status) : undefined)
+      .orderBy(desc(engineeringChangeOrders.createdAt));
+
+    return res.json(rows);
+  } catch (error) {
+    console.error('[EngineeringControl] list ECOs error:', error);
+    return res.status(500).json({ error: 'Failed to fetch engineering change orders' });
+  }
+});
+
+router.get('/ecos/:id', async (req: Request, res: Response) => {
+  try {
+    const [eco] = await db
+      .select()
+      .from(engineeringChangeOrders)
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .limit(1);
+    if (!eco) return res.status(404).json({ error: 'ECO not found' });
+
+    const links = await db
+      .select()
+      .from(engineeringEcoRevisionLinks)
+      .where(eq(engineeringEcoRevisionLinks.ecoId, req.params.id));
+    return res.json({ ...eco, revisionLinks: links });
+  } catch (error) {
+    console.error('[EngineeringControl] get ECO error:', error);
+    return res.status(500).json({ error: 'Failed to fetch ECO' });
+  }
+});
+
+router.post('/ecos', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = insertEngineeringChangeOrderSchema.safeParse({
+      ...req.body,
+      requestedBy: actorFromRequest(req, req.body?.requestedBy),
+    });
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [created] = await db.insert(engineeringChangeOrders).values(parsed.data).returning();
+    return res.status(201).json(created);
+  } catch (error: any) {
+    console.error('[EngineeringControl] create ECO error:', error);
+    return res.status(500).json({ error: 'Failed to create ECO', detail: error?.message });
+  }
+});
+
+router.post('/ecos/:id/impact-review', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = impactReviewSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [updated] = await db
+      .update(engineeringChangeOrders)
+      .set({
+        status: 'impact_review',
+        impactReview: parsed.data.impactReview,
+        ...(parsed.data.approvalPlan !== undefined ? { approvalPlan: parsed.data.approvalPlan } : {}),
+        impactReviewedBy: actorFromRequest(req, parsed.data.actor),
+        impactReviewedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .returning();
+    if (!updated) return res.status(404).json({ error: 'ECO not found' });
+    return res.json(updated);
+  } catch (error: any) {
+    console.error('[EngineeringControl] ECO impact review error:', error);
+    return res.status(500).json({ error: 'Failed to record ECO impact review', detail: error?.message });
+  }
+});
+
+router.post('/ecos/:id/submit-approval', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = approvalSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [updated] = await db
+      .update(engineeringChangeOrders)
+      .set({
+        status: 'approval',
+        ...(parsed.data.approvalPlan !== undefined ? { approvalPlan: parsed.data.approvalPlan } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .returning();
+    if (!updated) return res.status(404).json({ error: 'ECO not found' });
+    return res.json(updated);
+  } catch (error: any) {
+    console.error('[EngineeringControl] ECO submit approval error:', error);
+    return res.status(500).json({ error: 'Failed to submit ECO for approval', detail: error?.message });
+  }
+});
+
+router.post('/ecos/:id/approve', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = approvalSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [updated] = await db
+      .update(engineeringChangeOrders)
+      .set({
+        status: 'approved',
+        ...(parsed.data.approvalPlan !== undefined ? { approvalPlan: parsed.data.approvalPlan } : {}),
+        approvedBy: actorFromRequest(req, parsed.data.actor),
+        approvedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .returning();
+    if (!updated) return res.status(404).json({ error: 'ECO not found' });
+    return res.json(updated);
+  } catch (error: any) {
+    console.error('[EngineeringControl] ECO approve error:', error);
+    return res.status(500).json({ error: 'Failed to approve ECO', detail: error?.message });
+  }
+});
+
+router.post('/ecos/:id/reject', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = rejectionSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [updated] = await db
+      .update(engineeringChangeOrders)
+      .set({
+        status: 'rejected',
+        rejectedBy: actorFromRequest(req, parsed.data.actor),
+        rejectedAt: new Date(),
+        rejectionReason: parsed.data.rejectionReason,
+        updatedAt: new Date(),
+      })
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .returning();
+    if (!updated) return res.status(404).json({ error: 'ECO not found' });
+    return res.json(updated);
+  } catch (error: any) {
+    console.error('[EngineeringControl] ECO reject error:', error);
+    return res.status(500).json({ error: 'Failed to reject ECO', detail: error?.message });
+  }
+});
+
+router.post('/ecos/:id/implement', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = implementationSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [existing] = await db
+      .select()
+      .from(engineeringChangeOrders)
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .limit(1);
+    if (!existing) return res.status(404).json({ error: 'ECO not found' });
+    if (existing.status !== 'approved') {
+      return res.status(400).json({ error: 'Only approved ECOs can be implemented.' });
+    }
+
+    const [updated] = await db
+      .update(engineeringChangeOrders)
+      .set({
+        status: 'implemented',
+        implementationDate: parsed.data.implementationDate,
+        ...(parsed.data.releaseLinkage !== undefined ? { releaseLinkage: parsed.data.releaseLinkage } : {}),
+        implementedBy: actorFromRequest(req, parsed.data.actor),
+        implementedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .returning();
+    return res.json(updated);
+  } catch (error: any) {
+    console.error('[EngineeringControl] ECO implement error:', error);
+    return res.status(500).json({ error: 'Failed to implement ECO', detail: error?.message });
+  }
+});
+
+router.post('/ecos/:id/release', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = ecoReleaseSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [existing] = await db
+      .select()
+      .from(engineeringChangeOrders)
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .limit(1);
+    if (!existing) return res.status(404).json({ error: 'ECO not found' });
+    if (!['implemented', 'approved'].includes(existing.status)) {
+      return res.status(400).json({ error: 'Only approved or implemented ECOs can be released.' });
+    }
+
+    const [updated] = await db
+      .update(engineeringChangeOrders)
+      .set({
+        status: 'released',
+        ...(parsed.data.releaseLinkage !== undefined ? { releaseLinkage: parsed.data.releaseLinkage } : {}),
+        releasedBy: actorFromRequest(req, parsed.data.actor),
+        releasedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(engineeringChangeOrders.id, req.params.id))
+      .returning();
+    return res.json(updated);
+  } catch (error: any) {
+    console.error('[EngineeringControl] ECO release error:', error);
+    return res.status(500).json({ error: 'Failed to release ECO', detail: error?.message });
+  }
+});
+
+router.post('/ecos/:id/link-revision', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const parsed = insertEngineeringEcoRevisionLinkSchema.safeParse({
+      ...req.body,
+      ecoId: req.params.id,
+      createdBy: actorFromRequest(req, req.body?.createdBy),
+    });
+    if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
+
+    const [created] = await db.insert(engineeringEcoRevisionLinks).values(parsed.data).returning();
+    return res.status(201).json(created);
+  } catch (error: any) {
+    console.error('[EngineeringControl] ECO link revision error:', error);
+    return res.status(500).json({ error: 'Failed to link revision to ECO', detail: error?.message });
+  }
+});
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -111,6 +111,7 @@ import p2ProductionQueueRoutes from './p2ProductionQueue';
 import p2SerializedItemsRoutes from './p2SerializedItems';
 import partRoutingsRoutes from './partRoutings';
 import routingTemplatesRoutes from './routingTemplates';
+import engineeringControlRoutes from './engineeringControl';
 import anodizeJobsRoutes from './anodizeJobs';
 import travelersRoutes, { travelerComponentAssociationsRouter } from './travelers';
 import materialLotsRoutes from './materialLots';
@@ -749,6 +750,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   // Part routing management routes
   app.use('/api/part-routings', partRoutingsRoutes);
   app.use('/api/routing-templates', routingTemplatesRoutes);
+  app.use('/api/engineering-control', engineeringControlRoutes);
 
   // Anodize job tracking (outside process)
   app.use('/api/anodize-jobs', anodizeJobsRoutes);


### PR DESCRIPTION
## Summary
- Add reusable Engineering Control revision records for BOMs, routings, traveler templates, work instructions, specs, and QC forms
- Add release states and effectivity fields for serial range, date range, customer, and project
- Add ECO lifecycle tables and API routes for change request, impact review, approval, implementation date, release linkage, and revision links

## Validation
- git diff --cached --check
- git diff --check HEAD~1..HEAD after merging latest origin/main
- npm run check could not run locally because npm is not installed in this shell