### PR TITLE
[codex] Add P2 Avery product label generation

### DIFF
--- a/client/src/pages/ProductLabelsPage.tsx
+++ b/client/src/pages/ProductLabelsPage.tsx
@@ -1,11 +1,31 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
-import { Printer, Tag, Package, Plus, Minus, Trash2, FileSpreadsheet } from 'lucide-react';
+import {
+  FileSpreadsheet,
+  ImagePlus,
+  Minus,
+  Package,
+  Plus,
+  Printer,
+  Tag,
+  Trash2,
+} from 'lucide-react';
+
+type LabelMode = 'P1' | 'P2';
+type TemplateKey = '8160' | '8162';
+
+const LABEL_TEMPLATES: Record<TemplateKey, { label: string; columns: number; rows: number; labelsPerPage: number }> = {
+  '8162': { label: 'Avery 8162 - 14 labels', columns: 2, rows: 7, labelsPerPage: 14 },
+  '8160': { label: 'Avery 8160 - 30 labels', columns: 3, rows: 10, labelsPerPage: 30 },
+};
 
 interface ProductItem {
   id: number;
@@ -29,6 +49,24 @@ interface LabelItem {
   description: string;
   copies: number;
   fillPage: boolean;
+}
+
+interface P2ProjectOption {
+  projectName: string;
+  lotCount: number;
+}
+
+interface P2LotOption {
+  id: string;
+  lotNumber: string;
+  poNumber: string | null;
+  customerName: string | null;
+  partNumber: string | null;
+  partName: string | null;
+  quantity: number | null;
+  projectName: string;
+  packingSlipNumber: string | null;
+  createdAt: string;
 }
 
 function buildDescription(product: ProductItem): string {
@@ -64,7 +102,7 @@ function buildDescription(product: ProductItem): string {
 
   if (product.action_length) {
     const len = product.action_length.replace(/_/g, ' ').trim();
-    parts.push(len.charAt(0).toUpperCase() + len.slice(1) + ' Action');
+    parts.push(`${len.charAt(0).toUpperCase()}${len.slice(1)} Action`);
   } else {
     const pName = product.product_name || '';
     const pType = product.product_type || '';
@@ -96,15 +134,53 @@ function getLabelCode(product: ProductItem): string {
   return product.product_name || product.barcode || '';
 }
 
+function readLogoFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ''));
+    reader.onerror = () => reject(new Error('Failed to read logo file'));
+    reader.readAsDataURL(file);
+  });
+}
+
 export default function ProductLabelsPage() {
   const { toast } = useToast();
+  const [mode, setMode] = useState<LabelMode>('P1');
+  const [template, setTemplate] = useState<TemplateKey>('8162');
   const [selectedCustomer, setSelectedCustomer] = useState<string>('');
   const [productSearch, setProductSearch] = useState<string>('');
   const [labelItems, setLabelItems] = useState<LabelItem[]>([]);
+  const [selectedProject, setSelectedProject] = useState<string>('');
+  const [selectedLotId, setSelectedLotId] = useState<string>('');
+  const [includeLogo, setIncludeLogo] = useState(false);
+  const [logoBase64, setLogoBase64] = useState<string | null>(null);
+  const [logoFileName, setLogoFileName] = useState<string>('');
   const [isGenerating, setIsGenerating] = useState(false);
+  const [showPrintSetup, setShowPrintSetup] = useState(false);
+  const [usePartialSheet, setUsePartialSheet] = useState(false);
+  const [usedCells, setUsedCells] = useState<Set<number>>(new Set());
+
+  const templateConfig = LABEL_TEMPLATES[template];
 
   const { data: customers = [] } = useQuery<string[]>({
     queryKey: ['/api/product-labels/customers'],
+  });
+
+  const { data: p2Projects = [], isLoading: p2ProjectsLoading } = useQuery<P2ProjectOption[]>({
+    queryKey: ['/api/product-labels/p2-projects'],
+    enabled: mode === 'P2',
+  });
+
+  const { data: p2Lots = [], isLoading: p2LotsLoading } = useQuery<P2LotOption[]>({
+    queryKey: ['/api/product-labels/p2-lots', selectedProject],
+    queryFn: async () => {
+      const res = await fetch(`/api/product-labels/p2-lots?projectName=${encodeURIComponent(selectedProject)}`, {
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error('Failed to fetch P2 lots');
+      return res.json();
+    },
+    enabled: mode === 'P2' && !!selectedProject,
   });
 
   const productQueryKey = selectedCustomer
@@ -118,8 +194,13 @@ export default function ProductLabelsPage() {
       if (!res.ok) throw new Error('Failed to fetch products');
       return res.json();
     },
-    enabled: !!selectedCustomer,
+    enabled: mode === 'P1' && !!selectedCustomer,
   });
+
+  const selectedLot = useMemo(
+    () => p2Lots.find((lot) => lot.id === selectedLotId),
+    [p2Lots, selectedLotId]
+  );
 
   const addToLabels = (product: ProductItem) => {
     const existing = labelItems.find((item) => item.productId === product.id);
@@ -169,7 +250,11 @@ export default function ProductLabelsPage() {
     setLabelItems(
       labelItems.map((item) =>
         item.productId === productId
-          ? { ...item, fillPage: !item.fillPage, copies: !item.fillPage ? 14 : 1 }
+          ? {
+              ...item,
+              fillPage: !item.fillPage,
+              copies: !item.fillPage ? templateConfig.labelsPerPage : 1,
+            }
           : item
       )
     );
@@ -220,19 +305,76 @@ export default function ProductLabelsPage() {
 
   const clearAll = () => setLabelItems([]);
 
-  const generateLabels = async () => {
-    if (labelItems.length === 0) {
-      toast({ title: 'No items selected', description: 'Add products to generate labels.', variant: 'destructive' });
+  const totalLabels = mode === 'P2'
+    ? selectedLot?.quantity || 0
+    : labelItems.reduce((sum, item) => item.fillPage ? sum + templateConfig.labelsPerPage : sum + item.copies, 0);
+
+  const canPrint = mode === 'P2' ? !!selectedLotId : labelItems.length > 0;
+
+  const handleLogoChange = async (file?: File) => {
+    if (!file) {
+      setLogoBase64(null);
+      setLogoFileName('');
       return;
     }
 
+    if (!['image/png', 'image/jpeg'].includes(file.type)) {
+      toast({
+        title: 'Unsupported logo',
+        description: 'Use a PNG or JPEG logo file.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      const dataUrl = await readLogoFile(file);
+      setLogoBase64(dataUrl);
+      setLogoFileName(file.name);
+    } catch (error: any) {
+      toast({ title: 'Logo error', description: error.message, variant: 'destructive' });
+    }
+  };
+
+  const openPrintSetup = () => {
+    if (!canPrint) {
+      toast({
+        title: mode === 'P2' ? 'No lot selected' : 'No items selected',
+        description: mode === 'P2' ? 'Select a P2 project and lot first.' : 'Add products to generate labels.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (includeLogo && !logoBase64) {
+      toast({
+        title: 'Logo required',
+        description: 'Choose a PNG or JPEG logo file, or clear Add logo.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setUsedCells(new Set());
+    setUsePartialSheet(false);
+    setShowPrintSetup(true);
+  };
+
+  const generateLabels = async (skipIndexes: number[]) => {
     setIsGenerating(true);
     try {
       const response = await fetch('/api/product-labels/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ products: labelItems }),
+        body: JSON.stringify({
+          mode,
+          template,
+          products: mode === 'P1' ? labelItems : undefined,
+          lotId: mode === 'P2' ? selectedLotId : undefined,
+          logoBase64: includeLogo ? logoBase64 : null,
+          skipIndexes,
+        }),
       });
 
       if (!response.ok) {
@@ -244,8 +386,7 @@ export default function ProductLabelsPage() {
       const url = URL.createObjectURL(blob);
       window.open(url, '_blank');
 
-      const totalCount = labelItems.reduce((sum, i) => i.fillPage ? sum + 14 : sum + i.copies, 0);
-      toast({ title: 'Labels Generated', description: `${totalCount} labels ready to print.` });
+      toast({ title: 'Labels Generated', description: `${totalLabels} labels ready to print.` });
     } catch (error: any) {
       toast({ title: 'Error', description: error.message, variant: 'destructive' });
     } finally {
@@ -253,15 +394,89 @@ export default function ProductLabelsPage() {
     }
   };
 
-  const totalLabels = labelItems.reduce((sum, item) => item.fillPage ? sum + 14 : sum + item.copies, 0);
+  const confirmPrint = () => {
+    const skipIndexes = usePartialSheet ? Array.from(usedCells).sort((a, b) => a - b) : [];
+    setShowPrintSetup(false);
+    generateLabels(skipIndexes);
+  };
+
+  const toggleUsedCell = (index: number) => {
+    setUsedCells((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
 
   return (
     <div className="container mx-auto p-6 max-w-6xl">
-      <div className="flex items-center gap-3 mb-6">
-        <Tag className="h-8 w-8 text-primary" />
-        <div>
-          <h1 className="text-2xl font-bold">Product Label Generator</h1>
-          <p className="text-muted-foreground">Generate Avery 8162 product labels with barcodes</p>
+      <div className="flex flex-col gap-4 mb-6 lg:flex-row lg:items-end lg:justify-between">
+        <div className="flex items-center gap-3">
+          <Tag className="h-8 w-8 text-primary" />
+          <div>
+            <h1 className="text-2xl font-bold">Product Label Generator</h1>
+            <p className="text-muted-foreground">Generate P1 product labels or P2 lot serial labels</p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <div className="flex rounded-md border p-1">
+            <Button
+              type="button"
+              size="sm"
+              variant={mode === 'P1' ? 'default' : 'ghost'}
+              onClick={() => setMode('P1')}
+            >
+              P1
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={mode === 'P2' ? 'default' : 'ghost'}
+              onClick={() => setMode('P2')}
+            >
+              P2
+            </Button>
+          </div>
+
+          <Select value={template} onValueChange={(value) => setTemplate(value as TemplateKey)}>
+            <SelectTrigger className="w-[220px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(LABEL_TEMPLATES).map(([key, config]) => (
+                <SelectItem key={key} value={key}>{config.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="mb-6 rounded-lg border p-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="include-logo"
+              checked={includeLogo}
+              onCheckedChange={(checked) => setIncludeLogo(checked === true)}
+            />
+            <Label htmlFor="include-logo" className="text-sm font-medium">Add logo to labels</Label>
+          </div>
+          {includeLogo && (
+            <div className="flex flex-wrap items-center gap-3">
+              <Input
+                type="file"
+                accept="image/png,image/jpeg"
+                className="max-w-sm"
+                onChange={(event) => handleLogoChange(event.target.files?.[0])}
+              />
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <ImagePlus className="h-4 w-4" />
+                <span>{logoFileName || 'PNG or JPEG'}</span>
+              </div>
+            </div>
+          )}
         </div>
       </div>
 
@@ -270,70 +485,132 @@ export default function ProductLabelsPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Package className="h-5 w-5" />
-              Select Products
+              {mode === 'P1' ? 'Select Products' : 'Select P2 Shipment Lot'}
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <Select value={selectedCustomer} onValueChange={(v) => { setSelectedCustomer(v); setProductSearch(''); }}>
-              <SelectTrigger>
-                <SelectValue placeholder="Select a customer..." />
-              </SelectTrigger>
-              <SelectContent>
-                {customers.map((name) => (
-                  <SelectItem key={name} value={name}>{name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            {mode === 'P1' ? (
+              <>
+                <Select value={selectedCustomer} onValueChange={(v) => { setSelectedCustomer(v); setProductSearch(''); }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a customer..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {customers.map((name) => (
+                      <SelectItem key={name} value={name}>{name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
 
-            {selectedCustomer && (
-              <Input
-                placeholder="Search by name or product number..."
-                value={productSearch}
-                onChange={(e) => setProductSearch(e.target.value)}
-              />
-            )}
+                {selectedCustomer && (
+                  <Input
+                    placeholder="Search by name or product number..."
+                    value={productSearch}
+                    onChange={(e) => setProductSearch(e.target.value)}
+                  />
+                )}
 
-            {selectedCustomer && (
-              <div className="flex gap-2">
-                <Button variant="outline" size="sm" onClick={selectAll}>Select All</Button>
-                <Button variant="outline" size="sm" onClick={clearAll}>Clear All</Button>
-              </div>
-            )}
-
-            {productsLoading && <p className="text-muted-foreground text-sm">Loading products...</p>}
-
-            <div className="space-y-2 max-h-[500px] overflow-y-auto">
-              {filteredProducts.map((product) => {
-                const inQueue = labelItems.find((l) => l.productId === product.id);
-                const code = getLabelCode(product);
-                return (
-                  <div
-                    key={product.id}
-                    className={`flex items-center justify-between p-3 rounded-lg border cursor-pointer transition-colors ${
-                      inQueue ? 'bg-primary/10 border-primary' : 'hover:bg-muted'
-                    }`}
-                    onClick={() => !inQueue && addToLabels(product)}
-                  >
-                    <div className="flex-1 min-w-0">
-                      <p className="font-medium text-sm truncate">{product.product_name}</p>
-                      <p className="text-xs text-muted-foreground font-mono">
-                        {product.customer_product_number
-                          ? <>{product.customer_product_number}</>
-                          : null
-                        }
-                      </p>
-                    </div>
-                    {inQueue ? (
-                      <span className="text-xs text-primary font-medium ml-2">Added ({inQueue.fillPage ? 'Full Page' : inQueue.copies})</span>
-                    ) : (
-                      <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); addToLabels(product); }}>
-                        <Plus className="h-4 w-4" />
-                      </Button>
-                    )}
+                {selectedCustomer && (
+                  <div className="flex gap-2">
+                    <Button variant="outline" size="sm" onClick={selectAll}>Select All</Button>
+                    <Button variant="outline" size="sm" onClick={clearAll}>Clear All</Button>
                   </div>
-                );
-              })}
-            </div>
+                )}
+
+                {productsLoading && <p className="text-muted-foreground text-sm">Loading products...</p>}
+
+                <div className="space-y-2 max-h-[500px] overflow-y-auto">
+                  {filteredProducts.map((product) => {
+                    const inQueue = labelItems.find((l) => l.productId === product.id);
+                    return (
+                      <div
+                        key={product.id}
+                        className={`flex items-center justify-between p-3 rounded-lg border cursor-pointer transition-colors ${
+                          inQueue ? 'bg-primary/10 border-primary' : 'hover:bg-muted'
+                        }`}
+                        onClick={() => !inQueue && addToLabels(product)}
+                      >
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium text-sm truncate">{product.product_name}</p>
+                          <p className="text-xs text-muted-foreground font-mono">
+                            {product.customer_product_number || null}
+                          </p>
+                        </div>
+                        {inQueue ? (
+                          <span className="text-xs text-primary font-medium ml-2">Added ({inQueue.fillPage ? 'Full Page' : inQueue.copies})</span>
+                        ) : (
+                          <Button variant="ghost" size="sm" onClick={(e) => { e.stopPropagation(); addToLabels(product); }}>
+                            <Plus className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            ) : (
+              <>
+                <Select
+                  value={selectedProject}
+                  onValueChange={(value) => {
+                    setSelectedProject(value);
+                    setSelectedLotId('');
+                  }}
+                  disabled={p2ProjectsLoading}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a project..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {p2Projects.map((project) => (
+                      <SelectItem key={project.projectName} value={project.projectName}>
+                        {project.projectName} ({project.lotCount})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select
+                  value={selectedLotId}
+                  onValueChange={setSelectedLotId}
+                  disabled={!selectedProject || p2LotsLoading}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a shipment lot..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {p2Lots.map((lot) => (
+                      <SelectItem key={lot.id} value={lot.id}>
+                        {lot.lotNumber} - {lot.partNumber || 'SKU pending'} ({lot.quantity || 0})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                {selectedLot && (
+                  <div className="rounded-lg border p-4 text-sm">
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <div className="text-xs text-muted-foreground">Lot</div>
+                        <div className="font-mono font-medium">{selectedLot.lotNumber}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs text-muted-foreground">Labels</div>
+                        <div className="font-medium">{selectedLot.quantity || 0}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs text-muted-foreground">SKU</div>
+                        <div className="font-mono font-medium">{selectedLot.partNumber || 'Finalized SKU'}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs text-muted-foreground">PO</div>
+                        <div className="font-medium">{selectedLot.poNumber || 'None'}</div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
           </CardContent>
         </Card>
 
@@ -344,14 +621,31 @@ export default function ProductLabelsPage() {
                 <Printer className="h-5 w-5" />
                 Label Queue ({totalLabels} labels)
               </span>
-              <Button onClick={generateLabels} disabled={isGenerating || labelItems.length === 0} className="gap-2">
+              <Button onClick={openPrintSetup} disabled={isGenerating || !canPrint} className="gap-2">
                 <Printer className="h-4 w-4" />
                 {isGenerating ? 'Generating...' : 'Print Labels'}
               </Button>
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {labelItems.length === 0 ? (
+            {mode === 'P2' ? (
+              selectedLot ? (
+                <div className="space-y-3">
+                  <div className="border rounded-lg p-3">
+                    <div className="font-medium">{selectedLot.lotNumber}</div>
+                    <div className="text-sm text-muted-foreground">
+                      One label for each serialized item in the lot.
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-center py-12 text-muted-foreground">
+                  <Tag className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                  <p>No P2 lot selected</p>
+                  <p className="text-sm">Select a project and shipment lot to generate serial labels</p>
+                </div>
+              )
+            ) : labelItems.length === 0 ? (
               <div className="text-center py-12 text-muted-foreground">
                 <Tag className="h-12 w-12 mx-auto mb-3 opacity-50" />
                 <p>No products added yet</p>
@@ -391,7 +685,7 @@ export default function ProductLabelsPage() {
                           <Minus className="h-3 w-3" />
                         </Button>
                         <Input
-                          value={item.fillPage ? '14' : item.copies}
+                          value={item.fillPage ? String(templateConfig.labelsPerPage) : item.copies}
                           onChange={(e) => setCopies(item.productId, e.target.value)}
                           className="w-14 text-center text-sm"
                           disabled={item.fillPage}
@@ -417,6 +711,54 @@ export default function ProductLabelsPage() {
           </CardContent>
         </Card>
       </div>
+
+      <Dialog open={showPrintSetup} onOpenChange={setShowPrintSetup}>
+        <DialogContent className="max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Select label cells</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="partial-sheet"
+                checked={usePartialSheet}
+                onCheckedChange={(checked) => setUsePartialSheet(checked === true)}
+              />
+              <Label htmlFor="partial-sheet">Use a partially printed sheet</Label>
+            </div>
+
+            {usePartialSheet && (
+              <div
+                className="grid gap-2"
+                style={{ gridTemplateColumns: `repeat(${templateConfig.columns}, minmax(0, 1fr))` }}
+              >
+                {Array.from({ length: templateConfig.labelsPerPage }, (_, index) => {
+                  const used = usedCells.has(index);
+                  return (
+                    <Button
+                      key={index}
+                      type="button"
+                      variant={used ? 'default' : 'outline'}
+                      className="h-12"
+                      onClick={() => toggleUsedCell(index)}
+                    >
+                      {index + 1}
+                    </Button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowPrintSetup(false)}>Cancel</Button>
+            <Button onClick={confirmPrint} disabled={isGenerating}>
+              {isGenerating ? 'Generating...' : 'Generate PDF'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/server/src/routes/productLabels.ts
+++ b/server/src/routes/productLabels.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
+import { PDFDocument, PDFImage, PDFFont, rgb, StandardFonts } from 'pdf-lib';
 import { authenticateToken } from '../../middleware/auth';
 import bwipjs from 'bwip-js';
 import { pool } from '../../db';
@@ -8,32 +8,80 @@ import { z } from 'zod';
 const router = Router();
 
 const POINTS_PER_INCH = 72;
-const PAGE_WIDTH = 8.5 * POINTS_PER_INCH;    // 612pt
-const PAGE_HEIGHT = 11 * POINTS_PER_INCH;    // 792pt
+const PAGE_WIDTH = 8.5 * POINTS_PER_INCH;
+const PAGE_HEIGHT = 11 * POINTS_PER_INCH;
 
-// Avery 8162: 4" x 1-1/3", 2 columns x 7 rows = 14 per sheet
-const LABEL_WIDTH = 4 * POINTS_PER_INCH;          // 288pt exactly
-const LABEL_HEIGHT = (4 / 3) * POINTS_PER_INCH;  // 96pt exactly (not 1.333 * 72 = 95.976pt)
+type TemplateKey = '8160' | '8162';
 
-const COLUMNS = 2;
-const ROWS = 7;
-const LABELS_PER_PAGE = COLUMNS * ROWS;            // 14
+type LabelTemplate = {
+  key: TemplateKey;
+  label: string;
+  columns: number;
+  rows: number;
+  labelWidth: number;
+  labelHeight: number;
+  leftMargin: number;
+  topMargin: number;
+  horizontalGap: number;
+  verticalGap: number;
+};
 
-const LEFT_MARGIN = (156 / 1000) * POINTS_PER_INCH;  // 0.156" = 11.232pt exactly
-const TOP_MARGIN = 0.83 * POINTS_PER_INCH;        // 59.76pt exactly
-const H_GAP = 0.1875 * POINTS_PER_INCH;           // 13.5pt exactly
-const V_GAP = 0;
+type LabelItem = {
+  mode: 'P1' | 'P2';
+  barcodeValue?: string;
+  description?: string;
+  sku?: string;
+  serialNumber?: string;
+  lotNumber?: string;
+};
 
-function getLabelPosition(index: number): { x: number; y: number } {
-  const col = index % COLUMNS;
-  const row = Math.floor(index % (COLUMNS * ROWS) / COLUMNS);
-  const x = LEFT_MARGIN + col * (LABEL_WIDTH + H_GAP);
-  const y = PAGE_HEIGHT - TOP_MARGIN - (row + 1) * LABEL_HEIGHT - row * V_GAP;
+type EmbeddedLogo = {
+  image: PDFImage;
+  width: number;
+  height: number;
+} | null;
+
+const LABEL_TEMPLATES: Record<TemplateKey, LabelTemplate> = {
+  '8162': {
+    key: '8162',
+    label: 'Avery 8162 - 14 labels',
+    columns: 2,
+    rows: 7,
+    labelWidth: 4 * POINTS_PER_INCH,
+    labelHeight: (4 / 3) * POINTS_PER_INCH,
+    leftMargin: 0.156 * POINTS_PER_INCH,
+    topMargin: 0.83 * POINTS_PER_INCH,
+    horizontalGap: 0.1875 * POINTS_PER_INCH,
+    verticalGap: 0,
+  },
+  '8160': {
+    key: '8160',
+    label: 'Avery 8160 - 30 labels',
+    columns: 3,
+    rows: 10,
+    labelWidth: 2.625 * POINTS_PER_INCH,
+    labelHeight: 1 * POINTS_PER_INCH,
+    leftMargin: 0.1875 * POINTS_PER_INCH,
+    topMargin: 0.5 * POINTS_PER_INCH,
+    horizontalGap: 0.125 * POINTS_PER_INCH,
+    verticalGap: 0,
+  },
+};
+
+function labelsPerPage(template: LabelTemplate): number {
+  return template.columns * template.rows;
+}
+
+function getLabelPosition(template: LabelTemplate, index: number): { x: number; y: number } {
+  const col = index % template.columns;
+  const row = Math.floor(index / template.columns);
+  const x = template.leftMargin + col * (template.labelWidth + template.horizontalGap);
+  const y = PAGE_HEIGHT - template.topMargin - (row + 1) * template.labelHeight - row * template.verticalGap;
   return { x, y };
 }
 
-function wrapText(text: string, font: any, fontSize: number, maxWidth: number): string[] {
-  const words = text.split(' ');
+function wrapText(text: string, font: PDFFont, fontSize: number, maxWidth: number): string[] {
+  const words = text.split(' ').filter(Boolean);
   const lines: string[] = [];
   let currentLine = '';
 
@@ -51,19 +99,217 @@ function wrapText(text: string, font: any, fontSize: number, maxWidth: number): 
   return lines;
 }
 
-async function generateBarcodePng(value: string): Promise<Buffer> {
+function drawCenteredText(
+  page: any,
+  text: string,
+  font: PDFFont,
+  size: number,
+  centerX: number,
+  y: number
+): void {
+  const width = font.widthOfTextAtSize(text, size);
+  page.drawText(text, {
+    x: centerX - width / 2,
+    y,
+    size,
+    font,
+    color: rgb(0, 0, 0),
+  });
+}
+
+function fitText(text: string, font: PDFFont, preferredSize: number, maxWidth: number, minSize = 5): number {
+  let size = preferredSize;
+  while (size > minSize && font.widthOfTextAtSize(text, size) > maxWidth) {
+    size -= 0.5;
+  }
+  return size;
+}
+
+async function generateBarcodePng(value: string, template: LabelTemplate): Promise<Buffer> {
   const pngBuffer = await bwipjs.toBuffer({
     bcid: 'code128',
     text: value,
-    scale: 5,
-    height: 15,
+    scale: template.key === '8160' ? 4 : 5,
+    height: template.key === '8160' ? 10 : 15,
     includetext: false,
-    paddingleft: 10,
-    paddingright: 10,
+    paddingleft: 8,
+    paddingright: 8,
     paddingtop: 2,
     paddingbottom: 2,
   });
   return pngBuffer as Buffer;
+}
+
+async function embedLogo(pdfDoc: PDFDocument, logoBase64?: string | null): Promise<EmbeddedLogo> {
+  if (!logoBase64) return null;
+
+  const match = logoBase64.match(/^data:(image\/(?:png|jpeg|jpg));base64,(.+)$/);
+  if (!match) {
+    throw new Error('Logo must be a PNG or JPEG image');
+  }
+
+  const mimeType = match[1];
+  const imageBytes = Buffer.from(match[2], 'base64');
+  const image = mimeType === 'image/png'
+    ? await pdfDoc.embedPng(imageBytes)
+    : await pdfDoc.embedJpg(imageBytes);
+
+  return { image, width: image.width, height: image.height };
+}
+
+function drawLogo(
+  page: any,
+  logo: EmbeddedLogo,
+  fallbackText: string,
+  boldFont: PDFFont,
+  centerX: number,
+  topY: number,
+  maxWidth: number,
+  maxHeight: number
+): void {
+  if (!logo) {
+    const fontSize = fitText(fallbackText, boldFont, 9, maxWidth, 5);
+    drawCenteredText(page, fallbackText, boldFont, fontSize, centerX, topY - fontSize);
+    return;
+  }
+
+  const scale = Math.min(maxWidth / logo.width, maxHeight / logo.height);
+  const width = logo.width * scale;
+  const height = logo.height * scale;
+  page.drawImage(logo.image, {
+    x: centerX - width / 2,
+    y: topY - height,
+    width,
+    height,
+  });
+}
+
+async function drawP1Label(
+  pdfDoc: PDFDocument,
+  page: any,
+  item: LabelItem,
+  template: LabelTemplate,
+  x: number,
+  y: number,
+  font: PDFFont,
+  boldFont: PDFFont,
+  logo: EmbeddedLogo
+): Promise<void> {
+  const padding = template.key === '8160' ? 5 : 8;
+  const innerWidth = template.labelWidth - padding * 2;
+  const centerX = x + template.labelWidth / 2;
+  const topY = y + template.labelHeight - padding;
+
+  let cursorY = topY;
+
+  if (logo) {
+    const logoHeight = template.key === '8160' ? 13 : 18;
+    drawLogo(page, logo, '', boldFont, centerX, cursorY, innerWidth * 0.75, logoHeight);
+    cursorY -= logoHeight + 2;
+  }
+
+  const codeText = item.barcodeValue || '';
+  const codeFontSize = fitText(codeText, boldFont, template.key === '8160' ? 8 : 11, innerWidth);
+  drawCenteredText(page, codeText, boldFont, codeFontSize, centerX, cursorY - codeFontSize);
+  cursorY -= codeFontSize + (template.key === '8160' ? 3 : 5);
+
+  if (item.barcodeValue) {
+    try {
+      const pngBuffer = await generateBarcodePng(item.barcodeValue, template);
+      const barcodeImage = await pdfDoc.embedPng(pngBuffer);
+      const barcodeHeight = template.key === '8160' ? 22 : 42;
+      const barcodeWidth = Math.min(innerWidth - 8, template.key === '8160' ? 155 : 250);
+      page.drawImage(barcodeImage, {
+        x: centerX - barcodeWidth / 2,
+        y: cursorY - barcodeHeight,
+        width: barcodeWidth,
+        height: barcodeHeight,
+      });
+      cursorY -= barcodeHeight + (template.key === '8160' ? 2 : 4);
+    } catch (barcodeError) {
+      console.error('Barcode generation error:', barcodeError);
+      drawCenteredText(page, '[BARCODE ERROR]', boldFont, 7, centerX, cursorY - 8);
+      cursorY -= 12;
+    }
+  }
+
+  const descFontSize = template.key === '8160' ? 6.5 : 9;
+  const maxDescLines = template.key === '8160' ? 2 : 2;
+  const descLines = wrapText(item.description || '', font, descFontSize, innerWidth - 6).slice(0, maxDescLines);
+  descLines.forEach((line, lineIndex) => {
+    const textY = cursorY - descFontSize - lineIndex * (descFontSize + 1.5);
+    drawCenteredText(page, line, font, descFontSize, centerX, textY);
+  });
+}
+
+function drawP2Label(
+  page: any,
+  item: LabelItem,
+  template: LabelTemplate,
+  x: number,
+  y: number,
+  font: PDFFont,
+  boldFont: PDFFont,
+  logo: EmbeddedLogo
+): void {
+  const padding = template.key === '8160' ? 5 : 8;
+  const innerWidth = template.labelWidth - padding * 2;
+  const centerX = x + template.labelWidth / 2;
+  const topY = y + template.labelHeight - padding;
+  const logoHeight = template.key === '8160' ? 18 : 28;
+
+  drawLogo(page, logo, 'AG Composites', boldFont, centerX, topY, innerWidth * 0.78, logoHeight);
+
+  const sku = item.sku || '';
+  const skuFontSize = fitText(sku, boldFont, template.key === '8160' ? 10 : 14, innerWidth);
+  drawCenteredText(page, sku, boldFont, skuFontSize, centerX, topY - logoHeight - 8 - skuFontSize);
+
+  const serialLot = `SN: ${item.serialNumber || ''}  Lot: ${item.lotNumber || ''}`;
+  const serialFontSize = fitText(serialLot, font, template.key === '8160' ? 7 : 10, innerWidth, 5);
+  drawCenteredText(page, serialLot, font, serialFontSize, centerX, y + padding + 4);
+}
+
+function normalizeSkipIndexes(raw: number[] | undefined, template: LabelTemplate): Set<number> {
+  const max = labelsPerPage(template);
+  return new Set((raw || []).filter((n) => Number.isInteger(n) && n >= 0 && n < max));
+}
+
+async function drawLabels(
+  pdfDoc: PDFDocument,
+  items: LabelItem[],
+  template: LabelTemplate,
+  logoBase64?: string | null,
+  skipIndexes?: number[]
+): Promise<void> {
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+  const logo = await embedLogo(pdfDoc, logoBase64);
+  const firstPageSkips = normalizeSkipIndexes(skipIndexes, template);
+
+  let itemIndex = 0;
+  let pageIndex = 0;
+
+  while (itemIndex < items.length) {
+    const page = pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
+    const skips = pageIndex === 0 ? firstPageSkips : new Set<number>();
+
+    for (let slot = 0; slot < labelsPerPage(template) && itemIndex < items.length; slot++) {
+      if (skips.has(slot)) continue;
+
+      const { x, y } = getLabelPosition(template, slot);
+      const item = items[itemIndex];
+
+      if (item.mode === 'P2') {
+        drawP2Label(page, item, template, x, y, font, boldFont, logo);
+      } else {
+        await drawP1Label(pdfDoc, page, item, template, x, y, font, boldFont, logo);
+      }
+
+      itemIndex++;
+    }
+
+    pageIndex++;
+  }
 }
 
 router.get('/products', authenticateToken, async (req: Request, res: Response) => {
@@ -72,14 +318,14 @@ router.get('/products', authenticateToken, async (req: Request, res: Response) =
     let query = `SELECT id, customer_name, product_name, product_type, barcode, customer_product_number, material, handedness, action_length, action_inlet, bottom_metal, barrel_inlet, notes FROM po_products WHERE customer_name IS NOT NULL AND customer_name != ''`;
 
     const params: string[] = [];
-    
+
     if (customerName) {
       params.push(String(customerName));
       query += ` AND customer_name = $${params.length}`;
     }
-    
+
     query += ' ORDER BY customer_name, product_name';
-    
+
     const rows = await pool.query(query, params);
     res.json(rows);
   } catch (error: any) {
@@ -88,7 +334,7 @@ router.get('/products', authenticateToken, async (req: Request, res: Response) =
   }
 });
 
-router.get('/customers', authenticateToken, async (req: Request, res: Response) => {
+router.get('/customers', authenticateToken, async (_req: Request, res: Response) => {
   try {
     const rows = await pool.query(
       `SELECT DISTINCT customer_name FROM po_products WHERE customer_name IS NOT NULL AND customer_name != '' ORDER BY customer_name`
@@ -100,17 +346,144 @@ router.get('/customers', authenticateToken, async (req: Request, res: Response) 
   }
 });
 
-const generateSchema = z.object({
-  products: z.array(z.object({
-    barcodeValue: z.string().min(1).max(100).optional(),
-    barcode: z.string().min(1).max(100).optional(),
-    description: z.string().max(500).optional(),
-    product_name: z.string().max(500).optional(),
-    copies: z.number().int().min(1).max(200).optional(),
-    fillPage: z.boolean().optional(),
-  })).min(1).max(500),
-  copies: z.number().int().min(1).max(200).optional(),
+router.get('/p2-projects', authenticateToken, async (_req: Request, res: Response) => {
+  try {
+    const rows = await pool.query(`
+      SELECT
+        COALESCE(NULLIF(TRIM(po.project_name), ''), 'Unassigned Project') AS project_name,
+        COUNT(DISTINCT l.id)::int AS lot_count,
+        MAX(l.created_at) AS latest_lot_at
+      FROM p2_lot_numbers l
+      LEFT JOIN p2_purchase_orders po ON po.id = l.po_id
+      WHERE l.lot_type = 'SHIPPING'
+         OR l.packing_slip_id IS NOT NULL
+      GROUP BY COALESCE(NULLIF(TRIM(po.project_name), ''), 'Unassigned Project')
+      ORDER BY latest_lot_at DESC NULLS LAST, project_name
+    `);
+    res.json(rows.map((row: any) => ({
+      projectName: row.project_name,
+      lotCount: row.lot_count,
+    })));
+  } catch (error: any) {
+    console.error('Error fetching P2 label projects:', error);
+    res.status(500).json({ error: 'Failed to fetch P2 projects', details: error.message });
+  }
 });
+
+router.get('/p2-lots', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const projectName = String(req.query.projectName || '');
+    if (!projectName) {
+      return res.status(400).json({ error: 'projectName is required' });
+    }
+
+    const rows = await pool.query(`
+      SELECT
+        l.id,
+        l.lot_number,
+        l.po_number,
+        l.po_id,
+        l.customer_name,
+        l.part_number,
+        l.part_name,
+        l.quantity,
+        l.created_at,
+        COALESCE(NULLIF(TRIM(po.project_name), ''), 'Unassigned Project') AS project_name,
+        ps.packing_slip_number
+      FROM p2_lot_numbers l
+      LEFT JOIN p2_purchase_orders po ON po.id = l.po_id
+      LEFT JOIN p2_packing_slips ps ON ps.id = l.packing_slip_id
+      WHERE (l.lot_type = 'SHIPPING' OR l.packing_slip_id IS NOT NULL)
+        AND COALESCE(NULLIF(TRIM(po.project_name), ''), 'Unassigned Project') = $1
+      ORDER BY l.created_at DESC
+    `, [projectName]);
+
+    res.json(rows.map((row: any) => ({
+      id: row.id,
+      lotNumber: row.lot_number,
+      poNumber: row.po_number,
+      poId: row.po_id,
+      customerName: row.customer_name,
+      partNumber: row.part_number,
+      partName: row.part_name,
+      quantity: row.quantity,
+      projectName: row.project_name,
+      packingSlipNumber: row.packing_slip_number,
+      createdAt: row.created_at,
+    })));
+  } catch (error: any) {
+    console.error('Error fetching P2 label lots:', error);
+    res.status(500).json({ error: 'Failed to fetch P2 lots', details: error.message });
+  }
+});
+
+const productSchema = z.object({
+  barcodeValue: z.string().min(1).max(100).optional(),
+  barcode: z.string().min(1).max(100).optional(),
+  description: z.string().max(500).optional(),
+  product_name: z.string().max(500).optional(),
+  copies: z.number().int().min(1).max(200).optional(),
+  fillPage: z.boolean().optional(),
+});
+
+const generateSchema = z.object({
+  mode: z.enum(['P1', 'P2']).optional().default('P1'),
+  template: z.enum(['8160', '8162']).optional().default('8162'),
+  products: z.array(productSchema).min(1).max(500).optional(),
+  copies: z.number().int().min(1).max(200).optional(),
+  lotId: z.string().uuid().optional(),
+  logoBase64: z.string().max(2_000_000).nullable().optional(),
+  skipIndexes: z.array(z.number().int().min(0).max(29)).max(30).optional(),
+});
+
+async function buildP2LabelItems(lotId: string): Promise<LabelItem[]> {
+  const lotRows = await pool.query<{
+    id: string;
+    lot_number: string;
+    part_number: string | null;
+    serialized_item_ids: any;
+  }>(
+    `SELECT id, lot_number, part_number, serialized_item_ids
+       FROM p2_lot_numbers
+      WHERE id = $1`,
+    [lotId]
+  );
+
+  if (lotRows.length === 0) {
+    throw new Error('P2 lot not found');
+  }
+
+  const lot = lotRows[0];
+  const itemIds = Array.isArray(lot.serialized_item_ids) ? lot.serialized_item_ids : [];
+  if (itemIds.length === 0) {
+    throw new Error('P2 lot has no serialized items');
+  }
+
+  const placeholders = itemIds.map((_: string, index: number) => `$${index + 1}`).join(', ');
+  const serialRows = await pool.query<{
+    serial_number: string;
+    sku: string | null;
+    part_number: string | null;
+  }>(
+    `SELECT serial_number, sku, part_number
+       FROM p2_serialized_items
+      WHERE id IN (${placeholders})
+      ORDER BY serial_number`,
+    itemIds
+  );
+
+  const lotSku = serialRows.find((row) => row.sku)?.sku
+    || serialRows.find((row) => row.part_number)?.part_number
+    || lot.part_number
+    || '';
+
+  return serialRows.map((row) => ({
+    mode: 'P2',
+    sku: row.sku || lotSku,
+    serialNumber: row.serial_number,
+    lotNumber: lot.lot_number,
+  }));
+}
 
 router.post('/generate', authenticateToken, async (req: Request, res: Response) => {
   try {
@@ -119,22 +492,31 @@ router.post('/generate', authenticateToken, async (req: Request, res: Response) 
       return res.status(400).json({ error: 'Invalid request', details: parsed.error.issues });
     }
 
-    const { products, copies = 1 } = parsed.data;
+    const { mode, template: templateKey, products, copies = 1, lotId, logoBase64, skipIndexes } = parsed.data;
+    const template = LABEL_TEMPLATES[templateKey];
+    const labelItems: LabelItem[] = [];
 
-    const labelItems: Array<{ barcodeValue: string; description: string }> = [];
+    if (mode === 'P2') {
+      if (!lotId) {
+        return res.status(400).json({ error: 'lotId is required for P2 labels' });
+      }
+      labelItems.push(...await buildP2LabelItems(lotId));
+    } else {
+      if (!products?.length) {
+        return res.status(400).json({ error: 'At least one product is required for P1 labels' });
+      }
 
-    for (const product of products) {
-      const barcodeVal = product.barcodeValue || product.barcode || '';
-      const desc = (product.description || product.product_name || '').slice(0, 200);
+      for (const product of products) {
+        const barcodeVal = product.barcodeValue || product.barcode || '';
+        const desc = (product.description || product.product_name || '').slice(0, 200);
+        const qty = product.fillPage ? labelsPerPage(template) : product.copies || copies || 1;
 
-      if (product.fillPage) {
-        for (let i = 0; i < LABELS_PER_PAGE; i++) {
-          labelItems.push({ barcodeValue: barcodeVal, description: desc });
-        }
-      } else {
-        const qty = product.copies || copies || 1;
         for (let i = 0; i < qty; i++) {
-          labelItems.push({ barcodeValue: barcodeVal, description: desc });
+          labelItems.push({
+            mode: 'P1',
+            barcodeValue: barcodeVal,
+            description: desc,
+          });
         }
       }
     }
@@ -144,102 +526,7 @@ router.post('/generate', authenticateToken, async (req: Request, res: Response) 
     }
 
     const pdfDoc = await PDFDocument.create();
-    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
-    const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
-
-    const totalPages = Math.ceil(labelItems.length / LABELS_PER_PAGE);
-
-    for (let pageIndex = 0; pageIndex < totalPages; pageIndex++) {
-      const page = pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
-
-      const startIndex = pageIndex * LABELS_PER_PAGE;
-      const endIndex = Math.min(startIndex + LABELS_PER_PAGE, labelItems.length);
-
-      for (let i = startIndex; i < endIndex; i++) {
-        const labelIndex = i - startIndex;
-        const { x, y } = getLabelPosition(labelIndex);
-        const item = labelItems[i];
-
-        // Avery 8162: 288pt wide x 96pt tall (exact)
-        // Layout (from top): code text → barcode image → description
-        const padding = 8;
-        const labelInnerWidth = LABEL_WIDTH - padding * 2;  // 272pt usable width
-        const centerX = x + LABEL_WIDTH / 2;
-
-        // Vertical layout centered within LABEL_HEIGHT (96pt):
-        //   Content block: code(11pt) + gap(3pt) + barcode(42pt) + gap(4pt) + desc(20pt) = 80pt
-        //   Equal top/bottom padding: (96 - 80) / 2 = 8pt
-        //   Code text:   8pt from top   (occupies 8–19pt)
-        //   Barcode:     22pt from top  (occupies 22–64pt)
-        //   Description: 68pt from top  (occupies 68–88pt, leaves 8pt bottom margin)
-
-        const codeTopOffset = 8;    // 8pt from top
-        const barcodeTopOffset = 22; // 22pt from top (8 + 11 + 3)
-        const barcodeHeight = 42;    // 42pt tall (ends at 64pt)
-        const descTopOffset = 68;    // 68pt from top (22 + 42 + 4)
-
-        // Code value text at top (size 11 bold)
-        const codeText = item.barcodeValue;
-        const codeFontSize = 11;
-        const codeWidth = boldFont.widthOfTextAtSize(codeText, codeFontSize);
-        // y is the bottom-left of the label cell; pdf-lib draws text from baseline up
-        page.drawText(codeText, {
-          x: centerX - codeWidth / 2,
-          y: y + LABEL_HEIGHT - codeTopOffset - codeFontSize,
-          size: codeFontSize,
-          font: boldFont,
-          color: rgb(0, 0, 0),
-        });
-
-        // Barcode image in middle
-        if (item.barcodeValue) {
-          try {
-            const pngBuffer = await generateBarcodePng(item.barcodeValue);
-            const barcodeImage = await pdfDoc.embedPng(pngBuffer);
-
-            const barcodeDisplayWidth = Math.min(labelInnerWidth - 16, 250);
-            const barcodeX = centerX - barcodeDisplayWidth / 2;
-            // y-coordinate: label bottom + (label height minus offset from top minus barcode height)
-            const barcodeY = y + LABEL_HEIGHT - barcodeTopOffset - barcodeHeight;
-
-            page.drawImage(barcodeImage, {
-              x: barcodeX,
-              y: barcodeY,
-              width: barcodeDisplayWidth,
-              height: barcodeHeight,
-            });
-          } catch (barcodeError) {
-            console.error('Barcode generation error:', barcodeError);
-            page.drawText('[BARCODE ERROR]', {
-              x: centerX - 40,
-              y: y + LABEL_HEIGHT / 2,
-              size: 9,
-              font: font,
-              color: rgb(1, 0, 0),
-            });
-          }
-        }
-
-        // Description text at bottom (size 9, up to 2 lines)
-        const descFontSize = 9;
-        const lineSpacing = LABEL_HEIGHT * 0.115;  // ~11pt, proportional to label height
-        const maxDescLines = 2;
-        const descLines = wrapText(item.description, font, descFontSize, labelInnerWidth - 8).slice(0, maxDescLines);
-        // First description line baseline from label bottom
-        const descBaseY = y + LABEL_HEIGHT - descTopOffset - descFontSize;
-
-        descLines.forEach((line, lineIndex) => {
-          const lineWidth = font.widthOfTextAtSize(line, descFontSize);
-          page.drawText(line, {
-            x: centerX - lineWidth / 2,
-            y: descBaseY - lineIndex * lineSpacing,
-            size: descFontSize,
-            font: font,
-            color: rgb(0, 0, 0),
-          });
-        });
-      }
-    }
+    await drawLabels(pdfDoc, labelItems, template, logoBase64, skipIndexes);
 
     const pdfBytes = await pdfDoc.save();
     const buffer = Buffer.from(pdfBytes);


### PR DESCRIPTION
## Summary
- adds Avery 8160 and 8162 template support to the product label PDF generator
- adds optional PNG/JPEG logo placement at the top of labels
- adds a P1/P2 selector, with P1 remaining the default existing customer/product flow
- adds P2 project and shipment-lot selection, generating one label for each serialized item in the lot
- adds a print setup modal for marking already-used cells on a partially printed sheet

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/productLabels.ts` using bundled Codex Node

Full `npm run check` was not run because this clean worktree has no `node_modules`, and `npm` is not available in the shell.