### PR TITLE
[codex] Add Section 11 audit DCAA security controls

### DIFF
--- a/migrations/0130_audit_dcaa_security_section11.sql
+++ b/migrations/0130_audit_dcaa_security_section11.sql
@@ -1,0 +1,234 @@
+-- 0130_audit_dcaa_security_section11.sql
+-- Section 11: Audit / DCAA / Security foundation controls.
+--
+-- Adds:
+--   1. Required-event coverage matrix across compliance domains.
+--   2. Rich approval signature evidence metadata.
+--   3. Role/capability coverage for high-risk approvals and releases.
+--   4. Configurable retention/archive policy by governed object type.
+
+-- ---------------------------------------------------------------------------
+-- Approval and digital-signature evidence coverage
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.digital_signatures
+  ADD COLUMN IF NOT EXISTS signer_username TEXT,
+  ADD COLUMN IF NOT EXISTS signature_meaning TEXT,
+  ADD COLUMN IF NOT EXISTS signature_reason TEXT,
+  ADD COLUMN IF NOT EXISTS linked_object_type TEXT,
+  ADD COLUMN IF NOT EXISTS linked_object_id TEXT,
+  ADD COLUMN IF NOT EXISTS approval_request_id UUID;
+
+CREATE INDEX IF NOT EXISTS digital_signatures_linked_object_idx
+  ON public.digital_signatures (linked_object_type, linked_object_id);
+CREATE INDEX IF NOT EXISTS digital_signatures_approval_request_idx
+  ON public.digital_signatures (approval_request_id);
+
+ALTER TABLE public.approval_requests
+  ADD COLUMN IF NOT EXISTS signature_meaning TEXT,
+  ADD COLUMN IF NOT EXISTS signature_reason TEXT,
+  ADD COLUMN IF NOT EXISTS signer_username TEXT,
+  ADD COLUMN IF NOT EXISTS signer_role TEXT,
+  ADD COLUMN IF NOT EXISTS signature_linked_object_type TEXT,
+  ADD COLUMN IF NOT EXISTS signature_linked_object_id TEXT,
+  ADD COLUMN IF NOT EXISTS digital_signature_id UUID;
+
+CREATE INDEX IF NOT EXISTS approval_requests_signature_linked_object_idx
+  ON public.approval_requests (signature_linked_object_type, signature_linked_object_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'approval_requests_digital_signature_fk'
+  ) THEN
+    ALTER TABLE public.approval_requests
+      ADD CONSTRAINT approval_requests_digital_signature_fk
+      FOREIGN KEY (digital_signature_id) REFERENCES public.digital_signatures(id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'digital_signatures_approval_request_fk'
+  ) THEN
+    ALTER TABLE public.digital_signatures
+      ADD CONSTRAINT digital_signatures_approval_request_fk
+      FOREIGN KEY (approval_request_id) REFERENCES public.approval_requests(id);
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.approval_signature_evidence (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  approval_request_id UUID NOT NULL REFERENCES public.approval_requests(id) ON DELETE CASCADE,
+  decision_status TEXT NOT NULL,
+  signature_meaning TEXT NOT NULL,
+  signature_reason TEXT NOT NULL,
+  signer_user_id INTEGER,
+  signer_username TEXT NOT NULL,
+  signer_role TEXT NOT NULL,
+  linked_object_type TEXT NOT NULL,
+  linked_object_id TEXT NOT NULL,
+  digital_signature_id UUID REFERENCES public.digital_signatures(id),
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS approval_signature_evidence_request_idx
+  ON public.approval_signature_evidence (approval_request_id);
+CREATE INDEX IF NOT EXISTS approval_signature_evidence_linked_object_idx
+  ON public.approval_signature_evidence (linked_object_type, linked_object_id);
+CREATE INDEX IF NOT EXISTS approval_signature_evidence_signer_idx
+  ON public.approval_signature_evidence (signer_user_id);
+
+-- ---------------------------------------------------------------------------
+-- Required-event coverage matrix
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.audit_required_event_coverage (
+  id SERIAL PRIMARY KEY,
+  domain_key TEXT NOT NULL,
+  object_type TEXT NOT NULL,
+  lifecycle_stage TEXT NOT NULL,
+  required_event_type TEXT NOT NULL,
+  required_source_service TEXT NOT NULL,
+  evidence_requirement TEXT NOT NULL,
+  required_actor_role TEXT,
+  signature_required BOOLEAN NOT NULL DEFAULT FALSE,
+  retention_object_type TEXT NOT NULL,
+  compliance_basis TEXT NOT NULL DEFAULT 'DCAA audit evidence',
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT audit_required_event_coverage_event_unique
+    UNIQUE (domain_key, object_type, required_event_type)
+);
+
+CREATE INDEX IF NOT EXISTS audit_required_event_coverage_domain_idx
+  ON public.audit_required_event_coverage (domain_key);
+CREATE INDEX IF NOT EXISTS audit_required_event_coverage_object_idx
+  ON public.audit_required_event_coverage (object_type);
+
+INSERT INTO public.audit_required_event_coverage (
+  domain_key, object_type, lifecycle_stage, required_event_type, required_source_service,
+  evidence_requirement, required_actor_role, signature_required, retention_object_type, compliance_basis
+) VALUES
+  ('inventory', 'inventory_lot', 'receipt inspection', 'INVENTORY_LOT_RECEIVED', 'receiving.route', 'Receipt timestamp, quantity, lot/batch/heat/serial traceability, supplier, PO link, and receiving user.', 'RECEIVING', false, 'procurement', 'DCAA material traceability and AS9100 receiving evidence'),
+  ('inventory', 'inventory_lot', 'hold/release', 'INVENTORY_HOLD_RELEASED', 'receiving.route', 'Hold reason, missing-document clearance, release user, linked cert/report records, and downstream putaway state.', 'QUALITY', true, 'quality', 'DCAA/quality evidence for controlled material release'),
+  ('inventory', 'inventory_transaction', 'issue/consume/scrap', 'INVENTORY_TRANSACTION_POSTED', 'materialIssueService', 'Operator identity, source lot, destination WAD/traveler, quantity, UOM, reason, and approval override if used.', 'FLOOR_OPERATOR', false, 'traveler', 'DCAA material consumption and cost objective traceability'),
+  ('procurement', 'purchase_requisition', 'stage approval', 'REQUISITION_STAGE_APPROVED', 'purchaseRequisitions.route', 'Approver, role, threshold tier, reason, linked project/contract, requested items, and segregation-of-duties result.', 'PURCHASING_BUYER', true, 'procurement', 'DCAA procurement authorization evidence'),
+  ('procurement', 'vendor_po', 'PO approval/release', 'VENDOR_PO_RELEASED', 'vendorPOs.route', 'PO approver, vendor status, AVL/P2 check, FAR/DFARS flowdown, linked requisition, and release timestamp.', 'PURCHASING_MANAGER', true, 'procurement', 'DCAA purchasing system evidence'),
+  ('labor', 'punch_ledger', 'supervisor approval', 'LABOR_APPROVAL_RECORDED', 'laborApprovals.route', 'Employee, supervisor, charge code, WAD/traveler, before/after approval state, reason, and signed approval metadata.', 'SUPERVISOR', true, 'labor', 'DCAA timekeeping approval evidence'),
+  ('labor', 'labor_budget_override', 'override approval', 'LABOR_BUDGET_OVERRIDE_APPROVED', 'workOrders.route', 'Overrun amount, requester, approver, reason, linked WAD/project, and budget impact.', 'SUPERVISOR', true, 'labor', 'DCAA labor-cost override evidence'),
+  ('approvals', 'approval_request', 'decision', 'APPROVAL_REQUEST_APPROVED', 'escalationService', 'Meaning, reason, signer username, signer role, timestamp, linked object, and optional digital signature id.', 'APPROVER', true, 'contract', 'Electronic signature attribution and approval evidence'),
+  ('quality', 'nonconformance_record', 'closure', 'NCR_CLOSED', 'quality.route', 'NCR disposition, CAPA link, closure approver, effectiveness evidence, and affected serial/lot/traveler objects.', 'QUALITY_MANAGER', true, 'quality', 'AS9100/DCAA quality escape closure evidence'),
+  ('quality', 'calibration_record', 'certification', 'CALIBRATION_CERT_RECORDED', 'quality.route', 'Asset, cert, calibration result, due date, performed-by, reviewer, and out-of-tolerance disposition.', 'QUALITY', true, 'cert', 'Calibration cert retention and traceability evidence'),
+  ('engineering', 'engineering_revision', 'revision release', 'ENGINEERING_REVISION_RELEASED', 'engineering.route', 'Revision, ECO, affected documents/travelers, release approver, reason, and effective date.', 'ENGINEERING_MANAGER', true, 'engineering', 'Engineering change control evidence'),
+  ('engineering', 'controlled_document', 'document approval', 'CONTROLLED_DOCUMENT_APPROVED', 'controlledDocuments.route', 'Document revision, approver role, signature, approval meaning, distribution scope, and obsolete supersession.', 'DOCUMENT_MANAGER', true, 'engineering', 'Controlled document release evidence'),
+  ('shipping', 'shipment', 'release', 'SHIPMENT_RELEASED', 'shipping.route', 'Shipment release approver, packing slip/cert package, serial/lot contents, customer/contract, and export/quality blockers.', 'SHIPPING_MANAGER', true, 'procurement', 'Shipment release and contract-deliverable evidence'),
+  ('shipping', 'cert_package', 'customer delivery', 'CERT_PACKAGE_DELIVERED', 'shipping.route', 'Certificate package hash, contents, recipient, delivery timestamp, and shipment/contract link.', 'SHIPPING', false, 'cert', 'Certificate package retention evidence'),
+  ('security', 'vault_document', 'access grant', 'VAULT_ACCESS_GRANTED', 'vault.route', 'Grantor, grantee, classification, document id, reason, expiration, and least-privilege scope.', 'SECURITY_ADMIN', true, 'contract', 'CMMC/DCAA controlled evidence access record'),
+  ('security', 'session', 'auth/session', 'SESSION_EXTENDED', 'auth.service', 'User, role, session id, IP/user-agent, timestamp, and expiration boundary.', 'AUTHENTICATED_USER', false, 'contract', 'Security accountability and access audit evidence')
+ON CONFLICT (domain_key, object_type, required_event_type) DO UPDATE SET
+  lifecycle_stage = EXCLUDED.lifecycle_stage,
+  required_source_service = EXCLUDED.required_source_service,
+  evidence_requirement = EXCLUDED.evidence_requirement,
+  required_actor_role = EXCLUDED.required_actor_role,
+  signature_required = EXCLUDED.signature_required,
+  retention_object_type = EXCLUDED.retention_object_type,
+  compliance_basis = EXCLUDED.compliance_basis,
+  is_active = TRUE,
+  updated_at = NOW();
+
+-- ---------------------------------------------------------------------------
+-- Object-type retention/archive policy
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.audit_object_retention_policies (
+  id SERIAL PRIMARY KEY,
+  object_type TEXT NOT NULL UNIQUE,
+  min_retention_days INTEGER NOT NULL DEFAULT 2555,
+  archive_after_days INTEGER,
+  legal_hold_supported BOOLEAN NOT NULL DEFAULT TRUE,
+  description TEXT NOT NULL,
+  updated_by TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO public.audit_object_retention_policies (
+  object_type, min_retention_days, archive_after_days, legal_hold_supported, description, updated_by
+) VALUES
+  ('contract', 3650, NULL, TRUE, 'Contract, customer approval, security access, and contract-linked audit evidence. Default 10-year floor.', 'migration:0130'),
+  ('cert', 3650, NULL, TRUE, 'Certificates of conformance, calibration certs, material certs, SDS/TDS, and delivered cert packages.', 'migration:0130'),
+  ('traveler', 3650, NULL, TRUE, 'Traveler execution, material consumption, production signatures, and lot/serial traceability.', 'migration:0130'),
+  ('labor', 2555, NULL, TRUE, 'Punch ledger, labor approvals, corrections, payroll export, and labor override evidence.', 'migration:0130'),
+  ('procurement', 2555, NULL, TRUE, 'Purchase requisitions, vendor POs, supplier approval evidence, invoice-match, and closeout records.', 'migration:0130'),
+  ('quality', 3650, NULL, TRUE, 'NCR, CAPA, inspection, hold/release, calibration, and quality escape evidence.', 'migration:0130'),
+  ('engineering', 3650, NULL, TRUE, 'ECO, revision release, controlled document approvals, and engineering authority evidence.', 'migration:0130')
+ON CONFLICT (object_type) DO UPDATE SET
+  min_retention_days = EXCLUDED.min_retention_days,
+  archive_after_days = EXCLUDED.archive_after_days,
+  legal_hold_supported = EXCLUDED.legal_hold_supported,
+  description = EXCLUDED.description,
+  updated_by = EXCLUDED.updated_by,
+  updated_at = NOW();
+
+INSERT INTO public.audit_retention_policies (event_type, min_retention_days, archive_after_days, description)
+VALUES
+  ('INVENTORY_LOT_RECEIVED', 3650, NULL, 'Receiving inspection evidence with lot/batch/heat traceability'),
+  ('INVENTORY_HOLD_RELEASED', 3650, NULL, 'Document hold/release and quality disposition evidence'),
+  ('INVENTORY_TRANSACTION_POSTED', 3650, NULL, 'Material issue/consume/scrap evidence linked to traveler/WAD'),
+  ('VENDOR_PO_RELEASED', 2555, NULL, 'PO approval/release evidence'),
+  ('LABOR_APPROVAL_RECORDED', 2555, NULL, 'Signed labor approval evidence'),
+  ('LABOR_BUDGET_OVERRIDE_APPROVED', 2555, NULL, 'Signed labor override evidence'),
+  ('APPROVAL_REQUEST_APPROVED', 2555, NULL, 'Electronic signature decision evidence'),
+  ('NCR_CLOSED', 3650, NULL, 'NCR closure and CAPA evidence'),
+  ('ENGINEERING_REVISION_RELEASED', 3650, NULL, 'Engineering revision release evidence'),
+  ('SHIPMENT_RELEASED', 3650, NULL, 'Shipment release and cert package evidence'),
+  ('VAULT_ACCESS_GRANTED', 3650, NULL, 'Controlled evidence vault access grants')
+ON CONFLICT (event_type) DO UPDATE SET
+  min_retention_days = EXCLUDED.min_retention_days,
+  archive_after_days = EXCLUDED.archive_after_days,
+  description = EXCLUDED.description,
+  updated_at = NOW();
+
+-- ---------------------------------------------------------------------------
+-- Capability matrix expansion
+-- ---------------------------------------------------------------------------
+INSERT INTO public.perm_capabilities (key, description, category)
+VALUES
+  ('approvals.override', 'Perform privileged approval overrides after explicit reason capture and audit logging', 'approvals'),
+  ('labor.override', 'Approve labor overrides, labor budget overruns, and charge-code override exceptions', 'labor'),
+  ('engineering.release_revision', 'Release controlled engineering revisions and ECO-backed document revisions', 'engineering'),
+  ('procurement.approve_po', 'Approve and release vendor purchase orders', 'procurement'),
+  ('quality.close_ncr', 'Close NCR/CAPA records after disposition and effectiveness evidence is attached', 'quality'),
+  ('vault.access', 'Grant or use access to controlled secure-vault evidence objects', 'security'),
+  ('shipping.release_shipment', 'Release customer shipments and certify shipment evidence packages', 'shipping')
+ON CONFLICT (key) DO UPDATE SET
+  description = EXCLUDED.description,
+  category = EXCLUDED.category;
+
+INSERT INTO public.perm_roles (name, description, is_system)
+VALUES
+  ('ENGINEERING_MANAGER', 'Engineering manager role - can release controlled revisions', TRUE),
+  ('PURCHASING_MANAGER', 'Purchasing manager role - can approve and release vendor POs', TRUE),
+  ('QUALITY_MANAGER', 'Quality manager role - can close NCR/CAPA records', TRUE),
+  ('SHIPPING_MANAGER', 'Shipping manager role - can release shipments', TRUE),
+  ('SECURITY_ADMIN', 'Security admin role - can grant secure evidence vault access', TRUE)
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO public.perm_role_capabilities (role_id, capability_id)
+SELECT pr.id, pc.id
+FROM public.perm_roles pr
+JOIN public.perm_capabilities pc ON (
+  (pr.name IN ('ADMIN', 'OWNER') AND pc.key IN (
+    'approvals.override',
+    'labor.override',
+    'engineering.release_revision',
+    'procurement.approve_po',
+    'quality.close_ncr',
+    'vault.access',
+    'shipping.release_shipment'
+  ))
+  OR (pr.name IN ('SUPERVISOR', 'MANAGER') AND pc.key IN ('approvals.override', 'labor.override'))
+  OR (pr.name = 'ENGINEERING_MANAGER' AND pc.key = 'engineering.release_revision')
+  OR (pr.name = 'PURCHASING_MANAGER' AND pc.key = 'procurement.approve_po')
+  OR (pr.name = 'QUALITY_MANAGER' AND pc.key = 'quality.close_ncr')
+  OR (pr.name = 'DOCUMENT_MANAGER' AND pc.key = 'vault.access')
+  OR (pr.name = 'SECURITY_ADMIN' AND pc.key = 'vault.access')
+  OR (pr.name = 'SHIPPING_MANAGER' AND pc.key = 'shipping.release_shipment')
+)
+ON CONFLICT (role_id, capability_id) DO NOTHING;

--- a/server/index.ts
+++ b/server/index.ts
@@ -494,6 +494,7 @@ async function initializeBackgroundServices() {
           '0124_chart_of_accounts_foundation.sql',
           '0128_procurement_section6_supplier_controls.sql',
           '0129_quality_section9_ncr_capa_calibration.sql',
+          '0130_audit_dcaa_security_section11.sql',
           'investigation_308_order_duplication.sql',
         ];
         const criticalMigrations = new Set([
@@ -4345,6 +4346,13 @@ async function initializeBackgroundServices() {
           { key: 'projects.close', description: 'Create or submit a project closing record', category: 'projects' },
           { key: 'documents.approve', description: 'Approve controlled documents (replaces the hardcoded username guard)', category: 'documents' },
           { key: 'employees.manage_qualifications', description: 'Grant or revoke machine-class and operation-type qualifications for employees', category: 'employees' },
+          { key: 'approvals.override', description: 'Perform privileged approval overrides after explicit reason capture and audit logging', category: 'approvals' },
+          { key: 'labor.override', description: 'Approve labor overrides, labor budget overruns, and charge-code override exceptions', category: 'labor' },
+          { key: 'engineering.release_revision', description: 'Release controlled engineering revisions and ECO-backed document revisions', category: 'engineering' },
+          { key: 'procurement.approve_po', description: 'Approve and release vendor purchase orders', category: 'procurement' },
+          { key: 'quality.close_ncr', description: 'Close NCR/CAPA records after disposition and effectiveness evidence is attached', category: 'quality' },
+          { key: 'vault.access', description: 'Grant or use access to controlled secure-vault evidence objects', category: 'security' },
+          { key: 'shipping.release_shipment', description: 'Release customer shipments and certify shipment evidence packages', category: 'shipping' },
 
           // Orders
           { key: 'orders.create', description: 'Create draft orders and finalize them into production', category: 'orders' },

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -4447,9 +4447,15 @@ export const digitalSignatures = pgTable('digital_signatures', {
   id: uuid('id').primaryKey().defaultRandom(),
   signerUserId: integer('signer_user_id').notNull().references(() => users.id),
   signerRole: text('signer_role').notNull(),
+  signerUsername: text('signer_username'),
   certificateId: uuid('certificate_id').notNull().references(() => userSigningKeys.id),
   algorithm: text('algorithm').notNull().default('Ed25519'),
   transactionClass: text('transaction_class').notNull(),
+  signatureMeaning: text('signature_meaning'),
+  signatureReason: text('signature_reason'),
+  linkedObjectType: text('linked_object_type'),
+  linkedObjectId: text('linked_object_id'),
+  approvalRequestId: uuid('approval_request_id'),
   payloadHash: text('payload_hash').notNull(),
   payloadCanonical: jsonb('payload_canonical').$type<Record<string, unknown>>().notNull(),
   signatureBytes: text('signature_bytes').notNull(),
@@ -4459,6 +4465,8 @@ export const digitalSignatures = pgTable('digital_signatures', {
   signerIdx: index('digital_signatures_signer_idx').on(t.signerUserId),
   classIdx: index('digital_signatures_class_idx').on(t.transactionClass),
   certificateIdx: index('digital_signatures_certificate_idx').on(t.certificateId),
+  linkedObjectIdx: index('digital_signatures_linked_object_idx').on(t.linkedObjectType, t.linkedObjectId),
+  approvalRequestIdx: index('digital_signatures_approval_request_idx').on(t.approvalRequestId),
 }));
 
 export type DigitalSignature = typeof digitalSignatures.$inferSelect;
@@ -18936,6 +18944,13 @@ export const approvalRequests = pgTable('approval_requests', {
   resolvedByDisplayName: text('resolved_by_display_name'),
   resolutionNotes: text('resolution_notes'),
   resolutionSignature: text('resolution_signature'),
+  signatureMeaning: text('signature_meaning'),
+  signatureReason: text('signature_reason'),
+  signerUsername: text('signer_username'),
+  signerRole: text('signer_role'),
+  signatureLinkedObjectType: text('signature_linked_object_type'),
+  signatureLinkedObjectId: text('signature_linked_object_id'),
+  digitalSignatureId: uuid('digital_signature_id').references(() => digitalSignatures.id),
   resolutionReasonCode: text('resolution_reason_code'),
   policyId: integer('policy_id').references(() => escalationPolicies.id),
   createdAt: timestamp('created_at').notNull().defaultNow(),
@@ -18946,7 +18961,59 @@ export const approvalRequests = pgTable('approval_requests', {
   statusDeadlineIdx: index('approval_requests_status_deadline_idx').on(t.status, t.currentLevelDeadline),
   typeIdx: index('approval_requests_request_type_idx').on(t.requestType),
   subjectIdx: index('approval_requests_subject_idx').on(t.subjectType, t.subjectId),
+  signatureLinkedObjectIdx: index('approval_requests_signature_linked_object_idx').on(t.signatureLinkedObjectType, t.signatureLinkedObjectId),
 }));
+
+export const approvalSignatureEvidence = pgTable('approval_signature_evidence', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  approvalRequestId: uuid('approval_request_id').notNull().references(() => approvalRequests.id, { onDelete: 'cascade' }),
+  decisionStatus: text('decision_status').notNull(),
+  signatureMeaning: text('signature_meaning').notNull(),
+  signatureReason: text('signature_reason').notNull(),
+  signerUserId: integer('signer_user_id'),
+  signerUsername: text('signer_username').notNull(),
+  signerRole: text('signer_role').notNull(),
+  linkedObjectType: text('linked_object_type').notNull(),
+  linkedObjectId: text('linked_object_id').notNull(),
+  digitalSignatureId: uuid('digital_signature_id').references(() => digitalSignatures.id),
+  recordedAt: timestamp('recorded_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  approvalRequestIdx: index('approval_signature_evidence_request_idx').on(t.approvalRequestId),
+  linkedObjectIdx: index('approval_signature_evidence_linked_object_idx').on(t.linkedObjectType, t.linkedObjectId),
+  signerIdx: index('approval_signature_evidence_signer_idx').on(t.signerUserId),
+}));
+
+export const auditRequiredEventCoverage = pgTable('audit_required_event_coverage', {
+  id: serial('id').primaryKey(),
+  domainKey: text('domain_key').notNull(),
+  objectType: text('object_type').notNull(),
+  lifecycleStage: text('lifecycle_stage').notNull(),
+  requiredEventType: text('required_event_type').notNull(),
+  requiredSourceService: text('required_source_service').notNull(),
+  evidenceRequirement: text('evidence_requirement').notNull(),
+  requiredActorRole: text('required_actor_role'),
+  signatureRequired: boolean('signature_required').notNull().default(false),
+  retentionObjectType: text('retention_object_type').notNull(),
+  complianceBasis: text('compliance_basis').notNull().default('DCAA audit evidence'),
+  isActive: boolean('is_active').notNull().default(true),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  domainIdx: index('audit_required_event_coverage_domain_idx').on(t.domainKey),
+  objectIdx: index('audit_required_event_coverage_object_idx').on(t.objectType),
+  eventUidx: uniqueIndex('audit_required_event_coverage_event_uidx').on(t.domainKey, t.objectType, t.requiredEventType),
+}));
+
+export const auditObjectRetentionPolicies = pgTable('audit_object_retention_policies', {
+  id: serial('id').primaryKey(),
+  objectType: text('object_type').notNull().unique(),
+  minRetentionDays: integer('min_retention_days').notNull().default(2555),
+  archiveAfterDays: integer('archive_after_days'),
+  legalHoldSupported: boolean('legal_hold_supported').notNull().default(true),
+  description: text('description').notNull(),
+  updatedBy: text('updated_by'),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});
 
 export const approvalRequestHistory = pgTable('approval_request_history', {
   id: bigint('id', { mode: 'number' }).primaryKey().generatedByDefaultAsIdentity(),

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -117,6 +117,13 @@ const decisionBodySchema = z.object({
   notes: z.string().optional().nullable(),
   reasonCode: z.string().optional().nullable(),
   signature: z.string().optional().nullable(),
+  signatureMeaning: z.string().optional().nullable(),
+  signatureReason: z.string().optional().nullable(),
+  signerUsername: z.string().optional().nullable(),
+  signerRole: z.string().optional().nullable(),
+  linkedObjectType: z.string().optional().nullable(),
+  linkedObjectId: z.string().optional().nullable(),
+  digitalSignatureId: z.string().uuid().optional().nullable(),
 });
 
 approvalsRouter.post('/:id/approve', async (req: Request, res: Response) => {
@@ -163,6 +170,13 @@ approvalsRouter.post('/:id/approve', async (req: Request, res: Response) => {
       notes: body.notes ?? null,
       reasonCode: body.reasonCode ?? null,
       signature: body.signature ?? null,
+      signatureMeaning: body.signatureMeaning ?? null,
+      signatureReason: body.signatureReason ?? null,
+      signerUsername: body.signerUsername ?? null,
+      signerRole: body.signerRole ?? null,
+      linkedObjectType: body.linkedObjectType ?? null,
+      linkedObjectId: body.linkedObjectId ?? null,
+      digitalSignatureId: body.digitalSignatureId ?? null,
     });
 
     // Run the inventory executor inline so the operator sees the outcome
@@ -207,6 +221,13 @@ approvalsRouter.post('/:id/reject', async (req: Request, res: Response) => {
       notes: body.notes ?? null,
       reasonCode: body.reasonCode ?? null,
       signature: body.signature ?? null,
+      signatureMeaning: body.signatureMeaning ?? null,
+      signatureReason: body.signatureReason ?? null,
+      signerUsername: body.signerUsername ?? null,
+      signerRole: body.signerRole ?? null,
+      linkedObjectType: body.linkedObjectType ?? null,
+      linkedObjectId: body.linkedObjectId ?? null,
+      digitalSignatureId: body.digitalSignatureId ?? null,
     });
     res.json(result);
   } catch (err: any) {

--- a/server/src/routes/audit.ts
+++ b/server/src/routes/audit.ts
@@ -10,6 +10,12 @@
 
 import { Router, Request, Response } from 'express';
 import { auditService } from '../services/auditService';
+import {
+  getApprovalSignatureEvidence,
+  listObjectRetentionPolicies,
+  listRequiredEventCoverage,
+  type Section11AuditDomain,
+} from '../services/auditComplianceCoverageService';
 import { z } from 'zod';
 import { DEFAULT_AUDIT_EVENTS_LIMIT, MAX_AUDIT_EVENTS_LIMIT } from '../constants/audit';
 import { db } from '../../db';
@@ -18,6 +24,42 @@ import { eq, and, or, desc, sql, inArray } from 'drizzle-orm';
 import { requireAdminOrOwner, authenticateToken } from '../../middleware/auth';
 
 const router = Router();
+
+// Section 11: required-event coverage matrix for DCAA/security evidence.
+router.get('/required-event-coverage', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const domain = typeof req.query.domain === 'string'
+      ? req.query.domain as Section11AuditDomain
+      : undefined;
+    const coverage = await listRequiredEventCoverage(domain);
+    res.json(coverage);
+  } catch (error) {
+    console.error('Error fetching required audit event coverage:', error);
+    res.status(500).json({ error: 'Failed to fetch required audit event coverage' });
+  }
+});
+
+// Section 11: object-type retention/archive policy matrix.
+router.get('/retention/object-policies', authenticateToken, async (_req: Request, res: Response) => {
+  try {
+    const policies = await listObjectRetentionPolicies();
+    res.json(policies);
+  } catch (error) {
+    console.error('Error fetching object retention policies:', error);
+    res.status(500).json({ error: 'Failed to fetch object retention policies' });
+  }
+});
+
+// Section 11: electronic signature evidence for approval decisions.
+router.get('/approvals/:id/signature-evidence', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const evidence = await getApprovalSignatureEvidence(req.params.id);
+    res.json(evidence);
+  } catch (error) {
+    console.error('Error fetching approval signature evidence:', error);
+    res.status(500).json({ error: 'Failed to fetch approval signature evidence' });
+  }
+});
 
 // Get all audit settings
 router.get('/settings', async (req: Request, res: Response) => {

--- a/server/src/services/auditComplianceCoverageService.ts
+++ b/server/src/services/auditComplianceCoverageService.ts
@@ -1,0 +1,54 @@
+import { asc, eq } from 'drizzle-orm';
+import { db } from '../../db';
+import {
+  auditObjectRetentionPolicies,
+  auditRequiredEventCoverage,
+  approvalSignatureEvidence,
+} from '../../schema';
+
+export type Section11AuditDomain =
+  | 'inventory'
+  | 'procurement'
+  | 'labor'
+  | 'approvals'
+  | 'quality'
+  | 'engineering'
+  | 'shipping'
+  | 'security';
+
+export async function listRequiredEventCoverage(domainKey?: Section11AuditDomain) {
+  const query = db
+    .select()
+    .from(auditRequiredEventCoverage)
+    .orderBy(
+      asc(auditRequiredEventCoverage.domainKey),
+      asc(auditRequiredEventCoverage.objectType),
+      asc(auditRequiredEventCoverage.requiredEventType),
+    );
+
+  if (!domainKey) return await query;
+
+  return await db
+    .select()
+    .from(auditRequiredEventCoverage)
+    .where(eq(auditRequiredEventCoverage.domainKey, domainKey))
+    .orderBy(
+      asc(auditRequiredEventCoverage.objectType),
+      asc(auditRequiredEventCoverage.requiredEventType),
+    );
+}
+
+export async function listObjectRetentionPolicies() {
+  return await db
+    .select()
+    .from(auditObjectRetentionPolicies)
+    .orderBy(asc(auditObjectRetentionPolicies.objectType));
+}
+
+export async function getApprovalSignatureEvidence(approvalRequestId: string) {
+  return await db
+    .select()
+    .from(approvalSignatureEvidence)
+    .where(eq(approvalSignatureEvidence.approvalRequestId, approvalRequestId))
+    .orderBy(asc(approvalSignatureEvidence.recordedAt));
+}

--- a/server/src/services/auditLedgerService.ts
+++ b/server/src/services/auditLedgerService.ts
@@ -20,7 +20,12 @@
 
 import crypto from 'crypto';
 import { db } from '../../db';
-import { auditEvents, auditAnchors, auditRetentionPolicies } from '../../schema';
+import {
+  auditEvents,
+  auditAnchors,
+  auditObjectRetentionPolicies,
+  auditRetentionPolicies,
+} from '../../schema';
 import { sql, eq, desc, and, gte, lte, inArray, asc } from 'drizzle-orm';
 
 /**
@@ -529,6 +534,10 @@ export async function getRetentionPolicies() {
   return db.select().from(auditRetentionPolicies);
 }
 
+export async function getObjectRetentionPolicies() {
+  return db.select().from(auditObjectRetentionPolicies);
+}
+
 /** Default DCAA-aligned floor (years 7) in days. */
 export const DCAA_RETENTION_FLOOR_DAYS = 2555;
 
@@ -544,4 +553,13 @@ export async function getRetentionFloorDays(eventType: string): Promise<number> 
     specific?.minRetentionDays ?? 0,
     def?.minRetentionDays ?? DCAA_RETENTION_FLOOR_DAYS,
   );
+}
+
+/** Resolve retention by governed object type (contract/cert/traveler/etc.). */
+export async function getObjectRetentionFloorDays(objectType: string): Promise<number> {
+  const rows = await db
+    .select()
+    .from(auditObjectRetentionPolicies)
+    .where(eq(auditObjectRetentionPolicies.objectType, objectType));
+  return Math.max(rows[0]?.minRetentionDays ?? 0, DCAA_RETENTION_FLOOR_DAYS);
 }

--- a/server/src/services/escalationService.ts
+++ b/server/src/services/escalationService.ts
@@ -22,6 +22,7 @@ import { db } from '../../db';
 import {
   approvalRequestHistory,
   approvalRequests,
+  approvalSignatureEvidence,
   escalationPolicies,
   users,
   type ApprovalRequest,
@@ -140,6 +141,13 @@ export interface DecisionInput {
   notes?: string | null;
   reasonCode?: string | null;
   signature?: string | null;
+  signatureMeaning?: string | null;
+  signatureReason?: string | null;
+  signerUsername?: string | null;
+  signerRole?: string | null;
+  linkedObjectType?: string | null;
+  linkedObjectId?: string | null;
+  digitalSignatureId?: string | null;
 }
 
 interface ApprovalRequestRow {
@@ -298,6 +306,33 @@ async function resolveDecision(
     }
 
     const now = new Date();
+    const signatureMeaning =
+      input.signatureMeaning?.trim() ||
+      (toStatus === 'APPROVED'
+        ? 'I approve this action and accept responsibility for the linked business object.'
+        : 'I reject this action and record the reason for the linked business object.');
+    const signatureReason =
+      input.signatureReason?.trim() ||
+      input.reasonCode?.trim() ||
+      input.notes?.trim() ||
+      `${row.requestType} ${toStatus.toLowerCase()} decision`;
+    const signerUsername =
+      input.signerUsername?.trim() ||
+      input.approver.displayName;
+    const signerRole =
+      input.signerRole?.trim() ||
+      row.currentApproverRole ||
+      input.approver.roles?.[0] ||
+      'APPROVER';
+    const linkedObjectType =
+      input.linkedObjectType?.trim() ||
+      row.subjectType ||
+      'approval_request';
+    const linkedObjectId =
+      input.linkedObjectId?.trim() ||
+      row.subjectId ||
+      row.id;
+
     const [updated] = await tx
       .update(approvalRequests)
       .set({
@@ -308,10 +343,31 @@ async function resolveDecision(
         resolutionNotes: input.notes ?? null,
         resolutionReasonCode: input.reasonCode ?? null,
         resolutionSignature: input.signature ?? null,
+        signatureMeaning,
+        signatureReason,
+        signerUsername,
+        signerRole,
+        signatureLinkedObjectType: linkedObjectType,
+        signatureLinkedObjectId: linkedObjectId,
+        digitalSignatureId: input.digitalSignatureId ?? null,
         updatedAt: now,
       })
       .where(eq(approvalRequests.id, row.id))
       .returning();
+
+    await tx.insert(approvalSignatureEvidence).values({
+      approvalRequestId: row.id,
+      decisionStatus: toStatus,
+      signatureMeaning,
+      signatureReason,
+      signerUserId: input.approver.userId ?? null,
+      signerUsername,
+      signerRole,
+      linkedObjectType,
+      linkedObjectId,
+      digitalSignatureId: input.digitalSignatureId ?? null,
+      recordedAt: now,
+    });
 
     await tx.insert(approvalRequestHistory).values({
       approvalRequestId: row.id,
@@ -323,7 +379,17 @@ async function resolveDecision(
       actorUserId: input.approver.userId ?? null,
       actorDisplayName: input.approver.displayName,
       notes: input.notes ?? null,
-      metadata: { reasonCode: input.reasonCode ?? null, hasSignature: !!input.signature },
+      metadata: {
+        reasonCode: input.reasonCode ?? null,
+        hasSignature: !!input.signature,
+        signatureMeaning,
+        signatureReason,
+        signerUsername,
+        signerRole,
+        linkedObjectType,
+        linkedObjectId,
+        digitalSignatureId: input.digitalSignatureId ?? null,
+      },
     });
 
     await recordAuditEvent(
@@ -332,12 +398,28 @@ async function resolveDecision(
         subjectType: 'approval_request',
         subjectId: row.id,
         sourceService: SOURCE,
-        actor: { id: input.approver.userId ?? null, username: input.approver.displayName },
+        actor: {
+          id: input.approver.userId ?? null,
+          username: signerUsername,
+          role: signerRole,
+        },
         reason: input.notes ?? null,
         payload: {
           requestType: row.requestType,
           level: row.escalationLevel,
           reasonCode: input.reasonCode ?? null,
+          signature: {
+            meaning: signatureMeaning,
+            reason: signatureReason,
+            signerUsername,
+            signerRole,
+            signedAt: now.toISOString(),
+            digitalSignatureId: input.digitalSignatureId ?? null,
+          },
+          linkedObject: {
+            type: linkedObjectType,
+            id: linkedObjectId,
+          },
         },
       },
       tx,


### PR DESCRIPTION
## Summary

- Adds Section 11 audit/DCAA/security migration with a required-event coverage matrix for inventory, procurement, labor, approvals, quality, engineering, shipping, and security.
- Adds object-type retention/archive policies for contract, cert, traveler, labor, procurement, quality, and engineering evidence.
- Expands electronic approval signature evidence capture with meaning, reason, signer username, timestamp, signer role, linked object, and optional digital signature reference.
- Extends approval decision logging so `recordAuditEvent()` receives the richer signature and linked-object evidence payload.
- Adds audit API/service reads for required-event coverage, object retention policies, and approval signature evidence.
- Seeds Section 11 capability keys for approval overrides, labor overrides, revision releases, PO approvals, NCR closure, vault access, and shipment release.

## Validation

- `git diff --cached --check` passed.
- Full TypeScript/build checks were not run because this shell has no `npm` command and the worktree has no `node_modules`.

## Notes

This PR lays the shared Section 11 foundation. Follow-on domain PRs can now replace remaining raw domain-specific audit writes with `recordAuditEvent()` against the coverage matrix rows.