### PR TITLE
Gate contract review by PO role

### DIFF
--- a/client/src/components/P2POManager.tsx
+++ b/client/src/components/P2POManager.tsx
@@ -75,6 +75,7 @@ const p2PurchaseOrderSchema = z.object({
   status: z.enum(['OPEN', 'CLOSED', 'CANCELED']).default('OPEN'),
   notes: z.string().optional(),
   sourceQuoteId: z.string().optional().nullable(),
+  contractReviewRole: z.enum(['primary', 'secondary']).default('secondary'),
   projectName: z.string().optional().nullable(),
 });
 
@@ -106,6 +107,7 @@ interface P2PurchaseOrder
   expectedDelivery: string;
   attachments?: string[];
   sourceQuoteId?: string | null;
+  contractReviewRole?: 'primary' | 'secondary' | null;
   projectName?: string | null;
   lockedAt?: string | null;
   lockedBy?: string | null;
@@ -180,6 +182,7 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
       status: 'OPEN',
       notes: '',
       sourceQuoteId: null,
+      contractReviewRole: 'secondary',
       projectName: null,
     },
   });
@@ -426,6 +429,7 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
       status: po.status,
       notes: po.notes || '',
       sourceQuoteId: po.sourceQuoteId || null,
+      contractReviewRole: po.contractReviewRole || 'secondary',
       projectName: po.projectName || null,
     });
     setDialogOpen(true);
@@ -444,6 +448,7 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
       status: 'OPEN',
       notes: '',
       sourceQuoteId: null,
+      contractReviewRole: 'secondary',
       projectName: null,
     });
     setDialogOpen(true);
@@ -800,6 +805,31 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
                 </div>
                 <FormField
                   control={form.control}
