### PR TITLE
[codex] Fix parts request form focus loss

### DIFF
--- a/client/src/components/inventory/PartsRequestsCard.tsx
+++ b/client/src/components/inventory/PartsRequestsCard.tsx
@@ -396,7 +396,7 @@ export default function PartsRequestsCard() {
     }
   };
 
-  const FormContent = () => (
+  const renderFormContent = () => (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
         <Label htmlFor="inventoryItem">Inventory Part *</Label>
@@ -720,7 +720,7 @@ export default function PartsRequestsCard() {
             <DialogHeader>
               <DialogTitle>Create New Parts Request</DialogTitle>
             </DialogHeader>
-            <FormContent />
+            {renderFormContent()}
           </DialogContent>
         </Dialog>
       </div>
@@ -909,7 +909,7 @@ export default function PartsRequestsCard() {
           <DialogHeader>
             <DialogTitle>Edit Parts Request</DialogTitle>
           </DialogHeader>
-          <FormContent />
+          {renderFormContent()}
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- Fix the parts request create/edit dialog so typing into fields does not remount the form and kick focus out of the active input.
- Render the shared form content as a local render function result instead of as a freshly recreated nested component type.

## Root Cause
`FormContent` was declared inside `PartsRequestsCard` and rendered as `<FormContent />`. Every form state update recreated that function, so React saw a new component type, remounted the form, and dropped input focus while users typed.

## Validation
- `git diff --check`
- `git diff --cached --check`

Local app/build checks were not run because `npm` and `node_modules` are not available in this worktree.