### PR TITLE
[codex] Align P2 and PM serialized status counts

### DIFF
--- a/client/src/components/p2/P2StatusDashboard.tsx
+++ b/client/src/components/p2/P2StatusDashboard.tsx
@@ -38,6 +38,7 @@ interface POStatus {
   completedItems: number;
   scheduledItems: number;
   inProductionItems: number;
+  scrappedItems?: number;
   pendingItems: number;
   hasBOMsNeeded: boolean;
   status: 'pending' | 'scheduled' | 'in_progress' | 'completed';
@@ -349,6 +350,12 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                             <span className="flex items-center gap-1 text-green-600">
                               <Clock className="h-3 w-3" />
                               {po.scheduledItems} scheduled
+                            </span>
+                          )}
+                          {(po.scrappedItems ?? 0) > 0 && (
+                            <span className="flex items-center gap-1 text-red-600">
+                              <AlertCircle className="h-3 w-3" />
+                              {po.scrappedItems} scrapped
                             </span>
                           )}
                           {po.pendingItems > 0 && (

--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -174,10 +174,12 @@ interface P2PoStatusSummary {
   dueDate: string | null;
   totalItems: number;
   completedItems: number;
+  scheduledItems?: number;
   inProductionItems: number;
+  scrappedItems?: number;
   pendingItems: number;
   rawStatus: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'scheduled' | 'in_progress' | 'completed';
 }
 
 interface P2NcrMetrics {
@@ -219,12 +221,17 @@ interface P2SerializedBreakdownItem {
   updatedAt: string | null;
 }
 
-type SerializedStatusGroup = 'complete' | 'in_progress' | 'other';
+type SerializedStatusGroup = 'complete' | 'scheduled' | 'in_progress' | 'scrapped' | 'other';
 
 function serializedStatusGroup(item: P2SerializedBreakdownItem): SerializedStatusGroup {
   const rawStatus = String(item.status || '').trim().toUpperCase();
   const travelerStatus = String(item.activeTravelerStatus || '').trim().toUpperCase();
   const taskStatus = String(item.activeTaskStatus || '').trim().toUpperCase();
+  const department = String(item.currentDepartment || item.activeTaskDepartment || '').trim();
+
+  if (rawStatus === 'SCRAPPED' || rawStatus === 'SCRAP') {
+    return 'scrapped';
+  }
 
   if (
     item.completedAt ||
@@ -237,13 +244,16 @@ function serializedStatusGroup(item: P2SerializedBreakdownItem): SerializedStatu
     return 'complete';
   }
 
+  if (rawStatus === 'ACTIVE' && department === 'Layup') {
+    return 'scheduled';
+  }
+
   if (
     rawStatus === 'IN_PROGRESS' ||
     rawStatus === 'IN PROGRESS' ||
     travelerStatus === 'IN_PROGRESS' ||
     taskStatus === 'IN_PROGRESS' ||
-    item.currentDepartment ||
-    item.activeTaskDepartment
+    (!!department && department !== 'Pending Layup' && department !== 'Layup')
   ) {
     return 'in_progress';
   }
@@ -481,12 +491,14 @@ const WO_STATUS_COLORS: Record<string, string> = {
 
 const P2_PO_STATUS_COLORS: Record<P2PoStatusSummary['status'], string> = {
   pending: 'bg-gray-100 text-gray-700',
+  scheduled: 'bg-emerald-100 text-emerald-700',
   in_progress: 'bg-blue-100 text-blue-700',
   completed: 'bg-green-100 text-green-700',
 };
 
 function p2PoStatusLabel(status: P2PoStatusSummary['status']) {
   if (status === 'in_progress') return 'In Progress';
+  if (status === 'scheduled') return 'Scheduled';
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
@@ -865,6 +877,9 @@ function ProductionTab({ projectId }: { projectId: string }) {
   const serializedCompleteItems = selectedSerializedItems
     .filter(item => serializedStatusGroup(item) === 'complete')
     .sort((a, b) => (a.completedAt || a.updatedAt || '').localeCompare(b.completedAt || b.updatedAt || ''));
+  const serializedScheduledItems = selectedSerializedItems
+    .filter(item => serializedStatusGroup(item) === 'scheduled')
+    .sort((a, b) => (a.serialNumber || a.barcode || a.id).localeCompare(b.serialNumber || b.barcode || b.id));
   const serializedInProgressByDepartment = selectedSerializedItems
     .filter(item => serializedStatusGroup(item) === 'in_progress')
     .reduce<Record<string, P2SerializedBreakdownItem[]>>((acc, item) => {
@@ -879,6 +894,9 @@ function ProductionTab({ projectId }: { projectId: string }) {
       [...items].sort((a, b) => serializedDepartment(a).localeCompare(serializedDepartment(b)) || (a.serialNumber || a.barcode || a.id).localeCompare(b.serialNumber || b.barcode || b.id)),
     ] as const)
     .sort(([a], [b]) => a.localeCompare(b));
+  const serializedScrappedItems = selectedSerializedItems
+    .filter(item => serializedStatusGroup(item) === 'scrapped')
+    .sort((a, b) => (a.serialNumber || a.barcode || a.id).localeCompare(b.serialNumber || b.barcode || b.id));
   const serializedOtherItems = selectedSerializedItems
     .filter(item => serializedStatusGroup(item) === 'other')
     .sort((a, b) => (a.serialNumber || a.barcode || a.id).localeCompare(b.serialNumber || b.barcode || b.id));
@@ -1004,8 +1022,10 @@ function ProductionTab({ projectId }: { projectId: string }) {
                         <span className="font-semibold">{pct}%</span>
                       </div>
                       <Progress value={pct} className="h-2" />
-                      <div className="grid grid-cols-3 gap-2 text-center text-xs text-muted-foreground">
+                      <div className="grid grid-cols-2 gap-2 text-center text-xs text-muted-foreground sm:grid-cols-5">
                         <div><span className="block font-semibold text-foreground">{po.inProductionItems}</span>In production</div>
+                        <div><span className="block font-semibold text-foreground">{po.scheduledItems ?? 0}</span>Scheduled</div>
+                        <div><span className="block font-semibold text-foreground">{po.scrappedItems ?? 0}</span>Scrapped</div>
                         <div><span className="block font-semibold text-foreground">{po.pendingItems}</span>Pending</div>
                         <div><span className="block font-semibold text-foreground">{po.rawStatus}</span>Raw status</div>
                       </div>
@@ -1317,6 +1337,23 @@ function ProductionTab({ projectId }: { projectId: string }) {
                 </AccordionItem>
               )}
 
+              {serializedScheduledItems.length > 0 && (
+                <AccordionItem value="scheduled" className="rounded-md border px-3">
+                  <AccordionTrigger className="py-3 hover:no-underline">
+                    <span className="flex items-center gap-2 text-sm font-semibold">
+                      <Calendar className="h-4 w-4 text-emerald-600" />
+                      Scheduled
+                      <Badge variant="outline">{serializedScheduledItems.length} order{serializedScheduledItems.length === 1 ? '' : 's'}</Badge>
+                    </span>
+                  </AccordionTrigger>
+                  <AccordionContent className="pb-3">
+                    <div className="divide-y rounded-md border">
+                      {serializedScheduledItems.map(renderSerializedItem)}
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              )}
+
               {serializedInProgressDepartments.length > 0 && (
                 <AccordionItem value="in-progress" className="rounded-md border px-3">
                   <AccordionTrigger className="py-3 hover:no-underline">
@@ -1349,6 +1386,23 @@ function ProductionTab({ projectId }: { projectId: string }) {
                         </AccordionItem>
                       ))}
                     </Accordion>
+                  </AccordionContent>
+                </AccordionItem>
+              )}
+
+              {serializedScrappedItems.length > 0 && (
+                <AccordionItem value="scrapped" className="rounded-md border px-3">
+                  <AccordionTrigger className="py-3 hover:no-underline">
+                    <span className="flex items-center gap-2 text-sm font-semibold">
+                      <XCircle className="h-4 w-4 text-red-600" />
+                      Scrapped
+                      <Badge variant="outline">{serializedScrappedItems.length} order{serializedScrappedItems.length === 1 ? '' : 's'}</Badge>
+                    </span>
+                  </AccordionTrigger>
+                  <AccordionContent className="pb-3">
+                    <div className="divide-y rounded-md border">
+                      {serializedScrappedItems.map(renderSerializedItem)}
+                    </div>
                   </AccordionContent>
                 </AccordionItem>
               )}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3943,6 +3943,11 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           return dept === 'Layup';
         }).length;
 
+        const scrappedItems = poItems.filter((s: any) => {
+          const status = String(s.status || '').trim().toUpperCase();
+          return status === 'SCRAPPED' || status === 'SCRAP';
+        }).length;
+
         const serializedInProductionItems = poItems.filter((s: any) => {
           if (s.status !== 'ACTIVE') return false;
           const dept = normalizeP2ControlDepartment(s.currentDepartment || '');
@@ -3962,7 +3967,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
         // pendingItems = everything not yet completed or in-production (including
         // line item quantities that haven't had serialized items generated yet).
-        const pendingItems = Math.max(0, totalItems - completedItems - scheduledItems - inProductionItems);
+        const pendingItems = Math.max(0, totalItems - completedItems - scheduledItems - inProductionItems - scrappedItems);
         
         const rawStatus = normalizeP2Status(po.status) || 'OPEN';
 
@@ -3981,6 +3986,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           completedItems,
           scheduledItems,
           inProductionItems,
+          scrappedItems,
           pendingItems,
           hasBOMsNeeded: !po.bomConfigured,
           projectId: linkedProject?.projectId ?? null,
@@ -3988,7 +3994,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           projectName: linkedProject?.projectName ?? po.projectName ?? null,
           ...wadContext,
           rawStatus,
-          status: completedItems === totalItems && totalItems > 0 ? 'completed' :
+          status: (completedItems + scrappedItems) >= totalItems && totalItems > 0 ? 'completed' :
                   inProductionItems > 0 ? 'in_progress' :
                   scheduledItems > 0 ? 'scheduled' : 'pending'
         };

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -397,10 +397,12 @@ interface P2PoStatusSummary {
   dueDate: string | null;
   totalItems: number;
   completedItems: number;
+  scheduledItems: number;
   inProductionItems: number;
+  scrappedItems: number;
   pendingItems: number;
   rawStatus: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'scheduled' | 'in_progress' | 'completed';
 }
 
 interface P2SerializedBreakdownRow {
@@ -482,7 +484,9 @@ async function getProjectP2PoStatusSummaries(projectId: string): Promise<P2PoSta
     orderedQty: string;
     serializedQty: string;
     completedItems: string;
+    scheduledItems: string;
     inProductionItems: string;
+    scrappedItems: string;
   }>(`
     WITH item_state AS (
       SELECT
@@ -512,15 +516,24 @@ async function getProjectP2PoStatusSummaries(projectId: string): Promise<P2PoSta
       COALESCE(oq.ordered_qty, 0)::text AS "orderedQty",
       COUNT(psi.id)::text AS "serializedQty",
       COUNT(*) FILTER (
-        WHERE psi.status = 'COMPLETED' OR psi.has_completed_traveler
+        WHERE COALESCE(UPPER(psi.status), '') NOT IN ('SCRAPPED', 'CANCELLED', 'CANCELED')
+          AND (psi.status = 'COMPLETED' OR psi.has_completed_traveler)
       )::text AS "completedItems",
       COUNT(*) FILTER (
-        WHERE psi.status = 'ACTIVE'
+        WHERE COALESCE(UPPER(psi.status), '') = 'ACTIVE'
           AND NOT psi.has_completed_traveler
-          AND COALESCE(psi.current_department, '') <> ''
-          AND COALESCE(psi.current_department, '') <> 'Pending Layup'
-          AND COALESCE(psi.current_department, '') <> 'Layup'
-      )::text AS "inProductionItems"
+          AND LOWER(TRIM(COALESCE(psi.current_department, ''))) = 'layup'
+      )::text AS "scheduledItems",
+      COUNT(*) FILTER (
+        WHERE COALESCE(UPPER(psi.status), '') = 'ACTIVE'
+          AND NOT psi.has_completed_traveler
+          AND TRIM(COALESCE(psi.current_department, '')) <> ''
+          AND LOWER(TRIM(COALESCE(psi.current_department, ''))) <> 'pending layup'
+          AND LOWER(TRIM(COALESCE(psi.current_department, ''))) <> 'layup'
+      )::text AS "inProductionItems",
+      COUNT(*) FILTER (
+        WHERE COALESCE(UPPER(psi.status), '') = 'SCRAPPED'
+      )::text AS "scrappedItems"
     FROM p2_purchase_orders po
     LEFT JOIN ordered_qty oq ON oq.po_id = po.id
     LEFT JOIN item_state psi ON psi.po_id = po.id
@@ -535,13 +548,17 @@ async function getProjectP2PoStatusSummaries(projectId: string): Promise<P2PoSta
     const orderedQty = parseInt(row.orderedQty, 10) || 0;
     const totalItems = Math.max(orderedQty, serializedQty);
     const completedItems = parseInt(row.completedItems, 10) || 0;
+    const scheduledItems = parseInt(row.scheduledItems, 10) || 0;
     const inProductionItems = parseInt(row.inProductionItems, 10) || 0;
-    const pendingItems = Math.max(0, totalItems - completedItems - inProductionItems);
+    const scrappedItems = parseInt(row.scrappedItems, 10) || 0;
+    const pendingItems = Math.max(0, totalItems - completedItems - scheduledItems - inProductionItems - scrappedItems);
     const status: P2PoStatusSummary['status'] =
-      totalItems > 0 && completedItems >= totalItems
+      totalItems > 0 && (completedItems + scrappedItems) >= totalItems
         ? 'completed'
-        : (inProductionItems > 0 || rawStatus === 'IN_PRODUCTION')
+        : inProductionItems > 0
           ? 'in_progress'
+          : scheduledItems > 0
+            ? 'scheduled'
           : 'pending';
 
     return {
@@ -551,7 +568,9 @@ async function getProjectP2PoStatusSummaries(projectId: string): Promise<P2PoSta
       dueDate: row.dueDate,
       totalItems,
       completedItems,
+      scheduledItems,
       inProductionItems,
+      scrappedItems,
       pendingItems,
       rawStatus,
       status,


### PR DESCRIPTION
## Summary
- Align P2 Control Center PO status math with PM Control Center serialized status math by counting scrapped units explicitly.
- Treat completed + scrapped serialized units as closing the ordered quantity, so final scrap no longer leaves hidden pending/in-production units.
- Split PM serialized drawer rows into Scheduled, In Progress, Scrapped, Complete, and Other buckets so scrapped rows do not appear under In Progress just because they still have a department.
- Surface scrapped counts on both the P2 status card and PM P2 summary card.

## Root Cause
PM and P2 were using separate status classification paths. PM's drawer grouped any row with a `currentDepartment` as In Progress, so `SCRAPPED` rows with a department like `Scrapped` or `Layup` appeared under In Progress. P2 status math also did not subtract scrapped units from remaining counts, leaving final-scrap units as apparent blockers.

## Validation
- `git diff --check -- server/src/routes/index.ts server/src/routes/pmDashboard.ts client/src/pages/PMControlCenterPage.tsx client/src/components/p2/P2StatusDashboard.tsx` passed.
- `node --experimental-strip-types --check ...` could not run locally because Windows returned `node.exe` Access is denied, matching the known local tooling issue on this machine.