### PR TITLE
[codex] Capture RCC accepted receipts in inventory ledger

### DIFF
--- a/server/src/routes/receiving.ts
+++ b/server/src/routes/receiving.ts
@@ -32,6 +32,7 @@ import multer from 'multer';
 import { ObjectStorageService } from '../../replit_integrations/object_storage/objectStorage';
 import { generateBarcodeImage, generateReceivingUnitBarcodeValue } from '../utils/barcodeGenerator';
 import { requireRole } from '../../middleware/auth';
+import { createInventoryEvent } from '../services/inventoryEventService';
 
 const router = Router();
 const objectStorage = new ObjectStorageService();
@@ -1024,6 +1025,27 @@ async function handleAcceptedUnit(unit: ReceivedUnit, receipt: Receipt, user: Au
       notes: `Receipt ${receipt.receiptNumber} · unit barcode ${unit.barcode}`,
     });
     await db.insert(materialLotTransactions).values(txValues);
+
+    await createInventoryEvent({
+      agPartNumber: line.agPartNumber,
+      eventType: 'receipt',
+      quantity: Number(unit.quantity),
+      lotId: lot.id,
+      unitOfMeasure: unit.uom ?? 'EA',
+      toLocation: unit.location?.trim() || 'WAREHOUSE-MAIN',
+      referenceType: 'RECEIVED_UNIT',
+      referenceId: unit.id,
+      performedBy: displayName,
+      notes: `Receipt ${receipt.receiptNumber}: accepted unit ${unit.barcode}`,
+      metadata: {
+        receiptId: receipt.id,
+        receiptNumber: receipt.receiptNumber,
+        receivedUnitId: unit.id,
+        unitBarcode: unit.barcode,
+        materialLotId: lot.id,
+        internalControlNumber: icn,
+      },
+    });
 
   } catch (err: any) {
     // Re-throw so callers can return a 422 to the client with the exact reason

--- a/server/src/services/inventoryEventService.ts
+++ b/server/src/services/inventoryEventService.ts
@@ -25,6 +25,7 @@ export interface InventoryEventParams {
   agPartNumber: string;
   eventType: InventoryEventType;
   quantity: number;
+  lotId?: string | null;
   unitOfMeasure?: string;
   fromLocation?: string | null;
   toLocation?: string | null;
@@ -64,6 +65,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     agPartNumber,
     eventType,
     quantity,
+    lotId,
     unitOfMeasure,
     fromLocation,
     toLocation,
@@ -134,6 +136,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
       await recordInventoryBalanceLedgerChange({
         agPartNumber,
         transactionType: 'TRANSFER',
+        lotId,
         locationId: fromLocation,
         quantityDelta: change.delta,
         quantityBefore: change.before,
@@ -151,6 +154,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
       await recordInventoryBalanceLedgerChange({
         agPartNumber,
         transactionType: 'TRANSFER',
+        lotId,
         locationId: toLocation,
         quantityDelta: change.delta,
         quantityBefore: change.before,
@@ -172,6 +176,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     await recordInventoryBalanceLedgerChange({
       agPartNumber,
       transactionType: toLedgerTransactionType(eventType),
+      lotId,
       locationId: location,
       quantityDelta: change.delta,
       quantityBefore: change.before,
@@ -189,6 +194,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
       await recordInventoryBalanceLedgerChange({
         agPartNumber,
         transactionType: 'MOVE',
+        lotId,
         locationId: fromLocation,
         quantityDelta: sourceChange.delta,
         quantityBefore: sourceChange.before,
@@ -210,6 +216,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     await recordInventoryBalanceLedgerChange({
       agPartNumber,
       transactionType: toLedgerTransactionType(eventType),
+      lotId,
       locationId: location,
       quantityDelta: change.delta,
       quantityBefore: change.before,
@@ -230,6 +237,7 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
     await recordInventoryBalanceLedgerChange({
       agPartNumber,
       transactionType: 'RETURN',
+      lotId,
       locationId: location,
       quantityDelta: change.delta,
       quantityBefore: change.before,

--- a/server/src/services/inventoryTransactionLedgerService.ts
+++ b/server/src/services/inventoryTransactionLedgerService.ts
@@ -66,6 +66,7 @@ export type InventoryLedgerEntryInput = {
 export type InventoryLedgerBalanceChangeInput = {
   agPartNumber: string;
   transactionType: InventoryLedgerTransactionType;
+  lotId?: string | null;
   locationId?: string | null;
   quantityDelta: number;
   quantityBefore: number;
@@ -219,6 +220,7 @@ export async function recordInventoryBalanceLedgerChange(
     transactionType: input.transactionType,
     inventoryItemId: item.id,
     agPartNumber: item.agPartNumber,
+    lotId: input.lotId ?? null,
     locationId: input.locationId ?? null,
     quantityDelta: input.quantityDelta,
     quantityBefore: input.quantityBefore,


### PR DESCRIPTION
## Summary

- records Receiving Control Center accepted units as inventory `receipt` events
- carries the material lot id through inventory event writes into immutable ledger rows
- keeps the existing pending receipt event behavior unchanged

## Root Cause

The RCC acceptance path created `material_lots` and `material_lot_transactions`, but it did not call the inventory event writer. The Inventory Ledger page reads inventory transaction events, so it could show `receipt_pending` records from PO staging while missing the actual accepted receiving records from RCC.

## Validation

- `git diff --check -- server/src/routes/receiving.ts server/src/services/inventoryEventService.ts server/src/services/inventoryTransactionLedgerService.ts`
- `git diff --cached --check`

Local runtime tests were not run because this clean worktree has no `node_modules` installed.