### PR TITLE
[codex] Fix production endpoint 500 handling

### DIFF
--- a/server/src/lib/p2PurchaseOrderReadiness.ts
+++ b/server/src/lib/p2PurchaseOrderReadiness.ts
@@ -1,0 +1,55 @@
+import { pool } from '../../db';
+
+let p2PurchaseOrderReadinessPromise: Promise<void> | null = null;
+
+export async function ensureP2PurchaseOrderReadSchema(): Promise<void> {
+  if (p2PurchaseOrderReadinessPromise) return p2PurchaseOrderReadinessPromise;
+
+  p2PurchaseOrderReadinessPromise = (async () => {
+    await pool.query(`SELECT pg_advisory_lock(hashtext('epoch_p2_purchase_order_readiness'))`);
+    try {
+      await pool.query(`
+        DO $$
+        BEGIN
+          IF to_regclass('public.p2_purchase_orders') IS NOT NULL THEN
+            ALTER TABLE public.p2_purchase_orders
+              ADD COLUMN IF NOT EXISTS attachments jsonb DEFAULT '[]'::jsonb,
+              ADD COLUMN IF NOT EXISTS tolerance_authorizer_id integer,
+              ADD COLUMN IF NOT EXISTS tolerance_authorizer_name text,
+              ADD COLUMN IF NOT EXISTS tolerance_notes text,
+              ADD COLUMN IF NOT EXISTS bom_configured boolean DEFAULT false,
+              ADD COLUMN IF NOT EXISTS locked_at timestamp,
+              ADD COLUMN IF NOT EXISTS locked_by integer,
+              ADD COLUMN IF NOT EXISTS source_quote_id uuid,
+              ADD COLUMN IF NOT EXISTS contract_review_role text NOT NULL DEFAULT 'secondary',
+              ADD COLUMN IF NOT EXISTS created_by_id integer,
+              ADD COLUMN IF NOT EXISTS created_by_name text,
+              ADD COLUMN IF NOT EXISTS assigned_to_id integer,
+              ADD COLUMN IF NOT EXISTS assigned_to_name text,
+              ADD COLUMN IF NOT EXISTS bom_owner_id integer,
+              ADD COLUMN IF NOT EXISTS bom_owner_name text,
+              ADD COLUMN IF NOT EXISTS scheduled_by_id integer,
+              ADD COLUMN IF NOT EXISTS scheduled_by_name text,
+              ADD COLUMN IF NOT EXISTS production_lead_id integer,
+              ADD COLUMN IF NOT EXISTS production_lead_name text,
+              ADD COLUMN IF NOT EXISTS project_name text,
+              ADD COLUMN IF NOT EXISTS security_classification text NOT NULL DEFAULT 'internal',
+              ADD COLUMN IF NOT EXISTS cui_category text,
+              ADD COLUMN IF NOT EXISTS itar_category text,
+              ADD COLUMN IF NOT EXISTS export_control_jurisdiction text,
+              ADD COLUMN IF NOT EXISTS customer_file_access_rule text NOT NULL DEFAULT 'authenticated',
+              ADD COLUMN IF NOT EXISTS scrapped_item_count integer NOT NULL DEFAULT 0,
+              ADD COLUMN IF NOT EXISTS scrap_rate_percent real NOT NULL DEFAULT 0;
+          END IF;
+        END $$;
+      `);
+    } finally {
+      await pool.query(`SELECT pg_advisory_unlock(hashtext('epoch_p2_purchase_order_readiness'))`);
+    }
+  })().catch((error) => {
+    p2PurchaseOrderReadinessPromise = null;
+    throw error;
+  });
+
+  return p2PurchaseOrderReadinessPromise;
+}

--- a/server/src/routes/projectStepAttachments.ts
+++ b/server/src/routes/projectStepAttachments.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { storage } from '../../storage';
 import { insertProjectStepAttachmentSchema } from '../../schema';
-import { ObjectStorageService } from '../../replit_integrations/object_storage';
+import { ObjectNotFoundError, ObjectStorageService } from '../../replit_integrations/object_storage';
 import { sessionAwareAuth } from '../../middleware/auth';
 
 const router = express.Router();
