### PR TITLE
[codex] Fix WAD quality save and draft resume flow

### DIFF
--- a/client/src/components/wad/WADWizard.tsx
+++ b/client/src/components/wad/WADWizard.tsx
@@ -57,6 +57,7 @@ const REQUIRED_APPROVAL_ROLES = [
 ];
 
 const RISK_TYPES = ['Technical', 'Schedule', 'Material', 'Quality', 'Tooling', 'Supplier'];
+const EMPTY_SELECT_VALUE = '__none__';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 interface WorkBreakdownRow {
@@ -167,6 +168,7 @@ interface WadControlStatus {
 type Step1AutoSource = 'auto:project' | 'auto:po' | 'auto:po-review' | 'auto:rfq' | 'auto:wad' | 'user';
 
 interface WizardData {
+  currentStep?: number;
   step1?: {
     projectNumber: string;
     customer: string;
@@ -286,6 +288,25 @@ const STEPS = [
   { id: 12, title: 'Final Review', icon: CheckCircle, short: 'Review' },
 ];
 
+function clampWizardStep(value: unknown): number {
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numeric)) return 1;
+  return Math.min(Math.max(Math.trunc(numeric), 1), STEPS.length);
+}
+
+function inferResumeStep(wizardData: WizardData): number {
+  const explicitStep = clampWizardStep(wizardData.currentStep);
+  if (explicitStep > 1) return explicitStep;
+
+  for (let i = 10; i >= 1; i -= 1) {
+    if (wizardData[`step${i}` as keyof WizardData]) {
+      return clampWizardStep(i + 1);
+    }
+  }
+
+  return 1;
+}
+
 function BoolField({ label, value, onChange }: { label: string; value: boolean; onChange: (v: boolean) => void }) {
   return (
     <div className="flex items-center gap-2">
@@ -312,7 +333,9 @@ export default function WADWizard({ wadId, onClose }: WADWizardProps) {
 
   useEffect(() => {
     if (wizardCtx?.wad?.wizardData) {
-      setData(wizardCtx.wad.wizardData as WizardData);
+      const savedData = wizardCtx.wad.wizardData as WizardData;
+      setData(savedData);
+      setStep(inferResumeStep(savedData));
     }
   }, [wizardCtx]);
 
@@ -373,10 +396,11 @@ export default function WADWizard({ wadId, onClose }: WADWizardProps) {
   }, []);
 
   const saveAndGoTo = useCallback(async (targetStep: number) => {
+    const nextStep = clampWizardStep(targetStep);
     setSaving(true);
     try {
-      await saveMutation.mutateAsync({ wizardData: data });
-      setStep(targetStep);
+      await saveMutation.mutateAsync({ wizardData: { ...data, currentStep: nextStep } });
+      setStep(nextStep);
     } finally {
       setSaving(false);
     }
@@ -857,7 +881,7 @@ export default function WADWizard({ wadId, onClose }: WADWizardProps) {
         <div className="flex gap-2">
           <Button
             variant="outline"
-            onClick={() => saveMutation.mutate({ wizardData: data })}
+            onClick={() => saveMutation.mutate({ wizardData: { ...data, currentStep: step } })}
             disabled={saveMutation.isPending || saving}
           >
             {saveMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : null}
@@ -1738,10 +1762,13 @@ function Step8Schedule({ departments, data, onChange }: {
         </div>
         <div className="space-y-1">
           <Label>Bottleneck Department</Label>
-          <Select value={base.bottleneckDepartment} onValueChange={v => set('bottleneckDepartment', v)}>
+          <Select
+            value={base.bottleneckDepartment || EMPTY_SELECT_VALUE}
+            onValueChange={v => set('bottleneckDepartment', v === EMPTY_SELECT_VALUE ? '' : v)}
+          >
             <SelectTrigger><SelectValue placeholder="Select…" /></SelectTrigger>
             <SelectContent>
-              <SelectItem value="">None</SelectItem>
+              <SelectItem value={EMPTY_SELECT_VALUE}>None</SelectItem>
               {departments.map(d => (
                 <SelectItem key={d} value={d}>{deptLabels[d] ?? d}</SelectItem>
               ))}


### PR DESCRIPTION
## Summary

- Replace the WAD Schedule step's empty Radix Select item with a non-empty internal sentinel so the wizard no longer crashes after saving Quality and advancing to Schedule.
- Persist `currentStep` inside WAD `wizardData` on draft saves and step navigation.
- Resume older draft WADs from the last populated wizard step when `currentStep` has not been saved yet.

## Root Cause

Radix Select reserves the empty string value for clearing a selection. The Schedule step rendered `SelectItem value=""` for the Bottleneck Department "None" option, which crashes when the wizard reaches that step after the Quality save.

The wizard also saved the form data but not the user's current step, so draft WADs could reopen at the start instead of continuing where the user left off.

## Validation

- `git diff --check -- client/src/components/wad/WADWizard.tsx`
- Confirmed no remaining `value=""` Select item in `client/src/components/wad/WADWizard.tsx`

Full TypeScript/build validation was not run because `node_modules` is absent and `npm` is not available in this shell.