### PR TITLE
Repair P2 traveler routing schema guard

### DIFF
--- a/server/pre-deploy-migrate.ts
+++ b/server/pre-deploy-migrate.ts
@@ -349,6 +349,15 @@ async function main() {
     )
   `, 'Ensure inventory_audit_records table');
 
+  await runSql(`
+    DO $$ BEGIN
+      IF to_regclass('public.routing_operations') IS NOT NULL THEN
+        ALTER TABLE public.routing_operations
+          ADD COLUMN IF NOT EXISTS required_calibration_asset_tags text[] NOT NULL DEFAULT ARRAY[]::text[];
+      END IF;
+    END $$;
+  `, 'Ensure routing_operations.required_calibration_asset_tags column');
+
   // ------------------------------------------------------------------
   // STEP 4: Quick verification — report remaining integer→uuid mismatches
   // ------------------------------------------------------------------

--- a/server/src/lib/productionWorkflowReadiness.ts
+++ b/server/src/lib/productionWorkflowReadiness.ts
@@ -121,6 +121,11 @@ export async function ensureProductionWorkflowReadSchema(): Promise<void> {
             WHERE quantity_used IS NULL AND qty_used IS NOT NULL;
           END IF;
 
+          IF to_regclass('public.routing_operations') IS NOT NULL THEN
+            ALTER TABLE public.routing_operations
+              ADD COLUMN IF NOT EXISTS required_calibration_asset_tags text[] NOT NULL DEFAULT ARRAY[]::text[];
+          END IF;
+
           IF to_regclass('public.wad_production_controls') IS NULL
              AND to_regclass('public.production_work_orders') IS NOT NULL THEN
             CREATE TABLE public.wad_production_controls (

--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -28,8 +28,19 @@ import { storage } from '../../storage';
 import { createEmployeeIdentitySnapshot } from '../../identity/userIdentity';
 import { buildChargeContextFromTraveler } from '../helpers/travelerBarcodeResolver';
 import { executeTravelerAutoPunch, type TravelerAutoPunchResult } from './timeClock';
+import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
 
 const router = Router();
+
+router.use(async (_req, res, next) => {
+  try {
+    await ensureProductionWorkflowReadSchema();
+    next();
+  } catch (error) {
+    console.error('[P2Traveler] Schema readiness check failed:', error);
+    res.status(503).json({ error: 'Production traveler schema is not ready, please retry' });
+  }
+});
 
 /**
  * Task #188: Auto-switch the operator's punch_ledger session to the WAD's


### PR DESCRIPTION
## Summary
- Add an idempotent deploy-time guard for `routing_operations.required_calibration_asset_tags`.
- Run the same schema readiness guard before P2 traveler routes so production can self-repair the missing column before traveler generation queries routing operations.
- Return a retryable 503 if the readiness repair cannot complete instead of surfacing the raw missing-column 500.

## Validation
- `git diff --cached --check` passed.
- `git diff --check` passed before staging.
- Full `npm run check` could not run locally because `npm` is not available in this shell and this worktree has no `node_modules`.