### PR TITLE
Restore P2 traveler QC routing requirements

### DIFF
--- a/client/src/pages/TravelerExecution.tsx
+++ b/client/src/pages/TravelerExecution.tsx
@@ -748,6 +748,42 @@ export default function TravelerExecution() {
     return currentPartRouting.departmentConfig[departmentName] || null;
   };
 
+  const getRoutingQcStandardsForTask = (task: TravelerTask, departmentName: string) => {
+    if (task.taskType !== 'QC') return [];
+    const deptConfig = getDeptConfig(departmentName) as any;
+    if (!deptConfig) return [];
+
+    const phaseStandards =
+      task.taskPhase === 'START'
+        ? deptConfig.startQcStandards
+        : task.taskPhase === 'FINISH'
+          ? deptConfig.finishQcStandards
+          : deptConfig.qcStandards;
+    const fallbackStandards =
+      task.taskPhase === 'FINISH'
+        ? deptConfig.qcStandards
+        : deptConfig.finishQcStandards;
+
+    const standards = Array.isArray(phaseStandards) && phaseStandards.length > 0
+      ? phaseStandards
+      : (Array.isArray(fallbackStandards) ? fallbackStandards : []);
+    const seen = new Set<string>();
+
+    return standards
+      .map((qc: any) => ({
+        standard: qc.standard || qc.standardName || qc.name || qc.title || 'QC Check',
+        tolerance: qc.tolerance || '',
+        requirement: qc.requirement || qc.specification || qc.acceptanceCriteria || '',
+        referenceLink: qc.referenceLink || '',
+      }))
+      .filter((qc: any) => {
+        const key = `${qc.standard}|${qc.tolerance}|${qc.requirement}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return qc.standard || qc.tolerance || qc.requirement;
+      });
+  };
+
   const getTimerConfigForDepartment = (departmentName: string) => {
     const deptConfig = getDeptConfig(departmentName);
     if (deptConfig?.timerConfig?.enabled) return deptConfig.timerConfig;
@@ -2890,6 +2926,39 @@ export default function TravelerExecution() {
                                           />
                                         ) : (
                                           <>
+                                            {task.taskType === 'QC' && task.fields.length === 0 && getRoutingQcStandardsForTask(task, currentStep.departmentName).length > 0 && (
+                                              <div className="space-y-2 rounded-lg border border-green-200 bg-green-50/50 p-3">
+                                                <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-green-800">
+                                                  <ClipboardCheck className="h-4 w-4" />
+                                                  Routing QC Requirements
+                                                </div>
+                                                {getRoutingQcStandardsForTask(task, currentStep.departmentName).map((qc: any, index: number) => (
+                                                  <div key={`${qc.standard}-${index}`} className="rounded-md border border-green-100 bg-white p-2">
+                                                    <p className="text-sm font-medium">{qc.standard}</p>
+                                                    <div className="mt-1 flex flex-wrap gap-2 text-xs">
+                                                      {qc.tolerance && (
+                                                        <span className="inline-flex items-center gap-1 rounded border border-blue-200 bg-blue-50 px-2 py-0.5 text-blue-700">
+                                                          <Wrench className="h-3 w-3" />
+                                                          Tolerance: {qc.tolerance}
+                                                        </span>
+                                                      )}
+                                                      {qc.requirement && (
+                                                        <span className="inline-flex items-center gap-1 rounded border border-green-200 bg-green-50 px-2 py-0.5 text-green-700">
+                                                          <Shield className="h-3 w-3" />
+                                                          Requirement: {qc.requirement}
+                                                        </span>
+                                                      )}
+                                                      {qc.referenceLink && (
+                                                        <a href={qc.referenceLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 rounded border border-purple-200 bg-purple-50 px-2 py-0.5 text-purple-700 hover:bg-purple-100 no-underline">
+                                                          <ExternalLink className="h-3 w-3" />
+                                                          Reference
+                                                        </a>
+                                                      )}
+                                                    </div>
+                                                  </div>
+                                                ))}
+                                              </div>
+                                            )}
                                             {task.fields.length > 0 && (
                                               <div className="space-y-3">
                                                 {task.fields.filter((field) => {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19664,6 +19664,69 @@ export class DatabaseStorage implements IStorage {
         default: return 'WORK';
       }
     };
+    const sanitizeFieldKey = (value: string) =>
+      String(value || '')
+        .replace(/[^a-zA-Z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '')
+        .toLowerCase() || 'check';
+    const normalizeQcStandards = (raw: any): any[] => {
+      if (!Array.isArray(raw)) return [];
+      const standards = raw
+        .map((qc: any) => ({
+          standard: qc.standard || qc.standardName || qc.name || qc.title || qc.characteristic || qc.checkpoint || '',
+          tolerance: qc.tolerance || qc.acceptanceTolerance || qc.nominalTolerance || '',
+          requirement: qc.requirement || qc.specification || qc.acceptanceCriteria || qc.criteria || qc.nominal || '',
+          hardQcStop: qc.hardQcStop || qc.hardStop || false,
+          referenceLink: qc.referenceLink || qc.referenceUrl || qc.documentUrl || '',
+        }))
+        .filter((qc) => qc.standard || qc.tolerance || qc.requirement);
+
+      const seen = new Set<string>();
+      return standards.filter((qc) => {
+        const key = `${qc.standard}|${qc.tolerance}|${qc.requirement}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+    };
+    const getOperationQcStandards = (op: RoutingOperation, taskPhase: string): any[] => {
+      const pack = (op.instructionPack || {}) as any;
+      const packStandards = normalizeQcStandards(
+        pack.qcStandards ||
+        pack.qcRequirements ||
+        pack.qualityChecks ||
+        pack.inspectionRequirements ||
+        pack.checkpoints
+      );
+      if (packStandards.length > 0) return packStandards;
+
+      const departmentConfig = (routing.departmentConfig || {}) as Record<string, any>;
+      const deptConfig = departmentConfig[op.departmentName] || {};
+      const phaseStandards =
+        taskPhase === 'START'
+          ? normalizeQcStandards(deptConfig.startQcStandards)
+          : taskPhase === 'FINISH'
+            ? normalizeQcStandards(deptConfig.finishQcStandards)
+            : normalizeQcStandards(deptConfig.qcStandards);
+      if (phaseStandards.length > 0) return phaseStandards;
+
+      const fallbackStandards =
+        taskPhase === 'FINISH'
+          ? normalizeQcStandards(deptConfig.qcStandards)
+          : normalizeQcStandards(deptConfig.finishQcStandards);
+      if (fallbackStandards.length > 0) return fallbackStandards;
+
+      if (pack.specialNotes) {
+        return [{
+          standard: op.operationName,
+          tolerance: '',
+          requirement: pack.specialNotes,
+          hardQcStop: false,
+          referenceLink: '',
+        }];
+      }
+      return [];
+    };
 
     // Group ops by unique (stepNumber, departmentName)
     const stepGroups: Map<string, RoutingOperation[]> = new Map();
@@ -19698,7 +19761,7 @@ export class DatabaseStorage implements IStorage {
         const instPack = op.instructionPack as any;
         const instructions = instPack?.specialNotes || op.operationName;
 
-        await this.createTravelerTask({
+        const task = await this.createTravelerTask({
           travelerStepId: step.id,
           taskType: taskType as any,
           taskPhase: taskPhase as any,
@@ -19713,6 +19776,25 @@ export class DatabaseStorage implements IStorage {
           status: 'NOT_STARTED',
           instructionPack: op.instructionPack as any,
         });
+
+        if (taskType === 'QC') {
+          const qcStandards = getOperationQcStandards(op, taskPhase);
+          for (const qc of qcStandards) {
+            await this.createTravelerTaskField({
+              travelerTaskId: task.id,
+              fieldKey: `qc_${op.id}_${sanitizeFieldKey(qc.standard || op.operationName)}`,
+              fieldLabel: qc.standard || op.operationName,
+              fieldType: 'yes_no',
+              required: true,
+              validation: {
+                tolerance: qc.tolerance || '',
+                requirement: qc.requirement || '',
+                ...(qc.hardQcStop ? { hardQcStop: true } : {}),
+                ...(qc.referenceLink ? { referenceLink: qc.referenceLink } : {}),
+              },
+            });
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- stamp routing QC standards into traveler QC task fields when travelers are generated from structured routing operations
- preserve tolerance, requirement, hard QC stop, and reference-link metadata for the existing traveler QC UI
- add a traveler execution fallback so already-created QC tasks without fields still show route-level QC requirements

## Validation
- git diff --check
- git diff --cached --check
- git merge-tree --write-tree HEAD origin/main

Note: local TypeScript/build validation was not run because this fresh worktree has no node_modules and npm is not available in the shell.