### PR TITLE
Add running balance column to Chart of Accounts

### DIFF
--- a/client/src/pages/ChartOfAccountsPage.tsx
+++ b/client/src/pages/ChartOfAccountsPage.tsx
@@ -37,6 +37,7 @@ type CoaAccount = {
   systemControlled: boolean;
   isActive: boolean;
   description: string | null;
+  currentBalance?: number;
 };
 
 function badgeVariant(value: string) {
@@ -55,11 +56,11 @@ export default function ChartOfAccountsPage() {
     isLoading,
     isError,
   } = useQuery<CoaAccount[]>({
-    queryKey: ['/api/accounting/coa/accounts', activeFilter],
+    queryKey: ['/api/accounting/coa/accounts-with-balances', activeFilter],
     queryFn: async () => {
       const activeOnly = activeFilter === 'active';
       const response = await fetch(
-        `/api/accounting/coa/accounts?activeOnly=${activeOnly}`,
+        `/api/accounting/coa/accounts-with-balances?activeOnly=${activeOnly}`,
         {
           credentials: 'include',
         }
@@ -181,6 +182,7 @@ export default function ChartOfAccountsPage() {
                   <TableHead>Pool</TableHead>
                   <TableHead>Allowability</TableHead>
                   <TableHead>Direct/Indirect</TableHead>
+                  <TableHead className="text-right">Current Balance</TableHead>
                   <TableHead>Controls</TableHead>
                 </TableRow>
               </TableHeader>
@@ -220,6 +222,12 @@ export default function ChartOfAccountsPage() {
                       <Badge variant="secondary">
                         {account.defaultDirectIndirect}
                       </Badge>
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      <span className={account.currentBalance ? (account.currentBalance < 0 ? 'text-red-600' : 'text-green-700') : ''}>
+                        ${Math.abs(account.currentBalance ?? 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                        {account.currentBalance && account.currentBalance < 0 && ' (Cr)'}
+                      </span>
                     </TableCell>
                     <TableCell>
                       <div className="flex flex-wrap gap-1">

--- a/server/src/routes/chartOfAccounts.ts
+++ b/server/src/routes/chartOfAccounts.ts
@@ -1,8 +1,8 @@
 import { Router, type Request, type Response, type NextFunction, type RequestHandler } from 'express';
-import { and, asc, eq, ilike, or } from 'drizzle-orm';
+import { and, asc, eq, ilike, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
-import { accountingPeriods, chartOfAccounts } from '../../schema';
+import { accountingPeriods, chartOfAccounts, journalEntries, journalLines } from '../../schema';
 import { authenticateToken } from '../../middleware/auth';
 import { requireAccountingAdmin } from '../middleware/requireAccountingAdmin';
 import { recordAuditEvent } from '../services/auditLedgerService';
@@ -74,6 +74,54 @@ router.get('/accounts', h(async (req, res) => {
     .orderBy(asc(chartOfAccounts.accountNumber), asc(chartOfAccounts.accountName));
 
   res.json(rows);
+}));
+
+router.get('/accounts-with-balances', h(async (req, res) => {
+  const activeOnly = req.query.activeOnly !== 'false';
+
+  // Get all accounts
+  const accounts = await db
+    .select()
+    .from(chartOfAccounts)
+    .where(activeOnly ? eq(chartOfAccounts.isActive, true) : undefined)
+    .orderBy(asc(chartOfAccounts.accountNumber), asc(chartOfAccounts.accountName));
+
+  // Get balance for each account by summing posted journal lines
+  const accountsWithBalances = await Promise.all(
+    accounts.map(async (account) => {
+      const balanceResult = await db
+        .select({
+          totalDebit: sql<number>`COALESCE(SUM(CAST(${journalLines.debitAmount} AS DECIMAL)), 0)`,
+          totalCredit: sql<number>`COALESCE(SUM(CAST(${journalLines.creditAmount} AS DECIMAL)), 0)`,
+        })
+        .from(journalLines)
+        .innerJoin(journalEntries, eq(journalLines.journalEntryId, journalEntries.id))
+        .where(and(
+          eq(journalLines.accountId, account.id),
+          eq(journalEntries.status, 'POSTED'),
+        ));
+
+      const [balance] = balanceResult;
+      const totalDebit = Number(balance?.totalDebit ?? 0);
+      const totalCredit = Number(balance?.totalCredit ?? 0);
+
+      // Calculate balance based on normal balance direction
+      let currentBalance = 0;
+      if (account.normalBalance === 'DEBIT') {
+        currentBalance = totalDebit - totalCredit;
+      } else {
+        // CREDIT normal balance
+        currentBalance = totalCredit - totalDebit;
+      }
+
+      return {
+        ...account,
+        currentBalance,
+      };
+    })
+  );
+
+  res.json(accountsWithBalances);
 }));
 
 router.post('/accounts', requireAccountingAdmin, h(async (req, res) => {


### PR DESCRIPTION
- Add new /accounts-with-balances API endpoint that calculates current balance for each account by summing posted journal lines
- Respects account normal balance direction (DEBIT vs CREDIT)
- Update ChartOfAccountsPage to display running balance column with accounting currency formatting
- Color-code balances (green for positive, red for negative with Cr notation)
- Use monospaced font for balance values to prevent layout shift