### PR TITLE
Fix production workflow read schema readiness

### DIFF
--- a/server/src/lib/productionWorkflowReadiness.ts
+++ b/server/src/lib/productionWorkflowReadiness.ts
@@ -1,0 +1,174 @@
+import { pool } from '../../db';
+
+let productionWorkflowReadinessPromise: Promise<void> | null = null;
+
+export async function ensureProductionWorkflowReadSchema(): Promise<void> {
+  if (productionWorkflowReadinessPromise) return productionWorkflowReadinessPromise;
+
+  productionWorkflowReadinessPromise = (async () => {
+    await pool.query(`SELECT pg_advisory_lock(hashtext('epoch_production_workflow_readiness'))`);
+    try {
+      await pool.query(`
+        DO $$
+        BEGIN
+          IF to_regclass('public.projects') IS NOT NULL THEN
+            ALTER TABLE public.projects
+              ADD COLUMN IF NOT EXISTS current_stage text DEFAULT 'rfq_received',
+              ADD COLUMN IF NOT EXISTS stage_updated_at timestamp DEFAULT now(),
+              ADD COLUMN IF NOT EXISTS po_id integer,
+              ADD COLUMN IF NOT EXISTS project_manager_id integer,
+              ADD COLUMN IF NOT EXISTS reminder_days integer DEFAULT 3,
+              ADD COLUMN IF NOT EXISTS last_reminder_sent_at timestamp,
+              ADD COLUMN IF NOT EXISTS notes text,
+              ADD COLUMN IF NOT EXISTS default_charge_code_id integer,
+              ADD COLUMN IF NOT EXISTS created_by integer,
+              ADD COLUMN IF NOT EXISTS customers_integer_id integer,
+              ADD COLUMN IF NOT EXISTS customer_name_snapshot text;
+          END IF;
+
+          IF to_regclass('public.project_steps') IS NOT NULL THEN
+            ALTER TABLE public.project_steps
+              ADD COLUMN IF NOT EXISTS linked_rfq_id integer,
+              ADD COLUMN IF NOT EXISTS linked_quote_id uuid,
+              ADD COLUMN IF NOT EXISTS linked_purchase_review_id integer,
+              ADD COLUMN IF NOT EXISTS linked_preproduction_checklist_id uuid,
+              ADD COLUMN IF NOT EXISTS linked_p2_order_id integer,
+              ADD COLUMN IF NOT EXISTS completed_by_display_name text;
+          END IF;
+
+          IF to_regclass('public.production_work_orders') IS NOT NULL THEN
+            ALTER TABLE public.production_work_orders
+              ADD COLUMN IF NOT EXISTS department_budgets jsonb DEFAULT '{}'::jsonb,
+              ADD COLUMN IF NOT EXISTS total_budget_hours numeric,
+              ADD COLUMN IF NOT EXISTS start_date date,
+              ADD COLUMN IF NOT EXISTS due_date date,
+              ADD COLUMN IF NOT EXISTS warning_threshold numeric,
+              ADD COLUMN IF NOT EXISTS blocked_threshold numeric,
+              ADD COLUMN IF NOT EXISTS default_charge_code_id integer,
+              ADD COLUMN IF NOT EXISTS wad_status text NOT NULL DEFAULT 'DRAFT',
+              ADD COLUMN IF NOT EXISTS wizard_data jsonb,
+              ADD COLUMN IF NOT EXISTS updated_at timestamp DEFAULT now();
+          END IF;
+
+          IF to_regclass('public.travelers') IS NOT NULL THEN
+            ALTER TABLE public.travelers
+              ADD COLUMN IF NOT EXISTS production_work_order_id uuid,
+              ADD COLUMN IF NOT EXISTS project_id uuid,
+              ADD COLUMN IF NOT EXISTS default_charge_code_id integer,
+              ADD COLUMN IF NOT EXISTS off_system_completion_link text;
+          END IF;
+
+          IF to_regclass('public.traveler_steps') IS NOT NULL THEN
+            ALTER TABLE public.traveler_steps
+              ADD COLUMN IF NOT EXISTS blocked_reason text,
+              ADD COLUMN IF NOT EXISTS blocked_at timestamp with time zone;
+          END IF;
+
+          IF to_regclass('public.punch_ledger') IS NOT NULL THEN
+            ALTER TABLE public.punch_ledger
+              ADD COLUMN IF NOT EXISTS traveler_id text,
+              ADD COLUMN IF NOT EXISTS production_work_order_id uuid,
+              ADD COLUMN IF NOT EXISTS charge_code_id integer,
+              ADD COLUMN IF NOT EXISTS charge_code text,
+              ADD COLUMN IF NOT EXISTS department text,
+              ADD COLUMN IF NOT EXISTS operation text,
+              ADD COLUMN IF NOT EXISTS labor_class text DEFAULT 'REGULAR',
+              ADD COLUMN IF NOT EXISTS project_id uuid,
+              ADD COLUMN IF NOT EXISTS traveler_step_id varchar(255),
+              ADD COLUMN IF NOT EXISTS approval_status text DEFAULT 'PENDING_APPROVAL';
+          END IF;
+
+          IF to_regclass('public.labor_budget_overrides') IS NOT NULL THEN
+            ALTER TABLE public.labor_budget_overrides
+              ADD COLUMN IF NOT EXISTS production_work_order_id uuid,
+              ADD COLUMN IF NOT EXISTS requested_hours numeric,
+              ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'PENDING';
+          END IF;
+
+          IF to_regclass('public.work_orders') IS NOT NULL THEN
+            ALTER TABLE public.work_orders
+              ADD COLUMN IF NOT EXISTS downtime_start timestamp,
+              ADD COLUMN IF NOT EXISTS downtime_end timestamp,
+              ADD COLUMN IF NOT EXISTS closed_by integer,
+              ADD COLUMN IF NOT EXISTS maintenance_schedule_id integer;
+          END IF;
+
+          IF to_regclass('public.parts_requests') IS NOT NULL THEN
+            ALTER TABLE public.parts_requests
+              ADD COLUMN IF NOT EXISTS project_id uuid,
+              ADD COLUMN IF NOT EXISTS estimated_cost real,
+              ADD COLUMN IF NOT EXISTS is_active boolean DEFAULT true;
+          END IF;
+
+          IF to_regclass('public.material_lot_reservations') IS NOT NULL THEN
+            ALTER TABLE public.material_lot_reservations
+              ADD COLUMN IF NOT EXISTS traveler_id uuid,
+              ADD COLUMN IF NOT EXISTS quantity_reserved numeric,
+              ADD COLUMN IF NOT EXISTS status text DEFAULT 'active';
+          END IF;
+
+          IF to_regclass('public.traveler_material_consumption') IS NOT NULL THEN
+            ALTER TABLE public.traveler_material_consumption
+              ADD COLUMN IF NOT EXISTS qty_used numeric,
+              ADD COLUMN IF NOT EXISTS quantity_used numeric;
+
+            UPDATE public.traveler_material_consumption
+            SET qty_used = quantity_used
+            WHERE qty_used IS NULL AND quantity_used IS NOT NULL;
+
+            UPDATE public.traveler_material_consumption
+            SET quantity_used = qty_used
+            WHERE quantity_used IS NULL AND qty_used IS NOT NULL;
+          END IF;
+
+          IF to_regclass('public.wad_production_controls') IS NULL
+             AND to_regclass('public.production_work_orders') IS NOT NULL THEN
+            CREATE TABLE public.wad_production_controls (
+              id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+              work_order_id uuid NOT NULL,
+              part_type text NOT NULL,
+              production_type text NOT NULL,
+              routing_required boolean NOT NULL DEFAULT false,
+              traveler_required boolean NOT NULL DEFAULT false,
+              work_instruction_required boolean NOT NULL DEFAULT false,
+              spec_sheet_required boolean NOT NULL DEFAULT false,
+              final_qc_only boolean NOT NULL DEFAULT false,
+              in_process_inspection_required boolean NOT NULL DEFAULT false,
+              spot_check_plan_required boolean NOT NULL DEFAULT false,
+              cert_required boolean NOT NULL DEFAULT false,
+              ai_reason text,
+              ai_confidence_score numeric(3,2),
+              ai_risk_level text,
+              selected_template_ids jsonb,
+              provisioned_at timestamp with time zone,
+              provision_summary jsonb,
+              created_at timestamp with time zone DEFAULT now(),
+              CONSTRAINT wad_production_controls_work_order_unique UNIQUE (work_order_id)
+            );
+          END IF;
+
+          IF to_regclass('public.wad_document_links') IS NULL
+             AND to_regclass('public.production_work_orders') IS NOT NULL THEN
+            CREATE TABLE public.wad_document_links (
+              id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+              work_order_id uuid NOT NULL,
+              template_id uuid NOT NULL,
+              template_version integer NOT NULL DEFAULT 1,
+              template_type text NOT NULL,
+              template_name text NOT NULL,
+              file_url text,
+              linked_at timestamp with time zone DEFAULT now()
+            );
+          END IF;
+        END $$;
+      `);
+    } finally {
+      await pool.query(`SELECT pg_advisory_unlock(hashtext('epoch_production_workflow_readiness'))`);
+    }
+  })().catch((error) => {
+    productionWorkflowReadinessPromise = null;
+    throw error;
+  });
+
+  return productionWorkflowReadinessPromise;
+}

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -1,7 +1,18 @@
 import { Router, Request, Response } from 'express';
 import { pool } from '../../db';
