### PR TITLE
[codex] Respect routing material traceability steps

### DIFF
--- a/client/src/components/PartRoutingWizard.tsx
+++ b/client/src/components/PartRoutingWizard.tsx
@@ -663,10 +663,10 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
   const handleSave = () => {
     if (!selectedItem) return;
 
-    // Build traceabilityConfig from departmentConfig materials' requiredFields
-    // Preserve existing config when editing, only update departments that have materials configured
-    const existingTraceabilityConfig = editRouting?.traceabilityConfig || {};
-    const traceabilityConfig: Record<string, string[]> = { ...existingTraceabilityConfig };
+    // Build traceabilityConfig from current material assignments only.
+    // Preserving old department keys makes material prompts appear on steps
+    // after the user has moved or removed the material in routing.
+    const traceabilityConfig: Record<string, string[]> = {};
     
     selectedDepartments.forEach(dept => {
       const config = departmentConfig[dept];
@@ -676,18 +676,9 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
         config.materials.forEach(material => {
           material.requiredFields?.forEach(field => allFields.add(field));
         });
-        traceabilityConfig[dept] = Array.from(allFields);
-      } else if (!existingTraceabilityConfig[dept]) {
-        // Only set empty array for new departments that don't have existing config
-        traceabilityConfig[dept] = [];
-      }
-      // If department exists in existing config and no new materials, preserve existing
-    });
-    
-    // Remove departments no longer in sequence
-    Object.keys(traceabilityConfig).forEach(dept => {
-      if (!selectedDepartments.includes(dept)) {
-        delete traceabilityConfig[dept];
+        if (allFields.size > 0) {
+          traceabilityConfig[dept] = Array.from(allFields);
+        }
       }
     });
 

--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -1114,6 +1114,9 @@ async function backfillDepartmentConfiguredTravelerTasks(params: {
   const departmentConfigByName = (routing.departmentConfig || {}) as Record<string, any>;
   const departmentConfig = departmentConfigByName[departmentName] || {};
   const traceabilityConfig = (routing.traceabilityConfig || {}) as Record<string, string[]>;
+  const routingHasExplicitMaterials = Object.values(departmentConfigByName).some(
+    (config: any) => Array.isArray(config?.materials) && config.materials.length > 0,
+  );
   const enabledPhases = getEnabledTravelerTaskPhases(departmentConfig);
   const createdCustomFieldKeys = new Set<string>();
   const createdQcStandardKeys = new Set<string>();
@@ -1174,15 +1177,18 @@ async function backfillDepartmentConfiguredTravelerTasks(params: {
     });
   }
 
+  const routingMaterials = Array.isArray(departmentConfig.materials) ? departmentConfig.materials : [];
   const nonMaterialTraceFields = new Set(['operator', 'timestamp']);
-  const traceFields = (traceabilityConfig[departmentName] || [])
-    .filter((field: string) => !nonMaterialTraceFields.has(field))
-    .map((field: string) => ({
-      fieldKey: `trace_${field.replace(/\s+/g, '_').toLowerCase()}`,
-      fieldLabel: field.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
-      fieldType: 'text',
-      required: true,
-    }));
+  const traceFields = routingHasExplicitMaterials
+    ? []
+    : (traceabilityConfig[departmentName] || [])
+      .filter((field: string) => !nonMaterialTraceFields.has(field))
+      .map((field: string) => ({
+        fieldKey: `trace_${field.replace(/\s+/g, '_').toLowerCase()}`,
+        fieldLabel: field.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
+        fieldType: 'text',
+        required: true,
+      }));
   if (traceFields.length > 0) {
     await addTask({
       taskType: 'TRACE',
@@ -1192,7 +1198,6 @@ async function backfillDepartmentConfiguredTravelerTasks(params: {
     }, traceFields);
   }
 
-  const routingMaterials = Array.isArray(departmentConfig.materials) ? departmentConfig.materials : [];
   for (const [index, material] of routingMaterials.entries()) {
     const taskPhase = normalizeTravelerTaskPhase(material.traceabilityPhase || 'START');
     const materialLabel = material.partName || material.partNumber || `Material ${index + 1}`;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19463,6 +19463,9 @@ export class DatabaseStorage implements IStorage {
     const departmentSequence = routing.departmentSequence as string[];
     const traceabilityConfig = routing.traceabilityConfig as Record<string, string[]>;
     const departmentConfig = (routing.departmentConfig || {}) as Record<string, any>;
+    const routingHasExplicitMaterials = Object.values(departmentConfig).some(
+      (config: any) => Array.isArray(config?.materials) && config.materials.length > 0,
+    );
 
     let stepCounter = 0;
     for (let i = 0; i < departmentSequence.length; i++) {
@@ -19492,7 +19495,7 @@ export class DatabaseStorage implements IStorage {
       // ===== POLICY-DRIVEN MATERIAL TRACEABILITY =====
       const tracePolicy = this._getTracePolicyForDepartment(deptName);
       const routingMaterials = deptConfig.materials || [];
-      if (tracePolicy.enabled) {
+      if (tracePolicy.enabled && (!routingHasExplicitMaterials || routingMaterials.length > 0)) {
         if (routingMaterials.length > 0) {
           for (let matIdx = 0; matIdx < routingMaterials.length; matIdx++) {
             const mat = routingMaterials[matIdx];


### PR DESCRIPTION
## Summary

Fixes material traceability tasks appearing on multiple traveler steps instead of only on the department/phase where the user configured the material in routing.

## Root Cause

Traveler generation still applied department-level default material traceability policy to departments like Layup/CNC even when the routing had explicit material assignments. The routing wizard could also preserve stale `traceabilityConfig` keys for departments after material was moved or removed, causing old steps to keep material prompts.

## Changes

- Rebuild routing `traceabilityConfig` from the current material assignments on save instead of preserving stale department keys.
- In new traveler generation, suppress default policy material trace tasks on unrelated departments once explicit routing materials exist.
- In the P2 traveler repair/backfill path, skip generic traceability tasks when routing has explicit material assignments and create tasks only from the configured department materials.

## Validation

- `git diff --check` passed with only the repo's existing CRLF warning.
- `npm run check` remains unavailable in this environment because `npm` is not installed/visible on PATH.