### PR TITLE
[codex] Add canceled traveler reactivation

### DIFF
--- a/client/src/pages/TravelerManagement.tsx
+++ b/client/src/pages/TravelerManagement.tsx
@@ -66,6 +66,7 @@ import {
   ExternalLink,
   StickyNote,
   Link2,
+  RotateCcw,
   X,
 } from 'lucide-react';
 import { Link } from 'wouter';
@@ -479,6 +480,29 @@ export default function TravelerManagement() {
     },
   });
 
+  const reactivateMutation = useMutation({
+    mutationFn: (id: string) =>
+      apiRequest(`/api/travelers/${id}/reactivate`, {
+        method: 'POST',
+        body: JSON.stringify({ reactivatedBy: 'system' }),
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    onSuccess: () => {
+      toast({
+        title: 'Traveler Reactivated',
+        description: 'Traveler is available for production workflow again',
+      });
+      queryClient.invalidateQueries({ queryKey: ['/api/travelers'] });
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Error',
+        description: error.message || 'Failed to reactivate traveler',
+        variant: 'destructive',
+      });
+    },
+  });
+
   const blockMutation = useMutation({
     mutationFn: (data: { id: string; reason: string }) =>
       apiRequest(`/api/travelers/${data.id}/block`, {
@@ -706,6 +730,12 @@ export default function TravelerManagement() {
 
   const handleUnblock = (id: string) => {
     unblockMutation.mutate(id);
+  };
+
+  const handleReactivate = (traveler: Traveler) => {
+    if (confirm(`Reactivate traveler ${traveler.travelerNumber}?`)) {
+      reactivateMutation.mutate(traveler.id);
+    }
   };
 
   const handleDelete = (id: string) => {
@@ -1008,6 +1038,12 @@ export default function TravelerManagement() {
                                 <DropdownMenuItem onClick={() => handleUnblock(traveler.id)}>
                                   <ShieldCheck className="h-4 w-4 mr-2" />
                                   Unblock Traveler
+                                </DropdownMenuItem>
+                              )}
+                              {traveler.status === 'CANCELED' && (
+                                <DropdownMenuItem onClick={() => handleReactivate(traveler)}>
+                                  <RotateCcw className="h-4 w-4 mr-2" />
+                                  Reactivate Traveler
                                 </DropdownMenuItem>
                               )}
                               {!isTerminal && (

--- a/server/src/routes/travelers.ts
+++ b/server/src/routes/travelers.ts
@@ -2052,6 +2052,49 @@ router.post('/:id/cancel', async (req: Request, res: Response) => {
   }
 });
 
+// Reactivate canceled traveler
+router.post('/:id/reactivate', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { reactivatedBy } = req.body;
+
+    const traveler = await storage.getTraveler(id);
+    if (!traveler) {
+      return res.status(404).json({ error: 'Traveler not found' });
+    }
+
+    if (traveler.status !== 'CANCELED') {
+      return res.status(400).json({
+        error: 'Only canceled travelers can be reactivated',
+        currentStatus: traveler.status,
+      });
+    }
+
+    const events = await storage.getTravelerEvents(id);
+    const cancellationEvent = events.find((event) => {
+      const details = event.details as any;
+      return details?.to === 'CANCELED' && typeof details?.from === 'string';
+    });
+    const previousStatus = (cancellationEvent?.details as any)?.from;
+    const allowedTargetStatuses = new Set(['DRAFT', 'IN_PROGRESS', 'BLOCKED']);
+    const nextStatus = allowedTargetStatuses.has(previousStatus) ? previousStatus : 'DRAFT';
+
+    const updatedTraveler = await storage.updateTraveler(id, { status: nextStatus });
+
+    await storage.createTravelerEvent({
+      travelerId: id,
+      actor: reactivatedBy || 'system',
+      action: 'STATUS_CHANGED',
+      details: { from: 'CANCELED', to: nextStatus, restoredFrom: previousStatus || null },
+    });
+
+    res.json(updatedTraveler);
+  } catch (error: any) {
+    console.error('Error reactivating traveler:', error);
+    res.status(500).json({ error: 'Failed to reactivate traveler', message: error.message });
+  }
+});
+
 // ============================================================================
 // STEP ENDPOINTS
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add a traveler management action to reactivate travelers with `CANCELED` status.
- Add `POST /api/travelers/:id/reactivate` to restore the prior active traveler status from the cancellation event when available, falling back to `DRAFT`.
- Record a traveler event for the reactivation status change.

## Impact
Canceled travelers can be put back into the production workflow from Traveler Management without deleting or recreating them.

## Validation
- `git diff --check`
- Bundled Node syntax check for `server/src/routes/travelers.ts`

Full repo TypeScript validation was not run because this checkout has no `node_modules` and `npm` is not available in the shell.