### PR TITLE
Fix P2 traveler creation for serialized task start

### DIFF
--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -13,6 +13,8 @@ import {
   travelerSteps,
   travelerTasks,
   p2PurchaseOrderItems,
+  projects,
+  productionWorkOrders,
   inventoryItems,
   cuttingBuiltPackets,
   cuttingBuiltPacketFabricSources,
@@ -459,6 +461,164 @@ async function findActiveRoutingForSerializedItem(serializedItem: any) {
   }
 
   return routing ?? null;
+}
+
+async function findProductionWorkOrderForSerializedItem(params: {
+  serializedItem: typeof p2SerializedItems.$inferSelect;
+  routing: typeof partRoutings.$inferSelect | null;
+  inventoryIdentity: Awaited<ReturnType<typeof getSerializedItemInventoryIdentity>>;
+}) {
+  const { serializedItem, routing, inventoryIdentity } = params;
+  const projectRows = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(eq(projects.poId, serializedItem.poId));
+
+  if (projectRows.length === 0) return null;
+
+  const partCandidates = new Set<string>();
+  const addPart = (value?: string | null) => {
+    const trimmed = value?.trim();
+    if (trimmed) partCandidates.add(trimmed);
+  };
+  addPart(inventoryIdentity.internalPartNumber);
+  addPart(routing?.partNumber ?? null);
+  addPart(serializedItem.partNumber);
+
+  const partFilters = Array.from(partCandidates).flatMap((part) => [
+    eq(productionWorkOrders.partNumber, part),
+    sql`lower(trim(${productionWorkOrders.partNumber})) = lower(trim(${part}))`,
+  ]);
+
+  const whereParts: SQL<unknown>[] = [
+    inArray(productionWorkOrders.projectId, projectRows.map((project) => project.id)),
+    sql`${productionWorkOrders.status} NOT IN ('CANCELLED', 'CANCELED', 'CLOSED', 'COMPLETE')`,
+  ];
+  if (partFilters.length > 0) {
+    whereParts.push(or(...partFilters)!);
+  }
+
+  const [workOrder] = await db
+    .select()
+    .from(productionWorkOrders)
+    .where(and(...whereParts))
+    .orderBy(desc(productionWorkOrders.createdAt))
+    .limit(1);
+
+  return workOrder ?? null;
+}
+
+async function ensureTravelerForSerializedItem(params: {
+  serializedItem: typeof p2SerializedItems.$inferSelect;
+  routing: typeof partRoutings.$inferSelect;
+  inventoryIdentity: Awaited<ReturnType<typeof getSerializedItemInventoryIdentity>>;
+  actor: string;
+}) {
+  const { serializedItem, routing, inventoryIdentity, actor } = params;
+  const travelerPartMatches: SQL<unknown>[] = [
+    eq(travelers.partRoutingId, routing.id),
+    eq(travelers.partNumber, serializedItem.partNumber),
+  ];
+  if (inventoryIdentity.inventoryItemId != null) {
+    travelerPartMatches.push(
+      sql`${travelers.inventoryItemId} IS NOT NULL AND ${travelers.inventoryItemId}::text = ${String(inventoryIdentity.inventoryItemId)}`,
+    );
+  }
+  if (inventoryIdentity.internalPartNumber) {
+    travelerPartMatches.push(eq(travelers.partNumber, inventoryIdentity.internalPartNumber));
+    travelerPartMatches.push(sql`lower(trim(${travelers.partNumber})) = lower(trim(${inventoryIdentity.internalPartNumber}))`);
+  }
+
+  const existingTraveler = await db.query.travelers.findFirst({
+    where: and(
+      eq(travelers.serialNumber, serializedItem.serialNumber),
+      or(...travelerPartMatches),
+    ),
+  });
+
+  const workOrder = await findProductionWorkOrderForSerializedItem({
+    serializedItem,
+    routing,
+    inventoryIdentity,
+  });
+
+  if (existingTraveler) {
+    const repaired = await ensureExistingTravelerHasRoutingDetails({
+      traveler: existingTraveler,
+      routing,
+      actor,
+    });
+    let traveler = existingTraveler;
+    if (workOrder && existingTraveler.productionWorkOrderId !== workOrder.id) {
+      traveler = await storage.linkTravelerToProductionWorkOrder(existingTraveler.id, workOrder.id);
+    }
+    return { traveler, created: false, repaired, linkedWorkOrderId: workOrder?.id ?? null };
+  }
+
+  let traveler = await storage.generateTravelerFromRouting(routing.id, {
+    serialNumber: serializedItem.serialNumber,
+    lotNumber: serializedItem.poNumber || undefined,
+    createdBy: actor,
+  });
+
+  await storage.updateTraveler(traveler.id, { status: 'IN_PROGRESS' });
+  await alignNewTravelerToSerializedItemStage({
+    travelerId: traveler.id,
+    serializedItem,
+    actor,
+  });
+  if (workOrder) {
+    traveler = await storage.linkTravelerToProductionWorkOrder(traveler.id, workOrder.id);
+  }
+
+  return { traveler, created: true, repaired: true, linkedWorkOrderId: workOrder?.id ?? null };
+}
+
+async function alignNewTravelerToSerializedItemStage(params: {
+  travelerId: string;
+  serializedItem: typeof p2SerializedItems.$inferSelect;
+  actor: string;
+}) {
+  const { travelerId, serializedItem, actor } = params;
+  const currentStageIndex = serializedItem.currentStageIndex || 0;
+  const steps = await db
+    .select()
+    .from(travelerSteps)
+    .where(eq(travelerSteps.travelerId, travelerId))
+    .orderBy(asc(travelerSteps.stepNumber));
+
+  if (steps.length === 0) return;
+
+  const now = new Date();
+  for (let i = 0; i < steps.length && i < currentStageIndex; i++) {
+    await db
+      .update(travelerSteps)
+      .set({
+        status: 'COMPLETED',
+        completedAt: now,
+        completedBy: actor,
+      })
+      .where(eq(travelerSteps.id, steps[i].id));
+
+    await db
+      .update(travelerTasks)
+      .set({
+        status: 'COMPLETED',
+        completedAt: now,
+        completedBy: actor,
+      })
+      .where(eq(travelerTasks.travelerStepId, steps[i].id));
+  }
+
+  const activeStep = steps[Math.min(currentStageIndex, steps.length - 1)];
+  await db
+    .update(travelerSteps)
+    .set({
+      status: 'IN_PROGRESS',
+      startedAt: now,
+      startedBy: actor,
+    })
+    .where(eq(travelerSteps.id, activeStep.id));
 }
 
 function operationTypeToTravelerTaskType(operationType: string | null | undefined) {
@@ -1491,6 +1651,14 @@ router.post('/generate-traveler', async (req: Request, res: Response) => {
         routing,
         actor: resolvedDisplayName,
       });
+      const workOrder = await findProductionWorkOrderForSerializedItem({
+        serializedItem,
+        routing,
+        inventoryIdentity,
+      });
+      if (workOrder && existingTraveler.productionWorkOrderId !== workOrder.id) {
+        await storage.linkTravelerToProductionWorkOrder(existingTraveler.id, workOrder.id);
+      }
 
       return res.json({
         travelerId: existingTraveler.id,
@@ -1507,6 +1675,14 @@ router.post('/generate-traveler', async (req: Request, res: Response) => {
     });
 
     await storage.updateTraveler(traveler.id, { status: 'IN_PROGRESS' });
+    const workOrder = await findProductionWorkOrderForSerializedItem({
+      serializedItem,
+      routing,
+      inventoryIdentity,
+    });
+    if (workOrder) {
+      await storage.linkTravelerToProductionWorkOrder(traveler.id, workOrder.id);
+    }
 
     const currentStageIndex = serializedItem.currentStageIndex || 0;
     if (currentStageIndex > 0) {
@@ -1645,6 +1821,15 @@ router.post('/start-task', async (req: Request, res: Response) => {
       return res.status(403).json({ 
         error: `Employee ${employeeName} is not certified for ${department} on part ${partNumber}`,
         code: 'NOT_CERTIFIED'
+      });
+    }
+
+    if (routing) {
+      await ensureTravelerForSerializedItem({
+        serializedItem,
+        routing,
+        inventoryIdentity,
+        actor: displayName,
       });
     }
 


### PR DESCRIPTION
## Summary
- Repair/create the P2 traveler from the serialized item on `start-task` before labor auto-punch checks run.
- Link generated or existing serialized travelers to the matching project WAD through the serialized item PO/project path.
- Keep new travelers aligned to the serialized item current stage so the active traveler step matches the floor workflow.

## Validation
- `git diff --check`
- `node --experimental-strip-types --check server/src/routes/p2Traveler.ts`

Note: full npm/TypeScript test execution was not available locally because this worktree has no `npm` command and no `node_modules`.