### PR TITLE
[codex] Resolve traveler charge codes from WAD Step 4

### DIFF
--- a/client/src/pages/TravelerExecution.tsx
+++ b/client/src/pages/TravelerExecution.tsx
@@ -379,7 +379,7 @@ export default function TravelerExecution() {
   // Labor context query — fetched per-step for NOT_STARTED steps (Task #1235)
   interface LaborContext {
     chargeCode: string | null;
-    chargeCodeResolvedFrom: 'wad_default' | 'traveler_default' | 'department_match' | null;
+    chargeCodeResolvedFrom: 'wad_default' | 'traveler_default' | 'wad_department' | 'department_match' | null;
     chargeCodeError: string | null;
     isOverrun: boolean;
     nearlyExhausted: boolean;
@@ -2085,7 +2085,7 @@ export default function TravelerExecution() {
                               Charge code:{' '}
                               <span className="font-mono font-semibold text-foreground">{laborContext.chargeCode}</span>
                               <span className="ml-1 text-[10px] text-muted-foreground">
-                                ({laborContext.chargeCodeResolvedFrom === 'wad_default' ? 'WAD default' : laborContext.chargeCodeResolvedFrom === 'traveler_default' ? 'traveler default' : 'dept match'})
+                                ({laborContext.chargeCodeResolvedFrom === 'wad_default' ? 'WAD default' : laborContext.chargeCodeResolvedFrom === 'traveler_default' ? 'traveler default' : laborContext.chargeCodeResolvedFrom === 'wad_department' ? 'WAD dept' : 'dept match'})
                               </span>
                             </span>
                           ) : (

--- a/server/__tests__/resolveChargeCode.test.ts
+++ b/server/__tests__/resolveChargeCode.test.ts
@@ -17,7 +17,7 @@ vi.mock('../schema', () => ({
   routingOperations: {},
 }));
 
-import { getDepartmentChargeCodeCandidates } from '../src/lib/resolveChargeCode';
+import { findWadDepartmentChargeCode, getDepartmentChargeCodeCandidates } from '../src/lib/resolveChargeCode';
 
 describe('getDepartmentChargeCodeCandidates', () => {
   it('matches Quality Control routing steps to QC charge codes', () => {
@@ -30,5 +30,32 @@ describe('getDepartmentChargeCodeCandidates', () => {
 
   it('keeps non-aliased departments exact', () => {
     expect(getDepartmentChargeCodeCandidates('Layup')).toEqual(['Layup']);
+  });
+});
+
+describe('findWadDepartmentChargeCode', () => {
+  it('uses the WAD Step 4 QC code when routing says Quality Control', () => {
+    const wizardData = {
+      step4: {
+        chargeCodes: [
+          { department: 'Layup', chargeCode: 'LAYUP' },
+          { department: 'QC', chargeCode: 'QC' },
+        ],
+      },
+    };
+
+    expect(findWadDepartmentChargeCode(wizardData, 'Quality Control')).toBe('QC');
+  });
+
+  it('uses the WAD Step 4 Quality Control code when routing says QC', () => {
+    const wizardData = {
+      step4: {
+        chargeCodes: [
+          { department: 'Quality Control', chargeCode: 'QC' },
+        ],
+      },
+    };
+
+    expect(findWadDepartmentChargeCode(wizardData, 'QC')).toBe('QC');
   });
 });

--- a/server/src/lib/resolveChargeCode.ts
+++ b/server/src/lib/resolveChargeCode.ts
@@ -28,7 +28,7 @@ export type CertificationStatus = 'VALID' | 'EXPIRED' | 'MISSING';
 export interface ResolvedChargeCode {
   chargeCodeId: number;
   chargeCode: string;
-  resolvedFrom: 'wad_default' | 'traveler_default' | 'department_match';
+  resolvedFrom: 'wad_default' | 'traveler_default' | 'wad_department' | 'department_match';
 }
 
 export interface ResolveChargeCodeError {
@@ -56,6 +56,36 @@ export function getDepartmentChargeCodeCandidates(department: string | null | un
 
   const aliases = DEPARTMENT_ALIASES[departmentKey(trimmed)] ?? [];
   return Array.from(new Set([trimmed, ...aliases]));
+}
+
+interface WadChargeCodeRow {
+  department?: unknown;
+  chargeCode?: unknown;
+}
+
+export function findWadDepartmentChargeCode(
+  wizardData: unknown,
+  department: string | null | undefined
+): string | null {
+  const departmentCandidates = getDepartmentChargeCodeCandidates(department).map(departmentKey);
+  if (departmentCandidates.length === 0 || !wizardData || typeof wizardData !== 'object') return null;
+
+  const step4 = (wizardData as { step4?: unknown }).step4;
+  if (!step4 || typeof step4 !== 'object') return null;
+
+  const rows = (step4 as { chargeCodes?: unknown }).chargeCodes;
+  if (!Array.isArray(rows)) return null;
+
+  for (const row of rows as WadChargeCodeRow[]) {
+    const rowDepartment = typeof row.department === 'string' ? row.department.trim() : '';
+    const rowChargeCode = typeof row.chargeCode === 'string' ? row.chargeCode.trim() : '';
+    if (!rowDepartment || !rowChargeCode) continue;
+    if (departmentCandidates.includes(departmentKey(rowDepartment))) {
+      return rowChargeCode;
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -143,7 +173,10 @@ export async function resolveChargeCode(params: {
   }
 
   const [wad] = await db
-    .select({ defaultChargeCodeId: productionWorkOrders.defaultChargeCodeId })
+    .select({
+      defaultChargeCodeId: productionWorkOrders.defaultChargeCodeId,
+      wizardData: productionWorkOrders.wizardData,
+    })
     .from(productionWorkOrders)
     .where(eq(productionWorkOrders.id, productionWorkOrderId))
     .limit(1);
@@ -187,7 +220,23 @@ export async function resolveChargeCode(params: {
     }
   }
 
-  // Priority 3: Active charge code whose department matches the routing operation's
+  // Priority 3: WAD-authored Step 4 charge-code row for this department.
+  // This is the direct WAD source of truth when the routing says "Quality Control"
+  // and the WAD row carries the active code "QC".
+  const wadDepartmentChargeCode = findWadDepartmentChargeCode(wad.wizardData, effectiveDepartment);
+  if (wadDepartmentChargeCode) {
+    const [cc] = await db
+      .select({ id: chargeCodes.id, code: chargeCodes.code })
+      .from(chargeCodes)
+      .where(and(sql`upper(${chargeCodes.code}) = upper(${wadDepartmentChargeCode})`, eq(chargeCodes.active, true)))
+      .limit(1);
+
+    if (cc) {
+      return { chargeCodeId: cc.id, chargeCode: cc.code, resolvedFrom: 'wad_department' };
+    }
+  }
+
+  // Priority 4: Active charge code whose department matches the routing operation's
   // departmentName (operation-scoped via effectiveDepartment resolved from travelerStepId,
   // or caller-supplied department as fallback).
   const departmentCandidates = getDepartmentChargeCodeCandidates(effectiveDepartment);


### PR DESCRIPTION
## Summary
- Resolve traveler charge codes from the WAD Step 4 department charge-code rows before falling back to generic department matching.
- Keep the existing QC/Quality Control/Final QC department alias handling from the previous PR.
- Update the traveler UI resolver label type for the new `wad_department` resolution source.
- Add focused unit coverage for WAD Step 4 row selection when routing and WAD departments use `QC` vs `Quality Control`.

## Root cause
PR #824 fixed only the generic department fallback, but the failing part #711 path is WAD-authored: the routing step says `Quality Control` and the WAD Step 4 charge-code row can carry the active code `QC`. The traveler resolver was not reading `production_work_orders.wizard_data.step4.chargeCodes`, so it still failed closed with `CHARGE_CODE_UNRESOLVED`.

## Validation
- `git diff --check -- server/src/lib/resolveChargeCode.ts server/__tests__/resolveChargeCode.test.ts client/src/pages/TravelerExecution.tsx`
- `git diff --cached --check`

Vitest was not run locally because this worktree has no `node_modules` and `npm` is not available on PATH in this shell.