### PR TITLE
Require roll numbers during receiving roll split

### DIFF
--- a/client/src/pages/InventoryReceivingControlCenter.tsx
+++ b/client/src/pages/InventoryReceivingControlCenter.tsx
@@ -1475,23 +1475,14 @@ function UnitSplittingStep({ receipt, onNext, onUpdate }: {
       }
       if (splitMode === 'by_rolls') {
         payload.sqmPerRollArray = rollSqms.map(v => parseFloat(v));
+        payload.rollNumbers = rollNumbers.map(v => v.trim());
       }
       return apiRequest(`/api/receipts/${receipt.id}/lines/${selectedLineId}/split`, {
         method: 'POST',
         body: JSON.stringify(payload),
       });
     },
-    onSuccess: async (createdUnits: ReceivedUnit[]) => {
-      if (splitMode === 'by_rolls') {
-        await Promise.all((createdUnits ?? []).map((unit, idx) => {
-          const rollNumber = rollNumbers[idx]?.trim();
-          if (!rollNumber) return Promise.resolve();
-          return apiRequest(`/api/receipts/${receipt.id}/units/${unit.id}`, {
-            method: 'PATCH',
-            body: JSON.stringify({ rollNumber }),
-          });
-        }));
-      }
+    onSuccess: async () => {
       const updated = await apiRequest(`/api/receipts/${receipt.id}`);
       onUpdate(updated);
       setShowSplitDialog(false);
@@ -1740,7 +1731,7 @@ function UnitSplittingStep({ receipt, onNext, onUpdate }: {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="equal">Equal split — divide total quantity evenly</SelectItem>
-                  <SelectItem value="by_rolls">By rolls — enter SQM per roll</SelectItem>
+                  <SelectItem value="by_rolls">By rolls — enter exact roll # and SQM</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -1812,13 +1803,16 @@ function UnitSplittingStep({ receipt, onNext, onUpdate }: {
                     }}
                   />
                 </div>
+                <p className="text-xs text-gray-500">
+                  Enter the exact supplier/manufacturer roll number for each roll before creating the units.
+                </p>
                 <div className="space-y-1 max-h-48 overflow-y-auto pr-1">
                   {rollSqms.map((val, idx) => (
                     <div key={idx} className="grid grid-cols-[56px_1fr_1fr_34px] items-center gap-2">
                       <Label className="text-xs w-14 shrink-0">Roll {idx + 1}</Label>
                       <Input
                         className="h-7 text-xs"
-                        placeholder="Roll #"
+                        placeholder="Exact roll #"
                         value={rollNumbers[idx] ?? ''}
                         onChange={e => setRollNumbers(prev => {
                           const next = [...prev];
@@ -1863,7 +1857,10 @@ function UnitSplittingStep({ receipt, onNext, onUpdate }: {
               disabled={
                 splitLineMutation.isPending ||
                 parseInt(splitCount, 10) < 2 ||
-                (splitMode === 'by_rolls' && rollSqms.some(v => { const n = parseFloat(v); return !Number.isFinite(n) || n <= 0; }))
+                (splitMode === 'by_rolls' && (
+                  rollNumbers.some(v => !v.trim()) ||
+                  rollSqms.some(v => { const n = parseFloat(v); return !Number.isFinite(n) || n <= 0; })
+                ))
               }
             >
               {splitLineMutation.isPending

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -1286,7 +1286,10 @@ export default function CuttingOperatorDashboard() {
       null;
   }, [selectedMfgItem, packetBOMs]);
 
-  const pendingReceiving = fabricInventory.filter(f => f.squareMeters > 0 && !f.freezerLocation).length;
+  const freezerAssignmentQueue = fabricInventory.filter(
+    f => f.squareMeters > 0 && !f.freezerLocation && f.status !== 'depleted'
+  );
+  const pendingReceiving = freezerAssignmentQueue.length;
   const inProgressCount = mfgQueueItems.filter(i => i.status === 'IN_PROGRESS').length;
   const pendingCount = mfgQueueItems.filter(i => i.status === 'PENDING').length;
   const printableQueueItems = mfgQueueItems.filter(isPacketBarcodePrintable);
@@ -1912,8 +1915,7 @@ export default function CuttingOperatorDashboard() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {fabricInventory
-                      .filter(f => f.squareMeters > 0 && !f.freezerLocation)
+                    {freezerAssignmentQueue
                       .slice(0, 20)
                       .map((fabric) => (
                       <TableRow key={fabric.id} className="hover:bg-muted/50" data-testid={`row-fabric-${fabric.id}`}>

--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -1031,6 +1031,14 @@ router.post('/fabric-inventory/:id/assign-freezer', async (req, res) => {
     if (!freezerNumber || isNaN(parseInt(freezerNumber))) {
       return res.status(400).json({ error: 'Valid freezer number is required' });
     }
+
+    const existing = await storage.getCuttingFabricInventory(rollId);
+    if (!existing) {
+      return res.status(404).json({ error: 'Fabric inventory roll not found' });
+    }
+    if (existing.status === 'depleted') {
+      return res.status(409).json({ error: 'Cannot assign freezer to a depleted roll' });
+    }
     
     const inventory = await storage.updateCuttingFabricInventory(rollId, {
       freezerNumber: parseInt(freezerNumber),
@@ -1056,6 +1064,14 @@ router.post('/fabric-inventory/:id/receive', async (req, res) => {
     
     if (!freezerNumber || isNaN(parseInt(freezerNumber))) {
       return res.status(400).json({ error: 'Valid freezer number is required' });
+    }
+
+    const existing = await storage.getCuttingFabricInventory(rollId);
+    if (!existing) {
+      return res.status(404).json({ error: 'Fabric inventory roll not found' });
+    }
+    if (existing.status === 'depleted') {
+      return res.status(409).json({ error: 'Cannot receive depleted fabric into a freezer' });
     }
     
     const updateData: any = {

--- a/server/src/routes/receiving.ts
+++ b/server/src/routes/receiving.ts
@@ -20,6 +20,7 @@ import {
   vendorPOs,
   vendorPOItems,
   inventoryItems,
+  cuttingFabricInventory,
   insertMaterialLotSchema,
   insertMaterialLotTransactionSchema,
   insertMediaLibrarySchema,
@@ -1253,12 +1254,18 @@ async function handleAcceptedUnit(unit: ReceivedUnit, receipt: Receipt, user: Au
 
     // Find inventory item — required for material lot linkage; fail-fast if missing
     const invResult = await db.execute(
-      sql`SELECT id, name, shelf_life_controlled, frozen_shelf_life_days, room_temp_shelf_life_days, default_max_out_time_minutes
+      sql`SELECT id, name, ag_part_number, is_fabric, utilized_in_pl1, utilized_in_pl2, supplier_part_number,
+                 shelf_life_controlled, frozen_shelf_life_days, room_temp_shelf_life_days, default_max_out_time_minutes
           FROM inventory_items WHERE ag_part_number = ${line.agPartNumber} LIMIT 1`
     );
     const invRows = sqlRows<{
       id: number;
       name: string;
+      ag_part_number: string;
+      is_fabric: boolean | null;
+      utilized_in_pl1: boolean | null;
+      utilized_in_pl2: boolean | null;
+      supplier_part_number: string | null;
       shelf_life_controlled: boolean | null;
       frozen_shelf_life_days: number | null;
       room_temp_shelf_life_days: number | null;
@@ -1331,6 +1338,39 @@ async function handleAcceptedUnit(unit: ReceivedUnit, receipt: Receipt, user: Au
       notes: `Receipt ${receipt.receiptNumber} · unit barcode ${unit.barcode}`,
     });
     await db.insert(materialLotTransactions).values(txValues);
+
+    const isCuttingFabric = Boolean(invItem.is_fabric && (invItem.utilized_in_pl1 || invItem.utilized_in_pl2));
+    if (isCuttingFabric) {
+      const toDateOnly = (value: Date | string | null | undefined): string | undefined => {
+        if (!value) return undefined;
+        if (typeof value === 'string') return value.slice(0, 10);
+        return value.toISOString().slice(0, 10);
+      };
+      const qty = Number(unit.quantity);
+      const qtyForFabric = Number.isFinite(qty) && qty > 0 ? qty : 0;
+      const receivedDate = toDateOnly(receipt.receivedAt ?? receipt.receiptDate ?? new Date());
+      await db.insert(cuttingFabricInventory).values({
+        inventoryItemId: invItem.id,
+        source: receipt.vendorName ?? null,
+        fabric: invItem.name ?? line.description ?? line.agPartNumber,
+        fabricPartNumber: line.agPartNumber,
+        nickname: invItem.name ?? line.description ?? null,
+        supplierPartNumber: invItem.supplier_part_number ?? null,
+        supplierPoNumber: receipt.vendorPoNumber ?? null,
+        internalControlNumber: icn,
+        barcode: unit.barcode,
+        lotNumber: unit.lotNumber ?? null,
+        batchNumber: unit.batchNumber ?? unit.heatLot ?? null,
+        rollNumber: unit.rollNumber ?? null,
+        manufactureDate: toDateOnly(unit.manufactureDate) ?? null,
+        receivedDate,
+        expirationDate: toDateOnly(prefilledExpiration ?? unit.expirationDate) ?? null,
+        quantityInStock: qtyForFabric,
+        squareMeters: qtyForFabric > 0 ? String(qtyForFabric) : undefined,
+        notes: `Auto-created from Receiving Control Center receipt ${receipt.receiptNumber} unit ${unit.barcode}. Freezer assignment pending in Cutting Fabric Receiving.`,
+        status: 'active',
+      });
+    }
 
   } catch (err: any) {
     // Re-throw so callers can return a 422 to the client with the exact reason
@@ -1433,8 +1473,9 @@ router.post('/:id/ensure-units', requireReceivingAccess, async (req: Request, re
 // ── POST /api/receipts/:id/lines/:lineId/split ────────────────────────────────
 // Split a receipt line into N units.
 // Equal-split mode (default): Body: { count: number, templateFields?: Partial<InsertReceivedUnit> }
-// Roll-based mode (array): Body: { count: number, sqmPerRollArray: number[], templateFields?: Partial<InsertReceivedUnit> }
-//   Each unit gets the corresponding sqmPerRollArray[i] as its quantity; receivedQty is updated to the array sum.
+// Roll-based mode (array): Body: { count: number, sqmPerRollArray: number[], rollNumbers: string[], templateFields?: Partial<InsertReceivedUnit> }
+//   Each unit gets the corresponding sqmPerRollArray[i] as its quantity and rollNumbers[i] as its exact roll number;
+//   receivedQty is updated to the array sum.
 // Roll-based mode (legacy scalar): Body: { count: number, sqmPerRoll: number, templateFields?: Partial<InsertReceivedUnit> }
 //   All units share the same quantity; receivedQty updated to count × sqmPerRoll.
 router.post('/:id/lines/:lineId/split', requireReceivingAccess, async (req: Request, res: Response) => {
@@ -1442,10 +1483,11 @@ router.post('/:id/lines/:lineId/split', requireReceivingAccess, async (req: Requ
     const receiptId = parseInt(req.params.id);
     const lineId = parseInt(req.params.lineId);
     const user = req.user;
-    const { count, sqmPerRoll, sqmPerRollArray, templateFields } = req.body as {
+    const { count, sqmPerRoll, sqmPerRollArray, rollNumbers, templateFields } = req.body as {
       count: number;
       sqmPerRoll?: number;
       sqmPerRollArray?: number[];
+      rollNumbers?: string[];
       templateFields?: Record<string, unknown>;
     };
 
@@ -1453,6 +1495,7 @@ router.post('/:id/lines/:lineId/split', requireReceivingAccess, async (req: Requ
       return res.status(400).json({ error: 'count must be between 2 and 200' });
     }
 
+    let normalizedRollNumbers: string[] | undefined;
     if (sqmPerRollArray !== undefined) {
       if (!Array.isArray(sqmPerRollArray) || sqmPerRollArray.length !== count) {
         return res.status(400).json({ error: `sqmPerRollArray must have exactly ${count} entries` });
@@ -1460,6 +1503,13 @@ router.post('/:id/lines/:lineId/split', requireReceivingAccess, async (req: Requ
       if (sqmPerRollArray.some(v => typeof v !== 'number' || !Number.isFinite(v) || v <= 0)) {
         return res.status(400).json({ error: 'Every entry in sqmPerRollArray must be a finite positive number' });
       }
+      if (!Array.isArray(rollNumbers) || rollNumbers.length !== count) {
+        return res.status(400).json({ error: `rollNumbers must have exactly ${count} entries` });
+      }
+      if (rollNumbers.some(v => typeof v !== 'string' || v.trim().length === 0)) {
+        return res.status(400).json({ error: 'Every roll number must be provided for roll-based splits' });
+      }
+      normalizedRollNumbers = rollNumbers.map(v => v.trim());
     } else if (sqmPerRoll !== undefined && (typeof sqmPerRoll !== 'number' || !Number.isFinite(sqmPerRoll) || sqmPerRoll <= 0)) {
       return res.status(400).json({ error: 'sqmPerRoll must be a positive number' });
     }
@@ -1500,6 +1550,7 @@ router.post('/:id/lines/:lineId/split', requireReceivingAccess, async (req: Requ
         barcode,
         quantity: String(qtyForUnit),
         uom: line.uom ?? 'EA',
+        ...(isRollArray && normalizedRollNumbers ? { rollNumber: normalizedRollNumbers[i] } : {}),
       });
       unitBodies.push(body);
     }
@@ -1536,6 +1587,7 @@ router.post('/:id/lines/:lineId/split', requireReceivingAccess, async (req: Requ
       mode: isRollBased ? 'by_rolls' : 'equal',
       ...(isRollArray ? {
         sqmPerRollArray: sqmPerRollArray!.map(String),
+        rollNumbers: normalizedRollNumbers,
         totalQty: String(totalQtyForAudit),
       } : isRollScalar ? {
         sqmPerRoll: String(sqmPerRoll),


### PR DESCRIPTION
## Summary
- require exact roll numbers when Step 3 splits receiving lines by rolls
- send roll numbers with the split request and persist them on created received units in the same transaction
- create pending Cutting Fabric Inventory records for accepted cutting-fabric received units so operators can assign freezer location from Fabric Receiving
- remove depleted rolls from the Fabric Receiving freezer-assignment queue and reject stale freezer assignment attempts for depleted rolls
- record roll numbers in the split audit metadata

## Validation
- git diff --check
- git diff --cached --check

Note: local npm/node_modules were unavailable in this worktree, so I could not run the full frontend or TypeScript test suite.