### PR TITLE
[codex] Add material scan to made packets

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -298,6 +298,7 @@ export default function CuttingOperatorDashboard() {
   const [editingSource, setEditingSource] = useState<BuiltPacketFabricSource | null>(null);
   const [editingPacketId, setEditingPacketId] = useState<number | null>(null);
   const [confirmDeleteSourceId, setConfirmDeleteSourceId] = useState<number | null>(null);
+  const [packetMaterialScanValues, setPacketMaterialScanValues] = useState<Record<number, string>>({});
   const [fabricSourceForm, setFabricSourceForm] = useState({
     fabricType: '',
     lotNumber: '',
@@ -354,6 +355,33 @@ export default function CuttingOperatorDashboard() {
     },
     onError: () => {
       toast({ title: 'Error', description: 'Failed to delete fabric source.', variant: 'destructive' });
+    },
+  });
+
+  const scanPacketFabricSourceMutation = useMutation({
+    mutationFn: async ({ packetId, barcode }: { packetId: number; barcode: string }) => {
+      return apiRequest(`/api/cutting-table-mfg-queue/built-packets/${packetId}/fabric-sources/scan`, {
+        method: 'POST',
+        body: JSON.stringify({ barcode }),
+      });
+    },
+    onSuccess: (data: any, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['/api/cutting-table-mfg-queue/built-packets'] });
+      setPacketMaterialScanValues(prev => ({ ...prev, [variables.packetId]: '' }));
+      const roll = data?.roll;
+      toast({
+        title: 'Material attached',
+        description: roll?.rollNumber
+          ? `Roll ${roll.rollNumber} was added to this packet.`
+          : 'The scanned material was added to this packet.',
+      });
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Scan Error',
+        description: error?.message || 'Failed to add material to packet.',
+        variant: 'destructive',
+      });
     },
   });
 
