### PR TITLE
[codex] Fix P2 material barcode trace fields

### DIFF
--- a/client/src/pages/TravelerExecution.tsx
+++ b/client/src/pages/TravelerExecution.tsx
@@ -193,6 +193,18 @@ interface TravelerWithDetails {
   events: TravelerEvent[];
 }
 
+const addGeneratedTraceFieldAliases = (values: Record<string, string>) => ({
+  ...values,
+  trace_internalcontrolnumber: values.internalControlNumber || values.material_internal_control_number || values.material_icn || '',
+  trace_supplier: values.supplier || '',
+  trace_inventorypartnumber: values.inventoryPartNumber || values.material_part_number || '',
+  trace_batchlotnumber: values.batchLotNumber || values.material_batch_number || values.material_lot || '',
+  trace_manufacturer: values.manufacturer || values.material_brand || '',
+  trace_rollnumber: values.rollNumber || '',
+  trace_expirationdate: values.expirationDate || values.material_expiration_date || '',
+  trace_receiveddate: values.receivedDate || '',
+});
+
 const STEP_STATUS_COLORS: Record<string, string> = {
   NOT_STARTED: 'bg-gray-100 text-gray-800 border-gray-300',
   IN_PROGRESS: 'bg-blue-100 text-blue-800 border-blue-300',
@@ -2700,7 +2712,7 @@ export default function TravelerExecution() {
                                                 const icn = result.internalControlNumber || '';
                                                 const lot = result.updatedLot;
                                                 const hasInventoryMatch = !!lot;
-                                                const allManualVals: Record<string, string> = {
+                                                const allManualVals: Record<string, string> = addGeneratedTraceFieldAliases({
                                                   material_internal_control_number: icn,
                                                   internalControlNumber: icn,
                                                   material_icn: icn,
@@ -2720,7 +2732,7 @@ export default function TravelerExecution() {
                                                   manufacturer: lot?.manufacturer || 'Manual Entry',
                                                   rollNumber: lot?.rollNumber || 'N/A',
                                                   receivedDate: lot?.receivedDate || today,
-                                                };
+                                                });
                                                 const traceFieldVals: Record<string, string> = {};
                                                 for (const [key, val] of Object.entries(allManualVals)) {
                                                   if (taskFieldKeys.has(key)) {
@@ -2769,7 +2781,7 @@ export default function TravelerExecution() {
                                                   const combinedIcns = batch.rolls.map((r) => r.icn).filter(Boolean).join(', ');
                                                   const icnOrBarcode = combinedIcns || batch.packetBarcode;
 
-                                                  const allScanVals: Record<string, string> = {
+                                                  const allScanVals: Record<string, string> = addGeneratedTraceFieldAliases({
                                                     packetBarcode: batch.packetBarcode,
                                                     packet_barcode: batch.packetBarcode,
                                                     material_internal_control_number: icnOrBarcode,
@@ -2791,7 +2803,7 @@ export default function TravelerExecution() {
                                                     manufacturer: primaryLot?.manufacturer || '',
                                                     rollNumber: primaryLot?.rollNumber || '',
                                                     receivedDate: primaryLot?.receivedDate || '',
-                                                  };
+                                                  });
                                                   batch.rolls.forEach((r, idx) => {
                                                     allScanVals[`internalControlNumber_${idx + 1}`] = r.icn;
                                                   });
@@ -2839,7 +2851,7 @@ export default function TravelerExecution() {
                                                 return;
                                               }
 
-                                              const allScanVals: Record<string, string> = {
+                                              const allScanVals: Record<string, string> = addGeneratedTraceFieldAliases({
                                                 material_internal_control_number: icnValue,
                                                 internalControlNumber: icnValue,
                                                 material_icn: icnValue,
@@ -2859,7 +2871,7 @@ export default function TravelerExecution() {
                                                 manufacturer: lot?.manufacturer || '',
                                                 rollNumber: lot?.rollNumber || '',
                                                 receivedDate: lot?.receivedDate || '',
-                                              };
+                                              });
                                               const traceFieldVals: Record<string, string> = {};
                                               for (const [key, val] of Object.entries(allScanVals)) {
                                                 if (taskFieldKeys.has(key)) {

--- a/server/src/routes/travelers.ts
+++ b/server/src/routes/travelers.ts
@@ -64,6 +64,34 @@ const DEPT_ALIASES: Record<string, string> = {
   'shipping': 'shipping',
 };
 
+const TRACE_FIELD_ALIASES: Record<string, string[]> = {
+  trace_internalcontrolnumber: ['internalControlNumber', 'material_internal_control_number', 'material_icn'],
+  trace_supplier: ['supplier'],
+  trace_inventorypartnumber: ['inventoryPartNumber', 'material_part_number'],
+  trace_batchlotnumber: ['batchLotNumber', 'material_batch_number', 'material_lot'],
+  trace_manufacturer: ['manufacturer', 'material_brand'],
+  trace_rollnumber: ['rollNumber'],
+  trace_expirationdate: ['expirationDate', 'material_expiration_date'],
+  trace_receiveddate: ['receivedDate'],
+};
+
+function resolveTraceFieldValue(
+  fieldKey: string,
+  fieldValues: Record<string, unknown>,
+): unknown {
+  const aliases = TRACE_FIELD_ALIASES[fieldKey];
+  if (!aliases) return undefined;
+
+  for (const alias of aliases) {
+    const value = fieldValues[alias];
+    if (value !== undefined && value !== null && value !== '') {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
 function normalizeDept(d: string): string {
   let lower = d.toLowerCase().trim();
   lower = lower.replace(/^pending\s+/i, '');
@@ -2377,6 +2405,9 @@ router.post('/:travelerId/tasks/:taskId/complete', async (req: Request, res: Res
       const resolvedFieldValidations = fieldValidations || {};
       for (const field of fields) {
         let value = resolvedFieldValues[field.fieldKey];
+        if (value === undefined && (task.taskType === 'TRACE' || task.taskType === 'TRACEABILITY')) {
+          value = resolveTraceFieldValue(field.fieldKey, resolvedFieldValues);
+        }
         if (value === undefined && field.fieldKey === 'operator') {
           value = completedBy || step.startedBy || 'unknown';
         }


### PR DESCRIPTION
## Summary

- Populate generated traveler trace field keys (for example `trace_internalcontrolnumber`) when material barcode scans auto-fill traceability data.
- Add server-side alias resolution for generated trace fields so canonical scan payload keys still satisfy required trace fields.

## Root Cause

The material barcode validation succeeded and found the packet rolls, but the traveler task completion route was validating the generated routing field key `trace_internalcontrolnumber`. The client scan payload only included canonical aliases like `internalControlNumber`, `material_icn`, and `material_internal_control_number`, so the required generated field was treated as missing.

## Validation

- `git diff --check`
- `git diff --cached --check`

Full TypeScript/build validation was not run because `npm` is not available on PATH and `node_modules` is not present in this worktree.