### PR TITLE
[codex] Show shipping options on queue cards

### DIFF
--- a/client/src/pages/ShippingQueuePage.tsx
+++ b/client/src/pages/ShippingQueuePage.tsx
@@ -1301,6 +1301,18 @@ export default function ShippingQueuePage() {
     return null;
   }
 
+  function getShippingOptionsText(order: any) {
+    const options = [
+      order.shippingMethod && order.shippingMethod !== 'Ground'
+        ? String(order.shippingMethod)
+        : null,
+      getSpecialShippingText(order),
+    ].filter(Boolean);
+
+    if (options.length === 0) return null;
+    return options.join(' • ');
+  }
+
   // Function to get other in-progress orders for the same customer
   function getCustomerOtherOrders(customerId: string | null, currentOrderId: string) {
     if (!customerId) return [];
@@ -1352,6 +1364,7 @@ export default function ShippingQueuePage() {
     const customerInfo = getOrderShippingCustomerInfo(order);
     const customerAddress = getOrderShippingAddress(order);
     const specialShippingText = getSpecialShippingText(order);
+    const shippingOptionsText = getShippingOptionsText(order);
     const otherOrders = getCustomerOtherOrders(order.customerId, order.orderId);
 
     return (
@@ -1363,7 +1376,7 @@ export default function ShippingQueuePage() {
             ? 'border-yellow-400 bg-yellow-50 dark:border-yellow-600 dark:bg-yellow-900/20 ring-2 ring-yellow-300 shadow-lg'
             : isSelected
               ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 shadow-md'
-              : specialShippingText
+              : shippingOptionsText
                 ? 'border-yellow-400 bg-yellow-50 hover:border-yellow-500 hover:bg-yellow-100 dark:bg-yellow-900/20 dark:border-yellow-600'
                 : 'border-gray-200 hover:border-gray-300'
         }`}
@@ -1412,9 +1425,9 @@ export default function ShippingQueuePage() {
                   NOT PAID
                 </Badge>
               )}
-              {specialShippingText && (
-                <Badge className="bg-yellow-500 hover:bg-yellow-600 text-white text-xs">
-                  {specialShippingText}
+              {shippingOptionsText && (
+                <Badge className="bg-red-600 hover:bg-red-700 text-white text-xs font-bold uppercase tracking-wide">
+                  {shippingOptionsText}
                 </Badge>
               )}
               {materialType && (
@@ -1424,6 +1437,12 @@ export default function ShippingQueuePage() {
               )}
             </div>
           </div>
+
+          {shippingOptionsText && (
+            <div className="mb-3 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm font-bold uppercase tracking-wide text-red-700">
+              Shipping Option: {shippingOptionsText}
+            </div>
+          )}
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {/* Order Info */}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5882,6 +5882,7 @@ export class DatabaseStorage implements IStorage {
         status: allOrders.status,
         modelId: allOrders.modelId,
         shipping: allOrders.shipping,
+        shippingMethod: allOrders.shippingMethod,
         paymentAmount: allOrders.paymentAmount,
         isPaid: allOrders.isPaid,
         isVerified: allOrders.isVerified,


### PR DESCRIPTION
## Summary

Shows order-entry shipping options directly on Shipping Queue order cards in a noticeable red treatment.

## What changed

- Includes `shippingMethod` in the Shipping queue API payload.
- Combines non-default shipping method with special shipping flags like International, Next Day Air, Bill to Receiver, and Alt Ship To.
- Displays the shipping option as a red badge and a red banner on each shipping order card.

## Why

Shipping staff need the order-entry shipping choices to stand out before creating labels or processing the order, especially expedited or special handling options.

## Validation

- `git diff --check` passed.