### PR TITLE
Show final P2 scrap metrics in PM

### DIFF
--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -180,11 +180,19 @@ interface P2PoStatusSummary {
   status: 'pending' | 'in_progress' | 'completed';
 }
 
+interface P2NcrMetrics {
+  totalSerializedItems: number;
+  openNcrCount: number;
+  finalScrapCount: number;
+  finalScrapRatePercent: number;
+}
+
 interface ProductionResponse {
   rows: WorkOrderRow[];
   linkedP2Production?: WorkOrderRow[];
   linkedP2PoCount: number;
   linkedP2PoStatuses: P2PoStatusSummary[];
+  p2NcrMetrics?: P2NcrMetrics;
 }
 
 interface P2SerializedBreakdownItem {
@@ -777,6 +785,7 @@ function ProductionTab({ projectId }: { projectId: string }) {
   const rows = productionResponse?.rows ?? [];
   const linkedP2PoCount = productionResponse?.linkedP2PoCount ?? 0;
   const linkedP2PoStatuses = productionResponse?.linkedP2PoStatuses ?? [];
+  const p2NcrMetrics = productionResponse?.p2NcrMetrics;
 
   const { data: detail, isLoading: detailLoading } = useQuery<WorkOrderDetail>({
     queryKey: ['/api/pm-dashboard', projectId, 'production', selectedWO?.productionWorkOrderId],
@@ -914,6 +923,49 @@ function ProductionTab({ projectId }: { projectId: string }) {
 
   return (
     <>
+      {p2NcrMetrics && p2NcrMetrics.totalSerializedItems > 0 && (
+        <div className="mb-4 grid gap-3 sm:grid-cols-3">
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-medium uppercase text-muted-foreground">Open NCR</p>
+                  <p className="text-2xl font-semibold">{p2NcrMetrics.openNcrCount}</p>
+                </div>
+                <ShieldAlert className="h-5 w-5 text-orange-500" />
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">Items awaiting disposition</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-medium uppercase text-muted-foreground">Final Scrap</p>
+                  <p className="text-2xl font-semibold">{p2NcrMetrics.finalScrapCount}</p>
+                </div>
+                <XCircle className="h-5 w-5 text-red-500" />
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">Dispositioned as scrap/trash</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-medium uppercase text-muted-foreground">Scrap Rate</p>
+                  <p className="text-2xl font-semibold">{p2NcrMetrics.finalScrapRatePercent.toFixed(2)}%</p>
+                </div>
+                <TrendingUp className="h-5 w-5 text-red-500" />
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {p2NcrMetrics.finalScrapCount} of {p2NcrMetrics.totalSerializedItems} serialized items
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
       {linkedP2PoStatuses.length > 0 && (
         <div className="grid gap-3 mb-4">
           {linkedP2PoStatuses.map((po) => {

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -116,6 +116,13 @@ interface ProductionRow {
   productionConnectionDetail?: string | null;
 }
 
+interface P2NcrMetrics {
+  totalSerializedItems: number;
+  openNcrCount: number;
+  finalScrapCount: number;
+  finalScrapRatePercent: number;
+}
+
 interface WadBridgeRow {
   id: string;
   workOrderNumber: string;
@@ -612,6 +619,70 @@ async function getProjectP2SerializedBreakdown(projectId: string): Promise<P2Ser
       psi.sequence_number,
       psi.serial_number
   `, [linkedPoIds]);
+}
+
+async function getProjectP2NcrMetrics(projectId: string): Promise<P2NcrMetrics> {
+  const linkedPoIds = await getProjectLinkedP2PoIds(projectId);
+  if (!linkedPoIds.length) {
+    return {
+      totalSerializedItems: 0,
+      openNcrCount: 0,
+      finalScrapCount: 0,
+      finalScrapRatePercent: 0,
+    };
+  }
+
+  const rows = await pool.query<{
+    totalSerializedItems: string;
+    openNcrCount: string;
+    finalScrapCount: string;
+  }>(`
+    WITH linked_items AS (
+      SELECT psi.id, psi.status
+      FROM p2_serialized_items psi
+      WHERE psi.po_id = ANY($1::int[])
+        AND COALESCE(UPPER(psi.status), '') NOT IN ('CANCELLED', 'CANCELED')
+    ),
+    resolved_dispositions AS (
+      SELECT DISTINCT ON (ncr.serialized_item_id)
+        ncr.serialized_item_id,
+        ncr.disposition_type
+      FROM p2_nonconforming_dispositions ncr
+      JOIN linked_items li ON li.id = ncr.serialized_item_id
+      WHERE ncr.resolved = true
+      ORDER BY ncr.serialized_item_id, COALESCE(ncr.resolved_at, ncr.created_at) DESC, ncr.id DESC
+    )
+    SELECT
+      COUNT(li.id)::text AS "totalSerializedItems",
+      COUNT(li.id) FILTER (
+        WHERE UPPER(COALESCE(li.status, '')) = 'SCRAPPED'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM resolved_dispositions rd
+            WHERE rd.serialized_item_id = li.id
+          )
+      )::text AS "openNcrCount",
+      COUNT(*) FILTER (
+        WHERE LOWER(COALESCE(rd.disposition_type, '')) = 'scrap'
+      )::text AS "finalScrapCount"
+    FROM linked_items li
+    LEFT JOIN resolved_dispositions rd ON rd.serialized_item_id = li.id
+  `, [linkedPoIds]);
+
+  const row = rows[0];
+  const totalSerializedItems = parseInt(row?.totalSerializedItems ?? '0', 10) || 0;
+  const openNcrCount = parseInt(row?.openNcrCount ?? '0', 10) || 0;
+  const finalScrapCount = parseInt(row?.finalScrapCount ?? '0', 10) || 0;
+  const finalScrapRatePercent = totalSerializedItems > 0
+    ? Math.round((finalScrapCount / totalSerializedItems) * 10000) / 100
+    : 0;
+
+  return {
+    totalSerializedItems,
+    openNcrCount,
+    finalScrapCount,
+    finalScrapRatePercent,
+  };
 }
 
 function isWadReleasedForExecution(wad: WadBridgeRow): boolean {
@@ -1623,6 +1694,7 @@ router.get('/:projectId/production', h(async (req, res) => {
 
   const linkedP2PoCount = parseInt(linkRes[0]?.count ?? '0', 10) || 0;
   const linkedP2PoStatuses = await getProjectP2PoStatusSummaries(projectId);
+  const p2NcrMetrics = await getProjectP2NcrMetrics(projectId);
 
   // Item-level override: when serialized items exist for the project's linked
   // P2 PO, drive the P2 portion of the production table from p2_serialized_items
@@ -1773,6 +1845,7 @@ res.json({
   linkedP2Production,
   linkedP2PoCount,
   linkedP2PoStatuses,
+  p2NcrMetrics,
 });
 }));
 


### PR DESCRIPTION
## Summary
- add project-level P2 NCR metrics to the PM production endpoint
- count open NCR separately from final scrap dispositions
- show PM Production tab cards for Open NCR, Final Scrap, and Scrap Rate using only resolved `Scrap` dispositions for the scrap rate

## Notes
- Initial NCR/Scrap selection is not counted as final scrap here; the final scrap count/rate comes from `p2_nonconforming_dispositions.disposition_type = 'Scrap'` after resolution.

## Validation
- `git diff --check origin/main...HEAD` passed
- `npm run check` could not run locally because `npm` is not installed in this environment