+                  name="contractReviewRole"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Are we primary or secondary on this PO?</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value || 'secondary'}
+                        disabled={!!selectedPO?.lockedAt}
+                      >
+                        <FormControl>
+                          <SelectTrigger data-testid="select-contract-review-role">
+                            <SelectValue placeholder="Select role" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="secondary">Secondary - contract review not required now</SelectItem>
+                          <SelectItem value="primary">Primary - contract review required for P2 release</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
                   name="notes"
                   render={({ field }) => (
                     <FormItem>
@@ -993,6 +1023,16 @@ export function P2POManager({ onManageItems, selectedPOIds = [], initialSearch =
                   <div className="flex gap-2 items-center">
                     <Badge variant={getStatusBadgeVariant(po.status)}>
                       {po.status}
+                    </Badge>
+                    <Badge
+                      variant="outline"
+                      className={
+                        po.contractReviewRole === 'primary'
+                          ? 'border-blue-500 text-blue-700 dark:text-blue-400'
+                          : 'border-slate-300 text-slate-600 dark:text-slate-300'
+                      }
+                    >
+                      {po.contractReviewRole === 'primary' ? 'Primary - review required' : 'Secondary'}
                     </Badge>
                     {po.lockedAt && (
                       <Badge variant="outline" className="border-amber-500 text-amber-600 dark:text-amber-400 flex items-center gap-1">

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -492,7 +492,7 @@ export default function ProjectDetailPage() {
   });
 
   interface GateStatus {
-    gates: { key: string; label: string; passed: boolean }[];
+    gates: { key: string; label: string; passed: boolean; status?: string; message?: string }[];
     allPassed: boolean;
     currentStage: string;
     alreadyReleased: boolean;
@@ -1379,7 +1379,7 @@ export default function ProjectDetailPage() {
               </CardTitle>
             </div>
             <CardDescription>
-              All three conditions must be met before this project can enter the P2 Control Center.
+              Required conditions must be met before this project can enter the P2 Control Center.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -1397,7 +1397,7 @@ export default function ProjectDetailPage() {
                       {gate.label}
                     </span>
                     <Badge variant={gate.passed ? 'default' : 'secondary'} className={`ml-auto text-xs ${gate.passed ? 'bg-green-100 text-green-700 border-green-300' : 'bg-red-100 text-red-700 border-red-300'}`}>
-                      {gate.passed ? 'APPROVED' : 'PENDING'}
+                      {gate.status === 'not_required' ? 'N/A' : gate.passed ? 'APPROVED' : 'PENDING'}
                     </Badge>
                   </div>
                 ))
@@ -1420,7 +1420,7 @@ export default function ProjectDetailPage() {
                 <p className="text-xs font-medium text-red-700 dark:text-red-400 mb-1">Blocking conditions:</p>
                 <ul className="text-xs text-red-600 dark:text-red-400 space-y-0.5 list-disc list-inside">
                   {gateStatus.gates.filter(g => !g.passed).map(g => (
-                    <li key={g.key}>{g.label} must be completed</li>
+                    <li key={g.key}>{g.message || `${g.label} must be completed`}</li>
                   ))}
                 </ul>
               </div>
@@ -1441,7 +1441,7 @@ export default function ProjectDetailPage() {
                 onClick={() => releaseToP2Mutation.mutate()}
                 disabled={!project.poId || !gateStatus?.allPassed || releaseToP2Mutation.isPending}
                 className={`${project.currentStage === 'p2_release' ? 'bg-green-600 hover:bg-green-700' : ''}`}
-                title={!project.poId ? 'Link a P2 Purchase Order before releasing' : !gateStatus?.allPassed ? 'Complete all three gate conditions to enable release' : undefined}
+                title={!project.poId ? 'Link a P2 Purchase Order before releasing' : !gateStatus?.allPassed ? 'Complete all required gate conditions to enable release' : undefined}
               >
                 <Rocket className="h-4 w-4 mr-2" />
                 {releaseToP2Mutation.isPending

--- a/migrations/0135_p2_po_contract_review_role.sql
+++ b/migrations/0135_p2_po_contract_review_role.sql
@@ -1,0 +1,19 @@
+ALTER TABLE p2_purchase_orders
+  ADD COLUMN IF NOT EXISTS contract_review_role TEXT NOT NULL DEFAULT 'secondary';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'p2_purchase_orders_contract_review_role_check'
+  ) THEN
+    ALTER TABLE p2_purchase_orders
+      ADD CONSTRAINT p2_purchase_orders_contract_review_role_check
+      CHECK (contract_review_role IN ('primary', 'secondary'))
+      NOT VALID;
+  END IF;
+END $$;
+
+ALTER TABLE p2_purchase_orders
+  VALIDATE CONSTRAINT p2_purchase_orders_contract_review_role_check;

--- a/server/index.ts
+++ b/server/index.ts
@@ -4682,6 +4682,10 @@ async function initializeBackgroundServices() {
           ALTER TABLE p2_purchase_orders
           ADD COLUMN IF NOT EXISTS project_name TEXT
         `);
+        await pool.query(`
+          ALTER TABLE p2_purchase_orders
+          ADD COLUMN IF NOT EXISTS contract_review_role TEXT NOT NULL DEFAULT 'secondary'
+        `);
         console.log('✅ Ensured p2_nonconforming_dispositions and p2_rmas tables exist');
       } catch (ncErr: any) {
         console.warn('⚠️ p2_nonconforming_dispositions/p2_rmas migration:', ncErr?.message);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -5152,6 +5152,7 @@ export const p2PurchaseOrders = pgTable('p2_purchase_orders', {
   lockedBy: integer('locked_by').references(() => employees.id), // Who locked the PO
 
   sourceQuoteId: uuid('source_quote_id').references(() => quotes.id), // Links PO to originating quote
+  contractReviewRole: text('contract_review_role').notNull().default('secondary'), // primary requires contract review before P2 release; secondary does not
   
   // Ownership fields for accountability and audit compliance
   createdById: integer('created_by_id').references(() => employees.id), // Who created the PO
@@ -6726,6 +6727,7 @@ export const insertP2PurchaseOrderSchema = createInsertSchema(p2PurchaseOrders)
     status: z.enum(['OPEN', 'CLOSED', 'CANCELED']).default('OPEN'),
     notes: z.string().optional().nullable(),
     sourceQuoteId: z.string().uuid().optional().nullable(),
+    contractReviewRole: z.enum(['primary', 'secondary']).default('secondary'),
   });
 
 export const insertP2PurchaseOrderItemSchema = createInsertSchema(

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2468,7 +2468,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         toleranceAuthorizerId, toleranceAuthorizerName, toleranceNotes, notes, lineItems,
         assignedToId, assignedToName, productionLeadId, productionLeadName,
         customerName: bodyCustomerName, poDate: bodyPoDate, status: bodyStatus,
-        sourceQuoteId, projectName,
+        sourceQuoteId, projectName, contractReviewRole,
       } = req.body;
       
       // Use the customer-provided PO number — accept either field name
@@ -2504,6 +2504,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         productionLeadId: productionLeadId && productionLeadId !== 'none' ? parseInt(productionLeadId) : null,
         productionLeadName: productionLeadName || null,
         sourceQuoteId: sourceQuoteId || null,
+        contractReviewRole: contractReviewRole === 'primary' ? 'primary' : 'secondary',
         projectName: projectName || null,
       };
       
@@ -2552,6 +2553,11 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { storage } = await import('../../storage');
       const { id } = req.params;
       const poData = req.body;
+      if (poData.contractReviewRole && !['primary', 'secondary'].includes(poData.contractReviewRole)) {
+        return res.status(400).json({
+          error: 'contractReviewRole must be primary or secondary',
+        });
+      }
       
       const existingPO = await storage.getP2PurchaseOrder(parseInt(id));
       if (!existingPO) {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1278,7 +1278,7 @@ router.patch('/:projectId/steps/:stepId/reopen', async (req, res) => {
 });
 
 // POST /api/projects/:id/release-to-p2 — P2 Release Gate endpoint
-// Release gate: PO Review + Contract Review + WAD + Preproduction must all pass
+// Release gate: PO Review + WAD + Preproduction must pass; Contract Review is required for primary POs.
 // First call (pre-gate) → sets stage to p2_release and PO to ready_for_p2_release
 // Second call (staged) → sets stage to production and PO to in_production
 // Repeated calls once in production → 409 (idempotent-safe)
@@ -1336,7 +1336,7 @@ router.post('/:id/release-to-p2', async (req, res) => {
     const wadPassed = workOrders.some(wo => WAD_APPROVED_STATUSES.includes(wo.status));
 
     const quoteStep = steps.find(s => s.stepType === 'quote');
-    const contractReviewGate = await getQuoteContractReviewGate(quoteStep?.linkedQuoteId ?? null, id);
+    const contractReviewGate = await getQuoteContractReviewGate(quoteStep?.linkedQuoteId ?? null, id, project.poId);
 
     const gates = [
       { key: 'po_review', label: 'PO Review', passed: poReviewPassed },
@@ -1374,7 +1374,7 @@ router.post('/:id/release-to-p2', async (req, res) => {
       await storage.createProjectActivityLog({
         projectId: id,
         activityType: 'stage_changed',
-        description: 'Released to Production — P2 Release Gate passed (all three conditions met)',
+        description: 'Released to Production — P2 Release Gate passed (all required conditions met)',
       });
 
       return res.json({
@@ -1399,7 +1399,7 @@ router.post('/:id/release-to-p2', async (req, res) => {
     await storage.createProjectActivityLog({
       projectId: id,
       activityType: 'stage_changed',
-      description: 'P2 Release Gate passed — project staged for P2 (PO Review ✓, WAD ✓, Preproduction ✓)',
+      description: 'P2 Release Gate passed — project staged for P2 (PO Review, WAD, Preproduction, and any required Contract Review cleared)',
     });
 
     return res.json({
@@ -1438,7 +1438,7 @@ router.get('/:id/p2-gate-status', async (req, res) => {
     const wadPassed = workOrders.some(wo => WAD_APPROVED_STATUSES.includes(wo.status));
 
     const quoteStep = steps.find(s => s.stepType === 'quote');
-    const contractReviewGate = await getQuoteContractReviewGate(quoteStep?.linkedQuoteId ?? null, id);
+    const contractReviewGate = await getQuoteContractReviewGate(quoteStep?.linkedQuoteId ?? null, id, project.poId);
 
     const gates = [
       { key: 'po_review', label: 'PO Review', passed: poReviewPassed },

--- a/server/src/services/quoteContractService.ts
+++ b/server/src/services/quoteContractService.ts
@@ -303,22 +303,51 @@ export async function createQuoteSnapshot(
   return snapshot;
 }
 
-export async function getQuoteContractReviewGate(quoteId: string | null | undefined, projectId?: string | null) {
-  if (!quoteId && !projectId) {
+export async function getQuoteContractReviewGate(
+  quoteId: string | null | undefined,
+  projectId?: string | null,
+  p2PurchaseOrderId?: number | null,
+) {
+  const poContext = p2PurchaseOrderId
+    ? firstRow<{ contract_review_role: string | null; source_quote_id: string | null }>(
+        await pool.query(
+          `SELECT contract_review_role, source_quote_id
+           FROM p2_purchase_orders
+           WHERE id = $1`,
+          [p2PurchaseOrderId],
+        ),
+      )
+    : null;
+  const poRole = poContext?.contract_review_role ?? 'secondary';
+  const effectiveQuoteId = quoteId ?? poContext?.source_quote_id ?? null;
+
+  if (normalizeText(poRole) !== 'primary') {
+    return {
+      key: 'contract_review',
+      label: 'Contract Review',
+      passed: true,
+      status: 'not_required',
+      contractReviewRole: poRole,
+      message: 'Contract review is not required for secondary POs.',
+    };
+  }
+
+  if (!effectiveQuoteId && !projectId) {
     return {
       key: 'contract_review',
       label: 'Contract Review',
       passed: false,
       status: 'missing_link',
+      contractReviewRole: poRole,
       message: 'No source quote or project link is available for contract review.',
     };
   }
 
-  const snapshot = quoteId ? await latestSnapshot(quoteId) : null;
+  const snapshot = effectiveQuoteId ? await latestSnapshot(effectiveQuoteId) : null;
   const params: unknown[] = [];
   const predicates: string[] = [];
-  if (quoteId) {
-    params.push(quoteId);
+  if (effectiveQuoteId) {
+    params.push(effectiveQuoteId);
     predicates.push(`form_data->>'quoteId' = $${params.length}`);
     predicates.push(`form_data->>'quote_id' = $${params.length}`);
   }
@@ -347,6 +376,7 @@ export async function getQuoteContractReviewGate(quoteId: string | null | undefi
     label: 'Contract Review',
     passed: Boolean(snapshot && reviewApproved),
     status: !snapshot ? 'missing_snapshot' : reviewApproved ? 'approved' : review ? 'review_not_approved' : 'missing_review',
+    contractReviewRole: poRole,
     quoteSnapshotId: snapshot?.id ?? null,
     quoteRevision: snapshot?.revision_label ?? null,
     purchaseReviewChecklistId: review?.id ?? null,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -14812,7 +14812,8 @@ export class DatabaseStorage implements IStorage {
         tolerance_authorizer_name as "toleranceAuthorizerName",
         tolerance_notes as "toleranceNotes", bom_configured as "bomConfigured",
         locked_at as "lockedAt", locked_by as "lockedBy",
-        source_quote_id as "sourceQuoteId", created_by_id as "createdById",
+        source_quote_id as "sourceQuoteId", contract_review_role as "contractReviewRole",
+        created_by_id as "createdById",
         created_by_name as "createdByName", assigned_to_id as "assignedToId",
         assigned_to_name as "assignedToName", bom_owner_id as "bomOwnerId",
         bom_owner_name as "bomOwnerName", scheduled_by_id as "scheduledById",
@@ -14855,12 +14856,12 @@ export class DatabaseStorage implements IStorage {
       INSERT INTO p2_purchase_orders (
         po_number, customer_id, customer_name, po_date, expected_delivery,
         status, notes, attachments, tolerance_authorizer_id, tolerance_authorizer_name,
-        tolerance_notes, bom_configured, source_quote_id, created_by_id, created_by_name,
-        assigned_to_id, assigned_to_name, bom_owner_id, bom_owner_name,
+        tolerance_notes, bom_configured, source_quote_id, contract_review_role,
+        created_by_id, created_by_name, assigned_to_id, assigned_to_name, bom_owner_id, bom_owner_name,
         scheduled_by_id, scheduled_by_name, production_lead_id, production_lead_name,
         project_name
       ) VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25
       )
       RETURNING id, po_number as "poNumber", customer_id as "customerId",
         customer_name as "customerName", po_date as "poDate",
@@ -14869,7 +14870,8 @@ export class DatabaseStorage implements IStorage {
         tolerance_authorizer_name as "toleranceAuthorizerName",
         tolerance_notes as "toleranceNotes", bom_configured as "bomConfigured",
         locked_at as "lockedAt", locked_by as "lockedBy",
-        source_quote_id as "sourceQuoteId", created_by_id as "createdById",
+        source_quote_id as "sourceQuoteId", contract_review_role as "contractReviewRole",
+        created_by_id as "createdById",
         created_by_name as "createdByName", assigned_to_id as "assignedToId",
         assigned_to_name as "assignedToName", bom_owner_id as "bomOwnerId",
         bom_owner_name as "bomOwnerName", scheduled_by_id as "scheduledById",
@@ -14891,6 +14893,7 @@ export class DatabaseStorage implements IStorage {
       data.toleranceNotes || null,
       data.bomConfigured || false,
       data.sourceQuoteId || null,
+      data.contractReviewRole || 'secondary',
       data.createdById || null,
       data.createdByName || null,
       data.assignedToId || null,


### PR DESCRIPTION
## Summary
- Adds a Primary/Secondary contract-review role question to P2 purchase orders.
- Persists `contract_review_role` on P2 POs with migration/startup compatibility coverage.
- Makes the P2 Release Gate require Contract Review only when the linked PO is marked Primary; Secondary POs show Contract Review as not required.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/services/quoteContractService.ts`
- `node --experimental-strip-types --check server/src/routes/projects.ts`
- `node --experimental-strip-types --check server/src/routes/index.ts`
- `node --experimental-strip-types --check server/storage.ts`
- `node --experimental-strip-types --check server/schema.ts`

Full npm/TypeScript build was not run locally because `npm` is not available and `node_modules` is absent in this worktree.