### PR TITLE
Bridge legacy P2 work orders to travelers

### DIFF
--- a/client/src/components/p2/P2ProductionQueue.tsx
+++ b/client/src/components/p2/P2ProductionQueue.tsx
@@ -85,6 +85,10 @@ interface QueueItem {
   replacementReason?: string | null;
   isLegacyProductionOrder?: boolean;
   isLegacyProjectWorkOrder?: boolean;
+  productionWorkOrderId?: string | null;
+  workOrderNumber?: string | null;
+  activeTravelerId?: string | null;
+  activeTravelerNumber?: string | null;
   hasActiveTask: boolean;
   activeTask: ActiveTask | null;
   barcodePrintedAt?: string | null;
@@ -255,6 +259,67 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
     },
     onError: () => {
       toast({ title: 'Warning', description: 'Labels printed but print history could not be saved. The "previously printed" indicator may not appear until the next refresh.', variant: 'destructive' });
+    },
+  });
+
+  const openLegacyTravelerMutation = useMutation({
+    mutationFn: async (item: QueueItem) => {
+      if (item.activeTravelerId) {
+        return {
+          travelerId: item.activeTravelerId,
+          travelerNumber: item.activeTravelerNumber,
+          created: false,
+        };
+      }
+
+      if (!item.productionWorkOrderId) {
+        throw new Error('This project work order is missing its production work order link.');
+      }
+
+      const traveler = await apiRequest(`/api/travelers/from-part-number/${encodeURIComponent(item.partNumber)}`, {
+        method: 'POST',
+        body: {
+          productionWorkOrderId: item.productionWorkOrderId,
+          workOrderId: item.workOrderNumber || item.productionWorkOrderId,
+          lotNumber: item.poNumber,
+          serialNumber: item.workOrderNumber || undefined,
+          quantity: 1,
+          createdBy: 'P2 Control Center',
+        },
+      });
+
+      if (traveler?.id && traveler?.status === 'DRAFT') {
+        try {
+          await apiRequest(`/api/travelers/${traveler.id}/start`, { method: 'POST' });
+        } catch (startError: any) {
+          if (!String(startError?.message || '').includes('not in DRAFT status')) {
+            throw startError;
+          }
+        }
+      }
+
+      return traveler;
+    },
+    onSuccess: (traveler: any) => {
+      const travelerId = traveler?.travelerId || traveler?.id;
+      if (!travelerId) {
+        toast({
+          title: 'Traveler Error',
+          description: 'Traveler was created, but the response did not include an ID.',
+          variant: 'destructive',
+        });
+        return;
+      }
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/production-queue'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/travelers'] });
+      setLocation(`/travelers/${travelerId}/execute`);
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Traveler Error',
+        description: error.message || 'Failed to open the linked traveler',
+        variant: 'destructive',
+      });
     },
   });
 
@@ -974,6 +1039,22 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
                                                 data-testid={`button-open-pm-${item.id}`}
                                               >
                                                 <Factory className="h-4 w-4" />
+                                              </Button>
+                                            )}
+                                            {item.isLegacyProjectWorkOrder && item.status !== 'COMPLETED' && (
+                                              <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => openLegacyTravelerMutation.mutate(item)}
+                                                disabled={openLegacyTravelerMutation.isPending}
+                                                title={item.activeTravelerId ? 'Open active traveler' : 'Create linked traveler'}
+                                                data-testid={`button-open-legacy-traveler-${item.id}`}
+                                              >
+                                                {openLegacyTravelerMutation.isPending ? (
+                                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                                ) : (
+                                                  <Play className="h-4 w-4" />
+                                                )}
                                               </Button>
                                             )}
                                             {item.status !== 'COMPLETED' && !item.isLegacyProductionOrder && !item.isLegacyProjectWorkOrder && (

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3688,11 +3688,19 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
              ORDER BY ts.step_number ASC
              LIMIT 1
            ) AS "currentTravelerStep",
-           (
-             SELECT t.traveler_number
-             FROM travelers t
-             WHERE t.production_work_order_id = wo.id
-               AND COALESCE(UPPER(t.status), '') NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED', 'SCRAPPED', 'CANCELLED', 'CANCELED')
+            (
+              SELECT t.id
+              FROM travelers t
+              WHERE t.production_work_order_id = wo.id
+                AND COALESCE(UPPER(t.status), '') NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED', 'SCRAPPED', 'CANCELLED', 'CANCELED')
+              ORDER BY t.created_at DESC
+              LIMIT 1
+            ) AS "activeTravelerId",
+            (
+              SELECT t.traveler_number
+              FROM travelers t
+              WHERE t.production_work_order_id = wo.id
+                AND COALESCE(UPPER(t.status), '') NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED', 'SCRAPPED', 'CANCELLED', 'CANCELED')
              ORDER BY t.created_at DESC
              LIMIT 1
            ) AS "activeTravelerNumber"
@@ -3971,6 +3979,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         departmentQueues[dept].push({
           id: `legacy-project-work-order-${row.id}`,
           poId,
+          productionWorkOrderId: row.id,
+          workOrderNumber: row.workOrderNumber,
           barcode: row.activeTravelerNumber || row.workOrderNumber,
           serialNumber: row.activeTravelerNumber || row.workOrderNumber,
           partNumber: row.partNumber || row.workOrderNumber,
@@ -3984,6 +3994,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           projectCode: linkedProject?.projectCode ?? null,
           projectName: linkedProject?.projectName ?? null,
           isLegacyProjectWorkOrder: true,
+          activeTravelerId: row.activeTravelerId || null,
+          activeTravelerNumber: row.activeTravelerNumber || null,
           hasActiveTask,
           barcodePrintedAt: null,
           activeTask: hasActiveTask ? {


### PR DESCRIPTION
## Summary
- expose production work order and active traveler identifiers on legacy Project WO rows in the P2 Production queue
- add a Production-tab action that opens an existing active traveler or creates/starts a linked traveler from the project work order
- keep legacy records intact while allowing in-production project work to continue through the normal traveler execution screen

## Root cause
Legacy P2/project work orders can now be visible in the P2 Control Center, but those rows only had display metadata. The P2 traveler flow still needed a concrete active traveler or production work order link to continue execution.

## Verification
- `git diff --check`
- `npm run check` not run locally because `npm` and `node_modules` are unavailable in this Windows workspace