### PR TITLE
[codex] Filter completed travelers from P2 layup queues

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:dates": "node scripts/check-format-dates.js",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "backfill:p2-packets": "tsx server/scripts/backfillP2UsedPackets.ts",
+    "maintenance:backfill-stuck-p2-items": "tsx server/scripts/backfillStuckP2SerializedItems.ts",
     "maintenance:boot-repairs": "tsx server/scripts/maintenance/runBootRepairs.ts",
     "maintenance:safe-migrations": "tsx server/scripts/migrations/runSafeBootMigrations.ts",
     "predb:push": "npx tsx server/pre-deploy-migrate.ts",

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2897,6 +2897,46 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     }
   });
 
+  async function applyCompletedTravelerStateToP2Items(items: any[]): Promise<any[]> {
+    if (!items.length) return items;
+
+    const serials = [...new Set(
+      items
+        .map((item: any) => String(item.serialNumber ?? item.serial_number ?? '').trim())
+        .filter(Boolean)
+        .map((serial: string) => serial.toLowerCase())
+    )];
+    if (!serials.length) return items;
+
+    const { pool: dbPool } = await import('../../db');
+    const completedTravelerRows = await dbPool.query(
+      `SELECT DISTINCT
+         LOWER(TRIM(serial_number)) AS serial,
+         MAX(completed_at) AS completed_at
+       FROM travelers
+       WHERE status = 'COMPLETED'
+         AND serial_number IS NOT NULL
+         AND LOWER(TRIM(serial_number)) = ANY($1::text[])
+       GROUP BY LOWER(TRIM(serial_number))`,
+      [serials]
+    );
+    const rows = (completedTravelerRows as any).rows ?? completedTravelerRows;
+    const completedBySerial = new Map<string, any>(
+      rows.map((row: any) => [row.serial, row.completed_at])
+    );
+
+    return items.map((item: any) => {
+      const key = String(item.serialNumber ?? item.serial_number ?? '').trim().toLowerCase();
+      if (!key || !completedBySerial.has(key)) return item;
+      return {
+        ...item,
+        status: 'COMPLETED',
+        completedAt: item.completedAt ?? item.completed_at ?? completedBySerial.get(key) ?? new Date(),
+        completed_at: item.completed_at ?? item.completedAt ?? completedBySerial.get(key) ?? new Date(),
+      };
+    });
+  }
+
   // P2 Control Center API Routes
   app.get('/api/p2/control-center/stats', async (req, res) => {
     try {
@@ -2912,12 +2952,31 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           FROM p2_purchase_orders
         `),
         pool.query(`
+          WITH item_state AS (
+            SELECT
+              psi.*,
+              EXISTS (
+                SELECT 1
+                FROM travelers t
+                WHERE t.status = 'COMPLETED'
+                  AND t.serial_number IS NOT NULL
+                  AND LOWER(TRIM(t.serial_number)) = LOWER(TRIM(psi.serial_number))
+              ) AS has_completed_traveler
+            FROM p2_serialized_items psi
+          )
           SELECT
-            COUNT(*) FILTER (WHERE status = 'SCHEDULED') AS "scheduledItems",
-            COUNT(*) FILTER (WHERE status NOT IN ('PENDING','SCHEDULED','COMPLETED','SHIPPED') AND status IS NOT NULL) AS "inProduction",
-            COUNT(*) FILTER (WHERE status = 'COMPLETED' AND completed_at > $1) AS "completedThisWeek",
-            COUNT(*) FILTER (WHERE status = 'FINAL_QC') AS "pendingQC"
-          FROM p2_serialized_items
+            COUNT(*) FILTER (WHERE status = 'SCHEDULED' AND NOT has_completed_traveler) AS "scheduledItems",
+            COUNT(*) FILTER (
+              WHERE status NOT IN ('PENDING','SCHEDULED','COMPLETED','SHIPPED')
+                AND status IS NOT NULL
+                AND NOT has_completed_traveler
+            ) AS "inProduction",
+            COUNT(*) FILTER (
+              WHERE (status = 'COMPLETED' OR has_completed_traveler)
+                AND COALESCE(completed_at, updated_at) > $1
+            ) AS "completedThisWeek",
+            COUNT(*) FILTER (WHERE status = 'FINAL_QC' AND NOT has_completed_traveler) AS "pendingQC"
+          FROM item_state
         `, [oneWeekAgo]),
       ]);
 
@@ -3040,7 +3099,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         'READY_FOR_PRODUCTION',
         'IN_PRODUCTION',
       ]);
-      const serializedItems = await storage.getP2SerializedItems({});
+      const serializedItems = await applyCompletedTravelerStateToP2Items(
+        await storage.getP2SerializedItems({})
+      );
       const poIdsWithSerializedUnits = new Set<number>();
       for (const s of serializedItems as any[]) {
         const poId = s.poId ?? s.po_id;
@@ -3160,7 +3221,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   app.get('/api/p2/control-center/scheduling-list', async (req, res) => {
     try {
       const { storage } = await import('../../storage');
-      const serializedItems = await storage.getP2SerializedItems({});
+      const serializedItems = await applyCompletedTravelerStateToP2Items(
+        await storage.getP2SerializedItems({})
+      );
       const pos = await storage.getAllP2PurchaseOrders();
       
       // Filter for items that are ACTIVE and either pending layup or in early production stages
@@ -3286,8 +3349,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { storage } = await import('../../storage');
       
       // Get all active serialized items using storage method (which handles pool.query)
-      const allItems = await storage.getP2SerializedItems({ status: 'ACTIVE' });
-      const items = allItems || [];
+      const allItems = await applyCompletedTravelerStateToP2Items(
+        await storage.getP2SerializedItems({ status: 'ACTIVE' })
+      );
+      const items = (allItems || []).filter((item: any) => item.status === 'ACTIVE');
       const { pool: dbPool } = await import('../../db');
       const poIds = [...new Set(items.map((item: any) => item.poId ?? item.po_id).filter(Boolean))];
       const projectRows = poIds.length > 0

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -181,8 +181,8 @@ const ORDERED_PARTS_REQUEST_STATUSES = [
 // ─── Item-level progress helper ──────────────────────────────────────────────
 // Aggregates p2_serialized_items per (po_id, po_item_id) for a project so the
 // PM Control Center reports the same numbers as the order card. "Completed"
-// uses the same status set the order card uses (status = 'COMPLETED');
-// SCRAPPED / CANCELLED units are excluded from the totals.
+// includes rows whose serialized-item status is stale but whose matching
+// traveler has already completed; SCRAPPED / CANCELLED units are excluded.
 interface SerializedItemGroup {
   poId: number;
   poItemId: number;
@@ -248,6 +248,28 @@ async function getProjectSerializedItemAggregate(
     currentDepartment: string | null;
     dueDate: string | null;
   }>(`
+    WITH item_state AS (
+      SELECT
+        psi.*,
+        EXISTS (
+          SELECT 1
+          FROM travelers t
+          WHERE t.status = 'COMPLETED'
+            AND t.serial_number IS NOT NULL
+            AND LOWER(TRIM(t.serial_number)) = LOWER(TRIM(psi.serial_number))
+        ) AS has_completed_traveler,
+        COALESCE(
+          psi.completed_at,
+          (
+            SELECT MAX(t.completed_at)
+            FROM travelers t
+            WHERE t.status = 'COMPLETED'
+              AND t.serial_number IS NOT NULL
+              AND LOWER(TRIM(t.serial_number)) = LOWER(TRIM(psi.serial_number))
+          )
+        ) AS effective_completed_at
+      FROM p2_serialized_items psi
+    )
     SELECT
       psi.po_id::text AS "poId",
       psi.po_item_id::text AS "poItemId",
@@ -257,26 +279,31 @@ async function getProjectSerializedItemAggregate(
       COUNT(*) FILTER (
         WHERE psi.status NOT IN ('SCRAPPED', 'CANCELLED', 'CANCELED')
       )::text AS "totalUnits",
-      COUNT(*) FILTER (WHERE psi.status = 'COMPLETED')::text AS "completedUnits",
+      COUNT(*) FILTER (
+        WHERE psi.status = 'COMPLETED' OR psi.has_completed_traveler
+      )::text AS "completedUnits",
       COUNT(*) FILTER (
         WHERE psi.status NOT IN ('SCRAPPED', 'CANCELLED', 'CANCELED', 'COMPLETED')
+          AND NOT psi.has_completed_traveler
           AND psi.current_stage_index > 0
       )::text AS "inProductionUnits",
       COUNT(*) FILTER (
         WHERE psi.status NOT IN ('SCRAPPED', 'CANCELLED', 'CANCELED', 'COMPLETED')
+          AND NOT psi.has_completed_traveler
           AND psi.current_stage_index = 0
       )::text AS "pendingUnits",
       COUNT(*) FILTER (
-        WHERE psi.status = 'COMPLETED'
-          AND psi.completed_at IS NOT NULL
-          AND psi.completed_at::date = $2::date
+        WHERE (psi.status = 'COMPLETED' OR psi.has_completed_traveler)
+          AND psi.effective_completed_at IS NOT NULL
+          AND psi.effective_completed_at::date = $2::date
       )::text AS "completedTodayUnits",
       (
         SELECT psi2.current_department
-        FROM p2_serialized_items psi2
+        FROM item_state psi2
         WHERE psi2.po_id = psi.po_id
           AND psi2.po_item_id = psi.po_item_id
           AND psi2.status NOT IN ('SCRAPPED', 'CANCELLED', 'CANCELED', 'COMPLETED')
+          AND NOT psi2.has_completed_traveler
         GROUP BY psi2.current_department
         ORDER BY COUNT(*) DESC
         LIMIT 1
@@ -287,7 +314,7 @@ async function getProjectSerializedItemAggregate(
         WHERE p2po.p2_po_id = psi.po_id
           AND p2po.p2_po_item_id = psi.po_item_id
       ) AS "dueDate"
-    FROM p2_serialized_items psi
+    FROM item_state psi
     LEFT JOIN p2_purchase_order_items poi ON poi.id = psi.po_item_id
     WHERE psi.po_id = ANY($1::int[])
     GROUP BY psi.po_id, psi.po_item_id


### PR DESCRIPTION
## Summary
- Treat active P2 serialized items as completed in control-center reads when their matching traveler serial is already `COMPLETED`.
- Apply that completed-traveler guard to P2 status cards, scheduling list, production queue, and PM dashboard item aggregation so stale Layup rows no longer surface.
- Add a package script alias for the existing stuck-item backfill so the specific legacy serials can be reconciled with an audit-event trail.

## Root Cause
The traveler completion path can complete the traveler while a legacy `p2_serialized_items` row remains `ACTIVE` in `Pending Layup` or `Layup`. The dashboard read paths only trusted the serialized item status, so completed travelers could still appear as active production work.

## Cleanup Command
After merge, run the existing maintenance backfill for the reported serials:

```bash
npm run maintenance:backfill-stuck-p2-items -- --serial str2600118 --serial str2600125 --serial str2600134 --serial str2600139
```

Use `-- --dry-run` first if you want to preview the affected rows.

## Validation
- `git diff --check HEAD~1..HEAD`
- Rebased cleanly on current `origin/main` after PR #771 merged

Toolchain note: local `npm` is not available in this Codex environment and `node_modules` is absent, so TypeScript/runtime checks were not run here.