### PR TITLE
Fix P2 traveler WAD lookup for material budget drift

### DIFF
--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -526,7 +526,7 @@ async function findProductionWorkOrderForSerializedItem(params: {
   }
 
   const [workOrder] = await db
-    .select()
+    .select({ id: productionWorkOrders.id })
     .from(productionWorkOrders)
     .where(and(...whereParts))
     .orderBy(desc(productionWorkOrders.createdAt))


### PR DESCRIPTION
## Summary
- Add `production_work_orders.material_budget_amount` to the P2 traveler route-level readiness guard so `/api/p2-traveler/generate-traveler` repairs production schema drift before traveler generation
- Avoid selecting the full `production_work_orders` row when P2 traveler generation/repair only needs the WAD id
- Prevent missing `material_budget_amount` schema drift from blocking P2 production traveler submit/generate flows

## Validation
- `git diff --check -- server/src/lib/productionWorkflowReadiness.ts server/src/routes/p2Traveler.ts`
- Traced the live console failure to `POST /api/p2-traveler/generate-traveler` returning `column "material_budget_amount" does not exist`

## Notes
- Local `npm run check` was not run because this worktree does not have `node_modules` installed.