### PR TITLE
[codex] Add NCR inventory serial traveler links

### DIFF
--- a/client/src/components/inventory/InventoryBalancesCard.tsx
+++ b/client/src/components/inventory/InventoryBalancesCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'wouter';
 import { apiRequest } from '@/lib/queryClient';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -38,6 +39,7 @@ import {
   Edit,
   RefreshCw,
   Target,
+  ExternalLink,
 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 
@@ -69,6 +71,18 @@ interface InventoryBalance {
   updatedAt: Date;
   partName?: string;
   departmentMeta?: DepartmentBalanceMeta;
+  serializedItems?: SerializedInventoryItem[];
+}
+
+interface SerializedInventoryItem {
+  id: string;
+  serialNumber: string;
+  barcode: string;
+  travelerBarcode?: string | null;
+  travelerId?: string | null;
+  travelerNumber?: string | null;
+  dispositionId?: number | null;
+  dispositionType?: string | null;
 }
 
 interface BalancesResponse {
@@ -92,6 +106,7 @@ export default function InventoryBalancesCard() {
   );
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [expandedPart, setExpandedPart] = useState<string | null>(null);
+  const [selectedSerialByBalanceId, setSelectedSerialByBalanceId] = useState<Record<number, string>>({});
   const queryClient = useQueryClient();
 
   // Fetch inventory balances with department metadata
@@ -183,6 +198,14 @@ export default function InventoryBalancesCard() {
       color: 'bg-green-100 text-green-800',
       icon: Package,
     };
+  };
+
+  const getSelectedSerializedItem = (balance: InventoryBalance) => {
+    const serializedItems = balance.serializedItems || [];
+    if (serializedItems.length === 0) return null;
+
+    const selectedId = selectedSerialByBalanceId[balance.id] || serializedItems[0].id;
+    return serializedItems.find((item) => item.id === selectedId) || serializedItems[0];
   };
 
   const filteredBalances = balances.filter((balance) => {
@@ -408,6 +431,7 @@ export default function InventoryBalancesCard() {
                 <TableRow>
                   <TableHead>Part Number</TableHead>
                   <TableHead>Part Name</TableHead>
+                  <TableHead>Serialized Item</TableHead>
                   <TableHead>Department</TableHead>
                   <TableHead>Location</TableHead>
                   <TableHead className="text-right">On Hand</TableHead>
@@ -422,6 +446,12 @@ export default function InventoryBalancesCard() {
                   const stockStatus = getStockStatus(balance);
                   const IconComponent = stockStatus.icon;
                   const deptBreakdown = departmentBreakdowns[balance.agPartNumber] || [];
+                  const selectedSerializedItem = getSelectedSerializedItem(balance);
+                  const travelerHref = selectedSerializedItem?.travelerId
+                    ? `/travelers/${selectedSerializedItem.travelerId}`
+                    : selectedSerializedItem?.barcode
+                      ? `/p2-traveler-viewer?barcode=${encodeURIComponent(selectedSerializedItem.barcode)}`
+                      : null;
 
                   return (
                     <TableRow
@@ -458,6 +488,44 @@ export default function InventoryBalancesCard() {
                         )}
                       </TableCell>
                       <TableCell>{balance.partName || 'Unknown'}</TableCell>
+                      <TableCell>
+                        {(balance.serializedItems || []).length > 0 && selectedSerializedItem ? (
+                          <div className="flex items-center gap-2">
+                            <select
+                              value={selectedSerializedItem.id}
+                              onChange={(e) =>
+                                setSelectedSerialByBalanceId((current) => ({
+                                  ...current,
+                                  [balance.id]: e.target.value,
+                                }))
+                              }
+                              className="h-8 w-40 rounded-md border border-input bg-background px-2 py-1 font-mono text-xs ring-offset-background"
+                              data-testid={`select-serialized-item-${balance.agPartNumber}`}
+                            >
+                              {balance.serializedItems!.map((item) => (
+                                <option key={item.id} value={item.id}>
+                                  {item.serialNumber}
+                                </option>
+                              ))}
+                            </select>
+                            {travelerHref && (
+                              <Link href={travelerHref}>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-8 w-8 p-0"
+                                  title={selectedSerializedItem.travelerNumber || 'Open traveler'}
+                                  data-testid={`link-traveler-${selectedSerializedItem.serialNumber}`}
+                                >
+                                  <ExternalLink className="h-4 w-4" />
+                                </Button>
+                              </Link>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-gray-400 text-xs">N/A</span>
+                        )}
+                      </TableCell>
                       <TableCell>
                         {balance.departmentMeta ? (
                           <Badge variant="outline" className="text-xs">

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -3780,9 +3780,21 @@ export type DepartmentBalanceBreakdown = {
   locations: string[];
 };
 
+export type InventorySerializedItemOption = {
+  id: string;
+  serialNumber: string;
+  barcode: string;
+  travelerBarcode?: string | null;
+  travelerId?: string | null;
+  travelerNumber?: string | null;
+  dispositionId?: number | null;
+  dispositionType?: string | null;
+};
+
 export type EnrichedInventoryBalance = typeof inventoryBalances.$inferSelect & {
   partName?: string;
   departmentMeta?: DepartmentBalanceMeta;
+  serializedItems?: InventorySerializedItemOption[];
 };
 
 export type InventoryBalanceWithDepartments = {

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -29,6 +29,9 @@ import {
   getSupplySourceDashboard,
   type ManufacturedCategory,
   type InventoryItem,
+  p2NonconformingDispositions,
+  p2SerializedItems,
+  travelers,
 } from '@shared/schema';
 
 function withSupplySourceDashboard(item: InventoryItem) {
@@ -36,6 +39,12 @@ function withSupplySourceDashboard(item: InventoryItem) {
     ...item,
     supplySourceDashboard: getSupplySourceDashboard(item.manufacturedCategory as ManufacturedCategory),
   };
+}
+
+function isServiceInventoryItem(item: InventoryItem | undefined): boolean {
+  if (!item) return false;
+  const looseType = (item.type || '').trim().toLowerCase();
+  return item.utilizedInServices === true || looseType === 'service' || looseType === 'services';
 }
 
 import { storage } from '../../storage';
@@ -3109,12 +3118,64 @@ router.get('/restock-signals', async (req: Request, res: Response) => {
 router.get('/inventory/balances', async (req: Request, res: Response) => {
   try {
     const balances = await storage.getAllInventoryBalances();
+    const items = await storage.getAllInventoryItems();
+    const itemMap = new Map(items.map((item) => [item.agPartNumber, item]));
+    const nonServiceBalances = balances.filter((balance) => !isServiceInventoryItem(itemMap.get(balance.agPartNumber)));
+
+    const ncrInventorySerialRows = await db
+      .select({
+        agPartNumber: p2SerializedItems.partNumber,
+        id: p2SerializedItems.id,
+        serialNumber: p2SerializedItems.serialNumber,
+        barcode: p2SerializedItems.barcode,
+        travelerBarcode: p2SerializedItems.travelerBarcode,
+        travelerId: travelers.id,
+        travelerNumber: travelers.travelerNumber,
+        dispositionId: p2NonconformingDispositions.id,
+        dispositionType: p2NonconformingDispositions.dispositionType,
+      })
+      .from(p2NonconformingDispositions)
+      .innerJoin(
+        p2SerializedItems,
+        eq(p2NonconformingDispositions.serializedItemId, p2SerializedItems.id)
+      )
+      .leftJoin(
+        travelers,
+        eq(travelers.serialNumber, p2SerializedItems.serialNumber)
+      )
+      .where(eq(p2NonconformingDispositions.dispositionType, 'Use as Is'))
+      .orderBy(p2SerializedItems.partNumber, p2SerializedItems.serialNumber, desc(travelers.createdAt));
+
+    const serializedItemsByPart = new Map<string, EnrichedInventoryBalance['serializedItems']>();
+    const seenSerials = new Set<string>();
+
+    for (const row of ncrInventorySerialRows) {
+      const key = `${row.agPartNumber}:${row.id}`;
+      if (seenSerials.has(key)) continue;
+      seenSerials.add(key);
+
+      const options = serializedItemsByPart.get(row.agPartNumber) || [];
+      options.push({
+        id: row.id,
+        serialNumber: row.serialNumber,
+        barcode: row.barcode,
+        travelerBarcode: row.travelerBarcode,
+        travelerId: row.travelerId,
+        travelerNumber: row.travelerNumber,
+        dispositionId: row.dispositionId,
+        dispositionType: row.dispositionType,
+      });
+      serializedItemsByPart.set(row.agPartNumber, options);
+    }
     
     // Enrich balances with department metadata
-    const enrichedBalances: EnrichedInventoryBalance[] = balances.map((balance) => {
+    const enrichedBalances: EnrichedInventoryBalance[] = nonServiceBalances.map((balance) => {
       const deptInfo = DEPARTMENT_LOCATION_MAP[balance.locationId];
+      const item = itemMap.get(balance.agPartNumber);
       return {
         ...balance,
+        partName: item?.name,
+        serializedItems: serializedItemsByPart.get(balance.agPartNumber) || [],
         departmentMeta: deptInfo ? {
           departmentId: deptInfo.departmentId,
           departmentName: deptInfo.departmentName,


### PR DESCRIPTION
## Summary
- Exclude service-classified inventory rows from the inventory balance response.
- Enrich inventory balances with NCR `Use as Is` serialized items and linked traveler metadata.
- Add a serialized item dropdown and traveler action on the Inventory Balances table.

## Root cause
The inventory balance sheet only received aggregate balance rows, so an NCR item placed into inventory could increase quantity without surfacing the individual serialized item or traveler path. Service-classified inventory rows were also not filtered out of this balance view.

## Validation
- `git diff --check`

Full TypeScript checks were not run because this checkout does not have `node_modules`, and the local `node.exe` was blocked with `Access is denied` in the original workspace.