### PR TITLE
Fix P2 NCR scrap disposition routing

### DIFF
--- a/client/src/components/p2/P2ToleranceGate.tsx
+++ b/client/src/components/p2/P2ToleranceGate.tsx
@@ -89,7 +89,7 @@ export default function P2ToleranceGate({
       signature: string;
       reason: string;
     }) => {
-      const response = await apiRequest(`/api/p2/final-inspection/${inspectionId}/approve-deviation`, {
+      return apiRequest(`/api/p2/final-inspection/${inspectionId}/approve-deviation`, {
         method: 'POST',
         body: {
           serializedItemId,
@@ -99,7 +99,6 @@ export default function P2ToleranceGate({
           toleranceDeviationReason: data.reason,
         },
       });
-      return response.json();
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/p2/final-inspection'] });
@@ -121,7 +120,7 @@ export default function P2ToleranceGate({
 
   const rejectDeviationMutation = useMutation({
     mutationFn: async () => {
-      const response = await apiRequest(`/api/p2/final-inspection/${inspectionId}/reject-deviation`, {
+      return apiRequest(`/api/p2/final-inspection/${inspectionId}/reject-deviation`, {
         method: 'POST',
         body: {
           serializedItemId,
@@ -129,14 +128,16 @@ export default function P2ToleranceGate({
           rejectedByName: `${currentUser?.firstName} ${currentUser?.lastName}`,
         },
       });
-      return response.json();
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/p2/final-inspection'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/serialized-items'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/production-queue'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/po-statuses'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/serialized-items/scrapped'] });
       toast({
         title: 'Deviation Rejected',
-        description: 'The item has been flagged for rework or scrapping.',
+        description: 'The item has been moved to NCR/Scrap open disposition.',
         variant: 'destructive',
       });
       onComplete(false);
@@ -370,7 +371,7 @@ export default function P2ToleranceGate({
                   data-testid="button-reject"
                 >
                   <X className="mr-2 h-4 w-4" />
-                  {rejectDeviationMutation.isPending ? 'Rejecting...' : 'Reject & Flag for Rework'}
+                  {rejectDeviationMutation.isPending ? 'Rejecting...' : 'Reject to NCR/Scrap'}
                 </Button>
                 <Button
                   onClick={handleApprove}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -5870,8 +5870,6 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { inspectionId } = req.params;
       const { serializedItemId, rejectedBy, rejectedByName } = req.body;
 
-      const { storage } = await import('../../storage');
-      
       // Log the rejection
       console.log('Tolerance deviation rejected:', {
         inspectionId,
@@ -5880,17 +5878,70 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         rejectedByName
       });
 
-      // Flag the item for rework by updating its status
+      // Move the serialized item into the same nonconforming/disposition flow
+      // used by P2 Control Center scrap. The open disposition queue reads
+      // p2_serialized_items.status = SCRAPPED, while production only shows ACTIVE.
       if (serializedItemId) {
-        await storage.updateP2SerializedItem(serializedItemId, {
-          productionStatus: 'HOLD',
-          notes: `Tolerance deviation rejected by ${rejectedByName} on ${new Date().toISOString()} - requires rework or scrap`
+        const { db } = await import('../../db');
+        const { p2SerializedItems, p2SerializedItemEvents } = await import('../../schema');
+        const { eq } = await import('drizzle-orm');
+
+        const [item] = await db
+          .select()
+          .from(p2SerializedItems)
+          .where(eq(p2SerializedItems.id, serializedItemId))
+          .limit(1);
+
+        if (!item) {
+          return res.status(404).json({ error: 'Serialized item not found' });
+        }
+
+        const now = new Date();
+        const actor = rejectedByName || rejectedBy || 'System';
+        const reason = 'Tolerance deviation rejected - NCR/Scrap disposition required';
+        const existingMetadata =
+          item.metadata && typeof item.metadata === 'object' && !Array.isArray(item.metadata)
+            ? item.metadata
+            : {};
+
+        await db.update(p2SerializedItems)
+          .set({
+            status: 'SCRAPPED',
+            scrapReason: reason,
+            scrapBy: actor,
+            scrapAt: now,
+            notes: `Tolerance deviation rejected by ${actor} on ${now.toISOString()} - requires NCR/Scrap disposition`,
+            metadata: {
+              ...existingMetadata,
+              hasToleranceDeviation: true,
+              toleranceDeviationRejected: true,
+              toleranceDeviationRejectedAt: now.toISOString(),
+              toleranceDeviationRejectedBy: actor,
+              finalInspectionId: inspectionId,
+            },
+            updatedAt: now,
+          })
+          .where(eq(p2SerializedItems.id, serializedItemId));
+
+        await db.insert(p2SerializedItemEvents).values({
+          serializedItemId,
+          barcode: item.barcode,
+          eventType: 'SCRAP',
+          performedBy: actor,
+          notes: reason,
+          metadata: {
+            source: 'final-inspection-reject-deviation',
+            inspectionId,
+            previousStatus: item.status,
+            newStatus: 'SCRAPPED',
+            dispositionRequired: true,
+          },
         });
       }
 
       res.json({ 
         success: true, 
-        message: 'Tolerance deviation rejected - item flagged for rework',
+        message: 'Tolerance deviation rejected - item moved to NCR/Scrap open disposition',
         inspectionId,
         rejectedBy: rejectedByName,
         rejectedAt: new Date().toISOString()


### PR DESCRIPTION
## Summary
- move tolerance rejection/NCR scrap actions onto the canonical P2 serialized item `SCRAPPED` state
- populate scrap metadata and append a P2 serialized item SCRAP event so rejected items leave production and enter the open disposition queue
- refresh P2 production, status, and scrapped item queries after rejection and fix `apiRequest` handling in the tolerance gate

## Validation
- `git diff --check`
- Not run: `npm run check` because `npm` is not available in this environment