### PR TITLE
Add project revisions for P2 PO relinking

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -63,7 +63,8 @@ import {
   BarChart2,
   XCircle,
   Rocket,
-  ShieldCheck
+  ShieldCheck,
+  History
 } from 'lucide-react';
 import { format, formatDistanceToNow } from 'date-fns';
 
@@ -111,6 +112,8 @@ interface Project {
   actualShipDate: string | null;
   currentStage: string | null;
   stageUpdatedAt: string | null;
+  currentRevisionNumber: number;
+  currentRevisionLabel: string;
   poId: number | null;
   projectManagerId: number | null;
   reminderDays: number;
@@ -136,6 +139,22 @@ interface P2PurchaseOrder {
   customerName: string;
   status: string;
   createdAt?: string;
+}
+
+interface ProjectRevision {
+  id: number;
+  project_id: string;
+  revision_number: number;
+  revision_label: string;
+  revision_type: string;
+  summary: string;
+  reason: string;
+  previous_po_id: number | null;
+  previous_po_number: string | null;
+  new_po_id: number | null;
+  new_po_number: string | null;
+  created_by_display_name: string | null;
+  created_at: string;
 }
 
 interface StepAttachment {
@@ -387,12 +406,14 @@ export default function ProjectDetailPage() {
 
   const { data: p2PurchaseOrders = [] } = useQuery<P2PurchaseOrder[]>({
     queryKey: ['/api/p2-purchase-orders-bypass'],
-    enabled: !project?.poId,
+    enabled: !!project,
   });
 
   const [linkPoId, setLinkPoId] = useState<string>('');
   const [linkPoSearch, setLinkPoSearch] = useState('');
   const [showManualLink, setShowManualLink] = useState(false);
+  const [linkPoReason, setLinkPoReason] = useState('');
+  const [revisionForm, setRevisionForm] = useState({ summary: '', reason: '' });
 
   const suggestedPo = useMemo(() => {
     if (!project || p2PurchaseOrders.length === 0) return null;
@@ -405,19 +426,52 @@ export default function ProjectDetailPage() {
   }, [project, p2PurchaseOrders]);
 
   const linkPoMutation = useMutation({
-    mutationFn: (poId: number) =>
-      apiRequest('POST', `/api/projects/${id}/link-po`, { poId }),
+    mutationFn: ({ poId, reason }: { poId: number; reason?: string }) =>
+      apiRequest(`/api/projects/${id}/link-po`, {
+        method: 'POST',
+        body: {
+          poId,
+          reason,
+          createdByDisplayName: currentUser?.username,
+        },
+      }),
     onSuccess: () => {
-      toast({ title: 'PO linked', description: 'Purchase order successfully linked to this project.' });
+      toast({ title: 'PO linked', description: 'Purchase order link was saved as a project revision.' });
       queryClient.invalidateQueries({ queryKey: ['/api/projects', id] });
       queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'traceability'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'revisions'] });
       setLinkPoId('');
       setLinkPoSearch('');
+      setLinkPoReason('');
       setShowManualLink(false);
     },
     onError: (err: any) => {
       toast({ title: 'Link failed', description: err?.message || 'Failed to link PO.', variant: 'destructive' });
     },
+  });
+
+  const { data: projectRevisions = [] } = useQuery<ProjectRevision[]>({
+    queryKey: ['/api/projects', id, 'revisions'],
+    queryFn: () => fetch(`/api/projects/${id}/revisions`, { credentials: 'include' }).then(r => r.json()),
+    enabled: !!id,
+  });
+
+  const createRevisionMutation = useMutation({
+    mutationFn: (data: typeof revisionForm) =>
+      apiRequest(`/api/projects/${id}/revisions`, {
+        method: 'POST',
+        body: {
+          ...data,
+          createdByDisplayName: currentUser?.username,
+        },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id] });
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'revisions'] });
+      setRevisionForm({ summary: '', reason: '' });
+      toast({ title: 'Revision created', description: 'Project revision history was updated.' });
+    },
+    onError: (err: any) => toast({ title: 'Revision failed', description: err?.message || 'Could not create revision.', variant: 'destructive' }),
   });
 
   const { data: projectWorkOrders = [] } = useQuery<ProjectWorkOrder[]>({
@@ -1466,6 +1520,10 @@ export default function ProjectDetailPage() {
         <TabsList>
           <TabsTrigger value="workflow" data-testid="tab-workflow">Workflow</TabsTrigger>
           <TabsTrigger value="activity" data-testid="tab-activity">Activity Log</TabsTrigger>
+          <TabsTrigger value="revisions" data-testid="tab-revisions">
+            <History className="h-4 w-4 mr-1.5" />
+            Revisions
+          </TabsTrigger>
           <TabsTrigger value="traceability" data-testid="tab-traceability">Traceability</TabsTrigger>
           <TabsTrigger value="closing" data-testid="tab-closing">
             <BookOpen className="h-4 w-4 mr-1.5" />
@@ -2163,6 +2221,82 @@ export default function ProjectDetailPage() {
         </TabsContent>
 
         {/* ── TRACEABILITY TAB ── */}
+        <TabsContent value="revisions" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <History className="h-5 w-5" />
+                Project Revisions
+              </CardTitle>
+              <CardDescription>
+                Current project basis: {project.currentRevisionLabel || 'Rev 0'}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-3 md:grid-cols-[1fr_1.2fr_auto]">
+                <div className="space-y-2">
+                  <Label>Summary</Label>
+                  <Input
+                    value={revisionForm.summary}
+                    onChange={(e) => setRevisionForm((prev) => ({ ...prev, summary: e.target.value }))}
+                    placeholder="Scope, PO, routing, or schedule change"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Reason</Label>
+                  <Input
+                    value={revisionForm.reason}
+                    onChange={(e) => setRevisionForm((prev) => ({ ...prev, reason: e.target.value }))}
+                    placeholder="Why this revision is needed"
+                  />
+                </div>
+                <div className="flex items-end">
+                  <Button
+                    className="w-full md:w-auto"
+                    disabled={revisionForm.summary.trim().length < 3 || revisionForm.reason.trim().length < 3 || createRevisionMutation.isPending}
+                    onClick={() => createRevisionMutation.mutate(revisionForm)}
+                  >
+                    <Plus className="h-4 w-4 mr-1.5" />
+                    {createRevisionMutation.isPending ? 'Saving...' : 'Create Revision'}
+                  </Button>
+                </div>
+              </div>
+
+              <Separator />
+
+              {projectRevisions.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-4">No revisions recorded yet.</p>
+              ) : (
+                <div className="space-y-3">
+                  {projectRevisions.map((revision) => (
+                    <div key={revision.id} className="rounded-md border p-4 space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant="outline" className="font-mono">{revision.revision_label}</Badge>
+                        <Badge variant={revision.revision_type === 'PO_LINK_CHANGE' ? 'default' : 'secondary'}>
+                          {revision.revision_type === 'PO_LINK_CHANGE' ? 'PO Link' : 'Project Change'}
+                        </Badge>
+                        <span className="text-xs text-muted-foreground">
+                          {format(new Date(revision.created_at), 'MMM d, yyyy h:mm a')}
+                        </span>
+                      </div>
+                      <p className="text-sm font-medium">{revision.summary}</p>
+                      <p className="text-sm text-muted-foreground">{revision.reason}</p>
+                      {(revision.previous_po_number || revision.new_po_number) && (
+                        <p className="text-xs text-muted-foreground font-mono">
+                          PO: {revision.previous_po_number || 'none'} -&gt; {revision.new_po_number || 'none'}
+                        </p>
+                      )}
+                      {revision.created_by_display_name && (
+                        <p className="text-xs text-muted-foreground">Recorded by {revision.created_by_display_name}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
         <TabsContent value="traceability" className="space-y-4">
           {isLoadingTraceability ? (
             <Card>
@@ -2197,7 +2331,7 @@ export default function ProjectDetailPage() {
                     </div>
                     <div className="flex gap-2">
                       <Button
-                        onClick={() => linkPoMutation.mutate(suggestedPo.id)}
+                        onClick={() => linkPoMutation.mutate({ poId: suggestedPo.id })}
                         disabled={linkPoMutation.isPending}
                       >
                         {linkPoMutation.isPending ? 'Linking…' : 'Accept'}
@@ -2242,9 +2376,17 @@ export default function ProjectDetailPage() {
                         </SelectContent>
                       </Select>
                     </div>
+                    <div className="space-y-2">
+                      <Label>Revision Reason</Label>
+                      <Textarea
+                        placeholder="Initial PO link, customer PO changed, production PO superseded, etc."
+                        value={linkPoReason}
+                        onChange={(e) => setLinkPoReason(e.target.value)}
+                      />
+                    </div>
                     <Button
                       disabled={!linkPoId || linkPoMutation.isPending}
-                      onClick={() => linkPoMutation.mutate(parseInt(linkPoId))}
+                      onClick={() => linkPoMutation.mutate({ poId: parseInt(linkPoId), reason: linkPoReason })}
                     >
                       {linkPoMutation.isPending ? 'Linking…' : 'Link PO'}
                     </Button>
@@ -2255,7 +2397,7 @@ export default function ProjectDetailPage() {
           ) : (
             <>
               {/* ── SECTION 0: Linked PO ── */}
-              {traceability.po && (
+              {(traceability.po || project?.poId) && (
                 <Card>
                   <CardHeader className="pb-3">
                     <CardTitle className="flex items-center gap-2 text-base">
@@ -2270,24 +2412,88 @@ export default function ProjectDetailPage() {
                           onClick={() => setLocation(`/p2-control-center?tab=pos`)}
                           className="font-mono font-semibold text-sm text-primary hover:underline cursor-pointer"
                         >
-                          {traceability.po.po_number}
+                          {traceability.po?.po_number || `PO ID ${project.poId}`}
                         </button>
                       </div>
                       <div>
                         <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Customer</p>
-                        <p className="text-sm">{traceability.po.customer_name}</p>
+                        <p className="text-sm">{traceability.po?.customer_name || 'PO record not found'}</p>
                       </div>
                       <div>
                         <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Status</p>
-                        <Badge variant={traceability.po.status === 'COMPLETE' ? 'default' : 'secondary'} className="text-xs">
-                          {traceability.po.status}
+                        <Badge variant={traceability.po?.status === 'COMPLETE' ? 'default' : 'secondary'} className="text-xs">
+                          {traceability.po?.status || 'Missing'}
                         </Badge>
                       </div>
                       <div>
                         <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">PO Date</p>
-                        <p className="text-sm">{format(new Date(traceability.po.created_at), 'MMM d, yyyy')}</p>
+                        <p className="text-sm">
+                          {traceability.po?.created_at ? format(new Date(traceability.po.created_at), 'MMM d, yyyy') : 'Needs relink'}
+                        </p>
                       </div>
                     </div>
+                    <Separator className="my-4" />
+                    {!showManualLink ? (
+                      <Button variant="outline" size="sm" onClick={() => setShowManualLink(true)}>
+                        <LinkIcon className="h-4 w-4 mr-1.5" />
+                        Change Linked PO
+                      </Button>
+                    ) : (
+                      <div className="space-y-4 rounded-md border p-4">
+                        <div className="flex items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-medium">Create PO Link Revision</p>
+                            <p className="text-xs text-muted-foreground">
+                              Changing the linked PO creates a new project revision and preserves the prior link in history.
+                            </p>
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => {
+                              setShowManualLink(false);
+                              setLinkPoId('');
+                              setLinkPoReason('');
+                            }}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                        <div className="grid gap-3 md:grid-cols-2">
+                          <div className="space-y-2">
+                            <Label>New P2 PO</Label>
+                            <Select value={linkPoId} onValueChange={setLinkPoId}>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select replacement PO" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {p2PurchaseOrders
+                                  .filter(po => po.id !== project.poId)
+                                  .map(po => (
+                                    <SelectItem key={po.id} value={po.id.toString()}>
+                                      {po.poNumber} - {po.customerName}
+                                    </SelectItem>
+                                  ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="space-y-2">
+                            <Label>Required Reason</Label>
+                            <Textarea
+                              placeholder="Why is this project moving to a different production PO?"
+                              value={linkPoReason}
+                              onChange={(e) => setLinkPoReason(e.target.value)}
+                            />
+                          </div>
+                        </div>
+                        <Button
+                          disabled={!linkPoId || linkPoReason.trim().length < 3 || linkPoMutation.isPending}
+                          onClick={() => linkPoMutation.mutate({ poId: parseInt(linkPoId), reason: linkPoReason })}
+                        >
+                          {linkPoMutation.isPending ? 'Saving Revision...' : 'Save PO Revision'}
+                        </Button>
+                      </div>
+                    )}
                   </CardContent>
                 </Card>
               )}

--- a/migrations/0134_project_revisions.sql
+++ b/migrations/0134_project_revisions.sql
@@ -1,0 +1,28 @@
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS current_revision_number INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS current_revision_label TEXT NOT NULL DEFAULT 'Rev 0';
+
+CREATE TABLE IF NOT EXISTS project_revisions (
+  id SERIAL PRIMARY KEY,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  revision_number INTEGER NOT NULL,
+  revision_label TEXT NOT NULL,
+  revision_type TEXT NOT NULL DEFAULT 'PROJECT_CHANGE',
+  summary TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  previous_po_id INTEGER REFERENCES p2_purchase_orders(id),
+  new_po_id INTEGER REFERENCES p2_purchase_orders(id),
+  created_by INTEGER REFERENCES employees(id),
+  created_by_display_name TEXT,
+  metadata JSONB,
+  created_at TIMESTAMP DEFAULT NOW(),
+  CONSTRAINT project_revisions_project_revision_unique UNIQUE (project_id, revision_number)
+);
+
+CREATE INDEX IF NOT EXISTS project_revisions_project_id_idx
+  ON project_revisions(project_id);
+
+CREATE INDEX IF NOT EXISTS project_revisions_created_at_idx
+  ON project_revisions(created_at);

--- a/server/index.ts
+++ b/server/index.ts
@@ -4198,6 +4198,8 @@ async function initializeBackgroundServices() {
         // Add new columns
         await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS current_stage TEXT DEFAULT 'rfq_received'`);
         await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS stage_updated_at TIMESTAMP DEFAULT NOW()`);
+        await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS current_revision_number INTEGER NOT NULL DEFAULT 0`);
+        await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS current_revision_label TEXT NOT NULL DEFAULT 'Rev 0'`);
         await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS po_id INTEGER REFERENCES p2_purchase_orders(id)`);
         // Backfill current_stage from current_step_type for existing rows that still have the default
         await db.execute(sqlProj`
@@ -4239,7 +4241,27 @@ async function initializeBackgroundServices() {
           END $$
         `);
         await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS customer_name_snapshot TEXT`);
-        console.log('✅ Ensured projects table has pipeline stage columns and flexible step statuses');
+        await pool.query(`
+          CREATE TABLE IF NOT EXISTS project_revisions (
+            id SERIAL PRIMARY KEY,
+            project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+            revision_number INTEGER NOT NULL,
+            revision_label TEXT NOT NULL,
+            revision_type TEXT NOT NULL DEFAULT 'PROJECT_CHANGE',
+            summary TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            previous_po_id INTEGER REFERENCES p2_purchase_orders(id),
+            new_po_id INTEGER REFERENCES p2_purchase_orders(id),
+            created_by INTEGER REFERENCES employees(id),
+            created_by_display_name TEXT,
+            metadata JSONB,
+            created_at TIMESTAMP DEFAULT NOW(),
+            CONSTRAINT project_revisions_project_revision_unique UNIQUE (project_id, revision_number)
+          )
+        `);
+        await pool.query(`CREATE INDEX IF NOT EXISTS project_revisions_project_id_idx ON project_revisions(project_id)`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS project_revisions_created_at_idx ON project_revisions(created_at)`);
+        console.log('✅ Ensured projects table has pipeline stage, revision, and flexible step status support');
       } catch (projErr: any) {
         console.warn('⚠️ Projects pipeline migration:', projErr.message);
       }

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -11501,6 +11501,8 @@ export const projects = pgTable('projects', {
   actualShipDate: date('actual_ship_date'),
   currentStage: text('current_stage').default('rfq_received'),
   stageUpdatedAt: timestamp('stage_updated_at').defaultNow(),
+  currentRevisionNumber: integer('current_revision_number').notNull().default(0),
+  currentRevisionLabel: text('current_revision_label').notNull().default('Rev 0'),
   poId: integer('po_id').references(() => p2PurchaseOrders.id),
   projectManagerId: integer('project_manager_id').references(() => employees.id),
   reminderDays: integer('reminder_days').default(3), // Days before reminder is sent for stuck steps
@@ -11530,6 +11532,35 @@ export const insertProjectSchema = createInsertSchema(projects).omit({
 
 export type Project = typeof projects.$inferSelect;
 export type InsertProject = z.infer<typeof insertProjectSchema>;
+
+// Project Revisions - Controlled changes to project scope, PO linkage, and production basis
+export const projectRevisions = pgTable('project_revisions', {
+  id: serial('id').primaryKey(),
+  projectId: uuid('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  revisionNumber: integer('revision_number').notNull(),
+  revisionLabel: text('revision_label').notNull(),
+  revisionType: text('revision_type').notNull().default('PROJECT_CHANGE'),
+  summary: text('summary').notNull(),
+  reason: text('reason').notNull(),
+  previousPoId: integer('previous_po_id').references(() => p2PurchaseOrders.id),
+  newPoId: integer('new_po_id').references(() => p2PurchaseOrders.id),
+  createdBy: integer('created_by').references(() => employees.id),
+  createdByDisplayName: text('created_by_display_name'),
+  metadata: jsonb('metadata'),
+  createdAt: timestamp('created_at').defaultNow(),
+}, (table) => ({
+  projectIdIdx: index('project_revisions_project_id_idx').on(table.projectId),
+  projectRevisionUnique: uniqueIndex('project_revisions_project_revision_unique').on(table.projectId, table.revisionNumber),
+  createdAtIdx: index('project_revisions_created_at_idx').on(table.createdAt),
+}));
+
+export const insertProjectRevisionSchema = createInsertSchema(projectRevisions).omit({
+  id: true,
+  createdAt: true,
+});
+
+export type ProjectRevision = typeof projectRevisions.$inferSelect;
+export type InsertProjectRevision = z.infer<typeof insertProjectRevisionSchema>;
 
 // Project Steps - Individual workflow steps for each project
 export const projectSteps = pgTable('project_steps', {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -37,9 +37,57 @@ const uploadProjectDoc = multer({
 
 const router = Router();
 
+let projectRevisionSchemaReady = false;
+
+async function ensureProjectRevisionSchema() {
+  if (projectRevisionSchemaReady) return;
+
+  await pool.query(`
+    ALTER TABLE projects
+      ADD COLUMN IF NOT EXISTS current_revision_number INTEGER NOT NULL DEFAULT 0
+  `);
+  await pool.query(`
+    ALTER TABLE projects
+      ADD COLUMN IF NOT EXISTS current_revision_label TEXT NOT NULL DEFAULT 'Rev 0'
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS project_revisions (
+      id SERIAL PRIMARY KEY,
+      project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      revision_number INTEGER NOT NULL,
+      revision_label TEXT NOT NULL,
+      revision_type TEXT NOT NULL DEFAULT 'PROJECT_CHANGE',
+      summary TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      previous_po_id INTEGER REFERENCES p2_purchase_orders(id),
+      new_po_id INTEGER REFERENCES p2_purchase_orders(id),
+      created_by INTEGER REFERENCES employees(id),
+      created_by_display_name TEXT,
+      metadata JSONB,
+      created_at TIMESTAMP DEFAULT NOW(),
+      CONSTRAINT project_revisions_project_revision_unique UNIQUE (project_id, revision_number)
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS project_revisions_project_id_idx ON project_revisions(project_id)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS project_revisions_created_at_idx ON project_revisions(created_at)`);
+
+  projectRevisionSchemaReady = true;
+}
+
+async function getNextProjectRevisionNumber(projectId: string): Promise<number> {
+  const rows = await pool.query<{ next_revision: number }>(
+    `SELECT COALESCE(MAX(revision_number), 0) + 1 AS next_revision
+     FROM project_revisions
+     WHERE project_id = $1`,
+    [projectId]
+  );
+  return Number(rows[0]?.next_revision ?? 1);
+}
+
 router.use(async (_req, res, next) => {
   try {
     await ensureProductionWorkflowReadSchema();
+    await ensureProjectRevisionSchema();
     next();
   } catch (error) {
     console.error('[Projects] Production workflow schema readiness failed:', error);
@@ -507,21 +555,133 @@ router.post('/notifications/:recipientId/mark-all-read', async (req, res) => {
   }
 });
 
-router.post('/:id/link-po', async (req, res) => {
+router.get('/:id/revisions', async (req, res) => {
   try {
     const { id } = req.params;
-    const schema = z.object({ poId: z.number().int().positive() });
+    const project = await storage.getProject(id);
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+
+    const revisions = await pool.query(
+      `SELECT
+         pr.id,
+         pr.project_id,
+         pr.revision_number,
+         pr.revision_label,
+         pr.revision_type,
+         pr.summary,
+         pr.reason,
+         pr.previous_po_id,
+         prev_po.po_number AS previous_po_number,
+         pr.new_po_id,
+         new_po.po_number AS new_po_number,
+         pr.created_by,
+         pr.created_by_display_name,
+         pr.metadata,
+         pr.created_at
+       FROM project_revisions pr
+       LEFT JOIN p2_purchase_orders prev_po ON prev_po.id = pr.previous_po_id
+       LEFT JOIN p2_purchase_orders new_po ON new_po.id = pr.new_po_id
+       WHERE pr.project_id = $1
+       ORDER BY pr.revision_number DESC`,
+      [id]
+    );
+
+    res.json(revisions);
+  } catch (error) {
+    console.error('Error fetching project revisions:', error);
+    res.status(500).json({ message: 'Failed to fetch project revisions' });
+  }
+});
+
+router.post('/:id/revisions', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const schema = z.object({
+      summary: z.string().min(3),
+      reason: z.string().min(3),
+      revisionType: z.string().min(1).default('PROJECT_CHANGE'),
+      createdBy: z.number().int().positive().optional(),
+      createdByDisplayName: z.string().optional(),
+      metadata: z.record(z.any()).optional(),
+    });
     const parsed = schema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({ message: 'Invalid request: poId (number) required' });
+      return res.status(400).json({ message: 'Invalid revision request', errors: parsed.error.errors });
     }
-    const { poId } = parsed.data;
 
     const project = await storage.getProject(id);
     if (!project) return res.status(404).json({ message: 'Project not found' });
 
-    if (project.poId) {
-      return res.status(409).json({ message: 'Project already has a PO linked' });
+    const nextRevision = await getNextProjectRevisionNumber(id);
+    const revisionLabel = `Rev ${nextRevision}`;
+    const data = parsed.data;
+    const rows = await pool.query(
+      `INSERT INTO project_revisions (
+         project_id, revision_number, revision_label, revision_type, summary, reason,
+         created_by, created_by_display_name, metadata
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+       RETURNING *`,
+      [
+        id,
+        nextRevision,
+        revisionLabel,
+        data.revisionType,
+        data.summary,
+        data.reason,
+        data.createdBy ?? null,
+        data.createdByDisplayName ?? null,
+        JSON.stringify(data.metadata ?? {}),
+      ]
+    );
+
+    await pool.query(
+      `UPDATE projects
+       SET current_revision_number = $2, current_revision_label = $3, updated_at = NOW()
+       WHERE id = $1`,
+      [id, nextRevision, revisionLabel]
+    );
+
+    await storage.createProjectActivityLog({
+      projectId: id,
+      activityType: 'project_revision_created',
+      description: `${revisionLabel}: ${data.summary}`,
+      performedBy: data.createdBy ?? undefined,
+      performedByDisplayName: data.createdByDisplayName,
+      metadata: { revisionNumber: nextRevision, revisionType: data.revisionType },
+    } as any);
+
+    res.status(201).json(rows[0]);
+  } catch (error) {
+    console.error('Error creating project revision:', error);
+    res.status(500).json({ message: 'Failed to create project revision' });
+  }
+});
+
+router.post('/:id/link-po', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const schema = z.object({
+      poId: z.number().int().positive(),
+      reason: z.string().min(3).optional(),
+      createdBy: z.number().int().positive().optional(),
+      createdByDisplayName: z.string().optional(),
+    });
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ message: 'Invalid request: poId (number) required', errors: parsed.error.errors });
+    }
+    const { poId, reason, createdBy, createdByDisplayName } = parsed.data;
+
+    const project = await storage.getProject(id);
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+
+    if (project.poId === poId) {
+      return res.status(409).json({ message: 'Project is already linked to this PO' });
+    }
+
+    if (project.poId && !reason?.trim()) {
+      return res.status(400).json({ message: 'A revision reason is required when changing the linked PO' });
     }
 
     // Validate PO exists
@@ -536,17 +696,60 @@ router.post('/:id/link-po', async (req, res) => {
       `SELECT id FROM projects WHERE po_id = $1 LIMIT 1`,
       [poId]
     );
-    if (conflictRows.length > 0) {
+    if (conflictRows.length > 0 && conflictRows[0].id !== id) {
       return res.status(409).json({ message: 'Another project is already linked to this PO' });
     }
 
-    const updated = await storage.updateProject(id, { poId } as any);
+    const previousPoId = project.poId ?? null;
+    const nextRevision = await getNextProjectRevisionNumber(id);
+    const revisionLabel = `Rev ${nextRevision}`;
+    const isRelink = previousPoId !== null;
+    const revisionReason = reason?.trim() || 'Initial production PO link';
+    const revisionSummary = isRelink
+      ? `Changed linked P2 PO to ${poRows[0].po_number}`
+      : `Linked project to P2 PO ${poRows[0].po_number}`;
+
+    const updated = await storage.updateProject(id, {
+      poId,
+      currentRevisionNumber: nextRevision,
+      currentRevisionLabel: revisionLabel,
+    } as any);
+
+    await pool.query(
+      `UPDATE project_steps
+       SET linked_p2_order_id = $2, updated_at = NOW()
+       WHERE project_id = $1 AND step_type = 'p2_order'`,
+      [id, poId]
+    );
+
+    await pool.query(
+      `INSERT INTO project_revisions (
+         project_id, revision_number, revision_label, revision_type, summary, reason,
+         previous_po_id, new_po_id, created_by, created_by_display_name, metadata
+       )
+       VALUES ($1, $2, $3, 'PO_LINK_CHANGE', $4, $5, $6, $7, $8, $9, $10::jsonb)`,
+      [
+        id,
+        nextRevision,
+        revisionLabel,
+        revisionSummary,
+        revisionReason,
+        previousPoId,
+        poId,
+        createdBy ?? null,
+        createdByDisplayName ?? null,
+        JSON.stringify({ source: 'project_po_link', previousPoId, newPoId: poId }),
+      ]
+    );
 
     await storage.createProjectActivityLog({
       projectId: id,
-      activityType: 'project_updated',
-      description: `Linked to PO ${poRows[0].po_number}`,
-    });
+      activityType: isRelink ? 'project_po_relinked' : 'project_po_linked',
+      description: `${revisionLabel}: ${revisionSummary}`,
+      performedBy: createdBy,
+      performedByDisplayName: createdByDisplayName,
+      metadata: { revisionNumber: nextRevision, previousPoId, newPoId: poId, reason: revisionReason },
+    } as any);
 
     res.json(updated);
   } catch (error) {


### PR DESCRIPTION
## Summary
- add project revision fields and a `project_revisions` audit table with migration/startup guards
- allow project PO links to be changed through an audited revision instead of forcing a short close/new project
- add a Project Revisions tab and a controlled Change Linked PO action on project traceability

## Verification
- `git diff --check`
- `git diff --cached --check`

TypeScript check was not run locally because this shell does not have `npm` and the worktree has no `node_modules`.