### PR TITLE
[codex] Fix P2 nonconforming RMA tab endpoint

### DIFF
--- a/client/src/components/p2/P2ScrappedItemsTab.tsx
+++ b/client/src/components/p2/P2ScrappedItemsTab.tsx
@@ -159,7 +159,7 @@ function DispositionDialog({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/p2/serialized-items/scrapped'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/serialized-items/closed-ncr'] });
-      queryClient.invalidateQueries({ queryKey: ['/api/p2/rmas'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/nonconforming-rmas'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/production-queue'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/scheduling-list'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/po-statuses'] });
@@ -429,9 +429,9 @@ function RmaRow({ rma, onUpdated }: { rma: Rma; onUpdated: () => void }) {
 
   const updateMutation = useMutation({
     mutationFn: (data: object) =>
-      apiRequest(`/api/p2/rmas/${rma.rma.id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+      apiRequest(`/api/p2/nonconforming-rmas/${rma.rma.id}`, { method: 'PATCH', body: JSON.stringify(data) }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/p2/rmas'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/nonconforming-rmas'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/serialized-items/scrapped'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/serialized-items/closed-ncr'] });
       onUpdated();
@@ -662,9 +662,13 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
     : closedNcrItemsRaw;
 
   const { data: rmasRaw = [], refetch: refetchRmas } = useQuery<Rma[]>({
-    queryKey: ['/api/p2/rmas'],
+    queryKey: ['/api/p2/nonconforming-rmas'],
     refetchInterval: 60000,
   });
+
+  const rmas = selectedPOIds.length > 0
+    ? rmasRaw.filter((r) => r.item?.poId !== null && r.item?.poId !== undefined && selectedPOIds.includes(r.item.poId))
+    : rmasRaw;
 
   const filtered = openNcrItems.filter((item) => {
     if (!searchTerm) return true;
@@ -681,8 +685,8 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
   });
 
   const needsDispositionCount = openNcrItems.filter((i) => !i.disposition).length;
-  const openRmaCount = rmasRaw.filter((r) => r.rma.status === 'open').length;
-  const activeRmas = rmasRaw.filter((r) => r.rma.status === 'open' || r.rma.status === 'shipped');
+  const openRmaCount = rmas.filter((r) => r.rma.status === 'open').length;
+  const activeRmas = rmas.filter((r) => r.rma.status === 'open' || r.rma.status === 'shipped');
 
   if (isLoading) {
     return (
@@ -887,9 +891,9 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
                       {openRmaCount} open
                     </Badge>
                   )}
-                  {rmasRaw.length > activeRmas.length && (
+                  {rmas.length > activeRmas.length && (
                     <span className="text-xs text-muted-foreground">
-                      {rmasRaw.length - activeRmas.length} completed
+                      {rmas.length - activeRmas.length} completed
                     </span>
                   )}
                 </div>

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -962,8 +962,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     }
   });
 
-  // P2 RMAs - GET all open RMAs
-  app.get('/api/p2/rmas', async (req, res) => {
+  // P2 Nonconforming RMAs - production repair RMAs from P2 NCR dispositions.
+  // Keep this path separate from /api/p2/rmas, which is used for customer shipping RMAs.
+  app.get('/api/p2/nonconforming-rmas', async (req, res) => {
     try {
       const { db } = await import('../../db');
       const { p2Rmas, p2NonconformingDispositions, p2SerializedItems } = await import('../../schema');
@@ -984,8 +985,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     }
   });
 
-  // P2 RMAs - PATCH add materials and/or mark shipped/complete
-  app.patch('/api/p2/rmas/:id', async (req, res) => {
+  // P2 Nonconforming RMAs - PATCH add materials and/or mark shipped/complete
+  app.patch('/api/p2/nonconforming-rmas/:id', async (req, res) => {
     try {
       const { db } = await import('../../db');
       const { p2Rmas, p2SerializedItems, p2SerializedItemEvents, inventoryTransactions, travelers, travelerSteps } = await import('../../schema');


### PR DESCRIPTION
## Summary

- Move P2 nonconforming repair RMAs to a dedicated `/api/p2/nonconforming-rmas` endpoint.
- Point the P2 Control Center nonconforming RMA tab, cache invalidation, and RMA update calls at that endpoint.
- Apply the selected-PO filter to the RMA list so the active count matches the current Control Center selection.

## Root Cause

`/api/p2/rmas` is already mounted by the P2 shipping RMA router for packing-slip/customer return RMAs. The P2 Control Center nonconforming tab was using the same path for production repair RMAs, so it could receive the wrong RMA shape and show no active production RMAs.

## Validation

- `git diff --check -- client/src/components/p2/P2ScrappedItemsTab.tsx server/src/routes/index.ts`
- Confirmed the clean PR branch changes only the P2 nonconforming tab and route files.

Full build/typecheck was not run because `npm` is not installed in this workspace.