### PR TITLE
Fix vendor document viewing route

### DIFF
--- a/client/src/pages/VendorManagement.tsx
+++ b/client/src/pages/VendorManagement.tsx
@@ -697,6 +697,21 @@ export default function VendorManagement() {
     form.setValue('mainDocumentUrl', '');
   };
 
+  const getVendorPdfViewUrl = (url: string) => {
+    const trimmed = url.trim();
+    const normalized = trimmed.startsWith('objects/') ? `/${trimmed}` : trimmed;
+    const isVendorStoragePath =
+      normalized.startsWith('/objects/') ||
+      normalized.startsWith('/uploads/vendor-documents/') ||
+      normalized.startsWith('/uploads/vendor-approvals/') ||
+      normalized.startsWith('vendor-documents/') ||
+      normalized.startsWith('vendor-approvals/');
+
+    return isVendorStoragePath
+      ? `/api/vendors/documents/view?path=${encodeURIComponent(normalized)}`
+      : trimmed;
+  };
+
   // Opens a vendor PDF URL after a HEAD precheck so users get a clear toast
   // instead of a blank tab when the underlying object is missing / forbidden /
   // the storage backend is unavailable.
@@ -714,16 +729,18 @@ export default function VendorManagement() {
       return;
     }
 
+    const viewUrl = getVendorPdfViewUrl(trimmed);
+
     // Only HEAD-precheck same-origin storage paths (`/objects/...`,
-    // `/uploads/...`). For full external URLs (e.g. a legacy
+    // `/uploads/...`) through the vendor document API. For full external URLs (e.g. a legacy
     // `https://storage.googleapis.com/...` value) HEAD is typically blocked
     // by CORS or unsupported, so a precheck would produce false negatives.
     // In that case we just open the URL directly and let the browser handle it.
     const isSameOriginStoragePath =
