### PR TITLE
Match legacy P2 projects by PO project name

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3148,7 +3148,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
          GROUP BY p2_po_id`
       );
       const legacyProjectProductionRows = await dbPool.query(
-        `WITH project_po_link AS (
+         `WITH project_po_link AS (
            SELECT p.id AS project_id, p.po_id AS po_id
            FROM projects p
            WHERE p.po_id IS NOT NULL
@@ -3156,6 +3156,16 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
            SELECT ps.project_id, ps.linked_p2_order_id AS po_id
            FROM project_steps ps
            WHERE ps.linked_p2_order_id IS NOT NULL
+           UNION
+           SELECT p.id AS project_id, po.id AS po_id
+           FROM p2_purchase_orders po
+           JOIN projects p ON LOWER(TRIM(po.project_name)) IN (
+             LOWER(TRIM(p.project_code)),
+             LOWER(TRIM(p.project_name)),
+             LOWER(TRIM(CONCAT_WS(' - ', NULLIF(p.project_code, ''), NULLIF(p.project_name, ''))))
+           )
+           WHERE po.project_name IS NOT NULL
+             AND TRIM(po.project_name) <> ''
          ),
          work_order_quantities AS (
            SELECT
@@ -3246,9 +3256,24 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                        AND ps.linked_p2_order_id IS NOT NULL
                      ORDER BY ps.updated_at DESC NULLS LAST, ps.completed_at DESC NULLS LAST
                      LIMIT 1
-                   )
-                 ) AS linked_po_id
+                 )
+               ) AS linked_po_id
                FROM projects p
+               UNION
+               SELECT
+                 p.id,
+                 p.project_code,
+                 p.project_name,
+                 p.updated_at,
+                 po.id AS linked_po_id
+               FROM p2_purchase_orders po
+               JOIN projects p ON LOWER(TRIM(po.project_name)) IN (
+                 LOWER(TRIM(p.project_code)),
+                 LOWER(TRIM(p.project_name)),
+                 LOWER(TRIM(CONCAT_WS(' - ', NULLIF(p.project_code, ''), NULLIF(p.project_name, ''))))
+               )
+               WHERE po.project_name IS NOT NULL
+                 AND TRIM(po.project_name) <> ''
              )
              SELECT DISTINCT ON (linked_po_id)
                linked_po_id AS "poId",
@@ -3410,7 +3435,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       });
 
       const legacyProjectSchedulingRows = await dbPool.query(
-        `WITH project_po_link AS (
+         `WITH project_po_link AS (
            SELECT p.id AS project_id, p.po_id AS po_id
            FROM projects p
            WHERE p.po_id IS NOT NULL
@@ -3418,6 +3443,16 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
            SELECT ps.project_id, ps.linked_p2_order_id AS po_id
            FROM project_steps ps
            WHERE ps.linked_p2_order_id IS NOT NULL
+           UNION
+           SELECT p.id AS project_id, po.id AS po_id
+           FROM p2_purchase_orders po
+           JOIN projects p ON LOWER(TRIM(po.project_name)) IN (
+             LOWER(TRIM(p.project_code)),
+             LOWER(TRIM(p.project_name)),
+             LOWER(TRIM(CONCAT_WS(' - ', NULLIF(p.project_code, ''), NULLIF(p.project_name, ''))))
+           )
+           WHERE po.project_name IS NOT NULL
+             AND TRIM(po.project_name) <> ''
          )
          SELECT DISTINCT ON (wo.id)
            wo.id,
@@ -3592,7 +3627,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
          ORDER BY p2po.due_date NULLS LAST, p2po.created_at`
       );
       const legacyProjectProductionRows = await dbPool.query(
-        `WITH project_po_link AS (
+         `WITH project_po_link AS (
            SELECT p.id AS project_id, p.po_id AS po_id
            FROM projects p
            WHERE p.po_id IS NOT NULL
@@ -3600,6 +3635,16 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
            SELECT ps.project_id, ps.linked_p2_order_id AS po_id
            FROM project_steps ps
            WHERE ps.linked_p2_order_id IS NOT NULL
+           UNION
+           SELECT p.id AS project_id, po.id AS po_id
+           FROM p2_purchase_orders po
+           JOIN projects p ON LOWER(TRIM(po.project_name)) IN (
+             LOWER(TRIM(p.project_code)),
+             LOWER(TRIM(p.project_name)),
+             LOWER(TRIM(CONCAT_WS(' - ', NULLIF(p.project_code, ''), NULLIF(p.project_name, ''))))
+           )
+           WHERE po.project_name IS NOT NULL
+             AND TRIM(po.project_name) <> ''
          )
          SELECT DISTINCT ON (wo.id)
            wo.id,
@@ -3684,9 +3729,24 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                        AND ps.linked_p2_order_id IS NOT NULL
                      ORDER BY ps.updated_at DESC NULLS LAST, ps.completed_at DESC NULLS LAST
                      LIMIT 1
-                   )
-                 ) AS linked_po_id
+                 )
+               ) AS linked_po_id
                FROM projects p
+               UNION
+               SELECT
+                 p.id,
+                 p.project_code,
+                 p.project_name,
+                 p.updated_at,
+                 po.id AS linked_po_id
+               FROM p2_purchase_orders po
+               JOIN projects p ON LOWER(TRIM(po.project_name)) IN (
+                 LOWER(TRIM(p.project_code)),
+                 LOWER(TRIM(p.project_name)),
+                 LOWER(TRIM(CONCAT_WS(' - ', NULLIF(p.project_code, ''), NULLIF(p.project_name, ''))))
+               )
+               WHERE po.project_name IS NOT NULL
+                 AND TRIM(po.project_name) <> ''
              )
              SELECT DISTINCT ON (linked_po_id)
                linked_po_id AS "poId",


### PR DESCRIPTION
## Summary
- match legacy P2 PO project labels to projects by project code, project name, or the displayed `code - name` label
- use that match for P2 Status, Scheduling, and Production legacy project work-order fallback queries
- preserves existing production records and only expands read visibility for older PO projects that predate hard project/PO links

## Verification
- `git diff --check`
- `npm run check` could not be run locally because `npm` is not available on PATH in this Windows environment