### PR TITLE
Expand WAD backlog project coverage

### DIFF
--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -1251,7 +1251,7 @@ export default function PMControlCenterPage() {
             size="sm"
             onClick={() => navigate('/wad-status')}
             data-testid="button-wad-status-from-pmcc"
-            title="WAD authoring & backfill backlog across all P2 Release / Production projects"
+            title="WAD authoring & backfill backlog across active PO-ready projects"
           >
             <ShieldCheck className="h-4 w-4 mr-1.5" />
             WAD Status

--- a/client/src/pages/WADStatusDashboard.tsx
+++ b/client/src/pages/WADStatusDashboard.tsx
@@ -44,6 +44,7 @@ type WadStatusRow = {
 };
 
 const STAGE_LABELS: Record<string, string> = {
+  po_received: 'PO Received',
   p2_release: 'P2 Release',
   production: 'In Production',
 };
@@ -123,7 +124,7 @@ export default function WADStatusDashboard() {
             WAD Status Dashboard
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Every project in P2 Release or Production with the current state of its Work Authorization Document.
+            Every active PO-ready project with the current state of its Work Authorization Document.
             Backfill missing WADs without changing the project stage — full approvals are recorded as
             <strong> wad_backfill</strong> in the audit ledger.
           </p>
@@ -156,7 +157,7 @@ export default function WADStatusDashboard() {
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-base">Project WAD Backlog</CardTitle>
-          <CardDescription>One row per project in P2 Release or Production.</CardDescription>
+          <CardDescription>One row per active project that has reached PO/WAD readiness.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="flex items-center gap-2 flex-wrap">

--- a/client/src/pages/WADWizardLauncherPage.tsx
+++ b/client/src/pages/WADWizardLauncherPage.tsx
@@ -139,9 +139,9 @@ export default function WADWizardLauncherPage() {
     queryKey: ['/api/work-orders/production/wad-status'],
     enabled: missingOnly || searchTerm.length > 0,
   });
-  // "Zero-PWO / not-yet-released" backlog: any project whose WAD gate is not
-  // satisfied (no APPROVED+RELEASED PWO). Zero-PWO projects fall in here
-  // automatically because their aggregate wadStatus is 'NONE'.
+  // "Zero-PWO" backlog: active PO-ready projects whose WAD gate is not
+  // satisfied and that have no Production Work Order yet. These projects cannot
+  // be returned by the PWO-anchored /production endpoint.
   const zeroPwoProjects = useMemo(() => {
     const q = searchTerm.toLowerCase();
     return allWadStatus.filter((r) => {
@@ -255,10 +255,10 @@ export default function WADWizardLauncherPage() {
               size="sm"
               onClick={() => navigate('/wad-status')}
               data-testid="button-jump-wad-status"
-              title="Includes projects in P2 Release / Production with no PWO yet"
+              title="Includes active PO-ready projects with no PWO yet"
             >
               <LayoutDashboard className="h-3.5 w-3.5 mr-1" />
-              Backlog incl. zero-PWO projects →
+              Backlog incl. projects without PWOs →
             </Button>
           </div>
 
@@ -287,7 +287,7 @@ export default function WADWizardLauncherPage() {
               <p className="font-medium text-foreground mb-1">No production work orders match your filters</p>
               <p>
                 {missingOnly
-                  ? 'No projects in P2 Release / Production are missing a WAD.'
+                  ? 'No active PO-ready projects are missing a WAD.'
                   : searchTerm
                     ? 'No matching Production Work Orders or project-level WAD backlog entries were found.'
                     : 'Search for a project or include missing WAD projects to author a WAD before a Production Work Order exists.'}

--- a/server/src/routes/workOrders.ts
+++ b/server/src/routes/workOrders.ts
@@ -366,8 +366,9 @@ router.get('/production', authenticateToken, requirePermission('work_orders.rele
 });
 
 // GET /production/wad-status — WAD backlog dashboard.
-// Returns one row per project in p2_release or production with the aggregated WAD status,
-// PWO count, latest PWO id, percent-complete (from wizardData), and last-edited info.
+// Returns one row per active project that has reached PO/WAD readiness with the
+// aggregated WAD status, PWO count, latest PWO id, percent-complete (from
+// wizardData), and last-edited info.
 router.get('/production/wad-status', authenticateToken, requirePermission('work_orders.release'), async (_req: Request, res: Response) => {
   try {
     const projRows = await db
@@ -382,7 +383,20 @@ router.get('/production/wad-status', authenticateToken, requirePermission('work_
       })
       .from(projects)
       .leftJoin(p2PurchaseOrders, eq(projects.poId, p2PurchaseOrders.id))
-      .where(inArray(projects.currentStage, ['p2_release', 'production']));
+      .where(and(
+        sql`${projects.status} NOT IN ('cancelled', 'completed', 'inactive', 'lost')`,
+        or(
+          inArray(projects.currentStage, ['po_received', 'p2_release', 'production']),
+          sql`${projects.poId} IS NOT NULL`,
+          sql`EXISTS (
+            SELECT 1
+            FROM project_steps ps
+            WHERE ps.project_id = ${projects.id}
+              AND ps.status = 'completed'
+              AND ps.step_type IN ('purchase_review_checklist', 'preproduction_checklist', 'p2_order')
+          )`,
+        ),
+      ));
 
     const projectIds = projRows.map((p) => p.id);
     const woRows = projectIds.length > 0


### PR DESCRIPTION
## Summary
- Expand the WAD status backlog beyond only `p2_release` / `production` projects
- Include active PO-ready projects with a PO or completed purchase/preproduction/P2 workflow step
- Update WAD dashboard and launcher copy so the project count matches the broader backlog definition

## Why
The WAD dashboard was only counting projects whose `current_stage` was already `p2_release` or `production`, which is why it could show only 3 projects even when more active projects had no WAD. Projects that were PO-ready but had not advanced into those stages were being excluded from the backlog.

## Verification
- `git diff --check`
- `npm run check` could not run locally because `npm` is not available on PATH in this environment.