### PR TITLE
[codex] fix shipping customer notifications

### DIFF
--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -32,7 +32,12 @@ import {
 import { auditService } from '../services/auditService';
 import { orderActivityEvents } from '../../schema';
 import * as accountingService from '../services/accountingService';
-import { sendOrderConfirmationNotification, OrderConfirmationOutcome } from '../../utils/notifications';
+import {
+  normalizeNotificationMethods,
+  sendCustomerNotification,
+  sendOrderConfirmationNotification,
+  OrderConfirmationOutcome,
+} from '../../utils/notifications';
 import { generateOrderPdf, PdfIntent } from '../../services/orderPdfService';
 
 const router = Router();
@@ -1688,10 +1693,49 @@ router.post('/fulfill', async (req: Request, res: Response) => {
     };
     const updatedOrder = await storage.fulfillOrder(orderId, actor);
 
+    let notificationResult = null;
+    if (updatedOrder.trackingNumber && !updatedOrder.customerNotified) {
+      try {
+        if (!updatedOrder.customerId) {
+          console.warn(`[FULFILL-NOTIFY] Order ${orderId} has tracking but no customerId; skipping customer notification`);
+        } else {
+          const customer = await storage.getCustomerById(updatedOrder.customerId);
+          if (!customer || (!customer.email && !customer.phone)) {
+            console.warn(`[FULFILL-NOTIFY] Order ${orderId} has no usable customer contact; skipping customer notification`);
+          } else {
+            const preferredMethods = normalizeNotificationMethods(
+              customer.preferredCommunicationMethod,
+              { email: customer.email, phone: customer.phone }
+            );
+
+            notificationResult = await sendCustomerNotification({
+              orderId: updatedOrder.orderId,
+              trackingNumber: updatedOrder.trackingNumber,
+              carrier: updatedOrder.shippingCarrier || 'UPS',
+              estimatedDelivery: updatedOrder.estimatedDelivery
+                ? new Date(updatedOrder.estimatedDelivery)
+                : undefined,
+              customerEmail: customer.email || undefined,
+              customerPhone: customer.phone || undefined,
+              preferredMethods,
+            });
+
+            if (!notificationResult.success) {
+              console.error(`[FULFILL-NOTIFY] Customer notification failed for order ${orderId}:`, notificationResult.errors);
+            }
+          }
+        }
+      } catch (notificationError) {
+        console.error(`[FULFILL-NOTIFY] Customer notification failed for order ${orderId}:`, notificationError);
+      }
+    }
+
     res.json({
       success: true,
       message: 'Order fulfilled successfully',
       order: updatedOrder,
+      notificationSent: notificationResult?.success || false,
+      notificationMethods: notificationResult?.methods || [],
     });
   } catch (error) {
     console.error('Fulfill order error:', error);

--- a/server/src/routes/shipping.ts
+++ b/server/src/routes/shipping.ts
@@ -2753,13 +2753,14 @@ router.post('/notify-customer/:orderId', async (req: Request, res: Response) => 
     // ===========================================
     // 🔥 MANUAL RESEND - BYPASSES DEDUPLICATION
     // ===========================================
-    const { sendCustomerNotification } = await import('../../utils/notifications');
+    const { sendCustomerNotification, normalizeNotificationMethods } = await import('../../utils/notifications');
     
-    // Use customer's actual preferred communication method, or default to email if not set
-    const customerPreference = (customer.preferredCommunicationMethod as string[]) || [];
-    const preferredMethods: string[] = customerPreference.length > 0 
-      ? customerPreference 
-      : (customer.email ? ['email'] : (customer.phone ? ['sms'] : []));
+    // Use customer's actual preferred communication method, or default to the first available contact method.
+    const preferredMethods = normalizeNotificationMethods(
+      customer.preferredCommunicationMethod,
+      { email: customer.email, phone: customer.phone }
+    );
+    const customerPreference = customer.preferredCommunicationMethod;
     
     console.log('[NOTIFY-CUSTOMER] Customer preference:', customerPreference, '→ Using:', preferredMethods);
     
@@ -2768,6 +2769,8 @@ router.post('/notify-customer/:orderId', async (req: Request, res: Response) => 
       trackingNumber: order.trackingNumber,
       carrier: order.shippingCarrier || 'UPS',
       estimatedDelivery: order.estimatedDelivery ? new Date(order.estimatedDelivery) : undefined,
+      customerEmail: customer.email || undefined,
+      customerPhone: customer.phone || undefined,
       preferredMethods,
       forceResend: true, // Manual resend bypasses deduplication
     });

--- a/server/utils/notifications.ts
+++ b/server/utils/notifications.ts
@@ -26,8 +26,35 @@ export interface NotificationData {
   estimatedDelivery?: Date;
   customerEmail?: string;
   customerPhone?: string;
-  preferredMethods?: string[];
+  preferredMethods?: string[] | string | null;
   forceResend?: boolean; // Set true to bypass deduplication (manual resend)
+}
+
+export function normalizeNotificationMethods(
+  preferredMethods: unknown,
+  contact: { email?: string | null; phone?: string | null } = {}
+): string[] {
+  const rawMethods = Array.isArray(preferredMethods)
+    ? preferredMethods
+    : typeof preferredMethods === 'string'
+      ? preferredMethods.split(/[,\s]+/)
+      : [];
+
+  const normalized = rawMethods
+    .map((method) => String(method).trim().toLowerCase())
+    .map((method) => {
+      if (method === 'text' || method === 'phone') return 'sms';
+      if (method === 'e-mail') return 'email';
+      return method;
+    })
+    .filter((method): method is 'email' | 'sms' => method === 'email' || method === 'sms');
+
+  const uniqueMethods = Array.from(new Set(normalized));
+  if (uniqueMethods.length > 0) return uniqueMethods;
+
+  if (contact.email) return ['email'];
+  if (contact.phone) return ['sms'];
+  return [];
 }
 
 export async function sendCustomerNotification(
@@ -129,11 +156,18 @@ export async function sendCustomerNotification(
   }
 
   // Determine notification methods
-  let preferredMethods = (data.preferredMethods && data.preferredMethods.length)
-    ? [...data.preferredMethods]
-    : ((customer.preferredCommunicationMethod as string[]) || []);
+  let preferredMethods = normalizeNotificationMethods(
+    data.preferredMethods,
+    { email: data.customerEmail, phone: data.customerPhone }
+  );
   const email = data.customerEmail || customer.email;
   const phone = data.customerPhone || customer.phone;
+  if (!preferredMethods.length) {
+    preferredMethods = normalizeNotificationMethods(
+      customer.preferredCommunicationMethod,
+      { email, phone }
+    );
+  }
 
   // 1. Detect Twilio availability using centralized config
   const allowSms = isTwilioConfigured();


### PR DESCRIPTION
## Summary

- Normalize customer notification preferences so production values like `email`, `sms`, `text`, comma-separated strings, or arrays resolve to supported delivery channels.
- Fix the manual `/api/shipping/notify-customer/:orderId` resend path so it passes normalized customer contact details instead of failing with `No valid notification method could be delivered`.
- Attempt the customer tracking notification automatically after `/api/orders/fulfill` when the fulfilled order already has tracking and has not been notified.

## Root Cause

The shipping notification code assumed `preferredCommunicationMethod` was always an array. In production it can be stored or returned as a string such as `email`; spreading that string produced individual characters instead of a valid channel, so neither email nor SMS was attempted and the API returned 500.

## Validation

- `git diff --check` passed.
- `npm run check` could not be run in this Codex environment because `npm` is not available in PATH and this clean worktree has no `node_modules`.