### PR TITLE
[codex] Add PM linked P2 production status

### DIFF
--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -26,7 +26,7 @@ import {
   ChevronUp, ChevronDown, ArrowUpDown, LayoutDashboard, XCircle, Filter,
   Plus,
 } from 'lucide-react';
-import { format, differenceInDays, differenceInBusinessDays, parseISO } from 'date-fns';
+import { format, differenceInBusinessDays, parseISO } from 'date-fns';
 import { apiRequest } from '@/lib/queryClient';
 
 async function safeFetch<T>(url: string): Promise<T> {
@@ -161,6 +161,66 @@ interface WorkOrderDetail {
     startedAt: string;
     elapsedMinutes: number;
   }[];
+}
+
+interface P2PoStatusSummary {
+  id: number;
+  poNumber: string;
+  customerName: string | null;
+  dueDate: string | null;
+  totalItems: number;
+  completedItems: number;
+  inProductionItems: number;
+  pendingItems: number;
+  rawStatus: string;
+  status: 'pending' | 'in_progress' | 'completed';
+}
+
+interface ProductionResponse {
+  rows: WorkOrderRow[];
+  linkedP2PoCount: number;
+  linkedP2PoStatuses: P2PoStatusSummary[];
+}
+
+interface P2SerializedBreakdownItem {
+  id: string;
+  poId: number;
+  poNumber: string | null;
+  poItemId: number | null;
+  serialNumber: string | null;
+  barcode: string | null;
+  travelerBarcode: string | null;
+  partNumber: string | null;
+  partName: string | null;
+  status: string;
+  currentDepartment: string | null;
+  currentStageIndex: number | null;
+  activeTravelerId: string | null;
+  activeTravelerNumber: string | null;
+  activeTravelerStatus: string | null;
+  activeTaskDepartment: string | null;
+  activeTaskStatus: string | null;
+  holdReason: string | null;
+  scrapReason: string | null;
+  completedAt: string | null;
+  updatedAt: string | null;
+}
+
+interface DailyThroughputBoardData {
+  businessDate: string;
+  date: string;
+  isToday: boolean;
+  targetSlots: number;
+  summary: {
+    target: number;
+    started: number;
+    green: number;
+    inProcess: number;
+    blocked: number;
+    cancelled: number;
+    notStarted: number;
+    overflowCount: number;
+  };
 }
 
 interface LaborSummary {
@@ -360,6 +420,17 @@ const WO_STATUS_COLORS: Record<string, string> = {
   CLOSED: 'bg-gray-200 text-gray-500',
   BLOCKED: 'bg-red-100 text-red-700',
 };
+
+const P2_PO_STATUS_COLORS: Record<P2PoStatusSummary['status'], string> = {
+  pending: 'bg-gray-100 text-gray-700',
+  in_progress: 'bg-blue-100 text-blue-700',
+  completed: 'bg-green-100 text-green-700',
+};
+
+function p2PoStatusLabel(status: P2PoStatusSummary['status']) {
+  if (status === 'in_progress') return 'In Progress';
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
 
 const CONNECTION_STATUS_COLORS: Record<string, string> = {
   CONNECTED: 'bg-green-100 text-green-700 border-green-200',
@@ -613,22 +684,34 @@ function completionState(row: WorkOrderRow): CompletionFilter {
 function ProductionTab({ projectId }: { projectId: string }) {
   const [, navTo] = useLocation();
   const [selectedWO, setSelectedWO] = useState<WorkOrderRow | null>(null);
+  const [selectedP2Po, setSelectedP2Po] = useState<P2PoStatusSummary | null>(null);
   const [showBlockersOnly, setShowBlockersOnly] = useState(false);
   const [completionFilter, setCompletionFilter] = useState<CompletionFilter>('all');
   const [qtySort, setQtySort] = useState<QtySort>(null);
 
-  const { data: productionResponse, isLoading, isError } = useQuery<{ rows: WorkOrderRow[]; linkedP2PoCount: number }>({
+  const { data: productionResponse, isLoading, isError } = useQuery<ProductionResponse>({
     queryKey: ['/api/pm-dashboard', projectId, 'production'],
-    queryFn: () => safeFetch<{ rows: WorkOrderRow[]; linkedP2PoCount: number }>(`/api/pm-dashboard/${projectId}/production`),
+    queryFn: () => safeFetch<ProductionResponse>(`/api/pm-dashboard/${projectId}/production`),
     enabled: !!projectId,
   });
   const rows = productionResponse?.rows ?? [];
   const linkedP2PoCount = productionResponse?.linkedP2PoCount ?? 0;
+  const linkedP2PoStatuses = productionResponse?.linkedP2PoStatuses ?? [];
 
   const { data: detail, isLoading: detailLoading } = useQuery<WorkOrderDetail>({
     queryKey: ['/api/pm-dashboard', projectId, 'production', selectedWO?.productionWorkOrderId],
     queryFn: () => safeFetch<WorkOrderDetail>(`/api/pm-dashboard/${projectId}/production/${selectedWO!.productionWorkOrderId}`),
     enabled: !!selectedWO && selectedWO.sourceType !== 'p2_production_order',
+  });
+
+  const {
+    data: serializedBreakdown,
+    isLoading: serializedBreakdownLoading,
+    isError: serializedBreakdownError,
+  } = useQuery<{ items: P2SerializedBreakdownItem[] }>({
+    queryKey: ['/api/pm-dashboard', projectId, 'production', 'p2-serialized'],
+    queryFn: () => safeFetch<{ items: P2SerializedBreakdownItem[] }>(`/api/pm-dashboard/${projectId}/production/p2-serialized`),
+    enabled: !!projectId && !!selectedP2Po,
   });
 
   if (isLoading) {
@@ -639,7 +722,7 @@ function ProductionTab({ projectId }: { projectId: string }) {
     return <QueryErrorBanner message="Failed to load production data." />;
   }
 
-  if (!rows.length) {
+  if (!rows.length && linkedP2PoStatuses.length === 0) {
     if (linkedP2PoCount === 0) {
       return (
         <Card className="p-10 text-center" data-testid="empty-no-p2-link">
@@ -688,9 +771,71 @@ function ProductionTab({ projectId }: { projectId: string }) {
 
   const chipBase = 'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border text-sm font-medium transition-colors';
   const chipOff = 'bg-background border-border text-muted-foreground hover:text-foreground hover:bg-accent';
+  const selectedSerializedItems = (serializedBreakdown?.items ?? [])
+    .filter(item => !selectedP2Po || item.poId === selectedP2Po.id);
+  const serializedByDepartment = selectedSerializedItems.reduce<Record<string, P2SerializedBreakdownItem[]>>((acc, item) => {
+    const dept = item.currentDepartment || item.activeTaskDepartment || 'Pending Layup';
+    if (!acc[dept]) acc[dept] = [];
+    acc[dept].push(item);
+    return acc;
+  }, {});
+  const serializedDepartments = Object.entries(serializedByDepartment)
+    .sort(([a], [b]) => a.localeCompare(b));
 
   return (
     <>
+      {linkedP2PoStatuses.length > 0 && (
+        <div className="grid gap-3 mb-4">
+          {linkedP2PoStatuses.map((po) => {
+            const pct = po.totalItems > 0 ? Math.round((po.completedItems / po.totalItems) * 100) : 0;
+            return (
+              <Card
+                key={po.id}
+                className="cursor-pointer hover:border-primary/50 transition-colors"
+                onClick={() => setSelectedP2Po(po)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setSelectedP2Po(po);
+                  }
+                }}
+              >
+                <CardContent className="p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-lg font-semibold">{po.poNumber}</span>
+                        <Badge className={P2_PO_STATUS_COLORS[po.status]}>
+                          {p2PoStatusLabel(po.status)}
+                        </Badge>
+                        <Badge variant="outline">P2 PO Status</Badge>
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {po.customerName || 'Unknown customer'} · Due {fmtDate(po.dueDate)}
+                      </div>
+                    </div>
+                    <div className="min-w-[260px] space-y-2">
+                      <div className="flex justify-between text-sm">
+                        <span>{po.completedItems} / {po.totalItems} completed</span>
+                        <span className="font-semibold">{pct}%</span>
+                      </div>
+                      <Progress value={pct} className="h-2" />
+                      <div className="grid grid-cols-3 gap-2 text-center text-xs text-muted-foreground">
+                        <div><span className="block font-semibold text-foreground">{po.inProductionItems}</span>In production</div>
+                        <div><span className="block font-semibold text-foreground">{po.pendingItems}</span>Pending</div>
+                        <div><span className="block font-semibold text-foreground">{po.rawStatus}</span>Raw status</div>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-2 mb-3">
         <button
@@ -758,7 +903,11 @@ function ProductionTab({ projectId }: { projectId: string }) {
       {displayRows.length === 0 && (
         <Card className="p-10 text-center">
           <CheckCircle className="mx-auto h-10 w-10 text-green-500 mb-3" />
-          <p className="text-muted-foreground">No work orders match the selected filters.</p>
+          <p className="text-muted-foreground">
+            {rows.length === 0
+              ? 'No WAD/project work orders found; use the linked P2 PO status above for serialized production.'
+              : 'No work orders match the selected filters.'}
+          </p>
         </Card>
       )}
 
@@ -936,6 +1085,89 @@ function ProductionTab({ projectId }: { projectId: string }) {
         </Table>
       </div>
       )}
+
+      <Sheet open={!!selectedP2Po} onOpenChange={(open) => !open && setSelectedP2Po(null)}>
+        <SheetContent className="w-[520px] sm:w-[720px] overflow-y-auto">
+          <SheetHeader className="mb-4">
+            <SheetTitle className="flex items-center gap-2">
+              <Package className="h-5 w-5" />
+              {selectedP2Po?.poNumber} serialized production
+              {selectedP2Po && (
+                <Badge className={P2_PO_STATUS_COLORS[selectedP2Po.status]}>
+                  {p2PoStatusLabel(selectedP2Po.status)}
+                </Badge>
+              )}
+            </SheetTitle>
+          </SheetHeader>
+
+          {serializedBreakdownLoading && (
+            <div className="space-y-3">
+              {[1, 2, 3].map(i => <Skeleton key={i} className="h-20 w-full" />)}
+            </div>
+          )}
+
+          {serializedBreakdownError && (
+            <QueryErrorBanner message="Failed to load serialized item breakdown." />
+          )}
+
+          {!serializedBreakdownLoading && !serializedBreakdownError && selectedSerializedItems.length === 0 && (
+            <div className="rounded-md border p-8 text-center text-sm text-muted-foreground">
+              No serialized items are currently tied to this PO.
+            </div>
+          )}
+
+          {!serializedBreakdownLoading && !serializedBreakdownError && serializedDepartments.length > 0 && (
+            <div className="space-y-4">
+              {serializedDepartments.map(([department, items]) => (
+                <div key={department} className="rounded-md border">
+                  <div className="flex items-center justify-between border-b bg-muted/40 px-3 py-2">
+                    <span className="text-sm font-semibold">{department}</span>
+                    <Badge variant="outline">{items.length} item{items.length === 1 ? '' : 's'}</Badge>
+                  </div>
+                  <div className="divide-y">
+                    {items.map((item) => (
+                      <div key={item.id} className="grid gap-2 p-3 text-sm sm:grid-cols-[1.2fr_1fr_1fr]">
+                        <div>
+                          <div className="font-mono font-semibold">
+                            {item.serialNumber || item.barcode || item.id}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {item.partNumber || 'No part'} {item.partName ? `- ${item.partName}` : ''}
+                          </div>
+                        </div>
+                        <div>
+                          <Badge className={WO_STATUS_COLORS[item.status] ?? 'bg-gray-100 text-gray-700'}>
+                            {item.status.replace('_', ' ')}
+                          </Badge>
+                          {(item.holdReason || item.scrapReason) && (
+                            <div className="mt-1 text-xs text-red-700">
+                              {item.holdReason || item.scrapReason}
+                            </div>
+                          )}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {item.activeTravelerNumber && item.activeTravelerId ? (
+                            <Link
+                              to={`/travelers/${item.activeTravelerId}`}
+                              className="font-mono text-blue-600 hover:underline"
+                            >
+                              {item.activeTravelerNumber}
+                            </Link>
+                          ) : (
+                            <span>No active traveler</span>
+                          )}
+                          <div>{item.activeTaskStatus || item.activeTravelerStatus || 'No active task'}</div>
+                          <div>Updated {fmtTime(item.updatedAt)}</div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
 
       <Sheet open={!!selectedWO} onOpenChange={(open) => !open && setSelectedWO(null)}>
         <SheetContent className="w-[420px] sm:w-[540px] overflow-y-auto">
@@ -1677,9 +1909,9 @@ export default function PMControlCenterPage() {
   });
 
   // Page-level production query — shares cache with ProductionTab, only used for blockers sheet + throughput
-  const { data: productionData, isError: productionError } = useQuery<{ rows: WorkOrderRow[]; linkedP2PoCount: number }>({
+  const { data: productionData, isError: productionError } = useQuery<ProductionResponse>({
     queryKey: ['/api/pm-dashboard', selectedProjectId, 'production'],
-    queryFn: () => safeFetch<{ rows: WorkOrderRow[]; linkedP2PoCount: number }>(`/api/pm-dashboard/${selectedProjectId}/production`),
+    queryFn: () => safeFetch<ProductionResponse>(`/api/pm-dashboard/${selectedProjectId}/production`),
     enabled: !!selectedProjectId,
   });
   const productionRows = productionData?.rows ?? [];
@@ -1694,6 +1926,26 @@ export default function PMControlCenterPage() {
   const blockedWorkOrders = productionRows.filter(r => r.status === 'BLOCKED');
 
   const selectedProject = projects.find(p => String(p.id) === selectedProjectId);
+  const linkedP2PoStatus = productionData?.linkedP2PoStatuses?.[0] ?? null;
+
+  const throughputParams = new URLSearchParams();
+  if (selectedProjectId) throughputParams.set('projectId', selectedProjectId);
+  if (linkedP2PoStatus?.id) throughputParams.set('poId', String(linkedP2PoStatus.id));
+  else if (selectedProject?.poId) throughputParams.set('poId', String(selectedProject.poId));
+
+  const {
+    data: liveThroughput,
+    isLoading: liveThroughputLoading,
+    isError: liveThroughputError,
+  } = useQuery<DailyThroughputBoardData>({
+    queryKey: ['/api/p2/daily-throughput-board', selectedProjectId, linkedP2PoStatus?.id ?? selectedProject?.poId ?? null],
+    queryFn: () => safeFetch<DailyThroughputBoardData>(
+      `/api/p2/daily-throughput-board${throughputParams.toString() ? `?${throughputParams.toString()}` : ''}`
+    ),
+    enabled: !!selectedProjectId,
+    refetchInterval: 45000,
+    staleTime: 30000,
+  });
 
   // Derive lifecycle stage label from project steps
   const lifecycleStageLabel = (() => {
@@ -1718,20 +1970,9 @@ export default function PMControlCenterPage() {
     return deriveStageLabel(selectedProject);
   })();
 
-  // Daily throughput calculation
-  const dailyThroughput = (() => {
-    if (!productionRows.length || !selectedProject?.targetShipDate) return null;
-    const totalRequired = productionRows.reduce((sum, r) => sum + (r.quantityRequired || 0), 0);
-    const totalCompleted = productionRows.reduce((sum, r) => sum + (r.quantityCompleted || 0), 0);
-    const completedToday = productionRows.reduce((sum, r) => sum + (r.quantityCompletedToday || 0), 0);
-    const totalRemaining = Math.max(0, totalRequired - totalCompleted);
-    const daysRemaining = Math.max(1, differenceInBusinessDays(parseISO(selectedProject.targetShipDate), new Date()));
-    // Daily target = total units still needed / business days remaining (Mon-Fri, excl. weekends)
-    const neededPerDay = Math.ceil(totalRemaining / daysRemaining);
-    // Pace: today's actual completions vs. daily target
-    const pacePercent = neededPerDay > 0 ? Math.round((completedToday / neededPerDay) * 100) : 100;
-    return { totalRequired, totalCompleted, completedToday, totalRemaining, daysRemaining, neededPerDay, pacePercent, percentComplete: totalRequired > 0 ? Math.round((totalCompleted / totalRequired) * 100) : 0 };
-  })();
+  const liveThroughputPace = liveThroughput
+    ? Math.round((liveThroughput.summary.green / Math.max(1, liveThroughput.summary.target)) * 100)
+    : 0;
 
   // Detect current user for "Only My Projects" toggle
   const { data: currentUser } = useQuery<{ id: number; name: string; username: string }>({
@@ -2027,7 +2268,7 @@ export default function PMControlCenterPage() {
           )}
 
           {/* Stage + Throughput Row */}
-          {summary && !productionError && (lifecycleStageLabel || dailyThroughput) && (
+          {summary && !productionError && (lifecycleStageLabel || liveThroughput || liveThroughputLoading || liveThroughputError) && (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {lifecycleStageLabel && (
                 <KpiCard
@@ -2042,26 +2283,42 @@ export default function PMControlCenterPage() {
                   }
                 />
               )}
-              {dailyThroughput && (
+              {(liveThroughput || liveThroughputLoading || liveThroughputError) && (
                 <Card>
                   <CardContent className="p-4">
                     <div className="flex items-center gap-2 mb-2">
                       <TrendingUp className="h-4 w-4 text-blue-600" />
-                      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Daily Throughput</span>
+                      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Live Daily Throughput</span>
                     </div>
-                    <div className="flex items-end justify-between mb-2">
-                      <div>
-                        <p className="text-lg font-bold">{dailyThroughput.completedToday}<span className="text-sm text-muted-foreground"> / {dailyThroughput.neededPerDay} today's target</span></p>
-                        <p className="text-xs text-muted-foreground">{dailyThroughput.totalCompleted}/{dailyThroughput.totalRequired} total · {dailyThroughput.daysRemaining}d left</p>
+                    {liveThroughputLoading ? (
+                      <div className="space-y-2">
+                        <Skeleton className="h-6 w-40" />
+                        <Skeleton className="h-2 w-full" />
                       </div>
-                      <span className={`text-sm font-semibold ${dailyThroughput.pacePercent >= 100 ? 'text-green-600' : dailyThroughput.pacePercent >= 75 ? 'text-blue-600' : 'text-orange-600'}`}>
-                        {dailyThroughput.pacePercent}% pace
-                      </span>
-                    </div>
-                    <Progress
-                      value={Math.min(100, dailyThroughput.pacePercent)}
-                      className={`h-2 ${dailyThroughput.pacePercent >= 100 ? '[&>div]:bg-green-500' : dailyThroughput.pacePercent >= 75 ? '[&>div]:bg-blue-500' : '[&>div]:bg-orange-500'}`}
-                    />
+                    ) : liveThroughputError || !liveThroughput ? (
+                      <p className="text-sm text-red-600">Live throughput data is unavailable.</p>
+                    ) : (
+                      <>
+                        <div className="flex items-end justify-between mb-2">
+                          <div>
+                            <p className="text-lg font-bold">
+                              {liveThroughput.summary.green}
+                              <span className="text-sm text-muted-foreground"> / {liveThroughput.summary.target} green target</span>
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {liveThroughput.summary.started} started · {liveThroughput.summary.inProcess} in process · {liveThroughput.summary.blocked} blocked · {liveThroughput.date}
+                            </p>
+                          </div>
+                          <span className={`text-sm font-semibold ${liveThroughputPace >= 100 ? 'text-green-600' : liveThroughputPace >= 75 ? 'text-blue-600' : 'text-orange-600'}`}>
+                            {liveThroughputPace}% live pace
+                          </span>
+                        </div>
+                        <Progress
+                          value={Math.min(100, liveThroughputPace)}
+                          className={`h-2 ${liveThroughputPace >= 100 ? '[&>div]:bg-green-500' : liveThroughputPace >= 75 ? '[&>div]:bg-blue-500' : '[&>div]:bg-orange-500'}`}
+                        />
+                      </>
+                    )}
                   </CardContent>
                 </Card>
               )}

--- a/server/src/routes/dailyThroughputBoard.ts
+++ b/server/src/routes/dailyThroughputBoard.ts
@@ -57,6 +57,67 @@ function computeStatus(travelerStatus: string, steps: any[]): string {
 export async function dailyThroughputBoardHandler(req: Request, res: Response): Promise<void> {
   try {
     const { dateStr, isToday } = getNYDate(req.query.date as string | undefined);
+    const projectId = typeof req.query.projectId === 'string' && req.query.projectId.trim()
+      ? req.query.projectId.trim()
+      : null;
+    const poId = typeof req.query.poId === 'string' && /^\d+$/.test(req.query.poId)
+      ? Number(req.query.poId)
+      : null;
+
+    const params: any[] = [dateStr];
+    const scopeConditions: string[] = [];
+
+    if (poId) {
+      params.push(poId);
+      scopeConditions.push(`EXISTS (
+        SELECT 1
+        FROM p2_serialized_items psi
+        WHERE psi.po_id = $${params.length}
+          AND psi.serial_number IS NOT NULL
+          AND t.serial_number IS NOT NULL
+          AND LOWER(TRIM(psi.serial_number)) = LOWER(TRIM(t.serial_number))
+      )`);
+    }
+
+    if (projectId) {
+      params.push(projectId);
+      const projectParam = params.length;
+      scopeConditions.push(`(
+        EXISTS (
+          SELECT 1
+          FROM production_work_orders wo
+          WHERE wo.id = t.production_work_order_id
+            AND wo.project_id = $${projectParam}
+        )
+        OR EXISTS (
+          WITH project_po_link AS (
+            SELECT p.po_id AS po_id
+            FROM projects p
+            WHERE p.id = $${projectParam}
+              AND p.po_id IS NOT NULL
+            UNION
+            SELECT ps.linked_p2_order_id AS po_id
+            FROM project_steps ps
+            WHERE ps.project_id = $${projectParam}
+              AND ps.linked_p2_order_id IS NOT NULL
+            UNION
+            SELECT DISTINCT p2po.p2_po_id AS po_id
+            FROM p2_production_orders p2po
+            WHERE p2po.project_id = $${projectParam}::uuid
+          )
+          SELECT 1
+          FROM p2_serialized_items psi
+          JOIN project_po_link ppl ON ppl.po_id = psi.po_id
+          WHERE psi.serial_number IS NOT NULL
+            AND t.serial_number IS NOT NULL
+            AND LOWER(TRIM(psi.serial_number)) = LOWER(TRIM(t.serial_number))
+        )
+      )`);
+    }
+
+    const scopeSql = scopeConditions.length
+      ? `AND (${scopeConditions.join(' OR ')})`
+      : '';
 
     const travelerRows = await pool.query(
       `SELECT
@@ -73,8 +134,9 @@ export async function dailyThroughputBoardHandler(req: Request, res: Response): 
        JOIN travelers t ON t.id = ts.traveler_id
        WHERE ts.department_name = 'Layup'
          AND (ts.started_at AT TIME ZONE 'America/New_York')::date = $1::date
+         ${scopeSql}
        ORDER BY ts.started_at ASC`,
-      [dateStr]
+      params
     );
 
     const travelerIds = travelerRows.map((r: any) => r.traveler_id);
@@ -358,6 +420,8 @@ export async function dailyThroughputBoardHandler(req: Request, res: Response): 
       businessDate: dateStr,
       date: dateStr,
       isToday,
+      projectId,
+      poId,
       targetSlots: SLOTS_TARGET,
       summary,
       slots: allSlots,

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -266,8 +266,235 @@ interface SerializedItemAggregate {
   totalCompleted: number;
 }
 
+interface P2PoStatusSummary {
+  id: number;
+  poNumber: string;
+  customerName: string | null;
+  dueDate: string | null;
+  totalItems: number;
+  completedItems: number;
+  inProductionItems: number;
+  pendingItems: number;
+  rawStatus: string;
+  status: 'pending' | 'in_progress' | 'completed';
+}
+
+interface P2SerializedBreakdownRow {
+  id: string;
+  poId: number;
+  poNumber: string | null;
+  poItemId: number | null;
+  serialNumber: string | null;
+  barcode: string | null;
+  travelerBarcode: string | null;
+  partNumber: string | null;
+  partName: string | null;
+  status: string;
+  currentDepartment: string | null;
+  currentStageIndex: number | null;
+  activeTravelerId: string | null;
+  activeTravelerNumber: string | null;
+  activeTravelerStatus: string | null;
+  activeTaskDepartment: string | null;
+  activeTaskStatus: string | null;
+  holdReason: string | null;
+  scrapReason: string | null;
+  completedAt: string | null;
+  updatedAt: string | null;
+}
+
 function normalizePartKey(value: string | null | undefined): string {
   return String(value ?? '').trim().toLowerCase();
+}
+
+function normalizeP2Status(status: unknown): string {
+  return String(status || '').trim().toUpperCase();
+}
+
+async function getProjectLinkedP2PoIds(projectId: string): Promise<number[]> {
+  const rows = await pool.query<{ poId: string }>(`
+    WITH project_po_link AS (
+      SELECT p.po_id AS po_id
+      FROM projects p
+      WHERE p.id = $1 AND p.po_id IS NOT NULL
+      UNION
+      SELECT ps.linked_p2_order_id AS po_id
+      FROM project_steps ps
+      WHERE ps.project_id = $1 AND ps.linked_p2_order_id IS NOT NULL
+      UNION
+      SELECT DISTINCT p2po.p2_po_id AS po_id
+      FROM p2_production_orders p2po
+      WHERE p2po.project_id = $1::uuid
+      UNION
+      SELECT po.id AS po_id
+      FROM projects p
+      JOIN p2_purchase_orders po ON LOWER(TRIM(po.project_name)) IN (
+        LOWER(TRIM(p.project_code)),
+        LOWER(TRIM(p.project_name)),
+        LOWER(TRIM(CONCAT_WS(' - ', NULLIF(p.project_code, ''), NULLIF(p.project_name, ''))))
+      )
+      WHERE p.id = $1
+        AND po.project_name IS NOT NULL
+        AND TRIM(po.project_name) <> ''
+    )
+    SELECT DISTINCT po_id::text AS "poId" FROM project_po_link WHERE po_id IS NOT NULL
+  `, [projectId]);
+
+  return rows
+    .map(row => parseInt(row.poId, 10))
+    .filter(n => Number.isFinite(n));
+}
+
+async function getProjectP2PoStatusSummaries(projectId: string): Promise<P2PoStatusSummary[]> {
+  const linkedPoIds = await getProjectLinkedP2PoIds(projectId);
+  if (!linkedPoIds.length) return [];
+
+  const rows = await pool.query<{
+    id: number;
+    poNumber: string;
+    customerName: string | null;
+    dueDate: string | null;
+    rawStatus: string | null;
+    orderedQty: string;
+    serializedQty: string;
+    completedItems: string;
+    inProductionItems: string;
+  }>(`
+    WITH item_state AS (
+      SELECT
+        psi.*,
+        EXISTS (
+          SELECT 1
+          FROM travelers t
+          WHERE UPPER(COALESCE(t.status, '')) IN ('COMPLETE', 'COMPLETED', 'CLOSED')
+            AND t.serial_number IS NOT NULL
+            AND LOWER(TRIM(t.serial_number)) = LOWER(TRIM(psi.serial_number))
+        ) AS has_completed_traveler
+      FROM p2_serialized_items psi
+      WHERE psi.po_id = ANY($1::int[])
+    ),
+    ordered_qty AS (
+      SELECT po_id, COALESCE(SUM(quantity), 0)::int AS ordered_qty
+      FROM p2_purchase_order_items
+      WHERE po_id = ANY($1::int[])
+      GROUP BY po_id
+    )
+    SELECT
+      po.id,
+      po.po_number AS "poNumber",
+      po.customer_name AS "customerName",
+      po.expected_delivery AS "dueDate",
+      po.status AS "rawStatus",
+      COALESCE(oq.ordered_qty, 0)::text AS "orderedQty",
+      COUNT(psi.id)::text AS "serializedQty",
+      COUNT(*) FILTER (
+        WHERE psi.status = 'COMPLETED' OR psi.has_completed_traveler
+      )::text AS "completedItems",
+      COUNT(*) FILTER (
+        WHERE psi.status = 'ACTIVE'
+          AND NOT psi.has_completed_traveler
+          AND COALESCE(psi.current_department, '') <> ''
+          AND COALESCE(psi.current_department, '') <> 'Pending Layup'
+      )::text AS "inProductionItems"
+    FROM p2_purchase_orders po
+    LEFT JOIN ordered_qty oq ON oq.po_id = po.id
+    LEFT JOIN item_state psi ON psi.po_id = po.id
+    WHERE po.id = ANY($1::int[])
+    GROUP BY po.id, po.po_number, po.customer_name, po.expected_delivery, po.status, oq.ordered_qty
+    ORDER BY po.po_number ASC
+  `, [linkedPoIds]);
+
+  return rows.map((row) => {
+    const rawStatus = normalizeP2Status(row.rawStatus) || 'OPEN';
+    const serializedQty = parseInt(row.serializedQty, 10) || 0;
+    const orderedQty = parseInt(row.orderedQty, 10) || 0;
+    const totalItems = Math.max(orderedQty, serializedQty);
+    const completedItems = parseInt(row.completedItems, 10) || 0;
+    const inProductionItems = parseInt(row.inProductionItems, 10) || 0;
+    const pendingItems = Math.max(0, totalItems - completedItems - inProductionItems);
+    const status: P2PoStatusSummary['status'] =
+      totalItems > 0 && completedItems >= totalItems
+        ? 'completed'
+        : (inProductionItems > 0 || rawStatus === 'IN_PRODUCTION')
+          ? 'in_progress'
+          : 'pending';
+
+    return {
+      id: row.id,
+      poNumber: row.poNumber,
+      customerName: row.customerName,
+      dueDate: row.dueDate,
+      totalItems,
+      completedItems,
+      inProductionItems,
+      pendingItems,
+      rawStatus,
+      status,
+    };
+  });
+}
+
+async function getProjectP2SerializedBreakdown(projectId: string): Promise<P2SerializedBreakdownRow[]> {
+  const linkedPoIds = await getProjectLinkedP2PoIds(projectId);
+  if (!linkedPoIds.length) return [];
+
+  return pool.query<P2SerializedBreakdownRow>(`
+    WITH latest_traveler AS (
+      SELECT DISTINCT ON (LOWER(TRIM(serial_number)))
+        LOWER(TRIM(serial_number)) AS serial_key,
+        id::text AS "activeTravelerId",
+        traveler_number AS "activeTravelerNumber",
+        status AS "activeTravelerStatus"
+      FROM travelers
+      WHERE serial_number IS NOT NULL
+        AND TRIM(serial_number) <> ''
+      ORDER BY LOWER(TRIM(serial_number)), updated_at DESC NULLS LAST, created_at DESC NULLS LAST
+    ),
+    active_step AS (
+      SELECT DISTINCT ON (t.id)
+        t.id AS traveler_id,
+        ts.department_name AS "activeTaskDepartment",
+        ts.status AS "activeTaskStatus"
+      FROM travelers t
+      JOIN traveler_steps ts ON ts.traveler_id = t.id
+      WHERE UPPER(COALESCE(ts.status, '')) IN ('IN_PROGRESS', 'ACTIVE', 'STARTED', 'BLOCKED', 'ON_HOLD', 'HOLD')
+      ORDER BY t.id, ts.step_number ASC
+    )
+    SELECT
+      psi.id::text,
+      psi.po_id AS "poId",
+      psi.po_number AS "poNumber",
+      psi.po_item_id AS "poItemId",
+      psi.serial_number AS "serialNumber",
+      psi.barcode,
+      psi.traveler_barcode AS "travelerBarcode",
+      COALESCE(poi.part_number, psi.part_number) AS "partNumber",
+      COALESCE(poi.part_name, psi.part_name) AS "partName",
+      psi.status,
+      psi.current_department AS "currentDepartment",
+      psi.current_stage_index AS "currentStageIndex",
+      lt."activeTravelerId",
+      lt."activeTravelerNumber",
+      lt."activeTravelerStatus",
+      astep."activeTaskDepartment",
+      astep."activeTaskStatus",
+      psi.hold_reason AS "holdReason",
+      psi.scrap_reason AS "scrapReason",
+      psi.completed_at AS "completedAt",
+      psi.updated_at AS "updatedAt"
+    FROM p2_serialized_items psi
+    LEFT JOIN p2_purchase_order_items poi ON poi.id = psi.po_item_id
+    LEFT JOIN latest_traveler lt ON lt.serial_key = LOWER(TRIM(psi.serial_number))
+    LEFT JOIN active_step astep ON astep.traveler_id::text = lt."activeTravelerId"
+    WHERE psi.po_id = ANY($1::int[])
+      AND COALESCE(UPPER(psi.status), '') NOT IN ('CANCELLED', 'CANCELED')
+    ORDER BY
+      COALESCE(psi.current_stage_index, 0),
+      COALESCE(psi.current_department, 'Pending Layup'),
+      psi.po_number,
+      psi.sequence_number,
+      psi.serial_number
+  `, [linkedPoIds]);
 }
 
 function isWadReleasedForExecution(wad: WadBridgeRow): boolean {
@@ -1268,6 +1495,7 @@ router.get('/:projectId/production', h(async (req, res) => {
   `, [projectId]);
 
   const linkedP2PoCount = parseInt(linkRes[0]?.count ?? '0', 10) || 0;
+  const linkedP2PoStatuses = await getProjectP2PoStatusSummaries(projectId);
 
   // Item-level override: when serialized items exist for the project's linked
   // P2 PO, drive the P2 portion of the production table from p2_serialized_items
@@ -1410,7 +1638,14 @@ router.get('/:projectId/production', h(async (req, res) => {
     };
   });
 
-  res.json({ rows: rowsWithAssignments, linkedP2PoCount });
+  res.json({ rows: rowsWithAssignments, linkedP2PoCount, linkedP2PoStatuses });
+}));
+
+// GET /api/pm-dashboard/:projectId/production/p2-serialized - linked P2 PO item breakdown
+router.get('/:projectId/production/p2-serialized', h(async (req, res) => {
+  const { projectId } = req.params;
+  const items = await getProjectP2SerializedBreakdown(projectId);
+  res.json({ items });
 }));
 
 // GET /api/pm-dashboard/:projectId/production/:workOrderId — drawer detail


### PR DESCRIPTION
## Summary
- Adds linked P2 PO status summaries to the PM Control Center production payload so PM shows the same PO-level status concept as the P2 Control Center Status tab.
- Adds a PM-scoped serialized-item breakdown endpoint and an in-page PM production drawer grouped by department for linked P2 PO units.
- Replaces the PM daily-throughput estimate with live data from the Daily Throughput Board API, scoped by selected project / linked P2 PO.

## Why
The PM production tab was still centered on WAD/project work-order rows, which made the WO numbers look disconnected from the associated P2 Control Center project/PO. PMs need the linked P2 PO status first, then the serialized production location details behind it, while preserving WAD rows as supporting project work.

## Validation
- `git diff --check` passes.
- `npm run check` could not be run locally because `npm` and repo `node_modules` are not installed in this Windows workspace.