### PR TITLE
[codex] Fix P2 traveler routing for revisioned parts

### DIFF
--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -355,6 +355,11 @@ function getDepartmentVariants(department: string): string[] {
   return DEPARTMENT_ALIASES[department] || [department];
 }
 
+function getBasePartNumberWithoutRevision(partNumber?: string | null): string | null {
+  const match = partNumber?.match(/^(.+?)\s*Rev\s*\w+$/i);
+  return match ? match[1].trim() : null;
+}
+
 async function getSerializedItemInventoryIdentity(serializedItem: any) {
   let poItem: typeof p2PurchaseOrderItems.$inferSelect | null = null;
   let inventoryItem: typeof inventoryItems.$inferSelect | null = null;
@@ -427,6 +432,29 @@ async function findActiveRoutingForSerializedItem(serializedItem: any) {
     if (byInternalPartNumberCase) return byInternalPartNumberCase;
   }
 
+  const basePartCandidates = [
+    getBasePartNumberWithoutRevision(identity.internalPartNumber),
+    getBasePartNumberWithoutRevision(serializedItem.partNumber),
+  ].filter((partNumber): partNumber is string => Boolean(partNumber));
+
+  for (const basePartNumber of Array.from(new Set(basePartCandidates))) {
+    const byBasePartNumber = await db.query.partRoutings.findFirst({
+      where: and(
+        eq(partRoutings.partNumber, basePartNumber),
+        eq(partRoutings.isActive, true)
+      ),
+    });
+    if (byBasePartNumber) return byBasePartNumber;
+
+    const byBasePartNumberCase = await db.query.partRoutings.findFirst({
+      where: and(
+        ilike(partRoutings.partNumber, basePartNumber),
+        eq(partRoutings.isActive, true)
+      ),
+    });
+    if (byBasePartNumberCase) return byBasePartNumberCase;
+  }
+
   let routing = await db.query.partRoutings.findFirst({
     where: and(
       eq(partRoutings.partNumber, serializedItem.partNumber),
@@ -444,9 +472,8 @@ async function findActiveRoutingForSerializedItem(serializedItem: any) {
   }
 
   if (!routing) {
-    const basePartMatch = serializedItem.partNumber?.match(/^(.+?)\s*Rev\s*\w+$/i);
-    if (basePartMatch) {
-      const basePartNumber = basePartMatch[1].trim();
+    const basePartNumber = getBasePartNumberWithoutRevision(serializedItem.partNumber);
+    if (basePartNumber) {
       const allRoutings = await db
         .select()
         .from(partRoutings)


### PR DESCRIPTION
## Summary
- Allow P2 serialized items with revisioned part numbers such as `4002P0001 Rev P` to resolve active routings stored under the base internal part number.
- Keeps the existing labor/traveler gate intact so task start still requires a generated traveler/WAD link.

## Root Cause
The P2 traveler browser flow verified the serial and certification but returned no routing for revisioned part numbers when the routing was stored as the base part. That left the page in simple task mode, and `/api/p2-traveler/start-task` correctly failed with `NO_TRAVELER_LINK`.

## Validation
- Inspected the live browser failure on `https://agcompepoch.xyz/p2-traveler` for serial `STR2600092`.
- Ran `git diff --check` successfully.
- `npm run check` could not run because `npm` is not available in this shell.