### PR TITLE
[codex] Keep traveler starts resilient to WAD schema drift

### DIFF
--- a/server/src/helpers/laborBudgetHelper.ts
+++ b/server/src/helpers/laborBudgetHelper.ts
@@ -63,7 +63,12 @@ export async function evaluateWorkOrderLaborStatus(
   department?: string | null
 ): Promise<WorkOrderLaborStatusResult> {
   const [wad] = await db
-    .select()
+    .select({
+      totalBudgetHours: productionWorkOrders.totalBudgetHours,
+      departmentBudgets: productionWorkOrders.departmentBudgets,
+      warningThreshold: productionWorkOrders.warningThreshold,
+      blockedThreshold: productionWorkOrders.blockedThreshold,
+    })
     .from(productionWorkOrders)
     .where(eq(productionWorkOrders.id, workOrderId))
     .limit(1);

--- a/server/src/lib/travelerGates.ts
+++ b/server/src/lib/travelerGates.ts
@@ -1,6 +1,6 @@
 import { storage } from '../../storage';
 import { db } from '../../db';
-import { calibrationAssets, calibrationUseLogs, travelerAuthorizations, travelerMaterialConsumption } from '../../schema';
+import { calibrationAssets, calibrationUseLogs, productionWorkOrders, travelerAuthorizations, travelerMaterialConsumption } from '../../schema';
 import { eq, and, inArray } from 'drizzle-orm';
 
 export interface GateResult {
@@ -74,13 +74,21 @@ export function buildTrainingGateErrorBody(
  * @param wadId  UUID of the production_work_orders row
  */
 export async function evaluateWadReleaseGate(wadId: string): Promise<GateResult> {
-  const wad = await storage.getWorkOrderById(wadId);
+  const [wad] = await db
+    .select({
+      id: productionWorkOrders.id,
+      status: productionWorkOrders.status,
+      wadStatus: productionWorkOrders.wadStatus,
+    })
+    .from(productionWorkOrders)
+    .where(eq(productionWorkOrders.id, wadId))
+    .limit(1);
   if (!wad) {
     return { allowed: false, reason: 'The linked production work order could not be found.' };
   }
 
   const status = String(wad.status || '').trim().toUpperCase();
-  const wadStatus = String((wad as any).wadStatus || '').trim().toUpperCase();
+  const wadStatus = String(wad.wadStatus || '').trim().toUpperCase();
 
   if (status === 'RELEASED' || status === 'IN_PROGRESS') {
     return { allowed: true };

--- a/server/src/routes/travelers.ts
+++ b/server/src/routes/travelers.ts
@@ -1759,7 +1759,11 @@ async function promoteTravelerToInProgress(
 
   // WAD gate: traveler's linked production work order must be RELEASED or IN_PROGRESS.
   if (traveler.productionWorkOrderId) {
-    const wad = await storage.getWorkOrderById(traveler.productionWorkOrderId);
+    const [wad] = await db
+      .select({ id: productionWorkOrders.id, status: productionWorkOrders.status })
+      .from(productionWorkOrders)
+      .where(eq(productionWorkOrders.id, traveler.productionWorkOrderId))
+      .limit(1);
     if (!wad) {
       return {
         ok: false,
@@ -1811,7 +1815,11 @@ async function promoteTravelerToInProgress(
 
   // Auto-transition the WAD from RELEASED → IN_PROGRESS on first traveler start
   if (traveler.productionWorkOrderId) {
-    const wad = await storage.getWorkOrderById(traveler.productionWorkOrderId);
+    const [wad] = await db
+      .select({ id: productionWorkOrders.id, status: productionWorkOrders.status })
+      .from(productionWorkOrders)
+      .where(eq(productionWorkOrders.id, traveler.productionWorkOrderId))
+      .limit(1);
     if (wad && wad.status === 'RELEASED') {
       await storage.updateWorkOrderStatus(wad.id, 'IN_PROGRESS');
       console.log(`[Travelers] WAD ${wad.id} transitioned to IN_PROGRESS on first traveler start`);


### PR DESCRIPTION
## Summary
- Narrow traveler WAD release checks to only read the WAD fields needed for floor start decisions.
- Narrow labor budget evaluation to only read budget/threshold fields so unrelated WAD reporting columns cannot break traveler start or labor-context calls.
- Preserve existing approved-WAD promotion behavior while avoiding full-row `production_work_orders` selects in the traveler start path.

## Root cause
The production runtime is hitting a database where `production_work_orders.material_budget_amount` is not present, while Drizzle full-row selects include that schema column. Traveler start and labor-context only need WAD status, WAD approval status, labor budget hours, department budgets, and thresholds, so selecting the whole row made a reporting/schema drift issue block production travelers.

## Validation
- `git diff --check`
- Confirmed no remaining `storage.getWorkOrderById(traveler.productionWorkOrderId)` or full `productionWorkOrders` selects in the touched traveler start/labor budget paths.

## Note
Full TypeScript validation was not run locally because this clean worktree does not have `node_modules`.