### PR TITLE
[codex] Highlight P2 traveler notes

### DIFF
--- a/client/src/components/p2/TravelerCapturedData.tsx
+++ b/client/src/components/p2/TravelerCapturedData.tsx
@@ -328,8 +328,14 @@ function StepSection({ step, defaultExpanded = false }: { step: TravelerStep; de
           )}
 
           {step.notes && (
-            <div className="bg-muted/30 rounded-lg p-3 text-sm">
-              <strong>Notes:</strong> {step.notes}
+            <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 shadow-sm">
+              <div className="flex items-start gap-2">
+                <FileText className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
+                <div>
+                  <div className="font-semibold text-amber-900">Process Notes</div>
+                  <p className="mt-1 whitespace-pre-wrap leading-relaxed">{step.notes}</p>
+                </div>
+              </div>
             </div>
           )}
 
@@ -369,7 +375,12 @@ function StepSection({ step, defaultExpanded = false }: { step: TravelerStep; de
                       <div className="text-xs text-muted-foreground">
                         {sig.meaning} · {format(new Date(sig.signedAt), 'MMM d, yyyy h:mm a')}
                       </div>
-                      {sig.notes && <div className="text-xs text-muted-foreground">{sig.notes}</div>}
+                      {sig.notes && (
+                        <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-950">
+                          <span className="font-semibold text-amber-900">Notes: </span>
+                          <span className="whitespace-pre-wrap">{sig.notes}</span>
+                        </div>
+                      )}
                     </div>
                     {sig.signatureData && (
                       <div className="bg-white dark:bg-gray-800 border rounded p-1">

--- a/client/src/pages/P2TravelerViewer.tsx
+++ b/client/src/pages/P2TravelerViewer.tsx
@@ -1567,8 +1567,14 @@ export default function P2TravelerViewer() {
                           )}
                           
                           {sig.notes && (
-                            <div className="mt-2 pt-2 border-t text-sm text-gray-600">
-                              <span className="font-medium">Notes:</span> {sig.notes}
+                            <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950">
+                              <div className="flex items-start gap-2">
+                                <FileText className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
+                                <div>
+                                  <span className="font-semibold text-amber-900">Notes</span>
+                                  <p className="mt-1 whitespace-pre-wrap leading-relaxed">{sig.notes}</p>
+                                </div>
+                              </div>
                             </div>
                           )}
                         </div>
@@ -1633,7 +1639,17 @@ export default function P2TravelerViewer() {
                                   {safeFormat(event.createdAt, 'MMM d, yyyy h:mm a')}
                                 </span>
                               </div>
-                              {event.notes && <p className="text-sm mt-1">{event.notes}</p>}
+                              {event.notes && (
+                                <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950">
+                                  <div className="flex items-start gap-2">
+                                    <FileText className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
+                                    <div>
+                                      <span className="font-semibold text-amber-900">Notes</span>
+                                      <p className="mt-1 whitespace-pre-wrap leading-relaxed">{event.notes}</p>
+                                    </div>
+                                  </div>
+                                </div>
+                              )}
                               {isCycleSentinel && event.metadata?.travelerId && (
                                 <p className="text-xs text-gray-500 mt-0.5">
                                   Traveler: {event.metadata?.travelerNumber ?? event.metadata?.travelerId}


### PR DESCRIPTION
## Summary
- Highlight process notes in the P2 traveler captured-data view with amber callouts.
- Highlight signature notes and event-log notes in the P2 traveler viewer.
- Preserve note line breaks with `whitespace-pre-wrap` so operator-entered notes remain readable.

## Why
Process notes were rendered as low-contrast inline text, making them easy to miss during traveler review. This makes notes visually distinct wherever they appear in the P2 traveler viewer.

## Validation
- `git diff --check -- client/src/components/p2/TravelerCapturedData.tsx client/src/pages/P2TravelerViewer.tsx`