### PR TITLE
[codex] Show WAD context in P2 control center

### DIFF
--- a/client/src/components/p2/P2ProductionQueue.tsx
+++ b/client/src/components/p2/P2ProductionQueue.tsx
@@ -50,7 +50,8 @@ import {
   ArrowDown,
   Check,
   Users,
-  FolderOpen
+  FolderOpen,
+  FileText
 } from 'lucide-react';
 import JsBarcode from 'jsbarcode';
 import { getBarcodeFormat } from '@/lib/barcodeFormat';
@@ -87,6 +88,12 @@ interface QueueItem {
   isLegacyProjectWorkOrder?: boolean;
   productionWorkOrderId?: string | null;
   workOrderNumber?: string | null;
+  linkedWadId?: string | null;
+  linkedWadNumber?: string | null;
+  linkedWadStatus?: string | null;
+  linkedWadWorkOrderStatus?: string | null;
+  p2WadConnectionStatus?: 'WAD_READY' | 'WAD_INCOMPLETE' | 'WAD_MISSING' | 'WAD_NOT_MATCHED' | 'NO_PROJECT_LINK';
+  p2WadConnectionLabel?: string;
   activeTravelerId?: string | null;
   activeTravelerNumber?: string | null;
   hasActiveTask: boolean;
@@ -131,6 +138,20 @@ interface PartInfo {
   departmentConfig: any;
   traceabilityRequirements: any[];
 }
+
+const getP2WadBadgeClass = (status?: string | null) => {
+  switch (status) {
+    case 'WAD_READY':
+      return 'border-green-300 bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-300';
+    case 'WAD_INCOMPLETE':
+    case 'WAD_NOT_MATCHED':
+      return 'border-amber-300 bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300';
+    case 'WAD_MISSING':
+      return 'border-red-300 bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300';
+    default:
+      return 'border-slate-300 bg-slate-50 text-slate-700 dark:bg-slate-900 dark:text-slate-300';
+  }
+};
 
 interface P2ProductionQueueProps {
   selectedPONumbers?: string[];
@@ -1015,6 +1036,27 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
                                               Assign project from the POs tab
                                             </div>
                                           )}
+                                          <div className="mt-1 flex flex-wrap items-center gap-2">
+                                            {item.linkedWadId && item.linkedWadNumber && (
+                                              <button
+                                                type="button"
+                                                className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                                                onClick={() => setLocation(`/production-work-orders/${item.linkedWadId}`)}
+                                                title={item.linkedWadStatus || item.linkedWadWorkOrderStatus || undefined}
+                                              >
+                                                <FileText className="h-3 w-3" />
+                                                {item.linkedWadNumber}
+                                              </button>
+                                            )}
+                                            <Badge
+                                              variant="outline"
+                                              className={`gap-1 text-[10px] ${getP2WadBadgeClass(item.p2WadConnectionStatus)}`}
+                                              title={item.linkedWadStatus || item.linkedWadWorkOrderStatus || item.p2WadConnectionLabel || undefined}
+                                            >
+                                              <FileText className="h-3 w-3" />
+                                              {item.p2WadConnectionLabel || (item.projectId ? 'WAD missing' : 'No project link')}
+                                            </Badge>
+                                          </div>
                                         </TableCell>
                                         <TableCell>
                                           {item.status === 'COMPLETED' ? (

--- a/client/src/components/p2/P2StatusDashboard.tsx
+++ b/client/src/components/p2/P2StatusDashboard.tsx
@@ -44,6 +44,12 @@ interface POStatus {
   projectId?: string | null;
   projectCode?: string | null;
   projectName?: string | null;
+  linkedWadCount?: number;
+  approvedWadCount?: number;
+  releasedWadCount?: number;
+  wadNumbers?: string | null;
+  p2WadConnectionStatus?: 'WAD_READY' | 'WAD_INCOMPLETE' | 'WAD_MISSING' | 'WAD_NOT_MATCHED' | 'NO_PROJECT_LINK';
+  p2WadConnectionLabel?: string;
 }
 
 export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds = [] }: P2StatusDashboardProps) {
@@ -113,6 +119,45 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
       );
     }
     return null;
