### PR TITLE
[codex] Fix production traveler auth redirect

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -383,6 +383,14 @@ function useIsEmbedMode() {
   return typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('embed') === '1';
 }
 
+function isFloorOperatorRoute(location: string) {
+  return (
+    location.startsWith('/kiosk') ||
+    location.startsWith('/p2-traveler') ||
+    location.startsWith('/travelers/')
+  );
+}
+
 function ConditionalOfflineIndicator() {
   const isEmbed = useIsEmbedMode();
   return isEmbed ? null : <OfflineIndicator />;
@@ -391,7 +399,7 @@ function ConditionalOfflineIndicator() {
 function ConditionalMainWrapper({ children }: { children: React.ReactNode }) {
   const isEmbed = useIsEmbedMode();
   const [location] = useLocation();
-  if (isEmbed || location.startsWith('/kiosk') || location.startsWith('/vendor-confirm')) {
+  if (isEmbed || isFloorOperatorRoute(location) || location.startsWith('/vendor-confirm')) {
     return <div className="w-full min-h-screen overflow-auto">{children}</div>;
   }
   return <main className="container mx-auto px-4 py-8">{children}</main>;
@@ -412,7 +420,7 @@ function ConditionalNavigation() {
     location.startsWith('/vendor-confirm') || // Hide navigation on vendor PO confirmation page
     location.startsWith('/tv-display') || // Hide navigation on TV display page
     location.startsWith('/tv-timer-board') || // Hide navigation on timer board page
-    location.startsWith('/kiosk'); // Hide navigation on time-clock kiosk (PIN-based, no EPOCH nav)
+    isFloorOperatorRoute(location); // Hide navigation on badge/PIN based production floor pages
 
   return hideNavigation ? null : <Navigation />;
 }

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -98,6 +98,7 @@ const KIOSK_ROUTES = [
   '/p2-traveler',
   '/p2-traveler-viewer',
   '/traveler',
+  '/travelers',
   '/production/timers',
   '/badge-scan',
 ];

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -26,6 +26,15 @@ const LOGIN_MODES: { key: LoginMode; label: string; icon: typeof LogIn; descript
   { key: 'time-clock', label: 'Time Clock', icon: Clock, description: 'Employee clock in and clock out', color: 'text-gray-600 bg-gray-100 dark:bg-gray-800 dark:text-gray-400' },
 ];
 
+function isPublicFloorRedirect(path: string) {
+  return (
+    path.startsWith('/travelers/') ||
+    path.startsWith('/p2-traveler') ||
+    path.startsWith('/kiosk') ||
+    path.startsWith('/app/production/stations')
+  );
+}
+
 export default function LoginPage() {
   const [activeMode, setActiveMode] = useState<LoginMode | null>(null);
 
@@ -37,6 +46,20 @@ export default function LoginPage() {
   const [isBadgeLoading, setIsBadgeLoading] = useState(false);
   const [, setLocation] = useLocation();
   const { toast } = useToast();
+
+  useEffect(() => {
+    const redirect = new URLSearchParams(window.location.search).get('redirect');
+    if (!redirect) return;
+
+    try {
+      const decodedRedirect = decodeURIComponent(redirect);
+      if (isPublicFloorRedirect(decodedRedirect)) {
+        setLocation(decodedRedirect, { replace: true });
+      }
+    } catch {
+      // Ignore malformed redirect parameters and leave the login page available.
+    }
+  }, [setLocation]);
 
   useEffect(() => {
     if (activeMode === 'time-clock') {

--- a/client/src/pages/TravelerExecution.tsx
+++ b/client/src/pages/TravelerExecution.tsx
@@ -364,7 +364,16 @@ export default function TravelerExecution() {
 
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const { data: session } = useQuery<any>({ queryKey: ['/api/auth/session'] });
+  const { data: session } = useQuery<any | null>({
+    queryKey: ['/api/auth/session', 'traveler-execution-admin'],
+    queryFn: async () => {
+      const res = await fetch('/api/auth/session', { credentials: 'include' });
+      if (res.status === 401) return null;
+      if (!res.ok) throw new Error('Failed to fetch admin session');
+      return res.json();
+    },
+    retry: false,
+  });
   const isAdmin = session?.role === 'ADMIN' || session?.role === 'OWNER';
 
   // Labor context query — fetched per-step for NOT_STARTED steps (Task #1235)


### PR DESCRIPTION
## Summary

Fixes production-floor traveler execution links being forced back to login when the operator opens a `/travelers/:id/execute?badge=...` URL.

## Root Cause

The traveler execution route was public in `RouteGuard`, but the shared auth/session interceptor only classified `/p2-traveler`, `/p2-traveler-viewer`, and singular `/traveler` as kiosk/floor routes. Auth-only background requests from the normal app shell could return `401` and trigger a login redirect even though the traveler page is supposed to run by badge scan.

## Changes

- Treat `/travelers/...` as a kiosk/floor route in `queryClient.ts` so session expiry does not redirect operators away from traveler execution.
- Hide the authenticated navigation shell and use the full-width floor-operator wrapper on `/travelers/...` pages to avoid auth-only nav queries during traveler execution.
- Let `LoginPage` release stale `/login?redirect=/travelers/...` URLs back to the public traveler page.
- Make the optional admin-session lookup inside `TravelerExecution` return `null` on `401` instead of surfacing it as a page error.

## Validation

- `git diff --check` passed.
- Full build/typecheck was not run because this worktree has no `node_modules` and this environment does not have `npm`, `pnpm`, or `yarn` available.