### PR TITLE
Record receiving acceptances in inventory ledger

### DIFF
--- a/server/src/routes/receiving.ts
+++ b/server/src/routes/receiving.ts
@@ -37,6 +37,7 @@ import multer from 'multer';
 import { generateBarcodeImage, generateReceivingUnitBarcodeValue } from '../utils/barcodeGenerator';
 import { requireRole } from '../../middleware/auth';
 import { getFileStorageProvider, getStorageErrorResponse } from '../services/fileStorageProvider';
+import { createInventoryEvent } from '../services/inventoryEventService';
 
 const router = Router();
 
@@ -1423,6 +1424,10 @@ async function handleAcceptedUnit(unit: ReceivedUnit, receipt: Receipt, user: Au
       throw new Error(`No inventory_items record found for ag_part_number="${line.agPartNumber}" — create the inventory item before accepting units for this part`);
     }
     const invItem = invRows[0];
+    const receivedQty = Number(unit.quantity);
+    if (!Number.isFinite(receivedQty) || receivedQty <= 0) {
+      throw new Error(`Received unit ${unit.id} has invalid quantity "${unit.quantity}"`);
+    }
 
     // Shelf-life prefill (Task #165) — only when the part is shelf-life-controlled
     // and the receiving unit didn't already supply a value. Uses frozen days as
@@ -1486,6 +1491,27 @@ async function handleAcceptedUnit(unit: ReceivedUnit, receipt: Receipt, user: Au
       notes: `Receipt ${receipt.receiptNumber} · unit barcode ${unit.barcode}`,
     });
     await db.insert(materialLotTransactions).values(txValues);
+
+    await createInventoryEvent({
+      agPartNumber: line.agPartNumber,
+      eventType: 'receipt',
+      quantity: receivedQty,
+      lotId: lot.id,
+      unitOfMeasure: unit.uom ?? 'EA',
+      toLocation: unit.location?.trim() || 'WAREHOUSE-MAIN',
+      referenceType: 'RECEIVED_UNIT',
+      referenceId: unit.id,
+      performedBy: displayName,
+      notes: `Receipt ${receipt.receiptNumber}: accepted unit ${unit.barcode}`,
+      metadata: {
+        receiptId: receipt.id,
+        receiptNumber: receipt.receiptNumber,
+        receivedUnitId: unit.id,
+        unitBarcode: unit.barcode,
+        materialLotId: lot.id,
+        internalControlNumber: icn,
+      },
+    });
 
     const isCuttingFabric = Boolean(invItem.is_fabric && (invItem.utilized_in_pl1 || invItem.utilized_in_pl2));
     if (isCuttingFabric) {

--- a/server/src/services/inventoryEventService.ts
+++ b/server/src/services/inventoryEventService.ts
@@ -25,6 +25,7 @@ export interface InventoryEventParams {
   agPartNumber: string;
   eventType: InventoryEventType;
   quantity: number;
+  lotId?: string | null;
   unitOfMeasure?: string;
   fromLocation?: string | null;
   toLocation?: string | null;
@@ -64,6 +65,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     agPartNumber,
     eventType,
     quantity,
+    lotId,
     unitOfMeasure,
     fromLocation,
     toLocation,
@@ -134,6 +136,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
       await recordInventoryBalanceLedgerChange({
         agPartNumber,
         transactionType: 'TRANSFER',
+        lotId,
         locationId: fromLocation,
         quantityDelta: change.delta,
         quantityBefore: change.before,
@@ -151,6 +154,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
       await recordInventoryBalanceLedgerChange({
         agPartNumber,
         transactionType: 'TRANSFER',
+        lotId,
         locationId: toLocation,
         quantityDelta: change.delta,
         quantityBefore: change.before,
@@ -172,6 +176,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     await recordInventoryBalanceLedgerChange({
       agPartNumber,
       transactionType: toLedgerTransactionType(eventType),
+      lotId,
       locationId: location,
       quantityDelta: change.delta,
       quantityBefore: change.before,
@@ -189,6 +194,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
       await recordInventoryBalanceLedgerChange({
         agPartNumber,
         transactionType: 'MOVE',
+        lotId,
         locationId: fromLocation,
         quantityDelta: sourceChange.delta,
         quantityBefore: sourceChange.before,
@@ -210,6 +216,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     await recordInventoryBalanceLedgerChange({
       agPartNumber,
       transactionType: toLedgerTransactionType(eventType),
+      lotId,
       locationId: location,
       quantityDelta: change.delta,
       quantityBefore: change.before,
@@ -230,6 +237,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     await recordInventoryBalanceLedgerChange({
       agPartNumber,
       transactionType: 'RETURN',
+      lotId,
       locationId: location,
       quantityDelta: change.delta,
       quantityBefore: change.before,

--- a/server/src/services/inventoryTransactionLedgerService.ts
+++ b/server/src/services/inventoryTransactionLedgerService.ts
@@ -74,6 +74,7 @@ export type InventoryLedgerEntryInput = {
 export type InventoryLedgerBalanceChangeInput = {
   agPartNumber: string;
   transactionType: InventoryLedgerTransactionType;
+  lotId?: string | null;
   locationId?: string | null;
   quantityDelta: number;
   quantityBefore: number;
@@ -228,6 +229,7 @@ export async function recordInventoryBalanceLedgerChange(
     transactionType: input.transactionType,
     inventoryItemId: item.id,
     agPartNumber: item.agPartNumber,
+    lotId: input.lotId ?? null,
     locationId: input.locationId ?? null,
     quantityDelta: input.quantityDelta,
     quantityBefore: input.quantityBefore,


### PR DESCRIPTION
## Summary
- record accepted receiving units through the inventory event service
- update inventory balances and both inventory transaction ledgers for received material lots
- carry material lot ids through balance ledger changes so immutable ledger rows remain lot-traceable

## Validation
- `git diff --check`
- `git diff --cached --check`

Note: local TypeScript/test execution was not run because this worktree has no `node_modules` and `npm` is unavailable.