### PR TITLE
Add program manufacturing orchestration

### DIFF
--- a/client/src/components/p2/ProgramManufacturingOrchestration.tsx
+++ b/client/src/components/p2/ProgramManufacturingOrchestration.tsx
@@ -1,0 +1,336 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'wouter';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  GitBranch,
+  Layers3,
+  PackageCheck,
+  Route,
+  Truck,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type AssemblyStatus = 'PLANNED' | 'READY' | 'IN_PROGRESS' | 'BLOCKED' | 'COMPLETE';
+
+interface QueueLink {
+  id: string;
+  label: string;
+  department: string | null;
+  status: string | null;
+  manufacturingQueueId: number | null;
+  productionWorkOrderId: string | null;
+  travelerId: string | null;
+}
+
+export interface ProgramAssembly {
+  id: string;
+  assemblyCode: string;
+  assemblyName: string;
+  level: number;
+  sequence: number;
+  assemblyType: string;
+  partNumber: string | null;
+  status: string;
+  computedStatus: AssemblyStatus;
+  completionPercent: number;
+  totalQueueItems: number;
+  completedQueueItems: number;
+  links: QueueLink[];
+  blockedBy: {
+    assemblyId: string;
+    assemblyCode: string;
+    assemblyName: string;
+    dependencyType: string;
+    notes: string | null;
+  }[];
+  children: ProgramAssembly[];
+}
+
+interface ProgramManufacturingStatus {
+  ready: boolean;
+  build: {
+    id: string;
+    projectId: string | null;
+    projectCode: string | null;
+    projectName: string | null;
+    programCode: string;
+    programName: string;
+    buildName: string;
+    buildType: string;
+    status: string;
+    targetShipDate: string | null;
+    customerName: string | null;
+    poNumber: string | null;
+  } | null;
+  summary: {
+    totalAssemblies: number;
+    completeAssemblies: number;
+    blockedAssemblies: number;
+    inProgressAssemblies: number;
+    totalQueueItems: number;
+    completedQueueItems: number;
+    completionPercent: number;
+    shipReady: boolean;
+    criticalPath: ProgramAssembly[];
+  };
+  assemblies: ProgramAssembly[];
+  flatAssemblies: ProgramAssembly[];
+  blockers: ProgramAssembly[];
+  swimlanes: {
+    name: string;
+    assemblies: ProgramAssembly[];
+    completionPercent: number;
+    blockedCount: number;
+  }[];
+}
+
+interface ProgramManufacturingOrchestrationProps {
+  mode: 'overview' | 'tree' | 'swimlane';
+  projectId?: string;
+  compact?: boolean;
+}
+
+function statusVariant(status: AssemblyStatus) {
+  if (status === 'COMPLETE') return 'default';
+  if (status === 'BLOCKED') return 'destructive';
+  return 'secondary';
+}
+
+function statusLabel(status: AssemblyStatus) {
+  return status.replace(/_/g, ' ');
+}
+
+function buildStatusUrl(projectId?: string) {
+  const params = new URLSearchParams();
+  if (projectId) params.set('projectId', projectId);
+  const qs = params.toString();
+  return `/api/program-manufacturing/status${qs ? `?${qs}` : ''}`;
+}
+
+async function fetchProgramStatus(projectId?: string): Promise<ProgramManufacturingStatus> {
+  const res = await fetch(buildStatusUrl(projectId));
+  if (!res.ok) throw new Error('Failed to fetch program manufacturing status');
+  return res.json();
+}
+
+function EmptyProgramState({ compact = false }: { compact?: boolean }) {
+  return (
+    <Card>
+      <CardContent className={compact ? 'p-4' : 'p-8 text-center'}>
+        <PackageCheck className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+        <p className="text-sm font-medium">No program build is active</p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Existing P2 queues remain available; program orchestration appears once a build is seeded or linked.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AssemblyRow({ assembly }: { assembly: ProgramAssembly }) {
+  return (
+    <div className="rounded-md border bg-background p-3 space-y-2">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-mono text-xs text-muted-foreground">{assembly.assemblyCode}</span>
+            <span className="font-medium">{assembly.assemblyName}</span>
+            {assembly.partNumber && <Badge variant="outline">{assembly.partNumber}</Badge>}
+          </div>
+          {assembly.blockedBy.length > 0 && (
+            <p className="text-xs text-red-600 mt-1">
+              Blocked by {assembly.blockedBy.map((b) => b.assemblyCode).join(', ')}
+            </p>
+          )}
+        </div>
+        <Badge variant={statusVariant(assembly.computedStatus)}>
+          {statusLabel(assembly.computedStatus)}
+        </Badge>
+      </div>
+      <div className="flex items-center gap-3">
+        <Progress value={assembly.completionPercent} className="h-2" />
+        <span className="text-xs text-muted-foreground w-10 text-right">{assembly.completionPercent}%</span>
+      </div>
+      {assembly.links.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {assembly.links.map((link) => (
+            <Badge key={link.id} variant="outline" className="text-[11px]">
+              {link.label}{link.department ? ` - ${link.department}` : ''}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AssemblyTreeNode({ assembly }: { assembly: ProgramAssembly }) {
+  return (
+    <div className="space-y-2">
+      <AssemblyRow assembly={assembly} />
+      {assembly.children.length > 0 && (
+        <div className="ml-4 pl-4 border-l space-y-2">
+          {assembly.children.map((child) => (
+            <AssemblyTreeNode key={child.id} assembly={child} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Overview({ data }: { data: ProgramManufacturingStatus }) {
+  const build = data.build!;
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Layers3 className="h-4 w-4" />
+              Program Health
+            </div>
+            <div className="text-2xl font-bold mt-2">{data.summary.completionPercent}%</div>
+            <Progress value={data.summary.completionPercent} className="h-2 mt-3" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <AlertTriangle className="h-4 w-4" />
+              Blocked
+            </div>
+            <div className="text-2xl font-bold mt-2">{data.summary.blockedAssemblies}</div>
+            <p className="text-xs text-muted-foreground">{data.summary.inProgressAssemblies} in progress</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <CheckCircle2 className="h-4 w-4" />
+              Assemblies
+            </div>
+            <div className="text-2xl font-bold mt-2">{data.summary.completeAssemblies}/{data.summary.totalAssemblies}</div>
+            <p className="text-xs text-muted-foreground">complete</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Route className="h-4 w-4" />
+              Queue Links
+            </div>
+            <div className="text-2xl font-bold mt-2">{data.summary.completedQueueItems}/{data.summary.totalQueueItems}</div>
+            <p className="text-xs text-muted-foreground">complete</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Truck className="h-4 w-4" />
+              Ship Ready
+            </div>
+            <div className="text-2xl font-bold mt-2">{data.summary.shipReady ? 'Yes' : 'No'}</div>
+            <p className="text-xs text-muted-foreground">{build.targetShipDate ?? 'No target date'}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between gap-3">
+            <span>{build.buildName}</span>
+            {build.projectId && (
+              <Link href={`/pm-control-center?project=${build.projectId}`} className="text-sm font-normal text-blue-600 hover:underline">
+                Open PM
+              </Link>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid md:grid-cols-2 gap-4">
+          <div>
+            <p className="text-sm text-muted-foreground">Critical Path</p>
+            <div className="space-y-2 mt-2">
+              {data.summary.criticalPath.length > 0
+                ? data.summary.criticalPath.map((assembly) => <AssemblyRow key={assembly.id} assembly={assembly} />)
+                : <p className="text-sm text-muted-foreground">No open critical path items.</p>}
+            </div>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Blocked Assemblies</p>
+            <div className="space-y-2 mt-2">
+              {data.blockers.length > 0
+                ? data.blockers.map((assembly) => <AssemblyRow key={assembly.id} assembly={assembly} />)
+                : <p className="text-sm text-muted-foreground">No assembly blockers.</p>}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Tree({ data }: { data: ProgramManufacturingStatus }) {
+  return (
+    <div className="space-y-3">
+      {data.assemblies.map((assembly) => (
+        <AssemblyTreeNode key={assembly.id} assembly={assembly} />
+      ))}
+    </div>
+  );
+}
+
+function Swimlane({ data }: { data: ProgramManufacturingStatus }) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-3">
+      {data.swimlanes.map((lane) => (
+        <Card key={lane.name}>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center justify-between gap-2 text-base">
+              <span className="flex items-center gap-2">
+                <GitBranch className="h-4 w-4" />
+                {lane.name}
+              </span>
+              <Badge variant={lane.blockedCount > 0 ? 'destructive' : 'secondary'}>
+                {lane.completionPercent}%
+              </Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {lane.assemblies.map((assembly) => (
+              <AssemblyRow key={assembly.id} assembly={assembly} />
+            ))}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export default function ProgramManufacturingOrchestration({
+  mode,
+  projectId,
+  compact = false,
+}: ProgramManufacturingOrchestrationProps) {
+  const { data, isLoading, isError } = useQuery<ProgramManufacturingStatus>({
+    queryKey: ['/api/program-manufacturing/status', projectId ?? 'all'],
+    queryFn: () => fetchProgramStatus(projectId),
+    refetchInterval: 30000,
+  });
+
+  if (isLoading) {
+    return <Skeleton className={compact ? 'h-40 w-full' : 'h-72 w-full'} />;
+  }
+
+  if (isError || !data?.build) {
+    return <EmptyProgramState compact={compact} />;
+  }
+
+  if (mode === 'tree') return <Tree data={data} />;
+  if (mode === 'swimlane') return <Swimlane data={data} />;
+  return <Overview data={data} />;
+}

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -50,6 +50,7 @@ import P2ChangesTab from '@/components/p2/P2ChangesTab';
 import P2ShippingTab from '@/components/p2/P2ShippingTab';
 import P2NonconformingTab from '@/components/p2/P2ScrappedItemsTab';
 import { TravelerCapturedDataById } from '@/components/p2/TravelerCapturedData';
+import ProgramManufacturingOrchestration from '@/components/p2/ProgramManufacturingOrchestration';
 import { queryClient, apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -720,6 +721,18 @@ export default function P2ControlCenter() {
             <Factory className="h-4 w-4" />
             Production
           </TabsTrigger>
+          <TabsTrigger value="program" className="flex items-center gap-2" data-testid="tab-program-overview">
+            <Layers className="h-4 w-4" />
+            Program
+          </TabsTrigger>
+          <TabsTrigger value="assembly-tree" className="flex items-center gap-2" data-testid="tab-assembly-tree">
+            <Route className="h-4 w-4" />
+            Assembly Tree
+          </TabsTrigger>
+          <TabsTrigger value="swimlane" className="flex items-center gap-2" data-testid="tab-swimlane">
+            <BarChart3 className="h-4 w-4" />
+            Swimlane
+          </TabsTrigger>
           <TabsTrigger value="shipping" className="flex items-center gap-2" data-testid="tab-shipping">
             <Truck className="h-4 w-4" />
             Shipping
@@ -834,6 +847,18 @@ export default function P2ControlCenter() {
 
         <TabsContent value="production">
           <P2ProductionQueue selectedPONumbers={selectedPONumbers} />
+        </TabsContent>
+
+        <TabsContent value="program">
+          <ProgramManufacturingOrchestration mode="overview" projectId={wadProjectId || undefined} />
+        </TabsContent>
+
+        <TabsContent value="assembly-tree">
+          <ProgramManufacturingOrchestration mode="tree" projectId={wadProjectId || undefined} />
+        </TabsContent>
+
+        <TabsContent value="swimlane">
+          <ProgramManufacturingOrchestration mode="swimlane" projectId={wadProjectId || undefined} />
         </TabsContent>
 
         <TabsContent value="shipping" className="space-y-4">

--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -250,6 +250,41 @@ interface MaterialData {
   rows: MaterialRow[];
 }
 
+interface ProgramAssemblyWidgetRow {
+  id: string;
+  assemblyCode: string;
+  assemblyName: string;
+  computedStatus: 'PLANNED' | 'READY' | 'IN_PROGRESS' | 'BLOCKED' | 'COMPLETE';
+  completionPercent: number;
+  blockedBy: { assemblyCode: string; assemblyName: string }[];
+}
+
+interface ProgramHealthData {
+  ready: boolean;
+  build: {
+    id: string;
+    buildName: string;
+    programName: string;
+    programCode: string;
+    targetShipDate: string | null;
+  } | null;
+  widgets: {
+    programHealth: number;
+    criticalPath: ProgramAssemblyWidgetRow[];
+    blockedAssemblies: ProgramAssemblyWidgetRow[];
+    shipReadiness: {
+      ready: boolean;
+      completeAssemblies: number;
+      totalAssemblies: number;
+    };
+    laborMaterialImpact: {
+      queueItems: number;
+      completedQueueItems: number;
+      blockedAssemblies: number;
+    };
+  } | null;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function fmtDate(d: string | null) {
@@ -361,6 +396,98 @@ function KpiCard({
 }
 
 // ── Production Tab ────────────────────────────────────────────────────────────
+
+function ProgramManufacturingWidgets({ projectId }: { projectId: string }) {
+  const { data, isLoading } = useQuery<ProgramHealthData>({
+    queryKey: ['/api/program-manufacturing/projects', projectId, 'health'],
+    queryFn: () => safeFetch<ProgramHealthData>(`/api/program-manufacturing/projects/${projectId}/health`),
+    enabled: !!projectId,
+    refetchInterval: 60000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        {[1, 2, 3, 4, 5].map((i) => <Skeleton key={i} className="h-24" />)}
+      </div>
+    );
+  }
+
+  if (!data?.build || !data.widgets) {
+    return (
+      <Card>
+        <CardContent className="p-4 flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium">No program build linked</p>
+            <p className="text-xs text-muted-foreground">
+              PM production, labor, and material tabs still use the existing project queues.
+            </p>
+          </div>
+          <Badge variant="outline">Program layer idle</Badge>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const critical = data.widgets.criticalPath[0];
+  const blocked = data.widgets.blockedAssemblies[0];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="text-lg font-semibold">{data.build.buildName}</h2>
+          <p className="text-sm text-muted-foreground">
+            {data.build.programCode} - {data.build.programName}
+          </p>
+        </div>
+        <Link href={`/p2-control-center?tab=program&projectId=${projectId}`}>
+          <Button variant="outline" size="sm">
+            <LayoutDashboard className="h-3.5 w-3.5 mr-1.5" />
+            Open Program
+          </Button>
+        </Link>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <KpiCard
+          icon={<TrendingUp className="h-4 w-4" />}
+          label="Program Health"
+          value={`${data.widgets.programHealth}%`}
+          sub="assembly rollup"
+          colorClass={data.widgets.programHealth >= 80 ? 'text-green-600' : 'text-blue-600'}
+        />
+        <KpiCard
+          icon={<ArrowUpDown className="h-4 w-4" />}
+          label="Critical Path"
+          value={critical ? `${critical.completionPercent}%` : 'Clear'}
+          sub={critical ? `${critical.assemblyCode} ${critical.assemblyName}` : 'no open path'}
+          colorClass="text-amber-600"
+        />
+        <KpiCard
+          icon={<AlertCircle className="h-4 w-4" />}
+          label="Blocked Assemblies"
+          value={data.widgets.blockedAssemblies.length}
+          sub={blocked ? `First: ${blocked.assemblyCode}` : 'none blocked'}
+          colorClass={data.widgets.blockedAssemblies.length > 0 ? 'text-red-600' : 'text-green-600'}
+        />
+        <KpiCard
+          icon={<Calendar className="h-4 w-4" />}
+          label="Ship Readiness"
+          value={data.widgets.shipReadiness.ready ? 'Ready' : 'Not Ready'}
+          sub={`${data.widgets.shipReadiness.completeAssemblies}/${data.widgets.shipReadiness.totalAssemblies} assemblies`}
+          colorClass={data.widgets.shipReadiness.ready ? 'text-green-600' : 'text-orange-600'}
+        />
+        <KpiCard
+          icon={<Package className="h-4 w-4" />}
+          label="Labor/Material Impact"
+          value={`${data.widgets.laborMaterialImpact.completedQueueItems}/${data.widgets.laborMaterialImpact.queueItems}`}
+          sub={`${data.widgets.laborMaterialImpact.blockedAssemblies} blocked assemblies`}
+          colorClass="text-indigo-600"
+        />
+      </div>
+    </div>
+  );
+}
 
 type CompletionFilter = 'all' | 'not_started' | 'in_progress' | 'complete';
 type QtySort = null | 'asc' | 'desc';
@@ -1570,6 +1697,10 @@ export default function PMControlCenterPage() {
             </p>
           </CardContent>
         </Card>
+      )}
+
+      {selectedProjectId && (
+        <ProgramManufacturingWidgets projectId={selectedProjectId} />
       )}
 
       {/* KPI Summary Cards */}

--- a/migrations/0141_program_manufacturing_orchestration.sql
+++ b/migrations/0141_program_manufacturing_orchestration.sql
@@ -1,0 +1,184 @@
+CREATE TABLE IF NOT EXISTS program_builds (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
+  p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
+  program_code text NOT NULL UNIQUE,
+  program_name text NOT NULL,
+  build_name text NOT NULL,
+  build_type text NOT NULL DEFAULT 'program',
+  status text NOT NULL DEFAULT 'PLANNED',
+  priority integer NOT NULL DEFAULT 50,
+  target_ship_date date,
+  customer_name text,
+  notes text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS program_builds_project_id_idx ON program_builds(project_id);
+CREATE INDEX IF NOT EXISTS program_builds_po_id_idx ON program_builds(p2_purchase_order_id);
+CREATE INDEX IF NOT EXISTS program_builds_status_idx ON program_builds(status);
+
+CREATE TABLE IF NOT EXISTS program_assemblies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  program_build_id uuid NOT NULL REFERENCES program_builds(id) ON DELETE CASCADE,
+  parent_assembly_id uuid REFERENCES program_assemblies(id) ON DELETE CASCADE,
+  assembly_code text NOT NULL,
+  assembly_name text NOT NULL,
+  level integer NOT NULL DEFAULT 0,
+  sequence integer NOT NULL DEFAULT 0,
+  assembly_type text NOT NULL DEFAULT 'assembly',
+  part_number text,
+  required_quantity integer NOT NULL DEFAULT 1,
+  status text NOT NULL DEFAULT 'PLANNED',
+  planned_start_date date,
+  planned_finish_date date,
+  target_ship_date date,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now(),
+  CONSTRAINT program_assemblies_build_code_unique UNIQUE (program_build_id, assembly_code)
+);
+
+CREATE INDEX IF NOT EXISTS program_assemblies_build_idx ON program_assemblies(program_build_id);
+CREATE INDEX IF NOT EXISTS program_assemblies_parent_idx ON program_assemblies(parent_assembly_id);
+
+CREATE TABLE IF NOT EXISTS program_assembly_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  assembly_id uuid NOT NULL REFERENCES program_assemblies(id) ON DELETE CASCADE,
+  manufacturing_queue_id integer REFERENCES manufacturing_queue(id) ON DELETE SET NULL,
+  production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
+  traveler_id varchar(255) REFERENCES travelers(id) ON DELETE SET NULL,
+  p2_serialized_item_id uuid REFERENCES p2_serialized_items(id) ON DELETE SET NULL,
+  link_type text NOT NULL DEFAULT 'queue_item',
+  required_quantity integer NOT NULL DEFAULT 1,
+  created_at timestamp DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS program_assembly_links_assembly_idx ON program_assembly_links(assembly_id);
+CREATE INDEX IF NOT EXISTS program_assembly_links_queue_idx ON program_assembly_links(manufacturing_queue_id);
+CREATE INDEX IF NOT EXISTS program_assembly_links_traveler_idx ON program_assembly_links(traveler_id);
+
+CREATE TABLE IF NOT EXISTS program_assembly_dependencies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  assembly_id uuid NOT NULL REFERENCES program_assemblies(id) ON DELETE CASCADE,
+  depends_on_assembly_id uuid NOT NULL REFERENCES program_assemblies(id) ON DELETE CASCADE,
+  dependency_type text NOT NULL DEFAULT 'finish_to_start',
+  is_blocking boolean NOT NULL DEFAULT true,
+  notes text,
+  created_at timestamp DEFAULT now(),
+  CONSTRAINT program_assembly_dependencies_unique UNIQUE (assembly_id, depends_on_assembly_id)
+);
+
+CREATE INDEX IF NOT EXISTS program_assembly_dependencies_assembly_idx ON program_assembly_dependencies(assembly_id);
+CREATE INDEX IF NOT EXISTS program_assembly_dependencies_depends_on_idx ON program_assembly_dependencies(depends_on_assembly_id);
+
+DO $$
+DECLARE
+  v_build_id uuid;
+  v_airframe uuid;
+  v_propulsion uuid;
+  v_avionics uuid;
+  v_wing_left uuid;
+  v_wing_right uuid;
+  v_fuselage uuid;
+  v_motor_pods uuid;
+  v_harness uuid;
+  v_final_assembly uuid;
+BEGIN
+  INSERT INTO program_builds (
+    program_code,
+    program_name,
+    build_name,
+    build_type,
+    status,
+    priority,
+    target_ship_date,
+    customer_name,
+    notes,
+    metadata
+  )
+  VALUES (
+    'DRONE-BUILD-ALPHA',
+    'Drone Build Alpha',
+    'Drone Build Alpha - Sample Aircraft',
+    'drone',
+    'IN_PROGRESS',
+    20,
+    CURRENT_DATE + INTERVAL '45 days',
+    'Sample Aerospace Customer',
+    'Seed/sample orchestration build for validating program swimlane and assembly dependency logic.',
+    '{"sample": true, "aircraftType": "composite multirotor"}'::jsonb
+  )
+  ON CONFLICT (program_code) DO UPDATE SET
+    program_name = EXCLUDED.program_name,
+    build_name = EXCLUDED.build_name,
+    build_type = EXCLUDED.build_type,
+    status = EXCLUDED.status,
+    priority = EXCLUDED.priority,
+    target_ship_date = EXCLUDED.target_ship_date,
+    customer_name = EXCLUDED.customer_name,
+    notes = EXCLUDED.notes,
+    metadata = EXCLUDED.metadata,
+    updated_at = now()
+  RETURNING id INTO v_build_id;
+
+  INSERT INTO program_assemblies (program_build_id, assembly_code, assembly_name, level, sequence, assembly_type, status, metadata)
+  VALUES
+    (v_build_id, 'AIRFRAME', 'Airframe', 0, 10, 'major_assembly', 'IN_PROGRESS', '{"swimlane":"Structures"}'::jsonb),
+    (v_build_id, 'PROPULSION', 'Propulsion System', 0, 20, 'major_assembly', 'BLOCKED', '{"swimlane":"Assembly"}'::jsonb),
+    (v_build_id, 'AVIONICS', 'Avionics Bay', 0, 30, 'major_assembly', 'READY', '{"swimlane":"Electrical"}'::jsonb),
+    (v_build_id, 'FINAL-ASSY', 'Final Aircraft Assembly', 0, 40, 'final_assembly', 'BLOCKED', '{"swimlane":"Final Assembly"}'::jsonb)
+  ON CONFLICT (program_build_id, assembly_code) DO UPDATE SET
+    assembly_name = EXCLUDED.assembly_name,
+    level = EXCLUDED.level,
+    sequence = EXCLUDED.sequence,
+    assembly_type = EXCLUDED.assembly_type,
+    status = EXCLUDED.status,
+    metadata = EXCLUDED.metadata,
+    updated_at = now();
+
+  SELECT id INTO v_airframe FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'AIRFRAME';
+  SELECT id INTO v_propulsion FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'PROPULSION';
+  SELECT id INTO v_avionics FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'AVIONICS';
+  SELECT id INTO v_final_assembly FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'FINAL-ASSY';
+
+  INSERT INTO program_assemblies (program_build_id, parent_assembly_id, assembly_code, assembly_name, level, sequence, assembly_type, part_number, status, metadata)
+  VALUES
+    (v_build_id, v_airframe, 'WING-L', 'Left Wing Assembly', 1, 10, 'subassembly', 'DRN-WING-L', 'COMPLETE', '{"swimlane":"Layup"}'::jsonb),
+    (v_build_id, v_airframe, 'WING-R', 'Right Wing Assembly', 1, 20, 'subassembly', 'DRN-WING-R', 'IN_PROGRESS', '{"swimlane":"Layup"}'::jsonb),
+    (v_build_id, v_airframe, 'FUSELAGE', 'Composite Fuselage', 1, 30, 'subassembly', 'DRN-FUSE-001', 'IN_PROGRESS', '{"swimlane":"CNC"}'::jsonb),
+    (v_build_id, v_propulsion, 'MOTOR-PODS', 'Motor Pod Set', 1, 10, 'subassembly', 'DRN-MP-SET', 'BLOCKED', '{"swimlane":"Assembly"}'::jsonb),
+    (v_build_id, v_avionics, 'WIRE-HARNESS', 'Flight Control Harness', 1, 10, 'part', 'DRN-HARNESS-001', 'READY', '{"swimlane":"Electrical"}'::jsonb)
+  ON CONFLICT (program_build_id, assembly_code) DO UPDATE SET
+    parent_assembly_id = EXCLUDED.parent_assembly_id,
+    assembly_name = EXCLUDED.assembly_name,
+    level = EXCLUDED.level,
+    sequence = EXCLUDED.sequence,
+    assembly_type = EXCLUDED.assembly_type,
+    part_number = EXCLUDED.part_number,
+    status = EXCLUDED.status,
+    metadata = EXCLUDED.metadata,
+    updated_at = now();
+
+  SELECT id INTO v_wing_left FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'WING-L';
+  SELECT id INTO v_wing_right FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'WING-R';
+  SELECT id INTO v_fuselage FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'FUSELAGE';
+  SELECT id INTO v_motor_pods FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'MOTOR-PODS';
+  SELECT id INTO v_harness FROM program_assemblies WHERE program_build_id = v_build_id AND assembly_code = 'WIRE-HARNESS';
+
+  INSERT INTO program_assembly_dependencies (assembly_id, depends_on_assembly_id, dependency_type, is_blocking, notes)
+  VALUES
+    (v_airframe, v_wing_left, 'children_complete', true, 'Airframe cannot complete until left wing is complete.'),
+    (v_airframe, v_wing_right, 'children_complete', true, 'Airframe cannot complete until right wing is complete.'),
+    (v_airframe, v_fuselage, 'children_complete', true, 'Airframe cannot complete until fuselage is complete.'),
+    (v_propulsion, v_motor_pods, 'children_complete', true, 'Propulsion is blocked until motor pods are released.'),
+    (v_final_assembly, v_airframe, 'finish_to_start', true, 'Final assembly waits on airframe.'),
+    (v_final_assembly, v_propulsion, 'finish_to_start', true, 'Final assembly waits on propulsion.'),
+    (v_final_assembly, v_avionics, 'finish_to_start', true, 'Final assembly waits on avionics.')
+  ON CONFLICT (assembly_id, depends_on_assembly_id) DO UPDATE SET
+    dependency_type = EXCLUDED.dependency_type,
+    is_blocking = EXCLUDED.is_blocking,
+    notes = EXCLUDED.notes;
+END $$;

--- a/server/__tests__/programManufacturingOrchestration.test.ts
+++ b/server/__tests__/programManufacturingOrchestration.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { computeProgramAssemblyRollups, type ProgramAssemblyRollupInput } from '../src/lib/programManufacturingOrchestration';
+
+function assembly(partial: Partial<ProgramAssemblyRollupInput> & { id: string; assemblyCode: string }): ProgramAssemblyRollupInput {
+  return {
+    parentAssemblyId: null,
+    assemblyName: partial.assemblyCode,
+    level: 0,
+    sequence: 0,
+    assemblyType: 'assembly',
+    partNumber: null,
+    status: 'PLANNED',
+    requiredQuantity: 1,
+    targetShipDate: null,
+    metadata: {},
+    links: [],
+    ...partial,
+  };
+}
+
+describe('program manufacturing rollups', () => {
+  it('blocks an assembly until its required child dependency is complete', () => {
+    const roots = computeProgramAssemblyRollups(
+      [
+        assembly({
+          id: 'final',
+          assemblyCode: 'FINAL',
+          status: 'READY',
+        }),
+        assembly({
+          id: 'wing',
+          assemblyCode: 'WING',
+          status: 'IN_PROGRESS',
+          links: [{
+            id: 'queue-link',
+            linkType: 'queue_item',
+            manufacturingQueueId: 44,
+            productionWorkOrderId: null,
+            travelerId: null,
+            p2SerializedItemId: null,
+            label: 'MQ-44',
+            department: 'Layup',
+            status: 'IN_PROGRESS',
+            completedQuantity: 0,
+            requiredQuantity: 1,
+          }],
+        }),
+      ],
+      [{
+        assemblyId: 'final',
+        dependsOnAssemblyId: 'wing',
+        dependencyType: 'finish_to_start',
+        isBlocking: true,
+        notes: 'Final assembly waits on wing.',
+      }],
+    );
+
+    const finalAssembly = roots.find((item) => item.id === 'final');
+    expect(finalAssembly?.computedStatus).toBe('BLOCKED');
+    expect(finalAssembly?.blockedBy[0].assemblyCode).toBe('WING');
+  });
+
+  it('rolls completed queue links into complete parent progress', () => {
+    const roots = computeProgramAssemblyRollups(
+      [
+        assembly({
+          id: 'airframe',
+          assemblyCode: 'AIRFRAME',
+        }),
+        assembly({
+          id: 'left-wing',
+          parentAssemblyId: 'airframe',
+          assemblyCode: 'WING-L',
+          status: 'COMPLETE',
+          links: [{
+            id: 'traveler-link',
+            linkType: 'traveler',
+            manufacturingQueueId: null,
+            productionWorkOrderId: null,
+            travelerId: 'trav-1',
+            p2SerializedItemId: null,
+            label: 'TRAV-1',
+            department: 'Final QC',
+            status: 'COMPLETED',
+            completedQuantity: 1,
+            requiredQuantity: 1,
+          }],
+        }),
+      ],
+      [],
+    );
+
+    expect(roots[0].completionPercent).toBe(100);
+    expect(roots[0].computedStatus).toBe('COMPLETE');
+    expect(roots[0].totalQueueItems).toBe(1);
+    expect(roots[0].completedQueueItems).toBe(1);
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -16818,6 +16818,111 @@ export const insertProductionWorkOrderSchema = createInsertSchema(productionWork
 export type ProductionWorkOrder = typeof productionWorkOrders.$inferSelect;
 export type InsertProductionWorkOrder = z.infer<typeof insertProductionWorkOrderSchema>;
 
+// Program Manufacturing Orchestration - additive layer above P2 queues/WADs.
+export const programBuilds = pgTable('program_builds', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  projectId: uuid('project_id').references(() => projects.id, { onDelete: 'set null' }),
+  p2PurchaseOrderId: integer('p2_purchase_order_id').references(() => p2PurchaseOrders.id, { onDelete: 'set null' }),
+  programCode: text('program_code').notNull().unique(),
+  programName: text('program_name').notNull(),
+  buildName: text('build_name').notNull(),
+  buildType: text('build_type').notNull().default('program'),
+  status: text('status').notNull().default('PLANNED'),
+  priority: integer('priority').notNull().default(50),
+  targetShipDate: date('target_ship_date'),
+  customerName: text('customer_name'),
+  notes: text('notes'),
+  metadata: jsonb('metadata').default({}).notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+}, (table) => ({
+  projectIdIdx: index('program_builds_project_id_idx').on(table.projectId),
+  poIdIdx: index('program_builds_po_id_idx').on(table.p2PurchaseOrderId),
+  statusIdx: index('program_builds_status_idx').on(table.status),
+}));
+
+export const programAssemblies = pgTable('program_assemblies', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  programBuildId: uuid('program_build_id').notNull().references(() => programBuilds.id, { onDelete: 'cascade' }),
+  parentAssemblyId: uuid('parent_assembly_id').references((): AnyPgColumn => programAssemblies.id, { onDelete: 'cascade' }),
+  assemblyCode: text('assembly_code').notNull(),
+  assemblyName: text('assembly_name').notNull(),
+  level: integer('level').notNull().default(0),
+  sequence: integer('sequence').notNull().default(0),
+  assemblyType: text('assembly_type').notNull().default('assembly'),
+  partNumber: text('part_number'),
+  requiredQuantity: integer('required_quantity').notNull().default(1),
+  status: text('status').notNull().default('PLANNED'),
+  plannedStartDate: date('planned_start_date'),
+  plannedFinishDate: date('planned_finish_date'),
+  targetShipDate: date('target_ship_date'),
+  metadata: jsonb('metadata').default({}).notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+}, (table) => ({
+  buildIdx: index('program_assemblies_build_idx').on(table.programBuildId),
+  parentIdx: index('program_assemblies_parent_idx').on(table.parentAssemblyId),
+  codeUnique: uniqueIndex('program_assemblies_build_code_unique').on(table.programBuildId, table.assemblyCode),
+}));
+
+export const programAssemblyLinks = pgTable('program_assembly_links', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  assemblyId: uuid('assembly_id').notNull().references(() => programAssemblies.id, { onDelete: 'cascade' }),
+  manufacturingQueueId: integer('manufacturing_queue_id').references(() => manufacturingQueue.id, { onDelete: 'set null' }),
+  productionWorkOrderId: uuid('production_work_order_id').references(() => productionWorkOrders.id, { onDelete: 'set null' }),
+  travelerId: varchar('traveler_id', { length: 255 }).references(() => travelers.id, { onDelete: 'set null' }),
+  p2SerializedItemId: uuid('p2_serialized_item_id').references(() => p2SerializedItems.id, { onDelete: 'set null' }),
+  linkType: text('link_type').notNull().default('queue_item'),
+  requiredQuantity: integer('required_quantity').notNull().default(1),
+  createdAt: timestamp('created_at').defaultNow(),
+}, (table) => ({
+  assemblyIdx: index('program_assembly_links_assembly_idx').on(table.assemblyId),
+  queueIdx: index('program_assembly_links_queue_idx').on(table.manufacturingQueueId),
+  travelerIdx: index('program_assembly_links_traveler_idx').on(table.travelerId),
+}));
+
+export const programAssemblyDependencies = pgTable('program_assembly_dependencies', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  assemblyId: uuid('assembly_id').notNull().references(() => programAssemblies.id, { onDelete: 'cascade' }),
+  dependsOnAssemblyId: uuid('depends_on_assembly_id').notNull().references(() => programAssemblies.id, { onDelete: 'cascade' }),
+  dependencyType: text('dependency_type').notNull().default('finish_to_start'),
+  isBlocking: boolean('is_blocking').notNull().default(true),
+  notes: text('notes'),
+  createdAt: timestamp('created_at').defaultNow(),
+}, (table) => ({
+  assemblyIdx: index('program_assembly_dependencies_assembly_idx').on(table.assemblyId),
+  dependsOnIdx: index('program_assembly_dependencies_depends_on_idx').on(table.dependsOnAssemblyId),
+  uniqueDependency: uniqueIndex('program_assembly_dependencies_unique').on(table.assemblyId, table.dependsOnAssemblyId),
+}));
+
+export const insertProgramBuildSchema = createInsertSchema(programBuilds).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+export const insertProgramAssemblySchema = createInsertSchema(programAssemblies).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+export const insertProgramAssemblyLinkSchema = createInsertSchema(programAssemblyLinks).omit({
+  id: true,
+  createdAt: true,
+});
+export const insertProgramAssemblyDependencySchema = createInsertSchema(programAssemblyDependencies).omit({
+  id: true,
+  createdAt: true,
+});
+
+export type ProgramBuild = typeof programBuilds.$inferSelect;
+export type ProgramAssembly = typeof programAssemblies.$inferSelect;
+export type ProgramAssemblyLink = typeof programAssemblyLinks.$inferSelect;
+export type ProgramAssemblyDependency = typeof programAssemblyDependencies.$inferSelect;
+export type InsertProgramBuild = z.infer<typeof insertProgramBuildSchema>;
+export type InsertProgramAssembly = z.infer<typeof insertProgramAssemblySchema>;
+export type InsertProgramAssemblyLink = z.infer<typeof insertProgramAssemblyLinkSchema>;
+export type InsertProgramAssemblyDependency = z.infer<typeof insertProgramAssemblyDependencySchema>;
+
 // ─── LABOR THRESHOLD SETTINGS (system-wide singleton) ─────────────────────────
 
 export const laborThresholdSettings = pgTable('labor_threshold_settings', {

--- a/server/src/lib/programManufacturingOrchestration.ts
+++ b/server/src/lib/programManufacturingOrchestration.ts
@@ -1,0 +1,458 @@
+export type ProgramQueueLink = {
+  id: string;
+  linkType: string;
+  manufacturingQueueId: number | null;
+  productionWorkOrderId: string | null;
+  travelerId: string | null;
+  p2SerializedItemId: string | null;
+  label: string;
+  department: string | null;
+  status: string | null;
+  completedQuantity: number;
+  requiredQuantity: number;
+};
+
+export type ProgramAssemblyRollupInput = {
+  id: string;
+  parentAssemblyId: string | null;
+  assemblyCode: string;
+  assemblyName: string;
+  level: number;
+  sequence: number;
+  assemblyType: string;
+  partNumber: string | null;
+  status: string;
+  requiredQuantity: number;
+  targetShipDate: string | null;
+  metadata: Record<string, unknown>;
+  links: ProgramQueueLink[];
+};
+
+export type ProgramAssemblyDependencyInput = {
+  assemblyId: string;
+  dependsOnAssemblyId: string;
+  dependencyType: string;
+  isBlocking: boolean;
+  notes: string | null;
+};
+
+export type ProgramAssemblyRollup = ProgramAssemblyRollupInput & {
+  children: ProgramAssemblyRollup[];
+  dependencyIds: string[];
+  blockedBy: {
+    assemblyId: string;
+    assemblyCode: string;
+    assemblyName: string;
+    dependencyType: string;
+    notes: string | null;
+  }[];
+  directCompletionPercent: number;
+  completionPercent: number;
+  computedStatus: 'PLANNED' | 'READY' | 'IN_PROGRESS' | 'BLOCKED' | 'COMPLETE';
+  totalQueueItems: number;
+  completedQueueItems: number;
+};
+
+export type ProgramBuildStatus = {
+  build: {
+    id: string;
+    projectId: string | null;
+    projectCode: string | null;
+    projectName: string | null;
+    p2PurchaseOrderId: number | null;
+    poNumber: string | null;
+    programCode: string;
+    programName: string;
+    buildName: string;
+    buildType: string;
+    status: string;
+    priority: number;
+    targetShipDate: string | null;
+    customerName: string | null;
+    notes: string | null;
+  };
+  summary: {
+    totalAssemblies: number;
+    completeAssemblies: number;
+    blockedAssemblies: number;
+    inProgressAssemblies: number;
+    totalQueueItems: number;
+    completedQueueItems: number;
+    completionPercent: number;
+    shipReady: boolean;
+    criticalPath: ProgramAssemblyRollup[];
+  };
+  assemblies: ProgramAssemblyRollup[];
+  flatAssemblies: ProgramAssemblyRollup[];
+  blockers: ProgramAssemblyRollup[];
+  swimlanes: {
+    name: string;
+    assemblies: ProgramAssemblyRollup[];
+    completionPercent: number;
+    blockedCount: number;
+  }[];
+};
+
+const COMPLETE_STATUSES = new Set(['COMPLETE', 'COMPLETED', 'CLOSED', 'SHIPPED', 'DONE']);
+const ACTIVE_STATUSES = new Set(['IN_PROGRESS', 'RELEASED', 'ACTIVE', 'READY', 'SCHEDULED']);
+
+function normalizeStatus(status: unknown) {
+  return String(status ?? '').trim().toUpperCase();
+}
+
+function toNumber(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function isCompleteStatus(status: unknown) {
+  return COMPLETE_STATUSES.has(normalizeStatus(status));
+}
+
+function computeDirectCompletion(assembly: ProgramAssemblyRollupInput) {
+  if (assembly.links.length === 0) {
+    return isCompleteStatus(assembly.status) ? 100 : 0;
+  }
+
+  const required = assembly.links.reduce((sum, link) => sum + Math.max(1, link.requiredQuantity || 1), 0);
+  const completed = assembly.links.reduce((sum, link) => {
+    const requiredQuantity = Math.max(1, link.requiredQuantity || 1);
+    if (isCompleteStatus(link.status)) return sum + requiredQuantity;
+    return sum + Math.min(requiredQuantity, Math.max(0, link.completedQuantity || 0));
+  }, 0);
+
+  return required > 0 ? Math.round((completed / required) * 100) : 0;
+}
+
+export function computeProgramAssemblyRollups(
+  assemblies: ProgramAssemblyRollupInput[],
+  dependencies: ProgramAssemblyDependencyInput[],
+): ProgramAssemblyRollup[] {
+  const byId = new Map<string, ProgramAssemblyRollup>();
+  const dependencyMap = new Map<string, ProgramAssemblyDependencyInput[]>();
+
+  for (const dependency of dependencies) {
+    const existing = dependencyMap.get(dependency.assemblyId) ?? [];
+    existing.push(dependency);
+    dependencyMap.set(dependency.assemblyId, existing);
+  }
+
+  for (const assembly of assemblies) {
+    byId.set(assembly.id, {
+      ...assembly,
+      children: [],
+      dependencyIds: (dependencyMap.get(assembly.id) ?? []).map((d) => d.dependsOnAssemblyId),
+      blockedBy: [],
+      directCompletionPercent: computeDirectCompletion(assembly),
+      completionPercent: 0,
+      computedStatus: 'PLANNED',
+      totalQueueItems: assembly.links.length,
+      completedQueueItems: assembly.links.filter((link) => isCompleteStatus(link.status)).length,
+    });
+  }
+
+  const roots: ProgramAssemblyRollup[] = [];
+  for (const assembly of byId.values()) {
+    if (assembly.parentAssemblyId && byId.has(assembly.parentAssemblyId)) {
+      byId.get(assembly.parentAssemblyId)!.children.push(assembly);
+    } else {
+      roots.push(assembly);
+    }
+  }
+
+  const finalized = new Set<string>();
+  const visiting = new Set<string>();
+
+  const finalize = (assembly: ProgramAssemblyRollup): ProgramAssemblyRollup => {
+    if (finalized.has(assembly.id)) return assembly;
+    if (visiting.has(assembly.id)) return assembly;
+    visiting.add(assembly.id);
+
+    assembly.children.sort((a, b) => a.sequence - b.sequence || a.assemblyName.localeCompare(b.assemblyName));
+    assembly.children.forEach(finalize);
+
+    const childPercent = assembly.children.length > 0
+      ? Math.round(assembly.children.reduce((sum, child) => sum + child.completionPercent, 0) / assembly.children.length)
+      : null;
+    assembly.completionPercent = childPercent == null
+      ? assembly.directCompletionPercent
+      : assembly.links.length > 0
+        ? Math.round((childPercent + assembly.directCompletionPercent) / 2)
+        : childPercent;
+
+    const blockingDependencies = (dependencyMap.get(assembly.id) ?? [])
+      .filter((dependency) => dependency.isBlocking)
+      .map((dependency) => {
+        const dependedOn = byId.get(dependency.dependsOnAssemblyId);
+        if (dependedOn && !finalized.has(dependedOn.id)) finalize(dependedOn);
+        if (!dependedOn || dependedOn.computedStatus === 'COMPLETE') return null;
+        return {
+          assemblyId: dependedOn.id,
+          assemblyCode: dependedOn.assemblyCode,
+          assemblyName: dependedOn.assemblyName,
+          dependencyType: dependency.dependencyType,
+          notes: dependency.notes,
+        };
+      })
+      .filter((dependency): dependency is NonNullable<typeof dependency> => dependency != null);
+
+    assembly.blockedBy = blockingDependencies;
+
+    const normalized = normalizeStatus(assembly.status);
+    if (blockingDependencies.length > 0 || normalized === 'BLOCKED') {
+      assembly.computedStatus = 'BLOCKED';
+    } else if (assembly.completionPercent >= 100 || isCompleteStatus(assembly.status)) {
+      assembly.computedStatus = 'COMPLETE';
+      assembly.completionPercent = 100;
+    } else if (normalized === 'READY') {
+      assembly.computedStatus = 'READY';
+    } else if (assembly.completionPercent > 0 || ACTIVE_STATUSES.has(normalized)) {
+      assembly.computedStatus = 'IN_PROGRESS';
+    } else {
+      assembly.computedStatus = 'PLANNED';
+    }
+
+    assembly.totalQueueItems += assembly.children.reduce((sum, child) => sum + child.totalQueueItems, 0);
+    assembly.completedQueueItems += assembly.children.reduce((sum, child) => sum + child.completedQueueItems, 0);
+    visiting.delete(assembly.id);
+    finalized.add(assembly.id);
+    return assembly;
+  };
+
+  return roots.sort((a, b) => a.sequence - b.sequence || a.assemblyName.localeCompare(b.assemblyName)).map(finalize);
+}
+
+function flattenAssemblies(assemblies: ProgramAssemblyRollup[]): ProgramAssemblyRollup[] {
+  return assemblies.flatMap((assembly) => [assembly, ...flattenAssemblies(assembly.children)]);
+}
+
+function buildSwimlanes(flatAssemblies: ProgramAssemblyRollup[]) {
+  const lanes = new Map<string, ProgramAssemblyRollup[]>();
+  for (const assembly of flatAssemblies) {
+    const lane = String(assembly.metadata?.swimlane || assembly.assemblyType || 'Program');
+    lanes.set(lane, [...(lanes.get(lane) ?? []), assembly]);
+  }
+
+  return [...lanes.entries()].map(([name, laneAssemblies]) => ({
+    name,
+    assemblies: laneAssemblies,
+    completionPercent: laneAssemblies.length > 0
+      ? Math.round(laneAssemblies.reduce((sum, assembly) => sum + assembly.completionPercent, 0) / laneAssemblies.length)
+      : 0,
+    blockedCount: laneAssemblies.filter((assembly) => assembly.computedStatus === 'BLOCKED').length,
+  }));
+}
+
+async function tableExists(tableName: string) {
+  const { pool } = await import('../../db');
+  const result = await pool.query(
+    `SELECT EXISTS (
+       SELECT 1
+       FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = $1
+     ) AS "exists"`,
+    [tableName],
+  );
+  return Boolean(((result as any).rows ?? result)[0]?.exists);
+}
+
+export async function programManufacturingTablesReady() {
+  const requiredTables = [
+    'program_builds',
+    'program_assemblies',
+    'program_assembly_links',
+    'program_assembly_dependencies',
+  ];
+  const states = await Promise.all(requiredTables.map(tableExists));
+  return states.every(Boolean);
+}
+
+export async function getProgramBuilds(filters: { projectId?: string | null } = {}) {
+  if (!(await programManufacturingTablesReady())) return [];
+  const { pool } = await import('../../db');
+
+  const params: unknown[] = [];
+  const where: string[] = [];
+  if (filters.projectId) {
+    params.push(filters.projectId);
+    where.push(`pb.project_id = $${params.length}`);
+  }
+
+  const result = await pool.query(
+    `SELECT
+       pb.id,
+       pb.project_id AS "projectId",
+       p.project_code AS "projectCode",
+       p.project_name AS "projectName",
+       pb.p2_purchase_order_id AS "p2PurchaseOrderId",
+       po.po_number AS "poNumber",
+       pb.program_code AS "programCode",
+       pb.program_name AS "programName",
+       pb.build_name AS "buildName",
+       pb.build_type AS "buildType",
+       pb.status,
+       pb.priority,
+       pb.target_ship_date AS "targetShipDate",
+       COALESCE(pb.customer_name, po.customer_name) AS "customerName",
+       pb.notes
+     FROM program_builds pb
+     LEFT JOIN projects p ON p.id = pb.project_id
+     LEFT JOIN p2_purchase_orders po ON po.id = pb.p2_purchase_order_id
+     ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
+     ORDER BY pb.priority ASC, pb.target_ship_date ASC NULLS LAST, pb.created_at DESC`,
+    params,
+  );
+
+  return ((result as any).rows ?? result) as ProgramBuildStatus['build'][];
+}
+
+export async function getProgramBuildStatus(buildId?: string | null, filters: { projectId?: string | null } = {}): Promise<ProgramBuildStatus | null> {
+  const builds = await getProgramBuilds(filters);
+  const build = buildId ? builds.find((candidate) => candidate.id === buildId) : builds[0];
+  if (!build) return null;
+  const { pool } = await import('../../db');
+
+  const [assemblyResult, dependencyResult] = await Promise.all([
+    pool.query(
+      `SELECT
+         pa.id,
+         pa.parent_assembly_id AS "parentAssemblyId",
+         pa.assembly_code AS "assemblyCode",
+         pa.assembly_name AS "assemblyName",
+         pa.level,
+         pa.sequence,
+         pa.assembly_type AS "assemblyType",
+         pa.part_number AS "partNumber",
+         pa.required_quantity AS "requiredQuantity",
+         pa.status,
+         pa.target_ship_date AS "targetShipDate",
+         pa.metadata,
+         pal.id AS "linkId",
+         pal.link_type AS "linkType",
+         pal.manufacturing_queue_id AS "manufacturingQueueId",
+         pal.production_work_order_id AS "productionWorkOrderId",
+         pal.traveler_id AS "travelerId",
+         pal.p2_serialized_item_id AS "p2SerializedItemId",
+         pal.required_quantity AS "linkRequiredQuantity",
+         mq.department AS "queueDepartment",
+         mq.status AS "queueStatus",
+         mq.quantity_completed AS "queueCompletedQuantity",
+         mq.quantity_requested AS "queueRequiredQuantity",
+         pwo.work_order_number AS "workOrderNumber",
+         pwo.status AS "workOrderStatus",
+         t.traveler_number AS "travelerNumber",
+         t.status AS "travelerStatus",
+         psi.serial_number AS "serialNumber",
+         psi.barcode,
+         psi.status AS "serializedItemStatus",
+         psi.current_department AS "serializedItemDepartment"
+       FROM program_assemblies pa
+       LEFT JOIN program_assembly_links pal ON pal.assembly_id = pa.id
+       LEFT JOIN manufacturing_queue mq ON mq.id = pal.manufacturing_queue_id
+       LEFT JOIN production_work_orders pwo ON pwo.id = pal.production_work_order_id
+       LEFT JOIN travelers t ON t.id = pal.traveler_id
+       LEFT JOIN p2_serialized_items psi ON psi.id = pal.p2_serialized_item_id
+       WHERE pa.program_build_id = $1
+       ORDER BY pa.level ASC, pa.sequence ASC, pa.assembly_name ASC`,
+      [build.id],
+    ),
+    pool.query(
+      `SELECT
+         assembly_id AS "assemblyId",
+         depends_on_assembly_id AS "dependsOnAssemblyId",
+         dependency_type AS "dependencyType",
+         is_blocking AS "isBlocking",
+         notes
+       FROM program_assembly_dependencies
+       WHERE assembly_id IN (SELECT id FROM program_assemblies WHERE program_build_id = $1)`,
+      [build.id],
+    ),
+  ]);
+
+  const rows = ((assemblyResult as any).rows ?? assemblyResult) as any[];
+  const assembliesById = new Map<string, ProgramAssemblyRollupInput>();
+  for (const row of rows) {
+    if (!assembliesById.has(row.id)) {
+      assembliesById.set(row.id, {
+        id: row.id,
+        parentAssemblyId: row.parentAssemblyId,
+        assemblyCode: row.assemblyCode,
+        assemblyName: row.assemblyName,
+        level: toNumber(row.level),
+        sequence: toNumber(row.sequence),
+        assemblyType: row.assemblyType,
+        partNumber: row.partNumber,
+        status: row.status,
+        requiredQuantity: toNumber(row.requiredQuantity, 1),
+        targetShipDate: row.targetShipDate,
+        metadata: row.metadata ?? {},
+        links: [],
+      });
+    }
+
+    if (row.linkId) {
+      const linkStatus = row.travelerStatus ?? row.serializedItemStatus ?? row.workOrderStatus ?? row.queueStatus;
+      const label = row.travelerNumber
+        ?? row.workOrderNumber
+        ?? row.barcode
+        ?? (row.manufacturingQueueId ? `MQ-${row.manufacturingQueueId}` : row.linkType);
+      assembliesById.get(row.id)!.links.push({
+        id: row.linkId,
+        linkType: row.linkType,
+        manufacturingQueueId: row.manufacturingQueueId,
+        productionWorkOrderId: row.productionWorkOrderId,
+        travelerId: row.travelerId,
+        p2SerializedItemId: row.p2SerializedItemId,
+        label,
+        department: row.serializedItemDepartment ?? row.queueDepartment,
+        status: linkStatus,
+        completedQuantity: toNumber(row.queueCompletedQuantity, isCompleteStatus(linkStatus) ? 1 : 0),
+        requiredQuantity: toNumber(row.linkRequiredQuantity ?? row.queueRequiredQuantity, 1),
+      });
+    }
+  }
+
+  const dependencies = (((dependencyResult as any).rows ?? dependencyResult) as any[]).map((row) => ({
+    assemblyId: row.assemblyId,
+    dependsOnAssemblyId: row.dependsOnAssemblyId,
+    dependencyType: row.dependencyType,
+    isBlocking: row.isBlocking,
+    notes: row.notes,
+  }));
+
+  const assemblies = computeProgramAssemblyRollups([...assembliesById.values()], dependencies);
+  const flatAssemblies = flattenAssemblies(assemblies);
+  const blockers = flatAssemblies.filter((assembly) => assembly.computedStatus === 'BLOCKED');
+  const criticalPath = [...flatAssemblies]
+    .filter((assembly) => assembly.computedStatus !== 'COMPLETE')
+    .sort((a, b) => b.blockedBy.length - a.blockedBy.length || a.completionPercent - b.completionPercent || a.sequence - b.sequence)
+    .slice(0, 6);
+
+  const totalQueueItems = flatAssemblies.reduce((sum, assembly) => sum + assembly.links.length, 0);
+  const completedQueueItems = flatAssemblies.reduce(
+    (sum, assembly) => sum + assembly.links.filter((link) => isCompleteStatus(link.status)).length,
+    0,
+  );
+  const completionPercent = flatAssemblies.length > 0
+    ? Math.round(flatAssemblies.reduce((sum, assembly) => sum + assembly.completionPercent, 0) / flatAssemblies.length)
+    : 0;
+
+  return {
+    build,
+    summary: {
+      totalAssemblies: flatAssemblies.length,
+      completeAssemblies: flatAssemblies.filter((assembly) => assembly.computedStatus === 'COMPLETE').length,
+      blockedAssemblies: blockers.length,
+      inProgressAssemblies: flatAssemblies.filter((assembly) => assembly.computedStatus === 'IN_PROGRESS').length,
+      totalQueueItems,
+      completedQueueItems,
+      completionPercent,
+      shipReady: flatAssemblies.length > 0 && blockers.length === 0 && flatAssemblies.every((assembly) => assembly.computedStatus === 'COMPLETE'),
+      criticalPath,
+    },
+    assemblies,
+    flatAssemblies,
+    blockers,
+    swimlanes: buildSwimlanes(flatAssemblies),
+  };
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -135,6 +135,7 @@ import projectsRoutes from './projects';
 import projectStepAttachmentsRoutes from './projectStepAttachments';
 import projectClosingsRoutes from './projectClosings';
 import pmDashboardRoutes from './pmDashboard';
+import programManufacturingRoutes from './programManufacturing';
 import quoteFeedbackRoutes from './quoteFeedback';
 import modelAnalyticsRoutes from './modelAnalytics';
 import aqlSamplingRoutes from './aqlSampling';
@@ -1064,6 +1065,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   // PM Control Center dashboard routes
   app.use('/api/pm-dashboard', pmDashboardRoutes);
+
+  // Program Manufacturing Orchestration routes
+  app.use('/api/program-manufacturing', programManufacturingRoutes);
 
   // P2 Projects routes
   app.use('/api/projects', projectsRoutes);

--- a/server/src/routes/programManufacturing.ts
+++ b/server/src/routes/programManufacturing.ts
@@ -1,0 +1,115 @@
+import { Router, Request, Response } from 'express';
+import {
+  getProgramBuilds,
+  getProgramBuildStatus,
+  programManufacturingTablesReady,
+} from '../lib/programManufacturingOrchestration';
+
+const router = Router();
+
+function h(fn: (req: Request, res: Response) => Promise<void>) {
+  return (req: Request, res: Response) =>
+    fn(req, res).catch((err) => {
+      console.error('[Program Manufacturing]', err?.message ?? err);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Failed to load program manufacturing orchestration', message: err?.message });
+      }
+    });
+}
+
+router.get('/builds', h(async (req, res) => {
+  const ready = await programManufacturingTablesReady();
+  if (!ready) {
+    return res.json({ ready: false, builds: [] });
+  }
+
+  const projectId = typeof req.query.projectId === 'string' ? req.query.projectId : null;
+  const builds = await getProgramBuilds({ projectId });
+  res.json({ ready: true, builds });
+}));
+
+router.get('/status', h(async (req, res) => {
+  const ready = await programManufacturingTablesReady();
+  if (!ready) {
+    return res.json({
+      ready: false,
+      build: null,
+      summary: {
+        totalAssemblies: 0,
+        completeAssemblies: 0,
+        blockedAssemblies: 0,
+        inProgressAssemblies: 0,
+        totalQueueItems: 0,
+        completedQueueItems: 0,
+        completionPercent: 0,
+        shipReady: false,
+        criticalPath: [],
+      },
+      assemblies: [],
+      flatAssemblies: [],
+      blockers: [],
+      swimlanes: [],
+    });
+  }
+
+  const buildId = typeof req.query.buildId === 'string' ? req.query.buildId : null;
+  const projectId = typeof req.query.projectId === 'string' ? req.query.projectId : null;
+  const status = await getProgramBuildStatus(buildId, { projectId });
+  if (!status) {
+    return res.json({
+      ready: true,
+      build: null,
+      summary: {
+        totalAssemblies: 0,
+        completeAssemblies: 0,
+        blockedAssemblies: 0,
+        inProgressAssemblies: 0,
+        totalQueueItems: 0,
+        completedQueueItems: 0,
+        completionPercent: 0,
+        shipReady: false,
+        criticalPath: [],
+      },
+      assemblies: [],
+      flatAssemblies: [],
+      blockers: [],
+      swimlanes: [],
+    });
+  }
+
+  res.json({ ready: true, ...status });
+}));
+
+router.get('/projects/:projectId/health', h(async (req, res) => {
+  const ready = await programManufacturingTablesReady();
+  if (!ready) {
+    return res.json({ ready: false, build: null, widgets: null });
+  }
+
+  const status = await getProgramBuildStatus(null, { projectId: req.params.projectId });
+  if (!status) {
+    return res.json({ ready: true, build: null, widgets: null });
+  }
+
+  res.json({
+    ready: true,
+    build: status.build,
+    widgets: {
+      programHealth: status.summary.completionPercent,
+      criticalPath: status.summary.criticalPath,
+      blockedAssemblies: status.blockers,
+      shipReadiness: {
+        ready: status.summary.shipReady,
+        completeAssemblies: status.summary.completeAssemblies,
+        totalAssemblies: status.summary.totalAssemblies,
+      },
+      laborMaterialImpact: {
+        queueItems: status.summary.totalQueueItems,
+        completedQueueItems: status.summary.completedQueueItems,
+        blockedAssemblies: status.summary.blockedAssemblies,
+      },
+    },
+  });
+}));
+
+export default router;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -710,6 +710,11 @@ import { db, pool, rawSql } from './db';
 import { recordAuditEvent } from './src/services/auditLedgerService';
 import { recordInventoryLedgerEntry } from './src/services/inventoryTransactionLedgerService';
 import { assignDashboardForWorkOrder } from './src/lib/workOrderDashboardAssignment';
+import {
+  getProgramBuilds,
+  getProgramBuildStatus,
+  type ProgramBuildStatus,
+} from './src/lib/programManufacturingOrchestration';
 
 // Drizzle's transaction handle is API-compatible with `db` for the CRUD
 // surface our helpers use, but its TS type is a `PgTransaction` (not the
@@ -1780,6 +1785,10 @@ export interface IStorage {
   getRFQRiskAssessmentById(id: number): Promise<RFQRiskAssessment | undefined>;
   updateRFQRiskAssessment(id: number, data: Partial<InsertRFQRiskAssessment>): Promise<RFQRiskAssessment | undefined>;
   submitRFQRiskAssessment(id: number, username: string): Promise<RFQRiskAssessment | undefined>;
+
+  // Program Manufacturing Orchestration read methods
+  getProgramBuilds(filters?: { projectId?: string | null }): Promise<ProgramBuildStatus['build'][]>;
+  getProgramBuildStatus(buildId?: string | null, filters?: { projectId?: string | null }): Promise<ProgramBuildStatus | null>;
 
   // P2 Purchase Orders CRUD
   getAllP2PurchaseOrders(): Promise<P2PurchaseOrder[]>;
@@ -15191,6 +15200,17 @@ export class DatabaseStorage implements IStorage {
       .where(eq(rfqRiskAssessments.id, id))
       .returning();
     return submitted;
+  }
+
+  async getProgramBuilds(filters?: { projectId?: string | null }): Promise<ProgramBuildStatus['build'][]> {
+    return getProgramBuilds(filters);
+  }
+
+  async getProgramBuildStatus(
+    buildId?: string | null,
+    filters?: { projectId?: string | null }
+  ): Promise<ProgramBuildStatus | null> {
+    return getProgramBuildStatus(buildId, filters);
   }
 
   // P2 Purchase Orders CRUD


### PR DESCRIPTION
## Summary
- Add program build, assembly hierarchy, queue/traveler link, and dependency tables with a seeded drone build sample.
- Add program manufacturing rollup service/routes with safe empty-state fallback when no build exists.
- Add P2 Control Center Program, Assembly Tree, and Swimlane tabs plus PM Control Center program health/critical path/blocker/ship readiness/impact widgets.
- Add focused rollup dependency validation tests.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types -e "...rollup smoke..."`

Full Vitest/typecheck was not run locally because this checkout has no `npm`, no package manager shim, and no `node_modules`.