### PR TITLE
[codex] Fix made packet barcode display parsing

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -85,6 +85,7 @@ type BuiltPacket = {
   barcode: string;
   packetNumber: number;
   displayPacketNumber: number | null;
+  printedPacketNumber?: number | null;
   buildDate: string;
   status: string;
   isMixedFabric: boolean;
@@ -2444,7 +2445,7 @@ export default function CuttingOperatorDashboard() {
                           const mfgParsed = parseMfgBarcode(packet.barcode);
                           const mfgBarcode = mfgParsed.isMfgFormat
                             ? mfgParsed.raw
-                            : buildMfgBarcode(packet.queueId, packet.sku, packet.displayPacketNumber ?? packet.packetNumber);
+                            : buildMfgBarcode(packet.queueId, packet.sku, packet.printedPacketNumber ?? packet.displayPacketNumber ?? packet.packetNumber);
                           const segments = mfgBarcode ? parseMfgBarcode(mfgBarcode) : null;
                           const isInternalBarcode = !mfgParsed.isMfgFormat;
 

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -19,11 +19,27 @@ function nonZeroInventoryDelta(quantity: number): number {
 }
 
 function parseQueueIdFromBuiltPacketBarcode(barcode: string | null | undefined): number | null {
+  const parsed = parseBuiltPacketBarcode(barcode);
+  return parsed?.queueId ?? null;
+}
+
+function parseBuiltPacketBarcode(barcode: string | null | undefined): { sku: string; queueId: number; packetNumber: number } | null {
   if (!barcode) return null;
   const parts = barcode.split('-');
   if (parts.length < 5 || parts[0] !== 'PKT') return null;
-  const queueId = Number(parts[parts.length - 3]);
-  return Number.isInteger(queueId) ? queueId : null;
+
+  const maybeRepairIndex = parts[parts.length - 1];
+  const maybeTimestamp = parts[parts.length - 2];
+  const hasRepairIndex = /^\d+$/.test(maybeRepairIndex) && /^\d{10,}$/.test(maybeTimestamp);
+  const queueIndex = hasRepairIndex ? parts.length - 4 : parts.length - 3;
+  const packetNumberIndex = hasRepairIndex ? parts.length - 3 : parts.length - 2;
+
+  const queueId = Number(parts[queueIndex]);
+  const packetNumber = Number(parts[packetNumberIndex]);
+  const sku = parts.slice(1, queueIndex).join('-');
+
+  if (!sku || !Number.isInteger(queueId) || !Number.isInteger(packetNumber)) return null;
+  return { sku, queueId, packetNumber };
 }
 
 async function ensureBuiltPacketsForCompletedQueueRows(): Promise<void> {
@@ -1913,18 +1929,19 @@ router.get('/built-packets', async (req: Request, res: Response) => {
     }
 
     const parsedPackets = packets.map(packet => {
-      let sku: string | null = null;
-      let queueId: string | null = null;
+      const parsedBarcode = parseBuiltPacketBarcode(packet.barcode);
+      let sku: string | null = parsedBarcode?.sku ?? null;
+      let queueId: string | null = parsedBarcode ? String(parsedBarcode.queueId) : null;
       try {
         const parts = packet.barcode.split('-');
         if (parts.length >= 5 && parts[0] === 'PKT') {
-          queueId = parts[parts.length - 3];
-          sku = parts.slice(1, parts.length - 3).join('-');
+          queueId = queueId ?? parts[parts.length - 3];
+          sku = sku ?? parts.slice(1, parts.length - 3).join('-');
         }
       } catch {
         // non-standard barcode — leave sku and queueId as null
       }
-      return { ...packet, sku, queueId };
+      return { ...packet, sku, queueId, printedPacketNumber: parsedBarcode?.packetNumber ?? packet.packetNumber };
     });
 
     // Batch-fetch quantityRequested for all referenced queue items so the
@@ -1966,11 +1983,11 @@ router.get('/built-packets', async (req: Request, res: Response) => {
       // Group by derived queueId and assign rank
       const groupedById: Record<string, number[]> = {};
       for (const row of allPacketsForQueues) {
-        let qId: string | null = null;
+        let qId: string | null = parseBuiltPacketBarcode(row.barcode)?.queueId.toString() ?? null;
         try {
           const parts = row.barcode.split('-');
           if (parts.length >= 5 && parts[0] === 'PKT') {
-            qId = parts[parts.length - 3];
+            qId = qId ?? parts[parts.length - 3];
           }
         } catch {}
         if (qId !== null && relevantQueueIds.includes(qId)) {


### PR DESCRIPTION
## Summary
- Fix Made Packets barcode parsing for repaired/backfilled internal `PKT-...` IDs that include a repair suffix.
- Preserve the printed label order `MFG-{queueId}-{partNumber}-{packetSequence}` in the Made Packets card.
- Return the parsed printed packet number from the server and use it when rebuilding the displayed MFG barcode.

## Root Cause
Printed packet labels use `MFG-{queueId}-{partNumber}-{packetSequence}`. Some repaired Made Packet rows have internal IDs like `PKT-712-19-47-{timestamp}-{repairIndex}`. The old parser always read three segments from the end, so it treated `47` as the queue ID and `712-19` as the part, causing the UI to show `MFG-47-712-19-1` instead of the real printed barcode `MFG-19-712-47`.

## Validation
- Confirmed the parser now handles both normal `PKT-{part}-{queue}-{packet}-{timestamp}` and repaired `PKT-{part}-{queue}-{packet}-{timestamp}-{repairIndex}` formats.
- Ran `git diff --check` successfully.
- `npm run check` remains blocked locally because `npm` is not available on PATH in this shell.