### PR TITLE
Fix P2 traveler material capture and routing work tasks

### DIFF
--- a/client/src/pages/TravelerExecution.tsx
+++ b/client/src/pages/TravelerExecution.tsx
@@ -1332,6 +1332,55 @@ export default function TravelerExecution() {
     return merged;
   };
 
+  const appendTraceValue = (existing: string | undefined, incoming: string | undefined) => {
+    const nextValue = String(incoming ?? '').trim();
+    if (!nextValue) return existing || '';
+    const values = String(existing ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+    if (!values.includes(nextValue)) values.push(nextValue);
+    return values.join(', ');
+  };
+
+  const handleTraceMaterialCaptured = (
+    task: TravelerTask,
+    traceFieldVals: Record<string, string>,
+    traceFieldValidations?: Record<string, any>
+  ) => {
+    setFieldValues((prev) => {
+      const current = prev[task.id] || {};
+      const merged = { ...current };
+      for (const [key, value] of Object.entries(traceFieldVals)) {
+        merged[key] = appendTraceValue(current[key], value);
+      }
+      return { ...prev, [task.id]: merged };
+    });
+
+    if (traceFieldValidations && Object.keys(traceFieldValidations).length > 0) {
+      setPickerValidations((prev) => ({
+        ...prev,
+        [task.id]: {
+          ...(prev[task.id] || {}),
+          ...traceFieldValidations,
+        },
+      }));
+    }
+
+    const captured =
+      traceFieldVals.material_internal_control_number ||
+      traceFieldVals.internalControlNumber ||
+      traceFieldVals.material_icn ||
+      traceFieldVals.packetBarcode ||
+      traceFieldVals.packet_barcode ||
+      'material';
+
+    toast({
+      title: 'Material captured',
+      description: `${captured} added. Add another material or complete the traceability task.`,
+    });
+  };
+
   const handleCompleteTask = (task: TravelerTask, toleranceApproval?: { approvedBy: string; notes: string }) => {
     const taskFieldVals = collectCurrentTaskFieldValues(task);
     const traceLabelMap: Record<string, string> = {
@@ -2814,11 +2863,12 @@ export default function TravelerExecution() {
                                         })()}
 
                                         {(task.taskType === 'TRACE' || task.taskType === 'TRACEABILITY') && !fieldInputDisabled ? (
-                                          <MaterialScanner
-                                            travelerId={traveler.id}
-                                            travelerStepId={currentStep.id}
-                                            allowFreeTextEntry={true}
-                                            onMaterialConsumed={(result) => {
+                                          <div className="space-y-3">
+                                            <MaterialScanner
+                                              travelerId={traveler.id}
+                                              travelerStepId={currentStep.id}
+                                              allowFreeTextEntry={true}
+                                              onMaterialConsumed={(result) => {
                                               const taskFieldKeys = new Set(
                                                 task.fields.map((f) => f.fieldKey)
                                               );
@@ -2864,11 +2914,7 @@ export default function TravelerExecution() {
                                                 for (const key of Object.keys(traceFieldVals)) {
                                                   manualFieldValidations[key] = manualValidation;
                                                 }
-                                                completeTaskMutation.mutate({ 
-                                                  taskId: task.id, 
-                                                  fieldVals: traceFieldVals,
-                                                  fieldValidations: manualFieldValidations,
-                                                });
+                                                handleTraceMaterialCaptured(task, traceFieldVals, manualFieldValidations);
                                                 return;
                                               }
                                               const consumption = result?.consumption;
@@ -2957,11 +3003,7 @@ export default function TravelerExecution() {
                                                   for (const key of Object.keys(traceFieldVals)) {
                                                     traceFieldValidations[key] = inventoryValidation;
                                                   }
-                                                  completeTaskMutation.mutate({
-                                                    taskId: task.id,
-                                                    fieldVals: traceFieldVals,
-                                                    fieldValidations: traceFieldValidations,
-                                                  });
+                                                  handleTraceMaterialCaptured(task, traceFieldVals, traceFieldValidations);
                                                 }, 0);
                                                 return;
                                               }
@@ -3008,13 +3050,59 @@ export default function TravelerExecution() {
                                               for (const key of Object.keys(traceFieldVals)) {
                                                 traceFieldValidations[key] = inventoryValidation;
                                               }
-                                              completeTaskMutation.mutate({ 
-                                                taskId: task.id, 
-                                                fieldVals: traceFieldVals,
-                                                fieldValidations: traceFieldValidations,
-                                              });
-                                            }}
-                                          />
+                                              handleTraceMaterialCaptured(task, traceFieldVals, traceFieldValidations);
+                                              }}
+                                            />
+                                            {(() => {
+                                              const currentTraceValues = collectCurrentTaskFieldValues(task);
+                                              const capturedMaterials =
+                                                currentTraceValues.material_internal_control_number ||
+                                                currentTraceValues.internalControlNumber ||
+                                                currentTraceValues.material_icn ||
+                                                currentTraceValues.packetBarcode ||
+                                                currentTraceValues.packet_barcode ||
+                                                '';
+                                              const capturedList = capturedMaterials
+                                                .split(',')
+                                                .map((value) => value.trim())
+                                                .filter(Boolean);
+                                              if (capturedList.length === 0) return null;
+
+                                              return (
+                                                <div className="rounded-lg border border-blue-200 bg-blue-50/60 p-3 space-y-3">
+                                                  <div className="flex items-start justify-between gap-3">
+                                                    <div>
+                                                      <p className="text-sm font-medium text-blue-900">Captured Materials</p>
+                                                      <p className="text-xs text-blue-700">Scan or enter another material, then complete the traceability task when all materials are captured.</p>
+                                                    </div>
+                                                    <Badge variant="outline" className="border-blue-300 text-blue-800">
+                                                      {capturedList.length}
+                                                    </Badge>
+                                                  </div>
+                                                  <div className="flex flex-wrap gap-2">
+                                                    {capturedList.map((material, index) => (
+                                                      <Badge key={`${material}-${index}`} variant="secondary" className="bg-white text-blue-900 border border-blue-200">
+                                                        {material}
+                                                      </Badge>
+                                                    ))}
+                                                  </div>
+                                                  <Button
+                                                    size="sm"
+                                                    onClick={() => handleCompleteTask(task)}
+                                                    disabled={completeTaskMutation.isPending}
+                                                    data-testid={`button-complete-trace-task-${task.id}`}
+                                                  >
+                                                    {completeTaskMutation.isPending ? (
+                                                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                                    ) : (
+                                                      <CheckCircle className="h-4 w-4 mr-2" />
+                                                    )}
+                                                    Complete Traceability
+                                                  </Button>
+                                                </div>
+                                              );
+                                            })()}
+                                          </div>
                                         ) : (
                                           <>
                                             {task.taskType === 'QC' && task.fields.length === 0 && getRoutingQcStandardsForTask(task, currentStep.departmentName).length > 0 && (

--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -672,7 +672,7 @@ function operationTypeToTravelerPhase(operationType: string | null | undefined):
       return 'START';
     case 'QC':
     case 'INSPECT':
-      return 'FINISH';
+      return 'WORK';
     default:
       return 'WORK';
   }
@@ -765,6 +765,60 @@ function getRoutingOperationQcFields(params: {
       ...(standard.referenceLink ? { referenceLink: standard.referenceLink } : {}),
     },
   }));
+}
+
+function getRoutingOperationEvidenceFields(operation: any) {
+  const baseKey = `routing_op_${operation.id}`;
+  const fields = [
+    {
+      fieldKey: `${baseKey}_complete`,
+      fieldLabel: `Completed: ${operation.operationName}`,
+      fieldType: 'yes_no',
+      required: true,
+    },
+    {
+      fieldKey: `${baseKey}_department`,
+      fieldLabel: 'Routing Department',
+      fieldType: 'text',
+      required: false,
+      validation: { readonly: true, value: operation.departmentName },
+    },
+    {
+      fieldKey: `${baseKey}_operation_type`,
+      fieldLabel: 'Operation Type',
+      fieldType: 'text',
+      required: false,
+      validation: { readonly: true, value: operation.operationType },
+    },
+  ];
+
+  if (operation.workCenter) {
+    fields.push({
+      fieldKey: `${baseKey}_work_center`,
+      fieldLabel: 'Work Center',
+      fieldType: 'text',
+      required: false,
+      validation: { readonly: true, value: operation.workCenter },
+    });
+  }
+
+  if (operation.estimatedMinutes) {
+    fields.push({
+      fieldKey: `${baseKey}_estimated_minutes`,
+      fieldLabel: 'Estimated Minutes',
+      fieldType: 'number',
+      required: false,
+      validation: { readonly: true, value: String(operation.estimatedMinutes) },
+    });
+    fields.push({
+      fieldKey: `${baseKey}_actual_minutes`,
+      fieldLabel: 'Actual Minutes',
+      fieldType: 'number',
+      required: false,
+    });
+  }
+
+  return fields;
 }
 
 function getEnabledTravelerTaskPhases(departmentConfig: any): Set<'START' | 'WORK' | 'FINISH'> {
@@ -1062,6 +1116,37 @@ async function backfillDepartmentConfiguredTravelerTasks(params: {
       title: 'Material Traceability',
       instructions: 'Record required material traceability before work continues.',
     }, traceFields);
+  }
+
+  const routingMaterials = Array.isArray(departmentConfig.materials) ? departmentConfig.materials : [];
+  for (const [index, material] of routingMaterials.entries()) {
+    const taskPhase = normalizeTravelerTaskPhase(material.traceabilityPhase || 'START');
+    const materialLabel = material.partName || material.partNumber || `Material ${index + 1}`;
+    await addTask({
+      taskType: 'TRACE',
+      taskPhase,
+      title: routingMaterials.length > 1 ? `Material Traceability - ${material.partNumber || materialLabel}` : 'Material Traceability',
+      instructions: `Select ${materialLabel} from inventory. Fields will auto-fill.`,
+    }, [
+      {
+        fieldKey: 'material_internal_control_number',
+        fieldLabel: 'Material Internal Control Number (Select from Inventory)',
+        fieldType: 'inventory_select',
+        required: true,
+        validation: {
+          source: 'fabric_inventory',
+          valueKey: 'internalControlNumber',
+          picker: { type: 'FABRIC_INVENTORY' },
+        },
+      },
+      {
+        fieldKey: 'material_expiration_date',
+        fieldLabel: 'Expiration Date (Auto)',
+        fieldType: 'date',
+        required: true,
+        validation: { readonly: true, source: 'fabric_inventory', valueKey: 'expirationDate' },
+      },
+    ]);
   }
 
   const startCustomFields = dedupeCustomFieldsAcrossPhases(
@@ -1367,8 +1452,11 @@ async function ensureExistingTravelerHasRoutingDetails(params: {
         const taskPhase = getRoutingOperationTravelerPhase(op);
         const taskType = operationTypeToTravelerTaskType(op.operationType) as any;
         const operationFields = taskType === 'QC'
-          ? getRoutingOperationQcFields({ operation: op, routing, taskPhase })
-          : [];
+          ? [
+              ...getRoutingOperationEvidenceFields(op),
+              ...getRoutingOperationQcFields({ operation: op, routing, taskPhase }),
+            ]
+          : getRoutingOperationEvidenceFields(op);
         const created = await createTravelerTaskWithFieldsIfMissing({
           stepId: step.id,
           enabledPhases: new Set<'START' | 'WORK' | 'FINISH'>(['START', 'WORK', 'FINISH']),

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19493,17 +19493,18 @@ export class DatabaseStorage implements IStorage {
       const tracePolicy = this._getTracePolicyForDepartment(deptName);
       const routingMaterials = deptConfig.materials || [];
       if (tracePolicy.enabled) {
-        if (routingMaterials.length > 1) {
+        if (routingMaterials.length > 0) {
           for (let matIdx = 0; matIdx < routingMaterials.length; matIdx++) {
             const mat = routingMaterials[matIdx];
             const matLabel = mat.partName || mat.partNumber || `Material ${matIdx + 1}`;
             const matShort = mat.partNumber ? `#${mat.partNumber}` : `Material ${matIdx + 1}`;
             const perMatFields = this._buildTraceFields(tracePolicy.capture);
+            const traceTaskPhase = this._normalizePhase(mat.traceabilityPhase || tracePolicy.phase);
             if (perMatFields.length > 0) {
               const matTraceTask = await this._createTaskIfAllowed({
                 travelerStepId: step.id,
                 taskType: 'TRACE',
-                taskPhase: tracePolicy.phase,
+                taskPhase: traceTaskPhase,
                 title: `Material Traceability — ${matShort}`,
                 instructions: `Select ${matLabel} from inventory. Fields will auto-fill.`,
                 required: true,
@@ -19804,6 +19805,25 @@ export class DatabaseStorage implements IStorage {
           requiresSignature: false,
           requiresCertification: false,
           instructionPack: routingInstructionPack,
+          status: 'NOT_STARTED',
+        }, enabledPhases, createdTaskKeys);
+      }
+
+      // Explicit WORK checks from routing template
+      for (const check of deptConfig.workChecks || []) {
+        await this._createTaskIfAllowed({
+          travelerStepId: step.id,
+          taskType: check.taskType || 'CHECK',
+          taskPhase: 'WORK',
+          title: check.title,
+          instructions: check.instructions || `Complete: ${check.title}`,
+          required: check.required !== false,
+          sortOrder: sortOrder++,
+          timePolicy: check.timePolicy || 'AUTO_ON_COMPLETE',
+          requiresSignature: check.requiresSignature || false,
+          signatureRole: check.requiresSignature ? (check.signatureRole || 'OPERATOR') : null,
+          requiresCertification: check.requiresCertification || false,
+          instructionPack: check.instructionPack || null,
           status: 'NOT_STARTED',
         }, enabledPhases, createdTaskKeys);
       }
@@ -20281,8 +20301,8 @@ export class DatabaseStorage implements IStorage {
       switch (t) {
         case 'SETUP': return 'START';
         case 'MATERIAL': return 'START';
-        case 'QC': return 'FINISH';
-        case 'INSPECT': return 'FINISH';
+        case 'QC': return 'WORK';
+        case 'INSPECT': return 'WORK';
         default: return 'WORK';
       }
     };
@@ -20359,6 +20379,64 @@ export class DatabaseStorage implements IStorage {
         }];
       }
       return [];
+    };
+    const buildOperationEvidenceFields = (op: RoutingOperation) => {
+      const baseKey = `routing_op_${op.id}`;
+      const fields: Array<{
+        fieldKey: string;
+        fieldLabel: string;
+        fieldType: string;
+        required: boolean;
+        validation?: any;
+      }> = [
+        {
+          fieldKey: `${baseKey}_complete`,
+          fieldLabel: `Completed: ${op.operationName}`,
+          fieldType: 'yes_no',
+          required: true,
+        },
+        {
+          fieldKey: `${baseKey}_department`,
+          fieldLabel: 'Routing Department',
+          fieldType: 'text',
+          required: false,
+          validation: { readonly: true, value: op.departmentName },
+        },
+        {
+          fieldKey: `${baseKey}_operation_type`,
+          fieldLabel: 'Operation Type',
+          fieldType: 'text',
+          required: false,
+          validation: { readonly: true, value: op.operationType },
+        },
+      ];
+
+      if (op.workCenter) {
+        fields.push({
+          fieldKey: `${baseKey}_work_center`,
+          fieldLabel: 'Work Center',
+          fieldType: 'text',
+          required: false,
+          validation: { readonly: true, value: op.workCenter },
+        });
+      }
+      if (op.estimatedMinutes) {
+        fields.push({
+          fieldKey: `${baseKey}_estimated_minutes`,
+          fieldLabel: 'Estimated Minutes',
+          fieldType: 'number',
+          required: false,
+          validation: { readonly: true, value: String(op.estimatedMinutes) },
+        });
+        fields.push({
+          fieldKey: `${baseKey}_actual_minutes`,
+          fieldLabel: 'Actual Minutes',
+          fieldType: 'number',
+          required: false,
+        });
+      }
+
+      return fields;
     };
 
     const departmentSequence = Array.isArray(routing.departmentSequence)
@@ -20464,9 +20542,9 @@ export class DatabaseStorage implements IStorage {
 
         if (taskType === 'QC') {
           const qcStandards = getOperationQcStandards(op, taskPhase);
-          for (const qc of qcStandards) {
-            await this.createTravelerTaskField({
-              travelerTaskId: task.id,
+          const fields = [
+            ...buildOperationEvidenceFields(op),
+            ...qcStandards.map((qc) => ({
               fieldKey: `qc_${op.id}_${sanitizeFieldKey(qc.standard || op.operationName)}`,
               fieldLabel: qc.standard || op.operationName,
               fieldType: 'yes_no',
@@ -20477,6 +20555,27 @@ export class DatabaseStorage implements IStorage {
                 ...(qc.hardQcStop ? { hardQcStop: true } : {}),
                 ...(qc.referenceLink ? { referenceLink: qc.referenceLink } : {}),
               },
+            })),
+          ];
+          for (const field of this._dedupeFieldsByKey(fields)) {
+            await this.createTravelerTaskField({
+              travelerTaskId: task.id,
+              fieldKey: field.fieldKey,
+              fieldLabel: field.fieldLabel,
+              fieldType: field.fieldType,
+              required: field.required,
+              validation: field.validation,
+            });
+          }
+        } else {
+          for (const field of buildOperationEvidenceFields(op)) {
+            await this.createTravelerTaskField({
+              travelerTaskId: task.id,
+              fieldKey: field.fieldKey,
+              fieldLabel: field.fieldLabel,
+              fieldType: field.fieldType,
+              required: field.required,
+              validation: field.validation,
             });
           }
         }


### PR DESCRIPTION
## Summary
- Stop TRACE/TRACEABILITY material scans from immediately completing the generated traveler task
- Accumulate scanned/manual material control numbers on the task so operators can add another material before completion
- Show a captured-material summary with a dedicated Complete Traceability action once all materials are entered
- Restore routing WORK-stage tasks for generated P2 travelers, including Layup WORK checks and phase-specific material traceability
- Map QC/INSPECT routing operations to WORK and add per-operation traveler evidence fields such as `Completed: <operation>`

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/storage.ts`
- `node --experimental-strip-types --check server/src/routes/p2Traveler.ts`

Note: full frontend/typecheck was not run locally because this worktree does not have `node_modules`.