@@ -2492,6 +2520,37 @@ export default function CuttingOperatorDashboard() {
 
                   {expandedPacketId === packet.id && (
                     <div className="border-t bg-muted/20 px-4 py-3">
+                      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end">
+                        <div className="flex-1 space-y-1">
+                          <Label className="text-xs">Scan Material Into Packet</Label>
+                          <Input
+                            value={packetMaterialScanValues[packet.id] || ''}
+                            onChange={(e) => setPacketMaterialScanValues(prev => ({ ...prev, [packet.id]: e.target.value }))}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                const barcode = (packetMaterialScanValues[packet.id] || '').trim();
+                                if (barcode) {
+                                  scanPacketFabricSourceMutation.mutate({ packetId: packet.id, barcode });
+                                }
+                              }
+                            }}
+                            placeholder="Scan material roll barcode, ICN, or roll number..."
+                          />
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={scanPacketFabricSourceMutation.isPending || !(packetMaterialScanValues[packet.id] || '').trim()}
+                          onClick={() => {
+                            const barcode = (packetMaterialScanValues[packet.id] || '').trim();
+                            if (!barcode) return;
+                            scanPacketFabricSourceMutation.mutate({ packetId: packet.id, barcode });
+                          }}
+                        >
+                          <Scan className="h-3 w-3 mr-1" />
+                          Add Material
+                        </Button>
+                      </div>
                       {packet.fabricSources.length === 0 ? (
                         <p className="text-sm text-muted-foreground italic">No fabric source records for this packet.</p>
                       ) : (

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -2000,6 +2000,102 @@ router.get('/built-packets', async (req: Request, res: Response) => {
   }
 });
 
+// Add a fabric source to a built packet by scanning a material roll barcode.
+router.post('/built-packets/:packetId/fabric-sources/scan', async (req: Request, res: Response) => {
+  try {
+    const { packetId } = req.params;
+    const { barcode, quantityUsed = 1 } = req.body;
+    const scannedBarcode = String(barcode || '').trim();
+
+    if (!scannedBarcode) {
+      return res.status(400).json({ error: 'Material barcode is required' });
+    }
+
+    const packet = await db.query.cuttingBuiltPackets.findFirst({
+      where: eq(cuttingBuiltPackets.id, parseInt(packetId)),
+    });
+
+    if (!packet) {
+      return res.status(404).json({ error: 'Built packet not found' });
+    }
+
+    const matchedRoll = await db.query.cuttingFabricInventory.findFirst({
+      where: or(
+        eq(cuttingFabricInventory.barcode, scannedBarcode),
+        eq(cuttingFabricInventory.internalControlNumber, scannedBarcode),
+        eq(cuttingFabricInventory.rollNumber, scannedBarcode)
+      ),
+    });
+
+    if (!matchedRoll) {
+      return res.status(404).json({
+        error: 'Material roll not found',
+        scannedBarcode,
+      });
+    }
+
+    const existingSource = await db.query.cuttingBuiltPacketFabricSources.findFirst({
+      where: and(
+        eq(cuttingBuiltPacketFabricSources.builtPacketId, packet.id),
+        eq(cuttingBuiltPacketFabricSources.fabricInventoryId, matchedRoll.id)
+      ),
+    });
+
+    if (existingSource) {
+      return res.status(409).json({ error: 'This material roll is already attached to the packet' });
+    }
+
+    const currentSourceCount = await db
+      .select({ sourceCount: count() })
+      .from(cuttingBuiltPacketFabricSources)
+      .where(eq(cuttingBuiltPacketFabricSources.builtPacketId, packet.id));
+
+    const [createdSource] = await db
+      .insert(cuttingBuiltPacketFabricSources)
+      .values({
+        builtPacketId: packet.id,
+        fabricInventoryId: matchedRoll.id,
+        fabricType: matchedRoll.fabric || matchedRoll.nickname || null,
+        lotNumber: matchedRoll.lotNumber || null,
+        batchNumber: matchedRoll.batchNumber || null,
+        rollNumber: matchedRoll.rollNumber || null,
+        supplierPartNumber: matchedRoll.supplierPartNumber || null,
+        internalControlNumber: matchedRoll.internalControlNumber || null,
+        expirationDate: matchedRoll.expirationDate || null,
+        quantityUsed: parseInt(String(quantityUsed)) || 1,
+        isPrimary: (currentSourceCount[0]?.sourceCount || 0) === 0,
+      })
+      .returning();
+
+    const newSourceCount = (currentSourceCount[0]?.sourceCount || 0) + 1;
+    await db
+      .update(cuttingBuiltPackets)
+      .set({
+        fabricSourceCount: newSourceCount,
+        isMixedFabric: newSourceCount > 1,
+        updatedAt: new Date(),
+      })
+      .where(eq(cuttingBuiltPackets.id, packet.id));
+
+    res.status(201).json({
+      source: createdSource,
+      roll: {
+        id: matchedRoll.id,
+        barcode: matchedRoll.barcode,
+        fabric: matchedRoll.fabric,
+        nickname: matchedRoll.nickname,
+        lotNumber: matchedRoll.lotNumber,
+        batchNumber: matchedRoll.batchNumber,
+        rollNumber: matchedRoll.rollNumber,
+        internalControlNumber: matchedRoll.internalControlNumber,
+      },
+    });
+  } catch (error) {
+    console.error('Error scanning fabric source for built packet:', error);
+    res.status(500).json({ error: 'Failed to add fabric source from scan' });
+  }
+});
+
 // Update a fabric source for a built packet (e.g. correct lot/roll/batch number)
 router.patch('/built-packets/:packetId/fabric-sources/:sourceId', async (req: Request, res: Response) => {
   try {


### PR DESCRIPTION
## Summary
- Add a material scan field to each expanded Made Packets row in the Cutting Operator Dashboard.
- Add a server endpoint that resolves the scanned material by barcode, internal control number, or roll number.
- Insert the resolved roll as a `cutting_built_packet_fabric_sources` row for that packet and update the packet's fabric source count/mixed-fabric flag.

## Root Cause
Backfilled/basic-completion packet rows can exist without fabric source records. Operators need a floor-safe correction path to attach the real material source after the packet is made, instead of hand-entering traceability or relying on guessed backfill data.

## Validation
- Ran `git diff --check` successfully.
- Confirmed the branch is based on latest `origin/main` after the missing-packet backfill PR merged.
- Attempted `npm run check`, but `npm` is not available on PATH in this local shell.