### PR TITLE
[codex] Add Section 10 shipping cert package gate

### DIFF
--- a/client/src/pages/P2ShipmentDetail.tsx
+++ b/client/src/pages/P2ShipmentDetail.tsx
@@ -27,6 +27,7 @@ import {
   Receipt,
   ShieldAlert,
   History,
+  AlertTriangle,
 } from 'lucide-react';
 import OverrideShippingDataModal from '@/components/p2/OverrideShippingDataModal';
 
@@ -105,6 +106,29 @@ interface ShipmentDetail {
   certificate: Certificate | null;
   serializedItems: SerializedItem[];
   invoice: Invoice | null;
+}
+
+interface CertPackageBlocker {
+  code: string;
+  message: string;
+  references?: string[];
+}
+
+interface CertPackageEvidence {
+  type: string;
+  label: string;
+  status: 'present' | 'missing' | 'not_applicable';
+  source: string;
+  reference?: string | null;
+}
+
+interface CertPackageGate {
+  lotId: string;
+  lotNumber: string;
+  readyToShip: boolean;
+  blockers: CertPackageBlocker[];
+  evidence: CertPackageEvidence[];
+  revisionSnapshot: Record<string, unknown>;
 }
 
 interface AuditLogEntry {
@@ -214,6 +238,16 @@ export default function P2ShipmentDetail() {
     enabled: !!lotId && canOverride,
   });
 
+  const { data: certPackage, refetch: refetchCertPackage } = useQuery<CertPackageGate>({
+    queryKey: ['/api/p2/shipments', lotId, 'cert-package'],
+    queryFn: async () => {
+      const r = await fetch(`/api/p2/shipments/${lotId}/cert-package`);
+      if (!r.ok) throw new Error('Failed to evaluate cert package');
+      return r.json();
+    },
+    enabled: !!lotId,
+  });
+
   const packingSlipId = data?.packingSlip?.id;
   const { data: linkedRmas = [] } = useQuery<any[]>({
     queryKey: ['/api/p2/rmas', { packingSlipId }],
@@ -268,6 +302,7 @@ export default function P2ShipmentDetail() {
       toast({ title: 'Shipment updated', description: 'Changes saved successfully.' });
       setEditMode(false);
       qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId] });
+      qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId, 'cert-package'] });
     },
     onError: () => toast({ title: 'Save failed', variant: 'destructive' }),
   });
@@ -287,10 +322,15 @@ export default function P2ShipmentDetail() {
     onSuccess: () => {
       toast({ title: 'Marked as Shipped', description: 'Lot shipped and invoice auto-created.' });
       qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId] });
+      qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId, 'cert-package'] });
       qc.invalidateQueries({ queryKey: ['/api/p2/lots/existing-shipments'] });
       qc.invalidateQueries({ predicate: (q) => Array.isArray(q.queryKey) && q.queryKey[0] === '/api/ar-invoices' });
     },
-    onError: () => toast({ title: 'Mark shipped failed', variant: 'destructive' }),
+    onError: (err: any) => toast({
+      title: 'Mark shipped failed',
+      description: err?.message || 'Shipment is blocked until the cert package gate is clear.',
+      variant: 'destructive',
+    }),
   });
 
   async function handleBolUpload(file: File) {
@@ -318,6 +358,7 @@ export default function P2ShipmentDetail() {
       if (!r.ok) throw new Error('Upload failed');
       toast({ title: 'Packing Slip uploaded' });
       qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId] });
+      qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId, 'cert-package'] });
     } catch {
       toast({ title: 'Upload failed', variant: 'destructive' });
     } finally {
@@ -334,6 +375,7 @@ export default function P2ShipmentDetail() {
       if (!r.ok) throw new Error('Upload failed');
       toast({ title: 'Certificate of Conformance uploaded' });
       qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId] });
+      qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId, 'cert-package'] });
     } catch {
       toast({ title: 'Upload failed', variant: 'destructive' });
     } finally {
@@ -350,6 +392,7 @@ export default function P2ShipmentDetail() {
       if (!r.ok) throw new Error('Upload failed');
       toast({ title: 'Lot Validation Report uploaded' });
       qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId] });
