### PR TITLE
[codex] Add timeclock training help guides

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -318,6 +318,10 @@ const P2PipelineBoardPage = React.lazy(() => import('./pages/P2PipelineBoardPage
 const PMControlCenterPage = React.lazy(() => import('./pages/PMControlCenterPage'));
 const HelpCenter = React.lazy(() => import('./pages/HelpCenter'));
 const P2OrderGuide = React.lazy(() => import('./pages/P2OrderGuide'));
+const TimeclockTrainingProgramGuide = React.lazy(() => import('./pages/TimeclockTrainingProgramGuide'));
+const PTORequestGuide = React.lazy(() => import('./pages/PTORequestGuide'));
+const PunchEditRequestGuide = React.lazy(() => import('./pages/PunchEditRequestGuide'));
+const TimesheetReviewGuide = React.lazy(() => import('./pages/TimesheetReviewGuide'));
 const TravelerManagement = React.lazy(() => import('./pages/TravelerManagement'));
 const TravelerExecution = React.lazy(() => import('./pages/TravelerExecution'));
 const MaterialReceivingPage = React.lazy(() => import('./pages/MaterialReceivingPage'));
@@ -1111,6 +1115,10 @@ function App() {
                   <Route path="/refund-request" component={RefundRequest} />
                   <Route path="/help" component={HelpCenter} />
                   <Route path="/help/p2-order-guide" component={P2OrderGuide} />
+                  <Route path="/help/timeclock-training-program" component={TimeclockTrainingProgramGuide} />
+                  <Route path="/help/pto-request-guide" component={PTORequestGuide} />
+                  <Route path="/help/punch-edit-request-guide" component={PunchEditRequestGuide} />
+                  <Route path="/help/timesheet-review-guide" component={TimesheetReviewGuide} />
                   <Route path="/refund-queue" component={RefundQueue} />
                   <Route path="/rma-form" component={RMAFormPage} />
 

--- a/client/src/pages/HelpCenter.tsx
+++ b/client/src/pages/HelpCenter.tsx
@@ -17,6 +17,10 @@ import {
   BookOpen,
   FileText,
   ArrowRight,
+  CalendarCheck,
+  ClipboardCheck,
+  FilePenLine,
+  ShieldCheck,
 } from 'lucide-react';
 import { Link } from 'wouter';
 
@@ -149,13 +153,78 @@ const faqData: FAQItem[] = [
     answer: 'Refunds can only be issued for money that has been received. The system limits refund requests to the actual amount paid on the order to prevent over-refunding.',
     category: 'General',
   },
+
+  // Timekeeping
+  {
+    id: 'tk-1',
+    question: 'Where do I submit a PTO request?',
+    answer: 'Open Employee Portal and select the Time Off tab. Choose the request type, dates, optional note, and click Submit PTO Request. You can track the status in My Time-Off Requests.',
+    category: 'Timekeeping',
+  },
+  {
+    id: 'tk-2',
+    question: 'How do I request a punch correction?',
+    answer: 'Open Employee Portal and select the Time Clock tab. Use Request Punch Correction to select an existing punch or add a missing punch, enter the corrected time details, write a clear reason, and submit the request for review.',
+    category: 'Timekeeping',
+  },
+  {
+    id: 'tk-3',
+    question: 'Where do I review and certify my timesheet?',
+    answer: 'Open Employee Portal and select the Timesheets tab. Review the pay period, complete daily sign-offs, prepare the period for certification when needed, and certify any items listed under Needs Certification.',
+    category: 'Timekeeping',
+  },
+  {
+    id: 'tk-4',
+    question: 'Why does EPOCH ask me to certify time records?',
+    answer: 'Employee certification helps confirm that recorded labor is complete, accurate, and represents work actually performed. These acknowledgments support DCAA-ready timekeeping controls and audit evidence.',
+    category: 'Timekeeping',
+  },
 ];
 
 const categories = [
   { name: 'Order Entry', icon: ShoppingCart, color: 'bg-blue-100 text-blue-800' },
   { name: 'Production Queue', icon: Factory, color: 'bg-green-100 text-green-800' },
   { name: 'Bill of Materials', icon: Layers, color: 'bg-purple-100 text-purple-800' },
+  { name: 'Timekeeping', icon: ClipboardCheck, color: 'bg-amber-100 text-amber-800' },
   { name: 'General', icon: HelpCircle, color: 'bg-gray-100 text-gray-800' },
+];
+
+const guideCards = [
+  {
+    href: '/help/timeclock-training-program',
+    title: 'Timeclock Training and Certification Program',
+    description: 'Starter program outline for employee timeclock training and certification',
+    icon: ShieldCheck,
+    color: 'bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400',
+  },
+  {
+    href: '/help/pto-request-guide',
+    title: 'How to Submit a PTO Request',
+    description: 'Request full-day, half-day, hourly, or multi-day PTO from Employee Portal',
+    icon: CalendarCheck,
+    color: 'bg-green-100 dark:bg-green-900 text-green-600 dark:text-green-400',
+  },
+  {
+    href: '/help/punch-edit-request-guide',
+    title: 'How to Request a Punch Edit',
+    description: 'Submit missed or incorrect punch changes for supervisor review',
+    icon: FilePenLine,
+    color: 'bg-amber-100 dark:bg-amber-900 text-amber-600 dark:text-amber-400',
+  },
+  {
+    href: '/help/timesheet-review-guide',
+    title: 'How to View and Certify Timesheets',
+    description: 'Review daily sign-offs, certify pay periods, and view timesheet history',
+    icon: ClipboardCheck,
+    color: 'bg-purple-100 dark:bg-purple-900 text-purple-600 dark:text-purple-400',
+  },
+  {
+    href: '/help/p2-order-guide',
+    title: 'How to Create a New P2 Order',
+    description: 'Complete walkthrough of the P2 order creation process',
+    icon: FileText,
+    color: 'bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400',
+  },
 ];
 
 export default function HelpCenter() {
@@ -283,21 +352,26 @@ export default function HelpCenter() {
             Step-by-Step Guides
           </CardTitle>
         </CardHeader>
-        <CardContent>
-          <Link href="/help/p2-order-guide">
-            <div className="flex items-center justify-between p-3 rounded-md border hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors">
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-blue-100 dark:bg-blue-900 rounded-lg">
-                  <FileText className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        <CardContent className="space-y-3">
+          {guideCards.map((guide) => {
+            const Icon = guide.icon;
+            return (
+              <Link key={guide.href} href={guide.href}>
+                <div className="flex items-center justify-between p-3 rounded-md border hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors">
+                  <div className="flex items-center gap-3">
+                    <div className={`p-2 rounded-lg ${guide.color}`}>
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <div>
+                      <h3 className="font-medium">{guide.title}</h3>
+                      <p className="text-sm text-muted-foreground">{guide.description}</p>
+                    </div>
+                  </div>
+                  <ArrowRight className="h-4 w-4 text-muted-foreground" />
                 </div>
-                <div>
-                  <h3 className="font-medium">How to Create a New P2 Order</h3>
-                  <p className="text-sm text-muted-foreground">Complete walkthrough of the P2 order creation process</p>
-                </div>
-              </div>
-              <ArrowRight className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </Link>
+              </Link>
+            );
+          })}
         </CardContent>
       </Card>
 

--- a/client/src/pages/PTORequestGuide.tsx
+++ b/client/src/pages/PTORequestGuide.tsx
@@ -1,0 +1,130 @@
+import { Link } from 'wouter';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  AlertTriangle,
+  CalendarCheck,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  Info,
+} from 'lucide-react';
+
+export default function PTORequestGuide() {
+  return (
+    <div className="container mx-auto p-6 max-w-4xl">
+      <div className="mb-8">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+          <Link href="/help">
+            <span className="hover:text-foreground cursor-pointer">Help Center</span>
+          </Link>
+          <ChevronRight className="h-3 w-3" />
+          <span>Submit a PTO Request</span>
+        </div>
+        <div className="flex items-center gap-3 mb-2">
+          <CalendarCheck className="h-8 w-8 text-blue-600" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            How to Submit a PTO Request
+          </h1>
+        </div>
+        <p className="text-gray-600 dark:text-gray-400">
+          Use the Employee Portal to request full-day, half-day, hourly, or multi-day time off.
+        </p>
+      </div>
+
+      <Card className="mb-6 border-blue-200 bg-blue-50/50 dark:bg-blue-950/20 dark:border-blue-800">
+        <CardContent className="p-4">
+          <div className="flex items-start gap-3">
+            <Info className="h-5 w-5 text-blue-600 mt-0.5 shrink-0" />
+            <p className="text-sm text-blue-800 dark:text-blue-300">
+              PTO requests are submitted from <strong>Employee Portal</strong> on the <strong>Time Off</strong> tab. After submission, the request appears in <strong>My Time-Off Requests</strong> with its current approval status.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 1: Open Time Off</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p>Go to <strong>Employee Portal</strong>, then select the <strong>Time Off</strong> tab.</p>
+            <p className="text-sm text-muted-foreground">The request form is labeled <strong>Request Time Off</strong>. The history panel is labeled <strong>My Time-Off Requests</strong>.</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 2: Choose the Request Type</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p>Select the request type that matches the time you need away.</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {['Full Day', 'Half Day', 'Hourly', 'Multi-Day'].map((type) => (
+                <div key={type} className="rounded-md border p-3">
+                  <Badge variant="outline">{type}</Badge>
+                </div>
+              ))}
+            </div>
+            <p className="text-sm text-muted-foreground">If you choose <strong>Hourly</strong>, enter the number of hours requested.</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 3: Enter Dates and Notes</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <ul className="space-y-2">
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>Choose the start date.</span></li>
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>Choose the end date if this is a multi-day request.</span></li>
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>Add an optional note for your supervisor, HR, or payroll.</span></li>
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 4: Submit and Track</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p>Click <strong>Submit PTO Request</strong>. The request moves into the PTO approval queue.</p>
+            <p>Watch <strong>My Time-Off Requests</strong> for the current status and any denial note if the request is rejected.</p>
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>Submit PTO as early as possible. Future company policy may define exact advance notice requirements.</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-xl flex items-center gap-2">
+            <Clock className="h-5 w-5 text-blue-600" />
+            Quick Reference
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p><strong>Where:</strong> Employee Portal &gt; Time Off</p>
+          <p><strong>Button:</strong> Submit PTO Request</p>
+          <p><strong>History:</strong> My Time-Off Requests</p>
+          <p><strong>Records:</strong> Approved PTO may be used in timesheet and payroll workflows.</p>
+        </CardContent>
+      </Card>
+
+      <div className="mt-8 flex gap-3">
+        <Link href="/help/timeclock-training-program">
+          <Button variant="outline">Training Program</Button>
+        </Link>
+        <Link href="/help">
+          <Button variant="ghost">Back to Help Center</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/PunchEditRequestGuide.tsx
+++ b/client/src/pages/PunchEditRequestGuide.tsx
@@ -1,0 +1,143 @@
+import { Link } from 'wouter';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  FilePenLine,
+  Info,
+  MousePointerClick,
+} from 'lucide-react';
+
+export default function PunchEditRequestGuide() {
+  return (
+    <div className="container mx-auto p-6 max-w-4xl">
+      <div className="mb-8">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+          <Link href="/help">
+            <span className="hover:text-foreground cursor-pointer">Help Center</span>
+          </Link>
+          <ChevronRight className="h-3 w-3" />
+          <span>Request a Punch Edit</span>
+        </div>
+        <div className="flex items-center gap-3 mb-2">
+          <FilePenLine className="h-8 w-8 text-blue-600" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            How to Request a Punch Edit
+          </h1>
+        </div>
+        <p className="text-gray-600 dark:text-gray-400">
+          Submit missed or incorrect punch changes for supervisor review.
+        </p>
+      </div>
+
+      <Card className="mb-6 border-blue-200 bg-blue-50/50 dark:bg-blue-950/20 dark:border-blue-800">
+        <CardContent className="p-4">
+          <div className="flex items-start gap-3">
+            <Info className="h-5 w-5 text-blue-600 mt-0.5 shrink-0" />
+            <p className="text-sm text-blue-800 dark:text-blue-300">
+              Punch correction requests are created in <strong>Employee Portal</strong> on the <strong>Time Clock</strong> tab. They do not silently change a record; the request and reason are preserved for review.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 1: Open the Time Clock Tab</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p>Go to <strong>Employee Portal</strong>, then select <strong>Time Clock</strong>. The correction form is below the clock-in and clock-out controls.</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 2: Choose Edit or Add</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="rounded-md border p-3">
+                <Badge className="mb-2 bg-blue-100 text-blue-800 hover:bg-blue-100">Edit</Badge>
+                <p className="text-sm">Tap a punch under <strong>Active Shift Punches</strong> when a recorded punch time or type is wrong.</p>
+              </div>
+              <div className="rounded-md border p-3">
+                <Badge className="mb-2 bg-amber-100 text-amber-800 hover:bg-amber-100">Add</Badge>
+                <p className="text-sm">Click <strong>Add</strong> when a punch is missing and needs to be created.</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 3: Enter the Correct Punch Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <ul className="space-y-2">
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>Select the correct punch type, such as Clock in, Clock out, Meal out, or Meal in.</span></li>
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>Enter the corrected date and time in the appropriate field.</span></li>
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>For an edited session, include the correct clock-in or clock-out value that applies.</span></li>
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 4: Write a Clear Reason</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p>The <strong>Reason</strong> field is required. Be specific enough that a supervisor can understand what happened.</p>
+            <div className="rounded-md border bg-muted/30 p-3 text-sm">
+              <p className="font-medium mb-1">Good examples</p>
+              <p>Forgot to clock out at 3:30 PM after finishing shift.</p>
+              <p>Selected break start instead of clock out by mistake.</p>
+            </div>
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>Punch edits are audit-relevant. Do not submit a correction unless the request is accurate to the best of your knowledge.</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 5: Submit the Request</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p>Click <strong>Submit Correction Request</strong>. A supervisor or authorized reviewer will review the request before the record is corrected.</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-xl flex items-center gap-2">
+            <MousePointerClick className="h-5 w-5 text-blue-600" />
+            Quick Reference
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p><strong>Where:</strong> Employee Portal &gt; Time Clock &gt; Request Punch Correction</p>
+          <p><strong>Edit an existing punch:</strong> Tap a punch under Active Shift Punches.</p>
+          <p><strong>Add a missing punch:</strong> Click Add.</p>
+          <p><strong>Required:</strong> Correct time details and a written reason.</p>
+        </CardContent>
+      </Card>
+
+      <div className="mt-8 flex gap-3">
+        <Link href="/help/timeclock-training-program">
+          <Button variant="outline">Training Program</Button>
+        </Link>
+        <Link href="/help">
+          <Button variant="ghost">Back to Help Center</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/TimeclockTrainingProgramGuide.tsx
+++ b/client/src/pages/TimeclockTrainingProgramGuide.tsx
@@ -1,0 +1,164 @@
+import { Link } from 'wouter';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  ArrowRight,
+  BookOpen,
+  CalendarCheck,
+  CheckCircle2,
+  ChevronRight,
+  ClipboardCheck,
+  FilePenLine,
+  Info,
+  ShieldCheck,
+} from 'lucide-react';
+
+const modules = [
+  {
+    title: 'Use the Time Clock',
+    description: 'Clock in, select the correct charge code when required, start and end breaks, and certify the day at clock-out.',
+  },
+  {
+    title: 'Submit PTO Requests',
+    description: 'Request full-day, half-day, hourly, or multi-day PTO and track the request through approval.',
+  },
+  {
+    title: 'Request Punch Corrections',
+    description: 'Ask for a missed or incorrect punch to be corrected with a clear reason for supervisor review.',
+  },
+  {
+    title: 'Review Timesheets',
+    description: 'Review the running pay-period view, complete daily sign-offs, and certify pay-period timesheets.',
+  },
+];
+
+export default function TimeclockTrainingProgramGuide() {
+  return (
+    <div className="container mx-auto p-6 max-w-4xl">
+      <div className="mb-8">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+          <Link href="/help">
+            <span className="hover:text-foreground cursor-pointer">Help Center</span>
+          </Link>
+          <ChevronRight className="h-3 w-3" />
+          <span>Timeclock Training Program</span>
+        </div>
+        <div className="flex items-center gap-3 mb-2">
+          <ShieldCheck className="h-8 w-8 text-blue-600" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            Timeclock Training and Certification Program
+          </h1>
+        </div>
+        <p className="text-gray-600 dark:text-gray-400">
+          Starter structure for training employees on EPOCH timekeeping self-service.
+        </p>
+      </div>
+
+      <Card className="mb-6 border-blue-200 bg-blue-50/50 dark:bg-blue-950/20 dark:border-blue-800">
+        <CardContent className="p-4">
+          <div className="flex items-start gap-3">
+            <Info className="h-5 w-5 text-blue-600 mt-0.5 shrink-0" />
+            <div>
+              <p className="font-medium text-blue-900 dark:text-blue-200">Purpose</p>
+              <p className="text-sm text-blue-800 dark:text-blue-300 mt-1">
+                This program gives employees a consistent way to learn the timeclock system and gives the company a record that employees were trained before using DCAA-relevant labor records.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
+        <Card>
+          <CardContent className="p-4">
+            <Badge className="mb-3 bg-blue-100 text-blue-800 hover:bg-blue-100">Phase 1</Badge>
+            <h2 className="font-semibold text-gray-900">Learn</h2>
+            <p className="text-sm text-muted-foreground mt-1">Employee reads each guide and watches a supervisor or trainer demonstrate the workflow.</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <Badge className="mb-3 bg-amber-100 text-amber-800 hover:bg-amber-100">Phase 2</Badge>
+            <h2 className="font-semibold text-gray-900">Practice</h2>
+            <p className="text-sm text-muted-foreground mt-1">Employee walks through the self-service screens and asks questions before submitting live records.</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <Badge className="mb-3 bg-green-100 text-green-800 hover:bg-green-100">Phase 3</Badge>
+            <h2 className="font-semibold text-gray-900">Certify</h2>
+            <p className="text-sm text-muted-foreground mt-1">Employee acknowledges the required statements and the training completion is recorded.</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="text-xl flex items-center gap-2">
+            <ClipboardCheck className="h-5 w-5 text-blue-600" />
+            Training Modules
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {modules.map((module, index) => (
+            <div key={module.title} className="flex gap-3 rounded-md border p-3">
+              <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-600 text-sm font-bold text-white">
+                {index + 1}
+              </div>
+              <div>
+                <p className="font-medium text-gray-900">{module.title}</p>
+                <p className="text-sm text-muted-foreground mt-1">{module.description}</p>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="text-xl flex items-center gap-2">
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+            Starter Certification Statements
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-gray-700">
+          <p>
+            <strong>Training acknowledgment:</strong> I have been trained on the EPOCH timeclock self-service workflows assigned to me and understand that my time records must be complete, accurate, and submitted promptly.
+          </p>
+          <p>
+            <strong>Daily time certification:</strong> I certify that today's recorded time is complete, accurate, and represents work I actually performed.
+          </p>
+          <p>
+            <strong>Correction acknowledgment:</strong> I understand that punch corrections require a written reason and may require supervisor review before the labor record is updated.
+          </p>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
+        <Link href="/help/pto-request-guide">
+          <Button variant="outline" className="w-full justify-between h-auto py-3">
+            <span className="flex items-center gap-2"><CalendarCheck className="h-4 w-4" /> PTO Requests</span>
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </Link>
+        <Link href="/help/punch-edit-request-guide">
+          <Button variant="outline" className="w-full justify-between h-auto py-3">
+            <span className="flex items-center gap-2"><FilePenLine className="h-4 w-4" /> Punch Corrections</span>
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </Link>
+        <Link href="/help/timesheet-review-guide">
+          <Button variant="outline" className="w-full justify-between h-auto py-3">
+            <span className="flex items-center gap-2"><BookOpen className="h-4 w-4" /> Timesheets</span>
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </Link>
+      </div>
+
+      <Link href="/help">
+        <Button variant="ghost">Back to Help Center</Button>
+      </Link>
+    </div>
+  );
+}

--- a/client/src/pages/TimesheetReviewGuide.tsx
+++ b/client/src/pages/TimesheetReviewGuide.tsx
@@ -1,0 +1,147 @@
+import { Link } from 'wouter';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  AlertTriangle,
+  CalendarDays,
+  CheckCircle2,
+  ChevronRight,
+  ClipboardCheck,
+  FileCheck,
+  Info,
+  ShieldCheck,
+} from 'lucide-react';
+
+export default function TimesheetReviewGuide() {
+  return (
+    <div className="container mx-auto p-6 max-w-4xl">
+      <div className="mb-8">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+          <Link href="/help">
+            <span className="hover:text-foreground cursor-pointer">Help Center</span>
+          </Link>
+          <ChevronRight className="h-3 w-3" />
+          <span>View and Certify Timesheets</span>
+        </div>
+        <div className="flex items-center gap-3 mb-2">
+          <FileCheck className="h-8 w-8 text-blue-600" />
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            How to View and Certify Timesheets
+          </h1>
+        </div>
+        <p className="text-gray-600 dark:text-gray-400">
+          Review recorded time, complete daily sign-offs, and certify pay-period timesheets.
+        </p>
+      </div>
+
+      <Card className="mb-6 border-blue-200 bg-blue-50/50 dark:bg-blue-950/20 dark:border-blue-800">
+        <CardContent className="p-4">
+          <div className="flex items-start gap-3">
+            <Info className="h-5 w-5 text-blue-600 mt-0.5 shrink-0" />
+            <p className="text-sm text-blue-800 dark:text-blue-300">
+              Timesheets are reviewed in <strong>Employee Portal</strong> on the <strong>Timesheets</strong> tab. Hourly employees see a running pay-period view, daily sign-off, needs-certification items, and history. Salaried employees review their weekly salaried timesheet and certify it after review.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 1: Open Timesheets</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p>Go to <strong>Employee Portal</strong>, then select the <strong>Timesheets</strong> tab.</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl flex items-center gap-2">
+              <CalendarDays className="h-5 w-5 text-blue-600" />
+              Step 2: Review the Pay Period
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p>Use <strong>Previous</strong>, <strong>Current</strong>, and <strong>Next</strong> to move between pay periods.</p>
+            <p>Review the daily rows for clock-in, clock-out, break, charge code, traveler, regular hours, overtime, and total hours.</p>
+            <div className="grid grid-cols-3 gap-2 text-center text-sm">
+              <div className="rounded-md border p-3"><strong>Total</strong><br /><span className="text-muted-foreground">All hours</span></div>
+              <div className="rounded-md border p-3"><strong>Regular</strong><br /><span className="text-muted-foreground">Regular time</span></div>
+              <div className="rounded-md border p-3"><strong>OT</strong><br /><span className="text-muted-foreground">Overtime</span></div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-green-600" />
+              Step 3: Complete Daily Sign-Off
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p>Select the date, review that day's activity, then click <strong>Sign Off for This Day</strong> when the record is complete and accurate.</p>
+            <div className="rounded-md border bg-muted/30 p-3 text-sm italic">
+              "I certify that today's recorded time is complete, accurate, and represents work I actually performed."
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 4: Prepare and Certify the Pay Period</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <ul className="space-y-2">
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>If the period does not yet have a saved timesheet, click <strong>Prepare for Certification</strong>.</span></li>
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>Open items listed under <strong>Needs Certification</strong>.</span></li>
+              <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 text-green-600 mt-1 shrink-0" /><span>Review the certification statement and submit only when the time is complete and accurate.</span></li>
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Step 5: Use History for Prior Timesheets</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p>Use <strong>History</strong> to view prior timesheets and confirm what has already been submitted or certified.</p>
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>If a certified or locked timesheet is wrong, follow the punch correction process or contact your supervisor. Do not ignore an incorrect labor record.</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-xl flex items-center gap-2">
+            <ClipboardCheck className="h-5 w-5 text-blue-600" />
+            Quick Reference
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p><strong>Where:</strong> Employee Portal &gt; Timesheets</p>
+          <p><strong>Daily action:</strong> Sign Off for This Day</p>
+          <p><strong>Pay-period action:</strong> Prepare for Certification, then certify any Needs Certification item</p>
+          <p><strong>Past records:</strong> History</p>
+          <p><strong>Status signal:</strong> The Timesheets tab may show a count when items need certification.</p>
+        </CardContent>
+      </Card>
+
+      <div className="mt-8 flex gap-3">
+        <Link href="/help/timeclock-training-program">
+          <Button variant="outline">Training Program</Button>
+        </Link>
+        <Link href="/help">
+          <Button variant="ghost">Back to Help Center</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed

- Added a starter Timeclock Training and Certification Program guide.
- Added employee self-service guides for PTO requests, punch correction requests, and timesheet review/certification.
- Updated the Help Center with Timekeeping FAQs and guide cards.
- Wired the new Help routes into the app router.

## Why

This starts the employee training/certification program for EPOCH timeclock usage, with step-by-step guidance that can later be expanded into a more formal DCAA-ready training system.

## Validation

- Refreshed from latest `origin/main` before committing. Latest base used locally: `0a00da182`.
- `git diff --check` passed.
- Focused `esbuild` syntax/bundling checks passed for the new guide pages and the edited route file.
- Full `npm run check` was not available in this workspace because PowerShell blocks `npm.ps1`; the fallback TypeScript invocation also hits existing repo dependency/config issues: missing `@types/node`, missing `vite/client`, and the TypeScript 6 `baseUrl` deprecation warning.