### PR TITLE
Fix completed project step view links

### DIFF
--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -102,6 +102,7 @@ export default function P2ControlCenter() {
   const urlParams = new URLSearchParams(window.location.search);
   const tabFromUrl = urlParams.get('tab');
   const poFromUrl = urlParams.get('po') || undefined;
+  const poIdFromUrl = urlParams.get('poId') ? Number(urlParams.get('poId')) : null;
   const unitsFromUrl = urlParams.get('units') || undefined;
   const searchFromUrl = urlParams.get('search') || '';
   // WAD context: passed from project workflow card
@@ -180,15 +181,22 @@ export default function P2ControlCenter() {
 
   useEffect(() => {
     if (selectedPOIds.length === 0) return;
-    const openPOIdSet = new Set(openPOs.map((po) => po.id));
-    const pruned = selectedPOIds.filter((id) => openPOIdSet.has(id));
+    const knownPOIdSet = new Set(allPOStatuses.map((po) => po.id));
+    const pruned = selectedPOIds.filter((id) => knownPOIdSet.has(id));
     if (pruned.length !== selectedPOIds.length) {
       setSelectedPOIds(pruned);
     }
-  }, [openPOs]);
+  }, [allPOStatuses]);
+
+  useEffect(() => {
+    if (!poIdFromUrl || allPOStatuses.length === 0) return;
+    if (allPOStatuses.some((po) => po.id === poIdFromUrl)) {
+      setSelectedPOIds([poIdFromUrl]);
+    }
+  }, [poIdFromUrl, allPOStatuses]);
 
   const selectedPONumbers = selectedPOIds.length > 0
-    ? openPOs.filter((po) => selectedPOIds.includes(po.id)).map((po) => po.poNumber)
+    ? allPOStatuses.filter((po) => selectedPOIds.includes(po.id)).map((po) => po.poNumber)
     : poFromUrl
       ? [poFromUrl]
     : [];

--- a/client/src/pages/PreproductionChecklistPage.tsx
+++ b/client/src/pages/PreproductionChecklistPage.tsx
@@ -169,16 +169,17 @@ export default function PreproductionChecklistPage() {
 
   // Parse context query params passed from the project workflow card
   const searchParams = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '');
