### PR TITLE
[codex] Surface P2 demand in WAD status

### DIFF
--- a/client/src/pages/WADStatusDashboard.tsx
+++ b/client/src/pages/WADStatusDashboard.tsx
@@ -36,6 +36,14 @@ type WadStatusRow = {
   pwoCount: number;
   wadStatus: 'NONE' | 'DRAFT' | 'PENDING_APPROVAL' | 'APPROVED';
   gateSatisfied: boolean;
+  p2HasProductionDemand: boolean;
+  p2PoCount: number;
+  p2PoNumbers: string | null;
+  p2DemandQuantity: number;
+  p2SerializedCount: number;
+  p2ActiveUnits: number;
+  p2ProductionOrderCount: number;
+  p2WadConnectionStatus: 'P2_WAD_APPROVED' | 'P2_WAD_INCOMPLETE' | 'P2_WAD_MISSING' | 'NO_P2_DEMAND';
   latestPwoId: string | null;
   latestWorkOrderNumber: string | null;
   percentComplete: number;
@@ -54,6 +62,20 @@ const WAD_BADGE: Record<string, string> = {
   DRAFT: 'bg-gray-100 text-gray-700',
   PENDING_APPROVAL: 'bg-yellow-100 text-yellow-800',
   APPROVED: 'bg-green-100 text-green-800',
+};
+
+const P2_WAD_BADGE: Record<string, string> = {
+  P2_WAD_APPROVED: 'bg-green-100 text-green-800 border border-green-200',
+  P2_WAD_INCOMPLETE: 'bg-yellow-100 text-yellow-800 border border-yellow-200',
+  P2_WAD_MISSING: 'bg-red-100 text-red-800 border border-red-200',
+  NO_P2_DEMAND: 'bg-gray-100 text-gray-700 border border-gray-200',
+};
+
+const P2_WAD_LABEL: Record<string, string> = {
+  P2_WAD_APPROVED: 'P2 + WAD ready',
+  P2_WAD_INCOMPLETE: 'P2 + WAD incomplete',
+  P2_WAD_MISSING: 'P2 needs WAD',
+  NO_P2_DEMAND: 'No P2 demand',
 };
 
 export default function WADStatusDashboard() {
@@ -113,6 +135,8 @@ export default function WADStatusDashboard() {
     pending: data.filter((r) => r.wadStatus === 'PENDING_APPROVAL').length,
     approved: data.filter((r) => r.wadStatus === 'APPROVED').length,
     backfillCandidates: data.filter((r) => r.currentStage === 'production' && !r.gateSatisfied).length,
+    p2Demand: data.filter((r) => r.p2HasProductionDemand).length,
+    p2WadGaps: data.filter((r) => r.p2HasProductionDemand && !r.gateSatisfied).length,
   }), [data]);
 
   return (
@@ -135,12 +159,13 @@ export default function WADStatusDashboard() {
         </Button>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
         <SummaryCard label="Projects" value={counts.total} icon={<LayoutDashboard className="h-4 w-4" />} />
         <SummaryCard label="No WAD" value={counts.none} tone="red" icon={<FileWarning className="h-4 w-4" />} />
         <SummaryCard label="Draft" value={counts.draft} tone="gray" icon={<Clock className="h-4 w-4" />} />
         <SummaryCard label="Pending Approval" value={counts.pending} tone="amber" icon={<Clock className="h-4 w-4" />} />
         <SummaryCard label="Approved" value={counts.approved} tone="green" icon={<CheckCircle2 className="h-4 w-4" />} />
+        <SummaryCard label="P2 WAD Gaps" value={counts.p2WadGaps} tone="amber" icon={<AlertTriangle className="h-4 w-4" />} />
       </div>
 
       {counts.backfillCandidates > 0 && (
@@ -150,6 +175,9 @@ export default function WADStatusDashboard() {
             <strong>{counts.backfillCandidates}</strong> project{counts.backfillCandidates === 1 ? '' : 's'} already in
             production {counts.backfillCandidates === 1 ? 'is' : 'are'} missing an approved WAD. Approving here records
             a <code>wad_backfill</code> audit event and flips the WAD gate without regressing the stage.
+            {counts.p2WadGaps > 0 && (
+              <> P2-linked production demand is now shown on this dashboard so the gap is visible without changing production flow.</>
+            )}
           </div>
         </div>
       )}
@@ -208,6 +236,7 @@ export default function WADStatusDashboard() {
                     <TableHead>Customer / PO</TableHead>
                     <TableHead>Stage</TableHead>
                     <TableHead>WAD Status</TableHead>
+                    <TableHead>P2 Demand</TableHead>
                     <TableHead className="w-28 text-center">Progress</TableHead>
                     <TableHead>Latest WO</TableHead>
                     <TableHead className="hidden md:table-cell">Last Edited</TableHead>
@@ -252,6 +281,26 @@ export default function WADStatusDashboard() {
                               <Badge variant="outline" className="text-[10px] border-amber-400 text-amber-700">
                                 BACKFILL
                               </Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          <div className="flex min-w-[170px] flex-col gap-1">
+                            <Badge className={P2_WAD_BADGE[row.p2WadConnectionStatus] ?? P2_WAD_BADGE.NO_P2_DEMAND}>
+                              {P2_WAD_LABEL[row.p2WadConnectionStatus] ?? P2_WAD_LABEL.NO_P2_DEMAND}
+                            </Badge>
+                            {row.p2HasProductionDemand ? (
+                              <div className="text-muted-foreground">
+                                {row.p2DemandQuantity} units
+                                {row.p2ActiveUnits > 0 && <> · {row.p2ActiveUnits} active</>}
+                                {row.p2PoNumbers && (
+                                  <div className="truncate max-w-[190px]" title={row.p2PoNumbers}>
+                                    PO {row.p2PoNumbers}
+                                  </div>
+                                )}
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground">No linked P2 PO demand</span>
                             )}
                           </div>
                         </TableCell>

--- a/server/src/routes/workOrders.ts
+++ b/server/src/routes/workOrders.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { auditService } from '../services/auditService';
-import { db } from '../../db';
+import { db, pool } from '../../db';
 import {
   workOrders,
   workOrderParts,
@@ -57,6 +57,114 @@ import {
 } from '../services/productionControl/productionControlAI.service';
 
 const router = Router();
+
+type WadStatusP2Demand = {
+  projectId: string;
+  p2PoCount: number;
+  p2PoNumbers: string | null;
+  p2DemandQuantity: number;
+  p2SerializedCount: number;
+  p2ActiveUnits: number;
+  p2ProductionOrderCount: number;
+};
+
+async function getWadStatusP2Demand(projectIds: string[]): Promise<Map<string, WadStatusP2Demand>> {
+  if (projectIds.length === 0) return new Map();
+
+  const rows = await pool.query<{
+    projectId: string;
+    p2PoCount: string;
+    p2PoNumbers: string | null;
+    p2DemandQuantity: string;
+    p2SerializedCount: string;
+    p2ActiveUnits: string;
+    p2ProductionOrderCount: string;
+  }>(`
+    WITH project_po_link AS (
+      SELECT p.id AS project_id, p.po_id AS po_id
+      FROM projects p
+      WHERE p.id = ANY($1::uuid[])
+        AND p.po_id IS NOT NULL
+      UNION
+      SELECT ps.project_id, ps.linked_p2_order_id AS po_id
+      FROM project_steps ps
+      WHERE ps.project_id = ANY($1::uuid[])
+        AND ps.linked_p2_order_id IS NOT NULL
+      UNION
+      SELECT DISTINCT p2po.project_id, p2po.p2_po_id AS po_id
+      FROM p2_production_orders p2po
+      WHERE p2po.project_id = ANY($1::uuid[])
+        AND p2po.project_id IS NOT NULL
+      UNION
+      SELECT p.id AS project_id, po.id AS po_id
+      FROM p2_purchase_orders po
+      JOIN projects p ON LOWER(TRIM(po.project_name)) IN (
+        LOWER(TRIM(p.project_code)),
+        LOWER(TRIM(p.project_name)),
+        LOWER(TRIM(CONCAT_WS(' - ', NULLIF(p.project_code, ''), NULLIF(p.project_name, ''))))
+      )
+      WHERE p.id = ANY($1::uuid[])
+        AND po.project_name IS NOT NULL
+        AND TRIM(po.project_name) <> ''
+    ),
+    distinct_links AS (
+      SELECT DISTINCT project_id, po_id
+      FROM project_po_link
+      WHERE project_id IS NOT NULL
+        AND po_id IS NOT NULL
+    ),
+    ordered_qty AS (
+      SELECT dl.project_id, COALESCE(SUM(poi.quantity), 0)::int AS qty
+      FROM distinct_links dl
+      JOIN p2_purchase_order_items poi ON poi.po_id = dl.po_id
+      GROUP BY dl.project_id
+    ),
+    serialized AS (
+      SELECT
+        dl.project_id,
+        COUNT(psi.id)::int AS serialized_count,
+        COUNT(psi.id) FILTER (
+          WHERE COALESCE(UPPER(psi.status), '') NOT IN ('COMPLETED', 'CLOSED', 'CANCELLED', 'CANCELED', 'SCRAPPED', 'SHIPPED')
+        )::int AS active_units
+      FROM distinct_links dl
+      JOIN p2_serialized_items psi ON psi.po_id = dl.po_id
+      GROUP BY dl.project_id
+    ),
+    production_orders AS (
+      SELECT dl.project_id, COUNT(p2po.id)::int AS production_order_count
+      FROM distinct_links dl
+      JOIN p2_production_orders p2po ON p2po.p2_po_id = dl.po_id
+      GROUP BY dl.project_id
+    )
+    SELECT
+      dl.project_id::text AS "projectId",
+      COUNT(DISTINCT dl.po_id)::text AS "p2PoCount",
+      string_agg(DISTINCT po.po_number, ', ' ORDER BY po.po_number) AS "p2PoNumbers",
+      COALESCE(MAX(oq.qty), 0)::text AS "p2DemandQuantity",
+      COALESCE(MAX(s.serialized_count), 0)::text AS "p2SerializedCount",
+      COALESCE(MAX(s.active_units), 0)::text AS "p2ActiveUnits",
+      COALESCE(MAX(po2.production_order_count), 0)::text AS "p2ProductionOrderCount"
+    FROM distinct_links dl
+    JOIN p2_purchase_orders po ON po.id = dl.po_id
+    LEFT JOIN ordered_qty oq ON oq.project_id = dl.project_id
+    LEFT JOIN serialized s ON s.project_id = dl.project_id
+    LEFT JOIN production_orders po2 ON po2.project_id = dl.project_id
+    GROUP BY dl.project_id
+  `, [projectIds]);
+
+  return new Map(rows.map((row) => [
+    row.projectId,
+    {
+      projectId: row.projectId,
+      p2PoCount: parseInt(row.p2PoCount, 10) || 0,
+      p2PoNumbers: row.p2PoNumbers,
+      p2DemandQuantity: parseInt(row.p2DemandQuantity, 10) || 0,
+      p2SerializedCount: parseInt(row.p2SerializedCount, 10) || 0,
+      p2ActiveUnits: parseInt(row.p2ActiveUnits, 10) || 0,
+      p2ProductionOrderCount: parseInt(row.p2ProductionOrderCount, 10) || 0,
+    },
+  ]));
+}
 
 router.use(async (_req, res, next) => {
   try {
@@ -558,10 +666,33 @@ router.get('/production/wad-status', authenticateToken, requirePermission('work_
               AND ps.status = 'completed'
               AND ps.step_type IN ('purchase_review_checklist', 'preproduction_checklist', 'p2_order')
           )`,
+          sql`EXISTS (
+            SELECT 1
+            FROM project_steps ps
+            WHERE ps.project_id = ${projects.id}
+              AND ps.linked_p2_order_id IS NOT NULL
+          )`,
+          sql`EXISTS (
+            SELECT 1
+            FROM p2_production_orders p2po
+            WHERE p2po.project_id = ${projects.id}
+          )`,
+          sql`EXISTS (
+            SELECT 1
+            FROM p2_purchase_orders po
+            WHERE po.project_name IS NOT NULL
+              AND TRIM(po.project_name) <> ''
+              AND LOWER(TRIM(po.project_name)) IN (
+                LOWER(TRIM(${projects.projectCode})),
+                LOWER(TRIM(${projects.projectName})),
+                LOWER(TRIM(CONCAT_WS(' - ', NULLIF(${projects.projectCode}, ''), NULLIF(${projects.projectName}, ''))))
+              )
+          )`,
         ),
       ));
 
     const projectIds = projRows.map((p) => p.id);
+    const p2DemandByProject = await getWadStatusP2Demand(projectIds);
     const woRows = projectIds.length > 0
       ? await db
           .select({
@@ -608,6 +739,7 @@ router.get('/production/wad-status', authenticateToken, requirePermission('work_
 
     const result = projRows.map((p) => {
       const wos = byProject.get(p.id) ?? [];
+      const p2Demand = p2DemandByProject.get(p.id) ?? null;
       let aggregateStatus: 'NONE' | 'DRAFT' | 'PENDING_APPROVAL' | 'APPROVED' = 'NONE';
       let bestRank = 0;
       let latestPwo: typeof woRows[number] | null = null;
@@ -639,10 +771,29 @@ router.get('/production/wad-status', authenticateToken, requirePermission('work_
         projectName: p.projectName,
         customerName: p.customerName,
         currentStage: p.currentStage,
-        poNumber: p.poNumber,
+        poNumber: p.poNumber ?? p2Demand?.p2PoNumbers ?? null,
         pwoCount: wos.length,
         wadStatus: aggregateStatus,
         gateSatisfied,
+        p2HasProductionDemand: !!p2Demand && (
+          p2Demand.p2PoCount > 0 ||
+          p2Demand.p2DemandQuantity > 0 ||
+          p2Demand.p2SerializedCount > 0 ||
+          p2Demand.p2ProductionOrderCount > 0
+        ),
+        p2PoCount: p2Demand?.p2PoCount ?? 0,
+        p2PoNumbers: p2Demand?.p2PoNumbers ?? null,
+        p2DemandQuantity: p2Demand?.p2DemandQuantity ?? 0,
+        p2SerializedCount: p2Demand?.p2SerializedCount ?? 0,
+        p2ActiveUnits: p2Demand?.p2ActiveUnits ?? 0,
+        p2ProductionOrderCount: p2Demand?.p2ProductionOrderCount ?? 0,
+        p2WadConnectionStatus: p2Demand
+          ? gateSatisfied
+            ? 'P2_WAD_APPROVED'
+            : wos.length > 0
+              ? 'P2_WAD_INCOMPLETE'
+              : 'P2_WAD_MISSING'
+          : 'NO_P2_DEMAND',
         latestPwoId: latestPwo?.id ?? null,
         latestWorkOrderNumber: latestPwo?.workOrderNumber ?? null,
         percentComplete,


### PR DESCRIPTION
## Summary
- include P2-linked projects in the WAD status endpoint using existing P2 project-link signals
- expose P2 demand, matched WAD, and WAD gap fields in WAD status rows
- add a P2 WAD Gaps card and P2 Demand column to the WAD Status dashboard

## Validation
- `git diff --check -- server/src/routes/workOrders.ts client/src/pages/WADStatusDashboard.tsx`

Full app checks were not run because this local worktree does not have `node_modules` and `npm` is not on PATH.

## Notes
This is a standalone PR against `main`; it does not depend on the PM Control Center bridge PR.