### PR TITLE
[codex] Fix traveler release gate for approved WADs

### DIFF
--- a/server/__tests__/travelerGates.test.ts
+++ b/server/__tests__/travelerGates.test.ts
@@ -17,6 +17,8 @@ vi.mock('../storage', () => ({
     checkEmployeeHasValidTrainingCertificationForCert: vi.fn<(employeeId: number, certificationId: number) => Promise<{ id: number; status: string; expiresAt: Date | null } | undefined>>(),
     getActiveEmployeeMachineQualificationsForEmployee: vi.fn<(employeeId: number) => Promise<Array<{ id: number; machineClass: string | null; operationType: string | null; department: string | null; expiresAt: Date | null }>>>(),
     getRoutingCncOperationForRoutingOp: vi.fn<(routingOperationId: number) => Promise<RoutingCncOperation | undefined>>(),
+    getWorkOrderById: vi.fn(),
+    updateWorkOrderStatus: vi.fn(),
   },
 }));
 
@@ -39,6 +41,7 @@ vi.mock('../schema', () => ({
 import { storage } from '../storage';
 import { db } from '../db';
 import {
+  evaluateWadReleaseGate,
   evaluateTravelerStartGates,
   evaluateTravelerFinishGates,
 } from '../src/lib/travelerGates';
@@ -151,6 +154,48 @@ function mockDbSelectReturning(rows: Record<string, unknown>[]): void {
   const fromFn = vi.fn<() => SelectFromChain>().mockReturnValue({ where: whereFn });
   vi.mocked(db.select).mockReturnValue({ from: fromFn });
 }
+
+// ---------------------------------------------------------------------------
+// evaluateWadReleaseGate — unit tests
+// ---------------------------------------------------------------------------
+
+describe('evaluateWadReleaseGate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('self-heals an approved WAD whose production status has not been released yet', async () => {
+    vi.mocked(storage.getWorkOrderById).mockResolvedValue({
+      id: 'wad-1',
+      status: 'READY',
+      wadStatus: 'APPROVED',
+    } as any);
+    vi.mocked(storage.updateWorkOrderStatus).mockResolvedValue({
+      id: 'wad-1',
+      status: 'RELEASED',
+      wadStatus: 'APPROVED',
+    } as any);
+
+    const result = await evaluateWadReleaseGate('wad-1');
+
+    expect(result.allowed).toBe(true);
+    expect(storage.updateWorkOrderStatus).toHaveBeenCalledWith('wad-1', 'RELEASED');
+  });
+
+  it('continues to block WADs that have not been approved for release', async () => {
+    vi.mocked(storage.getWorkOrderById).mockResolvedValue({
+      id: 'wad-1',
+      status: 'READY',
+      wadStatus: 'PENDING_APPROVAL',
+    } as any);
+
+    const result = await evaluateWadReleaseGate('wad-1');
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/RELEASED or IN_PROGRESS/);
+    expect(storage.updateWorkOrderStatus).not.toHaveBeenCalled();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // evaluateTravelerStartGates — unit tests

--- a/server/src/lib/travelerGates.ts
+++ b/server/src/lib/travelerGates.ts
@@ -78,6 +78,16 @@ export async function evaluateWadReleaseGate(wadId: string): Promise<GateResult>
   if (!wad) {
     return { allowed: false, reason: 'The linked production work order could not be found.' };
   }
+  const terminalStatuses = new Set(['COMPLETE', 'COMPLETED', 'CANCELLED', 'CANCELED', 'CLOSED']);
+  if (
+    wad.wadStatus === 'APPROVED' &&
+    wad.status !== 'RELEASED' &&
+    wad.status !== 'IN_PROGRESS' &&
+    !terminalStatuses.has(String(wad.status).toUpperCase())
+  ) {
+    await storage.updateWorkOrderStatus(wad.id, 'RELEASED');
+    return { allowed: true };
+  }
   if (wad.status !== 'RELEASED' && wad.status !== 'IN_PROGRESS') {
     return {
       allowed: false,


### PR DESCRIPTION
## What changed
- Updated the shared traveler WAD release gate to self-heal approved WADs whose production work order status has not yet flipped to `RELEASED`.
- Added unit coverage for the approved-WAD repair path and the still-blocked pending-approval path.

## Why
A traveler execute page can be linked to a WAD that has completed WAD approval but still has a lagging production status such as `READY`. The step-start and auto-punch gates then show "Work order not released to floor" even though the WAD approval state says the work is authorized.

This keeps the hard release gate intact: only `wadStatus='APPROVED'` non-terminal work orders are repaired to `RELEASED`; unapproved WADs still block.

## Validation
- `git diff --check`
- `git diff --cached --check`

Node/Vitest validation could not be run locally because `node.exe` is blocked by Windows access permissions in this workspace and `node_modules` is not installed in the fresh worktree.