-      trimmed.startsWith('/objects/') || trimmed.startsWith('/uploads/');
+      viewUrl.startsWith('/api/vendors/documents/view');
 
     const openDirect = () => {
-      const win = window.open(trimmed, '_blank', 'noopener,noreferrer');
+      const win = window.open(viewUrl, '_blank', 'noopener,noreferrer');
       if (!win) {
         toast({
           title: 'Pop-up blocked',
@@ -741,7 +758,7 @@ export default function VendorManagement() {
 
     let res: Response;
     try {
-      res = await fetch(trimmed, { method: 'HEAD' });
+      res = await fetch(viewUrl, { method: 'HEAD' });
     } catch {
       // Network error or HEAD unsupported — fall back to direct open so we
       // don't block a document that might actually load via GET.

--- a/server/src/routes/vendors.ts
+++ b/server/src/routes/vendors.ts
@@ -11,10 +11,17 @@ import { storage } from '../../storage';
 import { db } from '../../db';
 import { authenticateToken } from '../../middleware/auth';
 import { authorizeApiRoute } from '../../middleware/routeAuthorization';
-import { objectStorageClient } from '../../replit_integrations/object_storage/objectStorage';
+import {
+  ObjectNotFoundError,
+  objectStorageClient,
+} from '../../replit_integrations/object_storage/objectStorage';
 import { setObjectAclPolicy } from '../../replit_integrations/object_storage/objectAcl';
 import { auditService } from '../services/auditService';
-import { getFileStorageProvider, getStorageErrorResponse } from '../services/fileStorageProvider';
+import {
+  getFileStorageProvider,
+  getFileStorageProviderForObjectPath,
+  getStorageErrorResponse,
+} from '../services/fileStorageProvider';
 import {
   insertSupplierAuditSchema,
   insertSupplierScopeSchema,
@@ -44,6 +51,108 @@ if (!fs.existsSync(vendorApprovalsDir)) {
 
 if (!fs.existsSync(vendorDocumentsDir)) {
   fs.mkdirSync(vendorDocumentsDir, { recursive: true });
+}
+
+type VendorDocumentPath =
+  | { type: 'object'; path: string }
+  | { type: 'upload'; path: string }
+  | { type: 'external'; url: string };
+
+function isVendorDocumentScope(pathValue: string): boolean {
+  return (
+    pathValue.includes('/vendor-documents/') ||
+    pathValue.includes('/vendor-approvals/') ||
+    pathValue.startsWith('vendor-documents/') ||
+    pathValue.startsWith('vendor-approvals/')
+  );
+}
+
+function normalizeVendorDocumentPath(rawValue: unknown): VendorDocumentPath | null {
+  const value = String(rawValue || '').trim();
+  if (!value) return null;
+
+  if (value.startsWith('https://storage.googleapis.com/')) {
+    try {
+      const privateObjectDir = process.env.PRIVATE_OBJECT_DIR;
+      const rawPath = new URL(value).pathname;
+      const entityDir = privateObjectDir
+        ? privateObjectDir.endsWith('/')
+          ? privateObjectDir
+          : `${privateObjectDir}/`
+        : null;
+
+      if (entityDir && rawPath.startsWith(entityDir)) {
+        const entityId = rawPath.slice(entityDir.length);
+        if (isVendorDocumentScope(entityId)) {
+          return { type: 'object', path: `/objects/${entityId}` };
+        }
+      }
+    } catch {
+      // Fall through to the direct external redirect below.
+    }
+
+    return { type: 'external', url: value };
+  }
+
+  const normalized = value.startsWith('objects/') ? `/${value}` : value;
+  if (normalized.startsWith('/objects/')) {
+    return isVendorDocumentScope(normalized)
+      ? { type: 'object', path: normalized }
+      : null;
+  }
+
+  if (normalized.startsWith('vendor-documents/') || normalized.startsWith('vendor-approvals/')) {
+    return { type: 'object', path: `/objects/${normalized}` };
+  }
+
+  const uploadPath = normalized.startsWith('uploads/') ? `/${normalized}` : normalized;
+  if (
+    uploadPath.startsWith('/uploads/vendor-documents/') ||
+    uploadPath.startsWith('/uploads/vendor-approvals/')
+  ) {
+    return { type: 'upload', path: uploadPath };
+  }
+
+  return null;
+}
+
+async function serveVendorDocumentPath(rawPath: unknown, res: Response): Promise<void> {
+  const docPath = normalizeVendorDocumentPath(rawPath);
+  if (!docPath) {
+    res.status(404).json({ error: 'Vendor document not found' });
+    return;
+  }
+
+  if (docPath.type === 'external') {
+    res.redirect(docPath.url);
+    return;
+  }
+
+  if (docPath.type === 'upload') {
+    const relativePath = docPath.path.replace(/^\/uploads\//, '');
+    const absolutePath = path.resolve(uploadsDir, relativePath);
+    const uploadsRoot = path.resolve(uploadsDir);
+    if (!absolutePath.startsWith(uploadsRoot + path.sep)) {
+      res.status(400).json({ error: 'Invalid vendor document path' });
+      return;
+    }
+    res.sendFile(absolutePath, (err) => {
+      if (err && !res.headersSent) {
+        res.status((err as any).status || 404).json({ error: 'Vendor document not found' });
+      }
+    });
+    return;
+  }
+
+  try {
+    await getFileStorageProviderForObjectPath(docPath.path).downloadObject(docPath.path, res);
+  } catch (error) {
+    if (error instanceof ObjectNotFoundError && !res.headersSent) {
+      res.status(404).json({ error: 'Vendor document not found' });
+      return;
+    }
+    throw error;
+  }
 }
 
 // Configure multer for vendor approval PDFs (memory storage for object storage upload)
@@ -401,6 +510,17 @@ router.get('/', async (req: Request, res: Response) => {
         .json({ error: 'Invalid query parameters', details: error.errors });
     }
     res.status(500).json({ error: 'Failed to fetch vendors' });
+  }
+});
+
+// GET /api/vendors/documents/view - Stream a vendor document through the API
+router.get('/documents/view', async (req: Request, res: Response) => {
+  try {
+    await serveVendorDocumentPath(req.query.path, res);
+  } catch (error) {
+    console.error('View vendor document error:', error);
+    const { status, reason, message } = getStorageErrorResponse(error);
+    res.status(status).json({ error: message, reason });
   }
 });
 


### PR DESCRIPTION
## Summary
- Route vendor document opens through a protected `/api/vendors/documents/view` endpoint instead of opening raw storage paths directly
- Normalize legacy `objects/...`, `/objects/...`, vendor object scopes, and `/uploads/vendor-*` paths before streaming
- Keep existing Vendor Management buttons and missing-document toasts, but avoid sending users to the SPA 404 page for uploaded PDFs

## Verification
- `git diff --check`
- `npm run check` could not run locally because `npm` is not installed on this Windows session and this worktree has no `node_modules`