### PR TITLE
Restrict cutting barcode printing to unallocated packets

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -149,6 +149,8 @@ type ManufacturingQueueItem = {
   estimatedCuts: number;
   packetBomId: string | null;
   poNumbers?: GroupedPO[] | null;
+  allocatedPacketCount?: number;
+  printableBarcodeCount?: number;
 };
 
 type PacketBOM = {
@@ -215,6 +217,17 @@ function parseMfgBarcode(barcode: string): MfgBarcodeSegments {
 function buildMfgBarcode(queueId: string | null, sku: string | null, packetNumber: number): string | null {
   if (!queueId || !sku) return null;
   return `MFG-${queueId}-${sku}-${packetNumber}`;
+}
+
+function getPrintableBarcodeCount(item: ManufacturingQueueItem): number {
+  if (typeof item.printableBarcodeCount === 'number') {
+    return Math.max(0, item.printableBarcodeCount);
+  }
+  return Math.max(0, (item.quantityOrdered || 0) - (item.quantityCompleted || 0));
+}
+
+function isPacketBarcodePrintable(item: ManufacturingQueueItem): boolean {
+  return (item.status === 'PENDING' || item.status === 'IN_PROGRESS') && getPrintableBarcodeCount(item) > 0;
 }
 
 function useIsAdmin() {
@@ -704,7 +717,7 @@ export default function CuttingOperatorDashboard() {
       toast({ title: 'Barcodes Ready', description: `${data.count} packet barcode labels ready to print.` });
     },
     onError: () => {
-      toast({ title: 'Error', description: 'Failed to generate packet barcodes.', variant: 'destructive' });
+      toast({ title: 'No barcodes available', description: 'Only unallocated packet barcodes can be printed.', variant: 'destructive' });
     },
   });
 
@@ -922,10 +935,10 @@ export default function CuttingOperatorDashboard() {
 
   const selectAllPendingForPrint = () => {
     const pendingIds = mfgQueueItems
-      .filter(i => i.status === 'PENDING' || i.status === 'IN_PROGRESS')
+      .filter(isPacketBarcodePrintable)
       .map(i => i.id);
     setSelectedPrintIds(prev => 
-      prev.length === pendingIds.length ? [] : pendingIds
+      prev.filter(id => pendingIds.includes(id)).length === pendingIds.length ? [] : pendingIds
     );
   };
 
@@ -1276,6 +1289,9 @@ export default function CuttingOperatorDashboard() {
   const pendingReceiving = fabricInventory.filter(f => f.squareMeters > 0 && !f.freezerLocation).length;
   const inProgressCount = mfgQueueItems.filter(i => i.status === 'IN_PROGRESS').length;
   const pendingCount = mfgQueueItems.filter(i => i.status === 'PENDING').length;
+  const printableQueueItems = mfgQueueItems.filter(isPacketBarcodePrintable);
+  const printableQueueIds = printableQueueItems.map(i => i.id);
+  const selectedPrintableIds = selectedPrintIds.filter(id => printableQueueIds.includes(id));
 
   return (
     <div className="space-y-6">
@@ -2125,26 +2141,25 @@ export default function CuttingOperatorDashboard() {
                 size="sm"
                 className="bg-green-600 hover:bg-green-700 text-white"
                 onClick={() => {
-                  const printableItems = mfgQueueItems.filter(i => i.status === 'PENDING' || i.status === 'IN_PROGRESS');
-                  const allIds = printableItems.map(i => i.id);
+                  const allIds = printableQueueItems.map(i => i.id);
                   if (allIds.length > 0) bulkPrintBarcodesMutation.mutate({ queueIds: allIds, quantities: printQuantities });
                 }}
-                disabled={bulkPrintBarcodesMutation.isPending || mfgQueueItems.filter(i => i.status === 'PENDING' || i.status === 'IN_PROGRESS').length === 0}
+                disabled={bulkPrintBarcodesMutation.isPending || printableQueueItems.length === 0}
                 data-testid="button-print-all-barcodes"
               >
                 <Printer className="h-4 w-4 mr-1" />
                 {bulkPrintBarcodesMutation.isPending ? 'Generating...' : 'Print Barcodes'}
               </Button>
-              {selectedPrintIds.length > 0 && (
+              {selectedPrintableIds.length > 0 && (
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() => bulkPrintBarcodesMutation.mutate({ queueIds: selectedPrintIds, quantities: printQuantities })}
+                  onClick={() => bulkPrintBarcodesMutation.mutate({ queueIds: selectedPrintableIds, quantities: printQuantities })}
                   disabled={bulkPrintBarcodesMutation.isPending}
                   data-testid="button-bulk-print-barcodes"
                 >
                   <Printer className="h-4 w-4 mr-1" />
-                  {`Print ${selectedPrintIds.length} Selected`}
+                  {`Print ${selectedPrintableIds.length} Selected`}
                 </Button>
               )}
             </div>
@@ -2170,10 +2185,11 @@ export default function CuttingOperatorDashboard() {
                     <TableHead className="w-10">
                       <input
                         type="checkbox"
-                        checked={selectedPrintIds.length > 0 && selectedPrintIds.length === mfgQueueItems.filter(i => i.status === 'PENDING' || i.status === 'IN_PROGRESS').length}
+                        checked={selectedPrintableIds.length > 0 && selectedPrintableIds.length === printableQueueItems.length}
                         onChange={selectAllPendingForPrint}
                         className="h-4 w-4 rounded border-gray-300"
                         title="Select all for printing"
+                        disabled={printableQueueItems.length === 0}
                       />
                     </TableHead>
                     <TableHead>Part Number</TableHead>
@@ -2199,7 +2215,7 @@ export default function CuttingOperatorDashboard() {
                       data-testid={`row-mfg-item-${item.id}`}
                     >
                       <TableCell>
-                        {(item.status === 'PENDING' || item.status === 'IN_PROGRESS') && (
+                        {isPacketBarcodePrintable(item) ? (
                           <input
                             type="checkbox"
                             checked={selectedPrintIds.includes(item.id)}
@@ -2207,6 +2223,8 @@ export default function CuttingOperatorDashboard() {
                             className="h-4 w-4 rounded border-gray-300"
                             data-testid={`checkbox-print-${item.id}`}
                           />
+                        ) : (
+                          <span className="text-xs text-muted-foreground">-</span>
                         )}
                       </TableCell>
                       <TableCell className="font-mono font-medium">{item.partNumber || '-'}</TableCell>
@@ -2235,22 +2253,25 @@ export default function CuttingOperatorDashboard() {
                         <Badge variant="outline" className="font-mono">{item.estimatedCuts}</Badge>
                       </TableCell>
                       <TableCell className="text-center">
-                        {(item.status === 'PENDING' || item.status === 'IN_PROGRESS') && (
+                        {isPacketBarcodePrintable(item) ? (
                           <Input
                             type="number"
                             min={1}
-                            max={item.quantityOrdered}
-                            value={printQuantities[item.id] ?? item.quantityOrdered}
+                            max={getPrintableBarcodeCount(item)}
+                            value={Math.min(printQuantities[item.id] ?? getPrintableBarcodeCount(item), getPrintableBarcodeCount(item))}
                             onChange={(e) => {
                               const val = parseInt(e.target.value) || 0;
+                              const maxPrintable = getPrintableBarcodeCount(item);
                               setPrintQuantities(prev => ({
                                 ...prev,
-                                [item.id]: Math.max(1, Math.min(val, item.quantityOrdered))
+                                [item.id]: Math.max(1, Math.min(val, maxPrintable))
                               }));
                             }}
                             className="w-16 h-7 text-center text-sm mx-auto"
                             data-testid={`input-print-qty-${item.id}`}
                           />
+                        ) : (
+                          <span className="text-xs text-muted-foreground">None</span>
                         )}
                       </TableCell>
                       <TableCell>{getStatusBadge(item.status)}</TableCell>

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -6,6 +6,14 @@ import { eq, and, or, asc, desc, inArray, like, count } from 'drizzle-orm';
 
 const router = express.Router();
 
+function parseQueueIdFromBuiltPacketBarcode(barcode: string | null | undefined): number | null {
+  if (!barcode) return null;
+  const parts = barcode.split('-');
+  if (parts.length < 5 || parts[0] !== 'PKT') return null;
+  const queueId = Number(parts[parts.length - 3]);
+  return Number.isInteger(queueId) ? queueId : null;
+}
+
 // Get manufacturing queue items for cutting table.
 // DEMAND ROUTING: A record belongs to the Cutting Table dashboard when:
 //   (a) manufacturing_queue.department = 'Cutting Table'  — legacy + BOM-exploded records
@@ -71,6 +79,17 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
       .from(cuttingPacketBOMs)
       .where(eq(cuttingPacketBOMs.isActive, true));
 
+    const builtPacketCounts = new Map<number, number>();
+    const builtPacketRows = await db
+      .select({ barcode: cuttingBuiltPackets.barcode })
+      .from(cuttingBuiltPackets);
+
+    for (const packet of builtPacketRows) {
+      const queueId = parseQueueIdFromBuiltPacketBarcode(packet.barcode);
+      if (queueId === null) continue;
+      builtPacketCounts.set(queueId, (builtPacketCounts.get(queueId) || 0) + 1);
+    }
+
     const formattedItems = queueItems.map(row => {
       // Extract bomId and other data from notes JSON if present
       let packetBomId = null;
@@ -113,6 +132,10 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
         null;
 
       const displayName = packetName || userNotes || row.item?.name || orderId || null;
+      const quantityRequested = row.queue.quantityRequested || 0;
+      const completedQuantity = row.queue.quantityCompleted || 0;
+      const allocatedPacketCount = Math.max(completedQuantity, builtPacketCounts.get(row.queue.id) || 0);
+      const printableBarcodeCount = Math.max(0, quantityRequested - allocatedPacketCount);
       
       return {
         ...row.queue,
@@ -128,6 +151,8 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
         orderId,
         packetName,
         poNumbers,
+        allocatedPacketCount,
+        printableBarcodeCount,
       };
     });
     
@@ -852,6 +877,14 @@ router.post('/bulk-print-barcodes', async (req: Request, res: Response) => {
     if (!queueIds || !Array.isArray(queueIds) || queueIds.length === 0) {
       return res.status(400).json({ error: 'At least one queue ID is required' });
     }
+
+    const parsedQueueIds = queueIds
+      .map((id: unknown) => Number(id))
+      .filter((id: number) => Number.isInteger(id));
+
+    if (parsedQueueIds.length === 0) {
+      return res.status(400).json({ error: 'At least one valid queue ID is required' });
+    }
     
     const printQuantities: Record<number, number> = quantities || {};
     
@@ -862,7 +895,7 @@ router.post('/bulk-print-barcodes', async (req: Request, res: Response) => {
       })
       .from(manufacturingQueue)
       .leftJoin(inventoryItems, eq(manufacturingQueue.inventoryItemId, inventoryItems.id))
-      .where(inArray(manufacturingQueue.id, queueIds));
+      .where(inArray(manufacturingQueue.id, parsedQueueIds));
     
     if (queueItems.length === 0) {
       return res.status(404).json({ error: 'No matching queue items found' });
@@ -870,14 +903,41 @@ router.post('/bulk-print-barcodes', async (req: Request, res: Response) => {
     
     const { generateBarcodeImage } = await import('../utils/barcodeGenerator');
     
+    const builtPacketCounts = new Map<number, number>();
+    const builtPacketRows = await db
+      .select({ barcode: cuttingBuiltPackets.barcode })
+      .from(cuttingBuiltPackets);
+
+    for (const packet of builtPacketRows) {
+      const queueId = parseQueueIdFromBuiltPacketBarcode(packet.barcode);
+      if (queueId === null || !parsedQueueIds.includes(queueId)) continue;
+      builtPacketCounts.set(queueId, (builtPacketCounts.get(queueId) || 0) + 1);
+    }
+
     const allLabels: any[] = [];
+    const skippedAllocated: any[] = [];
     
     for (const row of queueItems) {
       const partNumber = row.item?.agPartNumber || 'UNK';
       const maxQty = row.queue.quantityRequested || 1;
-      const qty = printQuantities[row.queue.id] ? Math.min(printQuantities[row.queue.id], maxQty) : maxQty;
+      const completedQuantity = row.queue.quantityCompleted || 0;
+      const allocatedPacketCount = Math.max(completedQuantity, builtPacketCounts.get(row.queue.id) || 0);
+      const availableToPrint = Math.max(0, maxQty - allocatedPacketCount);
+      const requestedQty = printQuantities[row.queue.id] ? Math.max(0, printQuantities[row.queue.id]) : availableToPrint;
+      const qty = Math.min(requestedQty, availableToPrint);
+
+      if (qty <= 0) {
+        skippedAllocated.push({
+          queueId: row.queue.id,
+          partNumber,
+          quantityRequested: maxQty,
+          allocatedPacketCount,
+        });
+        continue;
+      }
       
-      for (let seq = 1; seq <= qty; seq++) {
+      for (let offset = 0; offset < qty; offset++) {
+        const seq = allocatedPacketCount + offset + 1;
         const barcodeValue = `MFG-${row.queue.id}-${partNumber}-${seq}`;
         
         let barcodeImage;
@@ -900,9 +960,11 @@ router.post('/bulk-print-barcodes', async (req: Request, res: Response) => {
           barcodeImage,
           partNumber,
           partName: row.item?.name || 'Unknown',
-          quantityRequested: qty,
+          quantityRequested: maxQty,
           sequenceNumber: seq,
           quantityCompleted: row.queue.quantityCompleted || 0,
+          allocatedPacketCount,
+          printableBarcodeCount: availableToPrint,
           priority: row.queue.priority,
           dueDate: row.queue.dueDate,
           status: row.queue.status,
@@ -910,7 +972,14 @@ router.post('/bulk-print-barcodes', async (req: Request, res: Response) => {
       }
     }
     
-    res.json({ labels: allLabels, count: allLabels.length });
+    if (allLabels.length === 0) {
+      return res.status(409).json({
+        error: 'No unallocated packet barcodes available to print',
+        skippedAllocated,
+      });
+    }
+
+    res.json({ labels: allLabels, count: allLabels.length, skippedAllocated });
   } catch (error) {
     console.error('Error generating bulk barcodes:', error);
     res.status(500).json({ error: 'Failed to generate bulk barcodes' });


### PR DESCRIPTION
## Summary
- add server-side printable barcode counts for cutting-table queue rows based on completed/built packet allocation
- restrict bulk barcode printing to the unallocated sequence range and reject all-allocated print requests
- update the operator Scheduled Packets controls so select-all, selected-print, and print quantities only target printable/unallocated barcodes

## Validation
- git diff --check
- git diff --cached --check

Note: local app/typecheck was not run because this worktree has no npm command and no node_modules installed.