### PR TITLE
Gate TimeTrakGo payroll imports on readiness

### DIFF
--- a/server/__tests__/payrollExportPhase1.test.ts
+++ b/server/__tests__/payrollExportPhase1.test.ts
@@ -535,6 +535,16 @@ describe('payrollExport routes - static guards', () => {
       createFn.indexOf('.from(payrollExportBatchesTable)'),
     );
   });
+
+  it('TimeTrakGo imports check DCAA readiness blockers before mutating payroll export tables', () => {
+    const serviceFile = readFileSync(resolve(__dirname, '../src/services/timekeeping/payrollExport.service.ts'), 'utf8');
+    const importFn = serviceFile.slice(serviceFile.indexOf('export async function importTimeTrakGoGustoCsvBatch'));
+
+    expect(importFn.indexOf('await assertPayrollExportReady')).toBeGreaterThan(-1);
+    expect(importFn.indexOf('await assertPayrollExportReady')).toBeLessThan(
+      importFn.indexOf('.from(payrollExportBatchesTable)'),
+    );
+  });
 });
 
 describe('CSV helpers', () => {

--- a/server/src/services/timekeeping/payrollExport.service.ts
+++ b/server/src/services/timekeeping/payrollExport.service.ts
@@ -943,6 +943,11 @@ export interface ImportTimeTrakGoGustoCsvInput {
   actor: AuditActor;
   supersedeReason?: string;
   sourceFileName?: string | null;
+  /**
+   * Test seam for readiness gating. Production import callers should not pass
+   * this; they always evaluate readiness from the transaction data source.
+   */
+  dataSourceOverride?: PayrollSnapshotDataSource;
 }
 
 function requireActorId(actor: AuditActor): number {
@@ -1178,6 +1183,9 @@ export async function importTimeTrakGoGustoCsvBatch(
   const rows = await resolveImportedRows(parsedRows);
 
   return await withSerializableRetry(async (tx) => {
+    const dataSource = input.dataSourceOverride ?? txDataSource(tx);
+    await assertPayrollExportReady(dataSource, input.periodStart, input.periodEnd);
+
     const prior = await tx
       .select()
       .from(payrollExportBatchesTable)


### PR DESCRIPTION
## Summary
- Apply the DCAA payroll readiness gate to the TimeTrakGo/Gusto import export path
- Block imported payroll batches on unresolved certification, approval, or correction blockers before touching payroll export tables
- Add a regression guard that keeps the import readiness check before batch lookup/mutation

## Validation
- `git diff --check -- server\src\services\timekeeping\payrollExport.service.ts server\__tests__\payrollExportPhase1.test.ts`

Not run: Vitest/TypeScript checks; this local worktree has no `npm` and no `node_modules`.