### PR TITLE
Fix startup 503s and Vendor PO schema readiness

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -267,9 +267,9 @@ export async function apiRequest(url: string, options: ApiRequestOptions = {}) {
       }
 
       const err: any = new Error(errorMessage);
+      err.status = response.status;
       if (data) {
         err.responseData = data;
-        err.status = response.status;
       }
       throw err;
     }
@@ -407,7 +407,16 @@ export const queryClient = new QueryClient({
         if (error?.status === 401 || error?.status === 403) {
           return false;
         }
+        if (error?.status === 503) {
+          return failureCount < 6;
+        }
         return failureCount < 1;
+      },
+      retryDelay: (attemptIndex: number, error: any) => {
+        if (error?.status === 503) {
+          return Math.min(1000 * 2 ** attemptIndex, 5000);
+        }
+        return 1000;
       },
     },
     mutations: {

--- a/server/index.ts
+++ b/server/index.ts
@@ -230,11 +230,9 @@ app.use((req, res, next) => {
 const port = parseInt(process.env.PORT || '5000', 10);
 const earlyServer = createServer(app);
 
-// In production, register static file serving immediately so GET / returns
-// the built HTML (200) rather than 404 while routes are still loading.
-if (process.env.NODE_ENV !== 'development') {
-  serveStatic(app);
-}
+// Static SPA serving is registered after API routes are mounted. Serving the
+// React app during the early-listen route registration window lets the browser
+// fire authenticated API calls while the /api gate is still returning 503s.
 
 earlyServer.listen({ port, host: '0.0.0.0' }, () => {
   console.log(`Server started successfully`);
@@ -278,6 +276,10 @@ process.on('SIGINT',  () => gracefulShutdown('SIGINT'));
     console.log('✅ Routes registered — /api gate lifted');
 
     notificationManager.initialize(server);
+
+    if (app.get('env') !== 'development') {
+      serveStatic(app);
+    }
 
     app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
       const status = err.status || err.statusCode || 500;

--- a/server/src/routes/vendorPOs.ts
+++ b/server/src/routes/vendorPOs.ts
@@ -34,6 +34,7 @@ function ensureVendorPOReadSchema(): Promise<void> {
           company_website text,
           company_logo_url text,
           company_logo_filename text,
+          company_logo_mimetype text,
           created_at timestamp DEFAULT now() NOT NULL,
           updated_at timestamp DEFAULT now() NOT NULL
         )
@@ -48,6 +49,7 @@ function ensureVendorPOReadSchema(): Promise<void> {
           ADD COLUMN IF NOT EXISTS company_website text,
           ADD COLUMN IF NOT EXISTS company_logo_url text,
           ADD COLUMN IF NOT EXISTS company_logo_filename text,
+          ADD COLUMN IF NOT EXISTS company_logo_mimetype text,
           ADD COLUMN IF NOT EXISTS created_at timestamp DEFAULT now(),
           ADD COLUMN IF NOT EXISTS updated_at timestamp DEFAULT now()
       `);
@@ -159,12 +161,45 @@ function ensureVendorPOReadSchema(): Promise<void> {
               ADD COLUMN IF NOT EXISTS purchase_unit_price real,
               ADD COLUMN IF NOT EXISTS purchase_unit text,
               ADD COLUMN IF NOT EXISTS pricing_unit text,
+              ADD COLUMN IF NOT EXISTS vendor_unit text,
               ADD COLUMN IF NOT EXISTS conversion_factor real,
-              ADD COLUMN IF NOT EXISTS customer_po_id text,
+              ADD COLUMN IF NOT EXISTS customer_po_id integer,
               ADD COLUMN IF NOT EXISTS project_id uuid,
               ADD COLUMN IF NOT EXISTS production_work_order_id uuid,
               ADD COLUMN IF NOT EXISTS charge_code_id integer,
+              ADD COLUMN IF NOT EXISTS other_identifier text,
+              ADD COLUMN IF NOT EXISTS historical_avg_price real,
+              ADD COLUMN IF NOT EXISTS price_variance_percent real,
               ADD COLUMN IF NOT EXISTS variance_flag boolean DEFAULT false;
+
+            IF EXISTS (
+              SELECT 1
+              FROM information_schema.columns
+              WHERE table_schema = 'public'
+                AND table_name = 'vendor_po_items'
+                AND column_name = 'customer_po_id'
+                AND data_type <> 'integer'
+            ) THEN
+              ALTER TABLE vendor_po_items
+                ALTER COLUMN customer_po_id TYPE integer
+                USING CASE
+                  WHEN customer_po_id::text ~ '^[0-9]+$' THEN customer_po_id::integer
+                  ELSE NULL
+                END;
+            END IF;
+
+            IF EXISTS (
+              SELECT 1
+              FROM information_schema.columns
+              WHERE table_schema = 'public'
+                AND table_name = 'vendor_po_items'
+                AND column_name = 'received_quantity'
+                AND data_type = 'integer'
+            ) THEN
+              ALTER TABLE vendor_po_items
+                ALTER COLUMN received_quantity TYPE real
+                USING received_quantity::real;
+            END IF;
           END IF;
         END $$;
       `);


### PR DESCRIPTION
## Summary
- Delay production SPA static serving until API routes are registered so new page loads do not fire API calls while the startup gate is returning 503.
- Retry transient 503 responses from TanStack Query-backed requests during startup.
- Expand Vendor PO route schema readiness to include company logo MIME data and all current Vendor PO item fields used by read/PDF paths, including safe correction of `customer_po_id` to integer.

## Validation
- `git diff --check`
- Could not run `npm run check` locally because this worktree has no `node_modules` and `npm` is not available in the environment.