### PR TITLE
[codex] Handle vendor document storage URLs

### DIFF
--- a/client/src/pages/VendorManagement.tsx
+++ b/client/src/pages/VendorManagement.tsx
@@ -706,7 +706,21 @@ export default function VendorManagement() {
 
   const getVendorPdfViewUrl = (url: string) => {
     const trimmed = url.trim();
-    const normalized = trimmed.startsWith('objects/') ? `/${trimmed}` : trimmed;
+    let normalized = trimmed.startsWith('objects/') ? `/${trimmed}` : trimmed;
+
+    try {
+      const parsed = new URL(trimmed, window.location.origin);
+      if (parsed.origin === window.location.origin) {
+        normalized = parsed.pathname.startsWith('/objects/') ||
+          parsed.pathname.startsWith('/uploads/vendor-documents/') ||
+          parsed.pathname.startsWith('/uploads/vendor-approvals/')
+          ? parsed.pathname
+          : normalized;
+      }
+    } catch {
+      // Keep the original value when it is not a URL-like path.
+    }
+
     const isVendorStoragePath =
       normalized.startsWith('/objects/') ||
       normalized.startsWith('/uploads/vendor-documents/') ||

--- a/server/src/routes/vendors.ts
+++ b/server/src/routes/vendors.ts
@@ -59,17 +59,31 @@ type VendorDocumentPath =
   | { type: 'external'; url: string };
 
 function isVendorDocumentScope(pathValue: string): boolean {
-  return (
-    pathValue.includes('/vendor-documents/') ||
-    pathValue.includes('/vendor-approvals/') ||
-    pathValue.startsWith('vendor-documents/') ||
-    pathValue.startsWith('vendor-approvals/')
-  );
+  const parts = pathValue
+    .split(/[/?#]/)[0]
+    .split('/')
+    .filter(Boolean);
+  return parts.includes('vendor-documents') || parts.includes('vendor-approvals');
 }
 
 function normalizeVendorDocumentPath(rawValue: unknown): VendorDocumentPath | null {
-  const value = String(rawValue || '').trim();
-  if (!value) return null;
+  const raw = String(rawValue || '').trim();
+  if (!raw) return null;
+
+  let value = raw;
+  try {
+    value = decodeURIComponent(raw);
+  } catch {
+    value = raw;
+  }
+
+  if (/^https?:\/\//i.test(value) && !value.startsWith('https://storage.googleapis.com/')) {
+    try {
+      value = new URL(value).pathname;
+    } catch {
+      return null;
+    }
+  }
 
   if (value.startsWith('https://storage.googleapis.com/')) {
     try {
@@ -94,7 +108,8 @@ function normalizeVendorDocumentPath(rawValue: unknown): VendorDocumentPath | nu
     return { type: 'external', url: value };
   }
 
-  const normalized = value.startsWith('objects/') ? `/${value}` : value;
+  const pathOnlyValue = value.split(/[?#]/)[0];
+  const normalized = pathOnlyValue.startsWith('objects/') ? `/${pathOnlyValue}` : pathOnlyValue;
   if (normalized.startsWith('/objects/')) {
     return isVendorDocumentScope(normalized)
       ? { type: 'object', path: normalized }


### PR DESCRIPTION
## Summary
- Normalize same-origin vendor document URLs back through the vendor document API instead of opening raw `/objects` or `/uploads` paths.
- Make the vendor document view route accept encoded paths and full app-origin URLs before validating the vendor document scope.
- Preserve direct handling for true external legacy links while keeping vendor documents limited to `vendor-documents` and `vendor-approvals` storage scopes.

## Root Cause
Some vendor document records can be stored as full app-origin object/upload URLs or encoded storage paths, while the view helper expected mostly raw relative paths. Those shapes could bypass the authenticated view route or be rejected before the storage provider downloaded the file.

## Validation
- `git diff --check`
- Local TypeScript/build checks were not run because this worktree has no `node_modules` and `npm` is not available on PATH.