### PR TITLE
Auto-generate RFQ builder numbers

### DIFF
--- a/client/src/pages/RFQBuilderPage.tsx
+++ b/client/src/pages/RFQBuilderPage.tsx
@@ -496,18 +496,28 @@ export default function RFQBuilderPage() {
       return prev.filter((_, i) => i !== index).map((r, i) => ({ ...r, lineNumber: i + 1 }));
     });
 
+  const buildHeaderPayload = () => {
+    const payload = {
+      ...header,
+      customerId: header.customerId ? Number(header.customerId) : null,
+      quoteDueDate: header.quoteDueDate || null,
+      requestedDueDate: header.requestedDueDate || null,
+    };
+    if (!payload.rfqNumber.trim()) delete (payload as Partial<RfqHeader>).rfqNumber;
+    return payload;
+  };
+
   // ── Mutations ────────────────────────────────────────────────────────────────
 
   const createRfqMutation = useMutation({
     mutationFn: async () => {
-      const payload = { ...header, customerId: header.customerId ? Number(header.customerId) : null,
-        quoteDueDate: header.quoteDueDate || null, requestedDueDate: header.requestedDueDate || null };
-      return apiRequest("/api/estimating/rfqs", { method: "POST", body: payload });
+      return apiRequest("/api/estimating/rfqs", { method: "POST", body: buildHeaderPayload() });
     },
     onSuccess: async (created) => {
+      setHeader((prev) => ({ ...prev, rfqNumber: created.rfqNumber ?? prev.rfqNumber }));
       await saveParts(created.id);
       await queryClient.invalidateQueries({ queryKey: ["/api/estimating/rfqs"] });
-      setSaveMessage("Draft RFQ saved.");
+      setSaveMessage(`Draft RFQ ${created.rfqNumber ?? ""} saved.`);
       setLocation(`/rfq-builder/${created.id}`);
     },
     onError: () => setSaveMessage("Failed to save RFQ. Please try again."),
@@ -515,9 +525,7 @@ export default function RFQBuilderPage() {
 
   const updateRfqMutation = useMutation({
     mutationFn: async () => {
-      const payload = { ...header, customerId: header.customerId ? Number(header.customerId) : null,
-        quoteDueDate: header.quoteDueDate || null, requestedDueDate: header.requestedDueDate || null };
-      return apiRequest(`/api/estimating/rfqs/${rfqId}`, { method: "PATCH", body: payload });
+      return apiRequest(`/api/estimating/rfqs/${rfqId}`, { method: "PATCH", body: buildHeaderPayload() });
     },
     onSuccess: async () => {
       await saveParts(rfqId!);
@@ -531,7 +539,6 @@ export default function RFQBuilderPage() {
 
   const onSaveDraft = () => {
     setSaveMessage("");
-    if (!header.rfqNumber.trim()) { setSaveMessage("RFQ number is required."); return; }
     if (!parts.some((p) => p.partNumber.trim())) { setSaveMessage("Add at least one part number before saving."); return; }
     if (isEditMode) updateRfqMutation.mutate(); else createRfqMutation.mutate();
   };
@@ -1179,8 +1186,16 @@ export default function RFQBuilderPage() {
           <div className="border rounded-lg p-5 space-y-4">
             <h2 className="text-lg font-semibold">Step 1 — RFQ Header</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <div>
+                <label className="block text-sm mb-1">RFQ Number</label>
+                <input
+                  className="w-full border rounded px-3 py-2 bg-muted text-muted-foreground"
+                  value={header.rfqNumber || "Auto-generated when saved"}
+                  readOnly
+                />
+              </div>
               {([
-                ["rfqNumber", "RFQ Number"], ["customerId", "Customer ID"],
+                ["customerId", "Customer ID"],
                 ["customerNameSnapshot", "Customer Name Snapshot"], ["revision", "Revision"],
               ] as [keyof RfqHeader, string][]).map(([field, label]) => (
                 <div key={field}>

--- a/server/src/routes/estimating.ts
+++ b/server/src/routes/estimating.ts
@@ -77,6 +77,10 @@ const mitigationUpdateSchema = z.object({
   completedAt: z.coerce.date().nullable().optional(),
 });
 
+const createEstimatingRfqSchema = insertEstimatingRfqSchema.extend({
+  rfqNumber: z.string().optional(),
+});
+
 function getActor(req: any) {
   return {
     id: req.user?.id ?? req.session?.user?.id ?? null,
@@ -103,6 +107,34 @@ function getApprovalRouting(overallLevel: string, items: any[]): string[] {
   if (items.some((item) => item.category === 'FINANCIAL' || Number(item.score) >= 10)) routes.add('FINANCE');
   if (overallLevel === 'HIGH' || overallLevel === 'CRITICAL' || items.some((item) => item.requires_approval)) routes.add('EXECUTIVE');
   return Array.from(routes);
+}
+
+async function generateEstimatingRfqNumber(customerId?: number | null): Promise<string> {
+  if (customerId) {
+    const customerRows = await pool.query(
+      `SELECT customer_id FROM p2_customers WHERE id = $1 LIMIT 1`,
+      [customerId]
+    );
+
+    const customerNumber = customerRows[0]?.customer_id;
+    if (customerNumber) {
+      const result = await storage.reserveNextRFQNumber(customerNumber, new Date().getFullYear().toString());
+      return result.rfqNumber;
+    }
+  }
+
+  const yearSuffix = String(new Date().getFullYear()).slice(-2);
+  const prefix = `RFQ${yearSuffix}`;
+  const rows = await pool.query(
+    `SELECT rfq_number
+     FROM estimating_rfqs
+     WHERE rfq_number LIKE $1
+     ORDER BY rfq_number DESC
+     LIMIT 1`,
+    [`${prefix}%`]
+  );
+  const lastSequence = Number(String(rows[0]?.rfq_number ?? '').slice(prefix.length)) || 0;
+  return `${prefix}${String(lastSequence + 1).padStart(4, '0')}`;
 }
 
 async function refreshRiskAssessmentScore(riskAssessmentId: string) {
@@ -237,8 +269,9 @@ router.get('/rfqs', async (req, res) => {
 
 router.post('/rfqs', async (req, res) => {
   try {
-    const data = insertEstimatingRfqSchema.parse(req.body);
-    const rfq = await storage.createEstimatingRfq(data);
+    const data = createEstimatingRfqSchema.parse(req.body);
+    const rfqNumber = data.rfqNumber?.trim() || await generateEstimatingRfqNumber(data.customerId ?? null);
+    const rfq = await storage.createEstimatingRfq({ ...data, rfqNumber });
     res.status(201).json(rfq);
   } catch (err: any) {
     if (err instanceof z.ZodError) {


### PR DESCRIPTION
## Summary
- make the RFQ Builder number field read-only and display that it is generated on save
- generate missing RFQ numbers server-side during RFQ Builder draft creation
- reuse customer RFQ sequences when a numeric customer record is linked, with an RFQ-year fallback when no customer sequence is available

## Validation
- `git diff --check --cached`
- Not run: `npm run check` because `npm` is not installed and `node_modules` is absent in this environment.