### PR TITLE
[codex] Clarify FAR flowdown backfill scoring scope

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -108,6 +108,7 @@ import OfflineIndicator from './OfflineIndicator';
 import GlobalSearch from './GlobalSearch';
 import ExecutiveRundownDropdown from './ExecutiveRundownDropdown';
 import { useQuery } from '@tanstack/react-query';
+import { apiRequest } from '@/lib/queryClient';
 import { hasFullAccess, hasRouteAccess, isUserInPermissionsList, DEFAULT_USER_ROUTES, isAdminUser, getRequiredCapability } from '@/config/userPermissions';
 import { getDashboardRoute } from '@/config/dashboardMapping';
 import {
@@ -201,9 +202,11 @@ export default function Navigation() {
 
   const trainingAlertCount = recertCountData?.count ?? 0;
 
-  // Fetch compliance backfill queue count for nav badge
+  // Fetch score-impacting compliance backfill count for nav badge.
+  // Legacy pre-policy items stay visible on the queue page, but are isolated from ERDI scoring.
   const { data: backfillRows } = useQuery<Array<{ id: number }>>({
-    queryKey: ['/api/vendor-pos/compliance-backfill'],
+    queryKey: ['/api/vendor-pos/compliance-backfill', 'enforced'],
+    queryFn: () => apiRequest('/api/vendor-pos/compliance-backfill?filter=enforced'),
     staleTime: 5 * 60 * 1000,
     retry: false,
   });

--- a/client/src/pages/VendorPOComplianceBackfillPage.tsx
+++ b/client/src/pages/VendorPOComplianceBackfillPage.tsx
@@ -679,6 +679,14 @@ const POPULATION_FILTER_LABELS: Record<PopulationFilter, string> = {
   'audit-sensitive-legacy': 'Audit-Sensitive Legacy (exception-flagged)',
 };
 
+const POPULATION_FILTER_VALUES = new Set<PopulationFilter>(['all', 'enforced', 'legacy', 'audit-sensitive-legacy']);
+
+function getInitialPopulationFilter(): PopulationFilter {
+  if (typeof window === 'undefined') return 'all';
+  const filter = new URLSearchParams(window.location.search).get('filter');
+  return POPULATION_FILTER_VALUES.has(filter as PopulationFilter) ? (filter as PopulationFilter) : 'all';
+}
+
 export default function VendorPOComplianceBackfillPage() {
   const [, setLocation] = useLocation();
   const { toast } = useToast();
@@ -687,7 +695,15 @@ export default function VendorPOComplianceBackfillPage() {
   // Population filter mode — controls which server-side population is fetched.
   // 'all' fetches every failing PO and segments them into two sections client-side.
   // Other modes make a targeted server-side call for the specific population.
-  const [populationFilter, setPopulationFilter] = useState<PopulationFilter>('all');
+  const [populationFilter, setPopulationFilter] = useState<PopulationFilter>(getInitialPopulationFilter);
+
+  const updatePopulationFilter = (value: PopulationFilter) => {
+    setPopulationFilter(value);
+    setLocation(value === 'all'
+      ? '/vendor-pos/compliance-backfill'
+      : `/vendor-pos/compliance-backfill?filter=${value}`
+    );
+  };
 
   const backfillQueryUrl = populationFilter === 'all'
     ? '/api/vendor-pos/compliance-backfill'
@@ -772,7 +788,7 @@ export default function VendorPOComplianceBackfillPage() {
             Procurement Compliance Backfill Queue
           </h1>
           <p className="text-muted-foreground text-sm mt-1">
-            Issued POs with compliance gaps affecting the ERDI Procurement score. Enforced POs must be remediated; legacy POs are tracked separately.
+            Issued POs with compliance gaps, separated into current-score enforcement work and isolated legacy review.
           </p>
         </div>
         <Button
@@ -892,7 +908,7 @@ export default function VendorPOComplianceBackfillPage() {
       {/* Filters */}
       <div className="flex flex-wrap gap-3 items-center">
         {/* Population filter mode — server-side targeted fetch */}
-        <Select value={populationFilter} onValueChange={(v) => setPopulationFilter(v as PopulationFilter)}>
+        <Select value={populationFilter} onValueChange={(v) => updatePopulationFilter(v as PopulationFilter)}>
           <SelectTrigger className="w-64">
             <SelectValue placeholder="Population View" />
           </SelectTrigger>
@@ -934,7 +950,7 @@ export default function VendorPOComplianceBackfillPage() {
           </Select>
         )}
         {(filterCompliance !== 'all' || filterVendor !== 'all' || search || populationFilter !== 'all') && (
-          <Button variant="ghost" size="sm" onClick={() => { setFilterCompliance('all'); setFilterVendor('all'); setSearch(''); setPopulationFilter('all'); }}>
+          <Button variant="ghost" size="sm" onClick={() => { setFilterCompliance('all'); setFilterVendor('all'); setSearch(''); updatePopulationFilter('all'); }}>
             Clear filters
           </Button>
         )}

--- a/client/src/pages/admin/EdriDomainDetail.tsx
+++ b/client/src/pages/admin/EdriDomainDetail.tsx
@@ -72,13 +72,22 @@ export default function EdriDomainDetail() {
     queryKey: ['/api/edri/snapshot/latest'],
   });
 
-  const { data: backfillRows } = useQuery<Array<{ id: number }>>({
-    queryKey: ['/api/vendor-pos/compliance-backfill'],
+  const { data: enforcedBackfillRows } = useQuery<Array<{ id: number }>>({
+    queryKey: ['/api/vendor-pos/compliance-backfill', 'enforced'],
+    queryFn: () => apiRequest('/api/vendor-pos/compliance-backfill?filter=enforced'),
     enabled: domainKey === 'PROCUREMENT',
     staleTime: 5 * 60 * 1000,
     retry: false,
   });
-  const backfillCount = backfillRows?.length ?? 0;
+  const { data: legacyBackfillRows } = useQuery<Array<{ id: number }>>({
+    queryKey: ['/api/vendor-pos/compliance-backfill', 'legacy'],
+    queryFn: () => apiRequest('/api/vendor-pos/compliance-backfill?filter=legacy'),
+    enabled: domainKey === 'PROCUREMENT',
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+  const enforcedBackfillCount = enforcedBackfillRows?.length ?? 0;
+  const legacyBackfillCount = legacyBackfillRows?.length ?? 0;
 
   const evidenceMutation = useMutation({
     mutationFn: (snapshotId: number) => apiRequest('POST', '/api/edri/evidence/generate', { snapshotId, domainKey }),
@@ -281,39 +290,44 @@ export default function EdriDomainDetail() {
         </CardContent>
       </Card>
 
-      {/* Procurement: FAR_FLOWDOWN backfill queue CTA */}
+      {/* Procurement: FAR_FLOWDOWN current-score queue CTA */}
       {domainKey === 'PROCUREMENT' && (
-        <Card className={backfillCount > 0 ? 'border-orange-300 dark:border-orange-700' : ''}>
+        <Card className={enforcedBackfillCount > 0 ? 'border-orange-300 dark:border-orange-700' : ''}>
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-base">
-              <ShieldAlert className={`h-5 w-5 ${backfillCount > 0 ? 'text-orange-500' : 'text-green-500'}`} />
-              FAR_FLOWDOWN — Compliance Backfill Queue
+              <ShieldAlert className={`h-5 w-5 ${enforcedBackfillCount > 0 ? 'text-orange-500' : 'text-green-500'}`} />
+              FAR_FLOWDOWN — Current-Score Queue
             </CardTitle>
             <CardDescription>
-              Issued POs with compliance gaps that are directly hurting the FAR_FLOWDOWN score.
+              Enforced POs with compliance gaps count toward FAR_FLOWDOWN. Legacy pre-policy items are isolated unless flagged for Exception Review.
             </CardDescription>
           </CardHeader>
           <CardContent>
             <div className="flex items-center justify-between gap-4 flex-wrap">
               <div>
-                {backfillCount === 0 ? (
+                {enforcedBackfillCount === 0 ? (
                   <div className="flex items-center gap-2 text-green-600 dark:text-green-400">
                     <CheckCircle2 className="h-5 w-5" />
-                    <span className="text-sm font-medium">No issued POs require remediation</span>
+                    <span className="text-sm font-medium">No enforced POs are hurting FAR_FLOWDOWN</span>
                   </div>
                 ) : (
                   <div className="space-y-1">
-                    <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">{backfillCount}</p>
-                    <p className="text-sm text-muted-foreground">issued {backfillCount === 1 ? 'PO requires' : 'POs require'} remediation</p>
+                    <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">{enforcedBackfillCount}</p>
+                    <p className="text-sm text-muted-foreground">enforced {enforcedBackfillCount === 1 ? 'PO requires' : 'POs require'} remediation</p>
                   </div>
+                )}
+                {legacyBackfillCount > 0 && (
+                  <p className="text-xs text-muted-foreground mt-2">
+                    {legacyBackfillCount} legacy {legacyBackfillCount === 1 ? 'item is' : 'items are'} isolated from the current score.
+                  </p>
                 )}
               </div>
               <Button
-                variant={backfillCount > 0 ? 'default' : 'outline'}
-                onClick={() => setLocation('/vendor-pos/compliance-backfill')}
+                variant={enforcedBackfillCount > 0 ? 'default' : 'outline'}
+                onClick={() => setLocation('/vendor-pos/compliance-backfill?filter=enforced')}
               >
                 <ShieldAlert className="h-4 w-4 mr-2" />
-                Open Backfill Queue
+                Open Current-Score Queue
               </Button>
             </div>
           </CardContent>

--- a/server/src/routes/vendorPOs.ts
+++ b/server/src/routes/vendorPOs.ts
@@ -911,7 +911,8 @@ router.delete('/optional-settings/:id', async (req: Request, res: Response) => {
 });
 
 // GET /api/vendor-pos/compliance-backfill - Procurement Compliance Backfill Queue
-// Returns all issued POs with compliance gaps, enriched with per-row failing reasons and recommended actions.
+// Returns issued POs with compliance gaps, enriched with per-row failing reasons and recommended actions.
+// Default "all" includes isolated legacy rows; "enforced" matches the current ERDI scoring population.
 // Must be defined BEFORE /:id to avoid route conflict.
 // Query param: filter = 'all' | 'enforced' | 'legacy' | 'audit-sensitive-legacy'
 const backfillFilterSchema = z.enum(['all', 'enforced', 'legacy', 'audit-sensitive-legacy']).default('all');

--- a/server/src/services/procurementComplianceBackfill.ts
+++ b/server/src/services/procurementComplianceBackfill.ts
@@ -44,8 +44,10 @@ export interface BackfillRow {
 function assignPriority(row: Omit<BackfillRow, 'priority' | 'failingReasons' | 'recommendedActions'>): BackfillPriority {
   const isIssued = ['Sent', 'Partially Received', 'Fully Received'].includes(row.status);
 
-  // No review at all is the most severe failure — drops FAR_FLOWDOWN score to 0.
-  // We don't know FAR/gov status without a review, so all no-review issued POs are HIGH.
+  // No review at all is the most severe enforced-population failure — it drops
+  // FAR_FLOWDOWN to 0 when the PO is in the current scoring population.
+  // Legacy pre-policy rows remain isolated unless they are exception-flagged.
+  // We don't know FAR/gov status without a review, so no-review issued POs are HIGH.
   if (isIssued && row.missingReview) {
     return 'HIGH';
   }


### PR DESCRIPTION
## Summary

Clarifies the FAR_FLOWDOWN backfill queue so isolated legacy items are not presented as current-score failures.

## What changed

- EDRI Procurement domain detail now counts only `filter=enforced` rows as the current-score queue.
- The domain card separately notes legacy backfill items are isolated from the current score.
- The navigation badge now uses the enforced queue count instead of all populations.
- The backfill queue page can open directly in `?filter=enforced` mode and keeps that filter reflected in the URL.
- Server comments now document that the default queue includes isolated legacy rows, while `enforced` matches the current ERDI scoring population.

## Why

The scorer already excludes legacy pre-policy POs from FAR_FLOWDOWN unless they are exception-flagged, but the dashboard card and nav badge were using the unfiltered queue. That made the 48 backfill items look like they were directly hurting the current score.

## Validation

- `git diff --check` passed.
- Full TypeScript check was not run in this fresh clone because `node_modules` is not installed; PowerShell blocked `npm`, and direct `npx` attempted a registry fetch.