### PR TITLE
Fix P2 traveler material control entry autosave

### DIFF
--- a/client/src/pages/P2TravelerPage.tsx
+++ b/client/src/pages/P2TravelerPage.tsx
@@ -320,7 +320,7 @@ export default function P2TravelerPage() {
   const [notes, setNotes] = useState('');
   const [traceabilityMode, setTraceabilityMode] = useState<'scan' | 'manual'>('scan');
   const [pendingFocusMaterialIndex, setPendingFocusMaterialIndex] = useState<number | null>(null);
-  const [validatedMaterialIndices, setValidatedMaterialIndices] = useState<Set<number>>(new Set());
+  const [, setValidatedMaterialIndices] = useState<Set<number>>(new Set());
   const validateAbortControllersRef = useRef<Map<number, AbortController>>(new Map());
   const latestValidationIcnRef = useRef<Map<number, string>>(new Map());
   const [cameraTarget, setCameraTarget] = useState<'badge' | 'part' | null>(null);
@@ -850,6 +850,9 @@ export default function P2TravelerPage() {
           employeeCode: badgeInput,
           barcode: partInput,
           notes,
+          traceabilityData: traceabilityData.filter(item => item.value.trim()),
+          customData: Object.keys(customData).length > 0 ? customData : null,
+          qcResults: [...qcResults, ...startQcResults, ...finishQcResults],
         }),
       });
 
@@ -1046,12 +1049,30 @@ export default function P2TravelerPage() {
     }
   };
 
