### PR TITLE
Add payroll export readiness endpoint

### DIFF
--- a/server/__tests__/payrollExportPhase1.test.ts
+++ b/server/__tests__/payrollExportPhase1.test.ts
@@ -395,6 +395,35 @@ describe('payrollExport.service - Phase 1', () => {
     expect(harness.store.events).toHaveLength(0);
   });
 
+  it('reports payroll readiness blockers without mutating export evidence', async () => {
+    const readiness = await svc.getPayrollExportReadiness(
+      PERIOD_START,
+      PERIOD_END,
+      source({
+        fetchPayrollReadinessBlockers: vi.fn().mockResolvedValue([
+          {
+            code: 'MISSING_SUPERVISOR_APPROVAL',
+            employeeId: 2,
+            timesheetId: 12,
+            status: 'certified',
+            message: 'Certified/locked timesheet is missing supervisor review evidence.',
+          },
+        ]),
+      }),
+    );
+
+    expect(readiness).toMatchObject({
+      periodStart: PERIOD_START,
+      periodEnd: PERIOD_END,
+      ready: false,
+      blockerCount: 1,
+      blockers: [{ code: 'MISSING_SUPERVISOR_APPROVAL', employeeId: 2, timesheetId: 12 }],
+    });
+    expect(harness.store.batches).toHaveLength(0);
+    expect(harness.store.rows).toHaveLength(0);
+    expect(harness.store.events).toHaveLength(0);
+  });
+
   it('uses employee ids rather than names, so duplicate and compound names stay distinct', async () => {
     const ds = source({
       fetchTimesheets: vi.fn().mockResolvedValue([
@@ -520,6 +549,21 @@ describe('payrollExport routes - static guards', () => {
     expect(gustoRoute).toContain('getActiveBatchForPeriod');
     expect(gustoRoute).toContain('downloadBatchCsv');
     expect(gustoRoute).not.toContain('createRegularFullPeriodBatch');
+  });
+
+  it('exposes a read-only admin payroll readiness route', () => {
+    const routeFile = readFileSync(resolve(__dirname, '../src/routes/timekeeping/payrollExport.ts'), 'utf8');
+    const readinessStart = routeFile.indexOf('router.get(\n  "/admin/payroll/readiness"');
+    expect(readinessStart).toBeGreaterThan(-1);
+    const readinessRoute = routeFile.slice(
+      readinessStart,
+      routeFile.indexOf('/**\n * POST /admin/payroll/batches', readinessStart),
+    );
+
+    expect(readinessRoute).toContain('requireRole("ADMIN", "OWNER")');
+    expect(readinessRoute).toContain('getPayrollExportReadiness');
+    expect(readinessRoute).not.toContain('createRegularFullPeriodBatch');
+    expect(readinessRoute).not.toContain('importTimeTrakGoGustoCsvBatch');
   });
 
   it('batch creation checks DCAA readiness blockers before mutating payroll export tables', () => {

--- a/server/src/routes/timekeeping/payrollExport.ts
+++ b/server/src/routes/timekeeping/payrollExport.ts
@@ -73,6 +73,31 @@ const DownloadQuery = z.object({
 });
 
 /**
+ * GET /admin/payroll/readiness?periodStart=&periodEnd=
+ * Read-only DCAA export gate preview. Returns the same certification,
+ * supervisor approval, and correction blockers that batch creation enforces,
+ * without creating, superseding, or downloading a payroll export batch.
+ */
+router.get(
+  "/admin/payroll/readiness",
+  authenticateToken,
+  requireRole("ADMIN", "OWNER"),
+  h(async (req, res) => {
+    const q = PeriodQuery.safeParse(req.query);
+    if (!q.success) {
+      res.status(400).json({ error: q.error.errors.map((e) => e.message).join("; ") });
+      return;
+    }
+    if (q.data.periodStart > q.data.periodEnd) {
+      res.status(400).json({ error: "periodStart must not be after periodEnd" });
+      return;
+    }
+    const readiness = await svc.getPayrollExportReadiness(q.data.periodStart, q.data.periodEnd);
+    res.status(200).json(readiness);
+  }),
+);
+
+/**
  * POST /admin/payroll/batches
  * Create a new regular_full_period export batch.  If an active batch exists
  * for the same period, supersedeReason is REQUIRED and the prior batch is

--- a/server/src/services/timekeeping/payrollExport.service.ts
+++ b/server/src/services/timekeeping/payrollExport.service.ts
@@ -200,6 +200,14 @@ export class PayrollExportReadinessError extends Error {
   }
 }
 
+export interface PayrollExportReadinessResult {
+  periodStart: string;
+  periodEnd: string;
+  ready: boolean;
+  blockerCount: number;
+  blockers: PayrollExportReadinessBlocker[];
+}
+
 // ---------------------------------------------------------------------------
 // CSV building
 // ---------------------------------------------------------------------------
@@ -484,12 +492,39 @@ async function assertPayrollExportReady(
   periodStart: string,
   periodEnd: string,
 ): Promise<void> {
-  const blockers = dataSource.fetchPayrollReadinessBlockers
-    ? await dataSource.fetchPayrollReadinessBlockers(periodStart, periodEnd)
-    : [];
+  const blockers = await fetchPayrollExportReadinessBlockers(dataSource, periodStart, periodEnd);
   if (blockers.length > 0) {
     throw new PayrollExportReadinessError(blockers);
   }
+}
+
+async function fetchPayrollExportReadinessBlockers(
+  dataSource: PayrollSnapshotDataSource,
+  periodStart: string,
+  periodEnd: string,
+): Promise<PayrollExportReadinessBlocker[]> {
+  return dataSource.fetchPayrollReadinessBlockers
+    ? await dataSource.fetchPayrollReadinessBlockers(periodStart, periodEnd)
+    : [];
+}
+
+export async function getPayrollExportReadiness(
+  periodStart: string,
+  periodEnd: string,
+  dataSourceOverride?: PayrollSnapshotDataSource,
+): Promise<PayrollExportReadinessResult> {
+  const blockers = await fetchPayrollExportReadinessBlockers(
+    dataSourceOverride ?? txDataSource(db),
+    periodStart,
+    periodEnd,
+  );
+  return {
+    periodStart,
+    periodEnd,
+    ready: blockers.length === 0,
+    blockerCount: blockers.length,
+    blockers,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a read-only admin payroll readiness endpoint for DCAA export blockers
- Reuse the same certification, supervisor approval, and correction blocker query enforced by payroll export creation
- Cover the service result and route contract with payroll export phase 1 tests

## Validation
- `git diff --check -- server\src\services\timekeeping\payrollExport.service.ts server\src\routes\timekeeping\payrollExport.ts server\__tests__\payrollExportPhase1.test.ts`

Not run: Vitest/TypeScript checks; this local worktree has no `npm` and no `node_modules`.