+      qc.invalidateQueries({ queryKey: ['/api/p2/shipments', lotId, 'cert-package'] });
     } catch {
       toast({ title: 'Upload failed', variant: 'destructive' });
     } finally {
@@ -432,7 +475,7 @@ export default function P2ShipmentDetail() {
                   size="sm"
                   className="bg-green-600 hover:bg-green-700 text-white"
                   onClick={() => markShippedMutation.mutate()}
-                  disabled={markShippedMutation.isPending}
+                  disabled={markShippedMutation.isPending || certPackage?.readyToShip === false}
                 >
                   {markShippedMutation.isPending ? (
                     <Loader2 className="h-4 w-4 animate-spin mr-1" />
@@ -454,6 +497,72 @@ export default function P2ShipmentDetail() {
                 </Button>
               )}
             </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Cert package gate */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              {certPackage?.readyToShip ? (
+                <Shield className="h-4 w-4 text-green-600" />
+              ) : (
+                <AlertTriangle className="h-4 w-4 text-amber-600" />
+              )}
+              Cert Package Gate
+              {certPackage && (
+                <Badge className={certPackage.readyToShip ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'}>
+                  {certPackage.readyToShip ? 'Ready' : `${certPackage.blockers.length} blocker${certPackage.blockers.length === 1 ? '' : 's'}`}
+                </Badge>
+              )}
+            </CardTitle>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={() => refetchCertPackage()}>
+                <RefreshCw className="h-4 w-4 mr-1" /> Refresh Gate
+              </Button>
+              <a href={`/api/p2/shipments/${lotId}/cert-package/export`} target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" size="sm">
+                  <Download className="h-4 w-4 mr-1" /> Export Manifest
+                </Button>
+              </a>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {certPackage?.blockers?.length ? (
+            <div className="space-y-2">
+              {certPackage.blockers.map((blocker) => (
+                <div key={blocker.code} className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                  <p className="font-medium">{blocker.message}</p>
+                  {blocker.references?.length ? (
+                    <p className="mt-1 text-xs font-mono text-amber-800">{blocker.references.join(', ')}</p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Traveler, NCR, inspection, WAD, and required certificate evidence are clear for shipment.</p>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2">
+            {(certPackage?.evidence ?? []).map((item) => (
+              <div key={`${item.type}-${item.source}`} className="rounded border p-3">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-medium">{item.label}</p>
+                  <Badge className={
+                    item.status === 'present'
+                      ? 'bg-green-100 text-green-800'
+                      : item.status === 'missing'
+                        ? 'bg-red-100 text-red-800'
+                        : 'bg-gray-100 text-gray-700'
+                  }>
+                    {item.status === 'not_applicable' ? 'N/A' : item.status}
+                  </Badge>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground truncate">{item.reference || item.source}</p>
+              </div>
+            ))}
           </div>
         </CardContent>
       </Card>

--- a/server/__tests__/certPackageService.test.ts
+++ b/server/__tests__/certPackageService.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCertPackageExport,
+  evaluateShippingCertPackageGate,
+} from '../src/services/certPackageService';
+
+type Rows = Record<string, unknown>[];
+
+const completeLot = {
+  id: '11111111-1111-1111-1111-111111111111',
+  lot_number: '260511-01',
+  po_number: 'PO-100',
+  po_id: 10,
+  part_number: 'PN-100',
+  part_name: 'Bracket',
+  customer_name: 'ACME',
+  quantity: 1,
+  serialized_item_ids: ['22222222-2222-2222-2222-222222222222'],
+  status: 'OPEN',
+  shipped_at: null,
+  shipped_by: null,
+  packing_slip_id: '33333333-3333-3333-3333-333333333333',
+  certificate_id: '44444444-4444-4444-4444-444444444444',
+  lot_validation_report_url: null,
+  packing_slip_upload_url: null,
+  certificate_upload_url: null,
+  manufacturing_date: '2026-05-11T00:00:00.000Z',
+  updated_at: '2026-05-11T12:00:00.000Z',
+  created_at: '2026-05-11T11:00:00.000Z',
+};
+
+const completeSerial = {
+  id: '22222222-2222-2222-2222-222222222222',
+  serial_number: 'SN-100',
+  barcode: 'BC-100',
+  po_number: 'PO-100',
+  po_id: 10,
+  po_item_id: 20,
+  part_number: 'PN-100',
+  part_name: 'Bracket',
+  status: 'COMPLETED',
+  current_department: 'Final QC',
+  traveler_barcode: 'TRV-100',
+  finalized_at: '2026-05-11T12:00:00.000Z',
+  finalized_by: 'qa',
+  customer_serial_number: null,
+  part_routing_revision: 4,
+  updated_at: '2026-05-11T12:00:00.000Z',
+};
+
+function makeQuery(overrides: Partial<Record<string, Rows>> = {}) {
+  const rows: Record<string, Rows> = {
+    lot: [completeLot],
+    serials: [completeSerial],
+    travelers: [{
+      id: 'trv-1',
+      traveler_number: 'TRV-100',
+      traveler_revision: 2,
+      status: 'COMPLETED',
+      work_order_id: 'WO-100',
+      production_work_order_id: '55555555-5555-5555-5555-555555555555',
+      project_id: '66666666-6666-6666-6666-666666666666',
+      part_number: 'PN-100',
+      serial_number: 'SN-100',
+      lot_number: '260511-01',
+      off_system_completion_link: null,
+      updated_at: '2026-05-11T12:00:00.000Z',
+    }],
+    inspections: [{
+      id: 'insp-1',
+      serialized_item_id: completeSerial.id,
+      barcode: 'BC-100',
+      part_number: 'PN-100',
+      inspection_date: '2026-05-11T12:00:00.000Z',
+      inspection_type: 'FINAL',
+      overall_result: 'PASS',
+      accepted_as_is: false,
+      qa_mgr_approval: null,
+      qa_mgr_approval_date: null,
+      non_conformance_ids: [],
+      tolerance_deviation_required: false,
+      tolerance_authorization_date: null,
+      updated_at: '2026-05-11T12:00:00.000Z',
+    }],
+    ncrs: [],
+    wad: [{
+      id: '55555555-5555-5555-5555-555555555555',
+      work_order_number: 'WAD-100',
+      project_id: '66666666-6666-6666-6666-666666666666',
+      status: 'COMPLETE',
+      wad_status: 'APPROVED',
+      wizard_data: { revision: 3 },
+      updated_at: '2026-05-11T12:00:00.000Z',
+    }],
+    certificate: [{
+      id: completeLot.certificate_id,
+      certificate_number: 'COC-100',
+      status: 'APPROVED',
+      approved_by: 'qa',
+      approved_at: '2026-05-11T12:00:00.000Z',
+      issued_at: null,
+      qa_mgr_name: 'QA Manager',
+      qa_mgr_date: '2026-05-11T12:00:00.000Z',
+      material_certifications: [{ material: 'Carbon prepreg', certNumber: 'MC-1' }],
+      process_records: [{ process: 'Cure', recordId: 'CURE-1', result: 'PASS' }],
+      inspection_summary: [{ type: 'FINAL', result: 'PASS' }],
+      specifications: [{ clause: 'Customer clause A', result: 'met' }],
+      traceability_data: [{ lot: 'MAT-1' }],
+      updated_at: '2026-05-11T12:00:00.000Z',
+      created_at: '2026-05-11T11:00:00.000Z',
+    }],
+    packingSlip: [{
+      id: completeLot.packing_slip_id,
+      packing_slip_number: 'PS-100',
+      status: 'FINALIZED',
+      ship_date: null,
+      tracking_number: null,
+      carrier: null,
+      line_items: [{ partNumber: 'PN-100', quantity: 1 }],
+      updated_at: '2026-05-11T12:00:00.000Z',
+      created_at: '2026-05-11T11:00:00.000Z',
+    }],
+    ...overrides,
+  };
+
+  return async (sql: string): Promise<Rows> => {
+    if (sql.includes('FROM p2_lot_numbers') && sql.includes('WHERE id = $1')) return rows.lot;
+    if (sql.includes('FROM p2_serialized_items')) return rows.serials;
+    if (sql.includes('FROM travelers')) return rows.travelers;
+    if (sql.includes('FROM p2_final_inspection_results')) return rows.inspections;
+    if (sql.includes('FROM nonconformance_records')) return rows.ncrs;
+    if (sql.includes('FROM production_work_orders')) return rows.wad;
+    if (sql.includes('FROM p2_certificates_of_conformance')) return rows.certificate;
+    if (sql.includes('FROM p2_packing_slips')) return rows.packingSlip;
+    return [];
+  };
+}
+
+describe('cert package shipping gate', () => {
+  it('allows shipment when traveler, inspection, NCR, WAD, and CoC evidence are complete', async () => {
+    const gate = await evaluateShippingCertPackageGate(String(completeLot.id), makeQuery());
+
+    expect(gate?.readyToShip).toBe(true);
+    expect(gate?.blockers).toEqual([]);
+    expect(gate?.evidence.some((e) => e.type === 'coc' && e.status === 'present')).toBe(true);
+  });
+
+  it('blocks shipment when the traveler is incomplete and the CoC is missing', async () => {
+    const gate = await evaluateShippingCertPackageGate(String(completeLot.id), makeQuery({
+      travelers: [{ status: 'IN_PROGRESS', traveler_number: 'TRV-100' }],
+      certificate: [],
+      lot: [{ ...completeLot, certificate_id: null, certificate_upload_url: null }],
+    }));
+
+    expect(gate?.readyToShip).toBe(false);
+    expect(gate?.blockers.map((b) => b.code)).toContain('TRAVELER_INCOMPLETE');
+    expect(gate?.blockers.map((b) => b.code)).toContain('COC_MISSING');
+  });
+
+  it('exports an audit manifest with a deterministic package hash field', async () => {
+    const certPackage = await buildCertPackageExport(String(completeLot.id), makeQuery());
+
+    expect(certPackage?.auditManifest.algorithm).toBe('sha256');
+    expect(certPackage?.auditManifest.packageHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(certPackage?.revisionSnapshot).toBeDefined();
+  });
+});

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -15,6 +15,10 @@ import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
 import { generatePackingSlipPdf } from '../../utils/pdf/packingSlipPdf';
 import type { PackingSlipData, PackingSlipItem } from '../../utils/pdf/types';
 import { COMPANY_INFO } from '../../utils/pdf/pdfConfig';
+import {
+  buildCertPackageExport,
+  evaluateShippingCertPackageGate,
+} from '../services/certPackageService';
 import multer from 'multer';
 import { ObjectStorageService } from '../../replit_integrations/object_storage/objectStorage';
 
@@ -1287,11 +1291,56 @@ router.get('/shipments/:lotId', async (req: Request, res: Response) => {
   }
 });
 
+// GET /api/p2/shipments/:lotId/cert-package — evaluate shipment/cert-package readiness
+router.get('/shipments/:lotId/cert-package', async (req: Request, res: Response) => {
+  try {
+    const gate = await evaluateShippingCertPackageGate(req.params.lotId);
+    if (!gate) return res.status(404).json({ error: 'Lot not found' });
+    return res.json(gate);
+  } catch (err: any) {
+    console.error('Cert package gate error:', err);
+    return res.status(500).json({ error: 'Failed to evaluate cert package readiness' });
+  }
+});
+
+// GET /api/p2/shipments/:lotId/cert-package/export — deterministic package manifest + hash
+router.get('/shipments/:lotId/cert-package/export', async (req: Request, res: Response) => {
+  try {
+    const certPackage = await buildCertPackageExport(req.params.lotId);
+    if (!certPackage) return res.status(404).json({ error: 'Lot not found' });
+
+    res.set('Content-Type', 'application/json');
+    res.set(
+      'Content-Disposition',
+      `attachment; filename="cert-package-${certPackage.lotNumber}.json"`
+    );
+    return res.send(JSON.stringify(certPackage, null, 2));
+  } catch (err: any) {
+    console.error('Cert package export error:', err);
+    return res.status(500).json({ error: 'Failed to export cert package' });
+  }
+});
+
 // PATCH /api/p2/shipments/:lotId — update tracking, carrier, notes; optionally mark shipped
 router.patch('/shipments/:lotId', async (req: Request, res: Response) => {
   try {
     const { lotId } = req.params;
     const { trackingNumber, carrier, notes, markShipped, shippedBy } = req.body;
+
+    if (markShipped) {
+      const gate = await evaluateShippingCertPackageGate(lotId);
+      if (!gate) return res.status(404).json({ error: 'Lot not found' });
+      if (!gate.readyToShip) {
+        return res.status(409).json({
+          error: 'Shipment blocked by cert package gate',
+          gate: 'shipping_cert_package',
+          message: 'Shipment cannot be marked shipped until all required cert-package evidence is complete.',
+          blockers: gate.blockers,
+          evidence: gate.evidence,
+          revisionSnapshot: gate.revisionSnapshot,
+        });
+      }
+    }
 
     const setClauses: string[] = [];
     const vals: any[] = [];

--- a/server/src/services/certPackageService.ts
+++ b/server/src/services/certPackageService.ts
@@ -1,0 +1,424 @@
+import { createHash } from 'crypto';
+import { pool } from '../../db';
+
+type QueryFn = <T = Record<string, unknown>>(sql: string, params?: unknown[]) => Promise<T[]>;
+
+export interface CertPackageEvidence {
+  type: string;
+  label: string;
+  status: 'present' | 'missing' | 'not_applicable';
+  source: string;
+  reference?: string | null;
+  revision?: string | number | null;
+  details?: Record<string, unknown>;
+}
+
+export interface CertPackageBlocker {
+  code: string;
+  message: string;
+  references?: string[];
+}
+
+export interface CertPackageGateResult {
+  lotId: string;
+  lotNumber: string;
+  readyToShip: boolean;
+  blockers: CertPackageBlocker[];
+  evidence: CertPackageEvidence[];
+  revisionSnapshot: Record<string, unknown>;
+}
+
+interface ShippingCertPackageRows {
+  lot: any;
+  serials: any[];
+  travelers: any[];
+  inspections: any[];
+  ncrs: any[];
+  wad: any | null;
+  certificate: any | null;
+  packingSlip: any | null;
+}
+
+function normalizeStatus(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase().replace(/\s+/g, '_');
+}
+
+function jsonArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function hasEntries(value: unknown): boolean {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return Object.keys(value).length > 0;
+  }
+  return jsonArray(value).length > 0;
+}
+
+function latestBy<T extends Record<string, unknown>>(rows: T[], dateKey: keyof T): T[] {
+  const byKey = new Map<string, T>();
+  rows.forEach((row) => {
+    const itemId = String(row.serialized_item_id ?? row.serializedItemId ?? row.id ?? '');
+    const existing = byKey.get(itemId);
+    const currentTime = row[dateKey] ? new Date(String(row[dateKey])).getTime() : 0;
+    const existingTime = existing?.[dateKey] ? new Date(String(existing[dateKey])).getTime() : 0;
+    if (!existing || currentTime >= existingTime) byKey.set(itemId, row);
+  });
+  return Array.from(byKey.values());
+}
+
+async function loadShippingCertPackageRows(
+  lotId: string,
+  query: QueryFn = (sql, params) => pool.query(sql, params) as Promise<any[]>,
+): Promise<ShippingCertPackageRows | null> {
+  const lotRows = await query<any>(
+    `SELECT id, lot_number, po_number, po_id, part_number, part_name, customer_name,
+            quantity, serialized_item_ids, status, shipped_at, shipped_by,
+            packing_slip_id, certificate_id, lot_validation_report_url,
+            packing_slip_upload_url, certificate_upload_url, manufacturing_date,
+            updated_at, created_at
+       FROM p2_lot_numbers
+       WHERE id = $1`,
+    [lotId],
+  );
+  const lot = lotRows[0];
+  if (!lot) return null;
+
+  const serialIds = jsonArray(lot.serialized_item_ids).map(String);
+  const serials = serialIds.length > 0
+    ? await query<any>(
+        `SELECT id, serial_number, barcode, po_number, po_id, po_item_id, part_number,
+                part_name, status, current_department, traveler_barcode, finalized_at,
+                finalized_by, customer_serial_number, part_routing_revision, updated_at
+           FROM p2_serialized_items
+           WHERE id = ANY($1::uuid[])`,
+        [serialIds],
+      )
+    : [];
+
+  const travelerRefs = Array.from(new Set(
+    serials.flatMap((s) => [s.traveler_barcode, s.serial_number, s.barcode]).filter(Boolean).map(String),
+  ));
+  const travelers = travelerRefs.length > 0
+    ? await query<any>(
+        `SELECT id, traveler_number, traveler_revision, status, work_order_id,
+                production_work_order_id, project_id, part_number, serial_number,
+                lot_number, off_system_completion_link, updated_at
+           FROM travelers
+           WHERE traveler_number = ANY($1::text[])
+              OR serial_number = ANY($1::text[])
+              OR work_order_id = ANY($1::text[])`,
+        [travelerRefs],
+      )
+    : [];
+
+  const inspections = serialIds.length > 0
+    ? await query<any>(
+        `SELECT id, serialized_item_id, barcode, part_number, inspection_date,
+                inspection_type, overall_result, accepted_as_is,
+                qa_mgr_approval, qa_mgr_approval_date, non_conformance_ids,
+                tolerance_deviation_required, tolerance_authorization_date,
+                updated_at
+           FROM p2_final_inspection_results
+           WHERE serialized_item_id = ANY($1::uuid[])
+           ORDER BY inspection_date DESC`,
+        [serialIds],
+      )
+    : [];
+
+  const serialNumbers = serials.map((s) => s.serial_number).filter(Boolean);
+  const barcodes = serials.map((s) => s.barcode).filter(Boolean);
+  const ncrIds = Array.from(new Set(inspections.flatMap((i) => jsonArray(i.non_conformance_ids)).map(String)));
+  const ncrs = await query<any>(
+    `SELECT id, rma_number, order_id, serial_number, po_number, status,
+            disposition, resolved_at, updated_at
+       FROM nonconformance_records
+       WHERE ($1::text[] IS NOT NULL AND serial_number = ANY($1::text[]))
+          OR ($2::text[] IS NOT NULL AND order_id = ANY($2::text[]))
+          OR ($3::text[] IS NOT NULL AND id::text = ANY($3::text[]))
+          OR (po_number = $4 AND status IS DISTINCT FROM 'Resolved')`,
+    [serialNumbers.length ? serialNumbers : null, barcodes.length ? barcodes : null, ncrIds.length ? ncrIds : null, lot.po_number],
+  );
+
+  const wadId = travelers.find((t) => t.production_work_order_id)?.production_work_order_id;
+  const wadRows = wadId
+    ? await query<any>(
+        `SELECT id, work_order_number, project_id, status, wad_status,
+                wizard_data, updated_at
+           FROM production_work_orders
+           WHERE id = $1`,
+        [wadId],
+      )
+    : [];
+
+  const certRows = lot.certificate_id
+    ? await query<any>(
+        `SELECT id, certificate_number, status, approved_by, approved_at, issued_at,
+                qa_mgr_name, qa_mgr_date, material_certifications,
+                process_records, inspection_summary, specifications,
+                traceability_data, updated_at, created_at
+           FROM p2_certificates_of_conformance
+           WHERE id = $1`,
+        [lot.certificate_id],
+      )
+    : [];
+
+  const packingSlipRows = lot.packing_slip_id
+    ? await query<any>(
+        `SELECT id, packing_slip_number, status, ship_date, tracking_number,
+                carrier, line_items, updated_at, created_at
+           FROM p2_packing_slips
+           WHERE id = $1`,
+        [lot.packing_slip_id],
+      )
+    : [];
+
+  return {
+    lot,
+    serials,
+    travelers,
+    inspections,
+    ncrs,
+    wad: wadRows[0] ?? null,
+    certificate: certRows[0] ?? null,
+    packingSlip: packingSlipRows[0] ?? null,
+  };
+}
+
+export async function evaluateShippingCertPackageGate(
+  lotId: string,
+  query?: QueryFn,
+): Promise<CertPackageGateResult | null> {
+  const rows = await loadShippingCertPackageRows(lotId, query);
+  if (!rows) return null;
+
+  const blockers: CertPackageBlocker[] = [];
+  const evidence: CertPackageEvidence[] = [];
+  const latestInspections = latestBy(rows.inspections, 'inspection_date');
+  const serialIds = rows.serials.map((s) => String(s.id));
+  const travelerByRef = new Map<string, any>();
+  rows.travelers.forEach((t) => {
+    [t.traveler_number, t.serial_number, t.work_order_id].filter(Boolean).forEach((key) => {
+      travelerByRef.set(String(key), t);
+    });
+  });
+
+  const incompleteTravelers = rows.serials.filter((serial) => {
+    const traveler = [serial.traveler_barcode, serial.serial_number, serial.barcode]
+      .map((ref) => ref ? travelerByRef.get(String(ref)) : null)
+      .find(Boolean);
+    return !traveler || (normalizeStatus(traveler.status) !== 'COMPLETED' && !traveler.off_system_completion_link);
+  });
+  if (incompleteTravelers.length > 0) {
+    blockers.push({
+      code: 'TRAVELER_INCOMPLETE',
+      message: 'Every serialized item must have a completed traveler or controlled off-system completion link before shipment.',
+      references: incompleteTravelers.map((s) => s.serial_number || s.barcode),
+    });
+  }
+  evidence.push({
+    type: 'traveler_completion',
+    label: 'Traveler completion',
+    status: incompleteTravelers.length === 0 && rows.serials.length > 0 ? 'present' : 'missing',
+    source: 'travelers',
+    details: { travelerCount: rows.travelers.length, serializedItemCount: rows.serials.length },
+  });
+
+  const missingInspections = serialIds.filter((id) => !latestInspections.some((i) => String(i.serialized_item_id) === id));
+  const failedInspections = latestInspections.filter((i) => {
+    const result = normalizeStatus(i.overall_result);
+    const accepted = result === 'PASS' || (result === 'CONDITIONAL' && (i.accepted_as_is || i.qa_mgr_approval));
+    const toleranceClear = !i.tolerance_deviation_required || !!i.tolerance_authorization_date;
+    return !accepted || !toleranceClear;
+  });
+  if (missingInspections.length > 0 || failedInspections.length > 0) {
+    blockers.push({
+      code: 'INSPECTION_INCOMPLETE',
+      message: 'Final inspection must be recorded and cleared for every serialized item before shipment.',
+      references: [
+        ...missingInspections,
+        ...failedInspections.map((i) => i.barcode || i.serialized_item_id),
+      ],
+    });
+  }
+  evidence.push({
+    type: 'inspection_report',
+    label: 'Final inspection report',
+    status: missingInspections.length === 0 && failedInspections.length === 0 && serialIds.length > 0 ? 'present' : 'missing',
+    source: 'p2_final_inspection_results',
+    details: { inspectionCount: latestInspections.length },
+  });
+
+  const openNcrs = rows.ncrs.filter((ncr) => !['RESOLVED', 'CLOSED', 'COMPLETE', 'COMPLETED'].includes(normalizeStatus(ncr.status)));
+  if (openNcrs.length > 0) {
+    blockers.push({
+      code: 'NCR_OPEN',
+      message: 'Open nonconformance records tied to the lot, PO, serials, or inspection evidence must be closed before shipment.',
+      references: openNcrs.map((n) => n.rma_number || String(n.id)),
+    });
+  }
+  evidence.push({
+    type: 'ncr_closure',
+    label: 'NCR closure',
+    status: openNcrs.length === 0 ? 'present' : 'missing',
+    source: 'nonconformance_records',
+    details: { linkedNcrCount: rows.ncrs.length },
+  });
+
+  const wadStatus = normalizeStatus(rows.wad?.status);
+  const wadDocStatus = normalizeStatus(rows.wad?.wad_status);
+  const wadCleared = rows.wad
+    ? ['COMPLETE', 'CLOSED', 'IN_PROGRESS', 'RELEASED'].includes(wadStatus) && wadDocStatus === 'APPROVED'
+    : false;
+  if (!wadCleared) {
+    blockers.push({
+      code: 'WAD_PROJECT_STATE',
+      message: 'The linked WAD/project state must be approved and released through production before shipment.',
+      references: rows.wad ? [rows.wad.work_order_number || rows.wad.id] : ['No linked WAD found'],
+    });
+  }
+  evidence.push({
+    type: 'wad_project_state',
+    label: 'WAD/project release state',
+    status: wadCleared ? 'present' : 'missing',
+    source: 'production_work_orders',
+    reference: rows.wad?.work_order_number ?? null,
+    revision: rows.wad?.updated_at ?? null,
+  });
+
+  const cert = rows.certificate;
+  const cocPresent = !!cert || !!rows.lot.certificate_upload_url;
+  const cocApproved = cert ? ['APPROVED', 'ISSUED'].includes(normalizeStatus(cert.status)) || !!cert.approved_at : cocPresent;
+  if (!cocApproved) {
+    blockers.push({
+      code: 'COC_MISSING',
+      message: 'A certificate of conformance must be attached and approved before shipment.',
+      references: [rows.lot.lot_number],
+    });
+  }
+  evidence.push({
+    type: 'coc',
+    label: 'Certificate of Conformance',
+    status: cocApproved ? 'present' : 'missing',
+    source: cert ? 'p2_certificates_of_conformance' : 'p2_lot_numbers.certificate_upload_url',
+    reference: cert?.certificate_number ?? rows.lot.certificate_upload_url ?? null,
+    revision: cert?.updated_at ?? null,
+  });
+
+  evidence.push({
+    type: 'material_cert',
+    label: 'Material certifications',
+    status: hasEntries(cert?.material_certifications) || !!rows.lot.certificate_upload_url ? 'present' : 'missing',
+    source: 'p2_certificates_of_conformance.material_certifications',
+    details: { count: jsonArray(cert?.material_certifications).length },
+  });
+  evidence.push({
+    type: 'special_process_cert',
+    label: 'Special process certifications',
+    status: hasEntries(cert?.process_records) ? 'present' : 'not_applicable',
+    source: 'p2_certificates_of_conformance.process_records',
+    details: { count: jsonArray(cert?.process_records).length },
+  });
+  evidence.push({
+    type: 'fair',
+    label: 'FAIR / first article evidence',
+    status: hasEntries(cert?.specifications) || hasEntries(cert?.inspection_summary) ? 'present' : 'not_applicable',
+    source: 'p2_certificates_of_conformance.specifications',
+  });
+  evidence.push({
+    type: 'customer_clause_evidence',
+    label: 'Customer clause evidence',
+    status: hasEntries(cert?.specifications) || hasEntries(cert?.traceability_data) ? 'present' : 'not_applicable',
+    source: 'p2_certificates_of_conformance',
+  });
+
+  const revisionSnapshot = {
+    generatedAt: new Date().toISOString(),
+    lot: {
+      id: rows.lot.id,
+      lotNumber: rows.lot.lot_number,
+      status: rows.lot.status,
+      updatedAt: rows.lot.updated_at,
+    },
+    packingSlip: rows.packingSlip ? {
+      id: rows.packingSlip.id,
+      number: rows.packingSlip.packing_slip_number,
+      status: rows.packingSlip.status,
+      updatedAt: rows.packingSlip.updated_at,
+    } : null,
+    certificate: cert ? {
+      id: cert.id,
+      number: cert.certificate_number,
+      status: cert.status,
+      approvedAt: cert.approved_at,
+      issuedAt: cert.issued_at,
+      updatedAt: cert.updated_at,
+    } : null,
+    travelers: rows.travelers.map((t) => ({
+      id: t.id,
+      travelerNumber: t.traveler_number,
+      revision: t.traveler_revision,
+      status: t.status,
+      updatedAt: t.updated_at,
+    })),
+    inspections: latestInspections.map((i) => ({
+      id: i.id,
+      serializedItemId: i.serialized_item_id,
+      result: i.overall_result,
+      inspectionDate: i.inspection_date,
+      updatedAt: i.updated_at,
+    })),
+    wad: rows.wad ? {
+      id: rows.wad.id,
+      workOrderNumber: rows.wad.work_order_number,
+      status: rows.wad.status,
+      wadStatus: rows.wad.wad_status,
+      updatedAt: rows.wad.updated_at,
+    } : null,
+  };
+
+  return {
+    lotId: rows.lot.id,
+    lotNumber: rows.lot.lot_number,
+    readyToShip: blockers.length === 0,
+    blockers,
+    evidence,
+    revisionSnapshot,
+  };
+}
+
+export async function buildCertPackageExport(lotId: string, query?: QueryFn) {
+  const gate = await evaluateShippingCertPackageGate(lotId, query);
+  if (!gate) return null;
+
+  const manifest = {
+    packageType: 'shipping_cert_package',
+    packageVersion: 1,
+    lotId: gate.lotId,
+    lotNumber: gate.lotNumber,
+    readyToShip: gate.readyToShip,
+    generatedAt: new Date().toISOString(),
+    blockers: gate.blockers,
+    evidence: gate.evidence,
+    revisionSnapshot: gate.revisionSnapshot,
+  };
+  const hash = createHash('sha256').update(JSON.stringify(manifest)).digest('hex');
+
+  return {
+    ...manifest,
+    auditManifest: {
+      algorithm: 'sha256',
+      packageHash: hash,
+      evidenceCount: gate.evidence.length,
+      blockerCount: gate.blockers.length,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a Section 10 shipping certificate-package service that evaluates shipment readiness across traveler completion, final inspection completion, NCR closure, WAD/project state, and CoC/cert evidence.
- Blocks the existing P2 shipment `markShipped` path when the cert-package gate has blockers, returning structured blocker/evidence metadata.
- Adds cert-package readiness and export endpoints with an audit manifest, package hash, and revision snapshot.
- Surfaces the cert-package gate on the P2 shipment detail page with blockers, evidence tiles, refresh, and manifest export.
- Adds focused service tests for ready/blocked/export behavior.

## Validation
- `git diff --check`
- `git diff --cached --check`

## Notes
- Local Vitest/TypeScript scripts were not run because this checkout has no `node_modules` and `npm` is not available on PATH in the Codex shell.