### PR TITLE
Harden compliance flow gates

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -12,6 +12,7 @@ import { forecastActiveOrders, forecastOrder, simulateNewOrder } from '../servic
 import { simulateFactoryCompletion, invalidateSimulationCache } from '../services/productionSimulator';
 import { normalizeToTuesday } from '@shared/utils/dateNormalization';
 import { syncEmployeeRoles, findRoleMismatches } from '../migrations/syncEmployeeRoles';
+import { recordAuditEvent } from '../services/auditLedgerService';
 
 const router = Router();
 
@@ -1814,22 +1815,32 @@ router.post(
         ]
       );
 
-      // Write reason to audit_events for timeline
-      await pool.query(
-        `INSERT INTO audit_events
-           (entity_type, entity_id, action, actor_name, actor_role, reason, fields_changed, meta, timestamp)
-         VALUES ('order', $1, 'ADMIN_FIELD_OVERRIDE', $2, $3, $4, $5, $6, NOW())`,
-        [
-          resolvedOrderId,
-          user.username,
-          user.role ?? 'OWNER',
-          reason,
-          JSON.stringify([columnName]),
-          JSON.stringify({ column: columnName, oldValue, newValue: effectiveValue }),
-        ]
-      ).catch((err: any) => {
-        // audit_events may have schema differences — don't fail the whole request
-        console.warn('[OrderOverride] audit_events insert failed (non-fatal):', err.message);
+      await recordAuditEvent({
+        eventType: 'ADMIN_FIELD_OVERRIDE',
+        subjectType: 'order',
+        subjectId: resolvedOrderId,
+        sourceService: 'admin.orderOverride',
+        actor: {
+          id: typeof user.id === 'number' ? user.id : null,
+          username: user.username,
+          role: user.role ?? 'OWNER',
+        },
+        reason,
+        fieldsChanged: {
+          [columnName]: { before: oldValue, after: effectiveValue },
+        },
+        payload: {
+          column: columnName,
+          oldValue,
+          newValue: effectiveValue,
+        } as any,
+        meta: {
+          column: columnName,
+          oldValue,
+          newValue: effectiveValue,
+        } as any,
+        entityType: 'order',
+        entityId: resolvedOrderId,
       });
 
       res.json({

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -8,6 +8,7 @@ import { eq, sql } from 'drizzle-orm';
 import { pool, db } from '../../db';
 import { users, employees } from '../../schema';
 import { authenticateToken } from '../../middleware/auth';
+import { recordAuditEvent } from '../services/auditLedgerService';
 
 // ─── Session Hardening Types ──────────────────────────────────────────────────
 /** Minimal row shape returned by concurrent-session overflow queries */
@@ -90,24 +91,19 @@ async function logSessionAuditEvent(
   ipAddress?: string,
   userAgent?: string
 ): Promise<void> {
-  try {
-    await pool.query(
-      `INSERT INTO audit_events (entity_type, entity_id, action, actor_id, actor_name, actor_role, meta, ip_address, user_agent, created_at)
-       VALUES ('user_session', $1, $2, $3, $4, $5, $6, $7, $8, NOW())`,
-      [
-        sessionId,
-        action,
-        userId,
-        username,
-        role,
-        JSON.stringify(meta),
-        ipAddress ?? null,
-        userAgent ?? null,
-      ]
-    );
-  } catch (err) {
-    console.error('[SessionAudit] Failed to write audit event:', action, err);
-  }
+  await recordAuditEvent({
+    eventType: action,
+    subjectType: 'user_session',
+    subjectId: sessionId,
+    sourceService: 'auth.route',
+    actor: { id: userId, username, role },
+    ipAddress: ipAddress ?? null,
+    userAgent: userAgent ?? null,
+    payload: meta as any,
+    meta: meta as any,
+    entityType: 'user_session',
+    entityId: sessionId,
+  });
 }
 
 const router = Router();

--- a/server/src/routes/creditMemos.ts
+++ b/server/src/routes/creditMemos.ts
@@ -17,6 +17,7 @@ import { eq, desc, sql, and } from 'drizzle-orm';
 import { authenticateToken } from '../../middleware/auth';
 import { requireAdminAccess } from '../../middleware/routeAuthorization';
 import { auditService } from '../services/auditService';
+import { assertPostingAllowedForPeriod } from '../services/accountingPeriodService';
 
 const router = Router();
 
@@ -348,6 +349,12 @@ router.post('/', async (req: Request, res: Response) => {
     }
 
     const memoNumber = await generateMemoNumber();
+    const effectiveDate = new Date();
+    await assertPostingAllowedForPeriod({
+      effectiveDate,
+      user: (req as any).user ?? { username: createdBy || 'System' },
+      postingMode: 'ADJUSTMENT',
+    });
 
     const newMemo = await db.transaction(async (tx) => {
       const [memo] = await tx
@@ -373,7 +380,7 @@ router.post('/', async (req: Request, res: Response) => {
           transactionType: 'AR_CREDIT_MEMO',
           referenceType: 'credit_memo',
           referenceId: memo.id,
-          effectiveDate: new Date(),
+          effectiveDate,
           memo: `Credit Memo ${memoNumber} — Invoice ${invoice.invoiceNumber}`,
           status: 'DRAFT',
           createdBy: createdBy || 'System',

--- a/server/src/routes/engineeringControl.ts
+++ b/server/src/routes/engineeringControl.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { and, desc, eq } from 'drizzle-orm';
 import { db } from '../../db';
 import { authenticateToken } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/requirePermission';
+import { recordAuditEvent } from '../services/auditLedgerService';
 import {
   engineeringControlledRevisions,
   engineeringChangeOrders,
@@ -82,6 +84,39 @@ function actorFromRequest(req: Request, override?: string): string {
   if (override) return override;
   const user = (req as any).user;
   return user?.username || user?.email || user?.displayName || 'system';
+}
+
+function auditActor(req: Request) {
+  const user = (req as any).user;
+  return {
+    id: typeof user?.id === 'number' ? user.id : null,
+    username: user?.username ?? user?.email ?? user?.displayName ?? null,
+    role: user?.role ?? null,
+  };
+}
+
+async function logEngineeringControlEvent(req: Request, input: {
+  eventType: string;
+  subjectType: 'engineering_revision' | 'engineering_eco';
+  subjectId: string;
+  reason?: string | null;
+  payload: Record<string, unknown>;
+}) {
+  await recordAuditEvent({
+    eventType: input.eventType,
+    subjectType: input.subjectType,
+    subjectId: input.subjectId,
+    sourceService: 'engineeringControl.route',
+    actor: auditActor(req),
+    reason: input.reason ?? null,
+    payload: input.payload as any,
+    entityType: input.subjectType,
+    entityId: input.subjectId,
+    meta: {
+      ...input.payload,
+      route: 'server/src/routes/engineeringControl.ts',
+    } as any,
+  });
 }
 
 function transitionAllowed(current: string, next: string): boolean {
@@ -229,7 +264,7 @@ router.patch('/revisions/:id', authenticateToken, async (req: Request, res: Resp
   }
 });
 
-router.post('/revisions/:id/transition', authenticateToken, async (req: Request, res: Response) => {
+router.post('/revisions/:id/transition', authenticateToken, requirePermission('engineering.release_revision'), async (req: Request, res: Response) => {
   try {
     const parsed = transitionRevisionSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
@@ -298,6 +333,23 @@ router.post('/revisions/:id/transition', authenticateToken, async (req: Request,
         .onConflictDoNothing();
     }
 
+    await logEngineeringControlEvent(req, {
+      eventType: 'ENGINEERING_REVISION_TRANSITIONED',
+      subjectType: 'engineering_revision',
+      subjectId: updated.id,
+      reason: parsed.data.releaseNotes ?? null,
+      payload: {
+        revisionId: updated.id,
+        artifactType: updated.artifactType,
+        artifactId: updated.artifactId,
+        revision: updated.revision,
+        priorReleaseState: existing.releaseState,
+        nextReleaseState: parsed.data.releaseState,
+        ecoId: parsed.data.ecoId ?? null,
+        actor,
+      },
+    });
+
     return res.json(updated);
   } catch (error: any) {
     console.error('[EngineeringControl] transition revision error:', error);
@@ -359,7 +411,7 @@ router.post('/ecos', authenticateToken, async (req: Request, res: Response) => {
   }
 });
 
-router.post('/ecos/:id/impact-review', authenticateToken, async (req: Request, res: Response) => {
+router.post('/ecos/:id/impact-review', authenticateToken, requirePermission('engineering.release_revision'), async (req: Request, res: Response) => {
   try {
     const parsed = impactReviewSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
@@ -377,6 +429,18 @@ router.post('/ecos/:id/impact-review', authenticateToken, async (req: Request, r
       .where(eq(engineeringChangeOrders.id, req.params.id))
       .returning();
     if (!updated) return res.status(404).json({ error: 'ECO not found' });
+    await logEngineeringControlEvent(req, {
+      eventType: 'ENGINEERING_ECO_IMPACT_REVIEWED',
+      subjectType: 'engineering_eco',
+      subjectId: updated.id,
+      payload: {
+        ecoId: updated.id,
+        ecoNumber: updated.ecoNumber,
+        status: updated.status,
+        impactReviewedBy: updated.impactReviewedBy,
+        impactReviewedAt: updated.impactReviewedAt,
+      },
+    });
     return res.json(updated);
   } catch (error: any) {
     console.error('[EngineeringControl] ECO impact review error:', error);
@@ -384,7 +448,7 @@ router.post('/ecos/:id/impact-review', authenticateToken, async (req: Request, r
   }
 });
 
-router.post('/ecos/:id/submit-approval', authenticateToken, async (req: Request, res: Response) => {
+router.post('/ecos/:id/submit-approval', authenticateToken, requirePermission('engineering.release_revision'), async (req: Request, res: Response) => {
   try {
     const parsed = approvalSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
@@ -399,6 +463,17 @@ router.post('/ecos/:id/submit-approval', authenticateToken, async (req: Request,
       .where(eq(engineeringChangeOrders.id, req.params.id))
       .returning();
     if (!updated) return res.status(404).json({ error: 'ECO not found' });
+    await logEngineeringControlEvent(req, {
+      eventType: 'ENGINEERING_ECO_SUBMITTED_FOR_APPROVAL',
+      subjectType: 'engineering_eco',
+      subjectId: updated.id,
+      payload: {
+        ecoId: updated.id,
+        ecoNumber: updated.ecoNumber,
+        status: updated.status,
+        approvalPlan: updated.approvalPlan ?? null,
+      },
+    });
     return res.json(updated);
   } catch (error: any) {
     console.error('[EngineeringControl] ECO submit approval error:', error);
@@ -406,7 +481,7 @@ router.post('/ecos/:id/submit-approval', authenticateToken, async (req: Request,
   }
 });
 
-router.post('/ecos/:id/approve', authenticateToken, async (req: Request, res: Response) => {
+router.post('/ecos/:id/approve', authenticateToken, requirePermission('engineering.release_revision'), async (req: Request, res: Response) => {
   try {
     const parsed = approvalSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
@@ -423,6 +498,18 @@ router.post('/ecos/:id/approve', authenticateToken, async (req: Request, res: Re
       .where(eq(engineeringChangeOrders.id, req.params.id))
       .returning();
     if (!updated) return res.status(404).json({ error: 'ECO not found' });
+    await logEngineeringControlEvent(req, {
+      eventType: 'ENGINEERING_ECO_APPROVED',
+      subjectType: 'engineering_eco',
+      subjectId: updated.id,
+      payload: {
+        ecoId: updated.id,
+        ecoNumber: updated.ecoNumber,
+        status: updated.status,
+        approvedBy: updated.approvedBy,
+        approvedAt: updated.approvedAt,
+      },
+    });
     return res.json(updated);
   } catch (error: any) {
     console.error('[EngineeringControl] ECO approve error:', error);
@@ -430,7 +517,7 @@ router.post('/ecos/:id/approve', authenticateToken, async (req: Request, res: Re
   }
 });
 
-router.post('/ecos/:id/reject', authenticateToken, async (req: Request, res: Response) => {
+router.post('/ecos/:id/reject', authenticateToken, requirePermission('engineering.release_revision'), async (req: Request, res: Response) => {
   try {
     const parsed = rejectionSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
@@ -447,6 +534,19 @@ router.post('/ecos/:id/reject', authenticateToken, async (req: Request, res: Res
       .where(eq(engineeringChangeOrders.id, req.params.id))
       .returning();
     if (!updated) return res.status(404).json({ error: 'ECO not found' });
+    await logEngineeringControlEvent(req, {
+      eventType: 'ENGINEERING_ECO_REJECTED',
+      subjectType: 'engineering_eco',
+      subjectId: updated.id,
+      reason: parsed.data.rejectionReason,
+      payload: {
+        ecoId: updated.id,
+        ecoNumber: updated.ecoNumber,
+        status: updated.status,
+        rejectedBy: updated.rejectedBy,
+        rejectedAt: updated.rejectedAt,
+      },
+    });
     return res.json(updated);
   } catch (error: any) {
     console.error('[EngineeringControl] ECO reject error:', error);
@@ -454,7 +554,7 @@ router.post('/ecos/:id/reject', authenticateToken, async (req: Request, res: Res
   }
 });
 
-router.post('/ecos/:id/implement', authenticateToken, async (req: Request, res: Response) => {
+router.post('/ecos/:id/implement', authenticateToken, requirePermission('engineering.release_revision'), async (req: Request, res: Response) => {
   try {
     const parsed = implementationSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
@@ -481,6 +581,20 @@ router.post('/ecos/:id/implement', authenticateToken, async (req: Request, res: 
       })
       .where(eq(engineeringChangeOrders.id, req.params.id))
       .returning();
+    await logEngineeringControlEvent(req, {
+      eventType: 'ENGINEERING_ECO_IMPLEMENTED',
+      subjectType: 'engineering_eco',
+      subjectId: updated.id,
+      payload: {
+        ecoId: updated.id,
+        ecoNumber: updated.ecoNumber,
+        priorStatus: existing.status,
+        status: updated.status,
+        implementationDate: updated.implementationDate,
+        implementedBy: updated.implementedBy,
+        implementedAt: updated.implementedAt,
+      },
+    });
     return res.json(updated);
   } catch (error: any) {
     console.error('[EngineeringControl] ECO implement error:', error);
@@ -488,7 +602,7 @@ router.post('/ecos/:id/implement', authenticateToken, async (req: Request, res: 
   }
 });
 
-router.post('/ecos/:id/release', authenticateToken, async (req: Request, res: Response) => {
+router.post('/ecos/:id/release', authenticateToken, requirePermission('engineering.release_revision'), async (req: Request, res: Response) => {
   try {
     const parsed = ecoReleaseSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
@@ -514,6 +628,20 @@ router.post('/ecos/:id/release', authenticateToken, async (req: Request, res: Re
       })
       .where(eq(engineeringChangeOrders.id, req.params.id))
       .returning();
+    await logEngineeringControlEvent(req, {
+      eventType: 'ENGINEERING_ECO_RELEASED',
+      subjectType: 'engineering_eco',
+      subjectId: updated.id,
+      payload: {
+        ecoId: updated.id,
+        ecoNumber: updated.ecoNumber,
+        priorStatus: existing.status,
+        status: updated.status,
+        releasedBy: updated.releasedBy,
+        releasedAt: updated.releasedAt,
+        releaseLinkage: updated.releaseLinkage ?? null,
+      },
+    });
     return res.json(updated);
   } catch (error: any) {
     console.error('[EngineeringControl] ECO release error:', error);
@@ -521,7 +649,7 @@ router.post('/ecos/:id/release', authenticateToken, async (req: Request, res: Re
   }
 });
 
-router.post('/ecos/:id/link-revision', authenticateToken, async (req: Request, res: Response) => {
+router.post('/ecos/:id/link-revision', authenticateToken, requirePermission('engineering.release_revision'), async (req: Request, res: Response) => {
   try {
     const parsed = insertEngineeringEcoRevisionLinkSchema.safeParse({
       ...req.body,
@@ -531,6 +659,17 @@ router.post('/ecos/:id/link-revision', authenticateToken, async (req: Request, r
     if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
 
     const [created] = await db.insert(engineeringEcoRevisionLinks).values(parsed.data).returning();
+    await logEngineeringControlEvent(req, {
+      eventType: 'ENGINEERING_ECO_REVISION_LINKED',
+      subjectType: 'engineering_eco',
+      subjectId: req.params.id,
+      payload: {
+        ecoId: req.params.id,
+        revisionId: created.revisionId,
+        linkType: created.linkType,
+        createdBy: created.createdBy,
+      },
+    });
     return res.status(201).json(created);
   } catch (error: any) {
     console.error('[EngineeringControl] ECO link revision error:', error);

--- a/server/src/routes/microsoftAuth.ts
+++ b/server/src/routes/microsoftAuth.ts
@@ -3,8 +3,30 @@ import { ConfidentialClientApplication, type AuthorizationUrlRequest, type Autho
 import { pool } from '../../db';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
+import { recordAuditEvent } from '../services/auditLedgerService';
 
 const router = Router();
+
+async function logMicrosoftSessionEvent(input: {
+  eventType: string;
+  sessionId: string;
+  userId: number;
+  username: string;
+  role: string;
+  payload: Record<string, unknown>;
+}) {
+  await recordAuditEvent({
+    eventType: input.eventType,
+    subjectType: 'user_session',
+    subjectId: input.sessionId,
+    sourceService: 'microsoftAuth.route',
+    actor: { id: input.userId, username: input.username, role: input.role },
+    payload: input.payload as any,
+    meta: input.payload as any,
+    entityType: 'user_session',
+    entityId: input.sessionId,
+  });
+}
 
 const MICROSOFT_CLIENT_ID = process.env.MICROSOFT_CLIENT_ID;
 const MICROSOFT_CLIENT_SECRET = process.env.MICROSOFT_CLIENT_SECRET;
@@ -293,11 +315,17 @@ router.get('/callback', async (req: Request, res: Response) => {
       : [];
     for (const old of oauthToDeactivate) {
       await pool.query(`UPDATE user_sessions SET is_active = false WHERE id = $1`, [old.id]);
-      await pool.query(
-        `INSERT INTO audit_events (entity_type, entity_id, action, actor_id, actor_name, actor_role, meta, created_at)
-         VALUES ('user_session', $1, 'SESSION_SUPERSEDED', $2, $3, $4, $5, NOW())`,
-        [String(old.id), userId, username, role, JSON.stringify({ reason: 'Microsoft OAuth login exceeded concurrent session limit', maxSessions: oauthMaxSessions })]
-      );
+      await logMicrosoftSessionEvent({
+        eventType: 'SESSION_SUPERSEDED',
+        sessionId: String(old.id),
+        userId,
+        username,
+        role,
+        payload: {
+          reason: 'Microsoft OAuth login exceeded concurrent session limit',
+          maxSessions: oauthMaxSessions,
+        },
+      });
     }
 
     // Store session in database — OAuth login IS credential verification
@@ -321,15 +349,18 @@ router.get('/callback', async (req: Request, res: Response) => {
       );
       const oauthSessionId = oauthSessionRow.rows?.[0]?.id ?? oauthSessionRow[0]?.id;
       if (oauthSessionId) {
-        try {
-          await pool.query(
-            `INSERT INTO audit_events (entity_type, entity_id, action, actor_id, actor_name, actor_role, meta, created_at)
-             VALUES ('user_session', $1, 'SESSION_CREATED', $2, $3, $4, $5, NOW())`,
-            [String(oauthSessionId), userId, username, role, JSON.stringify({ loginMethod: 'microsoft_oauth', email, expiresAt: expiresAt.toISOString() })]
-          );
-        } catch (auditErr) {
-          console.error('[SessionAudit] Failed to emit SESSION_CREATED for Microsoft OAuth session', oauthSessionId, auditErr);
-        }
+        await logMicrosoftSessionEvent({
+          eventType: 'SESSION_CREATED',
+          sessionId: String(oauthSessionId),
+          userId,
+          username,
+          role,
+          payload: {
+            loginMethod: 'microsoft_oauth',
+            email,
+            expiresAt: expiresAt.toISOString(),
+          },
+        });
       }
     }
 

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -11,6 +11,7 @@ import {
 } from '../../schema';
 import { eq, inArray, desc } from 'drizzle-orm';
 import { authenticateToken, requireRole } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/requirePermission';
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
 import { generatePackingSlipPdf } from '../../utils/pdf/packingSlipPdf';
 import type { PackingSlipData, PackingSlipItem } from '../../utils/pdf/types';
@@ -19,6 +20,7 @@ import {
   buildCertPackageExport,
   evaluateShippingCertPackageGate,
 } from '../services/certPackageService';
+import { recordAuditEvent } from '../services/auditLedgerService';
 import multer from 'multer';
 import { ObjectStorageService } from '../../replit_integrations/object_storage/objectStorage';
 
@@ -26,6 +28,15 @@ const upload = multer({ storage: multer.memoryStorage() });
 const objectStorageService = new ObjectStorageService();
 
 const router = Router();
+
+function auditActor(req: Request) {
+  const user = (req as any).user;
+  return {
+    id: typeof user?.id === 'number' ? user.id : null,
+    username: user?.username ?? user?.email ?? user?.displayName ?? null,
+    role: user?.role ?? null,
+  };
+}
 
 // ─── Session auth helper (for PDF routes that use cookie-based sessions) ─────
 async function getUserFromSession(req: Request): Promise<{ username: string; role: string } | null> {
@@ -132,7 +143,7 @@ const createLotSchema = z.object({
   createdBy: z.string().min(1).default('system'),
 });
 
-router.post('/lots', async (req: Request, res: Response) => {
+router.post('/lots', authenticateToken, requirePermission('shipping.release_shipment'), async (req: Request, res: Response) => {
   try {
     const input = createLotSchema.parse(req.body);
 
@@ -278,7 +289,7 @@ const createPackingSlipSchema = z.object({
   isNoChargeReplacement: z.boolean().optional(),
 });
 
-router.post('/packing-slips', async (req: Request, res: Response) => {
+router.post('/packing-slips', authenticateToken, requirePermission('shipping.release_shipment'), async (req: Request, res: Response) => {
   try {
     const input = createPackingSlipSchema.parse(req.body);
 
@@ -763,7 +774,7 @@ router.get('/packing-slips/:id/pdf', async (req: Request, res: Response) => {
 // Accepts a multipart/form-data file field named "file" (PDF only).
 // Stores the file in object storage and saves the path to external_pdf_url.
 // ============================================================
-router.post('/packing-slips/:id/attach-pdf', upload.single('file'), async (req: Request, res: Response) => {
+router.post('/packing-slips/:id/attach-pdf', authenticateToken, requirePermission('shipping.release_shipment'), upload.single('file'), async (req: Request, res: Response) => {
   try {
     const [slip] = await db
       .select()
@@ -798,7 +809,7 @@ router.post('/packing-slips/:id/attach-pdf', upload.single('file'), async (req: 
 // ============================================================
 // DELETE /api/p2/packing-slips/:id/attach-pdf — Remove external PDF
 // ============================================================
-router.delete('/packing-slips/:id/attach-pdf', async (req: Request, res: Response) => {
+router.delete('/packing-slips/:id/attach-pdf', authenticateToken, requirePermission('shipping.release_shipment'), async (req: Request, res: Response) => {
   try {
     const [slip] = await db
       .select()
@@ -828,7 +839,7 @@ const createCertificateSchema = z.object({
   certificationText: z.string().optional(),
 });
 
-router.post('/certificates', async (req: Request, res: Response) => {
+router.post('/certificates', authenticateToken, requirePermission('shipping.release_shipment'), async (req: Request, res: Response) => {
   try {
     const input = createCertificateSchema.parse(req.body);
 
@@ -1322,22 +1333,23 @@ router.get('/shipments/:lotId/cert-package/export', async (req: Request, res: Re
 });
 
 // PATCH /api/p2/shipments/:lotId — update tracking, carrier, notes; optionally mark shipped
-router.patch('/shipments/:lotId', async (req: Request, res: Response) => {
+router.patch('/shipments/:lotId', authenticateToken, requirePermission('shipping.mark_shipped'), async (req: Request, res: Response) => {
   try {
     const { lotId } = req.params;
     const { trackingNumber, carrier, notes, markShipped, shippedBy } = req.body;
+    let shipmentGate: Awaited<ReturnType<typeof evaluateShippingCertPackageGate>> | null = null;
 
     if (markShipped) {
-      const gate = await evaluateShippingCertPackageGate(lotId);
-      if (!gate) return res.status(404).json({ error: 'Lot not found' });
-      if (!gate.readyToShip) {
+      shipmentGate = await evaluateShippingCertPackageGate(lotId);
+      if (!shipmentGate) return res.status(404).json({ error: 'Lot not found' });
+      if (!shipmentGate.readyToShip) {
         return res.status(409).json({
           error: 'Shipment blocked by cert package gate',
           gate: 'shipping_cert_package',
           message: 'Shipment cannot be marked shipped until all required cert-package evidence is complete.',
-          blockers: gate.blockers,
-          evidence: gate.evidence,
-          revisionSnapshot: gate.revisionSnapshot,
+          blockers: shipmentGate.blockers,
+          evidence: shipmentGate.evidence,
+          revisionSnapshot: shipmentGate.revisionSnapshot,
         });
       }
     }
@@ -1397,6 +1409,37 @@ router.patch('/shipments/:lotId', async (req: Request, res: Response) => {
       }
     }
 
+    if (markShipped && shipmentGate) {
+      await recordAuditEvent({
+        eventType: 'SHIPMENT_RELEASED',
+        subjectType: 'shipment',
+        subjectId: lotId,
+        sourceService: 'p2Shipping.route',
+        actor: auditActor(req),
+        reason: notes || 'Shipment marked shipped after cert package gate cleared',
+        payload: {
+          lotId,
+          trackingNumber: trackingNumber || null,
+          carrier: carrier || null,
+          shippedBy: shippedBy || auditActor(req).username || 'system',
+          gate: 'shipping_cert_package',
+          readyToShip: shipmentGate.readyToShip,
+          blockers: shipmentGate.blockers as any,
+          evidence: shipmentGate.evidence as any,
+          revisionSnapshot: shipmentGate.revisionSnapshot as any,
+        },
+        entityType: 'shipment',
+        entityId: lotId,
+        meta: {
+          lotId,
+          trackingNumber: trackingNumber || null,
+          carrier: carrier || null,
+          gate: 'shipping_cert_package',
+          readyToShip: shipmentGate.readyToShip,
+        },
+      });
+    }
+
     return res.json({ success: true });
   } catch (err: any) {
     console.error('Shipment update error:', err);
@@ -1405,7 +1448,7 @@ router.patch('/shipments/:lotId', async (req: Request, res: Response) => {
 });
 
 // POST /api/p2/shipments/:lotId/upload-bol — upload Bill of Lading PDF/image
-router.post('/shipments/:lotId/upload-bol', upload.single('file'), async (req: Request, res: Response) => {
+router.post('/shipments/:lotId/upload-bol', authenticateToken, requirePermission('shipping.release_shipment'), upload.single('file'), async (req: Request, res: Response) => {
   try {
     const { lotId } = req.params;
     if (!req.file) return res.status(400).json({ error: 'No file provided' });
@@ -1452,7 +1495,7 @@ router.get('/shipments/:lotId/bill-of-lading', async (req: Request, res: Respons
 });
 
 // POST /api/p2/shipments/:lotId/upload-lot-validation-report — upload Lot Validation Report PDF/image
-router.post('/shipments/:lotId/upload-lot-validation-report', upload.single('file'), async (req: Request, res: Response) => {
+router.post('/shipments/:lotId/upload-lot-validation-report', authenticateToken, requirePermission('shipping.release_shipment'), upload.single('file'), async (req: Request, res: Response) => {
   try {
     const { lotId } = req.params;
     if (!req.file) return res.status(400).json({ error: 'No file provided' });
@@ -1499,7 +1542,7 @@ router.get('/shipments/:lotId/lot-validation-report', async (req: Request, res: 
 });
 
 // POST /api/p2/shipments/:lotId/upload-packing-slip — upload external packing slip PDF
-router.post('/shipments/:lotId/upload-packing-slip', upload.single('file'), async (req: Request, res: Response) => {
+router.post('/shipments/:lotId/upload-packing-slip', authenticateToken, requirePermission('shipping.release_shipment'), upload.single('file'), async (req: Request, res: Response) => {
   try {
     const { lotId } = req.params;
     if (!req.file) return res.status(400).json({ error: 'No file provided' });
@@ -1546,7 +1589,7 @@ router.get('/shipments/:lotId/packing-slip-upload', async (req: Request, res: Re
 });
 
 // POST /api/p2/shipments/:lotId/upload-certificate — upload external certificate PDF
-router.post('/shipments/:lotId/upload-certificate', upload.single('file'), async (req: Request, res: Response) => {
+router.post('/shipments/:lotId/upload-certificate', authenticateToken, requirePermission('shipping.release_shipment'), upload.single('file'), async (req: Request, res: Response) => {
   try {
     const { lotId } = req.params;
     if (!req.file) return res.status(400).json({ error: 'No file provided' });

--- a/server/src/services/accountingService.ts
+++ b/server/src/services/accountingService.ts
@@ -1,6 +1,7 @@
 import { db } from '../../db';
 import { chartOfAccounts, journalEntries, journalLines } from '../../schema';
 import { eq, and } from 'drizzle-orm';
+import { assertPostingAllowedForPeriod } from './accountingPeriodService';
 
 export type PaymentRecord = {
   id: number;
@@ -56,6 +57,17 @@ export async function createOrUpdateFromPayment(
 
   let entryId: number;
   const isUpdate = !!existingEntry;
+  const effectiveDate =
+    existingEntry?.effectiveDate ??
+    (paymentRecord.paymentDate instanceof Date
+      ? paymentRecord.paymentDate
+      : new Date(paymentRecord.paymentDate));
+
+  await assertPostingAllowedForPeriod({
+    effectiveDate,
+    user,
+    postingMode: 'STANDARD',
+  });
 
   if (existingEntry) {
     if (existingEntry.status === 'EXPORTED') {
@@ -69,11 +81,6 @@ export async function createOrUpdateFromPayment(
       .where(eq(journalLines.journalEntryId, existingEntry.id));
     entryId = existingEntry.id;
   } else {
-    const effectiveDate =
-      paymentRecord.paymentDate instanceof Date
-        ? paymentRecord.paymentDate
-        : new Date(paymentRecord.paymentDate);
-
     const [newEntry] = await db
       .insert(journalEntries)
       .values({
@@ -147,6 +154,12 @@ export async function createBulkWireJournalEntry({
   user?: { id?: number; username?: string } | null;
 }): Promise<void> {
   try {
+    await assertPostingAllowedForPeriod({
+      effectiveDate: paymentDate,
+      user,
+      postingMode: 'STANDARD',
+    });
+
     const net = Math.round((totalGross - totalFee) * 100) / 100;
 
     if (net < 0) {
@@ -247,6 +260,12 @@ export async function deleteJournalEntryForPayment(paymentId: number): Promise<{
     );
     return { blocked: true };
   }
+
+  await assertPostingAllowedForPeriod({
+    effectiveDate: entry.effectiveDate,
+    user: null,
+    postingMode: 'REVERSAL',
+  });
 
   await db.delete(journalLines).where(eq(journalLines.journalEntryId, entry.id));
   await db.delete(journalEntries).where(eq(journalEntries.id, entry.id));

--- a/server/src/services/laborPostingService.ts
+++ b/server/src/services/laborPostingService.ts
@@ -2,6 +2,7 @@ import { db } from '../../db';
 import { journalEntries, journalLines, laborAccountConfig, laborCostRecords, laborPostingRuns } from '../../schema';
 import { and, eq, inArray, isNotNull, isNull } from 'drizzle-orm';
 import { verifyPeriodBurdenComplete } from './burdenRatesService';
+import { assertPostingAllowedForPeriod } from './accountingPeriodService';
 
 // Compound grouping key for WAD-linked labor cost records.
 // Every WAD record must resolve to exactly one journal entry.
@@ -65,6 +66,13 @@ export async function postLaborToGL(year: number, month: number, postedBy: strin
   let runId = 0;
   const journalEntryIds: number[] = [];
   let skippedAlreadyPosted = 0;
+  const effectiveDate = new Date(year, month - 1, 1);
+
+  await assertPostingAllowedForPeriod({
+    effectiveDate,
+    user: { username: postedBy },
+    postingMode: 'STANDARD',
+  });
 
   // All reads and writes are performed inside a single atomic transaction.
   // The posting run row is locked with SELECT ... FOR UPDATE at the start so
@@ -235,8 +243,6 @@ export async function postLaborToGL(year: number, month: number, postedBy: strin
         wadGroups.set(mk, { key, total: Number(rec.dollarCost) });
       }
     }
-
-    const effectiveDate = new Date(year, month - 1, 1);
 
     // ── 8a. Non-WAD records — one journal entry per costType ─────────────────
     for (const [costType, totalAmount] of Object.entries(nonWadTotals)) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -131,7 +131,6 @@ import {
   employeeDocuments,
   employeeAuditLog,
   adminAuditLog,
-  auditEvents,
   // Capability-based permission system tables
   capabilities,
   employeeCapabilities,
@@ -707,6 +706,7 @@ import {
   type InsertLocalCalendarEvent,
 } from './schema';
 import { db, pool, rawSql } from './db';
+import { recordAuditEvent } from './src/services/auditLedgerService';
 
 // Drizzle's transaction handle is API-compatible with `db` for the CRUD
 // surface our helpers use, but its TS type is a `PgTransaction` (not the
@@ -11068,13 +11068,36 @@ export class DatabaseStorage implements IStorage {
       }
 
       // Mandatory audit event — transactional with review write.
-      await tx.insert(auditEvents).values({
+      await recordAuditEvent({
+        eventType: isUpdate ? 'COMPLIANCE_REVIEW_UPDATED' : 'COMPLIANCE_REVIEW_SUBMITTED',
+        subjectType: 'vendor',
+        subjectId: String(data.vendorPoId),
+        sourceService: 'storage.vendorPoComplianceReview',
+        actor: {
+          id: data.reviewedByUserId ?? null,
+          username: data.reviewedByDisplayName ?? null,
+          role: null,
+        },
+        reason: data.reviewNotes ?? null,
         entityType: 'vendor',
         entityId: String(data.vendorPoId),
-        action: isUpdate ? 'COMPLIANCE_REVIEW_UPDATED' : 'COMPLIANCE_REVIEW_SUBMITTED',
-        actorId: data.reviewedByUserId ?? null,
-        actorName: data.reviewedByDisplayName ?? null,
-        reason: data.reviewNotes,
+        payload: {
+          vendorPoId: data.vendorPoId,
+          reviewStatus: computedStatus,
+          governmentContract: data.governmentContract,
+          farRequired: data.farRequired,
+          dpasRequired: data.dpasRequired,
+          cocRequired: data.cocRequired,
+          mtrRequired: data.mtrRequired,
+          sourceInspectionRequired: data.sourceInspectionRequired,
+          secondPartyComplete: data.secondPartyComplete,
+          vendorApproved: data.vendorApproved,
+          reviewNotes: data.reviewNotes,
+          reviewedByUserId: data.reviewedByUserId ?? null,
+          reviewedByDisplayName: data.reviewedByDisplayName ?? null,
+          reviewedAt: now.toISOString(),
+          isUpdate,
+        },
         meta: {
           // Full field snapshot for audit completeness
           vendorPoId: data.vendorPoId,
@@ -11093,7 +11116,7 @@ export class DatabaseStorage implements IStorage {
           reviewedAt: now.toISOString(),
           isUpdate,
         },
-      });
+      }, tx);
 
       return savedReview;
     });
@@ -11124,20 +11147,32 @@ export class DatabaseStorage implements IStorage {
         .set({ reviewStatus: 'requires_attention', updatedAt: now })
         .where(eq(vendorPoComplianceReviews.vendorPoId, poId));
 
-      await tx.insert(auditEvents).values({
+      await recordAuditEvent({
+        eventType: 'COMPLIANCE_REVIEW_INVALIDATED',
+        subjectType: 'vendor',
+        subjectId: String(poId),
+        sourceService: 'storage.vendorPoComplianceReview',
+        actor: {
+          id: actorId ?? null,
+          username: actorId ? String(actorId) : 'system',
+          role: null,
+        },
+        reason,
         entityType: 'vendor',
         entityId: String(poId),
-        action: 'COMPLIANCE_REVIEW_INVALIDATED',
-        actorId: actorId ?? null,
-        actorName: actorId ? String(actorId) : 'system',
-        reason,
+        payload: {
+          vendorPoId: poId,
+          previousStatus,
+          newStatus: 'requires_attention',
+          ...meta,
+        },
         meta: {
           vendorPoId: poId,
           previousStatus,
           newStatus: 'requires_attention',
           ...meta,
         },
-      });
+      }, tx);
     });
   }
 


### PR DESCRIPTION
## Summary
- Gate P2 shipping write/release endpoints with existing shipping capabilities and emit `SHIPMENT_RELEASED` through the unified audit ledger after the cert-package gate clears.
- Require `engineering.release_revision` for controlled engineering revision/ECO transitions and emit immutable engineering-control events.
- Replace direct `audit_events` writes in admin/session/vendor compliance paths with `recordAuditEvent()`.
- Add accounting-period guard checks to wire-payment journals, bulk wire journals, credit memo journals, and labor GL posting.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Source grep confirmed no remaining `INSERT INTO audit_events` or `insert(auditEvents)` matches under `server/src` or `server/storage.ts`.

## Not run
- Full TypeScript/build/tests: this worktree has no `npm`, no `node_modules`, and no `tsc` available in the shell.