### PR TITLE
[codex] Add burden rate accumulation workflow

### DIFF
--- a/client/src/pages/BurdenRatesAdmin.tsx
+++ b/client/src/pages/BurdenRatesAdmin.tsx
@@ -11,7 +11,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/hooks/use-toast';
-import { AlertTriangle, CheckCircle2, Calculator, Layers, History, FlaskConical } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Calculator, Layers, History, FlaskConical, FileSpreadsheet, Plus, Save } from 'lucide-react';
 
 type Pool = {
   id: number;
@@ -58,8 +58,47 @@ type Run = {
   notes: string | null;
 };
 
+type AccumulationPayload = {
+  accumulation: {
+    id: number;
+    calculationYear: number;
+    lookbackStart: string;
+    lookbackEnd: string;
+    rateType: 'PROVISIONAL' | 'BILLING' | 'FINAL';
+    effectiveFrom: string;
+    status: 'DRAFT' | 'POSTED';
+    createdBy: string;
+    createdAt: string;
+    postedAt: string | null;
+  };
+  summary: {
+    poolId: number;
+    poolCode: string;
+    poolName: string;
+    expenseTotal: number;
+    baseAmount: number;
+    calculatedRate: number;
+  }[];
+};
+
 const fmtMoney = (v: number | string) =>
   Number(v).toLocaleString(undefined, { style: 'currency', currency: 'USD', minimumFractionDigits: 2 });
+
+const monthKey = (date: Date) => `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+
+const monthKeysBetween = (start: string, end: string) => {
+  const keys: string[] = [];
+  const startDate = new Date(`${start}T00:00:00Z`);
+  const endDate = new Date(`${end}T00:00:00Z`);
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) return keys;
+  const cursor = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), 1));
+  const final = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), 1));
+  while (cursor <= final && keys.length < 12) {
+    keys.push(monthKey(cursor));
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+  return keys;
+};
 
 export default function BurdenRatesAdmin() {
   const { toast } = useToast();
@@ -86,6 +125,7 @@ export default function BurdenRatesAdmin() {
       <Tabs defaultValue="apply" className="space-y-4">
         <TabsList>
           <TabsTrigger value="apply" data-testid="tab-apply">Apply &amp; Verify</TabsTrigger>
+          <TabsTrigger value="accumulation" data-testid="tab-accumulation">Accumulation</TabsTrigger>
           <TabsTrigger value="pools" data-testid="tab-pools">Pools</TabsTrigger>
           <TabsTrigger value="rates" data-testid="tab-rates">Rates</TabsTrigger>
           <TabsTrigger value="bases" data-testid="tab-bases">Bases</TabsTrigger>
@@ -95,6 +135,9 @@ export default function BurdenRatesAdmin() {
 
         <TabsContent value="apply">
           <ApplyTab period={period} setPeriod={setPeriod} />
+        </TabsContent>
+        <TabsContent value="accumulation">
+          <AccumulationTab pools={pools.data ?? []} />
         </TabsContent>
         <TabsContent value="pools">
           <PoolsTab pools={pools.data ?? []} bases={bases.data ?? []} />
@@ -116,6 +159,197 @@ export default function BurdenRatesAdmin() {
   );
 
   // ── Apply tab ─────────────────────────────────────────────────────────────
+  function AccumulationTab({ pools }: { pools: Pool[] }) {
+    const defaultYear = now.getUTCFullYear();
+    const [form, setForm] = useState({
+      calculationYear: defaultYear,
+      lookbackStart: `${defaultYear - 1}-01-01`,
+      lookbackEnd: `${defaultYear - 1}-12-31`,
+      rateType: 'PROVISIONAL' as 'PROVISIONAL' | 'BILLING' | 'FINAL',
+      effectiveFrom: `${defaultYear}-01-01`,
+      notes: '',
+    });
+    const [lines, setLines] = useState<Array<{ localId: number; poolId: number; lineItem: string; monthlyAmounts: Record<string, string> }>>([
+      { localId: 1, poolId: pools[0]?.id ?? 0, lineItem: '', monthlyAmounts: {} },
+    ]);
+    const [basesByPool, setBasesByPool] = useState<Record<number, { baseAmount: string; baseSource: string }>>({});
+    const [result, setResult] = useState<AccumulationPayload | null>(null);
+
+    const months = monthKeysBetween(form.lookbackStart, form.lookbackEnd);
+    const activePools = pools.filter((pool) => pool.isActive);
+    const selectablePools = activePools.length > 0 ? activePools : pools;
+
+    const latest = useQuery<AccumulationPayload | null>({
+      queryKey: ['/api/burden-rates/accumulations/latest', form.calculationYear],
+      queryFn: async () => {
+        const r = await fetch(`/api/burden-rates/accumulations/latest?year=${form.calculationYear}`, { credentials: 'include' });
+        if (!r.ok) throw new Error('Failed to load latest accumulation');
+        return r.json();
+      },
+    });
+
+    const save = useMutation({
+      mutationFn: async () => {
+        const expenseLines = lines
+          .map((line) => ({
+            poolId: line.poolId || selectablePools[0]?.id,
+            lineItem: line.lineItem.trim(),
+            monthlyAmounts: Object.fromEntries(months.map((m) => [m, Number(line.monthlyAmounts[m] || 0)])),
+          }))
+          .filter((line) => line.poolId && line.lineItem);
+        const bases = selectablePools.map((pool) => ({
+          poolId: pool.id,
+          baseAmount: Number(basesByPool[pool.id]?.baseAmount || 0),
+          baseSource: basesByPool[pool.id]?.baseSource || null,
+        }));
+        return apiRequest('/api/burden-rates/accumulations', {
+          method: 'POST',
+          body: { ...form, expenseLines, bases },
+        });
+      },
+      onSuccess: (data: any) => {
+        setResult(data);
+        queryClient.invalidateQueries({ queryKey: ['/api/burden-rates/accumulations/latest', form.calculationYear] });
+        toast({ title: 'Accumulation saved', description: `Calculation #${data.accumulation.id} is ready to review.` });
+      },
+      onError: (e: any) => toast({ title: 'Save failed', description: e?.message || 'Unable to save accumulation', variant: 'destructive' }),
+    });
+
+    const postRates = useMutation({
+      mutationFn: async () => {
+        if (!result?.accumulation.id) throw new Error('Save an accumulation first');
+        return apiRequest(`/api/burden-rates/accumulations/${result.accumulation.id}/post-rates`, { method: 'POST' });
+      },
+      onSuccess: () => {
+        toast({ title: 'Rates posted', description: 'Calculated rates were added to the rate history.' });
+        queryClient.invalidateQueries({ queryKey: ['/api/burden-rates/pools'] });
+        setResult((current) => current ? { ...current, accumulation: { ...current.accumulation, status: 'POSTED' } } : current);
+      },
+      onError: (e: any) => toast({ title: 'Post failed', description: e?.message || 'Unable to post rates', variant: 'destructive' }),
+    });
+
+    const addLine = () => setLines((current) => [
+      ...current,
+      { localId: Date.now(), poolId: selectablePools[0]?.id ?? 0, lineItem: '', monthlyAmounts: {} },
+    ]);
+    const updateLine = (localId: number, patch: Partial<(typeof lines)[number]>) =>
+      setLines((current) => current.map((line) => (line.localId === localId ? { ...line, ...patch } : line)));
+    const updateMonth = (localId: number, month: string, value: string) =>
+      setLines((current) => current.map((line) => line.localId === localId
+        ? { ...line, monthlyAmounts: { ...line.monthlyAmounts, [month]: value } }
+        : line));
+
+    const draftSummary = selectablePools.map((pool) => {
+      const expenseTotal = lines
+        .filter((line) => (line.poolId || selectablePools[0]?.id) === pool.id)
+        .reduce((sum, line) => sum + months.reduce((monthSum, m) => monthSum + Number(line.monthlyAmounts[m] || 0), 0), 0);
+      const baseAmount = Number(basesByPool[pool.id]?.baseAmount || 0);
+      return { poolId: pool.id, poolCode: pool.code, poolName: pool.name, expenseTotal, baseAmount, calculatedRate: baseAmount > 0 ? expenseTotal / baseAmount : 0 };
+    });
+    const summary = result?.summary ?? draftSummary;
+
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><FileSpreadsheet className="h-5 w-5" /> Rate Accumulation</CardTitle>
+            <CardDescription>
+              Enter the last 12 months of QuickBooks actuals by pool, then enter the allocation base used for each pool.
+              The calculated rate can be posted into the existing insert-only rate history.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+              <div><Label>Rate Year</Label><Input type="number" value={form.calculationYear} onChange={(e) => setForm({ ...form, calculationYear: Number(e.target.value), effectiveFrom: `${Number(e.target.value)}-01-01` })} data-testid="input-accumulation-year" /></div>
+              <div><Label>Lookback Start</Label><Input type="date" value={form.lookbackStart} onChange={(e) => setForm({ ...form, lookbackStart: e.target.value })} data-testid="input-accumulation-start" /></div>
+              <div><Label>Lookback End</Label><Input type="date" value={form.lookbackEnd} onChange={(e) => setForm({ ...form, lookbackEnd: e.target.value })} data-testid="input-accumulation-end" /></div>
+              <div>
+                <Label>Rate Type</Label>
+                <Select value={form.rateType} onValueChange={(v) => setForm({ ...form, rateType: v as any })}>
+                  <SelectTrigger data-testid="select-accumulation-rate-type"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="PROVISIONAL">PROVISIONAL</SelectItem>
+                    <SelectItem value="BILLING">BILLING</SelectItem>
+                    <SelectItem value="FINAL">FINAL</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div><Label>Effective From</Label><Input type="date" value={form.effectiveFrom} onChange={(e) => setForm({ ...form, effectiveFrom: e.target.value })} data-testid="input-accumulation-effective" /></div>
+            </div>
+
+            {latest.data?.accumulation && !result && (
+              <div className="rounded-md border bg-muted/30 p-3 text-sm">
+                Latest saved calculation for {form.calculationYear}: #{latest.data.accumulation.id} ({latest.data.accumulation.status})
+              </div>
+            )}
+
+            <div className="overflow-x-auto rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="min-w-[160px]">Pool</TableHead>
+                    <TableHead className="min-w-[220px]">QuickBooks Line Item</TableHead>
+                    {months.map((m) => <TableHead key={m} className="text-right min-w-[110px]">{m}</TableHead>)}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {lines.map((line) => (
+                    <TableRow key={line.localId}>
+                      <TableCell>
+                        <Select value={String(line.poolId || selectablePools[0]?.id || '')} onValueChange={(v) => updateLine(line.localId, { poolId: Number(v) })}>
+                          <SelectTrigger><SelectValue placeholder="Pool" /></SelectTrigger>
+                          <SelectContent>
+                            {selectablePools.map((pool) => <SelectItem key={pool.id} value={String(pool.id)}>{pool.code}</SelectItem>)}
+                          </SelectContent>
+                        </Select>
+                      </TableCell>
+                      <TableCell><Input value={line.lineItem} placeholder="QB account or line item" onChange={(e) => updateLine(line.localId, { lineItem: e.target.value })} /></TableCell>
+                      {months.map((m) => (
+                        <TableCell key={m}><Input className="text-right" type="number" step="0.01" value={line.monthlyAmounts[m] ?? ''} onChange={(e) => updateMonth(line.localId, m, e.target.value)} /></TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <Button variant="outline" onClick={addLine} data-testid="button-add-accumulation-line"><Plus className="h-4 w-4 mr-2" /> Add Line</Button>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              {selectablePools.map((pool) => (
+                <Card key={pool.id}>
+                  <CardHeader className="pb-2"><CardTitle className="text-base">{pool.code} Base</CardTitle><CardDescription>{pool.name}</CardDescription></CardHeader>
+                  <CardContent className="space-y-2">
+                    <Input type="number" step="0.01" placeholder="Allocation base amount" value={basesByPool[pool.id]?.baseAmount ?? ''} onChange={(e) => setBasesByPool({ ...basesByPool, [pool.id]: { ...(basesByPool[pool.id] ?? { baseSource: '' }), baseAmount: e.target.value } })} data-testid={`input-base-${pool.code}`} />
+                    <Input placeholder="Base source / note" value={basesByPool[pool.id]?.baseSource ?? ''} onChange={(e) => setBasesByPool({ ...basesByPool, [pool.id]: { ...(basesByPool[pool.id] ?? { baseAmount: '' }), baseSource: e.target.value } })} />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Button onClick={() => save.mutate()} disabled={save.isPending || selectablePools.length === 0} data-testid="button-save-accumulation"><Save className="h-4 w-4 mr-2" /> {save.isPending ? 'Saving...' : 'Save Calculation'}</Button>
+              <Button variant="outline" onClick={() => postRates.mutate()} disabled={postRates.isPending || !result || result.accumulation.status === 'POSTED'} data-testid="button-post-accumulation-rates">{postRates.isPending ? 'Posting...' : 'Post Calculated Rates'}</Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {summary.map((row) => (
+            <Card key={row.poolId}>
+              <CardHeader className="pb-2"><CardTitle className="text-base">{row.poolCode}</CardTitle><CardDescription>{row.poolName}</CardDescription></CardHeader>
+              <CardContent className="space-y-1 text-sm">
+                <div className="flex justify-between"><span>Expense pool</span><span className="font-mono">{fmtMoney(row.expenseTotal)}</span></div>
+                <div className="flex justify-between"><span>Allocation base</span><span className="font-mono">{fmtMoney(row.baseAmount)}</span></div>
+                <div className="flex justify-between text-base font-semibold"><span>Rate</span><span className="font-mono">{(row.calculatedRate * 100).toFixed(4)}%</span></div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   function ApplyTab({
     period,
     setPeriod,
@@ -137,7 +371,7 @@ export default function BurdenRatesAdmin() {
 
     const apply = useMutation({
       mutationFn: async () => {
-        return await apiRequest('POST', '/api/burden-rates/apply', { ...period, runType, rateType });
+        return await apiRequest('/api/burden-rates/apply', { method: 'POST', body: { ...period, runType, rateType } });
       },
       onSuccess: (data: any) => {
         toast({
@@ -268,7 +502,7 @@ export default function BurdenRatesAdmin() {
       code: '', name: '', poolType: 'OVERHEAD', allocationBaseId: bases[0]?.id ?? 0, applyOrder: 100, isActive: true,
     });
     const create = useMutation({
-      mutationFn: async () => apiRequest('POST', '/api/burden-rates/pools', form),
+      mutationFn: async () => apiRequest('/api/burden-rates/pools', { method: 'POST', body: form }),
       onSuccess: () => {
         toast({ title: 'Pool created' });
         queryClient.invalidateQueries({ queryKey: ['/api/burden-rates/pools'] });
@@ -278,7 +512,7 @@ export default function BurdenRatesAdmin() {
     });
     const toggleActive = useMutation({
       mutationFn: async ({ id, isActive }: { id: number; isActive: boolean }) =>
-        apiRequest('PATCH', `/api/burden-rates/pools/${id}`, { isActive }),
+        apiRequest(`/api/burden-rates/pools/${id}`, { method: 'PATCH', body: { isActive } }),
       onSuccess: () => queryClient.invalidateQueries({ queryKey: ['/api/burden-rates/pools'] }),
     });
 
@@ -387,7 +621,7 @@ export default function BurdenRatesAdmin() {
     });
 
     const create = useMutation({
-      mutationFn: async () => apiRequest('POST', `/api/burden-rates/pools/${poolId}/rates`, newRate),
+      mutationFn: async () => apiRequest(`/api/burden-rates/pools/${poolId}/rates`, { method: 'POST', body: newRate }),
       onSuccess: () => {
         toast({ title: 'Rate added' });
         queryClient.invalidateQueries({ queryKey: ['/api/burden-rates/pools', poolId, 'rates'] });
@@ -577,7 +811,7 @@ export default function BurdenRatesAdmin() {
     const [result, setResult] = useState<any>(null);
 
     const preview = useMutation({
-      mutationFn: async () => apiRequest('POST', '/api/burden-rates/preview', form),
+      mutationFn: async () => apiRequest('/api/burden-rates/preview', { method: 'POST', body: form }),
       onSuccess: (data: any) => setResult(data),
       onError: (e: any) => toast({ title: 'Preview failed', description: e?.body?.error || e.message, variant: 'destructive' }),
     });

--- a/migrations/0101_burden_rate_accumulation.sql
+++ b/migrations/0101_burden_rate_accumulation.sql
@@ -1,0 +1,55 @@
+-- Migration 0101: burden rate accumulation support
+--
+-- Adds a reviewable manual-actuals workflow for provisional/final indirect
+-- rate calculations.  This is intentionally source-agnostic for the first
+-- release: QuickBooks line items are keyed by the user-entered line-item name,
+-- month, and pool, then summarized into rate calculation snapshots.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS burden_rate_accumulations (
+  id                  SERIAL PRIMARY KEY,
+  calculation_year    INTEGER     NOT NULL,
+  lookback_start      DATE        NOT NULL,
+  lookback_end        DATE        NOT NULL,
+  rate_type           TEXT        NOT NULL DEFAULT 'PROVISIONAL',
+  effective_from      DATE        NOT NULL,
+  status              TEXT        NOT NULL DEFAULT 'DRAFT',
+  notes               TEXT,
+  created_by          TEXT        NOT NULL,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  posted_at           TIMESTAMPTZ,
+  CONSTRAINT burden_rate_accumulations_rate_type_chk
+    CHECK (rate_type IN ('PROVISIONAL', 'BILLING', 'FINAL')),
+  CONSTRAINT burden_rate_accumulations_status_chk
+    CHECK (status IN ('DRAFT', 'POSTED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_burden_rate_accumulations_year
+  ON burden_rate_accumulations (calculation_year, rate_type, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS burden_rate_accumulation_expense_lines (
+  id                  SERIAL PRIMARY KEY,
+  accumulation_id     INTEGER     NOT NULL REFERENCES burden_rate_accumulations(id) ON DELETE CASCADE,
+  pool_id             INTEGER     NOT NULL REFERENCES indirect_cost_pools(id),
+  line_item           TEXT        NOT NULL,
+  monthly_amounts     JSONB       NOT NULL DEFAULT '{}'::jsonb,
+  notes               TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_burden_rate_accumulation_expense_lines_accumulation
+  ON burden_rate_accumulation_expense_lines (accumulation_id, pool_id);
+
+CREATE TABLE IF NOT EXISTS burden_rate_accumulation_bases (
+  id                  SERIAL PRIMARY KEY,
+  accumulation_id     INTEGER     NOT NULL REFERENCES burden_rate_accumulations(id) ON DELETE CASCADE,
+  pool_id             INTEGER     NOT NULL REFERENCES indirect_cost_pools(id),
+  base_amount         NUMERIC(14,4) NOT NULL DEFAULT 0,
+  base_source         TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT burden_rate_accumulation_bases_unique
+    UNIQUE (accumulation_id, pool_id)
+);
+
+COMMIT;

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -17516,6 +17516,54 @@ export const insertAppliedBurdenAmountSchema = createInsertSchema(appliedBurdenA
 export type AppliedBurdenAmount = typeof appliedBurdenAmounts.$inferSelect;
 export type InsertAppliedBurdenAmount = z.infer<typeof insertAppliedBurdenAmountSchema>;
 
+export const burdenRateAccumulations = pgTable('burden_rate_accumulations', {
+  id: serial('id').primaryKey(),
+  calculationYear: integer('calculation_year').notNull(),
+  lookbackStart: date('lookback_start').notNull(),
+  lookbackEnd: date('lookback_end').notNull(),
+  rateType: text('rate_type').notNull().default('PROVISIONAL'), // PROVISIONAL | BILLING | FINAL
+  effectiveFrom: date('effective_from').notNull(),
+  status: text('status').notNull().default('DRAFT'), // DRAFT | POSTED
+  notes: text('notes'),
+  createdBy: text('created_by').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  postedAt: timestamp('posted_at', { withTimezone: true }),
+});
+export const insertBurdenRateAccumulationSchema = createInsertSchema(burdenRateAccumulations).omit({
+  id: true, createdAt: true, postedAt: true,
+});
+export type BurdenRateAccumulation = typeof burdenRateAccumulations.$inferSelect;
+export type InsertBurdenRateAccumulation = z.infer<typeof insertBurdenRateAccumulationSchema>;
+
+export const burdenRateAccumulationExpenseLines = pgTable('burden_rate_accumulation_expense_lines', {
+  id: serial('id').primaryKey(),
+  accumulationId: integer('accumulation_id').notNull().references(() => burdenRateAccumulations.id, { onDelete: 'cascade' }),
+  poolId: integer('pool_id').notNull().references(() => indirectCostPools.id),
+  lineItem: text('line_item').notNull(),
+  monthlyAmounts: jsonb('monthly_amounts').$type<Record<string, number>>().notNull().default(sql`'{}'::jsonb`),
+  notes: text('notes'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+export const insertBurdenRateAccumulationExpenseLineSchema = createInsertSchema(burdenRateAccumulationExpenseLines).omit({
+  id: true, createdAt: true,
+});
+export type BurdenRateAccumulationExpenseLine = typeof burdenRateAccumulationExpenseLines.$inferSelect;
+export type InsertBurdenRateAccumulationExpenseLine = z.infer<typeof insertBurdenRateAccumulationExpenseLineSchema>;
+
+export const burdenRateAccumulationBases = pgTable('burden_rate_accumulation_bases', {
+  id: serial('id').primaryKey(),
+  accumulationId: integer('accumulation_id').notNull().references(() => burdenRateAccumulations.id, { onDelete: 'cascade' }),
+  poolId: integer('pool_id').notNull().references(() => indirectCostPools.id),
+  baseAmount: numeric('base_amount', { precision: 14, scale: 4 }).notNull().default('0'),
+  baseSource: text('base_source'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+export const insertBurdenRateAccumulationBaseSchema = createInsertSchema(burdenRateAccumulationBases).omit({
+  id: true, createdAt: true,
+});
+export type BurdenRateAccumulationBase = typeof burdenRateAccumulationBases.$inferSelect;
+export type InsertBurdenRateAccumulationBase = z.infer<typeof insertBurdenRateAccumulationBaseSchema>;
+
 // ============================================================================
 // CYCLE COUNT SESSIONS — AS9100 Physical Inventory Verification Workflow
 // ============================================================================

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -124,6 +124,7 @@ const safeFiles = [
   '0099_punch_ledger_pending_approval.sql',
   '0100_audit_ledger_privilege_hardening.sql',
   '0100_burden_rates_engine.sql',
+  '0101_burden_rate_accumulation.sql',
   '0101_audit_tamper_attempts_durable.sql',
   '0102_traveler_off_system_completion_link.sql',
   '0103_accounting_control_center.sql',

--- a/server/src/routes/burdenRates.ts
+++ b/server/src/routes/burdenRates.ts
@@ -5,7 +5,7 @@
  */
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { db } from '../../db';
 import {
   allocationBases,
@@ -19,14 +19,18 @@ import { authenticateToken } from '../../middleware/auth';
 import { requireAdminAccess } from '../../middleware/routeAuthorization';
 import {
   applyBurdenForPeriod,
+  getBurdenRateAccumulation,
+  getLatestBurdenRateAccumulation,
   getRunBreakdown,
   listApplicationRuns,
   listBases,
   listPools,
   listRatesForPool,
+  postAccumulationRates,
   previewRateChange,
   recomputeBurdenForApplied,
   resolveRateStack,
+  saveBurdenRateAccumulation,
   verifyPeriodBurdenComplete,
 } from '../services/burdenRatesService';
 
@@ -37,6 +41,26 @@ router.use(requireAdminAccess);
 const periodSchema = z.object({
   year: z.number().int().min(2000).max(2100),
   month: z.number().int().min(1).max(12),
+});
+
+const accumulationSchema = z.object({
+  calculationYear: z.number().int().min(2000).max(2100),
+  lookbackStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  lookbackEnd: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  rateType: z.enum(['PROVISIONAL', 'BILLING', 'FINAL']),
+  effectiveFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  notes: z.string().optional().nullable(),
+  expenseLines: z.array(z.object({
+    poolId: z.number().int(),
+    lineItem: z.string().min(1),
+    monthlyAmounts: z.record(z.coerce.number()),
+    notes: z.string().optional().nullable(),
+  })).min(1),
+  bases: z.array(z.object({
+    poolId: z.number().int(),
+    baseAmount: z.coerce.number().nonnegative(),
+    baseSource: z.string().optional().nullable(),
+  })).default([]),
 });
 
 // ── Allocation bases ────────────────────────────────────────────────────────
@@ -235,6 +259,53 @@ router.post('/preview', async (req, res) => {
 });
 
 // ── Application runs ────────────────────────────────────────────────────────
+router.get('/accumulations/latest', async (req, res) => {
+  const year = req.query.year ? Number(req.query.year) : undefined;
+  try {
+    res.json(await getLatestBurdenRateAccumulation(Number.isFinite(year) ? year : undefined));
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.get('/accumulations/:id', async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) return res.status(400).json({ error: 'Invalid id' });
+  try {
+    const payload = await getBurdenRateAccumulation(id);
+    if (!payload) return res.status(404).json({ error: 'Accumulation not found' });
+    res.json(payload);
+  } catch (e: any) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.post('/accumulations', async (req, res) => {
+  const parsed = accumulationSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Invalid accumulation', details: parsed.error.format() });
+  const actor = (req.user as any)?.username || (req.user as any)?.email || 'admin';
+  try {
+    res.status(201).json(await saveBurdenRateAccumulation(parsed.data, actor));
+  } catch (e: any) {
+    if (e.code === 'NO_EXPENSE_LINES') return res.status(400).json({ error: e.message, code: e.code });
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.post('/accumulations/:id/post-rates', async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) return res.status(400).json({ error: 'Invalid id' });
+  const actor = (req.user as any)?.username || (req.user as any)?.email || 'admin';
+  try {
+    res.json(await postAccumulationRates(id, actor));
+  } catch (e: any) {
+    if (['NOT_FOUND', 'ALREADY_POSTED', 'NO_POSTABLE_RATES', 'RATE_EXISTS'].includes(e.code)) {
+      return res.status(e.code === 'NOT_FOUND' ? 404 : 409).json({ error: e.message, code: e.code });
+    }
+    res.status(500).json({ error: e.message });
+  }
+});
+
 router.get('/runs', async (req, res) => {
   const limit = Math.min(Number(req.query.limit ?? 50) || 50, 200);
   try {

--- a/server/src/services/burdenRatesService.ts
+++ b/server/src/services/burdenRatesService.ts
@@ -18,6 +18,9 @@ import { db } from '../../db';
 import {
   appliedBurdenAmounts,
   burdenApplicationRuns,
+  burdenRateAccumulationBases,
+  burdenRateAccumulationExpenseLines,
+  burdenRateAccumulations,
   indirectCostPools,
   indirectRates,
   laborCostRecords,
@@ -28,6 +31,39 @@ import { and, asc, desc, eq, inArray, lte, sql } from 'drizzle-orm';
 
 export type RateType = 'PROVISIONAL' | 'BILLING' | 'FINAL';
 export type RunType = 'INITIAL' | 'TRUE_UP';
+
+export interface AccumulationExpenseLineInput {
+  poolId: number;
+  lineItem: string;
+  monthlyAmounts: Record<string, number>;
+  notes?: string | null;
+}
+
+export interface AccumulationBaseInput {
+  poolId: number;
+  baseAmount: number;
+  baseSource?: string | null;
+}
+
+export interface BurdenRateAccumulationInput {
+  calculationYear: number;
+  lookbackStart: string;
+  lookbackEnd: string;
+  rateType: RateType;
+  effectiveFrom: string;
+  notes?: string | null;
+  expenseLines: AccumulationExpenseLineInput[];
+  bases: AccumulationBaseInput[];
+}
+
+export interface AccumulationPoolSummary {
+  poolId: number;
+  poolCode: string;
+  poolName: string;
+  expenseTotal: number;
+  baseAmount: number;
+  calculatedRate: number;
+}
 
 export interface ResolvedPoolRate {
   pool: IndirectCostPool;
@@ -132,6 +168,209 @@ function periodBounds(year: number, month: number): { start: Date; end: Date } {
     start: new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0)),
     end: new Date(Date.UTC(year, month, 0, 23, 59, 59, 999)),
   };
+}
+
+function round6(n: number): number {
+  return Math.round((n + Number.EPSILON) * 1000000) / 1000000;
+}
+
+function sumMonthlyAmounts(monthlyAmounts: Record<string, number> | null | undefined): number {
+  return Object.values(monthlyAmounts ?? {}).reduce((sum, value) => {
+    const n = Number(value);
+    return Number.isFinite(n) ? sum + n : sum;
+  }, 0);
+}
+
+function summarizeAccumulation(
+  pools: Array<{ id: number; code: string; name: string }>,
+  expenseLines: Array<{ poolId: number; monthlyAmounts: Record<string, number> }>,
+  bases: Array<{ poolId: number; baseAmount: string | number }>,
+): AccumulationPoolSummary[] {
+  const expensesByPool = new Map<number, number>();
+  for (const line of expenseLines) {
+    expensesByPool.set(line.poolId, (expensesByPool.get(line.poolId) ?? 0) + sumMonthlyAmounts(line.monthlyAmounts));
+  }
+
+  const baseByPool = new Map<number, number>();
+  for (const base of bases) {
+    baseByPool.set(base.poolId, Number(base.baseAmount) || 0);
+  }
+
+  return pools.map((pool) => {
+    const expenseTotal = round4(expensesByPool.get(pool.id) ?? 0);
+    const baseAmount = round4(baseByPool.get(pool.id) ?? 0);
+    return {
+      poolId: pool.id,
+      poolCode: pool.code,
+      poolName: pool.name,
+      expenseTotal,
+      baseAmount,
+      calculatedRate: baseAmount > 0 ? round6(expenseTotal / baseAmount) : 0,
+    };
+  });
+}
+
+export async function getBurdenRateAccumulation(accumulationId: number) {
+  const [accumulation] = await db
+    .select()
+    .from(burdenRateAccumulations)
+    .where(eq(burdenRateAccumulations.id, accumulationId))
+    .limit(1);
+
+  if (!accumulation) return null;
+
+  const [pools, expenseLines, bases] = await Promise.all([
+    db.select().from(indirectCostPools).orderBy(asc(indirectCostPools.applyOrder)),
+    db
+      .select()
+      .from(burdenRateAccumulationExpenseLines)
+      .where(eq(burdenRateAccumulationExpenseLines.accumulationId, accumulationId)),
+    db
+      .select()
+      .from(burdenRateAccumulationBases)
+      .where(eq(burdenRateAccumulationBases.accumulationId, accumulationId)),
+  ]);
+
+  return {
+    accumulation,
+    expenseLines,
+    bases,
+    summary: summarizeAccumulation(pools, expenseLines, bases),
+  };
+}
+
+export async function getLatestBurdenRateAccumulation(calculationYear?: number) {
+  const rows = calculationYear
+    ? await db
+      .select()
+      .from(burdenRateAccumulations)
+      .where(eq(burdenRateAccumulations.calculationYear, calculationYear))
+      .orderBy(desc(burdenRateAccumulations.createdAt), desc(burdenRateAccumulations.id))
+      .limit(1)
+    : await db
+      .select()
+      .from(burdenRateAccumulations)
+      .orderBy(desc(burdenRateAccumulations.createdAt), desc(burdenRateAccumulations.id))
+      .limit(1);
+
+  if (!rows[0]) return null;
+  return getBurdenRateAccumulation(rows[0].id);
+}
+
+export async function saveBurdenRateAccumulation(input: BurdenRateAccumulationInput, createdBy: string) {
+  const expenseLines = input.expenseLines
+    .map((line) => ({
+      ...line,
+      lineItem: line.lineItem.trim(),
+      monthlyAmounts: Object.fromEntries(
+        Object.entries(line.monthlyAmounts ?? {}).map(([month, value]) => [month, Number(value) || 0]),
+      ),
+    }))
+    .filter((line) => line.lineItem.length > 0);
+
+  const bases = input.bases.map((base) => ({
+    poolId: base.poolId,
+    baseAmount: (Number(base.baseAmount) || 0).toFixed(4),
+    baseSource: base.baseSource?.trim() || null,
+  }));
+
+  if (expenseLines.length === 0) {
+    throw Object.assign(new Error('At least one QuickBooks expense line is required.'), { code: 'NO_EXPENSE_LINES' });
+  }
+
+  const [row] = await db.transaction(async (tx) => {
+    const [created] = await tx
+      .insert(burdenRateAccumulations)
+      .values({
+        calculationYear: input.calculationYear,
+        lookbackStart: input.lookbackStart,
+        lookbackEnd: input.lookbackEnd,
+        rateType: input.rateType,
+        effectiveFrom: input.effectiveFrom,
+        notes: input.notes?.trim() || null,
+        createdBy,
+      })
+      .returning();
+
+    await tx.insert(burdenRateAccumulationExpenseLines).values(
+      expenseLines.map((line) => ({
+        accumulationId: created.id,
+        poolId: line.poolId,
+        lineItem: line.lineItem,
+        monthlyAmounts: line.monthlyAmounts,
+        notes: line.notes?.trim() || null,
+      })),
+    );
+
+    if (bases.length > 0) {
+      await tx.insert(burdenRateAccumulationBases).values(
+        bases.map((base) => ({
+          accumulationId: created.id,
+          poolId: base.poolId,
+          baseAmount: base.baseAmount,
+          baseSource: base.baseSource,
+        })),
+      );
+    }
+
+    return [created];
+  });
+
+  return getBurdenRateAccumulation(row.id);
+}
+
+export async function postAccumulationRates(accumulationId: number, actor: string) {
+  const payload = await getBurdenRateAccumulation(accumulationId);
+  if (!payload) throw Object.assign(new Error('Burden rate accumulation not found.'), { code: 'NOT_FOUND' });
+  if (payload.accumulation.status === 'POSTED') {
+    throw Object.assign(new Error('This accumulation has already been posted to rates.'), { code: 'ALREADY_POSTED' });
+  }
+
+  const validSummaries = payload.summary.filter((row) => row.baseAmount > 0 && row.expenseTotal > 0);
+  if (validSummaries.length === 0) {
+    throw Object.assign(new Error('No pool has both expense dollars and a base amount, so no rates can be posted.'), { code: 'NO_POSTABLE_RATES' });
+  }
+
+  try {
+    const inserted = await db.transaction(async (tx) => {
+      const rateRows = [];
+      for (const summary of validSummaries) {
+        const [rate] = await tx
+          .insert(indirectRates)
+          .values({
+            poolId: summary.poolId,
+            rateType: payload.accumulation.rateType,
+            rate: summary.calculatedRate.toFixed(6),
+            effectiveFrom: payload.accumulation.effectiveFrom,
+            notes: `Calculated from accumulation #${payload.accumulation.id}: ${payload.accumulation.lookbackStart} through ${payload.accumulation.lookbackEnd}`,
+            createdBy: actor,
+          })
+          .returning();
+        rateRows.push(rate);
+      }
+
+      await tx
+        .update(burdenRateAccumulations)
+        .set({ status: 'POSTED', postedAt: new Date() })
+        .where(eq(burdenRateAccumulations.id, accumulationId));
+
+      return rateRows;
+    });
+
+    return {
+      accumulationId,
+      insertedRates: inserted,
+      summary: validSummaries,
+    };
+  } catch (e: any) {
+    if (e.code === '23505') {
+      throw Object.assign(
+        new Error('A rate already exists for one of these pools on the selected effective date and rate type. Use a different effective date or rate type.'),
+        { code: 'RATE_EXISTS' },
+      );
+    }
+    throw e;
+  }
 }
 
 export interface ApplyBurdenResult {


### PR DESCRIPTION
## Summary

Adds the first-pass burden rate accumulation workflow for manually entering QuickBooks actuals and calculating provisional/final/billing burden rates.

## What changed

- Added a new Burden Rates Admin `Accumulation` tab for 12-month QuickBooks line-item entry by indirect pool.
- Added manual allocation base entry per pool so the system can calculate `expense pool / allocation base` rates.
- Added persistence tables for accumulation headers, expense lines, and base inputs.
- Added API/service endpoints to save accumulation calculations and post calculated rates into existing insert-only `indirect_rates` history.
- Registered the new migration in the safe boot migration list.

## Why

The existing burden engine could apply manually entered rates but did not preserve the support for where those rates came from. This adds a reviewable calculation layer for 2026 provisional rate setup using the last 12 months of QuickBooks actuals.

## Validation

- `git diff --check` passed.
- Full TypeScript check could not complete in this local checkout because dependencies are not installed; a temporary TypeScript run stopped on missing `@types/node` and `vite/client` type definitions before checking the app code.