### PR TITLE
[codex] Fix routing operation traveler flow

### DIFF
--- a/client/src/pages/PartRoutingManagement.tsx
+++ b/client/src/pages/PartRoutingManagement.tsx
@@ -208,6 +208,26 @@ const emptyNewOp = {
   requiresCertification: false,
 };
 
+function buildNextOperationDraft(
+  routing: PartRouting | null,
+  existingOps: RoutingOperation[] = []
+) {
+  const maxStepNumber = existingOps.reduce(
+    (maxStep, op) => Math.max(maxStep, Number(op.stepNumber) || 0),
+    0
+  );
+  const nextStepNumber = maxStepNumber + 1;
+  const departments = routing?.departmentSequence || [];
+  const nextDepartment =
+    departments[Math.min(Math.max(nextStepNumber - 1, 0), Math.max(departments.length - 1, 0))] || '';
+
+  return {
+    ...emptyNewOp,
+    stepNumber: nextStepNumber,
+    departmentName: nextDepartment,
+  };
+}
+
 export default function PartRoutingManagement() {
   const [, navigate] = useLocation();
   const [searchTerm, setSearchTerm] = useState('');
@@ -332,9 +352,9 @@ export default function PartRoutingManagement() {
         body: JSON.stringify(data),
         headers: { 'Content-Type': 'application/json' },
       }),
