### PR TITLE
[codex] Persist made packets from basic cutting completion

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -543,6 +543,7 @@ export default function CuttingOperatorDashboard() {
     },
     onSuccess: (data: any) => {
       queryClient.invalidateQueries({ queryKey: ['/api/cutting-table-mfg-queue/cutting-table'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/cutting-table-mfg-queue/built-packets'] });
       setIsProductionDialogOpen(false);
       resetProductionForm();
       toast({

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -206,42 +206,113 @@ router.post('/:id/complete', async (req: Request, res: Response) => {
     if (!currentItem) {
       return res.status(404).json({ error: 'Manufacturing queue item not found' });
     }
-    
-    // Calculate total completed (existing + new)
-    const previousCompleted = currentItem.quantityCompleted || 0;
-    const newTotalCompleted = previousCompleted + quantityCompleted;
-    const quantityRequested = currentItem.quantityRequested;
-    
-    // Determine if this is a full or partial completion
-    const isFullyCompleted = newTotalCompleted >= quantityRequested;
-    
-    // Update the manufacturing queue item
-    const [updated] = await db
-      .update(manufacturingQueue)
-      .set({
-        quantityCompleted: newTotalCompleted,
-        status: isFullyCompleted ? 'COMPLETED' : 'IN_PROGRESS',
-        completedAt: isFullyCompleted ? new Date() : null,
-        fabricLot,
-        fabricBatch,
-        fabricRoll,
-        materialDetails,
-        completionNotes,
-        completedBy,
-        updatedAt: new Date(),
-      })
-      .where(eq(manufacturingQueue.id, parseInt(id)))
-      .returning();
-    
-    if (!updated) {
-      return res.status(404).json({ error: 'Manufacturing queue item not found' });
+
+    const inventoryItem = await db.query.inventoryItems.findFirst({
+      where: eq(inventoryItems.id, currentItem.inventoryItemId),
+    });
+
+    if (!inventoryItem) {
+      return res.status(404).json({ error: 'Inventory item not found' });
     }
+
+    let productCategory = await db.query.cuttingProductCategories.findFirst({
+      where: eq(cuttingProductCategories.categoryName, inventoryItem.name || 'Unknown'),
+    });
+
+    if (!productCategory) {
+      const [newCategory] = await db
+        .insert(cuttingProductCategories)
+        .values({
+          categoryName: inventoryItem.name || 'Unknown Packet Type',
+          isActive: true,
+        })
+        .returning();
+      productCategory = newCategory;
+    }
+
+    if (!productCategory) {
+      return res.status(500).json({ error: 'Failed to resolve packet category' });
+    }
+
+    const productCategoryId = productCategory.id;
+    const barcodePrefix = `PKT-${inventoryItem.agPartNumber}-${id}-%`;
+
+    const { updated, createdPackets, isFullyCompleted, newTotalCompleted } = await db.transaction(async (tx) => {
+      const [lockedItem] = await tx
+        .select({
+          quantityCompleted: manufacturingQueue.quantityCompleted,
+          quantityRequested: manufacturingQueue.quantityRequested,
+        })
+        .from(manufacturingQueue)
+        .where(eq(manufacturingQueue.id, parseInt(id)))
+        .for('update');
+
+      if (!lockedItem) {
+        throw new Error(`Manufacturing queue item ${id} disappeared inside transaction`);
+      }
+
+      const previousCompleted = lockedItem.quantityCompleted || 0;
+      const newTotalCompleted = previousCompleted + quantityCompleted;
+      const isFullyCompleted = newTotalCompleted >= lockedItem.quantityRequested;
+
+      const [{ existingCount }] = await tx
+        .select({ existingCount: count() })
+        .from(cuttingBuiltPackets)
+        .where(like(cuttingBuiltPackets.barcode, barcodePrefix));
+
+      const createdPackets = [];
+      for (let i = 0; i < quantityCompleted; i++) {
+        const packetNumber = existingCount + i + 1;
+        const barcode = `PKT-${inventoryItem.agPartNumber}-${id}-${packetNumber}-${Date.now()}`;
+
+        const [builtPacket] = await tx
+          .insert(cuttingBuiltPackets)
+          .values({
+            productCategoryId,
+            barcode,
+            packetNumber,
+            buildDate: new Date(),
+            status: 'AVAILABLE',
+            isMixedFabric: false,
+            fabricSourceCount: 0,
+            notes: completionNotes || null,
+            createdBy: completedBy || null,
+          })
+          .returning();
+
+        createdPackets.push(builtPacket);
+      }
+
+      const [updated] = await tx
+        .update(manufacturingQueue)
+        .set({
+          quantityCompleted: newTotalCompleted,
+          status: isFullyCompleted ? 'COMPLETED' : 'IN_PROGRESS',
+          completedAt: isFullyCompleted ? new Date() : null,
+          fabricLot,
+          fabricBatch,
+          fabricRoll,
+          materialDetails,
+          completionNotes,
+          completedBy,
+          updatedAt: new Date(),
+        })
+        .where(eq(manufacturingQueue.id, parseInt(id)))
+        .returning();
+
+      if (!updated) {
+        throw new Error(`Manufacturing queue item ${id} was not updated`);
+      }
+
+      return { updated, createdPackets, isFullyCompleted, newTotalCompleted };
+    });
     
     // Return additional info for partial completions
     res.json({
       ...updated,
+      createdPackets,
       isPartialCompletion: !isFullyCompleted,
-      remainingQuantity: isFullyCompleted ? 0 : quantityRequested - newTotalCompleted,
+      remainingQuantity: isFullyCompleted ? 0 : currentItem.quantityRequested - newTotalCompleted,
     });
   } catch (error) {
     console.error('Error completing manufacturing queue item:', error);


### PR DESCRIPTION
## Summary
- Persist `cutting_built_packets` rows when the Cutting Operator Dashboard uses the basic `/complete` path.
- Refresh the Made Packets query after the basic completion path succeeds.

## Root Cause
The live operator flow can complete a scanned packet without material-roll traceability. In that case the UI calls `/api/cutting-table-mfg-queue/:id/complete`, not `/complete-with-traceability`. The basic completion route only incremented `manufacturing_queue.quantity_completed`; it did not insert rows into `cutting_built_packets`, which is the source for the Made Packets card. So packets could be cut and counted on the queue while never appearing under Made Packets.

## Validation
- Traced the live dashboard path from `handleCompleteScannedPacket` to the basic `/complete` endpoint.
- Confirmed the traceability completion path already creates `cutting_built_packets`; this adds equivalent packet-row persistence for the basic path.
- Ran `git diff --check` successfully.
- Attempted live page access from the tool, but the app page could not be loaded from here.
- `npm run check` remains blocked because `npm` is not available on PATH in this local shell.