### PR TITLE
[codex] Lock all order due dates after creation

### DIFF
--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -47,6 +47,18 @@ import { generateOrderPdf, PdfIntent } from '../../services/orderPdfService';
 
 const router = Router();
 
+const IMMUTABLE_DUE_DATE_ERROR = 'Due date is locked after order creation';
+
+function stripImmutableDueDate<T extends Record<string, any>>(updates: T): T {
+  if (!Object.prototype.hasOwnProperty.call(updates, 'dueDate')) {
+    return updates;
+  }
+
+  const sanitized = { ...updates };
+  delete sanitized.dueDate;
+  return sanitized as T;
+}
+
 async function requiresP1PaymentAccountingApproval(paymentDate: Date, user: any): Promise<{ required: boolean; period: any }> {
   const period = await getOrCreateAccountingPeriod(paymentDate);
   const status = String(period.status).toUpperCase();
@@ -1453,7 +1465,7 @@ router.put('/draft/:id', async (req: Request, res: Response) => {
     console.log('Update data received:', req.body);
 
     // Validate the input data using the schema
-    const updates = insertAllOrderSchema.partial().parse(req.body);
+    const updates = stripImmutableDueDate(insertAllOrderSchema.partial().parse(req.body));
     console.log('Validated updates:', updates);
 
     // CRITICAL SERVER-SIDE VALIDATION: Prevent null/empty modelId for non-custom orders
@@ -1698,7 +1710,7 @@ router.get('/finalized/:id', async (req: Request, res: Response) => {
 router.put('/finalized/:id', async (req: Request, res: Response) => {
   try {
     const orderId = req.params.id;
-    const updates = req.body;
+    const updates = stripImmutableDueDate({ ...req.body });
 
     // Capture before state for audit
     const beforeOrder = await storage.getFinalizedOrderById(orderId);
@@ -3534,7 +3546,15 @@ router.patch(
         }
       }
 
-      // Normalize dueDate to Tuesday before persisting
+      if (fieldName === 'dueDate' && isFinalized) {
+        return res.status(409).json({
+          error: IMMUTABLE_DUE_DATE_ERROR,
+          fieldName,
+          orderId: orderStringId,
+        });
+      }
+
+      // Draft due dates can still be normalized before the order is created/finalized.
       if (fieldName === 'dueDate' && validatedValue != null) {
         validatedValue = normalizeDueDateForStorage(validatedValue);
       }
@@ -3635,7 +3655,7 @@ router.patch(
 router.patch('/:orderId', async (req: Request, res: Response) => {
   try {
     const orderId = req.params.orderId;
-    const updates = req.body;
+    const updates = stripImmutableDueDate({ ...req.body });
 
     console.log(`📋 PATCH /${orderId} - Department progression update`);
     console.log('📋 Update data:', updates);
@@ -3681,11 +3701,6 @@ router.patch('/:orderId', async (req: Request, res: Response) => {
           );
         }
       }
-    }
-
-    // Normalize dueDate to Tuesday if present in updates
-    if (updates.dueDate != null) {
-      updates.dueDate = normalizeDueDateForStorage(updates.dueDate);
     }
 
     // Try to find and update the order in finalized orders first
@@ -4242,6 +4257,14 @@ router.patch(
       const validatedData = adminFieldUpdateSchema.parse(req.body);
       const { fieldName, newValue } = validatedData;
 
+      if (fieldName === 'dueDate') {
+        return res.status(409).json({
+          error: IMMUTABLE_DUE_DATE_ERROR,
+          fieldName,
+          orderId,
+        });
+      }
+
       // Get field configuration
       const fieldConfig = ADMIN_FIELD_CONFIG[fieldName];
       if (!fieldConfig) {
@@ -4289,16 +4312,11 @@ router.patch(
       const dbField = fieldConfig.dbField;
       const oldValue = (currentOrder as any)[dbField];
 
-      // Normalize dueDate to Tuesday before persisting
-      const normalizedFieldValue = fieldName === 'dueDate' && newValue != null
-        ? normalizeDueDateForStorage(newValue)
-        : newValue;
-
       // Update the order
       await db
         .update(allOrders)
         .set({ 
-          [dbField]: normalizedFieldValue,
+          [dbField]: newValue,
           updatedAt: new Date(),
         })
         .where(eq(allOrders.orderId, orderId));
@@ -4309,7 +4327,7 @@ router.patch(
         fieldName,
         fieldLabel: fieldConfig.label,
         oldValue: oldValue !== null && oldValue !== undefined ? oldValue : null,
-        newValue: normalizedFieldValue,
+        newValue,
         changedBy: (req as any).user?.username || 'unknown',
         userRole: (req as any).user?.role || 'ADMIN',
         changeType: 'INLINE',
@@ -4352,6 +4370,14 @@ router.patch(
       const validatedData = adminBulkUpdateSchema.parse(req.body);
       const { orderIds, fieldName, newValue } = validatedData;
 
+      if (fieldName === 'dueDate') {
+        return res.status(409).json({
+          error: IMMUTABLE_DUE_DATE_ERROR,
+          fieldName,
+          orderIds,
+        });
+      }
+
       // Get field configuration
       const fieldConfig = ADMIN_FIELD_CONFIG[fieldName];
       if (!fieldConfig) {
@@ -4389,11 +4415,6 @@ router.patch(
 
       const dbField = fieldConfig.dbField;
 
-      // Normalize dueDate to Tuesday for bulk updates targeting the due_date field
-      const normalizedValue = fieldName === 'dueDate' && newValue != null
-        ? normalizeDueDateForStorage(newValue)
-        : newValue;
-
       const results = {
         success: [] as string[],
         failed: [] as { orderId: string; error: string }[],
@@ -4418,7 +4439,7 @@ router.patch(
           await db
             .update(allOrders)
             .set({ 
-              [dbField]: normalizedValue,
+              [dbField]: newValue,
               updatedAt: new Date(),
             })
             .where(eq(allOrders.orderId, orderId));
@@ -4429,7 +4450,7 @@ router.patch(
             fieldName,
             fieldLabel: fieldConfig.label,
             oldValue: oldValue !== null && oldValue !== undefined ? oldValue : null,
-            newValue: normalizedValue,
+            newValue,
             changedBy: (req as any).user?.username || 'unknown',
             userRole: (req as any).user?.role || 'ADMIN',
             changeType: 'BULK',

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -22377,19 +22377,26 @@ export class DatabaseStorage implements IStorage {
     data: Partial<InsertAllOrder>
   ): Promise<AllOrder> {
     try {
-      console.log(`[updateFinalizedOrder] Updating order ${orderId} with keys:`, Object.keys(data));
+      const updateData: Partial<InsertAllOrder> = { ...data };
+      if (Object.prototype.hasOwnProperty.call(updateData, 'dueDate')) {
+        delete updateData.dueDate;
+      }
+
+      console.log(`[updateFinalizedOrder] Updating order ${orderId} with keys:`, Object.keys(updateData));
 
       // Check upfront whether a production_orders record exists so we can sync it atomically.
       const productionRecord =
-        data.currentDepartment !== undefined
+        updateData.currentDepartment !== undefined
           ? await this.getProductionOrderByOrderId(orderId)
           : undefined;
 
       const order = await db.transaction(async (tx) => {
-        await tx
-          .update(allOrders)
-          .set({ ...data, updatedAt: new Date() })
-          .where(eq(allOrders.orderId, orderId));
+        if (Object.keys(updateData).length > 0) {
+          await tx
+            .update(allOrders)
+            .set({ ...updateData, updatedAt: new Date() })
+            .where(eq(allOrders.orderId, orderId));
+        }
 
         const [updated] = await tx
           .select()
@@ -22404,11 +22411,11 @@ export class DatabaseStorage implements IStorage {
         // If currentDepartment is being updated and a production_orders record exists,
         // sync it within the same transaction so getAllOrders deduplication
         // (which prefers production_orders) always returns the correct department.
-        if (data.currentDepartment !== undefined && productionRecord) {
+        if (updateData.currentDepartment !== undefined && productionRecord) {
           await tx.execute(
-            sql`UPDATE production_orders SET current_department = ${data.currentDepartment}, updated_at = NOW() WHERE order_id = ${orderId}`
+            sql`UPDATE production_orders SET current_department = ${updateData.currentDepartment}, updated_at = NOW() WHERE order_id = ${orderId}`
           );
-          console.log(`[updateFinalizedOrder] Synced production_orders.current_department for ${orderId} → ${data.currentDepartment}`);
+          console.log(`[updateFinalizedOrder] Synced production_orders.current_department for ${orderId} → ${updateData.currentDepartment}`);
         }
 
         return updated;


### PR DESCRIPTION
## Summary
- Keep creation-time due-date normalization intact for All Orders.
- Strip `dueDate` from broad finalized-order update payloads so saving other order fields cannot rewrite the stored due date.
- Return a clear `409` response for direct finalized-order due-date edits through field and admin bulk update routes.
- Add a storage-level backstop in `updateFinalizedOrder()` so future finalized-order update callers cannot accidentally persist `dueDate` changes.

## Root cause
All Orders due dates were normalized to the next Tuesday not only during order creation, but also during later update paths. Once an order was already created or placed in production, broad edit payloads or direct admin field updates could re-run that normalization and change the stored `all_orders.due_date`.

## Validation
- `git diff --check -- server/src/routes/orders.ts server/storage.ts`
- `node --experimental-strip-types --check server/src/routes/orders.ts`
- `node --experimental-strip-types --check server/storage.ts`

Created from a clean worktree based on the latest `origin/main` to avoid unrelated local changes.