### PR TITLE
Link NCR replacements into P2 and PM control

### DIFF
--- a/client/src/components/p2/P2ProductionQueue.tsx
+++ b/client/src/components/p2/P2ProductionQueue.tsx
@@ -79,6 +79,10 @@ interface QueueItem {
   projectId: string | null;
   projectCode: string | null;
   projectName: string | null;
+  isReplacement?: boolean;
+  replacementForSerializedItemId?: string | null;
+  replacementForSerialNumber?: string | null;
+  replacementReason?: string | null;
   hasActiveTask: boolean;
   activeTask: ActiveTask | null;
   barcodePrintedAt?: string | null;
@@ -202,10 +206,12 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
         body: JSON.stringify({ status, reason, notes, linkedTravelerId, performedBy: 'Supervisor' }),
       });
     },
-    onSuccess: (_, variables) => {
+    onSuccess: (data: any, variables) => {
       const desc = variables.status === 'COMPLETED' 
         ? 'Item marked as completed (off-system production) and added to traveler management'
-        : `Item status changed to ${variables.status}`;
+        : variables.status === 'SCRAPPED' && data?.replacementItem
+          ? `Item marked NCR/scrapped. Replacement ${data.replacementItem.serialNumber} was added to the production queue.`
+          : `Item status changed to ${variables.status}`;
       toast({
         title: 'Status Updated',
         description: desc,
@@ -832,6 +838,15 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
                                         <TableCell className="font-mono font-semibold">
                                           <div className="flex items-center gap-1.5">
                                             {item.barcode || item.serialNumber}
+                                            {item.isReplacement && (
+                                              <Badge
+                                                variant="outline"
+                                                className="border-blue-300 bg-blue-50 text-blue-700 text-[10px] font-sans"
+                                                title={item.replacementReason || undefined}
+                                              >
+                                                Replacement
+                                              </Badge>
+                                            )}
                                             {item.barcodePrintedAt && (
                                               <span
                                                 className="inline-flex items-center gap-0.5 text-muted-foreground/70"
@@ -846,6 +861,11 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
                                         <TableCell>
                                           <div>{item.partNumber}</div>
                                           <div className="text-xs text-muted-foreground">{item.partName}</div>
+                                          {item.isReplacement && (
+                                            <div className="text-xs text-blue-700 dark:text-blue-300">
+                                              Replaces {item.replacementForSerialNumber || item.replacementForSerializedItemId || 'NCR item'}
+                                            </div>
+                                          )}
                                         </TableCell>
                                         <TableCell>
                                           <div>{item.poNumber}</div>
@@ -1142,10 +1162,10 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-red-600">
               <XCircle className="h-5 w-5" />
-              Scrap Item
+              Mark Item NCR / Scrap
             </DialogTitle>
             <DialogDescription>
-              This action is permanent and will remove the item from production.
+              This removes the NCR item from active production and creates a linked replacement item in the P2 queue.
             </DialogDescription>
           </DialogHeader>
           
@@ -1154,7 +1174,7 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
               <div className="bg-red-50 dark:bg-red-950 p-3 rounded-lg border border-red-200">
                 <div className="flex items-center gap-2 text-red-700 dark:text-red-400">
                   <AlertTriangle className="h-4 w-4" />
-                  <span className="font-medium">Warning: This cannot be undone</span>
+                  <span className="font-medium">NCR replacement required</span>
                 </div>
                 <div className="mt-2">
                   <div className="font-medium">{selectedItem.barcode}</div>
@@ -1165,9 +1185,9 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
               </div>
               
               <div>
-                <label className="text-sm font-medium">Reason for Scrapping *</label>
+                <label className="text-sm font-medium">NCR / Scrap Reason *</label>
                 <Textarea
-                  placeholder="Enter reason for scrapping this item..."
+                  placeholder="Enter the NCR reason and replacement context..."
                   value={scrapReason}
                   onChange={(e) => setScrapReason(e.target.value)}
                   className="mt-1"
@@ -1192,7 +1212,7 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
               ) : (
                 <XCircle className="h-4 w-4 mr-2" />
               )}
-              Scrap Item
+              Mark NCR & Create Replacement
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -120,6 +120,9 @@ interface WorkOrderRow {
   currentTravelerStep: string | null;
   activeTravelerId: string | null;
   activeTravelerNumber: string | null;
+  ncrReplacementCount?: number;
+  activeReplacementCount?: number;
+  replacementSerialNumbers?: string | null;
   daysScheduleVariance: number | null;
   blockReason: string | null;
 }
@@ -533,9 +536,25 @@ function ProductionTab({ projectId }: { projectId: string }) {
                         P2
                       </Badge>
                     )}
+                    {(row.ncrReplacementCount ?? 0) > 0 && (
+                      <Badge
+                        variant="outline"
+                        className="font-sans text-[10px] px-1.5 py-0 border-blue-300 bg-blue-50 text-blue-700"
+                        title={row.replacementSerialNumbers || undefined}
+                      >
+                        NCR replacement
+                      </Badge>
+                    )}
                   </div>
                 </TableCell>
-                <TableCell className="text-sm">{row.partNumber}</TableCell>
+                <TableCell className="text-sm">
+                  <div>{row.partNumber}</div>
+                  {(row.ncrReplacementCount ?? 0) > 0 && (
+                    <div className="text-xs text-blue-700 dark:text-blue-300">
+                      {row.activeReplacementCount || 0} active replacement{(row.activeReplacementCount || 0) === 1 ? '' : 's'}
+                    </div>
+                  )}
+                </TableCell>
                 <TableCell className="text-right text-sm text-muted-foreground">
                   <div className="flex flex-col items-end gap-1">
                     <span>

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3331,6 +3331,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const activeTask = taskByItemId.get(item.id);
         const poId = item.poId ?? item.po_id ?? null;
         const linkedProject = poId ? projectByPoId.get(Number(poId)) : null;
+        const metadata = item.metadata || {};
         
         departmentQueues[dept].push({
           id: item.id,
@@ -3347,6 +3348,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           projectId: linkedProject?.projectId ?? null,
           projectCode: linkedProject?.projectCode ?? null,
           projectName: linkedProject?.projectName ?? null,
+          isReplacement: metadata.isReplacement === true,
+          replacementForSerializedItemId: metadata.replacementForSerializedItemId ?? null,
+          replacementForSerialNumber: metadata.replacementForSerialNumber ?? null,
+          replacementReason: metadata.replacementReason ?? null,
           hasActiveTask: !!activeTask,
           barcodePrintedAt: item.barcodePrintedAt || null,
           activeTask: activeTask ? {
@@ -3443,6 +3448,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { db } = await import('../../db');
       const { p2SerializedItems, p2SerializedItemEvents, travelers, auditEvents } = await import('../../schema');
       const { eq, desc } = await import('drizzle-orm');
+      const { randomUUID } = await import('crypto');
       
       const [item] = await db.select().from(p2SerializedItems).where(eq(p2SerializedItems.id, itemId)).limit(1);
       
@@ -3572,6 +3578,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
       let travelerCreated = false;
       let linkedTravelerFound = false;
+      let replacementItem: any = null;
       if (status === 'COMPLETED') {
         if (linkedTravelerId) {
           const [existingTraveler] = await db.select().from(travelers).where(eq(travelers.id, linkedTravelerId)).limit(1);
@@ -3629,12 +3636,156 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           travelerCreated = true;
         }
       }
+
+      if (status === 'SCRAPPED') {
+        const siblingItems = await db
+          .select()
+          .from(p2SerializedItems)
+          .where(eq(p2SerializedItems.poItemId, item.poItemId));
+
+        const existingReplacement = siblingItems.find((candidate: any) => {
+          const metadata = candidate.metadata || {};
+          return metadata.isReplacement === true && metadata.replacementForSerializedItemId === itemId;
+        });
+
+        if (!existingReplacement) {
+          const now = new Date();
+          const replacementNumber = siblingItems.filter((candidate: any) => {
+            const metadata = candidate.metadata || {};
+            return metadata.isReplacement === true
+              && (
+                metadata.replacementForSerializedItemId === itemId
+                || metadata.replacementForSerialNumber === item.serialNumber
+              );
+          }).length + 1;
+          const replacementSuffix = `R${replacementNumber}`;
+          const baseSerial = item.serialNumber || item.barcode || item.id;
+          const baseBarcode = item.barcode || baseSerial;
+          const replacementSerialNumber = `${baseSerial}-${replacementSuffix}`;
+          const replacementBarcode = `${baseBarcode}-${replacementSuffix}`;
+          const maxSequenceNumber = Math.max(
+            Number(item.sequenceNumber || 0),
+            ...siblingItems.map((candidate: any) => Number(candidate.sequenceNumber || 0))
+          );
+          const replacementId = randomUUID();
+          const replacementMetadata = {
+            ...((item.metadata as Record<string, unknown> | null) || {}),
+            isReplacement: true,
+            replacementForSerializedItemId: itemId,
+            replacementForSerialNumber: item.serialNumber,
+            replacementForBarcode: item.barcode,
+            replacementReason: reason,
+            replacementCreatedAt: now.toISOString(),
+            replacementCreatedBy: performedBy || 'System',
+            replacementSource: 'NCR_SCRAP',
+          };
+
+          const [createdReplacement] = await db.insert(p2SerializedItems).values({
+            id: replacementId,
+            poId: item.poId,
+            poItemId: item.poItemId,
+            poNumber: item.poNumber,
+            partNumber: item.partNumber,
+            partName: item.partName,
+            customerId: item.customerId,
+            customerName: item.customerName,
+            sequenceNumber: maxSequenceNumber + 1,
+            serialNumber: replacementSerialNumber,
+            barcode: replacementBarcode,
+            travelerBarcode: replacementBarcode,
+            buildFamilyKey: item.buildFamilyKey,
+            partRoutingId: item.partRoutingId,
+            partRoutingRevision: item.partRoutingRevision,
+            sku: item.sku,
+            drawingName: item.drawingName,
+            status: 'ACTIVE',
+            currentDepartment: item.currentDepartment || 'Pending Layup',
+            currentStageIndex: item.currentStageIndex || 0,
+            notes: `Replacement for NCR item ${item.serialNumber || item.barcode}. ${reason}`,
+            metadata: replacementMetadata,
+            createdAt: now,
+            updatedAt: now,
+          }).returning();
+
+          replacementItem = createdReplacement;
+
+          await db.update(p2SerializedItems)
+            .set({
+              metadata: {
+                ...((item.metadata as Record<string, unknown> | null) || {}),
+                ncrReplacementSerializedItemId: replacementId,
+                ncrReplacementSerialNumber: replacementSerialNumber,
+                ncrReplacementBarcode: replacementBarcode,
+                ncrReplacementCreatedAt: now.toISOString(),
+              },
+              updatedAt: now,
+            })
+            .where(eq(p2SerializedItems.id, itemId));
+
+          await db.insert(p2SerializedItemEvents).values({
+            serializedItemId: replacementId,
+            barcode: replacementBarcode,
+            eventType: 'NCR_REPLACEMENT_CREATED',
+            performedBy: performedBy || 'System',
+            notes: `Replacement created for NCR item ${item.serialNumber || item.barcode} - ${reason}`,
+            metadata: {
+              originalSerializedItemId: itemId,
+              originalSerialNumber: item.serialNumber,
+              originalBarcode: item.barcode,
+              replacementReason: reason,
+            },
+          });
+
+          await db.insert(p2SerializedItemEvents).values({
+            serializedItemId: itemId,
+            barcode: item.barcode,
+            eventType: 'NCR_REPLACEMENT_LINKED',
+            performedBy: performedBy || 'System',
+            notes: `Replacement item ${replacementSerialNumber} linked to this NCR scrap`,
+            metadata: {
+              replacementSerializedItemId: replacementId,
+              replacementSerialNumber,
+              replacementBarcode,
+              replacementReason: reason,
+            },
+          });
+
+          if (activeTraveler) {
+            await db.insert(auditEvents).values({
+              entityType: 'traveler',
+              entityId: activeTraveler.id,
+              action: 'NCR_REPLACEMENT_CREATED',
+              actorName: performedBy || 'System',
+              reason,
+              meta: {
+                travelerId: activeTraveler.id,
+                travelerNumber: activeTraveler.travelerNumber,
+                originalSerializedItemId: itemId,
+                replacementSerializedItemId: replacementId,
+                replacementSerialNumber,
+                replacementBarcode,
+                poId: item.poId,
+                poNumber: item.poNumber,
+              },
+            });
+          }
+        } else {
+          replacementItem = existingReplacement;
+        }
+      }
       
       res.json({
         success: true,
         message: `Item status updated to ${status}`,
         travelerCreated,
         linkedTravelerFound,
+        replacementCreated: Boolean(replacementItem),
+        replacementItem: replacementItem ? {
+          id: replacementItem.id,
+          serialNumber: replacementItem.serialNumber,
+          barcode: replacementItem.barcode,
+          currentDepartment: replacementItem.currentDepartment,
+        } : null,
       });
     } catch (_error) {
       console.error('P2 Update item status error:', _error);

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -91,6 +91,9 @@ interface ProductionRow {
   currentTravelerStep: string | null;
   activeTravelerId: string | null;
   activeTravelerNumber: string | null;
+  ncrReplacementCount: number;
+  activeReplacementCount: number;
+  replacementSerialNumbers: string | null;
   daysScheduleVariance: string | null;
   blockReason: string | null;
 }
@@ -413,6 +416,9 @@ router.get('/:projectId/production', h(async (req, res) => {
         ORDER BY t.created_at DESC
         LIMIT 1
       ) AS "activeTravelerNumber",
+      0::int AS "ncrReplacementCount",
+      0::int AS "activeReplacementCount",
+      NULL::text AS "replacementSerialNumbers",
       CASE
         WHEN wo.due_date IS NULL THEN NULL
         WHEN wo.status IN ('COMPLETE', 'CLOSED') THEN
@@ -459,6 +465,28 @@ router.get('/:projectId/production', h(async (req, res) => {
         NULL::text AS "currentTravelerStep",
         NULL::text AS "activeTravelerId",
         NULL::text AS "activeTravelerNumber",
+        (
+          SELECT COUNT(*)::int
+          FROM p2_serialized_items psi
+          WHERE psi.po_id = p2po_head.id
+            AND (p2po.p2_po_item_id IS NULL OR psi.po_item_id = p2po.p2_po_item_id)
+            AND psi.metadata->>'isReplacement' = 'true'
+        ) AS "ncrReplacementCount",
+        (
+          SELECT COUNT(*)::int
+          FROM p2_serialized_items psi
+          WHERE psi.po_id = p2po_head.id
+            AND (p2po.p2_po_item_id IS NULL OR psi.po_item_id = p2po.p2_po_item_id)
+            AND psi.status = 'ACTIVE'
+            AND psi.metadata->>'isReplacement' = 'true'
+        ) AS "activeReplacementCount",
+        (
+          SELECT string_agg(psi.serial_number, ', ' ORDER BY psi.created_at DESC)
+          FROM p2_serialized_items psi
+          WHERE psi.po_id = p2po_head.id
+            AND (p2po.p2_po_item_id IS NULL OR psi.po_item_id = p2po.p2_po_item_id)
+            AND psi.metadata->>'isReplacement' = 'true'
+        ) AS "replacementSerialNumbers",
         CASE
           WHEN p2po.due_date IS NULL THEN NULL
           WHEN p2po.status IN ('COMPLETED', 'CLOSED') THEN


### PR DESCRIPTION
## Summary
- Create an active replacement serialized item when a P2 queue item is marked NCR/scrapped
- Store replacement linkage in serialized-item metadata and append P2/audit events for the original and replacement items
- Surface replacement markers in the P2 production queue and PM Control Center production tab

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`

Note: local TypeScript/build validation was not runnable because this worktree has no `node_modules`, and `npm`/`gh` were unavailable in the shell.