### PR TITLE
Autofill receiving project targets and add PM material acceptance

### DIFF
--- a/client/src/pages/InventoryReceivingControlCenter.tsx
+++ b/client/src/pages/InventoryReceivingControlCenter.tsx
@@ -188,6 +188,15 @@ interface ReceivedUnit {
   allocatedToType?: string;
   allocatedToId?: number;
   materialLotId?: string;
+  targetProjectId?: string | null;
+}
+
+interface ReceivingProjectTarget {
+  id: string;
+  projectCode: string;
+  projectName: string;
+  status: string;
+  customerName?: string | null;
 }
 
 interface ReceiptDocument {
@@ -2666,14 +2675,14 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
   const queryClient = useQueryClient();
 
   const NONE_SENTINEL = '__none__';
+  const LEAVE_OPEN_SENTINEL = '__leave_open__';
 
   const [batchLocation, setBatchLocation] = useState('');
   const [batchFreezer, setBatchFreezer] = useState('');
   const [batchStorageType, setBatchStorageType] = useState<(typeof STORAGE_TYPES)[number]>('conex');
   const [batchStorageIdentifier, setBatchStorageIdentifier] = useState('');
   const [batchStorageNote, setBatchStorageNote] = useState('');
-  const [batchAllocType, setBatchAllocType] = useState('stock');
-  const [batchAllocId, setBatchAllocId] = useState('');
+  const [batchTargetProjectId, setBatchTargetProjectId] = useState(NONE_SENTINEL);
   const [batchPending, setBatchPending] = useState(false);
   const [selectedDeptId, setSelectedDeptId] = useState(
     receipt.departmentId ? String(receipt.departmentId) : NONE_SENTINEL,
@@ -2683,6 +2692,14 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
   const { data: departments = [] } = useQuery<InventoryDepartment[]>({
     queryKey: ['/api/inventory/departments'],
   });
+
+  const { data: projectTargetsResponse } = useQuery<{ data: ReceivingProjectTarget[] }>({
+    queryKey: ['/api/receipts/project-targets/open'],
+  });
+  const projectTargets = projectTargetsResponse?.data ?? [];
+
+  const renderProjectTargetLabel = (project: ReceivingProjectTarget) =>
+    `${project.projectCode} - ${project.projectName}${project.customerName ? ` (${project.customerName})` : ''}`;
 
   const applyDeptDefaults = async (dept: InventoryDepartment | null, newLocation: string | null, newFreezer: number | null, silent = false) => {
     if (!dept || (newLocation == null && newFreezer == null)) return;
@@ -2755,19 +2772,23 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
 
   const handleBatchAssign = async () => {
     const structuredLocation = buildStorageLocation(batchStorageType, batchStorageIdentifier, batchStorageNote);
-    if (!batchLocation && !structuredLocation && !batchFreezer && !batchAllocId) {
+    if (!batchLocation && !structuredLocation && !batchFreezer && batchTargetProjectId === NONE_SENTINEL) {
       toast.error('Enter at least one field to batch-assign');
       return;
     }
     setBatchPending(true);
-    const updates: Record<string, any> = { allocatedToType: batchAllocType };
+    const updates: Record<string, any> = {};
     if (structuredLocation || batchLocation) updates.location = structuredLocation || batchLocation;
     if (batchStorageType === 'freezer' && batchStorageIdentifier) {
       updates.freezerNumber = parseInt(batchStorageIdentifier, 10);
     } else if (batchFreezer) {
       updates.freezerNumber = parseInt(batchFreezer, 10);
     }
-    if (batchAllocId) updates.allocatedToId = parseInt(batchAllocId, 10);
+    if (batchTargetProjectId !== NONE_SENTINEL) {
+      updates.targetProjectId = batchTargetProjectId === LEAVE_OPEN_SENTINEL ? null : batchTargetProjectId;
+      updates.allocatedToType = batchTargetProjectId === LEAVE_OPEN_SENTINEL ? 'stock' : 'project';
+      updates.allocatedToId = null;
+    }
     try {
       await Promise.all(units.map(u =>
         apiRequest(`/api/receipts/${receipt.id}/units/${u.id}`, {
@@ -2872,21 +2893,20 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
               <Label className="text-xs">Freezer #</Label>
               <Input className="h-7 text-xs mt-0.5" type="number" min={1} value={batchFreezer} onChange={e => setBatchFreezer(e.target.value)} placeholder="1–5" />
             </div>
-            <div>
-              <Label className="text-xs">Allocation Type</Label>
-              <Select value={batchAllocType} onValueChange={setBatchAllocType}>
-                <SelectTrigger className="h-7 text-xs mt-0.5"><SelectValue /></SelectTrigger>
+            <div className="col-span-2">
+              <Label className="text-xs">Target Project</Label>
+              <Select value={batchTargetProjectId} onValueChange={setBatchTargetProjectId}>
+                <SelectTrigger className="h-7 text-xs mt-0.5"><SelectValue placeholder="No batch project change" /></SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="stock">Stock</SelectItem>
-                  <SelectItem value="work_order">Work Order</SelectItem>
-                  <SelectItem value="po_demand">PO Demand</SelectItem>
-                  <SelectItem value="quarantine">Quarantine</SelectItem>
+                  <SelectItem value={NONE_SENTINEL}>No batch project change</SelectItem>
+                  <SelectItem value={LEAVE_OPEN_SENTINEL}>Leave open</SelectItem>
+                  {projectTargets.map(project => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {renderProjectTargetLabel(project)}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
-            </div>
-            <div>
-              <Label className="text-xs">Target ID <span className="text-gray-400">(WO/PO #)</span></Label>
-              <Input className="h-7 text-xs mt-0.5" type="number" value={batchAllocId} onChange={e => setBatchAllocId(e.target.value)} placeholder="Optional" />
             </div>
           </div>
           <Button size="sm" variant="outline" className="w-full h-7 text-xs" onClick={handleBatchAssign} disabled={batchPending}>
@@ -2938,37 +2958,31 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
                 }}
               />
             </div>
-            <div>
-              <Label className="text-xs">Allocation</Label>
+            <div className="col-span-2">
+              <Label className="text-xs">Target Project</Label>
               <Select
-                defaultValue={unit.allocatedToType ?? 'stock'}
-                onValueChange={v => updateUnitMutation.mutate({ unitId: unit.id, updates: { allocatedToType: v } })}
+                value={unit.targetProjectId ?? LEAVE_OPEN_SENTINEL}
+                onValueChange={v => updateUnitMutation.mutate({
+                  unitId: unit.id,
+                  updates: {
+                    targetProjectId: v === LEAVE_OPEN_SENTINEL ? null : v,
+                    allocatedToType: v === LEAVE_OPEN_SENTINEL ? 'stock' : 'project',
+                    allocatedToId: null,
+                  },
+                })}
               >
                 <SelectTrigger className="h-7 text-xs mt-0.5">
-                  <SelectValue />
+                  <SelectValue placeholder="Leave open" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="stock">Stock</SelectItem>
-                  <SelectItem value="work_order">Work Order</SelectItem>
-                  <SelectItem value="po_demand">PO Demand</SelectItem>
-                  <SelectItem value="quarantine">Quarantine</SelectItem>
+                  <SelectItem value={LEAVE_OPEN_SENTINEL}>Leave open</SelectItem>
+                  {projectTargets.map(project => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {renderProjectTargetLabel(project)}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
-            </div>
-            <div>
-              <Label className="text-xs">Target ID <span className="text-gray-400">(WO/PO #)</span></Label>
-              <Input
-                className="h-7 text-xs mt-0.5"
-                type="number"
-                defaultValue={unit.allocatedToId ?? ''}
-                placeholder="Optional"
-                onBlur={e => {
-                  const val = e.target.value ? parseInt(e.target.value, 10) : null;
-                  if (val !== (unit.allocatedToId ?? null)) {
-                    updateUnitMutation.mutate({ unitId: unit.id, updates: { allocatedToId: val } });
-                  }
-                }}
-              />
             </div>
           </div>
         </div>

--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useLocation, Link } from 'wouter';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -315,14 +315,19 @@ interface MaterialSummary {
   committedCost: number;
   consumedCost: number;
   remainingCost: number;
+  pendingReceivedCost?: number;
+  acceptedReceivedCost?: number;
 }
 
 interface MaterialRow {
   inventoryItemId: string;
+  projectReceivedMaterialId?: number;
   itemCode: string;
   itemName: string;
   lotNumber: string | null;
   internalControlNumber: string | null;
+  receiptNumber?: string | null;
+  receivedUnitBarcode?: string | null;
   qtyRequired: number;
   qtyAllocated: number;
   qtyIssued: number;
@@ -484,8 +489,11 @@ const MATERIAL_STATUS_COLORS: Record<string, string> = {
   ON_HOLD: 'bg-orange-100 text-orange-700',
   PARTIAL: 'bg-yellow-100 text-yellow-700',
   ALLOCATED: 'bg-blue-100 text-blue-700',
+  PENDING_PM_ACCEPTANCE: 'bg-blue-100 text-blue-700',
   FULLY_ALLOCATED: 'bg-green-100 text-green-700',
   FULLY_ISSUED: 'bg-green-100 text-green-700',
+  RECEIVED_ACCEPTED: 'bg-green-100 text-green-700',
+  RECEIVED_REJECTED: 'bg-gray-100 text-gray-600',
 };
 
 const MATERIAL_STATUS_ORDER: Record<string, number> = {
@@ -493,9 +501,12 @@ const MATERIAL_STATUS_ORDER: Record<string, number> = {
   SHORT: 1,
   ON_HOLD: 2,
   PARTIAL: 3,
+  PENDING_PM_ACCEPTANCE: 4,
   ALLOCATED: 4,
   FULLY_ALLOCATED: 5,
   FULLY_ISSUED: 6,
+  RECEIVED_ACCEPTED: 7,
+  RECEIVED_REJECTED: 8,
 };
 
 function CertBadge({ status }: { status: string }) {
@@ -1661,6 +1672,7 @@ type SortDir = 'asc' | 'desc';
 
 function MaterialBudgetTab({ projectId }: { projectId: string }) {
   const [, navTo] = useLocation();
+  const queryClient = useQueryClient();
   const [sortField, setSortField] = useState<SortField>('status');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
 
@@ -1668,6 +1680,25 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
     queryKey: ['/api/pm-dashboard', projectId, 'materials'],
     queryFn: () => safeFetch<MaterialData>(`/api/pm-dashboard/${projectId}/materials`),
     enabled: !!projectId,
+  });
+
+  const receivedMaterialMutation = useMutation({
+    mutationFn: async ({ id, action }: { id: number; action: 'accept' | 'reject' }) => {
+      const res = await fetch(`/api/pm-dashboard/${projectId}/materials/received/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || body.message || 'Failed to update received material');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/pm-dashboard', projectId, 'materials'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/pm-dashboard', projectId, 'summary'] });
+    },
   });
 
   if (isLoading) {
@@ -1731,6 +1762,7 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
           icon={<TrendingUp className="h-4 w-4" />}
           label="Committed"
           value={fmtCurrency(summary.committedCost)}
+          sub={summary.pendingReceivedCost ? `${fmtCurrency(summary.pendingReceivedCost)} pending receipt` : undefined}
           colorClass="text-purple-600"
         />
         <KpiCard
@@ -1799,6 +1831,7 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
                       Consumed <SortIcon field="consumedCost" />
                     </button>
                   </TableHead>
+                  <TableHead className="text-right">Action</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -1814,7 +1847,9 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
                     <TableCell className="text-xs text-muted-foreground">
                       {row.lotNumber && <div className="font-mono">{row.lotNumber}</div>}
                       {row.internalControlNumber && <div className="text-xs opacity-70">{row.internalControlNumber}</div>}
-                      {!row.lotNumber && !row.internalControlNumber && '—'}
+                      {row.receiptNumber && <div className="text-xs opacity-70">Receipt {row.receiptNumber}</div>}
+                      {row.receivedUnitBarcode && <div className="text-xs opacity-70">{row.receivedUnitBarcode}</div>}
+                      {!row.lotNumber && !row.internalControlNumber && !row.receiptNumber && !row.receivedUnitBarcode && '—'}
                     </TableCell>
                     <TableCell className="text-right text-sm">{row.qtyRequired > 0 ? row.qtyRequired : '—'}</TableCell>
                     <TableCell className="text-right text-sm">{row.qtyAllocated > 0 ? row.qtyAllocated : '—'}</TableCell>
@@ -1822,6 +1857,34 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
                     <TableCell className="text-right text-sm">{row.unitCost > 0 ? fmtCurrency(row.unitCost) : '—'}</TableCell>
                     <TableCell className="text-right text-sm">{row.committedCost > 0 ? fmtCurrency(row.committedCost) : '—'}</TableCell>
                     <TableCell className="text-right text-sm">{row.consumedCost > 0 ? fmtCurrency(row.consumedCost) : '—'}</TableCell>
+                    <TableCell className="text-right">
+                      {row.status === 'PENDING_PM_ACCEPTANCE' && row.projectReceivedMaterialId ? (
+                        <div className="flex justify-end gap-1">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2"
+                            disabled={receivedMaterialMutation.isPending}
+                            onClick={() => receivedMaterialMutation.mutate({ id: row.projectReceivedMaterialId!, action: 'accept' })}
+                          >
+                            <CheckCircle className="h-3 w-3 mr-1" />
+                            Accept
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2"
+                            disabled={receivedMaterialMutation.isPending}
+                            onClick={() => receivedMaterialMutation.mutate({ id: row.projectReceivedMaterialId!, action: 'reject' })}
+                          >
+                            <XCircle className="h-3 w-3 mr-1" />
+                            Reject
+                          </Button>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/migrations/0115_receiving_project_material_acceptance.sql
+++ b/migrations/0115_receiving_project_material_acceptance.sql
@@ -1,0 +1,44 @@
+-- Link received material to P2 projects and require PM acceptance before it
+-- becomes accepted project material cost.
+
+ALTER TABLE received_units
+  ADD COLUMN IF NOT EXISTS target_project_id UUID REFERENCES projects(id) ON DELETE SET NULL;
+
+ALTER TABLE production_work_orders
+  ADD COLUMN IF NOT EXISTS material_budget_amount NUMERIC NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS received_units_target_project_idx
+  ON received_units(target_project_id);
+
+CREATE TABLE IF NOT EXISTS project_received_materials (
+  id SERIAL PRIMARY KEY,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  received_unit_id INTEGER NOT NULL REFERENCES received_units(id) ON DELETE CASCADE,
+  receipt_id INTEGER NOT NULL REFERENCES receipts(id) ON DELETE CASCADE,
+  material_lot_id UUID REFERENCES material_lots(id) ON DELETE SET NULL,
+  quantity NUMERIC NOT NULL,
+  unit_cost NUMERIC NOT NULL DEFAULT 0,
+  extended_cost NUMERIC NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'pending_pm_acceptance',
+  accepted_by_user_id INTEGER,
+  accepted_by_display_name TEXT,
+  accepted_at TIMESTAMP,
+  rejected_by_user_id INTEGER,
+  rejected_by_display_name TEXT,
+  rejected_at TIMESTAMP,
+  notes TEXT,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  CONSTRAINT project_received_materials_received_unit_unique UNIQUE(received_unit_id),
+  CONSTRAINT project_received_materials_status_check
+    CHECK (status IN ('pending_pm_acceptance', 'accepted', 'rejected'))
+);
+
+CREATE INDEX IF NOT EXISTS project_received_materials_project_idx
+  ON project_received_materials(project_id);
+
+CREATE INDEX IF NOT EXISTS project_received_materials_receipt_idx
+  ON project_received_materials(receipt_id);
+
+CREATE INDEX IF NOT EXISTS project_received_materials_status_idx
+  ON project_received_materials(status);

--- a/server/index.ts
+++ b/server/index.ts
@@ -3599,6 +3599,33 @@ async function initializeBackgroundServices() {
         `);
         await db.execute(sqlRcc`CREATE INDEX IF NOT EXISTS received_units_receipt_id_idx ON received_units(receipt_id)`);
         await db.execute(sqlRcc`CREATE INDEX IF NOT EXISTS received_units_disposition_idx ON received_units(disposition)`);
+        await db.execute(sqlRcc`ALTER TABLE received_units ADD COLUMN IF NOT EXISTS target_project_id UUID REFERENCES projects(id) ON DELETE SET NULL`);
+        await db.execute(sqlRcc`CREATE INDEX IF NOT EXISTS received_units_target_project_idx ON received_units(target_project_id)`);
+        await db.execute(sqlRcc`
+          CREATE TABLE IF NOT EXISTS project_received_materials (
+            id SERIAL PRIMARY KEY,
+            project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+            received_unit_id INTEGER NOT NULL REFERENCES received_units(id) ON DELETE CASCADE,
+            receipt_id INTEGER NOT NULL REFERENCES receipts(id) ON DELETE CASCADE,
+            material_lot_id UUID REFERENCES material_lots(id) ON DELETE SET NULL,
+            quantity NUMERIC NOT NULL,
+            unit_cost NUMERIC NOT NULL DEFAULT 0,
+            extended_cost NUMERIC NOT NULL DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'pending_pm_acceptance',
+            accepted_by_user_id INTEGER,
+            accepted_by_display_name TEXT,
+            accepted_at TIMESTAMP,
+            rejected_by_user_id INTEGER,
+            rejected_by_display_name TEXT,
+            rejected_at TIMESTAMP,
+            notes TEXT,
+            created_at TIMESTAMP DEFAULT NOW(),
+            updated_at TIMESTAMP DEFAULT NOW(),
+            CONSTRAINT project_received_materials_received_unit_unique UNIQUE(received_unit_id)
+          )
+        `);
+        await db.execute(sqlRcc`CREATE INDEX IF NOT EXISTS project_received_materials_project_idx ON project_received_materials(project_id)`);
+        await db.execute(sqlRcc`CREATE INDEX IF NOT EXISTS project_received_materials_status_idx ON project_received_materials(status)`);
 
         await db.execute(sqlRcc`
           CREATE TABLE IF NOT EXISTS receipt_documents (
@@ -6052,6 +6079,7 @@ async function initializeBackgroundServices() {
       await pool.query(`ALTER TABLE production_work_orders ADD COLUMN IF NOT EXISTS assigned_department TEXT`);
       await pool.query(`ALTER TABLE production_work_orders ADD COLUMN IF NOT EXISTS assigned_dashboard_route TEXT`);
       await pool.query(`ALTER TABLE production_work_orders ADD COLUMN IF NOT EXISTS manufacturing_queue_id INTEGER`);
+      await pool.query(`ALTER TABLE production_work_orders ADD COLUMN IF NOT EXISTS material_budget_amount NUMERIC NOT NULL DEFAULT 0`);
       console.log('✅ Ensured production_work_orders table and WAD spine columns exist');
     } catch (wadErr: any) {
       console.warn('⚠️ production_work_orders migration skipped:', wadErr?.message);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -16469,6 +16469,7 @@ export const receivedUnits = pgTable('received_units', {
   freezerNumber: integer('freezer_number'),
   allocatedToType: text('allocated_to_type'), // work_order | po_demand | stock | quarantine
   allocatedToId: integer('allocated_to_id'),
+  targetProjectId: uuid('target_project_id').references((): AnyPgColumn => projects.id, { onDelete: 'set null' }),
   // Link to material_lots when accepted
   materialLotId: uuid('material_lot_id'),
   createdAt: timestamp('created_at').defaultNow(),
@@ -16477,6 +16478,7 @@ export const receivedUnits = pgTable('received_units', {
   receiptLineIdx: index('received_units_receipt_line_idx').on(table.receiptLineId),
   receiptIdx: index('received_units_receipt_idx').on(table.receiptId),
   barcodeIdx: uniqueIndex('received_units_barcode_idx').on(table.barcode),
+  targetProjectIdx: index('received_units_target_project_idx').on(table.targetProjectId),
 }));
 
 export const insertReceivedUnitSchema = createInsertSchema(receivedUnits).omit({
@@ -16502,6 +16504,41 @@ export const cncSetupPhotos = pgTable('cnc_setup_photos', {
 
 export type ReceivedUnit = typeof receivedUnits.$inferSelect;
 export type InsertReceivedUnit = z.infer<typeof insertReceivedUnitSchema>;
+
+export const projectReceivedMaterials = pgTable('project_received_materials', {
+  id: serial('id').primaryKey(),
+  projectId: uuid('project_id').notNull().references((): AnyPgColumn => projects.id, { onDelete: 'cascade' }),
+  receivedUnitId: integer('received_unit_id').notNull().references(() => receivedUnits.id, { onDelete: 'cascade' }),
+  receiptId: integer('receipt_id').notNull().references(() => receipts.id, { onDelete: 'cascade' }),
+  materialLotId: uuid('material_lot_id').references(() => materialLots.id, { onDelete: 'set null' }),
+  quantity: numeric('quantity').notNull(),
+  unitCost: numeric('unit_cost').notNull().default('0'),
+  extendedCost: numeric('extended_cost').notNull().default('0'),
+  status: text('status').notNull().default('pending_pm_acceptance'),
+  acceptedByUserId: integer('accepted_by_user_id'),
+  acceptedByDisplayName: text('accepted_by_display_name'),
+  acceptedAt: timestamp('accepted_at'),
+  rejectedByUserId: integer('rejected_by_user_id'),
+  rejectedByDisplayName: text('rejected_by_display_name'),
+  rejectedAt: timestamp('rejected_at'),
+  notes: text('notes'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+}, (table) => ({
+  projectIdx: index('project_received_materials_project_idx').on(table.projectId),
+  receiptIdx: index('project_received_materials_receipt_idx').on(table.receiptId),
+  statusIdx: index('project_received_materials_status_idx').on(table.status),
+  unitUnique: unique('project_received_materials_received_unit_unique').on(table.receivedUnitId),
+}));
+
+export const insertProjectReceivedMaterialSchema = createInsertSchema(projectReceivedMaterials).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export type ProjectReceivedMaterial = typeof projectReceivedMaterials.$inferSelect;
+export type InsertProjectReceivedMaterial = z.infer<typeof insertProjectReceivedMaterialSchema>;
 
 export const receiptDocuments = pgTable('receipt_documents', {
   id: serial('id').primaryKey(),
@@ -16757,6 +16794,7 @@ export const productionWorkOrders = pgTable('production_work_orders', {
   status: text('status').notNull().default('PLANNED'),
   departmentBudgets: jsonb('department_budgets').default({}).notNull(),
   totalBudgetHours: numeric('total_budget_hours'),
+  materialBudgetAmount: numeric('material_budget_amount').default('0').notNull(),
   startDate: date('start_date'),
   dueDate: date('due_date'),
   warningThreshold: numeric('warning_threshold'),

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -202,6 +202,15 @@ interface MaterialSummaryRow {
   consumedCost: string;
 }
 
+interface MaterialBudgetAmountRow {
+  plannedCost: string;
+}
+
+interface ProjectReceivedMaterialSummaryRow {
+  pendingReceivedCost: string;
+  acceptedReceivedCost: string;
+}
+
 interface MaterialItemRow {
   inventoryItemId: string;
   itemCode: string;
@@ -215,6 +224,12 @@ interface MaterialItemRow {
   committedCost: string;
   consumedCost: string;
   status: string;
+}
+
+interface ProjectReceivedMaterialRow extends MaterialItemRow {
+  projectReceivedMaterialId: number;
+  receiptNumber: string | null;
+  receivedUnitBarcode: string | null;
 }
 
 const ORDERED_PARTS_REQUEST_STATUSES = [
@@ -993,6 +1008,26 @@ router.get('/:projectId/summary', h(async (req, res) => {
       AND status = ANY($2::text[])
   `, [projectId, ORDERED_PARTS_REQUEST_STATUSES]);
 
+  const wadMaterialBudgetRes = await pool.query<{ plannedMaterialCost: string }>(`
+    SELECT COALESCE(SUM(
+      COALESCE(
+        NULLIF(material_budget_amount::numeric, 0),
+        NULLIF(wizard_data->>'materialBudgetAmount', '')::numeric,
+        NULLIF(wizard_data->>'materialBudget', '')::numeric,
+        0
+      )
+    ), 0) AS "plannedMaterialCost"
+    FROM production_work_orders
+    WHERE project_id = $1
+  `, [projectId]);
+
+  const acceptedReceivedMaterialRes = await pool.query<{ acceptedMaterialCost: string }>(`
+    SELECT COALESCE(SUM(extended_cost), 0) AS "acceptedMaterialCost"
+    FROM project_received_materials
+    WHERE project_id = $1
+      AND status = 'accepted'
+  `, [projectId]);
+
   // Quantity-based production percent
   const qtyProgressRes = await pool.query<{ totalRequired: string; totalCompleted: string }>(`
     WITH project_po_link AS (
@@ -1203,8 +1238,10 @@ router.get('/:projectId/summary', h(async (req, res) => {
   const committedMaterialCost =
     (parseFloat(materialRes[0].committedMaterialCost) || 0) +
     (parseFloat(partsRequestMaterialRes[0]?.committedMaterialCost) || 0);
-  const consumedMaterialCost = parseFloat(consumedRes[0].consumedMaterialCost) || 0;
-  const plannedMaterialCost = parseFloat(materialRes[0].plannedMaterialCost) || 0;
+  const consumedMaterialCost =
+    (parseFloat(consumedRes[0].consumedMaterialCost) || 0) +
+    (parseFloat(acceptedReceivedMaterialRes[0]?.acceptedMaterialCost) || 0);
+  const plannedMaterialCost = parseFloat(wadMaterialBudgetRes[0]?.plannedMaterialCost) || 0;
   const remainingMaterialBudget = plannedMaterialCost - committedMaterialCost - consumedMaterialCost;
 
   res.json({
@@ -2263,6 +2300,19 @@ router.get('/:projectId/labor/entries', h(async (req, res) => {
 router.get('/:projectId/materials', h(async (req, res) => {
   const { projectId } = req.params;
 
+  const budgetRes = await pool.query<MaterialBudgetAmountRow>(`
+    SELECT COALESCE(SUM(
+      COALESCE(
+        NULLIF(material_budget_amount::numeric, 0),
+        NULLIF(wizard_data->>'materialBudgetAmount', '')::numeric,
+        NULLIF(wizard_data->>'materialBudget', '')::numeric,
+        0
+      )
+    ), 0) AS "plannedCost"
+    FROM production_work_orders
+    WHERE project_id = $1
+  `, [projectId]);
+
   const summaryRes = await pool.query<MaterialSummaryRow>(`
     SELECT
       COALESCE(wad_budget_sub.planned, 0) AS "plannedCost",
@@ -2299,6 +2349,14 @@ router.get('/:projectId/materials', h(async (req, res) => {
         AND status = ANY($2::text[])
     ) parts_request_sub
   `, [projectId, ORDERED_PARTS_REQUEST_STATUSES]);
+
+  const projectReceivedSummaryRes = await pool.query<ProjectReceivedMaterialSummaryRow>(`
+    SELECT
+      COALESCE(SUM(extended_cost) FILTER (WHERE status = 'pending_pm_acceptance'), 0) AS "pendingReceivedCost",
+      COALESCE(SUM(extended_cost) FILTER (WHERE status = 'accepted'), 0) AS "acceptedReceivedCost"
+    FROM project_received_materials
+    WHERE project_id = $1
+  `, [projectId]);
 
   const rowsRes = await pool.query<MaterialItemRow>(`
     SELECT
@@ -2382,19 +2440,97 @@ router.get('/:projectId/materials', h(async (req, res) => {
     ORDER BY pr.request_date DESC
   `, [projectId, ORDERED_PARTS_REQUEST_STATUSES]);
 
+  const projectReceivedRowsRes = await pool.query<ProjectReceivedMaterialRow>(`
+    SELECT
+      ('PRM-' || prm.id::text) AS "inventoryItemId",
+      COALESCE(ii.ag_part_number, rl.ag_part_number, '') AS "itemCode",
+      COALESCE(ii.name, rl.description, '') AS "itemName",
+      COALESCE(ru.lot_number, ml.lot_number) AS "lotNumber",
+      COALESCE(ru.internal_control_number, ml.internal_control_number) AS "internalControlNumber",
+      prm.quantity::numeric AS "qtyRequired",
+      CASE WHEN prm.status = 'pending_pm_acceptance' THEN prm.quantity::numeric ELSE 0::numeric END AS "qtyAllocated",
+      CASE WHEN prm.status = 'accepted' THEN prm.quantity::numeric ELSE 0::numeric END AS "qtyIssued",
+      prm.unit_cost::numeric AS "unitCost",
+      CASE WHEN prm.status = 'pending_pm_acceptance' THEN prm.extended_cost::numeric ELSE 0::numeric END AS "committedCost",
+      CASE WHEN prm.status = 'accepted' THEN prm.extended_cost::numeric ELSE 0::numeric END AS "consumedCost",
+      CASE
+        WHEN prm.status = 'pending_pm_acceptance' THEN 'PENDING_PM_ACCEPTANCE'
+        WHEN prm.status = 'accepted' THEN 'RECEIVED_ACCEPTED'
+        ELSE 'RECEIVED_REJECTED'
+      END AS "status",
+      prm.id AS "projectReceivedMaterialId",
+      r.receipt_number AS "receiptNumber",
+      ru.barcode AS "receivedUnitBarcode"
+    FROM project_received_materials prm
+    JOIN received_units ru ON ru.id = prm.received_unit_id
+    JOIN receipts r ON r.id = prm.receipt_id
+    JOIN receipt_lines rl ON rl.id = ru.receipt_line_id
+    LEFT JOIN material_lots ml ON ml.id = prm.material_lot_id
+    LEFT JOIN inventory_items ii ON ii.id = ml.inventory_item_id
+    WHERE prm.project_id = $1
+      AND prm.status IN ('pending_pm_acceptance', 'accepted')
+    ORDER BY
+      CASE WHEN prm.status = 'pending_pm_acceptance' THEN 0 ELSE 1 END,
+      prm.created_at DESC
+  `, [projectId]);
+
+  const plannedCost = parseFloat(budgetRes[0]?.plannedCost) || 0;
   const committedCost = parseFloat(summaryRes[0]?.committedCost) || 0;
-  const consumedCost = parseFloat(summaryRes[0]?.consumedCost) || 0;
-  const plannedCost = parseFloat(summaryRes[0]?.plannedCost) || 0;
+  const pendingReceivedCost = parseFloat(projectReceivedSummaryRes[0]?.pendingReceivedCost) || 0;
+  const acceptedReceivedCost = parseFloat(projectReceivedSummaryRes[0]?.acceptedReceivedCost) || 0;
+  const consumedCost = (parseFloat(summaryRes[0]?.consumedCost) || 0) + acceptedReceivedCost;
 
   res.json({
     summary: {
       plannedCost,
       committedCost,
       consumedCost,
+      pendingReceivedCost,
+      acceptedReceivedCost,
       remainingCost: plannedCost - committedCost - consumedCost,
     },
-    rows: [...rowsRes, ...partsRequestRowsRes],
+    rows: [...projectReceivedRowsRes, ...rowsRes, ...partsRequestRowsRes],
   });
+}));
+
+router.patch('/:projectId/materials/received/:receivedMaterialId', h(async (req, res) => {
+  const { projectId, receivedMaterialId } = req.params;
+  const action = String(req.body?.action ?? '').toLowerCase();
+  const notes = typeof req.body?.notes === 'string' ? req.body.notes : null;
+  const user = (req as any).user;
+  const userId = user?.employeeId ?? null;
+  const displayName = user?.username ?? 'PM';
+
+  if (!['accept', 'reject'].includes(action)) {
+    res.status(400).json({ error: 'action must be accept or reject' });
+    return;
+  }
+
+  const status = action === 'accept' ? 'accepted' : 'rejected';
+  const result = await pool.query(`
+    UPDATE project_received_materials
+    SET
+      status = $1,
+      accepted_by_user_id = CASE WHEN $1 = 'accepted' THEN $2 ELSE accepted_by_user_id END,
+      accepted_by_display_name = CASE WHEN $1 = 'accepted' THEN $3 ELSE accepted_by_display_name END,
+      accepted_at = CASE WHEN $1 = 'accepted' THEN NOW() ELSE accepted_at END,
+      rejected_by_user_id = CASE WHEN $1 = 'rejected' THEN $2 ELSE rejected_by_user_id END,
+      rejected_by_display_name = CASE WHEN $1 = 'rejected' THEN $3 ELSE rejected_by_display_name END,
+      rejected_at = CASE WHEN $1 = 'rejected' THEN NOW() ELSE rejected_at END,
+      notes = COALESCE($4, notes),
+      updated_at = NOW()
+    WHERE id = $5
+      AND project_id = $6
+      AND status = 'pending_pm_acceptance'
+    RETURNING *
+  `, [status, userId, displayName, notes, Number(receivedMaterialId), projectId]);
+
+  if (!result[0]) {
+    res.status(404).json({ error: 'Pending received material not found for this project' });
+    return;
+  }
+
+  res.json(result[0]);
 }));
 
 export default router;

--- a/server/src/routes/receiving.ts
+++ b/server/src/routes/receiving.ts
@@ -196,6 +196,148 @@ async function assertUnitOwnership(receiptId: number, unitId: number): Promise<R
   return unit ?? null;
 }
 
+async function getOpenReceivingProjectTargets(): Promise<Array<{
+  id: string;
+  projectCode: string;
+  projectName: string;
+  status: string;
+  customerName: string | null;
+}>> {
+  const result = await db.execute(sql`
+    SELECT
+      p.id::text AS id,
+      p.project_code AS "projectCode",
+      p.project_name AS "projectName",
+      p.status,
+      p.customer_name_snapshot AS "customerName"
+    FROM projects p
+    WHERE p.status IN ('active', 'won', 'on_hold')
+    ORDER BY p.project_code ASC, p.created_at DESC
+  `);
+  return sqlRows(result);
+}
+
+async function resolveDefaultTargetProjectId(receipt: Receipt, line: ReceiptLine): Promise<string | null> {
+  if (!receipt.vendorPoId) return null;
+
+  const partsRequestResult = await db.execute(sql`
+    SELECT p.id::text AS id
+    FROM parts_requests pr
+    JOIN projects p ON p.id = pr.project_id
+    LEFT JOIN vendor_po_items vpi ON vpi.id = ${line.vendorPoItemId ?? null}
+    WHERE pr.vendor_po_id = ${receipt.vendorPoId}
+      AND pr.project_id IS NOT NULL
+      AND p.status IN ('active', 'won', 'on_hold')
+      AND (
+        ${line.vendorPoItemId ?? null} IS NULL
+        OR pr.ag_part_number = vpi.ag_part_number
+        OR pr.part_number = vpi.ag_part_number
+        OR pr.part_number = vpi.description
+        OR pr.ag_part_number = ${line.agPartNumber ?? null}
+        OR pr.part_number = ${line.agPartNumber ?? null}
+      )
+    ORDER BY pr.updated_at DESC NULLS LAST, pr.request_date DESC NULLS LAST
+    LIMIT 1
+  `);
+  const partsRequestRows = sqlRows<{ id: string }>(partsRequestResult);
+  if (partsRequestRows[0]?.id) return partsRequestRows[0].id;
+
+  const requisitionResult = await db.execute(sql`
+    SELECT p.id::text AS id
+    FROM vendor_pos vpo
+    JOIN purchase_requisitions req ON req.id = vpo.requisition_id
+    JOIN projects p ON p.id::text = req.project_id
+    WHERE vpo.id = ${receipt.vendorPoId}
+      AND req.project_id IS NOT NULL
+      AND p.status IN ('active', 'won', 'on_hold')
+    LIMIT 1
+  `);
+  const requisitionRows = sqlRows<{ id: string }>(requisitionResult);
+  return requisitionRows[0]?.id ?? null;
+}
+
+async function syncProjectReceivedMaterial(unitId: number, user: AuthUser, notes?: string | null): Promise<void> {
+  const result = await db.execute(sql`
+    SELECT
+      ru.id AS "unitId",
+      ru.receipt_id AS "receiptId",
+      ru.target_project_id::text AS "targetProjectId",
+      ru.material_lot_id::text AS "materialLotId",
+      ru.quantity::numeric AS quantity,
+      COALESCE(vpi.purchase_unit_price, vpi.unit_price, ii.unit_cost, 0)::numeric AS "unitCost"
+    FROM received_units ru
+    JOIN receipt_lines rl ON rl.id = ru.receipt_line_id
+    LEFT JOIN vendor_po_items vpi ON vpi.id = rl.vendor_po_item_id
+    LEFT JOIN inventory_items ii ON ii.ag_part_number = rl.ag_part_number
+    WHERE ru.id = ${unitId}
+    LIMIT 1
+  `);
+  const [row] = sqlRows<{
+    unitId: number;
+    receiptId: number;
+    targetProjectId: string | null;
+    materialLotId: string | null;
+    quantity: string;
+    unitCost: string;
+  }>(result);
+
+  if (!row) return;
+
+  if (!row.targetProjectId || !row.materialLotId) {
+    await db.execute(sql`
+      DELETE FROM project_received_materials
+      WHERE received_unit_id = ${unitId}
+        AND status = 'pending_pm_acceptance'
+    `);
+    return;
+  }
+
+  const qty = Number(row.quantity) || 0;
+  const unitCost = Number(row.unitCost) || 0;
+  const extendedCost = qty * unitCost;
+  const displayName = actorName(user);
+
+  await db.execute(sql`
+    INSERT INTO project_received_materials (
+      project_id,
+      received_unit_id,
+      receipt_id,
+      material_lot_id,
+      quantity,
+      unit_cost,
+      extended_cost,
+      status,
+      notes,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      ${row.targetProjectId}::uuid,
+      ${row.unitId},
+      ${row.receiptId},
+      ${row.materialLotId}::uuid,
+      ${String(qty)}::numeric,
+      ${String(unitCost)}::numeric,
+      ${String(extendedCost)}::numeric,
+      'pending_pm_acceptance',
+      ${notes ?? `Assigned from receiving by ${displayName}`},
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT (received_unit_id) DO UPDATE
+      SET project_id = EXCLUDED.project_id,
+          receipt_id = EXCLUDED.receipt_id,
+          material_lot_id = EXCLUDED.material_lot_id,
+          quantity = EXCLUDED.quantity,
+          unit_cost = EXCLUDED.unit_cost,
+          extended_cost = EXCLUDED.extended_cost,
+          status = 'pending_pm_acceptance',
+          notes = EXCLUDED.notes,
+          updated_at = NOW()
+      WHERE project_received_materials.status <> 'accepted'
+  `);
+}
+
 // Auto-import PO lines into the receipt as receipt_lines
 async function importPoLines(receiptId: number, vendorPoId: number): Promise<void> {
   const poItems = await db.select().from(vendorPOItems).where(eq(vendorPOItems.vendorPoId, vendorPoId));
@@ -414,6 +556,15 @@ router.get('/', requireReceivingAccess, async (req: Request, res: Response) => {
 
 // ── POST /api/receipts ─────────────────────────────────────────────────────────
 // Supports resume: if vendorPoId provided and in_progress receipt exists, returns it
+router.get('/project-targets/open', requireReceivingAccess, async (_req: Request, res: Response) => {
+  try {
+    res.json({ data: await getOpenReceivingProjectTargets() });
+  } catch (err: any) {
+    console.error('GET /api/receipts/project-targets/open:', err);
+    res.status(500).json({ error: 'Failed to fetch open project targets' });
+  }
+});
+
 router.post('/', requireReceivingAccess, async (req: Request, res: Response) => {
   try {
     const user = req.user;
@@ -722,6 +873,9 @@ router.post('/:id/lines/:lineId/units', requireReceivingAccess, async (req: Requ
 
     const unitSequence = await getNextUnitSequence(receiptId);
     const barcode = generateUnitBarcode(receipt.receiptNumber, unitSequence);
+    const targetProjectId = req.body.targetProjectId !== undefined
+      ? req.body.targetProjectId
+      : await resolveDefaultTargetProjectId(receipt, line);
 
     const body = insertReceivedUnitSchema.parse({
       ...req.body,
@@ -729,6 +883,7 @@ router.post('/:id/lines/:lineId/units', requireReceivingAccess, async (req: Requ
       receiptLineId: lineId,
       unitSequence,
       barcode,
+      targetProjectId,
     });
     const [unit] = await db.insert(receivedUnits).values(body).returning();
 
@@ -764,6 +919,7 @@ router.post('/:id/lines/:lineId/units', requireReceivingAccess, async (req: Requ
       }
       try {
         await handleAcceptedUnit(unit, receipt, user);
+        await syncProjectReceivedMaterial(unit.id, user, 'Material accepted in receiving and queued for PM review');
       } catch (lotErr: any) {
         // Roll back all disposition metadata so the clerk can retry after fixing catalog data
         await db.update(receivedUnits).set({
@@ -827,7 +983,7 @@ router.patch('/:id/units/:unitId', requireReceivingAccess, async (req: Request, 
     const updates = insertReceivedUnitSchema.partial().parse(req.body);
 
     // Audit traceability-affecting changes (location, freezer, allocation, disposition fields)
-    const auditableKeys: (keyof typeof updates)[] = ['quantity', 'uom', 'unitType', 'location', 'freezerNumber', 'allocatedToType', 'allocatedToId', 'lotNumber', 'batchNumber', 'serialNumber', 'internalControlNumber', 'rollNumber', 'heatLot', 'manufactureDate', 'expirationDate', 'certReference'];
+    const auditableKeys: (keyof typeof updates)[] = ['quantity', 'uom', 'unitType', 'location', 'freezerNumber', 'allocatedToType', 'allocatedToId', 'targetProjectId', 'lotNumber', 'batchNumber', 'serialNumber', 'internalControlNumber', 'rollNumber', 'heatLot', 'manufactureDate', 'expirationDate', 'certReference'];
     const auditableChanges: Record<string, unknown> = {};
     for (const key of auditableKeys) {
       if (key in updates) auditableChanges[key] = updates[key];
@@ -1021,6 +1177,10 @@ router.patch('/:id/units/:unitId', requireReceivingAccess, async (req: Request, 
       await logAudit(receiptId, 'unit_updated', user?.employeeId, actorName(user), { unitId, changes: auditableChanges });
     }
 
+    if ('targetProjectId' in updates) {
+      await syncProjectReceivedMaterial(unitId, user, updates.targetProjectId ? 'Project target assigned from receiving putaway' : 'Project target cleared from receiving putaway');
+    }
+
     res.json(updated);
   } catch (err: any) {
     console.error('PATCH unit:', err);
@@ -1121,6 +1281,7 @@ router.post('/:id/units/:unitId/disposition', requireReceivingAccess, async (req
       if (receipt) {
         try {
           await handleAcceptedUnit(unit, receipt, user);
+          await syncProjectReceivedMaterial(unitId, user, 'Material accepted in receiving and queued for PM review');
         } catch (lotErr: any) {
           // Roll back all disposition metadata so the clerk can retry after fixing catalog data
           await db.update(receivedUnits).set({
@@ -1793,6 +1954,7 @@ router.post('/:id/ensure-units', requireReceivingAccess, async (req: Request, re
 
       const unitSequence = await getNextUnitSequence(receiptId);
       const barcode = generateUnitBarcode(receipt.receiptNumber, unitSequence);
+      const targetProjectId = await resolveDefaultTargetProjectId(receipt, line);
       const body = insertReceivedUnitSchema.parse({
         receiptId,
         receiptLineId: line.id,
@@ -1801,6 +1963,7 @@ router.post('/:id/ensure-units', requireReceivingAccess, async (req: Request, re
         unitType: 'other',
         quantity: String(receivedQty),
         uom: line.uom ?? 'EA',
+        targetProjectId,
       });
       const [unit] = await db.insert(receivedUnits).values(body).returning();
       created.push(unit);
@@ -1883,6 +2046,9 @@ router.post('/:id/lines/:lineId/split', requireReceivingAccess, async (req: Requ
     // Calling getNextUnitSequence inside the loop would return the same MAX+1 every
     // iteration because no units are inserted until the transaction below.
     let nextSequence = await getNextUnitSequence(receiptId);
+    const defaultTargetProjectId = templateFields && Object.prototype.hasOwnProperty.call(templateFields, 'targetProjectId')
+      ? templateFields.targetProjectId
+      : await resolveDefaultTargetProjectId(receipt, line);
     for (let i = 0; i < count; i++) {
       let qtyForUnit: number;
       if (isRollArray) {
@@ -1904,6 +2070,7 @@ router.post('/:id/lines/:lineId/split', requireReceivingAccess, async (req: Requ
         quantity: String(qtyForUnit),
         uom: line.uom ?? 'EA',
         ...(isRollArray && normalizedRollNumbers ? { rollNumber: normalizedRollNumbers[i] } : {}),
+        targetProjectId: defaultTargetProjectId,
       });
       unitBodies.push(body);
     }
@@ -1999,6 +2166,7 @@ router.post('/:id/units/:unitId/clone', requireReceivingAccess, async (req: Requ
       freezerNumber: source.freezerNumber,
       allocatedToType: source.allocatedToType,
       allocatedToId: source.allocatedToId,
+      targetProjectId: source.targetProjectId,
       disposition: 'pending_inspection',
     });
     const [cloned] = await db.insert(receivedUnits).values(body).returning();
@@ -2041,6 +2209,9 @@ router.post('/:id/units/batch-update', requireReceivingAccess, async (req: Reque
         .where(eq(receivedUnits.id, uid))
         .returning();
       if (updated) results.push(updated);
+      if ('targetProjectId' in safeUpdates) {
+        await syncProjectReceivedMaterial(uid, user, safeUpdates.targetProjectId ? 'Project target assigned from receiving putaway' : 'Project target cleared from receiving putaway');
+      }
     }
 
     await logAudit(receiptId, 'batch_unit_update', user?.employeeId, actorName(user), {


### PR DESCRIPTION
## Summary
- Add project target tracking for received units, including autofill from project-linked parts requests and requisitions
- Replace Receiving Control Center Step 5 numeric target ID with an open-project dropdown plus a Leave open option
- Add PM material acceptance so accepted received material is included in consumed material cost and subtracts from the WAD material budget

## Validation
- `git diff --check origin/main...HEAD`
- Confirmed PR branch is clean against `origin/main`: 1 commit, 7 changed files
- `npm run check` could not be run locally because `npm` is not installed/recognized in this environment