### PR TITLE
Restore P2 queue visibility after PM WO routing fix

### DIFF
--- a/client/src/components/p2/P2ProductionQueue.tsx
+++ b/client/src/components/p2/P2ProductionQueue.tsx
@@ -902,7 +902,12 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
                                           )}
                                         </TableCell>
                                         <TableCell>
-                                          {item.hasActiveTask && item.activeTask ? (
+                                          {item.status === 'COMPLETED' ? (
+                                            <Badge className="bg-green-600">
+                                              <CheckCircle className="h-3 w-3 mr-1" />
+                                              Completed
+                                            </Badge>
+                                          ) : item.hasActiveTask && item.activeTask ? (
                                             <div className="flex items-center gap-2">
                                               <Badge className="bg-green-600">
                                                 <Play className="h-3 w-3 mr-1" />
@@ -933,34 +938,38 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
                                             >
                                               <Eye className="h-4 w-4" />
                                             </Button>
-                                            <Button
-                                              variant="ghost"
-                                              size="sm"
-                                              onClick={() => openHoldDialog(item)}
-                                              className="text-amber-600 hover:text-amber-700"
-                                              data-testid={`button-hold-${item.id}`}
-                                            >
-                                              <Pause className="h-4 w-4" />
-                                            </Button>
-                                            <Button
-                                              variant="ghost"
-                                              size="sm"
-                                              onClick={() => openOffSystemDialog(item)}
-                                              className="text-indigo-600 hover:text-indigo-700"
-                                              title="Off-System Production Complete"
-                                              data-testid={`button-off-system-${item.id}`}
-                                            >
-                                              <ExternalLink className="h-4 w-4" />
-                                            </Button>
-                                            <Button
-                                              variant="ghost"
-                                              size="sm"
-                                              onClick={() => openScrapDialog(item)}
-                                              className="text-red-600 hover:text-red-700"
-                                              data-testid={`button-scrap-${item.id}`}
-                                            >
-                                              <XCircle className="h-4 w-4" />
-                                            </Button>
+                                            {item.status !== 'COMPLETED' && (
+                                              <>
+                                                <Button
+                                                  variant="ghost"
+                                                  size="sm"
+                                                  onClick={() => openHoldDialog(item)}
+                                                  className="text-amber-600 hover:text-amber-700"
+                                                  data-testid={`button-hold-${item.id}`}
+                                                >
+                                                  <Pause className="h-4 w-4" />
+                                                </Button>
+                                                <Button
+                                                  variant="ghost"
+                                                  size="sm"
+                                                  onClick={() => openOffSystemDialog(item)}
+                                                  className="text-indigo-600 hover:text-indigo-700"
+                                                  title="Off-System Production Complete"
+                                                  data-testid={`button-off-system-${item.id}`}
+                                                >
+                                                  <ExternalLink className="h-4 w-4" />
+                                                </Button>
+                                                <Button
+                                                  variant="ghost"
+                                                  size="sm"
+                                                  onClick={() => openScrapDialog(item)}
+                                                  className="text-red-600 hover:text-red-700"
+                                                  data-testid={`button-scrap-${item.id}`}
+                                                >
+                                                  <XCircle className="h-4 w-4" />
+                                                </Button>
+                                              </>
+                                            )}
                                           </div>
                                         </TableCell>
                                       </TableRow>

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3348,11 +3348,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     try {
       const { storage } = await import('../../storage');
       
-      // Get all active serialized items using storage method (which handles pool.query)
+      // Keep P2 Control Center as the visible source for WIP and finished units.
       const allItems = await applyCompletedTravelerStateToP2Items(
-        await storage.getP2SerializedItems({ status: 'ACTIVE' })
+        await storage.getP2SerializedItems({})
       );
-      const items = (allItems || []).filter((item: any) => item.status === 'ACTIVE');
+      const visibleStatuses = new Set(['ACTIVE', 'COMPLETED']);
+      const items = (allItems || []).filter((item: any) => visibleStatuses.has(item.status));
       const { pool: dbPool } = await import('../../db');
       const poIds = [...new Set(items.map((item: any) => item.poId ?? item.po_id).filter(Boolean))];
       const projectRows = poIds.length > 0
@@ -3392,22 +3393,42 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         (projectRows as any[]).map((row: any) => [Number(row.poId), row])
       );
       
-      // Work tasks and routings tables may not exist yet - use empty arrays as fallback
-      const activeTasks: any[] = [];
+      const itemIds = items.map((item: any) => item.id).filter(Boolean);
+      let activeTasks: any[] = [];
+      if (itemIds.length > 0) {
+        try {
+          activeTasks = await dbPool.query(
+            `SELECT
+               id::text AS id,
+               serialized_item_id::text AS "serializedItemId",
+               employee_name AS "employeeName",
+               employee_code AS "employeeCode",
+               started_at AS "startedAt"
+             FROM p2_work_tasks
+             WHERE serialized_item_id = ANY($1::uuid[])
+               AND status = 'IN_PROGRESS'
+             ORDER BY started_at DESC`,
+            [itemIds]
+          );
+        } catch (taskError: any) {
+          console.warn('P2 production queue active task lookup skipped:', taskError?.message);
+        }
+      }
       const allRoutings: any[] = [];
       
       // Create task lookup by serialized item ID
       const taskByItemId = new Map<string, any>();
-      activeTasks.forEach((task: any) => {
+      (activeTasks as any[]).forEach((task: any) => {
         taskByItemId.set(task.serializedItemId, task);
       });
       
       // Get unique departments from all items and routings
       const departmentsSet = new Set<string>();
       items.forEach((item: any) => {
-        if (item.currentDepartment) {
-          departmentsSet.add(item.currentDepartment);
-        }
+        const displayDepartment = item.status === 'COMPLETED'
+          ? 'Completed'
+          : item.currentDepartment;
+        if (displayDepartment) departmentsSet.add(displayDepartment);
       });
       allRoutings.forEach((routing: any) => {
         const sequence = routing.departmentSequence as string[] || [];
@@ -3423,7 +3444,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         'Finish',
         'Paint',
         'Final QC',
-        'Shipping'
+        'Shipping',
+        'Completed'
       ];
       
       // Add any departments not in standard order
@@ -3440,7 +3462,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       });
       
       items.forEach((item: any) => {
-        const dept = item.currentDepartment || 'Pending Layup';
+        const dept = item.status === 'COMPLETED'
+          ? 'Completed'
+          : (item.currentDepartment || 'Pending Layup');
         if (!departmentQueues[dept]) {
           departmentQueues[dept] = [];
         }
@@ -3486,7 +3510,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         .map(dept => {
           const queueItems = departmentQueues[dept] || [];
           const inProgressCount = queueItems.filter(i => i.hasActiveTask).length;
-          const waitingCount = queueItems.length - inProgressCount;
+          const waitingCount = queueItems.filter(i => i.status === 'ACTIVE' && !i.hasActiveTask).length;
           
           return {
             name: dept,
@@ -3500,8 +3524,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       res.json({
         departments,
         summary: {
-          totalActive: items.length,
-          totalInProgress: activeTasks.length,
+          totalActive: items.filter((item: any) => item.status === 'ACTIVE').length,
+          totalInProgress: (activeTasks as any[]).length,
           departmentCount: departments.filter(d => d.totalItems > 0).length,
         },
       });

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -468,6 +468,7 @@ router.get('/:projectId/summary', h(async (req, res) => {
         AND status NOT IN ('CANCELLED', 'CANCELED')
         AND NOT (
           work_order_number LIKE 'WAD-%'
+          AND status NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED')
           AND EXISTS (
             SELECT 1 FROM p2_superseding_parts psp
             WHERE psp.part_number = LOWER(TRIM(production_work_orders.part_number))
@@ -597,6 +598,7 @@ router.get('/:projectId/summary', h(async (req, res) => {
         AND wo2.status NOT IN ('CANCELLED', 'CANCELED')
         AND NOT (
           wo2.work_order_number LIKE 'WAD-%'
+          AND wo2.status NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED')
           AND EXISTS (
             SELECT 1
             FROM (
@@ -694,6 +696,7 @@ router.get('/:projectId/summary', h(async (req, res) => {
          AND status NOT IN ('CANCELLED', 'CANCELED')
          AND NOT (
            work_order_number LIKE 'WAD-%'
+           AND status NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED')
            AND EXISTS (
              SELECT 1 FROM p2_superseding_parts psp
              WHERE psp.part_number = LOWER(TRIM(production_work_orders.part_number))
@@ -739,6 +742,7 @@ router.get('/:projectId/summary', h(async (req, res) => {
          AND status IN ('COMPLETE', 'COMPLETED', 'CLOSED')
          AND NOT (
            work_order_number LIKE 'WAD-%'
+           AND status NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED')
            AND EXISTS (
              SELECT 1 FROM p2_superseding_parts psp
              WHERE psp.part_number = LOWER(TRIM(production_work_orders.part_number))
@@ -937,6 +941,7 @@ router.get('/:projectId/production', h(async (req, res) => {
         AND wo.status NOT IN ('CANCELLED', 'CANCELED')
         AND NOT (
           wo.work_order_number LIKE 'WAD-%'
+          AND wo.status NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED')
           AND EXISTS (
             SELECT 1 FROM p2_superseding_parts psp
             WHERE psp.part_number = LOWER(TRIM(wo.part_number))


### PR DESCRIPTION
## Summary
- Restore completed PM production WOs by only suppressing redundant WAD rows when they are still active, never when they are complete/closed.
- Restore P2 Control Center Production tab visibility for completed units by loading active and completed serialized items.
- Restore “Being Worked On” visibility by loading active `p2_work_tasks` instead of using an empty task list, and render completed units as view-only rows.

## Validation
- `git diff --check HEAD~2..HEAD -- server/src/routes/pmDashboard.ts server/src/routes/index.ts client/src/components/p2/P2ProductionQueue.tsx`

## Notes
- This is a corrective follow-up because PR #771 was already merged before the P2 visibility issue was fully addressed.
- Local `npm` is still unavailable in this PowerShell environment, so I could not run the full TypeScript check.