### PR TITLE
Add shared Media Library upload registration

### DIFF
--- a/server/src/routes/cuttingDocuments.ts
+++ b/server/src/routes/cuttingDocuments.ts
@@ -3,14 +3,14 @@ import { randomUUID } from 'crypto';
 import fs from 'fs/promises';
 import multer from 'multer';
 import path from 'path';
-import { db } from '../../db';
 import { storage } from '../../storage';
-import { insertCuttingDocumentSchema, mediaLibrary } from '../../schema';
+import { insertCuttingDocumentSchema } from '../../schema';
 import {
   getFileStorageProvider,
   getFileStorageProviderForObjectPath,
   getStorageErrorResponse,
 } from '../services/fileStorageProvider';
+import { registerMediaLibraryFile } from '../services/mediaLibraryService';
 
 const router = Router();
 const upload = multer({
@@ -67,7 +67,7 @@ async function createMediaLibraryDocument(input: {
   file: Express.Multer.File;
   user?: any;
 }) {
-  const [media] = await db.insert(mediaLibrary).values({
+  return registerMediaLibraryFile({
     filename: input.file.originalname || 'cutting-document',
     storagePath: input.fileUrl,
     mimeType: input.file.mimetype || 'application/octet-stream',
@@ -77,9 +77,7 @@ async function createMediaLibraryDocument(input: {
     title: input.file.originalname || 'Cutting document',
     notes: 'Cutting table reference document',
     category: 'document',
-  }).returning();
-
-  return media;
+  });
 }
 
 router.get('/', async (req, res) => {

--- a/server/src/routes/media.ts
+++ b/server/src/routes/media.ts
@@ -12,6 +12,7 @@ import {
   getFileStorageProviderForObjectPath,
   getStorageErrorResponse,
 } from '../services/fileStorageProvider';
+import { registerMediaLibraryFile } from '../services/mediaLibraryService';
 
 const router = Router();
 
@@ -108,7 +109,7 @@ router.post('/complete-upload', async (req, res) => {
       // Continue even if ACL fails - file is still accessible
     }
 
-    const [newMedia] = await db.insert(mediaLibrary).values({
+    const newMedia = await registerMediaLibraryFile({
       filename: filename,
       storagePath: objectPath, // Store the cloud object path
       mimeType: mimeType || 'application/octet-stream',
@@ -120,7 +121,7 @@ router.post('/complete-upload', async (req, res) => {
       notes: notes || null,
       tags: parsedTags,
       category: category || 'other',
-    }).returning();
+    });
 
     res.json(newMedia);
   } catch (error) {

--- a/server/src/services/mediaLibraryService.ts
+++ b/server/src/services/mediaLibraryService.ts
@@ -1,0 +1,35 @@
+import { db } from '../../db';
+import { mediaLibrary } from '../../schema';
+
+export interface RegisterMediaLibraryFileInput {
+  filename: string;
+  storagePath: string;
+  mimeType?: string | null;
+  fileSize?: number | null;
+  folderId?: string | null;
+  capturedById?: number | null;
+  capturedByName?: string | null;
+  title?: string | null;
+  notes?: string | null;
+  tags?: string[] | null;
+  category?: string | null;
+}
+
+export async function registerMediaLibraryFile(input: RegisterMediaLibraryFileInput) {
+  const [media] = await db.insert(mediaLibrary).values({
+    filename: input.filename,
+    storagePath: input.storagePath,
+    mimeType: input.mimeType || 'application/octet-stream',
+    fileSize: input.fileSize || 0,
+    folderId: input.folderId || null,
+    capturedById: input.capturedById || null,
+    capturedByName: input.capturedByName || 'Unknown',
+    title: input.title || input.filename,
+    notes: input.notes || null,
+    tags: input.tags || [],
+    category: input.category || 'other',
+  }).returning();
+
+  return media;
+}
+


### PR DESCRIPTION
## Summary
- Add a shared `registerMediaLibraryFile(...)` helper for creating Media Library records.
- Refactor `/api/media/complete-upload` to use the shared helper.
- Refactor Cutting Documents uploads to register central Media Library records through the same helper.

## Why
This establishes the reusable server-side path for upload surfaces to store files in central Media Library, so documents and attachments are easier to find and view across the app.

Follow-up surfaces that can move onto this helper include order attachments, receiving documents, vendor documents and approvals, project step attachments, controlled documents where access rules allow it, and accounting/payroll attachments where visibility is safe.

## Validation
- `git diff --check` passed.
- `npm run check` could not be run locally because `npm` is not available in this Windows workspace.