### PR TITLE
Keep PO-linked completed P2 work out of production tab

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3340,6 +3340,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
          SELECT
            LOWER(TRIM(key_value)) AS serial,
            t.status,
+           t.off_system_completion_link IS NOT NULL AS is_off_system_completion,
            t.traveler_number,
            t.updated_at,
            active_step.department_name,
@@ -3364,12 +3365,14 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
        SELECT DISTINCT ON (serial)
          serial,
          t.status,
+         t.is_off_system_completion AS "isOffSystemCompletion",
          t.traveler_number AS "travelerNumber",
          t.updated_at AS "updatedAt",
          t.department_name AS "activeDepartment",
          t.started_at AS "startedAt"
        FROM traveler_keys t
        ORDER BY serial,
+         CASE WHEN UPPER(t.status) = 'COMPLETED' AND t.is_off_system_completion THEN 0 ELSE 1 END,
          CASE WHEN UPPER(t.status) = 'IN_PROGRESS' THEN 0 ELSE 1 END,
          t.updated_at DESC NULLS LAST`,
       [serials]
@@ -4414,6 +4417,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           .filter(Boolean)
       );
       const legacyProductionControlRows = p2ControlRows(legacyProductionRows).filter((row: any) => {
+        if (row.poId) return false;
         const key = row.poId && row.poItemId ? `${row.poId}:${row.poItemId}` : null;
         const normalizedStatus = String(row.status || '').toUpperCase();
         const quantity = Math.max(1, Number(row.quantity || 1));
@@ -4422,6 +4426,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         return (!key || !serializedPoItemKeys.has(key)) && !isComplete;
       });
       const activeLegacyProjectProductionRows = legacyProjectProductionRows.filter((row: any) => {
+        if (row.poId) return false;
         const normalizedStatus = String(row.status || '').toUpperCase();
         return !['COMPLETE', 'COMPLETED', 'CLOSED'].includes(normalizedStatus);
       });
@@ -4709,7 +4714,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             + legacyProductionControlRows.filter((row: any) =>
               !['COMPLETED', 'CLOSED'].includes(String(row.status || '').toUpperCase())
             ).length
-            + legacyProjectProductionRows.filter((row: any) =>
+            + activeLegacyProjectProductionRows.filter((row: any) =>
               !['COMPLETE', 'COMPLETED', 'CLOSED'].includes(String(row.status || '').toUpperCase())
             ).length,
           totalInProgress: p2ControlRows(activeTasks).length
@@ -4719,7 +4724,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             + legacyProductionControlRows.filter((row: any) =>
               String(row.status || '').toUpperCase() === 'IN_PROGRESS'
             ).length
-            + legacyProjectProductionRows.filter((row: any) =>
+            + activeLegacyProjectProductionRows.filter((row: any) =>
               ['IN_PROGRESS', 'ACTIVE', 'STARTED', 'RELEASED'].includes(String(row.status || '').toUpperCase())
               || !!row.activeDepartment
             ).length,


### PR DESCRIPTION
## Summary
- prefer completed off-system traveler matches over duplicate in-progress traveler matches for the same P2 serial/barcode/lot key
- exclude PO-linked legacy/project WAD rows from the P2 Production tab so they are tracked through PO status/progress instead
- update production-tab summary counters to use the same filtered legacy/project rows

## Validation
- `git diff --check`
- Unable to run `npm run check`: `npm` is not available in this local shell and `node_modules/.bin/tsc.cmd` is not present.