### PR TITLE
[codex] Separate P2 scheduled and production counts

### DIFF
--- a/client/src/components/p2/P2StatusDashboard.tsx
+++ b/client/src/components/p2/P2StatusDashboard.tsx
@@ -36,10 +36,11 @@ interface POStatus {
   dueDate: string;
   totalItems: number;
   completedItems: number;
+  scheduledItems: number;
   inProductionItems: number;
   pendingItems: number;
   hasBOMsNeeded: boolean;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'scheduled' | 'in_progress' | 'completed';
   rawStatus?: string;
   projectId?: string | null;
   projectCode?: string | null;
@@ -94,6 +95,8 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
         return <CheckCircle className="h-4 w-4 text-green-600" />;
       case 'in_progress':
         return <Factory className="h-4 w-4 text-blue-600" />;
+      case 'scheduled':
+        return <Clock className="h-4 w-4 text-green-600" />;
       default:
         return <Clock className="h-4 w-4 text-amber-600" />;
     }
@@ -102,6 +105,7 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
   const getStatusBadge = (status: string) => {
     const config: Record<string, { variant: 'default' | 'secondary' | 'outline'; label: string }> = {
       pending: { variant: 'outline', label: 'Pending' },
+      scheduled: { variant: 'outline', label: 'Scheduled' },
       in_progress: { variant: 'default', label: 'In Progress' },
       completed: { variant: 'secondary', label: 'Completed' },
     };
@@ -339,6 +343,12 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                             <span className="flex items-center gap-1 text-blue-600">
                               <Factory className="h-3 w-3" />
                               {po.inProductionItems} in production
+                            </span>
+                          )}
+                          {po.scheduledItems > 0 && (
+                            <span className="flex items-center gap-1 text-green-600">
+                              <Clock className="h-3 w-3" />
+                              {po.scheduledItems} scheduled
                             </span>
                           )}
                           {po.pendingItems > 0 && (

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3936,11 +3936,17 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const legacyCompletedItems = Number(legacyStats?.completedQty ?? 0);
         const completedItems = Math.max(serializedCompletedItems, legacyCompletedItems);
 
+        const scheduledItems = poItems.filter((s: any) => {
+          if (s.status !== 'ACTIVE') return false;
+          const dept = normalizeP2ControlDepartment(s.currentDepartment || '');
+          return dept === 'Layup';
+        }).length;
+
         const serializedInProductionItems = poItems.filter((s: any) => {
           if (s.status !== 'ACTIVE') return false;
           const dept = normalizeP2ControlDepartment(s.currentDepartment || '');
-          // In production if past Pending Layup stage
-          return dept !== 'Pending Layup' && dept !== '';
+          // Scheduled Layup work is not floor production yet.
+          return dept !== 'Pending Layup' && dept !== 'Layup' && dept !== '';
         }).length;
         const legacyInProductionItems = Number(legacyStats?.inProductionQty ?? 0);
         const rawInProductionItems = Math.max(serializedInProductionItems, legacyInProductionItems);
@@ -3955,7 +3961,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
         // pendingItems = everything not yet completed or in-production (including
         // line item quantities that haven't had serialized items generated yet).
-        const pendingItems = Math.max(0, totalItems - completedItems - inProductionItems);
+        const pendingItems = Math.max(0, totalItems - completedItems - scheduledItems - inProductionItems);
         
         const rawStatus = normalizeP2Status(po.status) || 'OPEN';
 
@@ -3972,6 +3978,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           dueDate: po.expectedDelivery,
           totalItems,
           completedItems,
+          scheduledItems,
           inProductionItems,
           pendingItems,
           hasBOMsNeeded: !po.bomConfigured,
@@ -3980,8 +3987,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           projectName: linkedProject?.projectName ?? po.projectName ?? null,
           ...wadContext,
           rawStatus,
-          status: completedItems === totalItems && totalItems > 0 ? 'completed' : 
-                  (inProductionItems > 0 || rawStatus === 'IN_PRODUCTION') ? 'in_progress' : 'pending'
+          status: completedItems === totalItems && totalItems > 0 ? 'completed' :
+                  inProductionItems > 0 ? 'in_progress' :
+                  scheduledItems > 0 ? 'scheduled' : 'pending'
         };
       });
       


### PR DESCRIPTION
## Summary
- Treat active P2 items in `Layup` as scheduled, not in production, in the P2 Status endpoint.
- Add a visible scheduled count/status to P2 Status cards.
- Keep pending math aligned with completed + scheduled + true production counts.

## Root Cause
The Status tab treated any active serialized item outside `Pending Layup` as `in production`, so scheduled `Layup` units inflated the production count even when the Production tab had no true active production work.

## Validation
- `git diff --check`
- Attempted `node --experimental-strip-types --check server/src/routes/index.ts`, but local Windows `node.exe` returned `Access is denied`.