### PR TITLE
[codex] Keep legacy ROC backfill data entry editable

### DIFF
--- a/client/src/pages/TravelerExecution.tsx
+++ b/client/src/pages/TravelerExecution.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import SignatureCanvas from 'react-signature-canvas';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiRequest } from '@/lib/queryClient';
@@ -507,6 +507,23 @@ export default function TravelerExecution() {
   });
 
   const { traveler, steps = [], events = [] } = travelerData || {};
+  const legacyRocBackfillEditScope = useMemo(() => {
+    const stepIds = new Set<string>();
+    const taskIds = new Set<string>();
+
+    for (const event of events) {
+      if (event.action !== 'LEGACY_ROC_ROUTING_STEP_BACKFILLED') continue;
+      const details = event.details ?? {};
+      if (typeof details.stepId === 'string') stepIds.add(details.stepId);
+      if (Array.isArray(details.changedTaskIds)) {
+        details.changedTaskIds.forEach((id: unknown) => {
+          if (typeof id === 'string') taskIds.add(id);
+        });
+      }
+    }
+
+    return { stepIds, taskIds };
+  }, [events]);
 
   // Labor budget status for the WAD linked to this traveler
   const { data: wadLaborStatus } = useQuery<{ status: string; totalHours: number; totalBudget: number | null; percentUsed: number | null } | null>({
@@ -2610,6 +2627,10 @@ export default function TravelerExecution() {
                               {phaseTasks.map((task) => {
                                 const TaskIcon = TASK_TYPE_ICONS[task.taskType] || FileText;
                                 const isComplete = task.status === 'COMPLETED';
+                                const canEditLegacyRocBackfilledData =
+                                  legacyRocBackfillEditScope.stepIds.has(task.travelerStepId) ||
+                                  legacyRocBackfillEditScope.taskIds.has(task.id);
+                                const fieldInputDisabled = isComplete && !canEditLegacyRocBackfilledData;
 
                                 return (
                                   <AccordionItem key={task.id} value={task.id} className="border-b last:border-b-0">
@@ -2658,6 +2679,11 @@ export default function TravelerExecution() {
                                     </AccordionTrigger>
                                     <AccordionContent className="px-4">
                                       <div className="pl-12 space-y-4 pb-4">
+                                        {isComplete && canEditLegacyRocBackfilledData && (
+                                          <div className="rounded border border-blue-200 bg-blue-50 p-2 text-xs text-blue-800">
+                                            Legacy routing backfill is complete; collected data fields remain open for record entry.
+                                          </div>
+                                        )}
                                         {task.instructions && (
                                           <p className="text-sm text-muted-foreground">
                                             {task.instructions}
@@ -2743,7 +2769,7 @@ export default function TravelerExecution() {
                                           );
                                         })()}
 
-                                        {(task.taskType === 'TRACE' || task.taskType === 'TRACEABILITY') && !isComplete ? (
+                                        {(task.taskType === 'TRACE' || task.taskType === 'TRACEABILITY') && !fieldInputDisabled ? (
                                           <MaterialScanner
                                             travelerId={traveler.id}
                                             travelerStepId={currentStep.id}
@@ -3060,7 +3086,7 @@ export default function TravelerExecution() {
                                                               placeholder={field.validation?.tolerance ? `Enter result (Tolerance: ${field.validation.tolerance})` : 'Enter measured result...'}
                                                               value={fieldValues[task.id]?.[`${field.fieldKey}_result`] || (field.value?.includes('|') ? field.value.split('|')[1] : '') || ''}
                                                               onChange={(e) => handleFieldChange(task.id, `${field.fieldKey}_result`, e.target.value)}
-                                                              disabled={isComplete}
+                                                              disabled={fieldInputDisabled}
                                                               className="text-sm h-9"
                                                             />
                                                           </div>
@@ -3080,7 +3106,7 @@ export default function TravelerExecution() {
                                                                 checked ? 'yes' : 'no'
                                                               )
                                                             }
-                                                            disabled={isComplete}
+                                                            disabled={fieldInputDisabled}
                                                           />
                                                           <Label htmlFor={field.id} className="text-sm cursor-pointer">
                                                             Verified / Pass
@@ -3102,7 +3128,7 @@ export default function TravelerExecution() {
                                                             className="text-sm bg-muted flex-1"
                                                             placeholder="Select from Fabric Inventory..."
                                                           />
-                                                          {!isComplete && (
+                                                          {!fieldInputDisabled && (
                                                             <Button
                                                               size="sm"
                                                               variant="outline"
@@ -3140,7 +3166,7 @@ export default function TravelerExecution() {
                                                             e.target.value
                                                           )
                                                         }
-                                                        disabled={isComplete}
+                                                        disabled={fieldInputDisabled}
                                                         className="text-sm"
                                                       />
                                                     ) : (
@@ -3160,7 +3186,7 @@ export default function TravelerExecution() {
                                                             e.target.value
                                                           )
                                                         }
-                                                        disabled={isComplete || (field.validation?.readonly === true && !!field.value)}
+                                                        disabled={fieldInputDisabled || (field.validation?.readonly === true && !!field.value)}
                                                         className={`text-sm ${field.validation?.readonly && field.value ? 'bg-muted' : ''}`}
                                                         placeholder={field.validation?.readonly ? 'Auto-filled from inventory' : undefined}
                                                       />

--- a/client/src/pages/TravelerManagement.tsx
+++ b/client/src/pages/TravelerManagement.tsx
@@ -194,6 +194,16 @@ interface LegacyRocBackfillApplyResult {
   }[];
 }
 
+interface LegacyRocRestoreResult {
+  mode: 'restore_canceled';
+  writesPerformed: boolean;
+  status: 'restored' | 'skipped';
+  traveler?: Traveler;
+  travelerId?: string;
+  travelerNumber?: string;
+  message?: string;
+}
+
 const STATUS_COLORS: Record<string, string> = {
   DRAFT: 'bg-gray-100 text-gray-800',
   IN_PROGRESS: 'bg-blue-100 text-blue-800',
@@ -223,6 +233,7 @@ export default function TravelerManagement() {
   const [showLegacyRocBackfillDialog, setShowLegacyRocBackfillDialog] = useState(false);
   const [legacyRocBackfillReport, setLegacyRocBackfillReport] = useState<LegacyRocBackfillReport | null>(null);
   const [legacyRocApplyResult, setLegacyRocApplyResult] = useState<LegacyRocBackfillApplyResult | null>(null);
+  const [legacyRocRestoreResult, setLegacyRocRestoreResult] = useState<LegacyRocRestoreResult | null>(null);
   const [offSystemLinkDraft, setOffSystemLinkDraft] = useState('');
   const [selectedTraveler, setSelectedTraveler] = useState<Traveler | null>(null);
   const [selectedRouting, setSelectedRouting] = useState<string>('');
@@ -267,6 +278,7 @@ export default function TravelerManagement() {
     onSuccess: (report) => {
       setLegacyRocBackfillReport(report);
       setLegacyRocApplyResult(null);
+      setLegacyRocRestoreResult(null);
       setShowLegacyRocBackfillDialog(true);
       toast({
         title: 'Dry-run complete',
@@ -277,6 +289,33 @@ export default function TravelerManagement() {
       toast({
         title: 'Dry-run failed',
         description: error.message || 'Could not generate the legacy ROC backfill report',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const legacyRocRestoreCanceledMutation = useMutation({
+    mutationFn: () =>
+      apiRequest('/api/travelers/legacy-roc-backfill/restore-canceled', {
+        method: 'POST',
+        body: { confirmSupervisorApproval: true },
+        timeout: 120000,
+      }) as Promise<LegacyRocRestoreResult>,
+    onSuccess: (result) => {
+      setLegacyRocRestoreResult(result);
+      queryClient.invalidateQueries({ queryKey: ['/api/travelers'] });
+      toast({
+        title: result.status === 'restored' ? 'Traveler restored' : 'No restore needed',
+        description: result.status === 'restored'
+          ? 'TRV-2026-000271 is active again for supervised backfill.'
+          : result.message,
+      });
+      legacyRocBackfillDryRunMutation.mutate();
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Restore failed',
+        description: error.message || 'Could not restore the canceled ROC traveler',
         variant: 'destructive',
       });
     },
@@ -698,6 +737,9 @@ export default function TravelerManagement() {
     blocked: travelers.filter((t) => t.status === 'BLOCKED').length,
     scrapped: travelers.filter((t) => t.status === 'SCRAPPED').length,
   };
+  const hasCanceledLegacyRocTraveler = legacyRocBackfillReport?.rows.some(
+    (row) => row.traveler?.travelerNumber === 'TRV-2026-000271' && row.traveler.status.toUpperCase() === 'CANCELED'
+  ) ?? false;
 
   if (isLoading) {
     return (
@@ -1148,6 +1190,16 @@ export default function TravelerManagement() {
                   </div>
                 </div>
               )}
+
+              {legacyRocRestoreResult && (
+                <div className="rounded border border-blue-200 bg-blue-50 p-3 text-sm">
+                  <p className="font-medium text-blue-900">
+                    {legacyRocRestoreResult.status === 'restored'
+                      ? 'TRV-2026-000271 was restored to active status with an audit trail.'
+                      : legacyRocRestoreResult.message}
+                  </p>
+                </div>
+              )}
             </div>
           )}
 
@@ -1155,9 +1207,23 @@ export default function TravelerManagement() {
             <Button variant="outline" onClick={() => setShowLegacyRocBackfillDialog(false)}>
               Close
             </Button>
+            {hasCanceledLegacyRocTraveler && (
+              <Button
+                variant="outline"
+                onClick={() => {
+                  const ok = window.confirm('Restore TRV-2026-000271 from canceled to active status with a timestamped audit record?');
+                  if (ok) legacyRocRestoreCanceledMutation.mutate();
+                }}
+                disabled={legacyRocRestoreCanceledMutation.isPending}
+                data-testid="button-legacy-roc-restore-canceled"
+              >
+                {legacyRocRestoreCanceledMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                Restore Canceled Traveler
+              </Button>
+            )}
             <Button
               onClick={() => {
-                const ok = window.confirm('Apply the supervised legacy ROC backfill to the 11 active travelers and write timestamped audit records?');
+                const ok = window.confirm('Apply the supervised legacy ROC backfill to the active eligible travelers and write timestamped audit records?');
                 if (ok) legacyRocBackfillApplyMutation.mutate();
               }}
               disabled={legacyRocBackfillApplyMutation.isPending || !legacyRocBackfillReport}

--- a/server/src/routes/travelers.ts
+++ b/server/src/routes/travelers.ts
@@ -133,6 +133,15 @@ const legacyRocApplySchema = z.object({
   confirmSupervisorApproval: z.literal(true),
 });
 
+const LEGACY_ROC_RESTORE_REASON =
+  'Traveler TRV-2026-000271 was canceled accidentally during manual troubleshooting of the legacy routing/charge-code issue. Cancellation is preserved in the audit history. Traveler is restored to active status for supervised legacy routing remediation and continuation of production record completion.';
+
+const legacyRocRestoreSchema = z.object({
+  approver: z.string().trim().min(1).default(LEGACY_ROC_BACKFILL_DEFAULT_APPROVER),
+  reason: z.string().trim().min(1).default(LEGACY_ROC_RESTORE_REASON),
+  confirmSupervisorApproval: z.literal(true),
+});
+
 function normalizeLegacyRocValue(value: unknown): string {
   return String(value ?? '').trim().toLowerCase();
 }
@@ -901,7 +910,6 @@ router.post('/legacy-roc-backfill/apply', requirePermission('work_orders.overrid
       .where(inArray(travelers.serialNumber, defaultSerials));
     const allowedTravelerIds = new Set(
       allowedTravelerRows
-        .filter((traveler) => traveler.travelerNumber !== LEGACY_ROC_CANCELED_TRAVELER_NUMBER)
         .filter((traveler) => !['COMPLETED', 'CANCELED', 'CANCELLED'].includes(String(traveler.status).toUpperCase()))
         .map((traveler) => traveler.id)
     );
@@ -1199,7 +1207,7 @@ router.post('/legacy-roc-backfill/apply', requirePermission('work_orders.overrid
       writesPerformed: true,
       approver: parsed.approver,
       reason: parsed.reason,
-      excludedTravelerNumber: LEGACY_ROC_CANCELED_TRAVELER_NUMBER,
+      restoreRequiredTravelerNumber: LEGACY_ROC_CANCELED_TRAVELER_NUMBER,
       summary: {
         requested: requestedTravelerIds.length,
         applied: results.filter((result) => result.status === 'applied').length,
@@ -1213,6 +1221,112 @@ router.post('/legacy-roc-backfill/apply', requirePermission('work_orders.overrid
     }
     console.error('Error applying legacy ROC traveler backfill:', error);
     res.status(500).json({ error: 'Failed to apply legacy ROC traveler backfill', message: error.message });
+  }
+});
+
+router.post('/legacy-roc-backfill/restore-canceled', requirePermission('work_orders.override_charges'), async (req: Request, res: Response) => {
+  try {
+    const parsed = legacyRocRestoreSchema.parse(req.body ?? {});
+    const now = new Date();
+
+    const [traveler] = await db
+      .select()
+      .from(travelers)
+      .where(eq(travelers.travelerNumber, LEGACY_ROC_CANCELED_TRAVELER_NUMBER))
+      .limit(1);
+
+    if (!traveler) {
+      return res.status(404).json({
+        error: 'TRAVELER_NOT_FOUND',
+        message: `${LEGACY_ROC_CANCELED_TRAVELER_NUMBER} was not found.`,
+      });
+    }
+
+    const normalizedSerial = normalizeLegacyRocValue(traveler.serialNumber);
+    const inScope = [...LEGACY_ROC_BACKFILL_DEFAULT_SERIALS].map(normalizeLegacyRocValue).includes(normalizedSerial);
+    if (!inScope) {
+      return res.status(400).json({
+        error: 'TRAVELER_NOT_IN_LEGACY_ROC_SCOPE',
+        message: `${LEGACY_ROC_CANCELED_TRAVELER_NUMBER} is not linked to the approved ROC serial scope.`,
+      });
+    }
+
+    if (String(traveler.status).toUpperCase() !== 'CANCELED' && String(traveler.status).toUpperCase() !== 'CANCELLED') {
+      return res.json({
+        mode: 'restore_canceled',
+        writesPerformed: false,
+        status: 'skipped',
+        travelerId: traveler.id,
+        travelerNumber: traveler.travelerNumber,
+        message: `Traveler is already ${traveler.status}; no restore was needed.`,
+      });
+    }
+
+    const result = await db.transaction(async (tx) => {
+      const [updatedTraveler] = await tx
+        .update(travelers)
+        .set({
+          status: 'IN_PROGRESS',
+          updatedAt: now,
+        })
+        .where(eq(travelers.id, traveler.id))
+        .returning();
+
+      await tx.insert(travelerEvents).values({
+        travelerId: traveler.id,
+        actor: parsed.approver,
+        actorName: parsed.approver,
+        action: 'LEGACY_ROC_CANCELED_TRAVELER_RESTORED',
+        details: {
+          reason: parsed.reason,
+          restoredAt: now.toISOString(),
+          beforeTravelerStatus: traveler.status,
+          afterTravelerStatus: 'IN_PROGRESS',
+          serialNumber: traveler.serialNumber ?? null,
+        },
+      });
+
+      await recordAuditEvent({
+        eventType: 'LEGACY_ROC_CANCELED_TRAVELER_RESTORED',
+        subjectType: 'traveler',
+        subjectId: traveler.id,
+        sourceService: 'travelers.legacyRocBackfill',
+        actor: { username: parsed.approver, role: 'supervisor' },
+        occurredAt: now,
+        reason: parsed.reason,
+        entityType: 'traveler',
+        entityId: traveler.id,
+        payload: {
+          travelerId: traveler.id,
+          travelerNumber: traveler.travelerNumber,
+          serialNumber: traveler.serialNumber ?? null,
+          beforeTravelerStatus: traveler.status,
+          afterTravelerStatus: 'IN_PROGRESS',
+        },
+        meta: {
+          travelerId: traveler.id,
+          travelerNumber: traveler.travelerNumber,
+          serialNumber: traveler.serialNumber ?? null,
+        },
+      }, tx);
+
+      return updatedTraveler;
+    });
+
+    res.json({
+      mode: 'restore_canceled',
+      writesPerformed: true,
+      status: 'restored',
+      traveler: result,
+      approver: parsed.approver,
+      reason: parsed.reason,
+    });
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: 'Validation failed', issues: error.issues });
+    }
+    console.error('Error restoring legacy ROC canceled traveler:', error);
+    res.status(500).json({ error: 'Failed to restore legacy ROC canceled traveler', message: error.message });
   }
 });
 
@@ -3521,7 +3635,7 @@ router.get('/:travelerId/tasks/:taskId/fields', async (req: Request, res: Respon
 // Update a task field value
 router.patch('/:travelerId/tasks/:taskId/fields/:fieldId', async (req: Request, res: Response) => {
   try {
-    const { travelerId, fieldId } = req.params;
+    const { travelerId, taskId, fieldId } = req.params;
     const { value, recordedBy, validation } = req.body;
 
     const traveler = await storage.getTraveler(travelerId);
@@ -3538,7 +3652,81 @@ router.patch('/:travelerId/tasks/:taskId/fields/:fieldId', async (req: Request, 
       updateData.validation = validation;
     }
 
+    const [existingField] = await db
+      .select()
+      .from(travelerTaskFields)
+      .where(eq(travelerTaskFields.id, fieldId))
+      .limit(1);
+    const task = await storage.getTravelerTask(taskId);
+    const step = task ? await storage.getTravelerStep(task.travelerStepId) : null;
+
     const updatedField = await storage.updateTravelerTaskField(fieldId, updateData);
+
+    if (task && step) {
+      const legacyBackfillEvent = await db.query.travelerEvents.findFirst({
+        where: and(
+          eq(travelerEvents.travelerId, travelerId),
+          eq(travelerEvents.action, 'LEGACY_ROC_ROUTING_STEP_BACKFILLED'),
+          sql`${travelerEvents.details}->>'stepId' = ${step.id}`
+        ),
+      });
+
+      if (legacyBackfillEvent) {
+        const actor = recordedBy || 'unknown';
+        await storage.createTravelerEvent({
+          travelerId,
+          actor,
+          actorName: actor,
+          action: 'LEGACY_ROC_BACKFILL_FIELD_RECORDED',
+          details: {
+            stepId: step.id,
+            stepNumber: step.stepNumber,
+            departmentName: step.departmentName,
+            taskId,
+            taskTitle: task.title,
+            fieldId,
+            fieldKey: updatedField.fieldKey,
+            fieldLabel: updatedField.fieldLabel,
+            previousValue: existingField?.value ?? null,
+            recordedValue: value ?? null,
+            recordedAt: updateData.recordedAt.toISOString(),
+            reason: 'Collected traveler data entered after supervised legacy ROC routing backfill.',
+          },
+        });
+
+        await recordAuditEvent({
+          eventType: 'LEGACY_ROC_BACKFILL_FIELD_RECORDED',
+          subjectType: 'traveler_task_field',
+          subjectId: fieldId,
+          sourceService: 'travelers.legacyRocBackfill',
+          actor: { username: actor, role: null },
+          occurredAt: updateData.recordedAt,
+          reason: 'Collected traveler data entered after supervised legacy ROC routing backfill.',
+          entityType: 'traveler',
+          entityId: travelerId,
+          payload: {
+            travelerId,
+            travelerNumber: traveler.travelerNumber,
+            serialNumber: traveler.serialNumber ?? null,
+            stepId: step.id,
+            stepNumber: step.stepNumber,
+            departmentName: step.departmentName,
+            taskId,
+            taskTitle: task.title,
+            fieldId,
+            fieldKey: updatedField.fieldKey,
+            fieldLabel: updatedField.fieldLabel,
+            previousValue: existingField?.value ?? null,
+            recordedValue: value ?? null,
+          },
+          meta: {
+            travelerId,
+            travelerNumber: traveler.travelerNumber,
+            serialNumber: traveler.serialNumber ?? null,
+          },
+        });
+      }
+    }
 
     res.json(updatedField);
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- keeps collected-data fields editable for traveler tasks completed by the legacy ROC routing backfill
- adds timestamped traveler/audit events when data is recorded after a legacy ROC backfill
- preserves the supervised restore path for accidentally canceled legacy ROC travelers already on this branch

## Validation
- `git diff --check`
- `npm run check` was not run locally because `npm` is not available on PATH in this workspace