### PR TITLE
Fix P2 and PM control center handoff

### DIFF
--- a/client/src/components/p2/P2StatusDashboard.tsx
+++ b/client/src/components/p2/P2StatusDashboard.tsx
@@ -7,6 +7,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Progress } from '@/components/ui/progress';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Link } from 'wouter';
 import { 
   FileText,
   Package,
@@ -40,6 +41,8 @@ interface POStatus {
   hasBOMsNeeded: boolean;
   status: 'pending' | 'in_progress' | 'completed';
   rawStatus?: string;
+  projectId?: string | null;
+  projectCode?: string | null;
   projectName?: string | null;
 }
 
@@ -221,9 +224,23 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                         </div>
                         <p className="text-muted-foreground mb-1">{po.customerName}</p>
                         {po.projectName && (
-                          <div className="flex items-center gap-1 text-sm text-muted-foreground mb-2">
+                          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground mb-2">
                             <FolderOpen className="h-3 w-3" />
                             <span>Project: <span className="font-medium text-foreground">{po.projectName}</span></span>
+                            {po.projectId && (
+                              <>
+                                <Link href={`/projects/${po.projectId}`}>
+                                  <Button variant="link" size="sm" className="h-auto p-0 text-xs">
+                                    {po.projectCode || 'Project Detail'}
+                                  </Button>
+                                </Link>
+                                <Link href={`/pm-control-center?project=${po.projectId}`}>
+                                  <Button variant="link" size="sm" className="h-auto p-0 text-xs">
+                                    PM Control
+                                  </Button>
+                                </Link>
+                              </>
+                            )}
                           </div>
                         )}
                         
@@ -258,6 +275,18 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                       </div>
 
                       <div className="flex flex-col gap-2">
+                        {po.projectId && (
+                          <Link href={`/pm-control-center?project=${po.projectId}`}>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="w-full"
+                              data-testid={`button-pm-control-${po.id}`}
+                            >
+                              PM Control
+                            </Button>
+                          </Link>
+                        )}
                         <Button 
                           size="sm" 
                           variant={po.hasBOMsNeeded ? "default" : "outline"}
@@ -316,14 +345,27 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                       </TableCell>
                       <TableCell>{getStatusBadge(po.status)}</TableCell>
                       <TableCell>
-                        <Button 
-                          size="sm" 
-                          variant="ghost"
-                          onClick={() => onViewPO?.(po.id)}
-                          data-testid={`button-view-completed-po-${po.id}`}
-                        >
-                          View <ArrowRight className="h-4 w-4 ml-1" />
-                        </Button>
+                        <div className="flex justify-end gap-2">
+                          {po.projectId && (
+                            <Link href={`/pm-control-center?project=${po.projectId}`}>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                data-testid={`button-pm-control-completed-${po.id}`}
+                              >
+                                PM Control
+                              </Button>
+                            </Link>
+                          )}
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => onViewPO?.(po.id)}
+                            data-testid={`button-view-completed-po-${po.id}`}
+                          >
+                            View <ArrowRight className="h-4 w-4 ml-1" />
+                          </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -105,7 +105,7 @@ export default function P2ControlCenter() {
   const poIdFromUrl = urlParams.get('poId') ? Number(urlParams.get('poId')) : null;
   const unitsFromUrl = urlParams.get('units') || undefined;
   const searchFromUrl = urlParams.get('search') || '';
-  // WAD context: passed from project workflow card
+  // Project context: passed from PM/WAD project workflow cards
   const wadProjectId = urlParams.get('projectId') || '';
   const wadProjectName = urlParams.get('projectName') || '';
   const wadPoId = urlParams.get('poId') || '';
@@ -294,7 +294,7 @@ export default function P2ControlCenter() {
         <div className="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950 px-4 py-3">
           <FileText className="h-4 w-4 text-blue-600 shrink-0" />
           <div className="flex-1 text-sm">
-            <span className="font-medium text-blue-800 dark:text-blue-200">WAD context:</span>
+            <span className="font-medium text-blue-800 dark:text-blue-200">Project context:</span>
             <span className="ml-2 text-blue-700 dark:text-blue-300">{wadProjectName || 'Project'}</span>
             {wadPoId && <span className="ml-2 text-blue-600 dark:text-blue-400">· PO ID {wadPoId}</span>}
           </div>

--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -240,6 +240,10 @@ function fmtCurrency(n: number) {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 0 }).format(n);
 }
 
+function readProjectParam(params: URLSearchParams) {
+  return params.get('project') ?? params.get('projectId') ?? '';
+}
+
 function daysVarianceBadge(variance: number | null) {
   if (variance === null) return <span className="text-muted-foreground">—</span>;
   if (variance === 0) return <Badge className="bg-blue-100 text-blue-800">Due Today</Badge>;
@@ -1071,11 +1075,11 @@ interface PmOption {
 }
 
 export default function PMControlCenterPage() {
-  const [, navigate] = useLocation();
+  const [location, navigate] = useLocation();
   // Read URL params immediately as initial state so they are authoritative on first render
   const [selectedProjectId, setSelectedProjectId] = useState<string>(() => {
     const params = new URLSearchParams(window.location.search);
-    return params.get('project') ?? '';
+    return readProjectParam(params);
   });
   const [pmFilter, setPmFilter] = useState<string>(() => {
     const params = new URLSearchParams(window.location.search);
@@ -1108,6 +1112,15 @@ export default function PMControlCenterPage() {
     const qs = params.toString();
     return qs ? `?${qs}` : '';
   }
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const projectFromUrl = readProjectParam(params);
+    if (projectFromUrl && projectFromUrl !== selectedProjectId) {
+      setSelectedProjectId(projectFromUrl);
+      window.history.replaceState(null, '', `/pm-control-center${buildSearch(projectFromUrl, pmFilter)}`);
+    }
+  }, [location, selectedProjectId, pmFilter]);
 
   const handleProjectChange = (id: string) => {
     setSelectedProjectId(id);
@@ -1351,7 +1364,9 @@ export default function PMControlCenterPage() {
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    const params = new URLSearchParams();
+                    const params = new URLSearchParams({ tab: 'status' });
+                    params.set('projectId', selectedProjectId);
+                    if (selectedProject.projectName) params.set('projectName', selectedProject.projectName);
                     if (selectedProject.poId) params.set('poId', String(selectedProject.poId));
                     if (selectedProject.poNumber) params.set('po', selectedProject.poNumber);
                     navigate(`/p2-control-center${params.toString() ? `?${params.toString()}` : ''}`);


### PR DESCRIPTION
## Summary
- Adds direct PM Control actions to linked P2 status cards so P2 POs can jump to their PM project view from active and completed status lists.
- Makes the PM Control Center accept both `project` and `projectId` URL params and canonicalize the selected project.
- Preserves project context when PM links back to P2, with the P2 banner labeled as project context instead of WAD-only context.

## Validation
- `git diff --check`
- `git diff --cached --check`

Note: local `npm`/`node_modules` were unavailable in this worktree, so I could not run a frontend build locally.