+  const contextChecklistId = searchParams.get('id') || '';
   const contextProjectId = searchParams.get('projectId') || '';
   const contextProjectName = searchParams.get('projectName') || '';
   const contextPoNumber = searchParams.get('poNumber') || '';
 
   // Auto-open create dialog when navigated from a project workflow card
   useEffect(() => {
-    if (contextProjectId && !selectedChecklist) {
+    if (contextProjectId && !contextChecklistId && !selectedChecklist) {
       setIsCreateChecklistOpen(true);
     }
-  }, [contextProjectId]);
+  }, [contextProjectId, contextChecklistId, selectedChecklist]);
 
   return (
     <div className="container mx-auto p-6 space-y-6" data-testid="preproduction-checklist-page">
@@ -220,6 +221,7 @@ export default function PreproductionChecklistPage() {
               onSelectChecklist={setSelectedChecklist}
               isCreateOpen={isCreateChecklistOpen}
               setIsCreateOpen={setIsCreateChecklistOpen}
+              selectedChecklistId={contextChecklistId}
               initialProjectName={contextProjectName}
               initialPoNumber={contextPoNumber}
             />
@@ -257,6 +259,7 @@ function ChecklistsTab({
   onSelectChecklist,
   isCreateOpen,
   setIsCreateOpen,
+  selectedChecklistId = '',
   initialProjectName = '',
   initialPoNumber = '',
 }: {
@@ -267,6 +270,7 @@ function ChecklistsTab({
   onSelectChecklist: (c: Checklist) => void;
   isCreateOpen: boolean;
   setIsCreateOpen: (b: boolean) => void;
+  selectedChecklistId?: string;
   initialProjectName?: string;
   initialPoNumber?: string;
 }) {
@@ -277,6 +281,15 @@ function ChecklistsTab({
     queryKey: ['/api/preproduction-checklists', statusFilter],
     queryFn: () => apiRequest(`/api/preproduction-checklists?status=${statusFilter}`),
   });
+
+  useEffect(() => {
+    if (!selectedChecklistId || checklists.length === 0) return;
+
+    const linkedChecklist = checklists.find((checklist) => checklist.id === selectedChecklistId);
+    if (linkedChecklist) {
+      onSelectChecklist(linkedChecklist);
+    }
+  }, [selectedChecklistId, checklists, onSelectChecklist]);
 
   const { data: templates = [] } = useQuery<Template[]>({
     queryKey: ['/api/preproduction-checklists/templates'],

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -1177,6 +1177,48 @@ export default function ProjectDetailPage() {
 
   const allEmployees = employees;
 
+  const getStepFormRoute = (step: ProjectStep, preferLinkedRecord = false) => {
+    const config = STEP_CONFIG[step.stepType];
+    if (!config?.route) return null;
+
+    const linkedId = getLinkedId(step);
+    const params = new URLSearchParams();
+
+    if (preferLinkedRecord && linkedId) {
+      switch (step.stepType) {
+        case 'rfq_risk_assessment':
+        case 'quote':
+        case 'purchase_review_checklist':
+        case 'preproduction_checklist':
+          params.set('id', String(linkedId));
+          break;
+        case 'p2_order':
+          params.set('tab', 'status');
+          params.set('poId', String(linkedId));
+          break;
+      }
+    }
+
+    switch (step.stepType) {
+      case 'purchase_review_checklist':
+        params.set('projectId', project.id);
+        if (project.customerId) params.set('customerId', project.customerId);
+        break;
+      case 'preproduction_checklist':
+        params.set('projectId', project.id);
+        if (project.projectName) params.set('projectName', project.projectName);
+        if ((project as any).poNumber) params.set('poNumber', (project as any).poNumber);
+        break;
+      case 'rfq_risk_assessment':
+      case 'quote':
+        if (!params.has('id') && project.customerId) params.set('customerId', project.customerId);
+        break;
+    }
+
+    const query = params.toString();
+    return query ? `${config.route}?${query}` : config.route;
+  };
+
   return (
     <div className="container mx-auto p-6 space-y-6">
       <div className="flex items-center gap-4">
@@ -1569,7 +1611,9 @@ export default function ProjectDetailPage() {
                 title: 'Purchase Review Checklist',
                 description: 'Verify PO terms, pricing, and contract requirements before authorizing work.',
                 step: purchaseStep,
-                route: `/purchase-review-checklist?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`,
+                route: purchaseStep
+                  ? getStepFormRoute(purchaseStep, true) || `/purchase-review-checklist?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`
+                  : `/purchase-review-checklist?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`,
                 icon: <ListChecks className="h-5 w-5 text-blue-600" />,
                 gateLabel: 'Complete before WAD',
               },
@@ -1587,7 +1631,9 @@ export default function ProjectDetailPage() {
                 title: 'Pre-Production Checklist',
                 description: 'Confirm drawings, materials, tooling, and task assignments are ready before production release.',
                 step: preprodStep,
-                route: `/preproduction-checklists?projectId=${encodeURIComponent(project.id)}${project.projectName ? `&projectName=${encodeURIComponent(project.projectName)}` : ''}${project.poNumber ? `&poNumber=${encodeURIComponent(project.poNumber)}` : ''}`,
+                route: preprodStep
+                  ? getStepFormRoute(preprodStep, true) || `/preproduction-checklists?projectId=${encodeURIComponent(project.id)}${project.projectName ? `&projectName=${encodeURIComponent(project.projectName)}` : ''}${(project as any).poNumber ? `&poNumber=${encodeURIComponent((project as any).poNumber)}` : ''}`
+                  : `/preproduction-checklists?projectId=${encodeURIComponent(project.id)}${project.projectName ? `&projectName=${encodeURIComponent(project.projectName)}` : ''}${(project as any).poNumber ? `&poNumber=${encodeURIComponent((project as any).poNumber)}` : ''}`,
                 icon: <ClipboardList className="h-5 w-5 text-green-600" />,
                 gateLabel: 'Gate to P2 Production',
               },
@@ -1783,14 +1829,8 @@ export default function ProjectDetailPage() {
                                   variant="outline"
                                   size="sm"
                                   onClick={() => {
-                                    if (!config?.route) return;
-                                    const CUSTOMER_ID_STEPS = ['rfq_risk_assessment', 'quote', 'purchase_review_checklist'];
-                                    const route = step.stepType === 'purchase_review_checklist'
-                                      ? `${config.route}?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`
-                                      : CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
-                                        ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
-                                        : config.route;
-                                    setLocation(route);
+                                    const route = getStepFormRoute(step, true);
+                                    if (route) setLocation(route);
                                   }}
                                   data-testid={`button-open-${step.stepType}`}
                                 >
@@ -1852,14 +1892,8 @@ export default function ProjectDetailPage() {
                                   variant="outline"
                                   size="sm"
                                   onClick={() => {
-                                    if (!config?.route) return;
-                                    const CUSTOMER_ID_STEPS = ['rfq_risk_assessment', 'quote', 'purchase_review_checklist'];
-                                    const route = step.stepType === 'purchase_review_checklist'
-                                      ? `${config.route}?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`
-                                      : CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
-                                        ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
-                                        : config.route;
-                                    setLocation(route);
+                                    const route = getStepFormRoute(step, true);
+                                    if (route) setLocation(route);
                                   }}
                                   data-testid={`button-view-${step.stepType}`}
                                 >
@@ -1952,15 +1986,8 @@ export default function ProjectDetailPage() {
                                   size="sm"
                                   onClick={() => {
                                     startStepMutation.mutate(step.id);
-                                    if (config?.route) {
-                                      const CUSTOMER_ID_STEPS = ['rfq_risk_assessment', 'quote', 'purchase_review_checklist'];
-                                      const route = step.stepType === 'purchase_review_checklist'
-                                        ? `${config.route}?projectId=${encodeURIComponent(project.id)}${project.customerId ? `&customerId=${encodeURIComponent(project.customerId)}` : ''}`
-                                        : CUSTOMER_ID_STEPS.includes(step.stepType) && project?.customerId
-                                          ? `${config.route}?customerId=${encodeURIComponent(project.customerId)}`
-                                          : config.route;
-                                      setLocation(route);
-                                    }
+                                    const route = getStepFormRoute(step);
+                                    if (route) setLocation(route);
                                   }}
                                   disabled={startStepMutation.isPending}
                                 >

--- a/client/src/pages/RFQRiskAssessment.tsx
+++ b/client/src/pages/RFQRiskAssessment.tsx
@@ -95,12 +95,13 @@ export default function RFQRiskAssessment() {
   // Read customerId from URL query param (set when navigating from a project)
   const search = useSearch();
   const urlCustomerId = new URLSearchParams(search).get('customerId') ?? '';
+  const urlAssessmentId = new URLSearchParams(search).get('id') ?? '';
 
   // Tab and search state
   const [activeTab, setActiveTab] = useState('create');
   // If a customerId was passed via URL, keep the create tab active rather than
   // auto-switching to the view list (the operator is starting a new RFQ for that customer).
-  const [userSwitchedTab, setUserSwitchedTab] = useState(!!urlCustomerId);
+  const [userSwitchedTab, setUserSwitchedTab] = useState(!!urlCustomerId || !!urlAssessmentId);
   const [searchTerm, setSearchTerm] = useState('');
   const [editingAssessmentId, setEditingAssessmentId] = useState<number | null>(null);
   const [isViewingSubmitted, setIsViewingSubmitted] = useState(false);
@@ -179,6 +180,18 @@ export default function RFQRiskAssessment() {
       setActiveTab('view');
     }
   }, [assessments.length, userSwitchedTab]);
+
+  const loadedUrlAssessmentRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!urlAssessmentId || assessments.length === 0 || loadedUrlAssessmentRef.current === urlAssessmentId) return;
+
+    const linkedAssessment = assessments.find((assessment) => String(assessment.id) === urlAssessmentId);
+    if (!linkedAssessment) return;
+
+    loadedUrlAssessmentRef.current = urlAssessmentId;
+    loadAssessmentForEditing(linkedAssessment.rfqNumber);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlAssessmentId, assessments]);
 
   // Authorization logic for high-risk RFQs (score > 16)
   const isHighRisk = formData.totalOverallPoints > 16;


### PR DESCRIPTION
## Summary
- Route completed project workflow steps to their linked saved records instead of opening blank new forms
- Add deep-link handling for RFQ risk assessments, pre-production checklists, and P2 PO status selection
- Preserve project context params for new/unlinked forms

## Validation
- `git diff --check -- client/src/pages/ProjectDetailPage.tsx client/src/pages/RFQRiskAssessment.tsx client/src/pages/PreproductionChecklistPage.tsx client/src/pages/P2ControlCenter.tsx`
- `git diff --cached --check`

Note: this worktree does not have `npm` or `node_modules`, so the frontend test suite was not runnable locally.