### PR TITLE
[codex] Fix admin order pagination search

### DIFF
--- a/client/src/pages/AdminPanelPage.tsx
+++ b/client/src/pages/AdminPanelPage.tsx
@@ -1,11 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import {
   useReactTable,
   getCoreRowModel,
-  getFilteredRowModel,
-  getSortedRowModel,
-  getPaginationRowModel,
   ColumnDef,
   flexRender,
   SortingState,
@@ -81,7 +78,6 @@ interface Order {
   customerName: string;
   modelId: string;
   currentDepartment: string;
-  currentStatus: string; // Display value
   status: string | null; // Raw database value for status
   assignedTechnician: string | null; // Raw database value (username)
   urgency: string | null; // Raw database value (lowercase)
@@ -91,21 +87,79 @@ interface Order {
   fbOrderNumber: string;
 }
 
+interface PaginatedOrdersResponse {
+  orders: Order[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+const ADMIN_ORDER_PAGE_SIZE = 25;
+const ADMIN_ORDER_SORT_BY: Record<string, string> = {
+  orderId: 'orderId',
+  customerName: 'customer',
+  modelId: 'model',
+  currentDepartment: 'department',
+  orderDate: 'orderDate',
+  dueDate: 'dueDate',
+};
+
 export default function AdminPanelPage() {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = useState({});
   const [globalFilter, setGlobalFilter] = useState('');
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: ADMIN_ORDER_PAGE_SIZE,
+  });
   const [selectedOrderId, setSelectedOrderId] = useState<number | null>(null);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [editedFields, setEditedFields] = useState<Record<string, any>>({});
   const { toast } = useToast();
 
-  // Fetch orders
-  const { data: orders = [], isLoading } = useQuery<Order[]>({
-    queryKey: ['/api/orders/with-payment-status'],
+  const departmentFilter = (columnFilters.find((filter) => filter.id === 'currentDepartment')?.value as string | undefined) || 'all';
+  const statusFilter = (columnFilters.find((filter) => filter.id === 'status')?.value as string | undefined) || 'all';
+  const primarySort = sorting[0];
+
+  const ordersQueryParams = useMemo(() => {
+    const params = new URLSearchParams({
+      page: String(pagination.pageIndex + 1),
+      limit: String(pagination.pageSize),
+      sortBy: ADMIN_ORDER_SORT_BY[primarySort?.id || ''] || 'orderDate',
+      sortOrder: primarySort?.desc === false ? 'asc' : 'desc',
+    });
+
+    if (globalFilter.trim()) {
+      params.set('search', globalFilter.trim());
+    }
+
+    if (departmentFilter !== 'all') {
+      params.set('department', departmentFilter);
+    }
+
+    if (statusFilter !== 'all') {
+      params.set('status', statusFilter);
+    }
+
+    return params.toString();
+  }, [departmentFilter, globalFilter, pagination.pageIndex, pagination.pageSize, primarySort?.desc, primarySort?.id, statusFilter]);
+
+  // Fetch orders from the full server-side result set, not just the first 100 rows.
+  const { data: ordersResponse, isLoading } = useQuery<PaginatedOrdersResponse>({
+    queryKey: ['/api/orders/with-payment-status/paginated', ordersQueryParams],
+    queryFn: () => apiRequest(`/api/orders/with-payment-status/paginated?${ordersQueryParams}`),
   });
+  const orders = ordersResponse?.orders ?? [];
+  const totalOrders = ordersResponse?.total ?? 0;
+  const totalPages = ordersResponse?.totalPages ?? 0;
+
+  useEffect(() => {
+    setPagination((current) => ({ ...current, pageIndex: 0 }));
+    setRowSelection({});
+  }, [columnFilters, globalFilter, sorting]);
 
   // Fetch reference data for inline editing
   const { data: employees = [] } = useQuery<any[]>({
@@ -149,6 +203,7 @@ export default function AdminPanelPage() {
     onSuccess: async () => {
       // Force refetch instead of just invalidating
       await queryClient.refetchQueries({ queryKey: ['/api/orders/with-payment-status'] });
+      await queryClient.refetchQueries({ queryKey: ['/api/orders/with-payment-status/paginated'] });
       toast({
         title: 'Success',
         description: 'Order field updated successfully',
@@ -287,7 +342,7 @@ export default function AdminPanelPage() {
         },
       },
       {
-        accessorKey: 'currentStatus',
+        accessorKey: 'status',
         header: 'Status',
         cell: ({ row }) => {
           const statusValue = row.original.status; // Use raw database value
@@ -475,42 +530,30 @@ export default function AdminPanelPage() {
   const table = useReactTable({
     data: orders,
     columns,
+    pageCount: Math.max(totalPages, 1),
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
     onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    globalFilterFn: (row, columnId, filterValue) => {
-      const search = filterValue.toLowerCase();
-      const orderId = row.getValue('orderId') as string;
-      const fbOrderNumber = row.getValue('fbOrderNumber') as string;
-      const customerName = row.getValue('customerName') as string;
-      
-      return (
-        orderId?.toLowerCase().includes(search) ||
-        fbOrderNumber?.toLowerCase().includes(search) ||
-        customerName?.toLowerCase().includes(search)
-      );
-    },
+    manualFiltering: true,
+    manualPagination: true,
+    manualSorting: true,
     state: {
       sorting,
       columnFilters,
       columnVisibility,
       rowSelection,
       globalFilter,
-    },
-    initialState: {
-      pagination: {
-        pageSize: 25,
-      },
+      pagination,
     },
   });
 
-  const selectedOrders = table.getFilteredSelectedRowModel().rows;
+  const selectedOrders = table.getSelectedRowModel().rows;
+  const firstVisibleOrder = totalOrders === 0 ? 0 : pagination.pageIndex * pagination.pageSize + 1;
+  const lastVisibleOrder = Math.min((pagination.pageIndex + 1) * pagination.pageSize, totalOrders);
 
   return (
     <div className="container mx-auto py-6 space-y-6">
@@ -527,7 +570,7 @@ export default function AdminPanelPage() {
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
-                placeholder="Search orders by Order ID, FB Number, or Customer..."
+                placeholder="Search by Order ID, FB #, Customer, Customer PO, Customer ID, or Model..."
                 value={globalFilter ?? ''}
                 onChange={(event) => setGlobalFilter(event.target.value)}
                 className="pl-10"
@@ -557,9 +600,9 @@ export default function AdminPanelPage() {
             </Select>
 
             <Select
-              value={(table.getColumn('currentStatus')?.getFilterValue() as string) ?? 'ALL'}
+              value={(table.getColumn('status')?.getFilterValue() as string) ?? 'ALL'}
               onValueChange={(value) =>
-                table.getColumn('currentStatus')?.setFilterValue(value === 'ALL' ? undefined : value)
+                table.getColumn('status')?.setFilterValue(value === 'ALL' ? undefined : value)
               }
             >
               <SelectTrigger className="w-[200px]" data-testid="select-status">
@@ -666,12 +709,7 @@ export default function AdminPanelPage() {
           {/* Pagination */}
           <div className="flex items-center justify-between">
             <div className="text-sm text-muted-foreground">
-              Showing {table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1} to{' '}
-              {Math.min(
-                (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
-                table.getFilteredRowModel().rows.length
-              )}{' '}
-              of {table.getFilteredRowModel().rows.length} orders
+              Showing {firstVisibleOrder} to {lastVisibleOrder} of {totalOrders} orders
             </div>
             <div className="flex items-center gap-2">
               <Button
@@ -973,6 +1011,7 @@ export default function AdminPanelPage() {
                       
                       // Force refresh the order list and full order data
                       await queryClient.invalidateQueries({ queryKey: ['/api/orders/with-payment-status'] });
+                      await queryClient.invalidateQueries({ queryKey: ['/api/orders/with-payment-status/paginated'] });
                       await queryClient.invalidateQueries({ queryKey: [`/api/orders/${selectedOrderIdString}`] });
                       
                       setIsPanelOpen(false);

--- a/server/__tests__/ordersLimitCap.test.ts
+++ b/server/__tests__/ordersLimitCap.test.ts
@@ -13,6 +13,7 @@ vi.mock('../db', () => ({
 vi.mock('../storage', () => ({
   storage: {
     getAllOrdersWithPaymentStatus: vi.fn(),
+    getAllOrdersWithPaymentStatusPaginated: vi.fn(),
   },
 }));
 
@@ -37,20 +38,47 @@ describe('GET /with-payment-status — limit clamping', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(storage.getAllOrdersWithPaymentStatus).mockResolvedValue([]);
+    vi.mocked(storage.getAllOrdersWithPaymentStatusPaginated).mockResolvedValue({
+      orders: [],
+      total: 0,
+      page: 1,
+      limit: 25,
+      totalPages: 0,
+    });
   });
 
   it('defaults to DEFAULT_ORDERS_LIMIT when no limit param is provided', async () => {
     await request(app).get('/with-payment-status');
-    expect(vi.mocked(storage.getAllOrdersWithPaymentStatus)).toHaveBeenCalledWith('', DEFAULT_ORDERS_LIMIT);
+    expect(vi.mocked(storage.getAllOrdersWithPaymentStatus)).toHaveBeenCalledWith('', DEFAULT_ORDERS_LIMIT, undefined);
   });
 
   it('passes through a limit below MAX_ORDERS_LIMIT unchanged', async () => {
     await request(app).get('/with-payment-status?limit=50');
-    expect(vi.mocked(storage.getAllOrdersWithPaymentStatus)).toHaveBeenCalledWith('', 50);
+    expect(vi.mocked(storage.getAllOrdersWithPaymentStatus)).toHaveBeenCalledWith('', 50, undefined);
   });
 
   it('clamps a limit that exceeds MAX_ORDERS_LIMIT to MAX_ORDERS_LIMIT', async () => {
     await request(app).get('/with-payment-status?limit=99999');
-    expect(vi.mocked(storage.getAllOrdersWithPaymentStatus)).toHaveBeenCalledWith('', MAX_ORDERS_LIMIT);
+    expect(vi.mocked(storage.getAllOrdersWithPaymentStatus)).toHaveBeenCalledWith('', MAX_ORDERS_LIMIT, undefined);
+  });
+
+  it('passes admin pagination and search filters to the paginated storage path', async () => {
+    await request(app).get('/with-payment-status/paginated?page=3&limit=25&search=AG-123&department=Shipping&status=IN_PROGRESS&sortBy=orderId&sortOrder=asc');
+
+    expect(vi.mocked(storage.getAllOrdersWithPaymentStatusPaginated)).toHaveBeenCalledWith(
+      3,
+      25,
+      {
+        search: 'AG-123',
+        department: 'Shipping',
+        departmentMode: 'include',
+        status: 'IN_PROGRESS',
+        statusMode: 'include',
+        excludeStatuses: undefined,
+        sortBy: 'orderId',
+        sortOrder: 'asc',
+        customerId: undefined,
+      }
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Move Admin Panel Order Management from the capped `/api/orders/with-payment-status` fetch to the existing server-side paginated `/api/orders/with-payment-status/paginated` endpoint.
- Wire admin search, department filter, status filter, sorting, and pagination into the server request so the grid is not limited to the newest 100 loaded rows.
- Update the order route test to cover the paginated admin query contract.

## Root Cause

Admin Order Management fetched `/api/orders/with-payment-status` without a `limit`, so the backend applied `DEFAULT_ORDERS_LIMIT = 100`. The table then searched and filtered only that loaded client-side slice, which made older matching orders look missing from the admin panel.

## Validation

- `git diff --check` passed.
- Could not run Vitest locally because this clean worktree has no `node_modules` and `npx` is not available on PATH in the Codex environment.