+  };
+
+  const getWadConnectionBadge = (po: POStatus) => {
+    const status = po.p2WadConnectionStatus || (po.projectId ? 'WAD_MISSING' : 'NO_PROJECT_LINK');
+    const config: Record<string, { className: string; label: string; title: string }> = {
+      WAD_READY: {
+        className: 'border-green-300 bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-300',
+        label: po.p2WadConnectionLabel || 'WAD ready',
+        title: po.wadNumbers ? `WAD: ${po.wadNumbers}` : 'Linked WAD is approved or released',
+      },
+      WAD_INCOMPLETE: {
+        className: 'border-amber-300 bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300',
+        label: po.p2WadConnectionLabel || 'WAD incomplete',
+        title: po.wadNumbers ? `WAD: ${po.wadNumbers}` : 'Linked project has WAD work that is not ready',
+      },
+      WAD_MISSING: {
+        className: 'border-red-300 bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300',
+        label: po.p2WadConnectionLabel || 'WAD missing',
+        title: 'Linked project has no visible WAD work order',
+      },
+      WAD_NOT_MATCHED: {
+        className: 'border-amber-300 bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300',
+        label: po.p2WadConnectionLabel || 'WAD not matched',
+        title: 'Linked project has WAD work, but not for this P2 line',
+      },
+      NO_PROJECT_LINK: {
+        className: 'border-slate-300 bg-slate-50 text-slate-700 dark:bg-slate-900 dark:text-slate-300',
+        label: po.p2WadConnectionLabel || 'No project link',
+        title: 'Assign a project to show WAD context',
+      },
+    };
+    const badge = config[status] || config.WAD_MISSING;
+
+    return (
+      <Badge variant="outline" className={`gap-1 ${badge.className}`} title={badge.title}>
+        <FileText className="h-3 w-3" />
+        {badge.label}
+      </Badge>
+    );
   };
 
   const getProgressPercentage = (po: POStatus): number => {
@@ -245,6 +290,7 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                           <span className="font-semibold text-lg">{po.poNumber}</span>
                           {getStatusBadge(po.status)}
                           {getReadyForProductionBadge(po)}
+                          {getWadConnectionBadge(po)}
                           {po.hasBOMsNeeded && (
                             <Badge variant="destructive" className="gap-1">
                               <AlertCircle className="h-3 w-3" />

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3000,6 +3000,95 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     return Array.isArray(result) ? result : (result?.rows ?? []);
   }
 
+  function normalizeP2ControlPartKey(value: unknown): string {
+    return String(value || '').trim().toLowerCase();
+  }
+
+  function getP2ControlWadStatusLabel(status: string): string {
+    const labels: Record<string, string> = {
+      WAD_READY: 'WAD ready',
+      WAD_INCOMPLETE: 'WAD incomplete',
+      WAD_MISSING: 'WAD missing',
+      WAD_NOT_MATCHED: 'WAD not matched',
+      NO_PROJECT_LINK: 'No project link',
+    };
+    return labels[status] || 'WAD unknown';
+  }
+
+  function buildP2ProjectWadContext(project: any, summary: any) {
+    const linkedWadCount = Number(summary?.wadCount ?? 0);
+    const approvedWadCount = Number(summary?.approvedWadCount ?? 0);
+    const releasedWadCount = Number(summary?.releasedWadCount ?? 0);
+    const status = !project?.projectId
+      ? 'NO_PROJECT_LINK'
+      : linkedWadCount === 0
+        ? 'WAD_MISSING'
+        : (approvedWadCount > 0 || releasedWadCount > 0)
+          ? 'WAD_READY'
+          : 'WAD_INCOMPLETE';
+
+    return {
+      linkedWadCount,
+      approvedWadCount,
+      releasedWadCount,
+      wadNumbers: summary?.wadNumbers ?? null,
+      p2WadConnectionStatus: status,
+      p2WadConnectionLabel: getP2ControlWadStatusLabel(status),
+    };
+  }
+
+  function buildP2ItemWadContext(
+    project: any,
+    partNumber: unknown,
+    wadByProjectPart: Map<string, any>,
+    wadSummaryByProject: Map<string, any>,
+  ) {
+    if (!project?.projectId) {
+      const status = 'NO_PROJECT_LINK';
+      return {
+        linkedWadId: null,
+        linkedWadNumber: null,
+        linkedWadStatus: null,
+        linkedWadWorkOrderStatus: null,
+        p2WadConnectionStatus: status,
+        p2WadConnectionLabel: getP2ControlWadStatusLabel(status),
+      };
+    }
+
+    const projectId = String(project.projectId);
+    const partKey = normalizeP2ControlPartKey(partNumber);
+    const matchedWad = partKey ? wadByProjectPart.get(`${projectId}:${partKey}`) : null;
+    const projectSummary = wadSummaryByProject.get(projectId);
+
+    if (!matchedWad) {
+      const status = Number(projectSummary?.wadCount ?? 0) > 0 ? 'WAD_NOT_MATCHED' : 'WAD_MISSING';
+      return {
+        linkedWadId: null,
+        linkedWadNumber: null,
+        linkedWadStatus: null,
+        linkedWadWorkOrderStatus: null,
+        p2WadConnectionStatus: status,
+        p2WadConnectionLabel: getP2ControlWadStatusLabel(status),
+      };
+    }
+
+    const wadStatus = String(matchedWad.wadStatus || '').toUpperCase();
+    const workOrderStatus = String(matchedWad.status || '').toUpperCase();
+    const status = wadStatus === 'APPROVED'
+      || ['RELEASED', 'IN_PROGRESS', 'COMPLETE', 'COMPLETED', 'CLOSED'].includes(workOrderStatus)
+      ? 'WAD_READY'
+      : 'WAD_INCOMPLETE';
+
+    return {
+      linkedWadId: matchedWad.id ?? null,
+      linkedWadNumber: matchedWad.workOrderNumber ?? null,
+      linkedWadStatus: matchedWad.wadStatus ?? null,
+      linkedWadWorkOrderStatus: matchedWad.status ?? null,
+      p2WadConnectionStatus: status,
+      p2WadConnectionLabel: getP2ControlWadStatusLabel(status),
+    };
+  }
+
   // P2 Control Center API Routes
   app.get('/api/p2/control-center/stats', async (req, res) => {
     try {
@@ -3359,6 +3448,37 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const projectByPoId = new Map<number, any>(
         projectRows.map((r: any) => [r.poId, r])
       );
+      const projectIds = [...new Set(
+        projectRows
+          .map((row: any) => row.projectId)
+          .filter(Boolean)
+          .map((projectId: any) => String(projectId))
+      )];
+      const wadSummaryRows = projectIds.length > 0
+        ? await optionalP2Rows(
+            'WAD project summary',
+            dbPool.query(
+            `SELECT
+               project_id::text AS "projectId",
+               COUNT(*)::int AS "wadCount",
+               COUNT(*) FILTER (WHERE COALESCE(UPPER(wad_status), '') = 'APPROVED')::int AS "approvedWadCount",
+               COUNT(*) FILTER (
+                 WHERE COALESCE(UPPER(wad_status), '') = 'APPROVED'
+                    OR COALESCE(UPPER(status), '') IN ('RELEASED', 'IN_PROGRESS', 'COMPLETE', 'COMPLETED', 'CLOSED')
+               )::int AS "releasedWadCount",
+               STRING_AGG(work_order_number, ', ' ORDER BY created_at DESC NULLS LAST) AS "wadNumbers"
+             FROM production_work_orders
+             WHERE project_id = ANY($1::uuid[])
+               AND COALESCE(UPPER(status), '') NOT IN ('CANCELLED', 'CANCELED')
+               AND (work_order_number LIKE 'WAD-%' OR wad_status IS NOT NULL)
+             GROUP BY project_id`,
+            [projectIds]
+          )
+          )
+        : [];
+      const wadSummaryByProject = new Map<string, any>(
+        wadSummaryRows.map((row: any) => [String(row.projectId), row])
+      );
 
       // Sum ordered quantities from all PO line items, grouped by po_id.
       // This ensures PO lines that haven't had serialized items generated yet
@@ -3412,6 +3532,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         
         const rawStatus = normalizeP2Status(po.status) || 'OPEN';
 
+        const linkedProject = projectByPoId.get(po.id);
+        const wadContext = buildP2ProjectWadContext(
+          linkedProject,
+          linkedProject?.projectId ? wadSummaryByProject.get(String(linkedProject.projectId)) : null
+        );
+
         return {
           id: po.id,
           poNumber: po.poNumber,
@@ -3422,9 +3548,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           inProductionItems,
           pendingItems,
           hasBOMsNeeded: !po.bomConfigured,
-          projectId: projectByPoId.get(po.id)?.projectId ?? null,
-          projectCode: projectByPoId.get(po.id)?.projectCode ?? null,
-          projectName: projectByPoId.get(po.id)?.projectName ?? po.projectName ?? null,
+          projectId: linkedProject?.projectId ?? null,
+          projectCode: linkedProject?.projectCode ?? null,
+          projectName: linkedProject?.projectName ?? po.projectName ?? null,
+          ...wadContext,
           rawStatus,
           status: completedItems === totalItems && totalItems > 0 ? 'completed' : 
                   (inProductionItems > 0 || rawStatus === 'IN_PRODUCTION') ? 'in_progress' : 'pending'
@@ -3731,6 +3858,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
            wo.description,
            COALESCE(wo.quantity, 1)::int AS quantity,
            wo.status,
+           wo.wad_status AS "wadStatus",
            wo.due_date AS "dueDate",
            wo.project_id AS "projectId",
            p.project_code AS "projectCode",
@@ -3860,6 +3988,49 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const projectByPoId = new Map<number, any>(
         projectRows.map((row: any) => [Number(row.poId), row])
       );
+      const projectIds = [...new Set(
+        projectRows
+          .map((row: any) => row.projectId)
+          .filter(Boolean)
+          .map((projectId: any) => String(projectId))
+      )];
+      const wadRows = projectIds.length > 0
+        ? await optionalP2Rows(
+            'WAD item context',
+            dbPool.query(
+            `SELECT DISTINCT ON (project_id, LOWER(TRIM(COALESCE(part_number, ''))))
+               id::text AS id,
+               project_id::text AS "projectId",
+               work_order_number AS "workOrderNumber",
+               part_number AS "partNumber",
+               status,
+               wad_status AS "wadStatus",
+               created_at AS "createdAt"
+             FROM production_work_orders
+             WHERE project_id = ANY($1::uuid[])
+               AND COALESCE(UPPER(status), '') NOT IN ('CANCELLED', 'CANCELED')
+               AND (work_order_number LIKE 'WAD-%' OR wad_status IS NOT NULL)
+             ORDER BY project_id, LOWER(TRIM(COALESCE(part_number, ''))), created_at DESC NULLS LAST`,
+            [projectIds]
+          )
+          )
+        : [];
+      const wadByProjectPart = new Map<string, any>();
+      const wadSummaryByProject = new Map<string, any>();
+      wadRows.forEach((row: any) => {
+        const projectId = String(row.projectId || '');
+        if (!projectId) return;
+
+        const summary = wadSummaryByProject.get(projectId) || { wadCount: 0 };
+        summary.wadCount += 1;
+        wadSummaryByProject.set(projectId, summary);
+
+        const partKey = normalizeP2ControlPartKey(row.partNumber);
+        const mapKey = partKey ? `${projectId}:${partKey}` : '';
+        if (mapKey && !wadByProjectPart.has(mapKey)) {
+          wadByProjectPart.set(mapKey, row);
+        }
+      });
       
       const serializedPoItemKeys = new Set(
         items
@@ -3970,6 +4141,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const poId = item.poId ?? item.po_id ?? null;
         const linkedProject = poId ? projectByPoId.get(Number(poId)) : null;
         const metadata = item.metadata || {};
+        const wadContext = buildP2ItemWadContext(
+          linkedProject,
+          item.partNumber,
+          wadByProjectPart,
+          wadSummaryByProject
+        );
         
         departmentQueues[dept].push({
           id: item.id,
@@ -3986,6 +4163,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           projectId: linkedProject?.projectId ?? null,
           projectCode: linkedProject?.projectCode ?? null,
           projectName: linkedProject?.projectName ?? null,
+          ...wadContext,
           isReplacement: metadata.isReplacement === true,
           replacementForSerializedItemId: metadata.replacementForSerializedItemId ?? null,
           replacementForSerialNumber: metadata.replacementForSerialNumber ?? null,
@@ -4029,6 +4207,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           || manufactured >= quantity
           ? 'COMPLETED'
           : 'ACTIVE';
+        const wadContext = buildP2ItemWadContext(
+          linkedProject,
+          row.partNumber || row.orderId,
+          wadByProjectPart,
+          wadSummaryByProject
+        );
 
         departmentQueues[dept].push({
           id: `legacy-p2-production-order-${row.id}`,
@@ -4045,6 +4229,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           projectId: linkedProject?.projectId ?? null,
           projectCode: linkedProject?.projectCode ?? null,
           projectName: linkedProject?.projectName ?? null,
+          ...wadContext,
           isLegacyProductionOrder: true,
           hasActiveTask: normalizedStatus === 'IN_PROGRESS',
           barcodePrintedAt: null,
@@ -4080,6 +4265,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           ['IN_PROGRESS', 'ACTIVE', 'STARTED'].includes(String(row.activeTravelerStatus || '').toUpperCase()) ||
           ['IN_PROGRESS', 'ACTIVE', 'STARTED', 'RELEASED'].includes(normalizedStatus)
         );
+        const wadContext = buildP2ItemWadContext(
+          linkedProject,
+          row.partNumber || row.workOrderNumber,
+          wadByProjectPart,
+          wadSummaryByProject
+        );
 
         departmentQueues[dept].push({
           id: `legacy-project-work-order-${row.id}`,
@@ -4098,6 +4289,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           projectId: linkedProject?.projectId ?? null,
           projectCode: linkedProject?.projectCode ?? null,
           projectName: linkedProject?.projectName ?? null,
+          ...wadContext,
           isLegacyProjectWorkOrder: true,
           activeTravelerId: row.activeTravelerId || null,
           activeTravelerNumber: row.activeTravelerNumber || null,


### PR DESCRIPTION
## Summary
- add read-only WAD connection context to P2 Control Center PO statuses
- add WAD match/status context to P2 production queue rows by linked project and part number
- show compact WAD badges and WAD work-order links in the P2 UI without changing traveler or production actions

## Validation
- `git diff --check -- server/src/routes/index.ts client/src/components/p2/P2StatusDashboard.tsx client/src/components/p2/P2ProductionQueue.tsx`

Full app checks were not run because this local worktree does not have `node_modules` and `npm` is not on PATH.