@@ -234,7 +234,10 @@ router.get('/download/:attachmentId', sessionAwareAuth, async (req, res) => {
         return res.send(buffer);
       } catch (cloudError) {
         console.error('Error downloading from cloud storage:', cloudError);
-        return res.status(500).json({ error: 'Failed to retrieve file from cloud storage' });
+        if (cloudError instanceof ObjectNotFoundError) {
+          return res.status(404).json({ error: 'Attachment file not found in storage' });
+        }
+        return res.status(502).json({ error: 'Failed to retrieve file from cloud storage' });
       }
     } else {
       return res.status(404).json({ error: 'File not found' });

--- a/server/src/routes/shipping.ts
+++ b/server/src/routes/shipping.ts
@@ -2792,7 +2792,7 @@ router.post('/notify-customer/:orderId', async (req: Request, res: Response) => 
 
     // Otherwise fail (email+sms both failed)
     console.log('[API RESPONSE] All notification methods failed:', notificationResult.errors);
-    return res.status(500).json({
+    return res.status(422).json({
       success: false,
       error: 'No valid notification method could be delivered',
       details: notificationResult.errors,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -761,6 +761,7 @@ import {
 import { DEFAULT_SESSIONS_LIMIT } from './src/constants/sessions';
 import { userHasScopedCapability as _userHasScopedCapability } from './src/services/permissionService';
 import { formatDates } from './utils/formatDates';
+import { ensureP2PurchaseOrderReadSchema } from './src/lib/p2PurchaseOrderReadiness';
 import {
   laborEntryDraftsTable,
   type LaborEntryDraftInsert,
@@ -14871,6 +14872,8 @@ export class DatabaseStorage implements IStorage {
 
   // P2 Purchase Orders CRUD
   async getAllP2PurchaseOrders(): Promise<P2PurchaseOrder[]> {
+    await ensureP2PurchaseOrderReadSchema();
+
     // Use pg pool instead of Drizzle/Neon HTTP driver for better compatibility
     const result = await pool.query(`
       SELECT 
@@ -14902,6 +14905,8 @@ export class DatabaseStorage implements IStorage {
   ): Promise<
     (P2PurchaseOrder & { items?: P2PurchaseOrderItem[] }) | undefined
   > {
+    await ensureP2PurchaseOrderReadSchema();
+
     const [po] = await db
       .select()
       .from(p2PurchaseOrders)
@@ -14921,6 +14926,8 @@ export class DatabaseStorage implements IStorage {
   async createP2PurchaseOrder(
     data: InsertP2PurchaseOrder
   ): Promise<P2PurchaseOrder> {
+    await ensureP2PurchaseOrderReadSchema();
+
     // Use pg pool instead of Drizzle/Neon HTTP driver for better compatibility
     const result = await pool.query(`
       INSERT INTO p2_purchase_orders (
@@ -14983,6 +14990,8 @@ export class DatabaseStorage implements IStorage {
     id: number,
     data: Partial<InsertP2PurchaseOrder>
   ): Promise<P2PurchaseOrder> {
+    await ensureP2PurchaseOrderReadSchema();
+
     const [po] = await db
       .update(p2PurchaseOrders)
       .set(data)


### PR DESCRIPTION
## Summary

- Add a route-level P2 purchase order schema-readiness guard before P2 PO list/read/create/update paths touch newer columns.
- Return a business-level `422` for undeliverable manual shipping notifications instead of surfacing them as server `500`s.
- Return clean storage errors for project-step attachment downloads: `404` when the object is missing and `502` for upstream storage retrieval failures.

## Root Cause

The production logs showed several different failures being surfaced as generic internal server errors. The P2 purchase-order bypass path can query newer `p2_purchase_orders` columns before production has received the matching schema additions. Manual shipping notification failures can be valid business failures when no configured notification method can deliver. Project-step attachment downloads were also treating missing storage objects as server crashes.

## Validation

- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/lib/p2PurchaseOrderReadiness.ts`

Full `npm run check`/build was not run because this worktree does not have `npm` or `node_modules` available in the local shell.