### PR TITLE
[codex] Fix PM material budget schema fallback

### DIFF
--- a/server/src/helpers/laborBudgetHelper.ts
+++ b/server/src/helpers/laborBudgetHelper.ts
@@ -63,7 +63,12 @@ export async function evaluateWorkOrderLaborStatus(
   department?: string | null
 ): Promise<WorkOrderLaborStatusResult> {
   const [wad] = await db
-    .select()
+    .select({
+      totalBudgetHours: productionWorkOrders.totalBudgetHours,
+      departmentBudgets: productionWorkOrders.departmentBudgets,
+      warningThreshold: productionWorkOrders.warningThreshold,
+      blockedThreshold: productionWorkOrders.blockedThreshold,
+    })
     .from(productionWorkOrders)
     .where(eq(productionWorkOrders.id, workOrderId))
     .limit(1);

--- a/server/src/helpers/travelerBarcodeResolver.ts
+++ b/server/src/helpers/travelerBarcodeResolver.ts
@@ -89,7 +89,11 @@ export async function buildChargeContextFromTraveler(
   }
 
   const [wad] = await db
-    .select()
+    .select({
+      id: productionWorkOrders.id,
+      workOrderNumber: productionWorkOrders.workOrderNumber,
+      projectId: productionWorkOrders.projectId,
+    })
     .from(productionWorkOrders)
     .where(eq(productionWorkOrders.id, traveler.productionWorkOrderId))
     .limit(1);

--- a/server/src/lib/wadHelper.ts
+++ b/server/src/lib/wadHelper.ts
@@ -87,6 +87,36 @@ export interface EnsureWadResult {
   seedData: WadSeedData | null;
 }
 
+const productionWorkOrderReadColumns = {
+  id: productionWorkOrders.id,
+  workOrderNumber: productionWorkOrders.workOrderNumber,
+  projectId: productionWorkOrders.projectId,
+  partNumber: productionWorkOrders.partNumber,
+  description: productionWorkOrders.description,
+  quantity: productionWorkOrders.quantity,
+  status: productionWorkOrders.status,
+  departmentBudgets: productionWorkOrders.departmentBudgets,
+  totalBudgetHours: productionWorkOrders.totalBudgetHours,
+  startDate: productionWorkOrders.startDate,
+  dueDate: productionWorkOrders.dueDate,
+  warningThreshold: productionWorkOrders.warningThreshold,
+  blockedThreshold: productionWorkOrders.blockedThreshold,
+  defaultChargeCodeId: productionWorkOrders.defaultChargeCodeId,
+  dashboardType: productionWorkOrders.dashboardType,
+  queueType: productionWorkOrders.queueType,
+  assignedDepartment: productionWorkOrders.assignedDepartment,
+  assignedDashboardRoute: productionWorkOrders.assignedDashboardRoute,
+  manufacturingQueueId: productionWorkOrders.manufacturingQueueId,
+  wadStatus: productionWorkOrders.wadStatus,
+  wizardData: productionWorkOrders.wizardData,
+  createdAt: productionWorkOrders.createdAt,
+  updatedAt: productionWorkOrders.updatedAt,
+};
+
+function withDefaultMaterialBudgetAmount(row: Record<string, unknown>): ProductionWorkOrder {
+  return { ...row, materialBudgetAmount: '0' } as ProductionWorkOrder;
+}
+
 /**
  * Ensures a project has at least one Production Work Order (WAD).
  *
@@ -195,14 +225,14 @@ export async function ensureProjectHasWADFromCanonicalSources(
     await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${projectId}))`);
 
     const existingRows = await tx
-      .select()
+      .select(productionWorkOrderReadColumns)
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.projectId, projectId))
       .orderBy(desc(productionWorkOrders.createdAt));
     if (existingRows.length > 0) {
       const target =
         existingRows.find((w) => w.wadStatus !== 'APPROVED') ?? existingRows[0];
-      return { workOrder: target, created: false, seedData: null };
+      return { workOrder: withDefaultMaterialBudgetAmount(target), created: false, seedData: null };
     }
 
     const [project] = await tx.select().from(projects).where(eq(projects.id, projectId)).limit(1);

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -248,6 +248,41 @@ async function publicTableExists(tableName: string): Promise<boolean> {
   return rows[0]?.exists === true;
 }
 
+let hasProductionWorkOrderMaterialBudgetColumn: boolean | null = null;
+
+async function getProductionWorkOrderMaterialBudgetExpression() {
+  if (hasProductionWorkOrderMaterialBudgetColumn === null) {
+    const rows = await pool.query<{ exists: boolean }>(
+      `
+        SELECT EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_schema = current_schema()
+            AND table_name = 'production_work_orders'
+            AND column_name = 'material_budget_amount'
+        ) AS "exists"
+      `,
+    );
+
+    hasProductionWorkOrderMaterialBudgetColumn = rows[0]?.exists === true;
+  }
+
+  if (hasProductionWorkOrderMaterialBudgetColumn) {
+    return `
+        NULLIF(material_budget_amount::numeric, 0),
+        NULLIF(wizard_data->>'materialBudgetAmount', '')::numeric,
+        NULLIF(wizard_data->>'materialBudget', '')::numeric,
+        0
+    `;
+  }
+
+  return `
+        NULLIF(wizard_data->>'materialBudgetAmount', '')::numeric,
+        NULLIF(wizard_data->>'materialBudget', '')::numeric,
+        0
+  `;
+}
+
 function canTraceProjectLabor(user: { username?: string | null; role?: string | null } | undefined): boolean {
   const username = String(user?.username ?? '').trim().toLowerCase();
   const role = String(user?.role ?? '').trim().toUpperCase();
@@ -1008,13 +1043,11 @@ router.get('/:projectId/summary', h(async (req, res) => {
       AND status = ANY($2::text[])
   `, [projectId, ORDERED_PARTS_REQUEST_STATUSES]);
 
+  const materialBudgetExpression = await getProductionWorkOrderMaterialBudgetExpression();
   const wadMaterialBudgetRes = await pool.query<{ plannedMaterialCost: string }>(`
     SELECT COALESCE(SUM(
       COALESCE(
-        NULLIF(material_budget_amount::numeric, 0),
-        NULLIF(wizard_data->>'materialBudgetAmount', '')::numeric,
-        NULLIF(wizard_data->>'materialBudget', '')::numeric,
-        0
+${materialBudgetExpression}
       )
     ), 0) AS "plannedMaterialCost"
     FROM production_work_orders
@@ -2300,13 +2333,11 @@ router.get('/:projectId/labor/entries', h(async (req, res) => {
 router.get('/:projectId/materials', h(async (req, res) => {
   const { projectId } = req.params;
 
+  const materialBudgetExpression = await getProductionWorkOrderMaterialBudgetExpression();
   const budgetRes = await pool.query<MaterialBudgetAmountRow>(`
     SELECT COALESCE(SUM(
       COALESCE(
-        NULLIF(material_budget_amount::numeric, 0),
-        NULLIF(wizard_data->>'materialBudgetAmount', '')::numeric,
-        NULLIF(wizard_data->>'materialBudget', '')::numeric,
-        0
+${materialBudgetExpression}
       )
     ), 0) AS "plannedCost"
     FROM production_work_orders

--- a/server/src/routes/travelers.ts
+++ b/server/src/routes/travelers.ts
@@ -1365,7 +1365,7 @@ router.post('/', async (req: Request, res: Response) => {
 
     if (validatedData.productionWorkOrderId) {
       const [wad] = await db
-        .select()
+        .select({ id: productionWorkOrders.id })
         .from(productionWorkOrders)
         .where(eq(productionWorkOrders.id, validatedData.productionWorkOrderId));
       if (!wad) {
@@ -1485,7 +1485,7 @@ router.post('/from-part-number/:partNumber', async (req: Request, res: Response)
         return res.status(400).json({ error: 'productionWorkOrderId must be a valid UUID' });
       }
       const [wad] = await db
-        .select()
+        .select({ id: productionWorkOrders.id })
         .from(productionWorkOrders)
         .where(eq(productionWorkOrders.id, productionWorkOrderId));
       if (!wad) {
@@ -1586,7 +1586,7 @@ router.post('/from-routing/:partRoutingId', async (req: Request, res: Response) 
         return res.status(400).json({ error: 'productionWorkOrderId must be a valid UUID' });
       }
       const [wad] = await db
-        .select()
+        .select({ id: productionWorkOrders.id })
         .from(productionWorkOrders)
         .where(eq(productionWorkOrders.id, productionWorkOrderId));
       if (!wad) {

--- a/server/src/services/traceabilityService.ts
+++ b/server/src/services/traceabilityService.ts
@@ -32,6 +32,16 @@ import {
 import { verifyInventoryLedgerHashesByIds } from './inventoryTransactionLedgerService';
 import { resolveTravelerBarcode } from '../helpers/travelerBarcodeResolver';
 
+const productionWorkOrderTraceColumns = {
+  id: productionWorkOrders.id,
+  workOrderNumber: productionWorkOrders.workOrderNumber,
+  projectId: productionWorkOrders.projectId,
+  partNumber: productionWorkOrders.partNumber,
+  quantity: productionWorkOrders.quantity,
+  status: productionWorkOrders.status,
+  wadStatus: productionWorkOrders.wadStatus,
+};
+
 // ─────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────
@@ -488,7 +498,7 @@ async function resolveSearch(input: TraceabilitySearchInput): Promise<ResolvedSe
   switch (input.key) {
     case 'lotIcn': {
       const [lot] = await db
-        .select()
+        .select(productionWorkOrderTraceColumns)
         .from(materialLots)
         .where(eq(materialLots.internalControlNumber, value))
         .limit(1);
@@ -512,7 +522,7 @@ async function resolveSearch(input: TraceabilitySearchInput): Promise<ResolvedSe
       // Case-insensitive match on traveler_number; UUID match for direct id;
       // barcode-helper fallback for printable scan payloads (Task #183).
       let [trav] = await db
-        .select()
+        .select(productionWorkOrderTraceColumns)
         .from(travelers)
         .where(
           or(
@@ -555,7 +565,7 @@ async function resolveSearch(input: TraceabilitySearchInput): Promise<ResolvedSe
 
     case 'workOrder': {
       const [wo] = await db
-        .select()
+        .select(productionWorkOrderTraceColumns)
         .from(productionWorkOrders)
         .where(or(eq(productionWorkOrders.workOrderNumber, value), eq(productionWorkOrders.id, value)))
         .limit(1);
@@ -771,7 +781,7 @@ async function loadJoinDictionaries(rows: InventoryTransactionLedger[]): Promise
     itemIds.length ? db.select().from(inventoryItems).where(inArray(inventoryItems.id, itemIds)) : Promise.resolve([]),
     travelerIds.length ? db.select().from(travelers).where(inArray(travelers.id, travelerIds)) : Promise.resolve([]),
     stepIds.length ? db.select().from(travelerSteps).where(inArray(travelerSteps.id, stepIds)) : Promise.resolve([]),
-    woIds.length ? db.select().from(productionWorkOrders).where(inArray(productionWorkOrders.id, woIds)) : Promise.resolve([]),
+    woIds.length ? db.select(productionWorkOrderTraceColumns).from(productionWorkOrders).where(inArray(productionWorkOrders.id, woIds)) : Promise.resolve([]),
     ccIds.length ? db.select().from(chargeCodes).where(inArray(chargeCodes.id, ccIds)) : Promise.resolve([]),
     projIds.length ? db.select().from(projects).where(inArray(projects.id, projIds)) : Promise.resolve([]),
   ]);
@@ -781,7 +791,7 @@ async function loadJoinDictionaries(rows: InventoryTransactionLedger[]): Promise
     itemById: new Map(items.map((i) => [i.id, i])),
     travById: new Map(travs.map((t) => [t.id, t])),
     stepById: new Map(steps.map((s) => [s.id, s])),
-    woById: new Map(wos.map((w) => [w.id, w])),
+    woById: new Map(wos.map((w) => [w.id, w as typeof productionWorkOrders.$inferSelect])),
     ccById: new Map(ccs.map((c) => [c.id, c])),
     projById: new Map(projs.map((p) => [p.id, p])),
   };

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -871,6 +871,36 @@ const productionOrdersColumns = {
   itemCode: productionOrders.itemCode,
 };
 
+const productionWorkOrderReadColumns = {
+  id: productionWorkOrders.id,
+  workOrderNumber: productionWorkOrders.workOrderNumber,
+  projectId: productionWorkOrders.projectId,
+  partNumber: productionWorkOrders.partNumber,
+  description: productionWorkOrders.description,
+  quantity: productionWorkOrders.quantity,
+  status: productionWorkOrders.status,
+  departmentBudgets: productionWorkOrders.departmentBudgets,
+  totalBudgetHours: productionWorkOrders.totalBudgetHours,
+  startDate: productionWorkOrders.startDate,
+  dueDate: productionWorkOrders.dueDate,
+  warningThreshold: productionWorkOrders.warningThreshold,
+  blockedThreshold: productionWorkOrders.blockedThreshold,
+  defaultChargeCodeId: productionWorkOrders.defaultChargeCodeId,
+  dashboardType: productionWorkOrders.dashboardType,
+  queueType: productionWorkOrders.queueType,
+  assignedDepartment: productionWorkOrders.assignedDepartment,
+  assignedDashboardRoute: productionWorkOrders.assignedDashboardRoute,
+  manufacturingQueueId: productionWorkOrders.manufacturingQueueId,
+  wadStatus: productionWorkOrders.wadStatus,
+  wizardData: productionWorkOrders.wizardData,
+  createdAt: productionWorkOrders.createdAt,
+  updatedAt: productionWorkOrders.updatedAt,
+};
+
+function withDefaultMaterialBudgetAmount<T extends Record<string, unknown>>(row: T | undefined): (T & { materialBudgetAmount: string }) | undefined {
+  return row ? ({ ...row, materialBudgetAmount: '0' } as T & { materialBudgetAmount: string }) : undefined;
+}
+
 type P1OrderNoteParts = {
   productionOrderNotes?: string | null;
   poItemProductionNotes?: string | null;
@@ -18454,11 +18484,11 @@ export class DatabaseStorage implements IStorage {
       .limit(1);
     if (!traveler?.productionWorkOrderId) return undefined;
     const [wad] = await db
-      .select()
+      .select(productionWorkOrderReadColumns)
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, traveler.productionWorkOrderId))
       .limit(1);
-    return wad;
+    return withDefaultMaterialBudgetAmount(wad) as ProductionWorkOrder | undefined;
   }
 
   async createTimeClockEntryWithChargeContext(data: InsertTimeClockEntry): Promise<TimeClockEntry> {
@@ -20129,7 +20159,7 @@ export class DatabaseStorage implements IStorage {
     }
 
     const [wad] = await db
-      .select()
+      .select({ id: productionWorkOrders.id })
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, workOrderId));
     if (!wad) {
@@ -20163,15 +20193,15 @@ export class DatabaseStorage implements IStorage {
 
   async getProductionWorkOrderWithProject(id: string): Promise<ProductionWorkOrder | undefined> {
     const [wad] = await db
-      .select()
+      .select(productionWorkOrderReadColumns)
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, id));
-    return wad ?? undefined;
+    return withDefaultMaterialBudgetAmount(wad) as ProductionWorkOrder | undefined;
   }
 
   async findRoutingForProductionWorkOrder(wadId: string): Promise<PartRouting | undefined> {
     const [wad] = await db
-      .select()
+      .select({ partNumber: productionWorkOrders.partNumber })
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, wadId));
     if (!wad) return undefined;
@@ -20180,7 +20210,12 @@ export class DatabaseStorage implements IStorage {
 
   async createTravelerFromProductionWorkOrder(wadId: string, createdBy: string): Promise<Traveler> {
     const [wad] = await db
-      .select()
+      .select({
+        id: productionWorkOrders.id,
+        workOrderNumber: productionWorkOrders.workOrderNumber,
+        partNumber: productionWorkOrders.partNumber,
+        quantity: productionWorkOrders.quantity,
+      })
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, wadId));
     if (!wad) {
@@ -26226,31 +26261,36 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getAllProductionWorkOrders(): Promise<ProductionWorkOrder[]> {
-    return await db
-      .select()
+    const rows = await db
+      .select(productionWorkOrderReadColumns)
       .from(productionWorkOrders)
       .orderBy(desc(productionWorkOrders.createdAt));
+    return rows.map((row) => withDefaultMaterialBudgetAmount(row)!) as ProductionWorkOrder[];
   }
 
   async getWorkOrdersByProject(projectId: string): Promise<ProductionWorkOrder[]> {
-    return await db
-      .select()
+    const rows = await db
+      .select(productionWorkOrderReadColumns)
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.projectId, projectId))
       .orderBy(desc(productionWorkOrders.createdAt));
+    return rows.map((row) => withDefaultMaterialBudgetAmount(row)!) as ProductionWorkOrder[];
   }
 
   async getWorkOrderById(id: string): Promise<ProductionWorkOrder | undefined> {
     const [row] = await db
-      .select()
+      .select(productionWorkOrderReadColumns)
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, id));
-    return row || undefined;
+    return withDefaultMaterialBudgetAmount(row) as ProductionWorkOrder | undefined;
   }
 
   async checkWorkOrderMaterialAvailability(workOrderId: string): Promise<boolean> {
     const [wad] = await db
-      .select()
+      .select({
+        partNumber: productionWorkOrders.partNumber,
+        quantity: productionWorkOrders.quantity,
+      })
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, workOrderId))
       .limit(1);
@@ -26294,7 +26334,10 @@ export class DatabaseStorage implements IStorage {
 
   async getMaterialShortageDetail(workOrderId: string): Promise<string | null> {
     const [wad] = await db
-      .select()
+      .select({
+        partNumber: productionWorkOrders.partNumber,
+        quantity: productionWorkOrders.quantity,
+      })
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, workOrderId))
       .limit(1);
@@ -26337,7 +26380,7 @@ export class DatabaseStorage implements IStorage {
 
   async checkWorkOrderTrainingCoverage(workOrderId: string): Promise<boolean> {
     const [wad] = await db
-      .select()
+      .select({ partNumber: productionWorkOrders.partNumber })
       .from(productionWorkOrders)
       .where(eq(productionWorkOrders.id, workOrderId))
       .limit(1);
@@ -26401,8 +26444,8 @@ export class DatabaseStorage implements IStorage {
       .update(productionWorkOrders)
       .set({ status, updatedAt: new Date() })
       .where(eq(productionWorkOrders.id, workOrderId))
-      .returning();
-    return updated;
+      .returning(productionWorkOrderReadColumns);
+    return withDefaultMaterialBudgetAmount(updated) as ProductionWorkOrder;
   }
 
   // ── Estimating – RFQs ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a schema-aware material budget SQL expression for the PM dashboard.
- Uses `production_work_orders.material_budget_amount` when the column exists.
- Falls back to existing WAD `wizard_data` material budget fields when production has not received that column yet.

## Root Cause

The PM Control Center summary and materials endpoints directly referenced `production_work_orders.material_budget_amount`. In production, that column was missing, so Postgres rejected both queries during planning and the material budget page showed only an error after project material receiving activity triggered the page refresh.

## Impact

The PM material budget page can render again on databases that are behind the newer receiving/material-budget migration, while still using the dedicated budget column when it is present.

## Validation

- `git diff --check` passed.
- `npm run check` could not be run locally because `npm` is not installed in this shell.