### PR TITLE
Assign approvals to employee dashboards

### DIFF
--- a/client/src/components/MyTasksControlCenter.tsx
+++ b/client/src/components/MyTasksControlCenter.tsx
@@ -90,6 +90,25 @@ interface TimekeepingTasksResponse {
   stats: TaskStats;
 }
 
+interface ApprovalDashboardTask {
+  id: string;
+  type: 'approval_request';
+  title: string;
+  description: string;
+  requestType: string;
+  requestedByDisplayName: string;
+  createdAt: string;
+  dueAt: string | null;
+  priority: 'normal' | 'overdue';
+  actionUrl: string;
+  sourceId: string;
+}
+
+interface ApprovalTasksResponse {
+  tasks: ApprovalDashboardTask[];
+  stats: TaskStats;
+}
+
 interface MyTasksControlCenterProps {
   employeeId: number;
   userName?: string;
@@ -137,6 +156,13 @@ export default function MyTasksControlCenter({
     refetchInterval: 60_000,
   });
 
+  const { data: approvalTasksData } = useQuery<ApprovalTasksResponse>({
+    queryKey: ['/api/approvals/my-tasks', employeeId],
+    queryFn: () => apiRequest(`/api/approvals/my-tasks/${employeeId}`),
+    enabled: !!employeeId,
+    refetchInterval: 60_000,
+  });
+
   const updateTaskMutation = useMutation({
     mutationFn: ({ taskId, data }: { taskId: string; data: any }) =>
       apiRequest(`/api/preproduction-checklists/tasks/${taskId}`, {
@@ -159,14 +185,17 @@ export default function MyTasksControlCenter({
 
   const tasks = tasksData?.tasks || [];
   const timekeepingTasks = timekeepingTasksData?.tasks || [];
+  const approvalTasks = approvalTasksData?.tasks || [];
   const baseStats = tasksData?.stats || { total: 0, completed: 0, pending: 0, overdue: 0 };
   const sigPending = signatureStats?.pending || 0;
   const timekeepingPending = timekeepingTasksData?.stats?.pending || 0;
+  const approvalPending = approvalTasksData?.stats?.pending || 0;
+  const approvalOverdue = approvalTasksData?.stats?.overdue || 0;
   const stats = {
-    total: baseStats.total + sigPending + timekeepingPending,
+    total: baseStats.total + sigPending + timekeepingPending + approvalPending,
     completed: baseStats.completed,
-    pending: baseStats.pending + sigPending + timekeepingPending,
-    overdue: baseStats.overdue,
+    pending: baseStats.pending + sigPending + timekeepingPending + approvalPending,
+    overdue: baseStats.overdue + approvalOverdue,
   };
 
   const filteredTasks = tasks.filter((task) => {
@@ -264,6 +293,8 @@ export default function MyTasksControlCenter({
                 employeeName={userName || ''}
                 compact={true}
               />
+
+              <ApprovalRequestTasks tasks={approvalTasks} compact={true} />
 
               <TimekeepingApprovalTasks tasks={timekeepingTasks} compact={true} />
 
@@ -368,6 +399,8 @@ export default function MyTasksControlCenter({
           employeeName={userName || ''}
           compact={true}
         />
+
+        <ApprovalRequestTasks tasks={approvalTasks} />
 
         <TimekeepingApprovalTasks tasks={timekeepingTasks} />
 
@@ -534,6 +567,53 @@ export default function MyTasksControlCenter({
         </Tabs>
       </CardContent>
     </Card>
+  );
+}
+
+function ApprovalRequestTasks({
+  tasks,
+  compact = false,
+}: {
+  tasks: ApprovalDashboardTask[];
+  compact?: boolean;
+}) {
+  if (tasks.length === 0) return null;
+
+  const visibleTasks = compact ? tasks.slice(0, 3) : tasks;
+
+  return (
+    <div className="space-y-2" data-testid="approval-request-tasks">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground font-medium">
+          Assigned Approvals
+        </p>
+        <Badge variant="outline">{tasks.length}</Badge>
+      </div>
+      {visibleTasks.map((task) => (
+        <div
+          key={task.id}
+          className={`flex items-start gap-3 p-3 border rounded-lg ${
+            task.priority === 'overdue'
+              ? 'bg-red-50/70 border-red-200'
+              : 'bg-blue-50/70 border-blue-200'
+          }`}
+        >
+          <ClipboardList className="h-4 w-4 mt-0.5 text-blue-700 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold truncate">{task.title}</p>
+            <p className="text-xs text-muted-foreground truncate">{task.description}</p>
+            <p className="text-xs text-muted-foreground truncate">
+              Requested by {task.requestedByDisplayName}
+            </p>
+          </div>
+          <Link href={task.actionUrl}>
+            <Button variant="outline" size="sm">
+              <ExternalLink className="h-4 w-4" />
+            </Button>
+          </Link>
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/client/src/pages/ApprovalsInbox.tsx
+++ b/client/src/pages/ApprovalsInbox.tsx
@@ -9,7 +9,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
-import { CheckCircle2, XCircle, Clock, AlertTriangle, ShieldAlert } from 'lucide-react';
+import { CheckCircle2, XCircle, Clock, AlertTriangle, ShieldAlert, UserPlus } from 'lucide-react';
 
 interface ApprovalRequest {
   id: string;
@@ -18,12 +18,21 @@ interface ApprovalRequest {
   subjectType: string | null;
   subjectId: string | null;
   requestedByDisplayName: string;
+  requestedByUserId: number | null;
   status: string;
   currentApproverRole: string | null;
   currentApproverUserId: number | null;
   escalationLevel: number;
   currentLevelDeadline: string | null;
   createdAt: string;
+}
+
+interface EmployeeOption {
+  id: number;
+  name: string;
+  employeeCode?: string | null;
+  department?: string | null;
+  userId?: number | null;
 }
 
 interface DecisionState {
@@ -119,6 +128,10 @@ export default function ApprovalsInbox() {
     refetchInterval: 30000,
   });
 
+  const { data: employees = [] } = useQuery<EmployeeOption[]>({
+    queryKey: ['/api/employees'],
+  });
+
   const { data: detail } = useQuery<{
     request: ApprovalRequest;
     history: any[];
@@ -132,12 +145,12 @@ export default function ApprovalsInbox() {
     mutationFn: async (vars: { id: string; action: 'approve' | 'reject'; body: DecisionState }) =>
       apiRequest(`/api/approvals/${vars.id}/${vars.action}`, {
         method: 'POST',
-        body: JSON.stringify({
+        body: {
           notes: vars.body.notes || null,
           reasonCode: vars.body.reasonCode || null,
           signature: vars.body.signature || null,
-        }),
-      }).then((r) => r.json()),
+        },
+      }),
     onSuccess: (_data, vars) => {
       toast({
         title: vars.action === 'approve' ? 'Approved' : 'Rejected',
@@ -156,9 +169,43 @@ export default function ApprovalsInbox() {
     },
   });
 
+  const assignApproval = useMutation({
+    mutationFn: async (vars: { id: string; employeeId: number | null }) =>
+      apiRequest(`/api/approvals/${vars.id}/assignment`, {
+        method: 'PATCH',
+        body: { employeeId: vars.employeeId },
+      }),
+    onSuccess: (updated: ApprovalRequest) => {
+      const assignedEmployee = employees.find((emp) => emp.userId === updated.currentApproverUserId);
+      setSelected(updated);
+      toast({
+        title: assignedEmployee ? 'Approval assigned' : 'Assignment cleared',
+        description: assignedEmployee
+          ? `${updated.requestType} now appears on ${assignedEmployee.name}'s dashboard.`
+          : `${updated.requestType} is back in the role queue.`,
+      });
+      queryClient.invalidateQueries({ queryKey: ['/api/approvals'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/approvals', updated.id] });
+      queryClient.invalidateQueries({ queryKey: ['/api/approvals/my-tasks'] });
+    },
+    onError: (err: any) => {
+      toast({
+        title: 'Assignment failed',
+        description: err?.message ?? 'Could not assign this approval',
+        variant: 'destructive',
+      });
+    },
+  });
+
   const policy = detail?.policy;
   const requiresSignature = !!policy?.requiresSignature;
   const reasonCodes: string[] = Array.isArray(policy?.reasonCodes) ? policy.reasonCodes : [];
+  const selectedRequest = detail?.request ?? selected;
+  const assignableEmployees = employees.filter((emp) => emp.userId);
+  const assignedEmployeeId =
+    selectedRequest?.currentApproverUserId != null
+      ? assignableEmployees.find((emp) => emp.userId === selectedRequest.currentApproverUserId)?.id
+      : null;
 
   return (
     <div className="container mx-auto p-4 max-w-7xl" data-testid="page-approvals">
@@ -223,37 +270,78 @@ export default function ApprovalsInbox() {
                 Choose a pending approval from the list to review and act on it.
               </div>
             )}
-            {selected && (
+            {selectedRequest && (
               <>
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   <div>
                     <span className="text-muted-foreground">Status:</span>{' '}
-                    <Badge variant="outline" data-testid="text-status">{selected.status}</Badge>
+                    <Badge variant="outline" data-testid="text-status">{selectedRequest.status}</Badge>
                   </div>
                   <div>
-                    <span className="text-muted-foreground">Level:</span> {selected.escalationLevel}
+                    <span className="text-muted-foreground">Level:</span> {selectedRequest.escalationLevel}
                   </div>
                   <div>
                     <span className="text-muted-foreground">Approver role:</span>{' '}
-                    {selected.currentApproverRole ?? '—'}
+                    {selectedRequest.currentApproverRole ?? '—'}
                   </div>
                   <div>
                     <span className="text-muted-foreground">Requested by:</span>{' '}
-                    {selected.requestedByDisplayName}
+                    {selectedRequest.requestedByDisplayName}
                   </div>
                 </div>
 
-                {INVENTORY_REQUEST_TYPES.has(selected.requestType) ? (
+                <div className="rounded border bg-muted/20 p-3 space-y-2">
+                  <div className="flex items-center gap-2 text-sm font-semibold">
+                    <UserPlus className="h-4 w-4" />
+                    Assign approval task
+                  </div>
+                  <Select
+                    value={assignedEmployeeId ? String(assignedEmployeeId) : 'none'}
+                    onValueChange={(value) =>
+                      assignApproval.mutate({
+                        id: selectedRequest.id,
+                        employeeId: value === 'none' ? null : Number(value),
+                      })
+                    }
+                    disabled={assignApproval.isPending}
+                  >
+                    <SelectTrigger data-testid="select-approval-assignee">
+                      <SelectValue placeholder="Send to employee dashboard" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">Role queue only</SelectItem>
+                      {assignableEmployees.map((emp) => {
+                        const isRequester = emp.userId === selectedRequest.requestedByUserId;
+                        return (
+                          <SelectItem
+                            key={emp.id}
+                            value={String(emp.id)}
+                            disabled={isRequester}
+                          >
+                            {emp.name}
+                            {emp.employeeCode ? ` (${emp.employeeCode})` : ''}
+                            {isRequester ? ' - requester' : ''}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Assigned approvals appear as tasks on the linked employee dashboard.
+                  </p>
+                </div>
+
+                {INVENTORY_REQUEST_TYPES.has(selectedRequest.requestType) ? (
                   <InventoryApprovalSummary
-                    requestType={selected.requestType}
-                    payload={selected.requestPayload ?? {}}
+                    requestType={selectedRequest.requestType}
+                    payload={selectedRequest.requestPayload ?? {}}
                   />
                 ) : (
-                  selected.requestPayload && Object.keys(selected.requestPayload).length > 0 && (
+                  selectedRequest.requestPayload && Object.keys(selectedRequest.requestPayload).length > 0 && (
                     <div>
                       <div className="text-xs font-semibold text-muted-foreground mb-1">Payload</div>
                       <pre className="bg-muted p-2 rounded text-xs overflow-x-auto max-h-48">
-                        {JSON.stringify(selected.requestPayload, null, 2)}
+                        {JSON.stringify(selectedRequest.requestPayload, null, 2)}
                       </pre>
                     </div>
                   )
@@ -322,7 +410,7 @@ export default function ApprovalsInbox() {
                   <div className="flex gap-2 pt-2">
                     <Button
                       onClick={() =>
-                        decide.mutate({ id: selected.id, action: 'approve', body: decision })
+                        decide.mutate({ id: selectedRequest.id, action: 'approve', body: decision })
                       }
                       disabled={
                         decide.isPending || (requiresSignature && !decision.signature)
@@ -335,7 +423,7 @@ export default function ApprovalsInbox() {
                     <Button
                       variant="destructive"
                       onClick={() =>
-                        decide.mutate({ id: selected.id, action: 'reject', body: decision })
+                        decide.mutate({ id: selectedRequest.id, action: 'reject', body: decision })
                       }
                       disabled={
                         decide.isPending || (!decision.notes && !decision.reasonCode)

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -27,8 +27,8 @@ import {
   InventoryExecutorError,
 } from '../services/inventoryApprovalExecutor';
 import { db } from '../../db';
-import { approvalRequests } from '../../schema';
-import { eq } from 'drizzle-orm';
+import { approvalRequestHistory, approvalRequests, employees, users } from '../../schema';
+import { and, asc, eq } from 'drizzle-orm';
 
 export const approvalsRouter = Router();
 export const escalationPoliciesRouter = Router();
@@ -85,6 +85,75 @@ approvalsRouter.get('/', async (req: Request, res: Response) => {
   }
 });
 
+approvalsRouter.get('/my-tasks/:employeeId', async (req: Request, res: Response) => {
+  try {
+    const employeeId = Number(req.params.employeeId);
+    if (!Number.isInteger(employeeId) || employeeId <= 0) {
+      return res.status(400).json({ error: 'invalid employee id', code: 'INVALID_EMPLOYEE_ID' });
+    }
+
+    const actorEmployeeId = req.user?.employeeId ?? null;
+    if (!isAdminOrOwner(req) && actorEmployeeId !== employeeId) {
+      return res.status(403).json({ error: 'not authorized to view approval tasks', code: 'FORBIDDEN' });
+    }
+
+    const [linkedUser] = await db
+      .select({ userId: users.id })
+      .from(users)
+      .where(and(eq(users.employeeId, employeeId), eq(users.isActive, true)))
+      .limit(1);
+
+    if (!linkedUser) {
+      return res.json({ tasks: [], stats: { total: 0, pending: 0, completed: 0, overdue: 0 } });
+    }
+
+    const rows = await db
+      .select()
+      .from(approvalRequests)
+      .where(
+        and(
+          eq(approvalRequests.status, 'PENDING'),
+          eq(approvalRequests.currentApproverUserId, linkedUser.userId),
+        ),
+      )
+      .orderBy(asc(approvalRequests.currentLevelDeadline))
+      .limit(100);
+
+    const now = Date.now();
+    const tasks = rows.map((row) => {
+      const deadlineMs = row.currentLevelDeadline ? new Date(row.currentLevelDeadline).getTime() : null;
+      const overdue = deadlineMs != null && deadlineMs <= now;
+      return {
+        id: `approval-${row.id}`,
+        type: 'approval_request',
+        title: `Approval required: ${row.requestType}`,
+        description: row.subjectType && row.subjectId
+          ? `${row.subjectType} #${row.subjectId}`
+          : `Requested by ${row.requestedByDisplayName}`,
+        requestType: row.requestType,
+        requestedByDisplayName: row.requestedByDisplayName,
+        createdAt: row.createdAt,
+        dueAt: row.currentLevelDeadline,
+        priority: overdue ? 'overdue' : 'normal',
+        actionUrl: `/approvals?requestId=${row.id}`,
+        sourceId: row.id,
+      };
+    });
+
+    res.json({
+      tasks,
+      stats: {
+        total: tasks.length,
+        pending: tasks.length,
+        completed: 0,
+        overdue: tasks.filter((task) => task.priority === 'overdue').length,
+      },
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: err?.message ?? 'approval tasks failed' });
+  }
+});
+
 approvalsRouter.get('/:id', async (req: Request, res: Response) => {
   try {
     const result = await getRequest(req.params.id);
@@ -110,6 +179,101 @@ approvalsRouter.get('/:id', async (req: Request, res: Response) => {
     res.json(result);
   } catch (err: any) {
     res.status(500).json({ error: err?.message ?? 'fetch failed' });
+  }
+});
+
+const assignmentBodySchema = z.object({
+  employeeId: z.number().int().positive().nullable().optional(),
+});
+
+approvalsRouter.patch('/:id/assignment', async (req: Request, res: Response) => {
+  try {
+    const body = assignmentBodySchema.parse(req.body ?? {});
+    const [row] = await db
+      .select()
+      .from(approvalRequests)
+      .where(eq(approvalRequests.id, req.params.id));
+    if (!row) return res.status(404).json({ error: 'approval request not found', code: 'NOT_FOUND' });
+    if (row.status !== 'PENDING') {
+      return res.status(409).json({ error: `approval request is ${row.status}`, code: 'NOT_PENDING' });
+    }
+
+    const actor = actorFromReq(req);
+    const isAssignedUser =
+      row.currentApproverUserId != null &&
+      actor.userId != null &&
+      row.currentApproverUserId === actor.userId;
+    const isAssignedRole =
+      !!row.currentApproverRole && actor.roles.includes(row.currentApproverRole);
+    if (!isAdminOrOwner(req) && !isAssignedUser && !isAssignedRole) {
+      return res.status(403).json({ error: 'not authorized to assign this approval', code: 'FORBIDDEN' });
+    }
+
+    let assigneeUserId: number | null = null;
+    let assigneeName: string | null = null;
+    if (body.employeeId != null) {
+      const [assignee] = await db
+        .select({
+          employeeId: employees.id,
+          employeeName: employees.name,
+          userId: users.id,
+        })
+        .from(employees)
+        .leftJoin(users, and(eq(users.employeeId, employees.id), eq(users.isActive, true)))
+        .where(eq(employees.id, body.employeeId))
+        .limit(1);
+
+      if (!assignee) {
+        return res.status(404).json({ error: 'employee not found', code: 'EMPLOYEE_NOT_FOUND' });
+      }
+      if (assignee.userId == null) {
+        return res.status(400).json({
+          error: 'selected employee does not have an active user account',
+          code: 'EMPLOYEE_WITHOUT_USER',
+        });
+      }
+      if (row.requestedByUserId != null && row.requestedByUserId === assignee.userId) {
+        return res.status(403).json({
+          error: 'Self-approval is not permitted. Assign this request to another employee.',
+          code: 'SELF_APPROVAL_BLOCKED',
+        });
+      }
+      assigneeUserId = assignee.userId;
+      assigneeName = assignee.employeeName;
+    }
+
+    const now = new Date();
+    const [updated] = await db
+      .update(approvalRequests)
+      .set({
+        currentApproverUserId: assigneeUserId,
+        updatedAt: now,
+      })
+      .where(eq(approvalRequests.id, row.id))
+      .returning();
+
+    await db.insert(approvalRequestHistory).values({
+      approvalRequestId: row.id,
+      event: 'ASSIGNED',
+      fromLevel: row.escalationLevel,
+      toLevel: row.escalationLevel,
+      fromStatus: row.status,
+      toStatus: row.status,
+      actorUserId: actor.userId,
+      actorDisplayName: actor.displayName,
+      notes: assigneeUserId == null
+        ? 'Approval assignment cleared'
+        : `Approval assigned to ${assigneeName}`,
+      metadata: {
+        assignedEmployeeId: body.employeeId ?? null,
+        assignedUserId: assigneeUserId,
+        assignedEmployeeName: assigneeName,
+      },
+    });
+
+    res.json(updated);
+  } catch (err: any) {
+    handleEscalationError(err, res);
   }
 });
 


### PR DESCRIPTION
## Summary
- Add an approval assignment endpoint that pins a pending approval to a linked employee user and records assignment history.
- Add an employee assignee selector to the approvals inbox, with self-approval/requester assignment blocked.
- Surface assigned approvals in the existing My Tasks dashboard card for the assigned employee.

## Validation
- `git diff --check`
- `git diff --cached --check`

Note: full TypeScript/build validation was not available because this worktree has no `npm` on PATH and no `node_modules`.