### PR TITLE
[codex] Add serialized item traceability search

### DIFF
--- a/client/src/pages/InventoryTraceabilityPage.tsx
+++ b/client/src/pages/InventoryTraceabilityPage.tsx
@@ -40,6 +40,7 @@ import {
 type TraceabilitySearchKey =
   | 'lotIcn'
   | 'rollNumber'
+  | 'serializedItemNumber'
   | 'travelerNumber'
   | 'workOrder'
   | 'chargeCode'
@@ -51,6 +52,7 @@ type TraceabilitySearchKey =
 const SEARCH_KEYS: Array<{ value: TraceabilitySearchKey; label: string; placeholder: string }> = [
   { value: 'lotIcn', label: 'Material ICN', placeholder: 'ICN-MAT-20251223-000184' },
   { value: 'rollNumber', label: 'Roll #', placeholder: 'ROLL-001 or fabric ICN' },
+  { value: 'serializedItemNumber', label: 'Serialized Item #', placeholder: 'serial number, item barcode, or traveler barcode' },
   { value: 'travelerNumber', label: 'Traveler #', placeholder: 'TRV-000123' },
   { value: 'workOrder', label: 'WAD / Work Order #', placeholder: 'WO-000456' },
   { value: 'chargeCode', label: 'Charge Code', placeholder: 'DLM-100' },

--- a/server/src/services/traceabilityService.ts
+++ b/server/src/services/traceabilityService.ts
@@ -42,6 +42,7 @@ import { resolveTravelerBarcode } from '../helpers/travelerBarcodeResolver';
 export type TraceabilitySearchKey =
   | 'lotIcn'
   | 'rollNumber'
+  | 'serializedItemNumber'
   | 'travelerNumber'
   | 'workOrder'
   | 'chargeCode'
@@ -53,6 +54,7 @@ export type TraceabilitySearchKey =
 export const TRACEABILITY_SEARCH_KEYS: readonly TraceabilitySearchKey[] = [
   'lotIcn',
   'rollNumber',
+  'serializedItemNumber',
   'travelerNumber',
   'workOrder',
   'chargeCode',
@@ -589,6 +591,34 @@ async function resolveSearch(input: TraceabilitySearchInput): Promise<ResolvedSe
           href: fabric.internalControlNumber
             ? `/inventory/traceability?key=lotIcn&value=${encodeURIComponent(fabric.internalControlNumber)}`
             : null,
+        }],
+        ledgerCondition: undefined,
+      };
+    }
+
+    case 'serializedItemNumber': {
+      const [item] = await db
+        .select()
+        .from(p2SerializedItems)
+        .where(
+          or(
+            eq(p2SerializedItems.serialNumber, value),
+            eq(p2SerializedItems.barcode, value),
+            eq(p2SerializedItems.travelerBarcode, value),
+          ),
+        )
+        .limit(1);
+      if (!item) {
+        return { label: `Serialized item: ${value}`, matchedEntities: [], ledgerCondition: undefined, notFound: true };
+      }
+      return {
+        label: `Serialized item ${item.serialNumber}`,
+        detail: `${item.partNumber} - ${item.partName} - ${item.currentDepartment} - ${item.status}`,
+        matchedEntities: [{
+          kind: 'serializedItem',
+          id: item.id,
+          label: item.serialNumber,
+          href: `/p2-traveler-viewer?barcode=${encodeURIComponent(item.barcode)}`,
         }],
         ledgerCondition: undefined,
       };


### PR DESCRIPTION
## Summary
- Add `Serialized Item #` to the inventory Material Traceability Viewer search dropdown.
- Allow the traceability API to resolve serialized items by serial number, item barcode, or traveler barcode.
- Link resolved serialized items back to the P2 traveler viewer so traveler-captured material evidence appears through the existing traceability response.

## Why
The material traceability tab could search by material ICN, roll, traveler, and other anchors, but not directly by the P2 serialized item number operators use on the floor.

## Validation
- `git diff --cached --check`
- `git diff --check -- client/src/pages/InventoryTraceabilityPage.tsx server/src/services/traceabilityService.ts`
- `node --experimental-strip-types --check server/src/services/traceabilityService.ts` using the bundled Codex Node runtime

Note: full TypeScript compile was not available because this clean worktree does not have local `node_modules`.