-    onSuccess: () => {
+    onSuccess: (created: any) => {
       toast({ title: 'Operation added' });
-      setNewOp({ ...emptyNewOp });
+      setNewOp(buildNextOperationDraft(operationsDialog.routing, [...operations, created]));
       queryClient.invalidateQueries({ queryKey: ['/api/part-routings', operationsDialog.routing?.id, 'operations'] });
     },
     onError: (e: any) => toast({ title: 'Error', description: e.message, variant: 'destructive' }),
@@ -740,7 +760,7 @@ export default function PartRoutingManagement() {
                             variant="outline"
                             size="sm"
                             onClick={() => {
-                              setNewOp({ ...emptyNewOp });
+                              setNewOp(buildNextOperationDraft(routing));
                               setOperationsDialog({ open: true, routing });
                             }}
                             title="Manage operations"
@@ -932,12 +952,28 @@ export default function PartRoutingManagement() {
               </div>
               <div>
                 <Label className="text-xs mb-1 block">Department</Label>
-                <Input
-                  placeholder="e.g. Layup"
-                  value={newOp.departmentName}
-                  onChange={(e) => setNewOp((p) => ({ ...p, departmentName: e.target.value }))}
-                  className="h-8"
-                />
+                {operationsDialog.routing?.departmentSequence?.length ? (
+                  <Select
+                    value={newOp.departmentName}
+                    onValueChange={(value) => setNewOp((p) => ({ ...p, departmentName: value }))}
+                  >
+                    <SelectTrigger className="h-8">
+                      <SelectValue placeholder="Select department" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {operationsDialog.routing.departmentSequence.map((dept, idx) => (
+                        <SelectItem key={`${dept}-${idx}`} value={dept}>{dept}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input
+                    placeholder="e.g. Layup"
+                    value={newOp.departmentName}
+                    onChange={(e) => setNewOp((p) => ({ ...p, departmentName: e.target.value }))}
+                    className="h-8"
+                  />
+                )}
               </div>
               <div>
                 <Label className="text-xs mb-1 block">Operation Name</Label>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -17215,7 +17215,7 @@ export class DatabaseStorage implements IStorage {
       .select()
       .from(routingOperations)
       .where(eq(routingOperations.partRoutingId, partRoutingId))
-      .orderBy(routingOperations.stepNumber);
+      .orderBy(asc(routingOperations.stepNumber), asc(routingOperations.id));
   }
 
   async createRoutingOperation(data: InsertRoutingOperation): Promise<RoutingOperation> {
@@ -20225,22 +20225,43 @@ export class DatabaseStorage implements IStorage {
       return [];
     };
 
-    // Group ops by unique (stepNumber, departmentName)
-    const stepGroups: Map<string, RoutingOperation[]> = new Map();
-    for (const op of ops) {
-      const key = `${op.stepNumber}__${op.departmentName}`;
-      if (!stepGroups.has(key)) stepGroups.set(key, []);
-      stepGroups.get(key)!.push(op);
+    const departmentSequence = Array.isArray(routing.departmentSequence)
+      ? (routing.departmentSequence as string[])
+      : [];
+    const departmentOrder = new Map(
+      departmentSequence.map((dept, index) => [String(dept).trim().toLowerCase(), index])
+    );
+    const getDepartmentOrder = (departmentName: string) =>
+      departmentOrder.get(String(departmentName || '').trim().toLowerCase()) ?? Number.MAX_SAFE_INTEGER;
+    const compareOperations = (a: RoutingOperation, b: RoutingOperation) => {
+      const aStep = Number.isFinite(Number(a.stepNumber)) ? Number(a.stepNumber) : Number.MAX_SAFE_INTEGER;
+      const bStep = Number.isFinite(Number(b.stepNumber)) ? Number(b.stepNumber) : Number.MAX_SAFE_INTEGER;
+      if (aStep !== bStep) return aStep - bStep;
+
+      const deptDiff = getDepartmentOrder(a.departmentName) - getDepartmentOrder(b.departmentName);
+      if (deptDiff !== 0) return deptDiff;
+
+      return (a.id ?? 0) - (b.id ?? 0);
+    };
+
+    const orderedOps = [...ops].sort(compareOperations);
+
+    // Keep the exact operation placement in the traveler flow. Consecutive
+    // operations for the same department become one traveler step; if a
+    // department appears again later in the routing, it remains a later step.
+    const stepGroups: RoutingOperation[][] = [];
+    for (const op of orderedOps) {
+      const currentGroup = stepGroups[stepGroups.length - 1];
+      const currentDept = currentGroup?.[0]?.departmentName;
+      if (currentGroup && currentDept === op.departmentName) {
+        currentGroup.push(op);
+      } else {
+        stepGroups.push([op]);
+      }
     }
-    const sortedKeys = Array.from(stepGroups.keys()).sort((a, b) => {
-      const [aStep] = a.split('__').map(Number);
-      const [bStep] = b.split('__').map(Number);
-      return aStep - bStep;
-    });
 
     let stepCounter = 0;
-    for (const key of sortedKeys) {
-      const groupOps = stepGroups.get(key)!;
+    for (const groupOps of stepGroups) {
       const deptName = groupOps[0].departmentName;
       stepCounter++;
       const step = await this.createTravelerStep({
@@ -20255,8 +20276,39 @@ export class DatabaseStorage implements IStorage {
       for (const op of groupOps) {
         const taskType = operationTypeToTaskType(op.operationType);
         const taskPhase = operationTypeToPhase(op.operationType);
-        const instPack = op.instructionPack as any;
-        const instructions = instPack?.specialNotes || op.operationName;
+        const instPack = (op.instructionPack || {}) as any;
+        const operationDetails = [
+          instPack?.specialNotes,
+          op.workCenter ? `Work center: ${op.workCenter}` : null,
+          op.estimatedMinutes ? `Estimated time: ${op.estimatedMinutes} minutes` : null,
+          op.isOutsideProcess ? 'Outside process required' : null,
+          op.certificateRequired ? 'Certificate required' : null,
+          op.receivingInspectionRequired ? 'Receiving inspection required' : null,
+          Array.isArray(op.requiredCalibrationAssetTags) && op.requiredCalibrationAssetTags.length > 0
+            ? `Required calibration assets: ${op.requiredCalibrationAssetTags.join(', ')}`
+            : null,
+        ].filter(Boolean);
+        const instructions = operationDetails.length > 0
+          ? operationDetails.join('\n')
+          : op.operationName;
+        const instructionPack = {
+          ...instPack,
+          routingOperation: {
+            id: op.id,
+            stepNumber: op.stepNumber,
+            departmentName: op.departmentName,
+            operationName: op.operationName,
+            operationType: op.operationType,
+            workCenter: op.workCenter,
+            estimatedMinutes: op.estimatedMinutes,
+            isOutsideProcess: op.isOutsideProcess,
+            outsideProcessType: op.outsideProcessType,
+            expectedLeadDays: op.expectedLeadDays,
+            certificateRequired: op.certificateRequired,
+            receivingInspectionRequired: op.receivingInspectionRequired,
+            requiredCalibrationAssetTags: op.requiredCalibrationAssetTags || [],
+          },
+        };
 
         const task = await this.createTravelerTask({
           travelerStepId: step.id,
@@ -20271,7 +20323,7 @@ export class DatabaseStorage implements IStorage {
           requiresCertification: op.requiresCertification ?? false,
           signatureRole: op.requiresSignature ? 'OPERATOR' : null,
           status: 'NOT_STARTED',
-          instructionPack: op.instructionPack as any,
+          instructionPack,
         });
 
         if (taskType === 'QC') {


### PR DESCRIPTION
## Summary
- Preserve deterministic routing operation order when generating travelers from part routings.
- Group generated traveler steps by the actual ordered operation flow so repeated or later departments stay in the same placement operators entered.
- Carry routing operation details such as work center, estimated time, OSP/cert/inspection flags, and calibration asset requirements into generated traveler task instructions and task snapshots.
- Make the routing operations UI default to the next step number and select departments from the routing's department sequence instead of free-text entry when a sequence exists.

## Root Cause
Structured routing operations were read with only `step_number` ordering and then grouped by a loose `stepNumber + department` key. Equal step numbers could come back in unstable database order, and newly-added operations defaulted to step `1`, so the generated traveler flow could differ from the routing flow that was entered.

## Validation
- `git diff --check -- client/src/pages/PartRoutingManagement.tsx server/storage.ts` passed.
- `npm run check` could not be run locally because `npm` is not installed/on PATH in this desktop shell and the clean worktree has no `node_modules`.

## Notes
- PR is intentionally scoped to routing operation creation and traveler generation. It does not change unrelated traveler execution gates or production workflow behavior.