### PR TITLE
[codex] Add PM P2 WAD bridge visibility

### DIFF
--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -124,6 +124,13 @@ interface WorkOrderRow {
   replacementSerialNumbers?: string | null;
   daysScheduleVariance: number | null;
   blockReason: string | null;
+  linkedWadId?: string | null;
+  linkedWadNumber?: string | null;
+  linkedWadStatus?: string | null;
+  linkedWadWorkOrderStatus?: string | null;
+  productionConnectionStatus?: 'CONNECTED' | 'WAD_MISSING' | 'WAD_NOT_MATCHED' | 'WAD_INCOMPLETE' | 'TRAVELER_NOT_ACTIVE' | string | null;
+  productionConnectionLabel?: string | null;
+  productionConnectionDetail?: string | null;
 }
 
 interface WorkOrderDetail {
@@ -311,6 +318,51 @@ const WO_STATUS_COLORS: Record<string, string> = {
   CLOSED: 'bg-gray-200 text-gray-500',
   BLOCKED: 'bg-red-100 text-red-700',
 };
+
+const CONNECTION_STATUS_COLORS: Record<string, string> = {
+  CONNECTED: 'bg-green-100 text-green-700 border-green-200',
+  WAD_MISSING: 'bg-red-100 text-red-700 border-red-200',
+  WAD_NOT_MATCHED: 'bg-orange-100 text-orange-700 border-orange-200',
+  WAD_INCOMPLETE: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  TRAVELER_NOT_ACTIVE: 'bg-blue-100 text-blue-700 border-blue-200',
+};
+
+function ProductionConnectionCell({ row, navTo }: { row: WorkOrderRow; navTo: (path: string) => void }) {
+  if (row.sourceType !== 'p2_production_order') {
+    return (
+      <div className="text-xs text-muted-foreground">
+        WAD source
+      </div>
+    );
+  }
+
+  const status = row.productionConnectionStatus ?? 'WAD_MISSING';
+  const label = row.productionConnectionLabel ?? 'Connection check';
+  const detail = row.productionConnectionDetail ?? 'P2 production is shown without changing production flow.';
+
+  return (
+    <div className="flex min-w-[190px] flex-col gap-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Badge variant="outline" className={`text-[10px] px-1.5 py-0 ${CONNECTION_STATUS_COLORS[status] ?? 'bg-gray-100 text-gray-700 border-gray-200'}`}>
+          {label}
+        </Badge>
+        {row.linkedWadNumber && (
+          <button
+            type="button"
+            className="font-mono text-xs text-primary hover:underline"
+            onClick={() => row.linkedWadId && navTo(`/production-work-orders/${row.linkedWadId}`)}
+            title={row.linkedWadStatus || undefined}
+          >
+            {row.linkedWadNumber}
+          </button>
+        )}
+      </div>
+      <div className="text-xs text-muted-foreground line-clamp-2" title={detail}>
+        {detail}
+      </div>
+    </div>
+  );
+}
 
 const MATERIAL_STATUS_COLORS: Record<string, string> = {
   OVER_ISSUED: 'bg-red-100 text-red-700',
@@ -677,6 +729,7 @@ function ProductionTab({ projectId }: { projectId: string }) {
               <TableHead>Status</TableHead>
               <TableHead>Department</TableHead>
               <TableHead>Dashboard / Queue</TableHead>
+              <TableHead>Connection</TableHead>
               <TableHead>Current Step</TableHead>
               <TableHead>Active Traveler</TableHead>
               <TableHead>Due Date</TableHead>
@@ -783,6 +836,9 @@ function ProductionTab({ projectId }: { projectId: string }) {
                       <span className="text-muted-foreground">—</span>
                     )}
                   </div>
+                </TableCell>
+                <TableCell className="text-sm" onClick={(e) => e.stopPropagation()}>
+                  <ProductionConnectionCell row={row} navTo={navTo} />
                 </TableCell>
                 <TableCell className="text-sm">{row.currentTravelerStep ?? <span className="text-muted-foreground">—</span>}</TableCell>
                 <TableCell className="text-sm" onClick={(e) => e.stopPropagation()}>

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -112,6 +112,24 @@ interface ProductionRow {
   replacementSerialNumbers: string | null;
   daysScheduleVariance: string | null;
   blockReason: string | null;
+  linkedWadId?: string | null;
+  linkedWadNumber?: string | null;
+  linkedWadStatus?: string | null;
+  linkedWadWorkOrderStatus?: string | null;
+  productionConnectionStatus?: string | null;
+  productionConnectionLabel?: string | null;
+  productionConnectionDetail?: string | null;
+}
+
+interface WadBridgeRow {
+  id: string;
+  workOrderNumber: string;
+  partNumber: string | null;
+  status: string | null;
+  wadStatus: string | null;
+  activeTravelerId: string | null;
+  activeTravelerNumber: string | null;
+  currentTravelerStep: string | null;
 }
 
 interface ChargeCodeAggRow {
@@ -209,6 +227,127 @@ interface SerializedItemAggregate {
   groups: SerializedItemGroup[];
   totalRequired: number;
   totalCompleted: number;
+}
+
+function normalizePartKey(value: string | null | undefined): string {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function isWadReleasedForExecution(wad: WadBridgeRow): boolean {
+  const wadStatus = String(wad.wadStatus ?? '').trim().toUpperCase();
+  const workOrderStatus = String(wad.status ?? '').trim().toUpperCase();
+  return (
+    wadStatus === 'APPROVED' &&
+    ['RELEASED', 'IN_PROGRESS', 'COMPLETE', 'COMPLETED', 'CLOSED'].includes(workOrderStatus)
+  );
+}
+
+async function getProjectWadBridgeRows(projectId: string): Promise<WadBridgeRow[]> {
+  return pool.query<WadBridgeRow>(`
+    SELECT
+      wo.id::text AS id,
+      wo.work_order_number AS "workOrderNumber",
+      wo.part_number AS "partNumber",
+      wo.status,
+      wo.wad_status AS "wadStatus",
+      (
+        SELECT t.id::text
+        FROM travelers t
+        WHERE t.production_work_order_id = wo.id
+          AND UPPER(COALESCE(t.status, '')) NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED', 'SCRAPPED', 'CANCELLED', 'CANCELED')
+        ORDER BY t.updated_at DESC NULLS LAST, t.created_at DESC NULLS LAST
+        LIMIT 1
+      ) AS "activeTravelerId",
+      (
+        SELECT t.traveler_number
+        FROM travelers t
+        WHERE t.production_work_order_id = wo.id
+          AND UPPER(COALESCE(t.status, '')) NOT IN ('COMPLETE', 'COMPLETED', 'CLOSED', 'SCRAPPED', 'CANCELLED', 'CANCELED')
+        ORDER BY t.updated_at DESC NULLS LAST, t.created_at DESC NULLS LAST
+        LIMIT 1
+      ) AS "activeTravelerNumber",
+      (
+        SELECT ts.department_name
+        FROM traveler_steps ts
+        JOIN travelers t ON t.id = ts.traveler_id
+        WHERE t.production_work_order_id = wo.id
+          AND UPPER(COALESCE(ts.status, '')) IN ('IN_PROGRESS', 'ACTIVE', 'STARTED')
+        ORDER BY ts.step_number ASC
+        LIMIT 1
+      ) AS "currentTravelerStep"
+    FROM production_work_orders wo
+    WHERE wo.project_id = $1
+      AND UPPER(COALESCE(wo.status, '')) NOT IN ('CANCELLED', 'CANCELED')
+    ORDER BY wo.created_at DESC
+  `, [projectId]);
+}
+
+async function enrichP2RowsWithWadBridge(projectId: string, rows: ProductionRow[]): Promise<ProductionRow[]> {
+  const hasP2Rows = rows.some((row) => row.sourceType === 'p2_production_order');
+  if (!hasP2Rows) return rows;
+
+  const wads = await getProjectWadBridgeRows(projectId);
+  const wadByPart = new Map<string, WadBridgeRow>();
+  for (const wad of wads) {
+    const key = normalizePartKey(wad.partNumber);
+    if (key && !wadByPart.has(key)) {
+      wadByPart.set(key, wad);
+    }
+  }
+
+  return rows.map((row) => {
+    if (row.sourceType !== 'p2_production_order') return row;
+
+    const matchedWad = wadByPart.get(normalizePartKey(row.partNumber)) ?? null;
+    if (!matchedWad) {
+      const hasAnyWad = wads.length > 0;
+      return {
+        ...row,
+        productionConnectionStatus: hasAnyWad ? 'WAD_NOT_MATCHED' : 'WAD_MISSING',
+        productionConnectionLabel: hasAnyWad ? 'WAD not matched' : 'WAD missing',
+        productionConnectionDetail: hasAnyWad
+          ? 'Project has WAD records, but none match this P2 part. Production flow is unchanged.'
+          : 'P2 production demand exists, but no project WAD has been created yet. Production flow is unchanged.',
+      };
+    }
+
+    const linkedBase = {
+      ...row,
+      linkedWadId: matchedWad.id,
+      linkedWadNumber: matchedWad.workOrderNumber,
+      linkedWadStatus: matchedWad.wadStatus,
+      linkedWadWorkOrderStatus: matchedWad.status,
+      wadStatus: row.wadStatus ?? matchedWad.wadStatus,
+      activeTravelerId: row.activeTravelerId ?? matchedWad.activeTravelerId,
+      activeTravelerNumber: row.activeTravelerNumber ?? matchedWad.activeTravelerNumber,
+      currentTravelerStep: row.currentTravelerStep ?? matchedWad.currentTravelerStep,
+    };
+
+    if (!isWadReleasedForExecution(matchedWad)) {
+      return {
+        ...linkedBase,
+        productionConnectionStatus: 'WAD_INCOMPLETE',
+        productionConnectionLabel: 'WAD incomplete',
+        productionConnectionDetail: `${matchedWad.workOrderNumber} is ${matchedWad.wadStatus ?? 'not approved'} / ${matchedWad.status ?? 'not released'}. Production flow is unchanged.`,
+      };
+    }
+
+    if (!matchedWad.activeTravelerId && !matchedWad.currentTravelerStep) {
+      return {
+        ...linkedBase,
+        productionConnectionStatus: 'TRAVELER_NOT_ACTIVE',
+        productionConnectionLabel: 'No active traveler',
+        productionConnectionDetail: `${matchedWad.workOrderNumber} is approved/released, but no active traveler is currently started.`,
+      };
+    }
+
+    return {
+      ...linkedBase,
+      productionConnectionStatus: 'CONNECTED',
+      productionConnectionLabel: 'Linked',
+      productionConnectionDetail: `${matchedWad.workOrderNumber} is connected to the active traveler state.`,
+    };
+  });
 }
 
 async function getProjectSerializedItemAggregate(
@@ -1189,6 +1328,8 @@ router.get('/:projectId/production', h(async (req, res) => {
       return (a.workOrderNumber ?? '').localeCompare(b.workOrderNumber ?? '');
     });
   }
+
+  finalRows = await enrichP2RowsWithWadBridge(projectId, finalRows);
 
   const rowsWithAssignments = finalRows.map((row) => {
     if (row.sourceType === 'p2_production_order') {


### PR DESCRIPTION
## Summary
- Adds read-only PM dashboard bridge metadata for P2 production rows so PM can show whether each P2 row has a matching project WAD.
- Surfaces WAD missing, WAD not matched, WAD incomplete, no active traveler, and linked states in a new PM Production table Connection column.
- Reuses existing PM/P2 row routing and does not change P2 execution, WAD approval, traveler start, barcode, or production status workflows.

## Root Cause
PM Control Center already shows P2 pseudo work-order rows, but those rows did not explain whether they were connected to a WAD/traveler execution record. That made P2 demand visible while WAD/traveler state looked disconnected.

## Validation
- `git diff --check -- server/src/routes/pmDashboard.ts client/src/pages/PMControlCenterPage.tsx` passed.
- Full `npm run check` was not run because `npm` and local `node_modules` are not available in this desktop shell.