### PR TITLE
[codex] Fix OEM shipments list visibility

### DIFF
--- a/server/__tests__/packingSlipRoute.test.ts
+++ b/server/__tests__/packingSlipRoute.test.ts
@@ -108,6 +108,7 @@ vi.mock('../schema', () => ({
 // ---------------------------------------------------------------------------
 
 import { storage } from '../storage';
+import { pool } from '../db';
 import { generatePoPackingSlipPdf } from '../utils/pdf/packingSlipPdf';
 
 // ---------------------------------------------------------------------------
@@ -403,5 +404,50 @@ describe('POST /api/po-orders/process-shipment — packing slip description prio
     expect(res.body.success).toBe(true);
     expect(typeof res.body.trackingNumber).toBe('string');
     expect(res.body.trackingNumber).toMatch(/^TEST-/);
+  });
+});
+
+describe('GET /api/po-orders/oem-shipments', () => {
+  let app: express.Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    const poShippingRouter = (await import('../src/routes/poShippingQC')).default;
+    app.use('/api/po-orders', poShippingRouter);
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('uses only filter params for the total-count query when no filters are set', async () => {
+    vi.mocked(pool.query)
+      .mockResolvedValueOnce({ rows: [{ table_exists: true }] } as any)
+      .mockResolvedValueOnce({
+        rows: [{
+          id: '11111111-1111-1111-1111-111111111111',
+          customer_id: 'CUST-1',
+          customer_name: 'OEM Customer',
+          master_tracking_number: '1Z999',
+          created_at: '2026-05-20T12:00:00.000Z',
+          item_count: 1,
+          stock_count: 1,
+          accessory_count: 0,
+          po_count: 1,
+          has_shipping_label: true,
+          items: [],
+        }],
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ total: '1' }] } as any);
+
+    const res = await request(app).get('/api/po-orders/oem-shipments');
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.total).toBe(1);
+    expect(vi.mocked(pool.query).mock.calls[1][1]).toEqual([50, 0, false]);
+    expect(vi.mocked(pool.query).mock.calls[2][1]).toEqual([]);
   });
 });

--- a/server/src/routes/poShippingQC.ts
+++ b/server/src/routes/poShippingQC.ts
@@ -949,6 +949,8 @@ router.get('/oem-shipments', authenticateToken, async (req, res) => {
       SELECT * FROM shipment_aggregates
     `;
 
+    const countParams = [...params];
+
     params.push(parseInt(limit as string, 10));
     params.push(parseInt(offset as string, 10));
     const canSeePrices = req.user?.username === 'glennj';
@@ -963,7 +965,7 @@ router.get('/oem-shipments', authenticateToken, async (req, res) => {
       FROM shipment_records sr
       WHERE ${conditions.join(' AND ')}
     `;
-    const countResult = await pool.query(countQuery, params.slice(0, -2));
+    const countResult = await pool.query(countQuery, countParams);
     const total = parseInt((countResult.rows || countResult)[0]?.total || '0', 10);
 
     console.log(`📊 Found ${shipments.length} shipments (total: ${total})`);


### PR DESCRIPTION
## Summary
- Fixes the OEM Shipments endpoint so the pagination count query uses only filter parameters, not the list query's limit/offset/price parameters.
- Adds a route-level regression test for the no-filter OEM shipments request, which is the case shown by the page displaying summary counts while the shipment list is empty.

## Root Cause
The endpoint built one shared params array for filters, pagination, and price visibility. It then tried to reuse that array for the count query with `params.slice(0, -2)`, which removed only offset and price visibility while leaving `limit` behind. With no filters, the count query had no placeholders but still received one bound parameter, causing the shipment fetch to fail even though the independent stats endpoint still returned real shipment counts.

## Validation
- `git diff --check` passed.
- Targeted Vitest was not run locally because this fresh worktree has no `node_modules` and `npm` is not available on this shell's PATH.