### PR TITLE
[codex] Align P2 traveler completion visibility

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -4007,7 +4007,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       await ensureProductionWorkflowReadSchema();
       const { storage } = await import('../../storage');
       const { pool: dbPool } = await import('../../db');
-      const serializedItems = await storage.getP2SerializedItems({});
+      const serializedItems = await applyTravelerStateToP2Items(
+        await storage.getP2SerializedItems({})
+      );
 
       const poItemResult = await dbPool.query(
         `SELECT

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -519,6 +519,7 @@ async function getProjectP2PoStatusSummaries(projectId: string): Promise<P2PoSta
           AND NOT psi.has_completed_traveler
           AND COALESCE(psi.current_department, '') <> ''
           AND COALESCE(psi.current_department, '') <> 'Pending Layup'
+          AND COALESCE(psi.current_department, '') <> 'Layup'
       )::text AS "inProductionItems"
     FROM p2_purchase_orders po
     LEFT JOIN ordered_qty oq ON oq.po_id = po.id

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -312,11 +312,24 @@ router.get('/pipeline', async (req, res) => {
     const serialCountsByPoId: Record<number, { total: number; completed: number }> = {};
     if (poIds.length > 0) {
       const serialRows = await pool.query(
-        `SELECT po_id::text,
+        `WITH item_state AS (
+           SELECT
+             psi.po_id,
+             psi.status,
+             EXISTS (
+               SELECT 1
+               FROM travelers t
+               WHERE UPPER(COALESCE(t.status, '')) IN ('COMPLETE', 'COMPLETED', 'CLOSED')
+                 AND t.serial_number IS NOT NULL
+                 AND LOWER(TRIM(t.serial_number)) = LOWER(TRIM(psi.serial_number))
+             ) AS has_completed_traveler
+           FROM p2_serialized_items psi
+           WHERE psi.po_id = ANY($1::int[])
+         )
+         SELECT po_id::text,
                 COUNT(*)::text AS total,
-                COUNT(*) FILTER (WHERE status = 'COMPLETED')::text AS completed
-         FROM p2_serialized_items
-         WHERE po_id = ANY($1::int[])
+                COUNT(*) FILTER (WHERE status = 'COMPLETED' OR has_completed_traveler)::text AS completed
+         FROM item_state
          GROUP BY po_id`,
         [poIds]
       ) as any[];


### PR DESCRIPTION
## Summary
- Normalize P2 Schedule rows through the same traveler-state helper used by Production, so completed/off-system travelers no longer remain as invisible unfinished units.
- Count completed travelers in the project pipeline serial completion aggregation used for closeout progress.
- Stop PM Control Center from treating scheduled `Layup` rows as in-production WIP.

## Root Cause
Production already applies traveler-state normalization before showing P2 rows, but Schedule and project closeout counters still read raw `p2_serialized_items`. That allows a serialized row with a completed traveler to disappear from Production while still blocking scheduling/closeout as unfinished.

## Validation
- `git diff --check`
- Attempted `node --experimental-strip-types --check server/src/routes/index.ts`, but local Windows `node.exe` returned `Access is denied`.