### PR TITLE
Clarify P2 open NCR queue

### DIFF
--- a/client/src/components/p2/P2ProductionQueue.tsx
+++ b/client/src/components/p2/P2ProductionQueue.tsx
@@ -248,9 +248,9 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
         : variables.status === 'SCRAPPED'
           ? variables.rmaRequired
             ? data?.replacementItem?.serialNumber
-              ? `Item marked NCR/scrapped. RMA replacement ${data.replacementItem.serialNumber} was added for scheduling.`
-              : 'Item marked NCR/scrapped. The RMA replacement request was recorded.'
-            : 'Item marked NCR/scrapped and moved to the P2 nonconforming tab for disposition.'
+              ? `NCR opened. Replacement ${data.replacementItem.serialNumber} was added for scheduling, and the original item moved to open nonconforming.`
+              : 'NCR opened. The original item moved to open nonconforming for disposition.'
+            : 'NCR opened. The item moved out of production and into open nonconforming for disposition.'
           : `Item status changed to ${variables.status}`;
       toast({
         title: 'Status Updated',
@@ -1378,7 +1378,7 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
               Mark Item NCR / Scrap
             </DialogTitle>
             <DialogDescription>
-              This removes the item from active production and sends it to the P2 nonconforming tab for disposition.
+              This removes the original item from active production and sends it to open nonconforming for disposition.
             </DialogDescription>
           </DialogHeader>
           
@@ -1409,7 +1409,7 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
                     <span>
                       <span className="block font-medium">Yes, create RMA replacement</span>
                       <span className="block text-xs text-muted-foreground">
-                        Add a schedulable replacement using this serial number with an rma-XX suffix.
+                        Add a schedulable replacement and keep the original item in open nonconforming.
                       </span>
                     </span>
                   </Label>
@@ -1418,7 +1418,7 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
                     <span>
                       <span className="block font-medium">No, disposition only</span>
                       <span className="block text-xs text-muted-foreground">
-                        Move this item to P2 nonconforming so Quality can file the disposition.
+                        Move this item out of production so Quality can file the disposition.
                       </span>
                     </span>
                   </Label>
@@ -1453,7 +1453,7 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
               ) : (
                 <XCircle className="h-4 w-4 mr-2" />
               )}
-              {scrapRequiresRma ? 'Mark NCR & Create RMA Item' : 'Mark NCR for Disposition'}
+              {scrapRequiresRma ? 'Open NCR & Create Replacement' : 'Open NCR for Disposition'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/client/src/components/p2/P2ScrappedItemsTab.tsx
+++ b/client/src/components/p2/P2ScrappedItemsTab.tsx
@@ -496,21 +496,21 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedItem, setSelectedItem] = useState<ScrappedItem | null>(null);
 
