### PR TITLE
[codex] Fix P2 scheduling serialized gap

### DIFF
--- a/client/src/components/p2/P2ProductionScheduler.tsx
+++ b/client/src/components/p2/P2ProductionScheduler.tsx
@@ -147,6 +147,9 @@ export default function P2ProductionScheduler({ selectedPONumbers = [] }: P2Prod
     },
     onSuccess: (result: any, variables) => {
       queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/scheduling-list'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/production-queue'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/po-statuses'] });
       queryClient.invalidateQueries({ queryKey: ['/api/cutting-table-mfg-queue'] });
       const cuttingMsg = result?.cuttingTableDemands > 0 ? ` ${result.cuttingTableDemands} cutting table stock packet demand(s) created.` : '';
       toast({
@@ -195,6 +198,9 @@ export default function P2ProductionScheduler({ selectedPONumbers = [] }: P2Prod
     },
     onSuccess: (result: any) => {
       queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/scheduling-list'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/production-queue'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/po-statuses'] });
       queryClient.invalidateQueries({ queryKey: ['/api/cutting-table-mfg-queue'] });
       const cuttingMsg = result?.cuttingTableDemands > 0 ? ` ${result.cuttingTableDemands} cutting table stock packet demand(s) created.` : '';
       toast({

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -4031,6 +4031,22 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         serializedByPoItemId.get(poItemId)!.push(item);
       }
 
+      for (const poItem of poItems) {
+        const poItemId = Number(poItem.poItemId);
+        const orderedQuantity = Number(poItem.orderedQuantity) || 0;
+        const existingItems = serializedByPoItemId.get(poItemId) ?? [];
+        const missingCount = Math.max(0, orderedQuantity - existingItems.length);
+
+        if (missingCount === 0) continue;
+
+        // Historical POs can have ordered quantity that outruns generated
+        // serialized units, which makes pending work disappear from Schedule.
+        const createdItems = await storage.addP2SerializedItemsForPoItem(poItemId, missingCount);
+        if (createdItems.length > 0) {
+          serializedByPoItemId.set(poItemId, [...existingItems, ...createdItems]);
+        }
+      }
+
       const sortBySequence = (a: any, b: any) =>
         (Number(a.sequenceNumber) || 0) - (Number(b.sequenceNumber) || 0) ||
         String(a.id).localeCompare(String(b.id));


### PR DESCRIPTION
## Summary
- Repair P2 scheduling-list reads so historical PO lines with ordered quantity greater than generated serialized units create the missing pending serialized units before composing the schedule table.
- Separate scheduled Layup work from true production in P2 Status cards, including a visible `scheduled` count.
- Refresh the Schedule, Production, and Status query keys after scheduling so the three P2 Control Center tabs stay in sync.

## Root Cause
The Status tab counted ordered PO line quantity for progress, but treated any active serialized item outside `Pending Layup` as `in production`. That incorrectly included `Layup`, which the Schedule tab correctly treats as scheduled work. Separately, the Schedule tab only grouped existing serialized rows, so pending units could appear on Status but be impossible to find or schedule when serialized rows were missing.

## Validation
- `git diff --check`
- Attempted `node --experimental-strip-types --check` on touched files, but local Windows `node.exe` returned `Access is denied`.