### PR TITLE
Harden P2 Control Center reads for production schema drift

### DIFF
--- a/server/src/lib/productionWorkflowReadiness.ts
+++ b/server/src/lib/productionWorkflowReadiness.ts
@@ -136,7 +136,13 @@ export async function ensureProductionWorkflowReadSchema(): Promise<void> {
 
           IF to_regclass('public.p2_production_orders') IS NOT NULL THEN
             ALTER TABLE public.p2_production_orders
-              ADD COLUMN IF NOT EXISTS project_id uuid;
+              ADD COLUMN IF NOT EXISTS project_id uuid,
+              ADD COLUMN IF NOT EXISTS p2_po_item_id integer,
+              ADD COLUMN IF NOT EXISTS quantity_manufactured integer DEFAULT 0,
+              ADD COLUMN IF NOT EXISTS scheduled_layup_date timestamp,
+              ADD COLUMN IF NOT EXISTS due_date timestamp,
+              ADD COLUMN IF NOT EXISTS completed_at timestamp,
+              ADD COLUMN IF NOT EXISTS updated_at timestamp DEFAULT now();
           END IF;
 
           IF to_regclass('public.material_lot_reservations') IS NOT NULL THEN

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2940,6 +2940,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   // P2 Control Center API Routes
   app.get('/api/p2/control-center/stats', async (req, res) => {
     try {
+      const { ensureProductionWorkflowReadSchema } = await import('../lib/productionWorkflowReadiness');
+      await ensureProductionWorkflowReadSchema();
       const { pool } = await import('../../db');
       const oneWeekAgo = new Date();
       oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
@@ -2947,8 +2949,11 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const [poStats, itemStats, legacyStats] = await Promise.all([
         pool.query(`
           SELECT
-            COUNT(*) FILTER (WHERE status NOT IN ('COMPLETED','CANCELED')) AS "openPOs",
-            COUNT(*) FILTER (WHERE bom_configured = false AND status NOT IN ('COMPLETED','CANCELED')) AS "pendingBOMs"
+            COUNT(*) FILTER (WHERE COALESCE(UPPER(status), '') NOT IN ('COMPLETED','CLOSED','CANCELED','CANCELLED')) AS "openPOs",
+            COUNT(*) FILTER (
+              WHERE bom_configured = false
+                AND COALESCE(UPPER(status), '') NOT IN ('COMPLETED','CLOSED','CANCELED','CANCELLED')
+            ) AS "pendingBOMs"
           FROM p2_purchase_orders
         `),
         pool.query(`
@@ -3101,6 +3106,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   app.get('/api/p2/control-center/po-statuses', async (req, res) => {
     try {
+      const { ensureProductionWorkflowReadSchema } = await import('../lib/productionWorkflowReadiness');
+      await ensureProductionWorkflowReadSchema();
       const { storage } = await import('../../storage');
       const { pool: dbPool } = await import('../../db');
       const allPos = await storage.getAllP2PurchaseOrders();
@@ -3266,6 +3273,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   app.get('/api/p2/control-center/scheduling-list', async (req, res) => {
     try {
+      const { ensureProductionWorkflowReadSchema } = await import('../lib/productionWorkflowReadiness');
+      await ensureProductionWorkflowReadSchema();
       const { storage } = await import('../../storage');
       const { pool: dbPool } = await import('../../db');
       const serializedItems = await applyCompletedTravelerStateToP2Items(
@@ -3432,6 +3441,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   // P2 Production Queue - Get items grouped by department
   app.get('/api/p2/control-center/production-queue', async (req, res) => {
     try {
+      const { ensureProductionWorkflowReadSchema } = await import('../lib/productionWorkflowReadiness');
+      await ensureProductionWorkflowReadSchema();
       const { storage } = await import('../../storage');
       
       // Keep P2 Control Center as the visible source for WIP and finished units.

--- a/server/src/routes/p2ScheduleItems.ts
+++ b/server/src/routes/p2ScheduleItems.ts
@@ -24,6 +24,8 @@ router.post('/api/p2/schedule-items', async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Item IDs array is required' });
     }
 
+    const { ensureProductionWorkflowReadSchema } = await import('../lib/productionWorkflowReadiness');
+    await ensureProductionWorkflowReadSchema();
     const { db } = await import('../../db');
     const {
       p2SerializedItems,


### PR DESCRIPTION
## Summary
- Run the production workflow schema-readiness guard before P2 Control Center stats, status, scheduling, and production queue reads.
- Extend the readiness guard for legacy `p2_production_orders` columns used by the control-center fallback queries in Replit production.
- Make P2 open/pending summary counts case-insensitive for production data that stores statuses differently.

## Validation
- `git diff --check -- server/src/routes/index.ts server/src/routes/p2ScheduleItems.ts server/src/lib/productionWorkflowReadiness.ts`
- `npm run check` could not run because `npm` is not installed/available in this PowerShell environment.