-  const { data: scrappedItemsRaw = [], isLoading, isError, error, refetch: refetchItems } = useQuery<ScrappedItem[]>({
+  const { data: openNcrItemsRaw = [], isLoading, isError, error, refetch: refetchItems } = useQuery<ScrappedItem[]>({
     queryKey: ['/api/p2/serialized-items/scrapped'],
     refetchInterval: 60000,
   });
 
-  const scrappedItems = selectedPOIds.length > 0
-    ? scrappedItemsRaw.filter((item) => item.poId !== null && selectedPOIds.includes(item.poId))
-    : scrappedItemsRaw;
+  const openNcrItems = selectedPOIds.length > 0
+    ? openNcrItemsRaw.filter((item) => item.poId !== null && selectedPOIds.includes(item.poId))
+    : openNcrItemsRaw;
 
   const { data: rmasRaw = [], refetch: refetchRmas } = useQuery<Rma[]>({
     queryKey: ['/api/p2/rmas'],
     refetchInterval: 60000,
   });
 
-  const filtered = scrappedItems.filter((item) => {
+  const filtered = openNcrItems.filter((item) => {
     if (!searchTerm) return true;
     const term = searchTerm.toLowerCase();
     return (
@@ -524,7 +524,7 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
     );
   });
 
-  const pendingCount = scrappedItems.filter((i) => !i.disposition).length;
+  const needsDispositionCount = openNcrItems.filter((i) => !i.disposition).length;
   const openRmaCount = rmasRaw.filter((r) => r.rma.status === 'open').length;
   const activeRmas = rmasRaw.filter((r) => r.rma.status === 'open' || r.rma.status === 'shipped');
 
@@ -567,8 +567,8 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
           <TabsTrigger value="items" className="flex items-center gap-2">
             <AlertTriangle className="h-4 w-4" />
             Nonconforming Items
-            {pendingCount > 0 && (
-              <Badge variant="destructive" className="ml-1 text-xs px-1.5">{pendingCount}</Badge>
+            {needsDispositionCount > 0 && (
+              <Badge variant="destructive" className="ml-1 text-xs px-1.5">{needsDispositionCount}</Badge>
             )}
           </TabsTrigger>
           <TabsTrigger value="rmas" className="flex items-center gap-2">
@@ -588,11 +588,11 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
               <div className="flex items-center justify-between">
                 <CardTitle className="flex items-center gap-2">
                   <AlertTriangle className="h-5 w-5 text-orange-500" />
-                  Nonconforming P2 Items
-                  <Badge variant="secondary" className="ml-2">{scrappedItems.length}</Badge>
-                  {pendingCount > 0 && (
+                  Open Nonconforming P2 Items
+                  <Badge variant="secondary" className="ml-2">{openNcrItems.length}</Badge>
+                  {needsDispositionCount > 0 && (
                     <Badge variant="destructive" className="ml-1">
-                      {pendingCount} need attention
+                      {needsDispositionCount} need disposition
                     </Badge>
                   )}
                 </CardTitle>
@@ -611,10 +611,10 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
               {filtered.length === 0 ? (
                 <div className="text-center py-12 text-muted-foreground">
                   <AlertTriangle className="h-12 w-12 mx-auto mb-3 opacity-50" />
-                  {scrappedItems.length === 0 ? (
+                  {openNcrItems.length === 0 ? (
                     <>
-                      <p className="font-medium">No nonconforming items</p>
-                      <p className="text-sm">Items flagged as nonconforming will appear here</p>
+                      <p className="font-medium">No open nonconforming items</p>
+                      <p className="text-sm">Items opened as NCR will appear here until disposition is complete</p>
                     </>
                   ) : (
                     <>

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -458,7 +458,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   // P2 Production Queue routes
   app.use('/api/p2-production-queue', p2ProductionQueueRoutes);
   
-  // P2 Serialized Items - scrapped/nonconforming list (inline to avoid router mount ordering issues)
+  // P2 Serialized Items - open nonconforming list (inline to avoid router mount ordering issues)
   app.get('/api/p2/serialized-items/scrapped', async (req, res) => {
     try {
       const { db } = await import('../../db');
@@ -469,23 +469,33 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         orderBy: (t: any, { desc: d }: any) => [d(t.scrapAt)],
       });
 
-      // Enrich with disposition info
+      // Enrich with the latest disposition and return only open NCR items.
+      // The serialized item status is still SCRAPPED for compatibility, but
+      // operationally this endpoint is the open nonconforming attention queue.
       const itemIds = units.map((u: any) => u.id);
       let dispositions: any[] = [];
       if (itemIds.length > 0) {
         dispositions = await db
           .select()
           .from(p2NonconformingDispositions)
-          .where(inArray(p2NonconformingDispositions.serializedItemId, itemIds));
+          .where(inArray(p2NonconformingDispositions.serializedItemId, itemIds))
+          .orderBy(desc(p2NonconformingDispositions.createdAt));
       }
-      const dispositionMap = new Map(dispositions.map((d: any) => [d.serializedItemId, d]));
-      const enriched = units.map((u: any) => ({
-        ...u,
-        disposition: dispositionMap.get(u.id) || null,
-      }));
+      const dispositionMap = new Map();
+      dispositions.forEach((d: any) => {
+        if (!dispositionMap.has(d.serializedItemId)) {
+          dispositionMap.set(d.serializedItemId, d);
+        }
+      });
+      const enriched = units
+        .map((u: any) => ({
+          ...u,
+          disposition: dispositionMap.get(u.id) || null,
+        }))
+        .filter((u: any) => !u.disposition || u.disposition.resolved !== true);
       res.json(enriched);
     } catch (err: any) {
-      res.status(500).json({ error: err?.message || 'Failed to fetch scrapped items' });
+      res.status(500).json({ error: err?.message || 'Failed to fetch open nonconforming items' });
     }
   });
 
@@ -4439,7 +4449,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         updateFields.holdAt = null;
       }
 
-      // SCRAPPED transitions are atomic. If an RMA is required, the status
+      // SCRAPPED transitions are atomic. In this P2 flow, SCRAPPED means the
+      // original serial has left active production and entered open NCR.
+      // Final trash/scrap is recorded later by the disposition workflow.
+      // If an RMA is required, the status
       // update, trace events, and parent PO line qty bump all commit or roll
       // back together. If not, the item simply becomes P2 nonconforming and
       // waits for disposition in the P2 Control Center tab.
@@ -4627,7 +4640,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         return res.json({
           success: true,
           message: replacementItem
-            ? `Item scrapped and RMA replacement ${replacementItem.serialNumber} generated for scheduling`
+            ? `NCR opened and RMA replacement ${replacementItem.serialNumber} generated for scheduling`
             : `Item status updated to ${status}`,
           travelerCreated: false,
           linkedTravelerFound: false,


### PR DESCRIPTION
## Summary
- keep the P2 NCR/Scrap RMA flow intact while clarifying that the original serial moves to open nonconforming for disposition
- return only unresolved/open NCR items from the P2 nonconforming list, using the latest disposition record per serialized item
- update operator-facing copy so initial NCR creation is not confused with final scrap/trash disposition

## Validation
- `git diff --check origin/main...HEAD` passed
- `npm run check` could not run locally because `npm` is not installed in this environment