-  // Add another material traceability entry
-  const addMaterialTraceEntry = () => {
+  const materialControlFieldTypes = new Set([
+    'material_lot',
+    'internal_control_number',
+    'material_internal_control_number',
+    'material_icn',
+    'fabric_internal_control_number',
+  ]);
+
+  const isMaterialControlField = (item: any) => {
+    const type = String(item?.type || '').toLowerCase();
+    const label = String(item?.label || '').toLowerCase();
+    return materialControlFieldTypes.has(type) || label.includes('control number') || label.includes('icn');
+  };
+
+  const getNextMaterialIndex = () => {
     const existingMaterialIndices = traceabilityData
       .filter(item => item.materialIndex !== undefined)
       .map(item => item.materialIndex!);
-    const nextIndex = existingMaterialIndices.length > 0 ? Math.max(...existingMaterialIndices) + 1 : 0;
+    return existingMaterialIndices.length > 0 ? Math.max(...existingMaterialIndices) + 1 : 0;
+  };
+
+  // Add another material traceability entry
+  const addMaterialTraceEntry = () => {
+    const nextIndex = getNextMaterialIndex();
     
     const defaultFields = ['material_lot', 'material_expiration_date'];
     const newEntries = defaultFields.map(fieldType => ({
@@ -1430,12 +1451,11 @@ export default function P2TravelerPage() {
 
                           {materialGroupEntries.map(([matIdx, items], groupArrayIdx) => {
                             const isLastGroup = groupArrayIdx === materialGroupEntries.length - 1;
-                            const lotItem = (items as any[]).find((i) => i.type === 'material_lot');
+                            const controlItem = (items as any[]).find(isMaterialControlField);
                             const showAddAnotherPrompt =
                               isLastGroup &&
                               traceabilityMode === 'manual' &&
-                              !!lotItem?.value?.trim() &&
-                              validatedMaterialIndices.has(matIdx);
+                              !!controlItem?.value?.trim();
                             return (
                             <div key={matIdx} className="border rounded-lg p-3 bg-blue-50/30 dark:bg-blue-950/20 space-y-2">
                               <div className="flex items-center justify-between">
@@ -1484,10 +1504,7 @@ export default function P2TravelerPage() {
                                   size="sm"
                                   className="w-full mt-2 bg-blue-600 hover:bg-blue-700 text-white shadow-sm"
                                   onClick={() => {
-                                    const existing = traceabilityData
-                                      .filter((it) => it.materialIndex !== undefined)
-                                      .map((it) => it.materialIndex!);
-                                    const nextIdx = existing.length > 0 ? Math.max(...existing) + 1 : 0;
+                                    const nextIdx = getNextMaterialIndex();
                                     addMaterialTraceEntry();
                                     setPendingFocusMaterialIndex(nextIdx);
                                   }}

--- a/client/src/pages/TravelerExecution.tsx
+++ b/client/src/pages/TravelerExecution.tsx
@@ -1301,8 +1301,39 @@ export default function TravelerExecution() {
     });
   };
 
+  const collectCurrentTaskFieldValues = (task: TravelerTask) => {
+    const merged: Record<string, string> = { ...(fieldValues[task.id] || {}) };
+
+    for (const field of task.fields) {
+      const fieldInput = document.getElementById(`field-${task.id}-${field.fieldKey}`) as HTMLInputElement | null;
+      const textareaInput = document.getElementById(`ta-${task.id}-${field.fieldKey}`) as HTMLTextAreaElement | null;
+      const inventoryInput = document.getElementById(`inv-${task.id}-${field.fieldKey}`) as HTMLInputElement | null;
+      const qcResultInput = document.getElementById(`qc-result-${task.id}-${field.fieldKey}`) as HTMLInputElement | null;
+      const checkboxInput = document.getElementById(field.id) as HTMLInputElement | null;
+
+      const currentValue =
+        fieldInput?.value ??
+        textareaInput?.value ??
+        inventoryInput?.value;
+
+      if (currentValue !== undefined) {
+        merged[field.fieldKey] = currentValue;
+      }
+
+      if (qcResultInput?.value !== undefined) {
+        merged[`${field.fieldKey}_result`] = qcResultInput.value;
+      }
+
+      if (checkboxInput?.type === 'checkbox') {
+        merged[field.fieldKey] = checkboxInput.checked ? 'yes' : 'no';
+      }
+    }
+
+    return merged;
+  };
+
   const handleCompleteTask = (task: TravelerTask, toleranceApproval?: { approvedBy: string; notes: string }) => {
-    const taskFieldVals = fieldValues[task.id] || {};
+    const taskFieldVals = collectCurrentTaskFieldValues(task);
     const traceLabelMap: Record<string, string> = {
       internalControlNumber: 'Internal Control Number',
       supplier: 'Supplier',

--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -2223,6 +2223,9 @@ router.post('/complete-task', async (req: Request, res: Response) => {
       employeeCode,
       barcode,
       notes,
+      traceabilityData,
+      customData,
+      qcResults,
     } = req.body;
 
     let completeDisplayName = employeeCode || 'unknown';
@@ -2303,6 +2306,119 @@ router.post('/complete-task', async (req: Request, res: Response) => {
     }
 
     const routing = await findActiveRoutingForSerializedItem(serializedItem);
+
+    const incomingTraceabilityData = Array.isArray(traceabilityData)
+      ? traceabilityData.filter((item: any) => getTraceValue(item))
+      : [];
+
+    if (incomingTraceabilityData.length > 0 || customData || (Array.isArray(qcResults) && qcResults.length > 0)) {
+      const traceUpdate: any = { updatedAt: new Date() };
+
+      if (incomingTraceabilityData.length > 0) {
+        const {
+          expandedTraceability,
+          packetTraceRecords,
+          consumedPackets,
+        } = await expandAndConsumePacketTraceability({
+          traceabilityData: incomingTraceabilityData,
+          serializedItem,
+          department: workTask.department,
+          recordedBy: completeDisplayName,
+          workTaskId: workTask.id,
+        });
+
+        traceUpdate.traceabilityData = expandedTraceability;
+
+        await db.delete(p2SerializedItemTraceability)
+          .where(and(
+            eq(p2SerializedItemTraceability.serializedItemId, serializedItem.id),
+            eq(p2SerializedItemTraceability.department, workTask.department)
+          ));
+
+        const traceabilityRecords = expandedTraceability.map((item: any) => ({
+          serializedItemId: serializedItem.id,
+          department: workTask.department,
+          inventoryPartId: item.builtPacketId ? String(item.builtPacketId) : (item.inventoryPartId || null),
+          inventoryPartNumber: item.inventoryPartNumber || null,
+          traceabilityType: item.type,
+          traceabilityLabel: item.label,
+          traceabilityValue: item.value,
+          recordedBy: completeDisplayName,
+        }));
+
+        await db.insert(p2SerializedItemTraceability).values([
+          ...traceabilityRecords,
+          ...packetTraceRecords,
+        ]);
+
+        if (consumedPackets.length > 0) {
+          await db.insert(p2SerializedItemEvents).values({
+            serializedItemId: serializedItem.id,
+            barcode: serializedItem.barcode,
+            eventType: 'NOTE',
+            performedBy: completeDisplayName,
+            notes: `Material traceability auto-saved on task completion in ${workTask.department}`,
+            metadata: { taskId: workTask.id, action: 'complete_task_traceability_autosave', consumedPackets },
+          });
+        }
+      }
+
+      if (customData && Object.keys(customData).length > 0) {
+        traceUpdate.customData = customData;
+
+        const existingCustom = await db.query.p2SerializedItemCustomData.findFirst({
+          where: and(
+            eq(p2SerializedItemCustomData.serializedItemId, serializedItem.id),
+            eq(p2SerializedItemCustomData.department, workTask.department)
+          ),
+        });
+
+        if (existingCustom) {
+          const merged = { ...((existingCustom.customData as any) || {}), ...customData };
+          if ((existingCustom.customData as any)?.qcResults) {
+            merged.qcResults = (existingCustom.customData as any).qcResults;
+          }
+          await db.update(p2SerializedItemCustomData)
+            .set({ customData: merged, recordedBy: completeDisplayName })
+            .where(eq(p2SerializedItemCustomData.id, existingCustom.id));
+        } else {
+          await db.insert(p2SerializedItemCustomData).values({
+            serializedItemId: serializedItem.id,
+            department: workTask.department,
+            customData,
+            recordedBy: completeDisplayName,
+          });
+        }
+      }
+
+      if (Array.isArray(qcResults) && qcResults.length > 0) {
+        const existingQc = await db.query.p2SerializedItemCustomData.findFirst({
+          where: and(
+            eq(p2SerializedItemCustomData.serializedItemId, serializedItem.id),
+            eq(p2SerializedItemCustomData.department, workTask.department),
+            sql`(custom_data->>'qcResults') IS NOT NULL`
+          ),
+        });
+
+        if (existingQc) {
+          const merged = { ...((existingQc.customData as any) || {}), qcResults };
+          await db.update(p2SerializedItemCustomData)
+            .set({ customData: merged, recordedBy: completeDisplayName })
+            .where(eq(p2SerializedItemCustomData.id, existingQc.id));
+        } else {
+          await db.insert(p2SerializedItemCustomData).values({
+            serializedItemId: serializedItem.id,
+            department: workTask.department,
+            customData: { qcResults },
+            recordedBy: completeDisplayName,
+          });
+        }
+      }
+
+      await db.update(p2WorkTasks)
+        .set(traceUpdate)
+        .where(eq(p2WorkTasks.id, workTask.id));
+    }
 
     const departmentSequence = routing?.departmentSequence
       ? (routing.departmentSequence as string[])


### PR DESCRIPTION
## Summary
- Restore the inline add-another control number flow for manual P2 material traceability entries
- Send traceability, custom data, and QC values when completing a P2 traveler task so the form is persisted even without a separate submit/save action
- Capture currently rendered traveler task field values at completion time in the generic traveler execution page

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/p2Traveler.ts`

Note: full frontend/typecheck was not run locally because this worktree does not have `node_modules`.