### PR TITLE
Sync cutting fabric balances with receiving and usage

### DIFF
--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -10,6 +10,7 @@ import {
   cuttingPacketBOMParts,
   cuttingPacketBOMCuts,
   cuttingFabricInventory,
+  cuttingFabricInventoryTransactions,
 } from '../../schema';
 import { and, gte, lte, eq, desc, ilike, or, isNull } from 'drizzle-orm';
 import {
@@ -33,6 +34,34 @@ import {
 } from '../../schema';
 
 const router = Router();
+
+function parseFabricStockQuantity(value: unknown): number {
+  if (value === null || value === undefined || value === '') return 0;
+  const parsed = typeof value === 'number' ? value : parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function nonZeroInventoryDelta(quantity: number): number {
+  if (quantity === 0) return 0;
+  const magnitude = Math.max(1, Math.round(Math.abs(quantity)));
+  return quantity < 0 ? -magnitude : magnitude;
+}
+
+function syncFabricStockFields<T extends Record<string, any>>(data: T): T {
+  const next = { ...data };
+  const hasQuantityInStock = next.quantityInStock !== undefined && next.quantityInStock !== null && next.quantityInStock !== '';
+  const hasSquareMeters = next.squareMeters !== undefined && next.squareMeters !== null && next.squareMeters !== '';
+
+  if (hasSquareMeters) {
+    const quantity = parseFabricStockQuantity(next.squareMeters);
+    next.quantityInStock = quantity;
+  } else if (hasQuantityInStock) {
+    const quantity = parseFabricStockQuantity(next.quantityInStock);
+    next.squareMeters = String(quantity);
+  }
+
+  return next as T;
+}
 
 // Materials endpoints
 router.get('/materials', async (req, res) => {
@@ -836,30 +865,31 @@ router.get('/fabric-inventory-by-barcode/:barcode', async (req, res) => {
 router.post('/fabric-inventory', async (req, res) => {
   try {
     const validatedData = insertCuttingFabricInventorySchema.parse(req.body);
+    const fabricInventoryData = syncFabricStockFields(validatedData);
     
-    if (!validatedData.barcode) {
+    if (!fabricInventoryData.barcode) {
       const date = new Date().toISOString().split('T')[0].replace(/-/g, '');
       const random = Math.floor(Math.random() * 9999).toString().padStart(4, '0');
       
       let prefix = 'FAB';
-      if (validatedData.productionLineId) {
-        const line = await storage.getCuttingProductionLine(validatedData.productionLineId);
+      if (fabricInventoryData.productionLineId) {
+        const line = await storage.getCuttingProductionLine(fabricInventoryData.productionLineId);
         if (line && line.lineName === 'P2') {
           prefix = 'FI-P2';
         }
       }
       
-      validatedData.barcode = `${prefix}-${date}-${random}`;
+      fabricInventoryData.barcode = `${prefix}-${date}-${random}`;
     }
     
-    if (!validatedData.internalControlNumber) {
+    if (!fabricInventoryData.internalControlNumber) {
       const date = new Date().toISOString().split('T')[0].replace(/-/g, '');
       const seq = Date.now().toString().slice(-6);
       const rand = Math.floor(Math.random() * 9999).toString().padStart(4, '0');
-      validatedData.internalControlNumber = `ICN-${date}-${seq}-${rand}`;
+      fabricInventoryData.internalControlNumber = `ICN-${date}-${seq}-${rand}`;
     }
     
-    const inventory = await storage.createCuttingFabricInventory(validatedData);
+    const inventory = await storage.createCuttingFabricInventory(fabricInventoryData);
     res.json(inventory);
   } catch (error) {
     console.error('Error creating fabric inventory:', error);
@@ -870,7 +900,7 @@ router.post('/fabric-inventory', async (req, res) => {
 router.put('/fabric-inventory/:id', async (req, res) => {
   try {
     const validatedData = insertCuttingFabricInventorySchema.partial().parse(req.body);
-    const inventory = await storage.updateCuttingFabricInventory(req.params.id, validatedData);
+    const inventory = await storage.updateCuttingFabricInventory(req.params.id, syncFabricStockFields(validatedData));
     res.json(inventory);
   } catch (error) {
     console.error('Error updating fabric inventory:', error);
@@ -881,7 +911,7 @@ router.put('/fabric-inventory/:id', async (req, res) => {
 router.patch('/fabric-inventory/:id', async (req, res) => {
   try {
     const validatedData = insertCuttingFabricInventorySchema.partial().parse(req.body);
-    const inventory = await storage.updateCuttingFabricInventory(req.params.id, validatedData);
+    const inventory = await storage.updateCuttingFabricInventory(req.params.id, syncFabricStockFields(validatedData));
     res.json(inventory);
   } catch (error) {
     console.error('Error updating fabric inventory:', error);
@@ -909,6 +939,7 @@ router.post('/fabric-inventory/:id/deplete', async (req, res) => {
       depletedAt: new Date(),
       depletedBy: depletedBy,
       quantityInStock: 0,
+      squareMeters: '0',
     });
 
     await storage.createCuttingFabricInventoryTransaction({
@@ -3552,15 +3583,30 @@ router.post('/packet-boms/:id/cuts', async (req, res) => {
         
         if (currentInventory) {
           const currentSquareMeters = parseFloat(currentInventory.squareMeters?.toString() || '0');
+          const currentQuantityInStock = parseFabricStockQuantity(currentInventory.quantityInStock);
           const usedSquareMeters = parseFloat(squareMetersUsed) || 0;
           const newSquareMeters = Math.max(0, currentSquareMeters - usedSquareMeters);
+          const newQuantityInStock = Math.max(0, currentQuantityInStock - usedSquareMeters);
+          const isDepleted = newSquareMeters <= 0 && newQuantityInStock <= 0;
           
           await db.update(cuttingFabricInventory)
             .set({ 
               squareMeters: newSquareMeters.toString(),
+              quantityInStock: newQuantityInStock,
+              status: isDepleted ? 'depleted' : currentInventory.status,
+              depletedAt: isDepleted ? new Date() : currentInventory.depletedAt,
+              depletedBy: isDepleted ? (operatorName || 'unknown') : currentInventory.depletedBy,
               updatedAt: new Date(),
             })
             .where(eq(cuttingFabricInventory.id, fabricInventoryId));
+
+          await db.insert(cuttingFabricInventoryTransactions).values({
+            fabricInventoryId,
+            changeType: 'ISSUE',
+            quantityDelta: nonZeroInventoryDelta(-usedSquareMeters),
+            performedBy: operatorName || 'unknown',
+            notes: `Cut record ${newCut.id}: ${usedSquareMeters} square meters used from roll ${rollNumber}`,
+          });
           
           console.log(`[CUT RECORDED] Roll ${rollNumber}: ${usedSquareMeters}m² consumed, ${newSquareMeters}m² remaining`);
         }

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -1,10 +1,22 @@
 import express, { Request, Response } from 'express';
 import { storage } from '../../storage';
 import { db } from '../../db';
-import { manufacturingQueue, inventoryItems, p2ProductionOrders, p2PurchaseOrders, cuttingPacketBOMs, cuttingPacketBOMMaterials, cuttingPacketBOMParts, cuttingFabricInventory, cuttingBuiltPackets, cuttingBuiltPacketFabricSources, cuttingProductCategories, getDashboardCategories, supplySourceDashboardToLegacyDept } from '../../schema';
+import { manufacturingQueue, inventoryItems, p2ProductionOrders, p2PurchaseOrders, cuttingPacketBOMs, cuttingPacketBOMMaterials, cuttingPacketBOMParts, cuttingFabricInventory, cuttingFabricInventoryTransactions, cuttingBuiltPackets, cuttingBuiltPacketFabricSources, cuttingProductCategories, getDashboardCategories, supplySourceDashboardToLegacyDept } from '../../schema';
 import { eq, and, or, asc, desc, inArray, like, count } from 'drizzle-orm';
 
 const router = express.Router();
+
+function parseFabricStockQuantity(value: unknown): number {
+  if (value === null || value === undefined || value === '') return 0;
+  const parsed = typeof value === 'number' ? value : parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function nonZeroInventoryDelta(quantity: number): number {
+  if (quantity === 0) return 0;
+  const magnitude = Math.max(1, Math.round(Math.abs(quantity)));
+  return quantity < 0 ? -magnitude : magnitude;
+}
 
 function parseQueueIdFromBuiltPacketBarcode(barcode: string | null | undefined): number | null {
   if (!barcode) return null;
@@ -565,6 +577,55 @@ router.post('/:id/complete-with-traceability', async (req: Request, res: Respons
         createdPackets.push({
           ...builtPacket,
           fabricSources,
+        });
+      }
+
+      const fabricUsageByRoll = new Map<string, { quantityUsed: number; rollNumber: string | null }>();
+      for (const source of fabricSources) {
+        if (!source.fabricInventoryId) continue;
+        const perPacketQty = parseFabricStockQuantity(source.quantityUsed || 1);
+        const totalUsed = perPacketQty * quantityCompleted;
+        if (totalUsed <= 0) continue;
+        const existingUsage = fabricUsageByRoll.get(source.fabricInventoryId);
+        fabricUsageByRoll.set(source.fabricInventoryId, {
+          quantityUsed: (existingUsage?.quantityUsed ?? 0) + totalUsed,
+          rollNumber: source.rollNumber || existingUsage?.rollNumber || null,
+        });
+      }
+
+      for (const [fabricInventoryId, usage] of fabricUsageByRoll.entries()) {
+        const [roll] = await tx
+          .select()
+          .from(cuttingFabricInventory)
+          .where(eq(cuttingFabricInventory.id, fabricInventoryId))
+          .for('update');
+
+        if (!roll) continue;
+
+        const currentSquareMeters = parseFabricStockQuantity(roll.squareMeters);
+        const currentQuantityInStock = parseFabricStockQuantity(roll.quantityInStock);
+        const newSquareMeters = Math.max(0, currentSquareMeters - usage.quantityUsed);
+        const newQuantityInStock = Math.max(0, currentQuantityInStock - usage.quantityUsed);
+        const isDepleted = newSquareMeters <= 0 && newQuantityInStock <= 0;
+
+        await tx
+          .update(cuttingFabricInventory)
+          .set({
+            squareMeters: newSquareMeters.toString(),
+            quantityInStock: newQuantityInStock,
+            status: isDepleted ? 'depleted' : roll.status,
+            depletedAt: isDepleted ? new Date() : roll.depletedAt,
+            depletedBy: isDepleted ? (completedBy || 'unknown') : roll.depletedBy,
+            updatedAt: new Date(),
+          })
+          .where(eq(cuttingFabricInventory.id, fabricInventoryId));
+
+        await tx.insert(cuttingFabricInventoryTransactions).values({
+          fabricInventoryId,
+          changeType: 'ISSUE',
+          quantityDelta: nonZeroInventoryDelta(-usage.quantityUsed),
+          performedBy: completedBy || 'unknown',
+          notes: `Cutting table completion ${id}: ${usage.quantityUsed} used for ${quantityCompleted} packet(s)${usage.rollNumber ? ` from roll ${usage.rollNumber}` : ''}`,
         });
       }
 

--- a/server/src/routes/receiving.ts
+++ b/server/src/routes/receiving.ts
@@ -21,6 +21,7 @@ import {
   vendorPOItems,
   inventoryItems,
   cuttingFabricInventory,
+  cuttingFabricInventoryTransactions,
   insertMaterialLotSchema,
   insertMaterialLotTransactionSchema,
   insertMediaLibrarySchema,
@@ -71,6 +72,12 @@ function sqlRows<T = Record<string, unknown>>(result: unknown): T[] {
     return (result as { rows: T[] }).rows;
   }
   return result as T[];
+}
+
+function nonZeroInventoryDelta(quantity: number): number {
+  if (quantity === 0) return 0;
+  const magnitude = Math.max(1, Math.round(Math.abs(quantity)));
+  return quantity < 0 ? -magnitude : magnitude;
 }
 
 type AuthUser = Express.Request['user'];
@@ -1374,7 +1381,7 @@ async function handleAcceptedUnit(unit: ReceivedUnit, receipt: Receipt, user: Au
       const qty = Number(unit.quantity);
       const qtyForFabric = Number.isFinite(qty) && qty > 0 ? qty : 0;
       const receivedDate = toDateOnly(receipt.receivedAt ?? receipt.receiptDate ?? new Date());
-      await db.insert(cuttingFabricInventory).values({
+      const [fabricInventory] = await db.insert(cuttingFabricInventory).values({
         inventoryItemId: invItem.id,
         source: receipt.vendorName ?? null,
         fabric: invItem.name ?? line.description ?? line.agPartNumber,
@@ -1390,11 +1397,22 @@ async function handleAcceptedUnit(unit: ReceivedUnit, receipt: Receipt, user: Au
         manufactureDate: toDateOnly(unit.manufactureDate) ?? null,
         receivedDate,
         expirationDate: toDateOnly(prefilledExpiration ?? unit.expirationDate) ?? null,
+        location: unit.location ?? null,
         quantityInStock: qtyForFabric,
         squareMeters: qtyForFabric > 0 ? String(qtyForFabric) : undefined,
         notes: `Auto-created from Receiving Control Center receipt ${receipt.receiptNumber} unit ${unit.barcode}. Freezer assignment pending in Cutting Fabric Receiving.`,
         status: 'active',
-      });
+      }).returning();
+
+      if (fabricInventory?.id && qtyForFabric > 0) {
+        await db.insert(cuttingFabricInventoryTransactions).values({
+          fabricInventoryId: fabricInventory.id,
+          changeType: 'RECEIPT',
+          quantityDelta: nonZeroInventoryDelta(qtyForFabric),
+          performedBy: displayName,
+          notes: `Receipt ${receipt.receiptNumber}: received unit ${unit.barcode} into cutting fabric inventory`,
+        });
+      }
     }
 
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- keep cutting fabric `quantityInStock` and `squareMeters` synchronized so fabric inventory on-hand matches the cutting control table
- decrement both balances when cutting records or packet completions consume fabric rolls
- create cutting fabric receipt transaction history when accepted receiving units auto-create fabric inventory rows

## Validation
- `git diff --check -- server/src/routes/cuttingTable.ts server/src/routes/cuttingTableManufacturingQueue.ts server/src/routes/receiving.ts`
- `git diff --cached --check`

## Not run
- `npm run check` because `npm` is not available in this worktree (`npm` is not recognized as a command).