### PR TITLE
[codex] fix P2 to PM control center links

### DIFF
--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -189,11 +189,16 @@ export default function P2ControlCenter() {
   }, [allPOStatuses]);
 
   useEffect(() => {
-    if (!poIdFromUrl || allPOStatuses.length === 0) return;
-    if (allPOStatuses.some((po) => po.id === poIdFromUrl)) {
-      setSelectedPOIds([poIdFromUrl]);
+    if (allPOStatuses.length === 0) return;
+    const selectedPO = poIdFromUrl
+      ? allPOStatuses.find((po) => po.id === poIdFromUrl)
+      : poFromUrl
+        ? allPOStatuses.find((po) => po.poNumber === poFromUrl)
+        : null;
+    if (selectedPO) {
+      setSelectedPOIds([selectedPO.id]);
     }
-  }, [poIdFromUrl, allPOStatuses]);
+  }, [poIdFromUrl, poFromUrl, allPOStatuses]);
 
   const selectedPONumbers = selectedPOIds.length > 0
     ? allPOStatuses.filter((po) => selectedPOIds.includes(po.id)).map((po) => po.poNumber)

--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -522,6 +522,7 @@ function ProductionTab({ projectId }: { projectId: string }) {
                 onClick={() => {
                   if (row.sourceType === 'p2_production_order') {
                     const params = new URLSearchParams({ tab: 'production' });
+                    if (row.p2PoId) params.set('poId', String(row.p2PoId));
                     if (row.p2PoNumber) params.set('po', row.p2PoNumber);
                     navTo(`/p2-control-center?${params.toString()}`);
                     return;
@@ -1350,8 +1351,10 @@ export default function PMControlCenterPage() {
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    const poParam = selectedProject.poNumber ? `?po=${encodeURIComponent(selectedProject.poNumber)}` : '';
-                    navigate(`/p2-control-center${poParam}`);
+                    const params = new URLSearchParams();
+                    if (selectedProject.poId) params.set('poId', String(selectedProject.poId));
+                    if (selectedProject.poNumber) params.set('po', selectedProject.poNumber);
+                    navigate(`/p2-control-center${params.toString() ? `?${params.toString()}` : ''}`);
                   }}
                 >
                   <TrendingUp className="h-3.5 w-3.5 mr-1.5" />

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3058,13 +3058,39 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         poIdsWithSerializedUnits.has(po.id)
       );
 
-      // Look up projects linked to these POs
+      // Look up projects linked to these POs. PM Control Center resolves the
+      // same relationship through either projects.po_id or the p2_order step.
       const poIds = pos.map((po: any) => po.id);
       const projectRows = poIds.length > 0
         ? await dbPool.query(
-            `SELECT po_id AS "poId", id AS "projectId", project_code AS "projectCode", project_name AS "projectName"
-             FROM projects
-             WHERE po_id = ANY($1)`,
+            `WITH project_po_link AS (
+               SELECT
+                 p.id,
+                 p.project_code,
+                 p.project_name,
+                 p.updated_at,
+                 COALESCE(
+                   p.po_id,
+                   (
+                     SELECT ps.linked_p2_order_id
+                     FROM project_steps ps
+                     WHERE ps.project_id = p.id
+                       AND ps.step_type = 'p2_order'
+                       AND ps.linked_p2_order_id IS NOT NULL
+                     ORDER BY ps.updated_at DESC NULLS LAST, ps.completed_at DESC NULLS LAST
+                     LIMIT 1
+                   )
+                 ) AS linked_po_id
+               FROM projects p
+             )
+             SELECT DISTINCT ON (linked_po_id)
+               linked_po_id AS "poId",
+               id AS "projectId",
+               project_code AS "projectCode",
+               project_name AS "projectName"
+             FROM project_po_link
+             WHERE linked_po_id = ANY($1)
+             ORDER BY linked_po_id, updated_at DESC NULLS LAST`,
             [poIds]
           )
         : [];
@@ -3271,9 +3297,34 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const poIds = [...new Set(items.map((item: any) => item.poId ?? item.po_id).filter(Boolean))];
       const projectRows = poIds.length > 0
         ? await dbPool.query(
-            `SELECT po_id AS "poId", id AS "projectId", project_code AS "projectCode", project_name AS "projectName"
-             FROM projects
-             WHERE po_id = ANY($1)`,
+            `WITH project_po_link AS (
+               SELECT
+                 p.id,
+                 p.project_code,
+                 p.project_name,
+                 p.updated_at,
+                 COALESCE(
+                   p.po_id,
+                   (
+                     SELECT ps.linked_p2_order_id
+                     FROM project_steps ps
+                     WHERE ps.project_id = p.id
+                       AND ps.step_type = 'p2_order'
+                       AND ps.linked_p2_order_id IS NOT NULL
+                     ORDER BY ps.updated_at DESC NULLS LAST, ps.completed_at DESC NULLS LAST
+                     LIMIT 1
+                   )
+                 ) AS linked_po_id
+               FROM projects p
+             )
+             SELECT DISTINCT ON (linked_po_id)
+               linked_po_id AS "poId",
+               id AS "projectId",
+               project_code AS "projectCode",
+               project_name AS "projectName"
+             FROM project_po_link
+             WHERE linked_po_id = ANY($1)
+             ORDER BY linked_po_id, updated_at DESC NULLS LAST`,
             [poIds]
           )
         : [];


### PR DESCRIPTION
## Summary
- Resolve P2 Control Center PO/project links through the same direct PO or workflow-step relationship used by PM Control Center.
- Preserve exact PO selection when PM Control Center sends users back into P2 by passing `poId` as well as the PO number.
- Allow P2 to select a PO from either `poId` or `po` URL context so the related Project and PM Control shortcuts appear consistently.

## Root Cause
P2 Control Center only looked up linked projects through `projects.po_id`. Projects connected through the `p2_order` workflow step via `project_steps.linked_p2_order_id` were invisible to the P2 header and production queue link rendering, even though PM Control Center already recognized that relationship.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/main..HEAD`
- `git merge-tree --write-tree HEAD origin/main`

Full build/test was not run locally because this worktree has `node` but no `npm` command and no `node_modules`.