### PR TITLE
Add COA 10300 startup repair

### DIFF
--- a/server/__tests__/coaStartupRepair.test.ts
+++ b/server/__tests__/coaStartupRepair.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('COA startup repair', () => {
+  const source = readFileSync(join(process.cwd(), 'server/index.ts'), 'utf8');
+
+  it('normalizes legacy account 10300 during normal app startup', () => {
+    expect(source).toContain("account_number = '10300'");
+    expect(source).toContain("account_name = 'Undeposited Funds'");
+    expect(source).toContain("account_name = 'Customer Payment Clearing'");
+    expect(source).toContain('Individually traceable customer payments awaiting bank reconciliation or settlement matching');
+  });
+
+  it('adds the COA foundation columns needed by the startup repair if missing', () => {
+    expect(source).toContain('ADD COLUMN IF NOT EXISTS account_number TEXT');
+    expect(source).toContain("ADD COLUMN IF NOT EXISTS normal_balance TEXT NOT NULL DEFAULT 'DEBIT'");
+    expect(source).toContain("ADD COLUMN IF NOT EXISTS billing_treatment TEXT NOT NULL DEFAULT 'NOT_BILLABLE'");
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -2854,6 +2854,112 @@ async function initializeBackgroundServices() {
             ('Bank Service Charges', 'EXPENSE')
           ON CONFLICT (account_name) DO NOTHING
         `);
+        await db.execute(sqlAcct`
+          ALTER TABLE chart_of_accounts
+            ADD COLUMN IF NOT EXISTS account_number TEXT,
+            ADD COLUMN IF NOT EXISTS parent_account_id INTEGER REFERENCES chart_of_accounts(id),
+            ADD COLUMN IF NOT EXISTS normal_balance TEXT NOT NULL DEFAULT 'DEBIT',
+            ADD COLUMN IF NOT EXISTS financial_statement_section TEXT,
+            ADD COLUMN IF NOT EXISTS cost_pool TEXT NOT NULL DEFAULT 'NONE',
+            ADD COLUMN IF NOT EXISTS default_allowability TEXT NOT NULL DEFAULT 'ALLOWABLE',
+            ADD COLUMN IF NOT EXISTS default_direct_indirect TEXT NOT NULL DEFAULT 'UNASSIGNED',
+            ADD COLUMN IF NOT EXISTS billing_treatment TEXT NOT NULL DEFAULT 'NOT_BILLABLE',
+            ADD COLUMN IF NOT EXISTS requires_documentation BOOLEAN NOT NULL DEFAULT FALSE,
+            ADD COLUMN IF NOT EXISTS requires_review BOOLEAN NOT NULL DEFAULT FALSE,
+            ADD COLUMN IF NOT EXISTS system_controlled BOOLEAN NOT NULL DEFAULT FALSE,
+            ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            ADD COLUMN IF NOT EXISTS description TEXT
+        `);
+        await db.execute(sqlAcct`
+          DO $$
+          DECLARE
+            target_id integer;
+            duplicate_id integer;
+          BEGIN
+            SELECT id
+              INTO target_id
+              FROM chart_of_accounts
+             WHERE account_number = '10300'
+                OR account_name = 'Undeposited Funds'
+             ORDER BY CASE WHEN account_number = '10300' THEN 0 ELSE 1 END, id
+             LIMIT 1;
+
+            IF target_id IS NULL THEN
+              INSERT INTO chart_of_accounts (
+                account_number,
+                account_name,
+                account_type,
+                normal_balance,
+                financial_statement_section,
+                cost_pool,
+                default_allowability,
+                default_direct_indirect,
+                billing_treatment,
+                requires_documentation,
+                requires_review,
+                system_controlled,
+                description,
+                is_active
+              )
+              VALUES (
+                '10300',
+                'Customer Payment Clearing',
+                'ASSET',
+                'DEBIT',
+                'Current Assets',
+                'NONE',
+                'ALLOWABLE',
+                'UNASSIGNED',
+                'NOT_BILLABLE',
+                FALSE,
+                FALSE,
+                FALSE,
+                'Individually traceable customer payments awaiting bank reconciliation or settlement matching',
+                TRUE
+              )
+              RETURNING id INTO target_id;
+            END IF;
+
+            SELECT id
+              INTO duplicate_id
+              FROM chart_of_accounts
+             WHERE account_name = 'Customer Payment Clearing'
+               AND id <> target_id
+             LIMIT 1;
+
+            IF duplicate_id IS NOT NULL THEN
+              UPDATE journal_lines
+                 SET account_id = target_id,
+                     updated_at = NOW()
+               WHERE account_id = duplicate_id;
+
+              UPDATE chart_of_accounts
+                 SET account_name = 'Customer Payment Clearing (Duplicate - inactive)',
+                     account_number = NULL,
+                     is_active = FALSE,
+                     updated_at = NOW()
+               WHERE id = duplicate_id;
+            END IF;
+
+            UPDATE chart_of_accounts
+               SET account_number = '10300',
+                   account_name = 'Customer Payment Clearing',
+                   account_type = 'ASSET',
+                   normal_balance = 'DEBIT',
+                   financial_statement_section = 'Current Assets',
+                   cost_pool = 'NONE',
+                   default_allowability = 'ALLOWABLE',
+                   default_direct_indirect = 'UNASSIGNED',
+                   billing_treatment = 'NOT_BILLABLE',
+                   requires_documentation = FALSE,
+                   requires_review = FALSE,
+                   system_controlled = FALSE,
+                   is_active = TRUE,
+                   description = 'Individually traceable customer payments awaiting bank reconciliation or settlement matching',
+                   updated_at = NOW()
+             WHERE id = target_id;
+          END $$;
+        `);
         console.log('✅ Ensured accounting shadow layer tables and seed accounts exist');
       } catch (acctErr: any) {
         console.warn('⚠️ Accounting shadow layer migration:', acctErr.message);


### PR DESCRIPTION
## Summary
- normalize legacy COA account 10300 from Undeposited Funds to Customer Payment Clearing during normal app startup
- ensure required COA foundation columns exist before the repair runs
- add a source-level regression test for the startup repair

## Verification
- git diff --check
- attempted: npx vitest run server/__tests__/coaStartupRepair.test.ts --reporter=dot (blocked locally because this fresh worktree has no node_modules; standalone npx vitest could not resolve vite/Replit plugins)