+import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
 
 const router = Router();
+
+router.use(async (_req, res, next) => {
+  try {
+    await ensureProductionWorkflowReadSchema();
+    next();
+  } catch (error) {
+    console.error('[PM Dashboard] Production workflow schema readiness failed:', error);
+    res.status(503).json({ error: 'Production workflow schema is being prepared, please retry' });
+  }
+});
 
 function h(fn: (req: Request, res: Response) => Promise<void>) {
   return (req: Request, res: Response) =>
@@ -254,18 +265,18 @@ router.get('/:projectId/summary', h(async (req, res) => {
     FROM material_lot_reservations mlr
     JOIN material_lots ml ON ml.id = mlr.material_lot_id
     LEFT JOIN inventory_items ii ON ii.id = ml.inventory_item_id
-    WHERE mlr.traveler_id IN (
-      SELECT id FROM travelers WHERE project_id = $1
+    WHERE mlr.traveler_id::text IN (
+      SELECT id::text FROM travelers WHERE project_id = $1
     )
   `, [projectId]);
 
   const consumedRes = await pool.query<ConsumedCostRow>(`
-    SELECT COALESCE(SUM(tmc.quantity_used * COALESCE(ii.unit_cost, 0)), 0) AS "consumedMaterialCost"
+    SELECT COALESCE(SUM(COALESCE(tmc.qty_used, tmc.quantity_used, 0) * COALESCE(ii.unit_cost, 0)), 0) AS "consumedMaterialCost"
     FROM traveler_material_consumption tmc
     JOIN material_lots ml ON ml.id = tmc.material_lot_id
     LEFT JOIN inventory_items ii ON ii.id = ml.inventory_item_id
-    WHERE tmc.traveler_id IN (
-      SELECT id FROM travelers WHERE project_id = $1
+    WHERE tmc.traveler_id::text IN (
+      SELECT id::text FROM travelers WHERE project_id = $1
     )
   `, [projectId]);
 
@@ -752,17 +763,17 @@ router.get('/:projectId/materials', h(async (req, res) => {
       FROM material_lot_reservations mlr
       JOIN material_lots ml ON ml.id = mlr.material_lot_id
       LEFT JOIN inventory_items ii ON ii.id = ml.inventory_item_id
-      WHERE mlr.traveler_id IN (
-        SELECT id FROM travelers WHERE project_id = $1
+      WHERE mlr.traveler_id::text IN (
+        SELECT id::text FROM travelers WHERE project_id = $1
       )
     ) committed_sub,
     (
-      SELECT SUM(tmc.quantity_used * COALESCE(ii.unit_cost, 0)) AS consumed
+      SELECT SUM(COALESCE(tmc.qty_used, tmc.quantity_used, 0) * COALESCE(ii.unit_cost, 0)) AS consumed
       FROM traveler_material_consumption tmc
       JOIN material_lots ml ON ml.id = tmc.material_lot_id
       LEFT JOIN inventory_items ii ON ii.id = ml.inventory_item_id
-      WHERE tmc.traveler_id IN (
-        SELECT id FROM travelers WHERE project_id = $1
+      WHERE tmc.traveler_id::text IN (
+        SELECT id::text FROM travelers WHERE project_id = $1
       )
     ) consumed_sub,
     (
@@ -802,13 +813,13 @@ router.get('/:projectId/materials', h(async (req, res) => {
     LEFT JOIN (
       SELECT material_lot_id, SUM(quantity_reserved) AS qty_reserved
       FROM material_lot_reservations
-      WHERE traveler_id IN (SELECT id FROM travelers WHERE project_id = $1)
+      WHERE traveler_id::text IN (SELECT id::text FROM travelers WHERE project_id = $1)
       GROUP BY material_lot_id
     ) mlr_agg ON mlr_agg.material_lot_id = ml.id
     LEFT JOIN (
-      SELECT material_lot_id, SUM(quantity_used) AS qty_consumed
+      SELECT material_lot_id, SUM(COALESCE(qty_used, quantity_used, 0)) AS qty_consumed
       FROM traveler_material_consumption
-      WHERE traveler_id IN (SELECT id FROM travelers WHERE project_id = $1)
+      WHERE traveler_id::text IN (SELECT id::text FROM travelers WHERE project_id = $1)
       GROUP BY material_lot_id
     ) tmc_agg ON tmc_agg.material_lot_id = ml.id
     WHERE

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -6,6 +6,7 @@ import { insertProjectSchema, insertProjectStepSchema, insertProjectActivityLogS
 import { createEmployeeIdentitySnapshot } from '../../identity/userIdentity';
 import { validateProjectClosing, deriveClosingStatus } from '../lib/projectClosingValidation';
 import { ensureProjectHasWAD } from '../lib/wadHelper';
+import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
 import { resolveCustomersIntegerId } from '../lib/customerResolver';
 import { getQuoteContractReviewGate } from '../services/quoteContractService';
 import multer from 'multer';
@@ -35,6 +36,16 @@ const uploadProjectDoc = multer({
 });
 
 const router = Router();
+
+router.use(async (_req, res, next) => {
+  try {
+    await ensureProductionWorkflowReadSchema();
+    next();
+  } catch (error) {
+    console.error('[Projects] Production workflow schema readiness failed:', error);
+    res.status(503).json({ error: 'Production workflow schema is being prepared, please retry' });
+  }
+});
 
 const PROJECT_STEP_TYPES = [
   { type: 'rfq_risk_assessment', order: 1, label: 'RFQ Risk Assessment', route: '/rfq-risk-assessment' },

--- a/server/src/routes/workOrders.ts
+++ b/server/src/routes/workOrders.ts
@@ -42,6 +42,7 @@ import { requireScopedCapability, ScopedForbiddenError } from '../permissions';
 import { evaluateWorkOrderLaborStatus } from '../helpers/laborBudgetHelper';
 import { evaluateWorkOrderReadiness } from '../lib/workOrderReadiness';
 import { ensureProjectHasWADFromCanonicalSources } from '../lib/wadHelper';
+import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
 import {
   getProductionControlRecommendation,
   type WadContext,
@@ -49,6 +50,16 @@ import {
 } from '../services/productionControl/productionControlAI.service';
 
 const router = Router();
+
+router.use(async (_req, res, next) => {
+  try {
+    await ensureProductionWorkflowReadSchema();
+    next();
+  } catch (error) {
+    console.error('[WorkOrders] Production workflow schema readiness failed:', error);
+    res.status(503).json({ error: 'Production workflow schema is being prepared, please retry' });
+  }
+});
 
 function requireAdmin(req: Request, res: Response, next: NextFunction) {
   const user = (req as any).user;


### PR DESCRIPTION
## Summary
- Add shared production workflow schema readiness for Projects, PM Dashboard, and Work Orders reads so missing deployed columns are repaired before route queries run.
- Cover the project/WAD fields shown in the production 500 traces, including `project_manager_id`, `customer_name_snapshot`, `wad_status`, `wizard_data`, work-order downtime fields, WAD control/link tables, and related traveler/labor/material fields.
- Make PM dashboard material consumption totals tolerate both historical `quantity_used` and current `qty_used`, with text-safe traveler ID comparisons.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git fetch origin main`
- `git merge-tree --write-tree HEAD origin/main` -> `346dec1d14cb47f9e245a9498deca06e298e56f3`
- Could not run `npm run check` locally because this worktree has no `node_modules` and `npm` is not available in the environment.