### PR TITLE
[codex] Add canonical manufacturing routing map

### DIFF
--- a/client/src/components/inventory/InventoryItemsCard.tsx
+++ b/client/src/components/inventory/InventoryItemsCard.tsx
@@ -409,6 +409,7 @@ const InventoryForm = ({
                   <SelectItem value="CORE">Core</SelectItem>
                   <SelectItem value="SUB_ASSEMBLY">Sub-Assembly</SelectItem>
                   <SelectItem value="ASSEMBLY">Assembly</SelectItem>
+                  <SelectItem value="FINAL_ASSEMBLY">Final Assembly</SelectItem>
                   <SelectItem value="COMPOSITE">Composite</SelectItem>
                   <SelectItem value="COMPONENT">Component</SelectItem>
                 </SelectContent>
@@ -1275,7 +1276,7 @@ const inventoryFormSchema = z.object({
   agPartNumber: z.string().min(1, 'AG Part# is required'),
   name: z.string().min(1, 'Name is required'),
   itemType: z.enum(['PURCHASED', 'MANUFACTURED']).optional().nullable(),
-  manufacturedCategory: z.enum(['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'COMPOSITE', 'COMPONENT']).optional().nullable(),
+  manufacturedCategory: z.enum(['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT']).optional().nullable(),
 }).refine(
   (data) => {
     if (data.itemType === 'MANUFACTURED') return !!data.manufacturedCategory;
@@ -2111,7 +2112,7 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
         type: formData.type || 'Purchased',
         itemType: (formData.itemType || (formData.type === 'Manufactured' ? 'MANUFACTURED' : 'PURCHASED')) as 'PURCHASED' | 'MANUFACTURED',
         manufacturedCategory: (formData.itemType === 'MANUFACTURED' || formData.type === 'Manufactured') && formData.manufacturedCategory
-          ? formData.manufacturedCategory as 'PACKET' | 'KIT' | 'MACHINED_PART' | 'CORE' | 'SUB_ASSEMBLY' | 'ASSEMBLY' | 'COMPOSITE' | 'COMPONENT'
+          ? formData.manufacturedCategory as 'PACKET' | 'KIT' | 'MACHINED_PART' | 'CORE' | 'SUB_ASSEMBLY' | 'ASSEMBLY' | 'FINAL_ASSEMBLY' | 'COMPOSITE' | 'COMPONENT'
           : null,
         manufacturingLevel: (formData.itemType === 'MANUFACTURED' || formData.type === 'Manufactured') && formData.manufacturingLevel
           ? formData.manufacturingLevel as 'COMPONENT' | 'INTERMEDIATE' | 'FINAL'

--- a/client/src/lib/inventoryConstants.ts
+++ b/client/src/lib/inventoryConstants.ts
@@ -7,6 +7,7 @@ export const MANUFACTURED_CATEGORY_ORDER: ManufacturedCategory[] = [
   'CORE',
   'SUB_ASSEMBLY',
   'ASSEMBLY',
+  'FINAL_ASSEMBLY',
   'COMPOSITE',
   'COMPONENT',
 ];
@@ -18,13 +19,18 @@ export const CATEGORY_DISPLAY_NAMES: Record<ManufacturedCategory, string> = {
   CORE: 'Core',
   SUB_ASSEMBLY: 'Sub-Assembly',
   ASSEMBLY: 'Assembly',
+  FINAL_ASSEMBLY: 'Final Assembly',
   COMPOSITE: 'Composite',
   COMPONENT: 'Component',
 };
 
 export const DASHBOARD_DISPLAY_NAMES: Record<SupplySourceDashboard, string> = {
   CUTTING_TABLE: 'Cutting Table',
+  KITTING: 'Kitting',
   CNC: 'CNC',
   CORE: 'Core',
+  SUB_ASSEMBLY: 'Sub-Assembly',
   ASSEMBLY: 'Assembly',
+  FINAL_ASSEMBLY: 'Final Assembly',
+  LAYUP: 'Layup',
 };

--- a/client/src/pages/AssemblyQueue.tsx
+++ b/client/src/pages/AssemblyQueue.tsx
@@ -204,9 +204,9 @@ export default function AssemblyQueue() {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const { data: rawItems = [], isLoading } = useQuery<AssemblyQueueItem[]>({
-    queryKey: ['/api/manufacturing-queue', 'ASSEMBLY', selectedStatus],
+    queryKey: ['/api/manufacturing-queue', 'ASSEMBLY_TREE', selectedStatus],
     queryFn: () => {
-      const params = new URLSearchParams({ queueType: 'ASSEMBLY' });
+      const params = new URLSearchParams({ department: 'Assembly' });
       if (selectedStatus && selectedStatus !== 'ALL') params.append('status', selectedStatus);
       return apiRequest(`/api/manufacturing-queue?${params.toString()}`);
     },
@@ -342,6 +342,7 @@ export default function AssemblyQueue() {
                       <TableHead className="dark:text-gray-300">Work Order</TableHead>
                       <TableHead className="dark:text-gray-300">Part Number</TableHead>
                       <TableHead className="dark:text-gray-300">Item Name</TableHead>
+                      <TableHead className="dark:text-gray-300">Swimlane</TableHead>
                       <TableHead className="dark:text-gray-300">Department</TableHead>
                       <TableHead className="dark:text-gray-300">Readiness</TableHead>
                       <TableHead className="dark:text-gray-300">Quantity</TableHead>
@@ -382,8 +383,9 @@ export default function AssemblyQueue() {
                           {item.inventoryItem?.name ?? 'Unknown'}
                         </TableCell>
                         <TableCell className="dark:text-gray-300">
-                          {item.department}
+                          {item.queueType === 'FINAL_ASSEMBLY' ? 'Final Assembly' : 'Assembly'}
                         </TableCell>
+                        <TableCell className="dark:text-gray-300">{item.department}</TableCell>
                         <TableCell>
                           <div className="flex items-center gap-1">
                             <ReadinessBadge status={item.readinessStatus} percent={item.percentReady} />

--- a/migrations/0146_final_assembly_manufactured_category.sql
+++ b/migrations/0146_final_assembly_manufactured_category.sql
@@ -1,0 +1,2 @@
+-- Add final assembly as a distinct manufactured inventory category.
+ALTER TYPE inventory_manufactured_category ADD VALUE IF NOT EXISTS 'FINAL_ASSEMBLY';

--- a/server/index.ts
+++ b/server/index.ts
@@ -1982,10 +1982,11 @@ async function initializeBackgroundServices() {
         await db.execute(sqlInvClass`
           DO $$ BEGIN
             IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'inventory_manufactured_category') THEN
-              CREATE TYPE inventory_manufactured_category AS ENUM ('PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY');
+              CREATE TYPE inventory_manufactured_category AS ENUM ('PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT');
             END IF;
           END $$
         `);
+        await db.execute(sqlInvClass`ALTER TYPE inventory_manufactured_category ADD VALUE IF NOT EXISTS 'FINAL_ASSEMBLY'`);
         await db.execute(sqlInvClass`
           DO $$ BEGIN
             IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'inventory_manufacturing_level') THEN

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -39,6 +39,7 @@ import {
 import { sql, relations } from 'drizzle-orm';
 import { createInsertSchema } from 'drizzle-zod';
 import { z } from 'zod';
+import { getManufacturingRouteDefinition as resolveManufacturingRouteDefinition } from '../shared/utils/manufacturingRouting';
 
 // Order Department Types Reference Table (separate from order_departments tracking table)
 export const inventoryDepartments = pgTable('inventory_departments', {
@@ -619,12 +620,19 @@ export const formSubmissions = pgTable('form_submissions', {
 
 // Inventory Item Type Enums
 export const inventoryItemTypeEnum = pgEnum('inventory_item_type', ['PURCHASED', 'MANUFACTURED']);
-export const inventoryManufacturedCategoryEnum = pgEnum('inventory_manufactured_category', ['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'COMPOSITE', 'COMPONENT']);
+export const inventoryManufacturedCategoryEnum = pgEnum('inventory_manufactured_category', ['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT']);
 export const inventoryManufacturingLevelEnum = pgEnum('inventory_manufacturing_level', ['COMPONENT', 'INTERMEDIATE', 'FINAL']);
 
-// Supply source dashboard mapping — re-exported from canonical shared utility
-export type { ManufacturedCategory, SupplySourceDashboard } from '../shared/utils/supplySourceDashboard';
-export { getSupplySourceDashboard, supplySourceDashboardToLegacyDept, getDashboardCategories } from '../shared/utils/supplySourceDashboard';
+// Manufacturing routing mapping — re-exported from canonical shared utility
+export type { ManufacturedCategory, ManufacturingQueueType, ManufacturingSwimlane, SupplySourceDashboard } from '../shared/utils/manufacturingRouting';
+export {
+  getManufacturingCategoriesForDashboard,
+  getManufacturingCategoriesForDepartment,
+  getManufacturingRouteDefinition,
+  getSupplySourceDashboard,
+  supplySourceDashboardToLegacyDept,
+  getDashboardCategories,
+} from '../shared/utils/supplySourceDashboard';
 
 // Inventory Management Tables
 export const inventoryItems = pgTable('inventory_items', {
@@ -698,7 +706,7 @@ export const inventoryItems = pgTable('inventory_items', {
   // Formal item type classification (replaces loose text `type` field)
   itemType: inventoryItemTypeEnum('item_type'), // PURCHASED | MANUFACTURED
   // Manufactured items only — category determines production routing
-  manufacturedCategory: inventoryManufacturedCategoryEnum('manufactured_category'), // PACKET | KIT | MACHINED_PART | CORE | SUB_ASSEMBLY | ASSEMBLY
+  manufacturedCategory: inventoryManufacturedCategoryEnum('manufactured_category'), // PACKET | KIT | MACHINED_PART | CORE | SUB_ASSEMBLY | ASSEMBLY | FINAL_ASSEMBLY | COMPOSITE | COMPONENT
   // Manufactured items only — production level independent of category
   manufacturingLevel: inventoryManufacturingLevelEnum('manufacturing_level'), // COMPONENT | INTERMEDIATE | FINAL
   // Machined parts only — type of machine required to produce the part
@@ -2446,7 +2454,7 @@ export const insertInventoryItemSchema = createInsertSchema(inventoryItems)
     utilizedInServices: z.boolean().default(false),
     isActive: z.boolean().default(true),
     itemType: z.enum(['PURCHASED', 'MANUFACTURED']).optional().nullable(),
-    manufacturedCategory: z.enum(['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'COMPOSITE', 'COMPONENT']).optional().nullable(),
+    manufacturedCategory: z.enum(['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT']).optional().nullable(),
     manufacturingLevel: z.enum(['COMPONENT', 'INTERMEDIATE', 'FINAL']).optional().nullable(),
     machineType: z.enum(['CNC Mill 3rd Axis', 'CNC Mill 4th Axis', 'Lathe']).optional().nullable(),
     shelfLifeControlled: z.boolean().default(false),
@@ -9716,7 +9724,7 @@ export const manufacturingQueue = pgTable('manufacturing_queue', {
   p2PoItemId: integer('p2_po_item_id'), // Reference to P2 PO item
   // BOM explosion lineage — set when this record is created by explodeBomDemand
   parentProductionOrderId: text('parent_production_order_id'), // Production order that triggered this demand (FK to production_orders.order_id)
-  department: text('department').notNull(), // CNC, Cutting Table, Cores, or Assembly — derived via getSupplySourceDashboard()
+  department: text('department').notNull(), // Derived from manufactured category routing
   quantityRequested: integer('quantity_requested').notNull().default(1),
   quantityCompleted: integer('quantity_completed').default(0),
   priority: integer('priority').default(50), // 1-100, lower = higher priority
@@ -9738,7 +9746,7 @@ export const manufacturingQueue = pgTable('manufacturing_queue', {
   sourceId: text('source_id'), // Source identifier (e.g. PO number, order ID) that generated this entry
   sourceType: text('source_type'), // Source type (e.g. 'vendor_po', 'production_order', 'manual')
   // Readiness tracking fields (added for queue readiness engine)
-  queueType: text('queue_type'), // LAYUP | CORE | SUB_ASSEMBLY | ASSEMBLY | KIT
+  queueType: text('queue_type'), // CUTTING_TABLE | KIT | CNC | CORE | SUB_ASSEMBLY | ASSEMBLY | FINAL_ASSEMBLY | LAYUP
   readinessStatus: text('readiness_status').default('NOT_READY'), // NOT_READY | PARTIAL | READY | BLOCKED
   percentReady: numeric('percent_ready').default('0'),
   blockedReason: text('blocked_reason'),
@@ -10063,22 +10071,13 @@ export const insertAllocationRequirementSchema = createInsertSchema(allocationRe
 export type AllocationRequirement = typeof allocationRequirements.$inferSelect;
 export type InsertAllocationRequirement = z.infer<typeof insertAllocationRequirementSchema>;
 
-// mapQueueType — maps manufacturedCategory to { queueType, department } pairs
-export type QueueType = 'LAYUP' | 'CORE' | 'SUB_ASSEMBLY' | 'ASSEMBLY' | 'KIT';
+// mapQueueType — compatibility wrapper around the canonical manufactured category routing map.
+export type QueueType = import('../shared/utils/manufacturingRouting').ManufacturingQueueType;
 
 export function mapQueueType(category: import('../shared/utils/supplySourceDashboard').ManufacturedCategory | null): { queueType: QueueType; department: string } | null {
-  if (!category) return null;
-  if (category === 'COMPONENT') return null;
-  const mapping: Record<string, { queueType: QueueType; department: string }> = {
-    PACKET: { queueType: 'LAYUP', department: 'Cutting Table' },
-    KIT: { queueType: 'KIT', department: 'Kitting' },
-    MACHINED_PART: { queueType: 'ASSEMBLY', department: 'CNC' },
-    CORE: { queueType: 'CORE', department: 'Cores' },
-    SUB_ASSEMBLY: { queueType: 'SUB_ASSEMBLY', department: 'Assembly' },
-    ASSEMBLY: { queueType: 'ASSEMBLY', department: 'Assembly' },
-    COMPOSITE: { queueType: 'LAYUP', department: 'Cutting Table' },
-  };
-  return mapping[category] ?? null;
+  const route = resolveManufacturingRouteDefinition(category);
+  if (!route?.queueType || !route.department) return null;
+  return { queueType: route.queueType, department: route.department };
 }
 
 // Controlled Documents - Master Document Register

--- a/server/src/lib/workOrderDashboardAssignment.ts
+++ b/server/src/lib/workOrderDashboardAssignment.ts
@@ -145,6 +145,16 @@ function assignmentForDepartment(rawDepartment: string | null | undefined): Work
     };
   }
 
+  if (normalized.includes('finalassembly') || normalized.includes('finalassy')) {
+    return {
+      dashboardType: 'FINAL_ASSEMBLY',
+      queueType: 'FINAL_ASSEMBLY',
+      assignedDepartment: 'Assembly',
+      assignedDashboardRoute: '/assembly-queue',
+      dashboardLabel: 'Final Assembly Swimlane',
+    };
+  }
+
   if (normalized.includes('assembly') || normalized === 'assy') {
     return {
       dashboardType: 'ASSEMBLY',

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -872,7 +872,7 @@ router.post('/items/:id/routing', async (req: Request, res: Response) => {
     const inferredRoutingType = (() => {
       if (routingType) return routingType;
       const cat = (item as any).manufacturedCategory;
-      if (cat === 'ASSEMBLY') return 'ASSEMBLY';
+      if (cat === 'ASSEMBLY' || cat === 'FINAL_ASSEMBLY') return 'ASSEMBLY';
       if (cat === 'SUB_ASSEMBLY') return 'SUB_ASSEMBLY';
       if (cat === 'MACHINED_PART') return 'CNC';
       if (cat === 'KIT') return 'KIT';

--- a/server/src/routes/manufacturingQueue.ts
+++ b/server/src/routes/manufacturingQueue.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { db, pool } from '../../db';
-import { manufacturingQueue, inventoryItems, supplySourceDashboardToLegacyDept, getDashboardCategories } from '../../schema';
+import { manufacturingQueue, inventoryItems, supplySourceDashboardToLegacyDept, getDashboardCategories, getManufacturingCategoriesForDepartment } from '../../schema';
 import type { SupplySourceDashboard } from '../../schema';
 import { eq, and, or, desc, inArray } from 'drizzle-orm';
 import { insertManufacturingQueueSchema } from '../../schema';
@@ -22,9 +22,9 @@ router.get('/', async (req, res) => {
     const { department, status, dashboard, queueType } = req.query;
 
     // Resolve routing signal — additive OR of dept and category matches
-    let routingSignal: ReturnType<typeof eq> | ReturnType<typeof or> | undefined;
+    let routingSignal: ReturnType<typeof eq> | ReturnType<typeof or> | ReturnType<typeof inArray> | undefined;
 
-    const VALID_DASHBOARDS: SupplySourceDashboard[] = ['CUTTING_TABLE', 'CNC', 'CORE', 'ASSEMBLY'];
+    const VALID_DASHBOARDS: SupplySourceDashboard[] = ['CUTTING_TABLE', 'KITTING', 'CNC', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'LAYUP'];
 
     if (dashboard && typeof dashboard === 'string') {
       // Strict validation — reject unknown dashboard values
@@ -35,15 +35,16 @@ router.get('/', async (req, res) => {
       const legacyDept = supplySourceDashboardToLegacyDept(dash);
       const categories = getDashboardCategories(dash);
       if (legacyDept) {
-        routingSignal = categories.length > 0
+        routingSignal = dash === 'FINAL_ASSEMBLY' && categories.length > 0
+          ? inArray(inventoryItems.manufacturedCategory, categories)
+          : categories.length > 0
           ? or(eq(manufacturingQueue.department, legacyDept), inArray(inventoryItems.manufacturedCategory, categories))
           : eq(manufacturingQueue.department, legacyDept);
       }
     } else if (department && typeof department === 'string') {
       // Legacy dept param — also match by category for this dept via getDashboardCategories
       // Reverse-lookup from legacy dept name to dashboard, then get categories
-      const matchedDash = VALID_DASHBOARDS.find(d => supplySourceDashboardToLegacyDept(d) === department);
-      const categories = matchedDash ? getDashboardCategories(matchedDash) : [];
+      const categories = getManufacturingCategoriesForDepartment(department);
       routingSignal = categories.length > 0
         ? or(eq(manufacturingQueue.department, department), inArray(inventoryItems.manufacturedCategory, categories))
         : eq(manufacturingQueue.department, department);
@@ -58,8 +59,7 @@ router.get('/', async (req, res) => {
       : undefined;
 
     const filters = [routingSignal, statusFilter, queueTypeFilter].filter(Boolean);
-    const whereClause = filters.length > 1 ? and(...(filters as [ReturnType<typeof eq>, ...ReturnType<typeof eq>[]]))
-      : filters[0];
+    const whereClause = filters.length > 1 ? and(...(filters as any)) : filters[0];
 
     const baseQuery = db
       .select({
@@ -153,7 +153,7 @@ router.get('/', async (req, res) => {
 //   (a) manufacturing_queue.department matches the legacy dept name for this dashboard, OR
 //   (b) inventoryItems.manufacturedCategory is in the category set for this dashboard
 // Using both conditions ensures both legacy records and BOM-exploded records appear.
-// Valid dashboard values: CUTTING_TABLE | CNC | ASSEMBLY | CORE
+// Valid dashboard values: CUTTING_TABLE | KITTING | CNC | CORE | SUB_ASSEMBLY | ASSEMBLY | FINAL_ASSEMBLY | LAYUP
 router.get('/by-dashboard/:dashboard', async (req, res) => {
   try {
     const dashboard = req.params.dashboard as SupplySourceDashboard;
@@ -165,7 +165,9 @@ router.get('/by-dashboard/:dashboard', async (req, res) => {
     const categories = getDashboardCategories(dashboard);
 
     // Additive routing signal: dept match OR category match
-    const routingSignal = categories.length > 0
+    const routingSignal = dashboard === 'FINAL_ASSEMBLY' && categories.length > 0
+      ? inArray(inventoryItems.manufacturedCategory, categories)
+      : categories.length > 0
       ? or(
           eq(manufacturingQueue.department, legacyDept),
           inArray(inventoryItems.manufacturedCategory, categories)
@@ -423,8 +425,9 @@ router.post('/:id/generate-requirements', async (req, res) => {
 });
 
 // POST /api/manufacturing-queue/:id/release
-// Formally releases a KIT, LAYUP, CORE, SUB_ASSEMBLY, or ASSEMBLY queue item, setting status = RELEASED and recording releasedAt.
-// Requires: queueType = KIT | LAYUP | CORE | SUB_ASSEMBLY | ASSEMBLY, readinessStatus = READY, status not already IN_PROGRESS/COMPLETED/RELEASED/CANCELLED.
+// Formally releases a routable queue item, setting status = RELEASED and recording releasedAt.
+// Requires: queueType = CUTTING_TABLE | KIT | CNC | LAYUP | CORE | SUB_ASSEMBLY | ASSEMBLY | FINAL_ASSEMBLY,
+// readinessStatus = READY, status not already IN_PROGRESS/COMPLETED/RELEASED/CANCELLED.
 router.post('/:id/release', async (req, res) => {
   try {
     const id = parseInt(req.params.id, 10);
@@ -446,8 +449,8 @@ router.post('/:id/release', async (req, res) => {
     if (!item) {
       return res.status(404).json({ error: 'Manufacturing queue item not found' });
     }
-    if (item.queueType !== 'KIT' && item.queueType !== 'LAYUP' && item.queueType !== 'CORE' && item.queueType !== 'SUB_ASSEMBLY' && item.queueType !== 'ASSEMBLY') {
-      return res.status(400).json({ error: 'Only KIT, LAYUP, CORE, SUB_ASSEMBLY, or ASSEMBLY queue items can be released' });
+    if (item.queueType !== 'CUTTING_TABLE' && item.queueType !== 'KIT' && item.queueType !== 'CNC' && item.queueType !== 'LAYUP' && item.queueType !== 'CORE' && item.queueType !== 'SUB_ASSEMBLY' && item.queueType !== 'ASSEMBLY' && item.queueType !== 'FINAL_ASSEMBLY') {
+      return res.status(400).json({ error: 'Only CUTTING_TABLE, KIT, CNC, LAYUP, CORE, SUB_ASSEMBLY, ASSEMBLY, or FINAL_ASSEMBLY queue items can be released' });
     }
     if (item.readinessStatus !== 'READY') {
       return res.status(400).json({ error: `${item.queueType} must be READY before it can be released` });

--- a/server/src/services/queueReadinessService.ts
+++ b/server/src/services/queueReadinessService.ts
@@ -34,7 +34,7 @@ export async function evaluateQueueReadiness(queueId: number): Promise<Readiness
     .where(eq(manufacturingQueue.id, queueId))
     .limit(1);
 
-  const isLayup = queueRow?.queueType === 'LAYUP';
+  const isLayup = queueRow?.queueType === 'LAYUP' || queueRow?.queueType === 'CUTTING_TABLE';
 
   const requirements = await db
     .select()

--- a/server/src/utils/manufacturingQueueHelper.ts
+++ b/server/src/utils/manufacturingQueueHelper.ts
@@ -5,8 +5,7 @@ import {
   boms,
   bomRevisions,
   bomLines,
-  getSupplySourceDashboard,
-  supplySourceDashboardToLegacyDept,
+  getManufacturingRouteDefinition,
   insertManufacturingQueueSchema,
   type ManufacturedCategory,
   type ManufacturingQueue,
@@ -44,10 +43,17 @@ export async function autoPopulateManufacturingQueue(
       where: eq(inventoryItems.agPartNumber, params.inventoryPartNumber),
     });
 
-    // Only proceed if item is manufactured and has a manufacturing department
+    const route = getManufacturingRouteDefinition(inventoryItem?.manufacturedCategory as ManufacturedCategory | null);
+    const department = route?.department || inventoryItem?.manufacturingDepartment;
+    const queueType = route?.queueType ?? null;
+    const isManufactured =
+      inventoryItem?.itemType === 'MANUFACTURED' ||
+      inventoryItem?.type === 'Manufactured';
+
+    // Only proceed if item is manufactured and has a routable department
     if (!inventoryItem ||
-        inventoryItem.type !== 'Manufactured' ||
-        !inventoryItem.manufacturingDepartment) {
+        !isManufactured ||
+        !department) {
       return null;
     }
 
@@ -113,13 +119,14 @@ export async function autoPopulateManufacturingQueue(
       vendorPoItemId: params.vendorPoItemId ?? null,
       p2PoId: params.p2PoId || null,
       p2PoItemId: params.p2PoItemId || null,
-      department: inventoryItem.manufacturingDepartment,
+      department,
       quantityRequested: params.quantity,
       quantityCompleted: 0,
       status: 'PENDING',
       priority: 50,
       dueDate: params.dueDate || null,
       assignedTo: null,
+      queueType,
       notes,
     });
 
@@ -130,7 +137,7 @@ export async function autoPopulateManufacturingQueue(
 
     const poType = params.vendorPoId ? 'Vendor' : 'P2';
     const poId = params.vendorPoId || params.p2PoId;
-    console.log(`✅ Auto-created manufacturing queue entry for ${inventoryItem.agPartNumber} in ${inventoryItem.manufacturingDepartment} (Queue ID: ${newQueueItem.id}, ${poType} PO #${poId})`);
+    console.log(`✅ Auto-created manufacturing queue entry for ${inventoryItem.agPartNumber} in ${department} (Queue ID: ${newQueueItem.id}, ${poType} PO #${poId})`);
 
     // Auto-generate allocation requirements from routing (best-effort, non-blocking)
     generateRequirementsFromRouting(newQueueItem.id).catch(err =>
@@ -258,8 +265,15 @@ export async function explodeBOMForManufacturing(params: {
         where: eq(inventoryItems.agPartNumber, component.childPartNumber),
       });
 
+      const route = getManufacturingRouteDefinition(inventoryItem?.manufacturedCategory as ManufacturedCategory | null);
+      const department = route?.department || inventoryItem?.manufacturingDepartment;
+      const queueType = route?.queueType ?? null;
+      const isManufactured =
+        inventoryItem?.itemType === 'MANUFACTURED' ||
+        inventoryItem?.type === 'Manufactured';
+
       // Only create queue entries for manufactured components
-      if (inventoryItem?.type === 'Manufactured' && inventoryItem.manufacturingDepartment) {
+      if (inventoryItem && isManufactured && department) {
         const requiredQty = params.quantity * parseFloat(component.qtyPer);
 
         // Check for duplicates
@@ -284,12 +298,13 @@ export async function explodeBOMForManufacturing(params: {
           inventoryItemId: inventoryItem.id,
           p2PoId: params.p2PoId,
           p2PoItemId: params.p2PoItemId,
-          department: inventoryItem.manufacturingDepartment,
+          department,
           quantityRequested: requiredQty,
           quantityCompleted: 0,
           status: 'PENDING',
           priority: 50,
           dueDate: params.dueDate || null,
+          queueType,
           notes: `Auto-generated from P2 PO #${params.p2PoId} BOM explosion for ${params.partNumber} (${params.quantity} units × ${component.qtyPer} per unit)`,
         });
 
@@ -300,7 +315,7 @@ export async function explodeBOMForManufacturing(params: {
 
         createdQueueItems.push(newQueueItem);
 
-        console.log(`✅ BOM explosion: Created queue entry for ${component.childPartNumber} in ${inventoryItem.manufacturingDepartment} (Qty: ${requiredQty}, Queue ID: ${newQueueItem.id})`);
+        console.log(`✅ BOM explosion: Created queue entry for ${component.childPartNumber} in ${department} (Qty: ${requiredQty}, Queue ID: ${newQueueItem.id})`);
 
         // Auto-generate allocation requirements from routing (best-effort, non-blocking)
         generateRequirementsFromRouting(newQueueItem.id).catch(err =>
@@ -327,16 +342,19 @@ export async function explodeBOMForManufacturing(params: {
  *   inventory item (ASSEMBLY | SUB_ASSEMBLY)
  *     → BOM explosion (boms → bom_revisions[isReleased=true] → bom_lines)
  *     → demand record inserted into manufacturing_queue
- *         - department derived from child.manufacturedCategory via getSupplySourceDashboard()
+ *         - department and queueType derived from child.manufacturedCategory
  *         - parentProductionOrderId links back to the triggering order (traceable)
  *         - notes contain parentPartNumber and context for human readability
  *     → dashboard query reads manufacturing_queue.department
- *         - Cutting Table dashboard: department = 'Cutting Table'  (PACKET | KIT)
- *         - CNC queue:              department = 'CNC'             (MACHINED_PART)
- *         - Assembly queue:         department = 'Assembly'        (ASSEMBLY | SUB_ASSEMBLY)
- *         - Core queue:             department = 'Cores'           (CORE)
+ *         - Cutting Table demand: department = 'Cutting Table' (PACKET)
+ *         - Kitting queue:        department = 'Kitting'       (KIT)
+ *         - CNC queue:            department = 'CNC'           (MACHINED_PART)
+ *         - Core queue:           department = 'Core'          (CORE)
+ *         - Sub Assembly queue:   department = 'Sub Assembly'  (SUB_ASSEMBLY)
+ *         - Assembly queue:       department = 'Assembly'      (ASSEMBLY | FINAL_ASSEMBLY)
+ *         - Layup queue:          department = 'Layup'         (COMPOSITE)
  *
- * Recursion: if a child item is ASSEMBLY or SUB_ASSEMBLY and has its own released BOM,
+ * Recursion: if a child item is ASSEMBLY, FINAL_ASSEMBLY, or SUB_ASSEMBLY and has its own released BOM,
  * explodeBomDemand is called recursively for that child (depth-first).
  * Purchased items and items without BOMs are leaf nodes — no further explosion.
  *
@@ -415,10 +433,9 @@ export async function explodeBomDemand(
       }
 
       const category = childItem.manufacturedCategory as ManufacturedCategory | null;
-      const dashboard = getSupplySourceDashboard(category);
-      const legacyDept = supplySourceDashboardToLegacyDept(dashboard);
+      const route = getManufacturingRouteDefinition(category);
 
-      if (!legacyDept) {
+      if (!route?.department) {
         const fallbackDept = childItem.manufacturingDepartment;
         if (!fallbackDept) {
           console.warn(`⚠️ Cannot determine department for ${line.childPartNumber} (no category, no manufacturingDepartment) — skipping`);
@@ -426,7 +443,8 @@ export async function explodeBomDemand(
         }
       }
 
-      const department = legacyDept || childItem.manufacturingDepartment!;
+      const department = route?.department || childItem.manufacturingDepartment!;
+      const queueType = route?.queueType ?? null;
       const requiredQty = qty * parseFloat(line.qtyPer || '1');
 
       const queueData = insertManufacturingQueueSchema.parse({
@@ -437,12 +455,14 @@ export async function explodeBomDemand(
         status: 'PENDING',
         priority: 50,
         parentProductionOrderId: productionOrderId,
+        queueType,
         notes: JSON.stringify({
           source: 'BOM_EXPLOSION',
           parentPartNumber,
           childPartNumber: line.childPartNumber,
           qtyPer: line.qtyPer,
-          supplySourceDashboard: dashboard,
+          manufacturingDashboard: route?.dashboard ?? null,
+          manufacturingSwimlane: route?.swimlane ?? null,
         }),
       });
 
@@ -459,7 +479,7 @@ export async function explodeBomDemand(
         console.warn(`[explodeBomDemand] requirement generation failed for queue ${newItem.id}:`, err.message)
       );
 
-      if (category === 'ASSEMBLY' || category === 'SUB_ASSEMBLY') {
+      if (category === 'ASSEMBLY' || category === 'FINAL_ASSEMBLY' || category === 'SUB_ASSEMBLY') {
         const childCreated = await explodeBomDemand(
           line.childPartNumber,
           requiredQty,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -555,8 +555,7 @@ import {
   type InsertTicketOrder,
   type TicketActivity,
   type InsertTicketActivity,
-  getSupplySourceDashboard,
-  supplySourceDashboardToLegacyDept,
+  getManufacturingRouteDefinition,
   type ManufacturedCategory,
   // CNC Dashboard types
   type CncScheduleSettings,
@@ -13234,11 +13233,12 @@ export class DatabaseStorage implements IStorage {
               .limit(1);
             const childInvItem = rows[0] ?? null;
 
-            // Trigger BOM explosion when manufacturedCategory is ASSEMBLY or SUB_ASSEMBLY.
+            // Trigger BOM explosion when manufacturedCategory is ASSEMBLY, FINAL_ASSEMBLY, or SUB_ASSEMBLY.
             // itemType === 'MANUFACTURED' is an optional guard — some legacy rows may lack itemType
             // while still having a valid manufacturedCategory, so category is the primary signal.
             const isAssembly =
               childInvItem?.manufacturedCategory === 'ASSEMBLY' ||
+              childInvItem?.manufacturedCategory === 'FINAL_ASSEMBLY' ||
               childInvItem?.manufacturedCategory === 'SUB_ASSEMBLY';
             const isManufactured =
               !childInvItem?.itemType || childInvItem?.itemType === 'MANUFACTURED';
@@ -15812,10 +15812,8 @@ export class DatabaseStorage implements IStorage {
             }
 
             // Derive department: category takes priority; fall back to legacy isPacket/manufacturingDepartment for unmigrated items.
-            const derivedDashboard = getSupplySourceDashboard(part.manufacturedCategory as ManufacturedCategory);
-            const effectiveDepartment = derivedDashboard
-              ? supplySourceDashboardToLegacyDept(derivedDashboard)
-              : (isPacketItem ? 'Cutting Table' : part.manufacturingDepartment);
+            const route = getManufacturingRouteDefinition(part.manufacturedCategory as ManufacturedCategory);
+            const effectiveDepartment = route?.department || (isPacketItem ? 'Cutting Table' : part.manufacturingDepartment);
 
             if (!effectiveDepartment) {
               const skipMsg = `Manufactured part ${line.childPartAgNumber} has no manufacturing department assigned`;
@@ -15905,10 +15903,8 @@ export class DatabaseStorage implements IStorage {
             }
 
             // Derive department: category takes priority; fall back to legacy isPacket/manufacturingDepartment for unmigrated items.
-            const derivedDashboard2 = getSupplySourceDashboard(part?.manufacturedCategory as ManufacturedCategory);
-            const effectiveDepartment = derivedDashboard2
-              ? supplySourceDashboardToLegacyDept(derivedDashboard2)
-              : (isPacketItem ? 'Cutting Table' : (item.firstDept || part?.manufacturingDepartment || null));
+            const route = getManufacturingRouteDefinition(part?.manufacturedCategory as ManufacturedCategory);
+            const effectiveDepartment = route?.department || (isPacketItem ? 'Cutting Table' : (item.firstDept || part?.manufacturingDepartment || null));
 
             if (!effectiveDepartment) {
               const skipMsg = `Part ${itemPartNumber} has no department assigned`;
@@ -15966,10 +15962,8 @@ export class DatabaseStorage implements IStorage {
 
       if (topLevelPart.length > 0 && (topIsManufactured || topIsPacket)) {
         const part = topLevelPart[0];
-        const topDerivedDashboard = getSupplySourceDashboard(part.manufacturedCategory as ManufacturedCategory);
-        const topDepartment = topDerivedDashboard
-          ? supplySourceDashboardToLegacyDept(topDerivedDashboard)
-          : (topIsPacket ? 'Cutting Table' : part.manufacturingDepartment);
+        const topRoute = getManufacturingRouteDefinition(part.manufacturedCategory as ManufacturedCategory);
+        const topDepartment = topRoute?.department || (topIsPacket ? 'Cutting Table' : part.manufacturingDepartment);
         
         if (topDepartment) {
           console.log(`🔧 Top-level item ${poItem.partNumber} is ${topIsPacket ? 'Packet' : 'Manufactured'} (dept: ${topDepartment}) - queuing ${effectiveQuantity} production orders`);

--- a/shared/utils/manufacturingRouting.ts
+++ b/shared/utils/manufacturingRouting.ts
@@ -1,0 +1,165 @@
+export type ManufacturedCategory =
+  | 'PACKET'
+  | 'KIT'
+  | 'MACHINED_PART'
+  | 'CORE'
+  | 'SUB_ASSEMBLY'
+  | 'ASSEMBLY'
+  | 'FINAL_ASSEMBLY'
+  | 'COMPOSITE'
+  | 'COMPONENT';
+
+export type ManufacturingQueueType =
+  | 'CUTTING_TABLE'
+  | 'KIT'
+  | 'CNC'
+  | 'CORE'
+  | 'SUB_ASSEMBLY'
+  | 'ASSEMBLY'
+  | 'FINAL_ASSEMBLY'
+  | 'LAYUP';
+
+export type ManufacturingSwimlane =
+  | 'CUTTING_TABLE_DEMAND'
+  | 'KITTING'
+  | 'CNC'
+  | 'CORE'
+  | 'SUB_ASSEMBLY'
+  | 'ASSEMBLY'
+  | 'FINAL_ASSEMBLY'
+  | 'LAYUP';
+
+export type SupplySourceDashboard =
+  | 'CUTTING_TABLE'
+  | 'KITTING'
+  | 'CNC'
+  | 'CORE'
+  | 'SUB_ASSEMBLY'
+  | 'ASSEMBLY'
+  | 'FINAL_ASSEMBLY'
+  | 'LAYUP';
+
+export interface ManufacturingRouteDefinition {
+  category: ManufacturedCategory;
+  displayName: string;
+  dashboard: SupplySourceDashboard | null;
+  queueType: ManufacturingQueueType | null;
+  swimlane: ManufacturingSwimlane | null;
+  department: string | null;
+  canRelease: boolean;
+  includeInBomExplosion: boolean;
+}
+
+export const MANUFACTURING_ROUTE_DEFINITIONS: Record<ManufacturedCategory, ManufacturingRouteDefinition> = {
+  PACKET: {
+    category: 'PACKET',
+    displayName: 'Packet',
+    dashboard: 'CUTTING_TABLE',
+    queueType: 'CUTTING_TABLE',
+    swimlane: 'CUTTING_TABLE_DEMAND',
+    department: 'Cutting Table',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  KIT: {
+    category: 'KIT',
+    displayName: 'Kitting',
+    dashboard: 'KITTING',
+    queueType: 'KIT',
+    swimlane: 'KITTING',
+    department: 'Kitting',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  MACHINED_PART: {
+    category: 'MACHINED_PART',
+    displayName: 'Machined Part',
+    dashboard: 'CNC',
+    queueType: 'CNC',
+    swimlane: 'CNC',
+    department: 'CNC',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  CORE: {
+    category: 'CORE',
+    displayName: 'Core',
+    dashboard: 'CORE',
+    queueType: 'CORE',
+    swimlane: 'CORE',
+    department: 'Core',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  SUB_ASSEMBLY: {
+    category: 'SUB_ASSEMBLY',
+    displayName: 'Sub-Assembly',
+    dashboard: 'SUB_ASSEMBLY',
+    queueType: 'SUB_ASSEMBLY',
+    swimlane: 'SUB_ASSEMBLY',
+    department: 'Sub Assembly',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  ASSEMBLY: {
+    category: 'ASSEMBLY',
+    displayName: 'Assembly',
+    dashboard: 'ASSEMBLY',
+    queueType: 'ASSEMBLY',
+    swimlane: 'ASSEMBLY',
+    department: 'Assembly',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  FINAL_ASSEMBLY: {
+    category: 'FINAL_ASSEMBLY',
+    displayName: 'Final Assembly',
+    dashboard: 'FINAL_ASSEMBLY',
+    queueType: 'FINAL_ASSEMBLY',
+    swimlane: 'FINAL_ASSEMBLY',
+    department: 'Assembly',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  COMPOSITE: {
+    category: 'COMPOSITE',
+    displayName: 'Composite',
+    dashboard: 'LAYUP',
+    queueType: 'LAYUP',
+    swimlane: 'LAYUP',
+    department: 'Layup',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  COMPONENT: {
+    category: 'COMPONENT',
+    displayName: 'Component',
+    dashboard: null,
+    queueType: null,
+    swimlane: null,
+    department: null,
+    canRelease: false,
+    includeInBomExplosion: false,
+  },
+};
+
+export function getManufacturingRouteDefinition(
+  category: ManufacturedCategory | null | undefined,
+): ManufacturingRouteDefinition | null {
+  if (!category) return null;
+  return MANUFACTURING_ROUTE_DEFINITIONS[category] ?? null;
+}
+
+export function getManufacturingCategoriesForDashboard(
+  dashboard: SupplySourceDashboard,
+): ManufacturedCategory[] {
+  return Object.values(MANUFACTURING_ROUTE_DEFINITIONS)
+    .filter((route) => route.dashboard === dashboard)
+    .map((route) => route.category);
+}
+
+export function getManufacturingCategoriesForDepartment(department: string): ManufacturedCategory[] {
+  return Object.values(MANUFACTURING_ROUTE_DEFINITIONS)
+    .filter((route) => route.department === department)
+    .map((route) => route.category);
+}

--- a/shared/utils/supplySourceDashboard.ts
+++ b/shared/utils/supplySourceDashboard.ts
@@ -1,45 +1,34 @@
-export type ManufacturedCategory = 'PACKET' | 'KIT' | 'MACHINED_PART' | 'CORE' | 'SUB_ASSEMBLY' | 'ASSEMBLY' | 'COMPOSITE' | 'COMPONENT';
-export type SupplySourceDashboard = 'CUTTING_TABLE' | 'CNC' | 'CORE' | 'ASSEMBLY';
+import {
+  getManufacturingCategoriesForDashboard,
+  getManufacturingRouteDefinition,
+  type ManufacturedCategory,
+  type SupplySourceDashboard,
+} from './manufacturingRouting';
 
-const CATEGORY_TO_DASHBOARD: Partial<Record<ManufacturedCategory, SupplySourceDashboard>> = {
-  PACKET: 'CUTTING_TABLE',
-  KIT: 'CUTTING_TABLE',
-  MACHINED_PART: 'CNC',
-  CORE: 'CORE',
-  SUB_ASSEMBLY: 'ASSEMBLY',
-  ASSEMBLY: 'ASSEMBLY',
-  COMPOSITE: 'ASSEMBLY',
-  // COMPONENT has no supply source dashboard mapping
-};
+export type {
+  ManufacturedCategory,
+  SupplySourceDashboard,
+} from './manufacturingRouting';
 
-const DASHBOARD_TO_LEGACY_DEPT: Record<SupplySourceDashboard, string> = {
-  CUTTING_TABLE: 'Cutting Table',
-  CNC: 'CNC',
-  CORE: 'Cores',
-  ASSEMBLY: 'Assembly',
-};
+export {
+  getManufacturingCategoriesForDashboard,
+  getManufacturingCategoriesForDashboard as getDashboardCategories,
+  getManufacturingCategoriesForDepartment,
+  getManufacturingRouteDefinition,
+} from './manufacturingRouting';
 
 export function getSupplySourceDashboard(
   category: ManufacturedCategory | null | undefined,
 ): SupplySourceDashboard | null {
-  if (!category) return null;
-  return CATEGORY_TO_DASHBOARD[category] ?? null;
+  return getManufacturingRouteDefinition(category)?.dashboard ?? null;
 }
 
 export function supplySourceDashboardToLegacyDept(
   dashboard: SupplySourceDashboard | null,
 ): string | null {
   if (!dashboard) return null;
-  return DASHBOARD_TO_LEGACY_DEPT[dashboard] ?? null;
-}
-
-const DASHBOARD_TO_CATEGORIES: Record<SupplySourceDashboard, ManufacturedCategory[]> = {
-  CUTTING_TABLE: ['PACKET', 'KIT'],
-  CNC: ['MACHINED_PART'],
-  CORE: ['CORE'],
-  ASSEMBLY: ['ASSEMBLY', 'SUB_ASSEMBLY', 'COMPOSITE'],
-};
-
-export function getDashboardCategories(dashboard: SupplySourceDashboard): ManufacturedCategory[] {
-  return DASHBOARD_TO_CATEGORIES[dashboard] ?? [];
+  const route = getManufacturingCategoriesForDashboard(dashboard)
+    .map((category) => getManufacturingRouteDefinition(category))
+    .find((definition) => definition?.department);
+  return route?.department ?? null;
 }


### PR DESCRIPTION
## Summary

- Add a canonical manufactured-category routing map for queue type, department, dashboard, and swimlane decisions.
- Correct category routing so packet demand, kitting, CNC, core, sub-assembly, assembly, final assembly, layup, and component behavior come from one shared source.
- Add `FINAL_ASSEMBLY` as a manufactured inventory category and expose it in inventory UI, routing inference, BOM demand recursion, and the Assembly queue swimlane display.
- Update manufacturing queue creation paths to set `department` and `queueType` from the canonical route definition.

## Validation

- `git diff --check` passed.
- Full `npm run check` could not be run in this desktop environment because `npm` is not installed.

## Notes

This is the foundation PR. Follow-up PRs should handle any data backfill/repair for existing `manufacturing_queue` rows and any richer final-assembly tree UI beyond the initial Assembly queue swimlane marker.