### PR TITLE
[codex] Fix cycle count and packet audit inventory paths

### DIFF
--- a/client/src/pages/CycleCountPage.tsx
+++ b/client/src/pages/CycleCountPage.tsx
@@ -179,7 +179,7 @@ function CreateSessionDialog({ onCreated }: { onCreated: (id: number) => void })
 
   const { data: policies = [] } = useQuery<VariancePolicy[]>({
     queryKey: [API_BASE, 'variance-policies'],
-    queryFn: async () => (await apiRequest('GET', `${API_BASE}/variance-policies`)).json(),
+    queryFn: async () => apiRequest(`${API_BASE}/variance-policies`),
     enabled: open,
   });
 
@@ -194,8 +194,7 @@ function CreateSessionDialog({ onCreated }: { onCreated: (id: number) => void })
         variancePolicyId: variancePolicyId || null,
         notes: notes.trim() || null,
       };
-      const res = await apiRequest('POST', API_BASE, body);
-      return (await res.json()) as CycleCountSession;
+      return apiRequest(API_BASE, { method: 'POST', body }) as Promise<CycleCountSession>;
     },
     onSuccess: (sess) => {
       toast.success(`Session ${sess.sessionNumber ?? `#${sess.id}`} created`);
@@ -369,7 +368,7 @@ function SessionDetail({ sessionId, onBack }: { sessionId: number; onBack: () =>
 
   const { data: session, isLoading } = useQuery<CycleCountSession>({
     queryKey: [API_BASE, sessionId, reveal],
-    queryFn: async () => (await apiRequest('GET', `${API_BASE}/${sessionId}${reveal ? '?reveal=true' : ''}`)).json(),
+    queryFn: async () => apiRequest(`${API_BASE}/${sessionId}${reveal ? '?reveal=true' : ''}`),
   });
 
   const recordMutation = useMutation({
@@ -382,7 +381,7 @@ function SessionDetail({ sessionId, onBack }: { sessionId: number; onBack: () =>
           notes: localNotes[parseInt(lineId, 10)],
         }));
       if (counts.length === 0) throw new Error('No counts to save');
-      return (await apiRequest('POST', `${API_BASE}/${sessionId}/counts`, { counts })).json();
+      return apiRequest(`${API_BASE}/${sessionId}/counts`, { method: 'POST', body: { counts } });
     },
     onSuccess: () => {
       toast.success('Counts saved');
@@ -394,7 +393,7 @@ function SessionDetail({ sessionId, onBack }: { sessionId: number; onBack: () =>
 
   const transitionMutation = useMutation({
     mutationFn: async (action: 'submit' | 'approve' | 'post' | 'cancel') => {
-      return (await apiRequest('POST', `${API_BASE}/${sessionId}/${action}`)).json();
+      return apiRequest(`${API_BASE}/${sessionId}/${action}`, { method: 'POST' });
     },
     onSuccess: (_data, action) => {
       toast.success(`Session ${action}ed`);
@@ -577,7 +576,7 @@ function SessionDetail({ sessionId, onBack }: { sessionId: number; onBack: () =>
 function VarianceHistoryTab() {
   const { data: history = [], isLoading } = useQuery<VarianceHistoryRow[]>({
     queryKey: [API_BASE, 'variance-history'],
-    queryFn: async () => (await apiRequest('GET', `${API_BASE}/variance-history?limit=200`)).json(),
+    queryFn: async () => apiRequest(`${API_BASE}/variance-history?limit=200`),
   });
   if (isLoading) return <div className="p-8 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin inline mr-2" /> Loading…</div>;
   if (history.length === 0) return <div className="text-center py-12 text-muted-foreground text-sm">No posted variances yet.</div>;
@@ -626,7 +625,7 @@ export default function CycleCountPage() {
 
   const { data: sessions = [], isLoading } = useQuery<CycleCountSession[]>({
     queryKey: [API_BASE],
-    queryFn: async () => (await apiRequest('GET', API_BASE)).json(),
+    queryFn: async () => apiRequest(API_BASE),
   });
 
   const buckets = useMemo(() => {

--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -3855,15 +3855,18 @@ router.put('/inventory-audit/settings', async (req, res) => {
 router.get('/inventory-audit/packets', async (req, res) => {
   try {
     const allItems = await storage.getAllInventoryItems();
-    const packets = allItems.filter((item: any) => item.isPacket === true);
+    const packets = allItems.filter((item: any) =>
+      item.isPacket === true || item.manufacturedCategory === 'PACKET'
+    );
     const result = await Promise.all(
       packets.map(async (p) => {
         const latest = await storage.getLatestAuditRecordByPacket(p.id);
+        const systemQty = Number((p as any).onHand ?? (p as any).quantityInStock ?? (p as any).available ?? 0);
         return {
           id: p.id,
           agPartNumber: p.agPartNumber,
           name: p.name,
-          systemQty: p.onHand ?? p.quantityInStock ?? 0,
+          systemQty: Number.isFinite(systemQty) ? systemQty : 0,
           lastAuditRecord: latest ?? null,
         };
       })
@@ -3887,14 +3890,17 @@ router.post('/inventory-audit/submit', async (req, res) => {
     }
 
     const allItems = await storage.getAllInventoryItems();
-    const packets = allItems.filter((item: any) => item.isPacket === true);
+    const packets = allItems.filter((item: any) =>
+      item.isPacket === true || item.manufacturedCategory === 'PACKET'
+    );
     const packetMap = new Map(packets.map((p) => [p.id, p]));
 
     const records = [];
     for (const entry of entries) {
       const packet = packetMap.get(entry.packetId);
       if (!packet) continue;
-      const systemQty = (packet as any).onHand ?? (packet as any).quantityInStock ?? 0;
+      const rawSystemQty = (packet as any).onHand ?? (packet as any).quantityInStock ?? (packet as any).available ?? 0;
+      const systemQty = Number.isFinite(Number(rawSystemQty)) ? Number(rawSystemQty) : 0;
       const variance = entry.actualQty - systemQty;
       const record = await storage.createInventoryAuditRecord({
         packetId: entry.packetId,


### PR DESCRIPTION
## Summary
- Fix the cycle count page to use the current `apiRequest(url, options)` helper contract instead of the old method-first/Response `.json()` pattern.
- Include current `manufacturedCategory = PACKET` inventory items in the cutting packet audit endpoints, while preserving legacy `isPacket` support.
- Normalize packet audit system quantity from available legacy quantity fields so audit records do not default to zero unnecessarily.

## Root Cause
The cycle count UI was still calling `apiRequest('GET', url).json()`, but the current helper expects the URL as the first argument and returns parsed data. Packet audits were also filtering only the legacy `isPacket` flag, which can miss newer packet-classified inventory items.

## Validation
- `git diff --check -- client/src/pages/CycleCountPage.tsx server/src/routes/cuttingTable.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/routes/cuttingTable.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/services/cycleCountService.ts`