### PR TITLE
[codex] Add Section 9 quality system controls

### DIFF
--- a/client/src/components/NonconformanceDashboard.tsx
+++ b/client/src/components/NonconformanceDashboard.tsx
@@ -122,7 +122,7 @@ export default function NonconformanceDashboard() {
       </div>
 
       {/* Summary Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
         <Card>
           <CardContent className="p-4">
             <div className="text-2xl font-bold text-blue-600">
@@ -159,6 +159,14 @@ export default function NonconformanceDashboard() {
               {records.length}
             </div>
             <div className="text-sm text-gray-600">Total Records</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-2xl font-bold text-slate-700">
+              {records.filter((r) => r.capaRequired).length}
+            </div>
+            <div className="text-sm text-gray-600">CAPA Required</div>
           </CardContent>
         </Card>
       </div>
@@ -302,6 +310,8 @@ export default function NonconformanceDashboard() {
                     <th className="text-left p-2 font-medium">Issue Cause</th>
                     <th className="text-left p-2 font-medium">Mfr Defect</th>
                     <th className="text-left p-2 font-medium">Disposition</th>
+                    <th className="text-left p-2 font-medium">CAPA</th>
+                    <th className="text-left p-2 font-medium">Effectiveness</th>
                     <th className="text-left p-2 font-medium">Status</th>
                     <th className="text-left p-2 font-medium">Tracking</th>
                     <th className="text-left p-2 font-medium">Progress</th>
@@ -339,6 +349,21 @@ export default function NonconformanceDashboard() {
                           )}
                         </td>
                         <td className="p-2">{record.disposition}</td>
+                        <td className="p-2">
+                          {record.capaRequired ? (
+                            <Badge variant="secondary" className="text-xs">Required</Badge>
+                          ) : (
+                            <span className="text-gray-400 text-xs">Not required</span>
+                          )}
+                        </td>
+                        <td className="p-2">
+                          <Badge
+                            variant={record.effectivenessStatus === 'effective' ? 'default' : 'secondary'}
+                            className="text-xs"
+                          >
+                            {record.effectivenessStatus || 'not_started'}
+                          </Badge>
+                        </td>
                         <td className="p-2">
                           <Badge
                             variant={

--- a/client/src/components/NonconformanceFormModal.tsx
+++ b/client/src/components/NonconformanceFormModal.tsx
@@ -144,6 +144,20 @@ export default function NonconformanceFormModal({
       zipCode: '',
       country: 'United States',
     },
+    containmentAction: '',
+    containmentOwner: '',
+    containmentDueDate: '',
+    containmentCompletedAt: '',
+    rootCause: '',
+    rootCauseMethod: '',
+    correctiveAction: '',
+    preventiveAction: '',
+    capaRequired: false,
+    dispositionRationale: '',
+    effectivenessReview: '',
+    effectivenessStatus: 'not_started',
+    effectivenessReviewedAt: '',
+    recurrenceDetected: false,
   });
 
   const [orderAddress, setOrderAddress] = useState<any>(null);
@@ -234,6 +248,20 @@ export default function NonconformanceFormModal({
           zipCode: '',
           country: 'United States',
         },
+        containmentAction: recordToEdit.containmentAction || '',
+        containmentOwner: recordToEdit.containmentOwner || '',
+        containmentDueDate: recordToEdit.containmentDueDate?.split('T')[0] || '',
+        containmentCompletedAt: recordToEdit.containmentCompletedAt?.split('T')[0] || '',
+        rootCause: recordToEdit.rootCause || '',
+        rootCauseMethod: recordToEdit.rootCauseMethod || '',
+        correctiveAction: recordToEdit.correctiveAction || '',
+        preventiveAction: recordToEdit.preventiveAction || '',
+        capaRequired: recordToEdit.capaRequired || false,
+        dispositionRationale: recordToEdit.dispositionRationale || '',
+        effectivenessReview: recordToEdit.effectivenessReview || '',
+        effectivenessStatus: recordToEdit.effectivenessStatus || 'not_started',
+        effectivenessReviewedAt: recordToEdit.effectivenessReviewedAt?.split('T')[0] || '',
+        recurrenceDetected: recordToEdit.recurrenceDetected || false,
       });
 
       // If editing and record has useOrderAddress set, fetch the order address
@@ -390,6 +418,26 @@ export default function NonconformanceFormModal({
         toast({
           title: 'Validation Error',
           description: 'No address found for the selected order. Please provide a manual address.',
+          variant: 'destructive',
+        });
+        return;
+      }
+    }
+
+    if (form.status === 'Resolved') {
+      const missing = [
+        !form.containmentAction.trim() && 'containment action',
+        !form.rootCause.trim() && 'root cause',
+        !form.correctiveAction.trim() && 'corrective action',
+        !form.dispositionRationale.trim() && 'disposition rationale',
+        form.effectivenessStatus !== 'effective' && 'effective effectiveness review',
+        form.recurrenceDetected && !form.preventiveAction.trim() && 'preventive action',
+      ].filter(Boolean);
+
+      if (missing.length > 0) {
+        toast({
+          title: 'Closure Evidence Required',
+          description: `Resolved NCRs require ${missing.join(', ')}.`,
           variant: 'destructive',
         });
         return;
@@ -734,6 +782,142 @@ export default function NonconformanceFormModal({
                 <Label htmlFor="defect-no">No</Label>
               </div>
             </RadioGroup>
+          </div>
+
+          <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900">
+            <div>
+              <h3 className="font-semibold text-slate-900 dark:text-slate-100">Section 9 Quality Evidence</h3>
+              <p className="text-sm text-slate-600 dark:text-slate-400">
+                Containment, cause, action, disposition approval, and effectiveness closure.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Containment Owner</Label>
+                <Input
+                  value={form.containmentOwner}
+                  onChange={(e) => setForm({ ...form, containmentOwner: e.target.value })}
+                  placeholder="Owner"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Containment Due Date</Label>
+                <Input
+                  type="date"
+                  value={form.containmentDueDate}
+                  onChange={(e) => setForm({ ...form, containmentDueDate: e.target.value })}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Containment Action</Label>
+              <Textarea
+                value={form.containmentAction}
+                onChange={(e) => setForm({ ...form, containmentAction: e.target.value })}
+                placeholder="Immediate action to isolate, hold, segregate, notify, or protect affected product..."
+                rows={3}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Root Cause Method</Label>
+                <Select
+                  value={form.rootCauseMethod || 'unspecified'}
+                  onValueChange={(value) => setForm({ ...form, rootCauseMethod: value === 'unspecified' ? '' : value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="unspecified">Unspecified</SelectItem>
+                    <SelectItem value="5 Whys">5 Whys</SelectItem>
+                    <SelectItem value="Fishbone">Fishbone</SelectItem>
+                    <SelectItem value="Process Audit">Process Audit</SelectItem>
+                    <SelectItem value="Supplier Investigation">Supplier Investigation</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Effectiveness Status</Label>
+                <Select
+                  value={form.effectivenessStatus}
+                  onValueChange={(value) => setForm({ ...form, effectivenessStatus: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="not_started">Not Started</SelectItem>
+                    <SelectItem value="pending_review">Pending Review</SelectItem>
+                    <SelectItem value="effective">Effective</SelectItem>
+                    <SelectItem value="ineffective">Ineffective</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Root Cause</Label>
+              <Textarea
+                value={form.rootCause}
+                onChange={(e) => setForm({ ...form, rootCause: e.target.value })}
+                placeholder="Verified cause, not just symptom..."
+                rows={3}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Corrective Action</Label>
+              <Textarea
+                value={form.correctiveAction}
+                onChange={(e) => setForm({ ...form, correctiveAction: e.target.value })}
+                placeholder="Action taken to correct the specific nonconformance..."
+                rows={3}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Preventive Action</Label>
+              <Textarea
+                value={form.preventiveAction}
+                onChange={(e) => setForm({ ...form, preventiveAction: e.target.value })}
+                placeholder="Systemic action to prevent recurrence..."
+                rows={3}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Disposition Rationale</Label>
+              <Textarea
+                value={form.dispositionRationale}
+                onChange={(e) => setForm({ ...form, dispositionRationale: e.target.value })}
+                placeholder="Why this disposition is acceptable for the part, customer, and contract requirements..."
+                rows={3}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Effectiveness Review</Label>
+              <Textarea
+                value={form.effectivenessReview}
+                onChange={(e) => setForm({ ...form, effectivenessReview: e.target.value })}
+                placeholder="Evidence that the action worked, recurrence check result, and closure notes..."
+                rows={3}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="capaRequired"
+                  checked={form.capaRequired}
+                  onCheckedChange={(checked) => setForm({ ...form, capaRequired: checked === true })}
+                />
+                <Label htmlFor="capaRequired">CAPA required</Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="recurrenceDetected"
+                  checked={form.recurrenceDetected}
+                  onCheckedChange={(checked) => setForm({ ...form, recurrenceDetected: checked === true })}
+                />
+                <Label htmlFor="recurrenceDetected">Recurrence detected</Label>
+              </div>
+            </div>
           </div>
 
           {/* Disposition */}

--- a/migrations/0129_quality_section9_ncr_capa_calibration.sql
+++ b/migrations/0129_quality_section9_ncr_capa_calibration.sql
@@ -1,0 +1,138 @@
+-- Section 9 Quality System controls: NCR lifecycle, CAPA, and calibration lockout.
+
+ALTER TABLE nonconformance_records
+  ADD COLUMN IF NOT EXISTS containment_action text,
+  ADD COLUMN IF NOT EXISTS containment_owner text,
+  ADD COLUMN IF NOT EXISTS containment_due_date date,
+  ADD COLUMN IF NOT EXISTS containment_completed_at timestamp,
+  ADD COLUMN IF NOT EXISTS root_cause text,
+  ADD COLUMN IF NOT EXISTS root_cause_method text,
+  ADD COLUMN IF NOT EXISTS corrective_action text,
+  ADD COLUMN IF NOT EXISTS preventive_action text,
+  ADD COLUMN IF NOT EXISTS capa_required boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS capa_id uuid,
+  ADD COLUMN IF NOT EXISTS disposition_rationale text,
+  ADD COLUMN IF NOT EXISTS disposition_approved_by_user_id integer,
+  ADD COLUMN IF NOT EXISTS disposition_approved_by_display_name text,
+  ADD COLUMN IF NOT EXISTS disposition_approved_at timestamp,
+  ADD COLUMN IF NOT EXISTS effectiveness_review text,
+  ADD COLUMN IF NOT EXISTS effectiveness_status text DEFAULT 'not_started',
+  ADD COLUMN IF NOT EXISTS effectiveness_reviewed_by_user_id integer,
+  ADD COLUMN IF NOT EXISTS effectiveness_reviewed_by_display_name text,
+  ADD COLUMN IF NOT EXISTS effectiveness_reviewed_at timestamp,
+  ADD COLUMN IF NOT EXISTS recurrence_detected boolean DEFAULT false;
+
+CREATE TABLE IF NOT EXISTS capa_records (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  capa_number text NOT NULL UNIQUE,
+  source_type text NOT NULL DEFAULT 'NCR',
+  source_id text,
+  nonconformance_id integer REFERENCES nonconformance_records(id) ON DELETE SET NULL,
+  title text NOT NULL,
+  problem_statement text NOT NULL,
+  containment_action text,
+  root_cause text,
+  corrective_action text,
+  preventive_action text,
+  recurrence_check_plan text,
+  recurrence_detected boolean NOT NULL DEFAULT false,
+  effectiveness_criteria text,
+  effectiveness_review text,
+  effectiveness_status text NOT NULL DEFAULT 'not_started',
+  status text NOT NULL DEFAULT 'open',
+  owner_user_id integer,
+  owner_display_name text,
+  due_date date,
+  closed_by_user_id integer,
+  closed_by_display_name text,
+  closed_at timestamp,
+  evidence_urls text[] NOT NULL DEFAULT ARRAY[]::text[],
+  created_by_user_id integer,
+  created_by_display_name text,
+  created_at timestamp NOT NULL DEFAULT NOW(),
+  updated_at timestamp NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS capa_records_source_idx ON capa_records(source_type, source_id);
+CREATE INDEX IF NOT EXISTS capa_records_ncr_idx ON capa_records(nonconformance_id);
+CREATE INDEX IF NOT EXISTS capa_records_status_idx ON capa_records(status);
+CREATE INDEX IF NOT EXISTS capa_records_effectiveness_idx ON capa_records(effectiveness_status);
+
+CREATE TABLE IF NOT EXISTS calibration_assets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  asset_tag text NOT NULL UNIQUE,
+  name text NOT NULL,
+  asset_type text NOT NULL DEFAULT 'gage',
+  serial_number text,
+  location text,
+  owner_department text,
+  status text NOT NULL DEFAULT 'active',
+  calibration_interval_days integer NOT NULL DEFAULT 365,
+  last_calibration_date date,
+  calibration_due_date date,
+  evidence_url text,
+  lockout_reason text,
+  locked_out_at timestamp,
+  metadata jsonb DEFAULT '{}'::jsonb,
+  created_at timestamp NOT NULL DEFAULT NOW(),
+  updated_at timestamp NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS calibration_assets_asset_tag_idx ON calibration_assets(asset_tag);
+CREATE INDEX IF NOT EXISTS calibration_assets_status_idx ON calibration_assets(status);
+CREATE INDEX IF NOT EXISTS calibration_assets_due_date_idx ON calibration_assets(calibration_due_date);
+
+CREATE TABLE IF NOT EXISTS calibration_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  asset_id uuid NOT NULL REFERENCES calibration_assets(id) ON DELETE CASCADE,
+  event_type text NOT NULL DEFAULT 'calibration',
+  event_date date NOT NULL,
+  result text NOT NULL DEFAULT 'pass',
+  performed_by text,
+  vendor_name text,
+  certificate_number text,
+  evidence_url text,
+  next_due_date date,
+  notes text,
+  created_by_user_id integer,
+  created_by_display_name text,
+  created_at timestamp NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS calibration_events_asset_idx ON calibration_events(asset_id);
+CREATE INDEX IF NOT EXISTS calibration_events_date_idx ON calibration_events(event_date);
+
+CREATE TABLE IF NOT EXISTS calibration_use_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  asset_id uuid REFERENCES calibration_assets(id) ON DELETE SET NULL,
+  asset_tag text NOT NULL,
+  traveler_id varchar(255),
+  traveler_step_id varchar(255),
+  routing_operation_id integer,
+  order_id text,
+  used_by_user_id integer,
+  used_by_display_name text,
+  use_status text NOT NULL DEFAULT 'accepted',
+  gate_message text,
+  used_at timestamp NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS calibration_use_logs_asset_tag_idx ON calibration_use_logs(asset_tag);
+CREATE INDEX IF NOT EXISTS calibration_use_logs_traveler_idx ON calibration_use_logs(traveler_id);
+CREATE INDEX IF NOT EXISTS calibration_use_logs_status_idx ON calibration_use_logs(use_status);
+
+ALTER TABLE routing_operations
+  ADD COLUMN IF NOT EXISTS required_calibration_asset_tags text[] NOT NULL DEFAULT ARRAY[]::text[];
+
+INSERT INTO perm_capabilities (key, description, category)
+VALUES
+  ('quality.manage_capa', 'Create and close CAPA records and effectiveness reviews', 'quality'),
+  ('quality.manage_calibration', 'Manage calibration assets, evidence, and lockout state', 'quality')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT pr.id, pc.id
+FROM perm_roles pr, perm_capabilities pc
+WHERE pr.name IN ('ADMIN', 'OWNER', 'MANAGER')
+  AND pc.key IN ('quality.manage_capa', 'quality.manage_calibration')
+ON CONFLICT (role_id, capability_id) DO NOTHING;

--- a/server/governance/schemaDrift.ts
+++ b/server/governance/schemaDrift.ts
@@ -35,6 +35,10 @@ const CRITICAL_TABLES = new Set([
   'followup_orders',
   'schema_change_log',
   'nonconformance_records',
+  'capa_records',
+  'calibration_assets',
+  'calibration_events',
+  'calibration_use_logs',
 ]);
 
 /**

--- a/server/governance/schemaPolicy.ts
+++ b/server/governance/schemaPolicy.ts
@@ -38,7 +38,14 @@ export const CRITICAL_COLUMNS: Record<string, Set<string>> = {
     'id', 'timestamp', 'actor', 'action_type', 'table_name', 'column_name',
   ]),
   nonconformance_records: new Set([
-    'id', 'order_id', 'status', 'created_at',
+    'id', 'order_id', 'status', 'created_at', 'containment_action', 'root_cause',
+    'corrective_action', 'effectiveness_status',
+  ]),
+  capa_records: new Set([
+    'id', 'capa_number', 'problem_statement', 'corrective_action', 'effectiveness_status', 'status',
+  ]),
+  calibration_assets: new Set([
+    'id', 'asset_tag', 'status', 'calibration_due_date', 'evidence_url',
   ]),
 };
 
@@ -50,6 +57,10 @@ export const CRITICAL_TABLES: Set<string> = new Set([
   'followup_orders',
   'schema_change_log',
   'nonconformance_records',
+  'capa_records',
+  'calibration_assets',
+  'calibration_events',
+  'calibration_use_logs',
   'p2_customers',
   'p2_lot_numbers',
   'p2_final_inspection_results',

--- a/server/index.ts
+++ b/server/index.ts
@@ -493,6 +493,7 @@ async function initializeBackgroundServices() {
           '0123_charge_code_cost_handling.sql',
           '0124_chart_of_accounts_foundation.sql',
           '0128_procurement_section6_supplier_controls.sql',
+          '0129_quality_section9_ncr_capa_calibration.sql',
           'investigation_308_order_duplication.sql',
         ];
         const criticalMigrations = new Set([

--- a/server/routes/nonconformance.ts
+++ b/server/routes/nonconformance.ts
@@ -75,7 +75,22 @@ router.get('/', async (req, res) => {
         use_order_address as "useOrderAddress", repair_address as "repairAddress",
         shipping_status as "shippingStatus", tracking_number as "trackingNumber",
         shipping_carrier as "shippingCarrier", shipped_date as "shippedDate",
-        customer_notified as "customerNotified", created_at as "createdAt", updated_at as "updatedAt"
+        customer_notified as "customerNotified",
+        containment_action as "containmentAction", containment_owner as "containmentOwner",
+        containment_due_date as "containmentDueDate", containment_completed_at as "containmentCompletedAt",
+        root_cause as "rootCause", root_cause_method as "rootCauseMethod",
+        corrective_action as "correctiveAction", preventive_action as "preventiveAction",
+        capa_required as "capaRequired", capa_id as "capaId",
+        disposition_rationale as "dispositionRationale",
+        disposition_approved_by_user_id as "dispositionApprovedByUserId",
+        disposition_approved_by_display_name as "dispositionApprovedByDisplayName",
+        disposition_approved_at as "dispositionApprovedAt",
+        effectiveness_review as "effectivenessReview", effectiveness_status as "effectivenessStatus",
+        effectiveness_reviewed_by_user_id as "effectivenessReviewedByUserId",
+        effectiveness_reviewed_by_display_name as "effectivenessReviewedByDisplayName",
+        effectiveness_reviewed_at as "effectivenessReviewedAt",
+        recurrence_detected as "recurrenceDetected",
+        created_at as "createdAt", updated_at as "updatedAt"
       FROM nonconformance_records
       ${whereClause}
       ORDER BY created_at DESC
@@ -345,6 +360,21 @@ async function generateRmaNumber(): Promise<string> {
   return `${datePrefix}-${nextNumber}`;
 }
 
+function validateNcrClosure(data: z.infer<typeof insertNonconformanceRecordSchema>): string[] {
+  if (data.status !== 'Resolved') return [];
+
+  const missing: string[] = [];
+  if (!data.containmentAction?.trim()) missing.push('containment action');
+  if (!data.rootCause?.trim()) missing.push('root cause');
+  if (!data.correctiveAction?.trim()) missing.push('corrective action');
+  if (!data.dispositionRationale?.trim()) missing.push('disposition rationale');
+  if (data.effectivenessStatus !== 'effective') missing.push('effective effectiveness review');
+  if (data.recurrenceDetected && !data.preventiveAction?.trim()) {
+    missing.push('preventive action for recurrence');
+  }
+  return missing;
+}
+
 // POST /api/nonconformance - Create new record
 router.post('/', async (req, res) => {
   try {
@@ -352,6 +382,10 @@ router.post('/', async (req, res) => {
     const sanitizedBody = { ...req.body };
     if (sanitizedBody.dateReceived === '') sanitizedBody.dateReceived = null;
     if (sanitizedBody.dispositionDate === '') sanitizedBody.dispositionDate = null;
+    if (sanitizedBody.containmentDueDate === '') sanitizedBody.containmentDueDate = null;
+    if (sanitizedBody.containmentCompletedAt === '') sanitizedBody.containmentCompletedAt = null;
+    if (sanitizedBody.dispositionApprovedAt === '') sanitizedBody.dispositionApprovedAt = null;
+    if (sanitizedBody.effectivenessReviewedAt === '') sanitizedBody.effectivenessReviewedAt = null;
     
     const validatedData = insertNonconformanceRecordSchema.parse(sanitizedBody);
 
@@ -455,8 +489,19 @@ router.put('/:id', async (req, res) => {
     const sanitizedBody = { ...req.body };
     if (sanitizedBody.dateReceived === '') sanitizedBody.dateReceived = null;
     if (sanitizedBody.dispositionDate === '') sanitizedBody.dispositionDate = null;
+    if (sanitizedBody.containmentDueDate === '') sanitizedBody.containmentDueDate = null;
+    if (sanitizedBody.containmentCompletedAt === '') sanitizedBody.containmentCompletedAt = null;
+    if (sanitizedBody.dispositionApprovedAt === '') sanitizedBody.dispositionApprovedAt = null;
+    if (sanitizedBody.effectivenessReviewedAt === '') sanitizedBody.effectivenessReviewedAt = null;
     
     const validatedData = insertNonconformanceRecordSchema.parse(sanitizedBody);
+    const closureMissing = validateNcrClosure(validatedData);
+    if (closureMissing.length > 0) {
+      return res.status(400).json({
+        error: 'NCR closure requires complete Section 9 quality evidence',
+        missing: closureMissing,
+      });
+    }
 
     // Set resolvedAt timestamp if status is changing to Resolved
     const updateData: any = {

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -4734,9 +4734,128 @@ export const nonconformanceRecords = pgTable('nonconformance_records', {
   lastConfirmedByUserId: integer('last_confirmed_by_user_id'), // Who confirmed the state
   confirmationNote: text('confirmation_note'), // Optional short note with confirmation
   attentionRisk: text('attention_risk').$type<'low' | 'medium' | 'high'>(), // Computed staleness risk level
+  containmentAction: text('containment_action'),
+  containmentOwner: text('containment_owner'),
+  containmentDueDate: date('containment_due_date'),
+  containmentCompletedAt: timestamp('containment_completed_at'),
+  rootCause: text('root_cause'),
+  rootCauseMethod: text('root_cause_method'),
+  correctiveAction: text('corrective_action'),
+  preventiveAction: text('preventive_action'),
+  capaRequired: boolean('capa_required').default(false),
+  capaId: uuid('capa_id'),
+  dispositionRationale: text('disposition_rationale'),
+  dispositionApprovedByUserId: integer('disposition_approved_by_user_id'),
+  dispositionApprovedByDisplayName: text('disposition_approved_by_display_name'),
+  dispositionApprovedAt: timestamp('disposition_approved_at'),
+  effectivenessReview: text('effectiveness_review'),
+  effectivenessStatus: text('effectiveness_status').default('not_started'),
+  effectivenessReviewedByUserId: integer('effectiveness_reviewed_by_user_id'),
+  effectivenessReviewedByDisplayName: text('effectiveness_reviewed_by_display_name'),
+  effectivenessReviewedAt: timestamp('effectiveness_reviewed_at'),
+  recurrenceDetected: boolean('recurrence_detected').default(false),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
 });
+
+export const capaRecords = pgTable('capa_records', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  capaNumber: text('capa_number').notNull().unique(),
+  sourceType: text('source_type').notNull().default('NCR'),
+  sourceId: text('source_id'),
+  nonconformanceId: integer('nonconformance_id').references(() => nonconformanceRecords.id, { onDelete: 'set null' }),
+  title: text('title').notNull(),
+  problemStatement: text('problem_statement').notNull(),
+  containmentAction: text('containment_action'),
+  rootCause: text('root_cause'),
+  correctiveAction: text('corrective_action'),
+  preventiveAction: text('preventive_action'),
+  recurrenceCheckPlan: text('recurrence_check_plan'),
+  recurrenceDetected: boolean('recurrence_detected').default(false).notNull(),
+  effectivenessCriteria: text('effectiveness_criteria'),
+  effectivenessReview: text('effectiveness_review'),
+  effectivenessStatus: text('effectiveness_status').notNull().default('not_started'),
+  status: text('status').notNull().default('open'),
+  ownerUserId: integer('owner_user_id'),
+  ownerDisplayName: text('owner_display_name'),
+  dueDate: date('due_date'),
+  closedByUserId: integer('closed_by_user_id'),
+  closedByDisplayName: text('closed_by_display_name'),
+  closedAt: timestamp('closed_at'),
+  evidenceUrls: text('evidence_urls').array().notNull().default(sql`ARRAY[]::text[]`),
+  createdByUserId: integer('created_by_user_id'),
+  createdByDisplayName: text('created_by_display_name'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  sourceIdx: index('capa_records_source_idx').on(table.sourceType, table.sourceId),
+  ncrIdx: index('capa_records_ncr_idx').on(table.nonconformanceId),
+  statusIdx: index('capa_records_status_idx').on(table.status),
+  effectivenessIdx: index('capa_records_effectiveness_idx').on(table.effectivenessStatus),
+}));
+
+export const calibrationAssets = pgTable('calibration_assets', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  assetTag: text('asset_tag').notNull().unique(),
+  name: text('name').notNull(),
+  assetType: text('asset_type').notNull().default('gage'),
+  serialNumber: text('serial_number'),
+  location: text('location'),
+  ownerDepartment: text('owner_department'),
+  status: text('status').notNull().default('active'),
+  calibrationIntervalDays: integer('calibration_interval_days').notNull().default(365),
+  lastCalibrationDate: date('last_calibration_date'),
+  calibrationDueDate: date('calibration_due_date'),
+  evidenceUrl: text('evidence_url'),
+  lockoutReason: text('lockout_reason'),
+  lockedOutAt: timestamp('locked_out_at'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  assetTagIdx: index('calibration_assets_asset_tag_idx').on(table.assetTag),
+  statusIdx: index('calibration_assets_status_idx').on(table.status),
+  dueDateIdx: index('calibration_assets_due_date_idx').on(table.calibrationDueDate),
+}));
+
+export const calibrationEvents = pgTable('calibration_events', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  assetId: uuid('asset_id').notNull().references(() => calibrationAssets.id, { onDelete: 'cascade' }),
+  eventType: text('event_type').notNull().default('calibration'),
+  eventDate: date('event_date').notNull(),
+  result: text('result').notNull().default('pass'),
+  performedBy: text('performed_by'),
+  vendorName: text('vendor_name'),
+  certificateNumber: text('certificate_number'),
+  evidenceUrl: text('evidence_url'),
+  nextDueDate: date('next_due_date'),
+  notes: text('notes'),
+  createdByUserId: integer('created_by_user_id'),
+  createdByDisplayName: text('created_by_display_name'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => ({
+  assetIdx: index('calibration_events_asset_idx').on(table.assetId),
+  eventDateIdx: index('calibration_events_date_idx').on(table.eventDate),
+}));
+
+export const calibrationUseLogs = pgTable('calibration_use_logs', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  assetId: uuid('asset_id').references(() => calibrationAssets.id, { onDelete: 'set null' }),
+  assetTag: text('asset_tag').notNull(),
+  travelerId: varchar('traveler_id', { length: 255 }),
+  travelerStepId: varchar('traveler_step_id', { length: 255 }),
+  routingOperationId: integer('routing_operation_id'),
+  orderId: text('order_id'),
+  usedByUserId: integer('used_by_user_id'),
+  usedByDisplayName: text('used_by_display_name'),
+  useStatus: text('use_status').notNull().default('accepted'),
+  gateMessage: text('gate_message'),
+  usedAt: timestamp('used_at').defaultNow().notNull(),
+}, (table) => ({
+  assetTagIdx: index('calibration_use_logs_asset_tag_idx').on(table.assetTag),
+  travelerIdx: index('calibration_use_logs_traveler_idx').on(table.travelerId),
+  statusIdx: index('calibration_use_logs_status_idx').on(table.useStatus),
+}));
 
 export const insertNonconformanceRecordSchema = createInsertSchema(
   nonconformanceRecords
@@ -4779,6 +4898,26 @@ export const insertNonconformanceRecordSchema = createInsertSchema(
     shippingCarrier: z.string().optional().nullable(),
     shippedDate: z.string().optional().nullable(),
     customerNotified: z.boolean().optional().default(false),
+    containmentAction: z.string().optional().nullable(),
+    containmentOwner: z.string().optional().nullable(),
+    containmentDueDate: z.string().optional().nullable(),
+    containmentCompletedAt: z.coerce.date().optional().nullable(),
+    rootCause: z.string().optional().nullable(),
+    rootCauseMethod: z.string().optional().nullable(),
+    correctiveAction: z.string().optional().nullable(),
+    preventiveAction: z.string().optional().nullable(),
+    capaRequired: z.boolean().optional().default(false),
+    capaId: z.string().uuid().optional().nullable(),
+    dispositionRationale: z.string().optional().nullable(),
+    dispositionApprovedByUserId: z.number().int().optional().nullable(),
+    dispositionApprovedByDisplayName: z.string().optional().nullable(),
+    dispositionApprovedAt: z.coerce.date().optional().nullable(),
+    effectivenessReview: z.string().optional().nullable(),
+    effectivenessStatus: z.enum(['not_started', 'pending_review', 'effective', 'ineffective']).optional().default('not_started'),
+    effectivenessReviewedByUserId: z.number().int().optional().nullable(),
+    effectivenessReviewedByDisplayName: z.string().optional().nullable(),
+    effectivenessReviewedAt: z.coerce.date().optional().nullable(),
+    recurrenceDetected: z.boolean().optional().default(false),
   });
 
 // Types for Module 8
@@ -4802,6 +4941,36 @@ export type InsertNonconformanceRecord = z.infer<
   typeof insertNonconformanceRecordSchema
 >;
 export type NonconformanceRecord = typeof nonconformanceRecords.$inferSelect;
+export const insertCapaRecordSchema = createInsertSchema(capaRecords)
+  .omit({ id: true, capaNumber: true, createdAt: true, updatedAt: true, closedAt: true })
+  .extend({
+    title: z.string().min(1, 'CAPA title is required'),
+    problemStatement: z.string().min(1, 'Problem statement is required'),
+    status: z.enum(['open', 'in_progress', 'effectiveness_review', 'closed', 'void']).default('open'),
+    effectivenessStatus: z.enum(['not_started', 'pending_review', 'effective', 'ineffective']).default('not_started'),
+    evidenceUrls: z.array(z.string()).optional().default([]),
+  });
+export type CapaRecord = typeof capaRecords.$inferSelect;
+export type InsertCapaRecord = z.infer<typeof insertCapaRecordSchema>;
+
+export const insertCalibrationAssetSchema = createInsertSchema(calibrationAssets)
+  .omit({ id: true, createdAt: true, updatedAt: true, lockedOutAt: true })
+  .extend({
+    assetTag: z.string().min(1, 'Asset tag is required'),
+    name: z.string().min(1, 'Asset name is required'),
+    status: z.enum(['active', 'due_soon', 'expired', 'locked_out', 'retired']).default('active'),
+  });
+export const insertCalibrationEventSchema = createInsertSchema(calibrationEvents)
+  .omit({ id: true, createdAt: true })
+  .extend({
+    assetId: z.string().uuid(),
+    eventDate: z.string().min(1, 'Event date is required'),
+    result: z.enum(['pass', 'fail', 'limited_use']).default('pass'),
+  });
+export type CalibrationAsset = typeof calibrationAssets.$inferSelect;
+export type InsertCalibrationAsset = z.infer<typeof insertCalibrationAssetSchema>;
+export type CalibrationEvent = typeof calibrationEvents.$inferSelect;
+export type InsertCalibrationEvent = z.infer<typeof insertCalibrationEventSchema>;
 export type InsertPdfDocument = z.infer<typeof insertPdfDocumentSchema>;
 export type PdfDocument = typeof pdfDocuments.$inferSelect;
 
@@ -5246,6 +5415,7 @@ export const routingOperations = pgTable('routing_operations', {
   expectedLeadDays: integer('expected_lead_days'),
   certificateRequired: boolean('certificate_required').default(false),
   receivingInspectionRequired: boolean('receiving_inspection_required').default(false),
+  requiredCalibrationAssetTags: text('required_calibration_asset_tags').array().notNull().default(sql`ARRAY[]::text[]`),
 
   instructionPack: jsonb('instruction_pack').default('{}'),
 

--- a/server/src/lib/travelerGates.ts
+++ b/server/src/lib/travelerGates.ts
@@ -1,7 +1,7 @@
 import { storage } from '../../storage';
 import { db } from '../../db';
-import { travelerAuthorizations, travelerMaterialConsumption } from '../../schema';
-import { eq, and } from 'drizzle-orm';
+import { calibrationAssets, calibrationUseLogs, travelerAuthorizations, travelerMaterialConsumption } from '../../schema';
+import { eq, and, inArray } from 'drizzle-orm';
 
 export interface GateResult {
   allowed: boolean;
@@ -120,6 +120,94 @@ export interface GateCheckResult {
   label: string;
   passed: boolean;
   reason?: string;
+}
+
+function isCalibrationAssetUsable(asset: { status: string; calibrationDueDate: Date | string | null }): boolean {
+  if (asset.status === 'locked_out' || asset.status === 'expired' || asset.status === 'retired') {
+    return false;
+  }
+  if (!asset.calibrationDueDate) return false;
+  const due = new Date(asset.calibrationDueDate);
+  due.setHours(23, 59, 59, 999);
+  return due >= new Date();
+}
+
+async function evaluateRequiredCalibrationAssets(
+  requiredAssetTags: string[],
+  context: {
+    travelerId?: string;
+    travelerStepId?: string;
+    routingOperationId?: number;
+    orderId?: string | null;
+    employeeId?: number;
+    employeeName?: string;
+    logAccepted?: boolean;
+    logBlocked?: boolean;
+  } = {}
+): Promise<GateResult> {
+  const tags = Array.from(new Set(requiredAssetTags.map((tag) => tag.trim()).filter(Boolean)));
+  if (tags.length === 0) return { allowed: true };
+
+  const assets = await db
+    .select()
+    .from(calibrationAssets)
+    .where(inArray(calibrationAssets.assetTag, tags));
+
+  const byTag = new Map(assets.map((asset) => [asset.assetTag, asset]));
+  const missing = tags.filter((tag) => !byTag.has(tag));
+  const blocked = assets.filter((asset) => !isCalibrationAssetUsable(asset));
+
+  if (missing.length > 0 || blocked.length > 0) {
+    const blockedDetails = blocked.map((asset) => {
+      const due = asset.calibrationDueDate ? ` due ${asset.calibrationDueDate}` : ' with no due date';
+      return `${asset.assetTag} (${asset.status}${due})`;
+    });
+    const reason = [
+      missing.length > 0 ? `Missing calibration asset(s): ${missing.join(', ')}` : null,
+      blockedDetails.length > 0 ? `Unavailable calibration asset(s): ${blockedDetails.join(', ')}` : null,
+    ].filter(Boolean).join('. ');
+
+    if (context.logBlocked) {
+      await db.insert(calibrationUseLogs).values(
+        tags.map((tag) => ({
+          assetId: byTag.get(tag)?.id ?? null,
+          assetTag: tag,
+          travelerId: context.travelerId ?? null,
+          travelerStepId: context.travelerStepId ?? null,
+          routingOperationId: context.routingOperationId ?? null,
+          orderId: context.orderId ?? null,
+          usedByUserId: context.employeeId ?? null,
+          usedByDisplayName: context.employeeName ?? null,
+          useStatus: 'blocked',
+          gateMessage: reason,
+        }))
+      );
+    }
+
+    return {
+      allowed: false,
+      reason: `${reason}. Calibration evidence must be current before this operation can start.`,
+    };
+  }
+
+  if (context.logAccepted) {
+    await db.insert(calibrationUseLogs).values(
+      tags.map((tag) => ({
+        assetId: byTag.get(tag)?.id ?? null,
+        assetTag: tag,
+        travelerId: context.travelerId ?? null,
+        travelerStepId: context.travelerStepId ?? null,
+        routingOperationId: context.routingOperationId ?? null,
+        orderId: context.orderId ?? null,
+        usedByUserId: context.employeeId ?? null,
+        usedByDisplayName: context.employeeName ?? null,
+        useStatus: 'accepted',
+        gateMessage: 'Calibration asset current at traveler start gate.',
+      }))
+    );
+  }
+
+  return { allowed: true };
 }
 
 /**
@@ -285,6 +373,21 @@ export async function evaluateTravelerStartGates(
           };
         }
       }
+
+      const calibrationGate = await evaluateRequiredCalibrationAssets(
+        routingOp.requiredCalibrationAssetTags ?? [],
+        {
+          travelerId,
+          travelerStepId: stepId,
+          routingOperationId: routingOp.id,
+          orderId: traveler.workOrderId,
+          employeeId: options.employeeId,
+          employeeName: options.employeeName,
+          logAccepted: true,
+          logBlocked: true,
+        }
+      );
+      if (!calibrationGate.allowed) return calibrationGate;
     }
   }
 
@@ -487,6 +590,27 @@ export async function evaluateStartGatesDetailed(
             });
           }
         }
+      }
+
+      const calibrationTags = routingOp.requiredCalibrationAssetTags ?? [];
+      if (calibrationTags.length > 0) {
+        const calibrationGate = await evaluateRequiredCalibrationAssets(
+          calibrationTags,
+          {
+            travelerId,
+            travelerStepId: stepId,
+            routingOperationId: routingOp.id,
+            orderId: traveler.workOrderId,
+            employeeId: options.employeeId,
+            employeeName: options.employeeName,
+          }
+        );
+        results.push({
+          key: 'calibration_assets',
+          label: `Calibration current: ${calibrationTags.join(', ')}`,
+          passed: calibrationGate.allowed,
+          reason: calibrationGate.reason,
+        });
       }
     }
   }

--- a/server/src/routes/quality.ts
+++ b/server/src/routes/quality.ts
@@ -5,11 +5,31 @@ import {
   insertMaintenanceScheduleSchema,
   insertMaintenanceLogSchema,
 } from '@shared/schema';
+import { desc, eq, sql } from 'drizzle-orm';
 
+import { db } from '../../db';
+import {
+  capaRecords,
+  calibrationAssets,
+  calibrationEvents,
+  insertCapaRecordSchema,
+  insertCalibrationAssetSchema,
+  insertCalibrationEventSchema,
+} from '../../schema';
 import { storage } from '../../storage';
 import { requirePermission } from '../../middleware/requirePermission';
 
 const router = Router();
+
+async function nextCapaNumber(): Promise<string> {
+  const prefix = `CAPA-${new Date().getFullYear()}-`;
+  const [row] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(capaRecords)
+    .where(sql`${capaRecords.capaNumber} LIKE ${`${prefix}%`}`);
+
+  return `${prefix}${String(Number(row?.count ?? 0) + 1).padStart(4, '0')}`;
+}
 
 // Quality Control Definitions
 router.get('/definitions', async (req: Request, res: Response) => {
@@ -192,6 +212,135 @@ router.post('/maintenance/logs', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Create maintenance log error:', error);
     res.status(500).json({ error: 'Failed to create maintenance log' });
+  }
+});
+
+// Section 9 CAPA records
+router.get('/capa', async (_req: Request, res: Response) => {
+  try {
+    const records = await db
+      .select()
+      .from(capaRecords)
+      .orderBy(desc(capaRecords.createdAt));
+    res.json(records);
+  } catch (error) {
+    console.error('Get CAPA records error:', error);
+    res.status(500).json({ error: 'Failed to fetch CAPA records' });
+  }
+});
+
+router.post('/capa', requirePermission('quality.manage_capa'), async (req: Request, res: Response) => {
+  try {
+    const data = insertCapaRecordSchema.parse(req.body);
+    const capaNumber = await nextCapaNumber();
+    const [record] = await db
+      .insert(capaRecords)
+      .values({ ...data, capaNumber, updatedAt: new Date() })
+      .returning();
+    res.status(201).json(record);
+  } catch (error) {
+    console.error('Create CAPA record error:', error);
+    if (error instanceof Error) return res.status(400).json({ error: error.message });
+    res.status(500).json({ error: 'Failed to create CAPA record' });
+  }
+});
+
+router.put('/capa/:id', requirePermission('quality.manage_capa'), async (req: Request, res: Response) => {
+  try {
+    const updateData = {
+      ...req.body,
+      updatedAt: new Date(),
+      closedAt: req.body.status === 'closed' ? new Date() : req.body.closedAt ?? null,
+    };
+    const [record] = await db
+      .update(capaRecords)
+      .set(updateData)
+      .where(eq(capaRecords.id, req.params.id))
+      .returning();
+    if (!record) return res.status(404).json({ error: 'CAPA record not found' });
+    res.json(record);
+  } catch (error) {
+    console.error('Update CAPA record error:', error);
+    res.status(500).json({ error: 'Failed to update CAPA record' });
+  }
+});
+
+// Section 9 calibration asset, evidence, and lockout management
+router.get('/calibration/assets', async (_req: Request, res: Response) => {
+  try {
+    const assets = await db
+      .select()
+      .from(calibrationAssets)
+      .orderBy(calibrationAssets.assetTag);
+    res.json(assets);
+  } catch (error) {
+    console.error('Get calibration assets error:', error);
+    res.status(500).json({ error: 'Failed to fetch calibration assets' });
+  }
+});
+
+router.post('/calibration/assets', requirePermission('quality.manage_calibration'), async (req: Request, res: Response) => {
+  try {
+    const data = insertCalibrationAssetSchema.parse(req.body);
+    const [asset] = await db
+      .insert(calibrationAssets)
+      .values({ ...data, updatedAt: new Date() })
+      .returning();
+    res.status(201).json(asset);
+  } catch (error) {
+    console.error('Create calibration asset error:', error);
+    if (error instanceof Error) return res.status(400).json({ error: error.message });
+    res.status(500).json({ error: 'Failed to create calibration asset' });
+  }
+});
+
+router.put('/calibration/assets/:id', requirePermission('quality.manage_calibration'), async (req: Request, res: Response) => {
+  try {
+    const status = req.body.status;
+    const updateData = {
+      ...req.body,
+      lockedOutAt: status === 'locked_out' || status === 'expired' ? new Date() : null,
+      updatedAt: new Date(),
+    };
+    const [asset] = await db
+      .update(calibrationAssets)
+      .set(updateData)
+      .where(eq(calibrationAssets.id, req.params.id))
+      .returning();
+    if (!asset) return res.status(404).json({ error: 'Calibration asset not found' });
+    res.json(asset);
+  } catch (error) {
+    console.error('Update calibration asset error:', error);
+    res.status(500).json({ error: 'Failed to update calibration asset' });
+  }
+});
+
+router.post('/calibration/assets/:id/events', requirePermission('quality.manage_calibration'), async (req: Request, res: Response) => {
+  try {
+    const data = insertCalibrationEventSchema.parse({ ...req.body, assetId: req.params.id });
+    const [event] = await db
+      .insert(calibrationEvents)
+      .values(data)
+      .returning();
+
+    await db
+      .update(calibrationAssets)
+      .set({
+        lastCalibrationDate: data.eventDate,
+        calibrationDueDate: data.nextDueDate ?? null,
+        evidenceUrl: data.evidenceUrl ?? null,
+        status: data.result === 'pass' ? 'active' : 'locked_out',
+        lockoutReason: data.result === 'pass' ? null : `Calibration ${data.result}`,
+        lockedOutAt: data.result === 'pass' ? null : new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(calibrationAssets.id, req.params.id));
+
+    res.status(201).json(event);
+  } catch (error) {
+    console.error('Create calibration event error:', error);
+    if (error instanceof Error) return res.status(400).json({ error: error.message });
+    res.status(500).json({ error: 'Failed to create calibration event' });
   }
 });
 


### PR DESCRIPTION
## Summary

Adds the Section 9 quality-system foundation across NCR, CAPA, and calibration controls.

- Expands NCR records with containment, root cause, corrective/preventive action, disposition rationale, CAPA linkage, recurrence tracking, and effectiveness review fields.
- Adds CAPA records plus quality API endpoints for CAPA creation, updates, recurrence/effectiveness closure, and calibration asset/evidence management.
- Adds calibration assets, calibration events, and calibration use logs with a traveler start-gate lockout for routing operations that require calibrated gages/tools.
- Updates the existing nonconformance UI to capture Section 9 evidence and show CAPA/effectiveness status.
- Registers the Section 9 migration and marks CAPA/calibration tables as protected governance/drift surfaces.

## Validation

- `git diff --cached --check` passed.
- Full `npm run check` was not available in this worktree because `npm`, `pnpm`, `yarn`, and `node_modules` are missing from the local environment.