### PR TITLE
Add DCAA payroll export readiness gate

### DIFF
--- a/server/__tests__/payrollExportPhase1.test.ts
+++ b/server/__tests__/payrollExportPhase1.test.ts
@@ -357,6 +357,44 @@ describe('payrollExport.service - Phase 1', () => {
     expect(harness.store.batches).toHaveLength(0);
   });
 
+  it('blocks payroll export when readiness controls are unresolved', async () => {
+    await expect(
+      createBatch({
+        dataSourceOverride: source({
+          fetchPayrollReadinessBlockers: vi.fn().mockResolvedValue([
+            {
+              code: 'MISSING_EMPLOYEE_ATTESTATION',
+              employeeId: 1,
+              timesheetId: 11,
+              status: 'certified',
+              message: 'Certified/locked timesheet is missing employee attestation evidence.',
+            },
+            {
+              code: 'OPEN_TIMESHEET_CORRECTION',
+              employeeId: 2,
+              timesheetId: 12,
+              status: 'locked',
+              message: 'Timesheet has an unresolved correction request.',
+            },
+          ]),
+        }),
+      }),
+    ).rejects.toMatchObject({
+      name: 'PayrollExportReadinessError',
+      httpStatus: 422,
+      details: {
+        blockers: [
+          { code: 'MISSING_EMPLOYEE_ATTESTATION', employeeId: 1, timesheetId: 11 },
+          { code: 'OPEN_TIMESHEET_CORRECTION', employeeId: 2, timesheetId: 12 },
+        ],
+      },
+    });
+
+    expect(harness.store.batches).toHaveLength(0);
+    expect(harness.store.rows).toHaveLength(0);
+    expect(harness.store.events).toHaveLength(0);
+  });
+
   it('uses employee ids rather than names, so duplicate and compound names stay distinct', async () => {
     const ds = source({
       fetchTimesheets: vi.fn().mockResolvedValue([
@@ -482,6 +520,20 @@ describe('payrollExport routes - static guards', () => {
     expect(gustoRoute).toContain('getActiveBatchForPeriod');
     expect(gustoRoute).toContain('downloadBatchCsv');
     expect(gustoRoute).not.toContain('createRegularFullPeriodBatch');
+  });
+
+  it('batch creation checks DCAA readiness blockers before mutating payroll export tables', () => {
+    const serviceFile = readFileSync(resolve(__dirname, '../src/services/timekeeping/payrollExport.service.ts'), 'utf8');
+    const createFn = serviceFile.slice(serviceFile.indexOf('export async function createRegularFullPeriodBatch'));
+
+    expect(serviceFile).toContain('MISSING_EMPLOYEE_ATTESTATION');
+    expect(serviceFile).toContain('MISSING_SUPERVISOR_APPROVAL');
+    expect(serviceFile).toContain('OPEN_TIMESHEET_CORRECTION');
+    expect(serviceFile).toContain('timekeeping.timesheet_corrections');
+    expect(createFn.indexOf('await assertPayrollExportReady')).toBeGreaterThan(-1);
+    expect(createFn.indexOf('await assertPayrollExportReady')).toBeLessThan(
+      createFn.indexOf('.from(payrollExportBatchesTable)'),
+    );
   });
 });
 

--- a/server/src/services/timekeeping/payrollExport.service.ts
+++ b/server/src/services/timekeeping/payrollExport.service.ts
@@ -174,6 +174,32 @@ export class PayrollImportEmployeeMatchError extends Error {
   }
 }
 
+export interface PayrollExportReadinessBlocker {
+  code:
+    | "TIMESHEET_NOT_READY"
+    | "MISSING_EMPLOYEE_ATTESTATION"
+    | "MISSING_SUPERVISOR_APPROVAL"
+    | "OPEN_TIMESHEET_CORRECTION";
+  employeeId: number;
+  timesheetId: number;
+  status?: string | null;
+  message: string;
+}
+
+export class PayrollExportReadinessError extends Error {
+  readonly httpStatus = 422;
+  readonly details: { blockers: PayrollExportReadinessBlocker[] };
+
+  constructor(blockers: PayrollExportReadinessBlocker[]) {
+    super(
+      `Payroll export is blocked by ${blockers.length} unresolved timekeeping control ` +
+        `${blockers.length === 1 ? "issue" : "issues"}. Resolve certification, approval, and correction blockers before export.`,
+    );
+    this.name = "PayrollExportReadinessError";
+    this.details = { blockers };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // CSV building
 // ---------------------------------------------------------------------------
@@ -245,6 +271,10 @@ export interface PayrollSnapshotDataSource {
   fetchTimesheets(periodStart: string, periodEnd: string): Promise<PayrollSnapshotTimesheet[]>;
   fetchLeaveEntries(periodStart: string, periodEnd: string): Promise<PayrollSnapshotLeaveEntry[]>;
   fetchEmployees(employeeIds: number[]): Promise<PayrollSnapshotEmployee[]>;
+  fetchPayrollReadinessBlockers?(
+    periodStart: string,
+    periodEnd: string,
+  ): Promise<PayrollExportReadinessBlocker[]>;
 }
 
 /**
@@ -349,12 +379,116 @@ function txDataSource(client: DbOrTx): PayrollSnapshotDataSource {
       }
       return out;
     },
+    async fetchPayrollReadinessBlockers(periodStart, periodEnd) {
+      const result = await client.execute(sql`
+        WITH period_timesheets AS (
+          SELECT
+            id,
+            employee_id,
+            status,
+            total_hours,
+            employee_attested,
+            attested_at,
+            certification_statement,
+            certification_version,
+            reviewed_at,
+            reviewed_by
+          FROM timekeeping.timesheets
+          WHERE period_start >= ${periodStart}
+            AND period_end <= ${periodEnd}
+        ),
+        blockers AS (
+          SELECT
+            'TIMESHEET_NOT_READY'::text AS code,
+            employee_id,
+            id AS timesheet_id,
+            status,
+            'Timesheet has recorded hours but is not certified or locked.'::text AS message
+          FROM period_timesheets
+          WHERE status NOT IN ('certified', 'locked')
+            AND COALESCE(total_hours, 0) > 0
+
+          UNION ALL
+
+          SELECT
+            'MISSING_EMPLOYEE_ATTESTATION'::text AS code,
+            employee_id,
+            id AS timesheet_id,
+            status,
+            'Certified/locked timesheet is missing employee attestation evidence.'::text AS message
+          FROM period_timesheets
+          WHERE status IN ('certified', 'locked')
+            AND (
+              employee_attested IS DISTINCT FROM TRUE
+              OR attested_at IS NULL
+              OR certification_statement IS NULL
+              OR BTRIM(certification_statement) = ''
+              OR certification_version IS NULL
+            )
+
+          UNION ALL
+
+          SELECT
+            'MISSING_SUPERVISOR_APPROVAL'::text AS code,
+            employee_id,
+            id AS timesheet_id,
+            status,
+            'Certified/locked timesheet is missing supervisor review evidence.'::text AS message
+          FROM period_timesheets
+          WHERE status IN ('certified', 'locked')
+            AND (reviewed_at IS NULL OR reviewed_by IS NULL)
+
+          UNION ALL
+
+          SELECT
+            'OPEN_TIMESHEET_CORRECTION'::text AS code,
+            pt.employee_id,
+            pt.id AS timesheet_id,
+            pt.status,
+            'Timesheet has an unresolved correction request.'::text AS message
+          FROM period_timesheets pt
+          JOIN timekeeping.timesheet_corrections tc
+            ON tc.timesheet_id = pt.id
+          WHERE tc.status NOT IN ('approved', 'rejected')
+        )
+        SELECT code, employee_id, timesheet_id, status, message
+        FROM blockers
+        ORDER BY employee_id, timesheet_id, code
+      `);
+      const rows = ((result as { rows?: unknown[] }).rows ?? result) as Array<{
+        code: PayrollExportReadinessBlocker["code"];
+        employee_id: number;
+        timesheet_id: number;
+        status: string | null;
+        message: string;
+      }>;
+      return rows.map((row) => ({
+        code: row.code,
+        employeeId: Number(row.employee_id),
+        timesheetId: Number(row.timesheet_id),
+        status: row.status,
+        message: row.message,
+      }));
+    },
   };
 }
 
 function assertFiniteNonNegative(value: number, field: string, context: string): void {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
     throw new InvalidHourValueError(field, value, context);
+  }
+}
+
+async function assertPayrollExportReady(
+  dataSource: PayrollSnapshotDataSource,
+  periodStart: string,
+  periodEnd: string,
+): Promise<void> {
+  const blockers = dataSource.fetchPayrollReadinessBlockers
+    ? await dataSource.fetchPayrollReadinessBlockers(periodStart, periodEnd)
+    : [];
+  if (blockers.length > 0) {
+    throw new PayrollExportReadinessError(blockers);
   }
 }
 
@@ -835,6 +969,7 @@ export async function createRegularFullPeriodBatch(
     // Build the snapshot data source from the tx so all reads see the same
     // SERIALIZABLE snapshot as the supersede + insert pair.
     const dataSource = input.dataSourceOverride ?? txDataSource(tx);
+    await assertPayrollExportReady(dataSource, input.periodStart, input.periodEnd);
 
     // Look up prior batches for this (period, regular_full_period).  At most one
     // active or processed; many superseded revisions possible.


### PR DESCRIPTION
## Summary
- Add a payroll export readiness gate before regular payroll batch creation mutates export tables
- Return record-level blockers for unready timesheets, missing employee attestation, missing supervisor approval, and unresolved corrections
- Cover the gate with payroll export service tests plus a static guard that ensures readiness checks stay before batch mutation

## Validation
- `git diff --check -- server\src\services\timekeeping\payrollExport.service.ts server\__tests__\payrollExportPhase1.test.ts`

Not run: Vitest/TypeScript checks; this local worktree has no `npm` and no `node_modules`.