### PR TITLE
Repair P2 traveler material budget schema readiness

### DIFF
--- a/server/src/lib/productionWorkflowReadiness.ts
+++ b/server/src/lib/productionWorkflowReadiness.ts
@@ -40,6 +40,7 @@ export async function ensureProductionWorkflowReadSchema(): Promise<void> {
             ALTER TABLE public.production_work_orders
               ADD COLUMN IF NOT EXISTS department_budgets jsonb DEFAULT '{}'::jsonb,
               ADD COLUMN IF NOT EXISTS total_budget_hours numeric,
+              ADD COLUMN IF NOT EXISTS material_budget_amount numeric NOT NULL DEFAULT 0,
               ADD COLUMN IF NOT EXISTS start_date date,
               ADD COLUMN IF NOT EXISTS due_date date,
               ADD COLUMN IF NOT EXISTS warning_threshold numeric,

--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -526,7 +526,7 @@ async function findProductionWorkOrderForSerializedItem(params: {
   }
 
   const [workOrder] = await db
-    .select()
+    .select({ id: productionWorkOrders.id })
     .from(productionWorkOrders)
     .where(and(...whereParts))
     .orderBy(desc(productionWorkOrders.createdAt))


### PR DESCRIPTION
## Summary
- Add `production_work_orders.material_budget_amount` to the P2 traveler route-level readiness guard so `/api/p2-traveler/generate-traveler` repairs production schema drift before traveler generation
- Avoid selecting the full `production_work_orders` row when P2 traveler generation/repair only needs the WAD id
- Addresses the live 500: `column "material_budget_amount" does not exist` from `/api/p2-traveler/generate-traveler`

## Validation
- `git diff --check -- server/src/lib/productionWorkflowReadiness.ts server/src/routes/p2Traveler.ts`
- Traced the provided production console log to `POST /api/p2-traveler/generate-traveler` after badge lookup and certification succeed

## Notes
- Local `npm run check` was not run because this worktree does not have `node_modules` installed.