### PR TITLE
Move P2 PO entry into project PO tab

### DIFF
--- a/client/src/components/p2/P2POCreationWizard.tsx
+++ b/client/src/components/p2/P2POCreationWizard.tsx
@@ -44,10 +44,20 @@ interface P2InternalName {
   name: string;
 }
 
+interface Project {
+  id: string;
+  projectCode: string;
+  projectName: string;
+  status: string;
+  customerName?: string | null;
+}
+
 interface P2POCreationWizardProps {
   onComplete: (poId: number) => void;
   onCancel: () => void;
 }
+
+const NO_PROJECT_VALUE = '__no_project__';
 
 const steps = [
   { id: 'customer', title: 'Customer', icon: User },
@@ -67,6 +77,7 @@ const detailsSchema = z.object({
   assignedTo: z.string().optional(), // Who is responsible for this PO
   productionLead: z.string().optional(), // Production lead for this PO
   notes: z.string().optional(),
+  projectId: z.string().optional(),
   projectName: z.string().optional(), // Optional project association
 });
 
@@ -115,6 +126,17 @@ export default function P2POCreationWizard({ onComplete, onCancel }: P2POCreatio
     queryKey: ['/api/p2/internal-names'],
   });
 
+  const { data: projects = [] } = useQuery<Project[]>({
+    queryKey: ['/api/projects'],
+  });
+
+  const openProjects = projects.filter((project) =>
+    !['completed', 'cancelled', 'closed'].includes(String(project.status || '').toLowerCase())
+  );
+
+  const renderProjectLabel = (project: Project) =>
+    `${project.projectCode} - ${project.projectName}${project.customerName ? ` (${project.customerName})` : ''}`;
+
   const createProductMutation = useMutation({
     mutationFn: async (data: typeof newProductForm) => {
       return apiRequest('/api/p2/product-items', {
@@ -156,6 +178,7 @@ export default function P2POCreationWizard({ onComplete, onCancel }: P2POCreatio
       assignedTo: '',
       productionLead: '',
       notes: '',
+      projectId: NO_PROJECT_VALUE,
       projectName: '',
     },
   });
@@ -201,7 +224,14 @@ export default function P2POCreationWizard({ onComplete, onCancel }: P2POCreatio
   };
 
   const handleDetailsSubmit = (data: z.infer<typeof detailsSchema>) => {
-    setPODetails(data);
+    const selectedProject = data.projectId && data.projectId !== NO_PROJECT_VALUE
+      ? projects.find((project) => project.id === data.projectId)
+      : null;
+    setPODetails({
+      ...data,
+      projectId: selectedProject?.id || '',
+      projectName: selectedProject ? renderProjectLabel(selectedProject) : '',
+    });
     setCurrentStep(2);
   };
 
@@ -299,6 +329,7 @@ export default function P2POCreationWizard({ onComplete, onCancel }: P2POCreatio
       productionLeadName: productionLeadEmployee
         ? `${productionLeadEmployee.firstName} ${productionLeadEmployee.lastName}`
         : null,
+      projectId: poDetails?.projectId && poDetails.projectId !== NO_PROJECT_VALUE ? poDetails.projectId : null,
       projectName: poDetails?.projectName || null,
       lineItems: lineItems.map((item) => ({
         partNumber: `${item.sku}${item.revision ? ` Rev ${item.revision}` : ''}`,
@@ -552,13 +583,25 @@ export default function P2POCreationWizard({ onComplete, onCancel }: P2POCreatio
 
               <FormField
                 control={detailsForm.control}
-                name="projectName"
+                name="projectId"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Project (Optional)</FormLabel>
-                    <FormControl>
-                      <Input {...field} placeholder="e.g., Project Alpha or PRJ-001" data-testid="input-project-name" />
-                    </FormControl>
+                    <Select onValueChange={field.onChange} value={field.value || NO_PROJECT_VALUE}>
+                      <FormControl>
+                        <SelectTrigger data-testid="select-project">
+                          <SelectValue placeholder="Select project..." />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value={NO_PROJECT_VALUE}>No linked project</SelectItem>
+                        {openProjects.map((project) => (
+                          <SelectItem key={project.id} value={project.id}>
+                            {renderProjectLabel(project)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -33,7 +33,8 @@ import {
   ChevronRight,
   Filter,
   X,
-  Lock
+  Lock,
+  Users
 } from 'lucide-react';
 import { Link, useLocation } from 'wouter';
 import P2POCreationWizard from '@/components/p2/P2POCreationWizard';
@@ -44,11 +45,10 @@ import P2ProductionQueue from '@/components/p2/P2ProductionQueue';
 import P2CertificationsManager from './P2CertificationsManager';
 import PartRoutingManagement from './PartRoutingManagement';
 import RoutingDocumentManagement from './RoutingDocumentManagement';
-import { P2POManager } from '@/components/P2POManager';
-import { P2POItemsManager } from '@/components/P2POItemsManager';
 import P2ChangesTab from '@/components/p2/P2ChangesTab';
 import P2ShippingTab from '@/components/p2/P2ShippingTab';
 import P2NonconformingTab from '@/components/p2/P2ScrappedItemsTab';
+import P2CustomersTab from '@/components/p2/P2CustomersTab';
 import { TravelerCapturedDataById } from '@/components/p2/TravelerCapturedData';
 import ProgramManufacturingOrchestration from '@/components/p2/ProgramManufacturingOrchestration';
 import { queryClient, apiRequest } from '@/lib/queryClient';
@@ -105,23 +105,21 @@ export default function P2ControlCenter() {
   const poFromUrl = urlParams.get('po') || undefined;
   const poIdFromUrl = urlParams.get('poId') ? Number(urlParams.get('poId')) : null;
   const unitsFromUrl = urlParams.get('units') || undefined;
-  const searchFromUrl = urlParams.get('search') || '';
   // Project context: passed from PM/WAD project workflow cards
   const wadProjectId = urlParams.get('projectId') || '';
   const wadProjectName = urlParams.get('projectName') || '';
   const wadPoId = urlParams.get('poId') || '';
-  const [activeTab, setActiveTab] = useState(tabFromUrl || 'status');
+  const [activeTab, setActiveTab] = useState(tabFromUrl === 'pos' ? 'status' : tabFromUrl || 'status');
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const tab = params.get('tab');
-    if (tab) setActiveTab(tab);
+    if (tab) setActiveTab(tab === 'pos' ? 'status' : tab);
   }, [location]);
 
   const [showPOWizard, setShowPOWizard] = useState(false);
   const [showBOMWizard, setShowBOMWizard] = useState(false);
   const [selectedPOForBOM, setSelectedPOForBOM] = useState<number | null>(null);
-  const [poItemsView, setPOItemsView] = useState<{ poId: number; poNumber: string } | null>(null);
   const [selectedPOIds, setSelectedPOIds] = useState<number[]>([]);
 
   const { data: stats } = useQuery<P2Stats>({
@@ -705,9 +703,9 @@ export default function P2ControlCenter() {
             <BarChart3 className="h-4 w-4" />
             Status
           </TabsTrigger>
-          <TabsTrigger value="pos" className="flex items-center gap-2" data-testid="tab-pos">
-            <FileText className="h-4 w-4" />
-            POs
+          <TabsTrigger value="customers" className="flex items-center gap-2" data-testid="tab-customers">
+            <Users className="h-4 w-4" />
+            Customers
           </TabsTrigger>
           <TabsTrigger value="setup" className="flex items-center gap-2" data-testid="tab-setup">
             <Settings className="h-4 w-4" />
@@ -777,20 +775,8 @@ export default function P2ControlCenter() {
           />
         </TabsContent>
 
-        <TabsContent value="pos">
-          {poItemsView ? (
-            <P2POItemsManager
-              poId={poItemsView.poId}
-              poNumber={poItemsView.poNumber}
-              onBack={() => setPOItemsView(null)}
-            />
-          ) : (
-            <P2POManager 
-              onManageItems={(poId, poNumber) => setPOItemsView({ poId, poNumber })}
-              selectedPOIds={selectedPOIds}
-              initialSearch={searchFromUrl}
-            />
-          )}
+        <TabsContent value="customers">
+          <P2CustomersTab />
         </TabsContent>
 
         <TabsContent value="setup">

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -138,6 +138,10 @@ interface P2PurchaseOrder {
   customerId: string;
   customerName: string;
   status: string;
+  projectId?: string | null;
+  projectName?: string | null;
+  poDate?: string | null;
+  expectedDelivery?: string | null;
   createdAt?: string;
 }
 
@@ -415,16 +419,34 @@ export default function ProjectDetailPage() {
   const [showManualLink, setShowManualLink] = useState(false);
   const [linkPoReason, setLinkPoReason] = useState('');
   const [revisionForm, setRevisionForm] = useState({ summary: '', reason: '' });
+  const [newPoForm, setNewPoForm] = useState({
+    poNumber: '',
+    expectedDelivery: '',
+    notes: '',
+  });
 
   const suggestedPo = useMemo(() => {
-    if (!project || p2PurchaseOrderOptions.length === 0) return null;
-    const sameCustomer = p2PurchaseOrderOptions.filter(po => po.customerId === project.customerId);
-    const pool = sameCustomer.length > 0 ? sameCustomer : p2PurchaseOrderOptions;
+    if (!project || p2PurchaseOrders.length === 0) return null;
+    const available = p2PurchaseOrders.filter(po =>
+      !po.projectId || po.projectId === project.id || po.id === project.poId
+    );
+    const sameCustomer = available.filter(po => po.customerId === project.customerId);
+    const pool = sameCustomer.length > 0 ? sameCustomer : available;
     return pool.slice().sort((a, b) => {
       if (a.createdAt && b.createdAt) return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       return b.id - a.id;
     })[0] ?? null;
-  }, [project, p2PurchaseOrderOptions]);
+  }, [project, p2PurchaseOrders]);
+
+  const projectP2POs = useMemo(() => {
+    if (!project) return [];
+    return p2PurchaseOrders
+      .filter(po => po.projectId === project.id || po.id === project.poId)
+      .sort((a, b) => {
+        if (a.createdAt && b.createdAt) return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+        return b.id - a.id;
+      });
+  }, [project, p2PurchaseOrders]);
 
   const linkPoMutation = useMutation({
     mutationFn: ({ poId, reason }: { poId: number; reason?: string }) =>
@@ -441,6 +463,7 @@ export default function ProjectDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['/api/projects', id] });
       queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'traceability'] });
       queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'revisions'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2-purchase-orders-bypass'] });
       setLinkPoId('');
       setLinkPoSearch('');
       setLinkPoReason('');
@@ -473,6 +496,51 @@ export default function ProjectDetailPage() {
       toast({ title: 'Revision created', description: 'Project revision history was updated.' });
     },
     onError: (err: any) => toast({ title: 'Revision failed', description: err?.message || 'Could not create revision.', variant: 'destructive' }),
+  });
+
+  const createProjectPOMutation = useMutation({
+    mutationFn: async () => {
+      if (!project) throw new Error('Project is not loaded');
+      const po = await apiRequest('/api/p2-purchase-orders-bypass', {
+        method: 'POST',
+        body: {
+          poNumber: newPoForm.poNumber.trim(),
+          customerId: project.customer?.customerId || project.customerId,
+          customerName: project.customer?.name || project.customerId,
+          poDate: new Date().toISOString().split('T')[0],
+          expectedDelivery: newPoForm.expectedDelivery || null,
+          status: 'OPEN',
+          notes: newPoForm.notes || null,
+          projectId: project.id,
+          projectName: `${project.projectCode} - ${project.projectName}`,
+        },
+      });
+
+      if (!project.poId && po?.id) {
+        await apiRequest(`/api/projects/${id}/link-po`, {
+          method: 'POST',
+          body: {
+            poId: po.id,
+            reason: 'Initial production PO link',
+            createdByDisplayName: currentUser?.username,
+          },
+        });
+      }
+
+      return po;
+    },
+    onSuccess: () => {
+      toast({ title: 'PO entered', description: 'P2 purchase order added to this project.' });
+      setNewPoForm({ poNumber: '', expectedDelivery: '', notes: '' });
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id] });
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'traceability'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'revisions'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2-purchase-orders-bypass'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/po-statuses'] });
+    },
+    onError: (err: any) => {
+      toast({ title: 'PO entry failed', description: err?.message || 'Failed to create project PO.', variant: 'destructive' });
+    },
   });
 
   const { data: projectWorkOrders = [] } = useQuery<ProjectWorkOrder[]>({
@@ -1571,6 +1639,10 @@ export default function ProjectDetailPage() {
         <TabsList>
           <TabsTrigger value="workflow" data-testid="tab-workflow">Workflow</TabsTrigger>
           <TabsTrigger value="activity" data-testid="tab-activity">Activity Log</TabsTrigger>
+          <TabsTrigger value="po" data-testid="tab-po">
+            <Receipt className="h-4 w-4 mr-1.5" />
+            PO
+          </TabsTrigger>
           <TabsTrigger value="revisions" data-testid="tab-revisions">
             <History className="h-4 w-4 mr-1.5" />
             Revisions
@@ -2256,6 +2328,176 @@ export default function ProjectDetailPage() {
           </Card>
         </TabsContent>
 
+        {/* P2 purchase orders assigned to this project */}
+        <TabsContent value="po" className="space-y-4">
+          <div className="grid grid-cols-1 xl:grid-cols-[1fr_380px] gap-4">
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Receipt className="h-4 w-4" /> Project P2 Purchase Orders
+                </CardTitle>
+                <CardDescription>P2 POs assigned to {project.projectCode}.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {projectP2POs.length === 0 ? (
+                  <div className="rounded-md border border-dashed p-6 text-center text-muted-foreground">
+                    <Receipt className="mx-auto h-8 w-8 mb-2 opacity-50" />
+                    <p className="text-sm font-medium">No P2 POs assigned yet</p>
+                    <p className="text-xs">Enter a PO here or link an existing P2 PO to this project.</p>
+                  </div>
+                ) : (
+                  projectP2POs.map((po) => (
+                    <div key={po.id} className="flex flex-col gap-3 rounded-md border p-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="space-y-1 min-w-0">
+                        <p className="font-mono font-semibold text-primary">{po.poNumber}</p>
+                        <p className="text-sm text-muted-foreground truncate">{po.customerName}</p>
+                        {po.projectName && <p className="text-xs text-muted-foreground truncate">{po.projectName}</p>}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={po.status === 'OPEN' ? 'secondary' : 'default'}>{po.status}</Badge>
+                        {project.poId === po.id && <Badge variant="outline">Primary</Badge>}
+                        {po.expectedDelivery && (
+                          <span className="text-xs text-muted-foreground">
+                            Due {format(new Date(po.expectedDelivery), 'MMM d, yyyy')}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+
+            <div className="space-y-4">
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Plus className="h-4 w-4" /> Enter P2 PO
+                  </CardTitle>
+                  <CardDescription>Add a new P2 PO directly to this project.</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="project-po-number">PO Number</Label>
+                    <Input
+                      id="project-po-number"
+                      value={newPoForm.poNumber}
+                      onChange={(event) => setNewPoForm((current) => ({ ...current, poNumber: event.target.value }))}
+                      placeholder="Customer PO number"
+                      data-testid="input-project-po-number"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="project-po-due-date">Expected Delivery</Label>
+                    <Input
+                      id="project-po-due-date"
+                      type="date"
+                      value={newPoForm.expectedDelivery}
+                      onChange={(event) => setNewPoForm((current) => ({ ...current, expectedDelivery: event.target.value }))}
+                      data-testid="input-project-po-due-date"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="project-po-notes">Notes</Label>
+                    <Textarea
+                      id="project-po-notes"
+                      value={newPoForm.notes}
+                      onChange={(event) => setNewPoForm((current) => ({ ...current, notes: event.target.value }))}
+                      placeholder="Optional notes"
+                      rows={3}
+                      data-testid="textarea-project-po-notes"
+                    />
+                  </div>
+                  <Button
+                    className="w-full"
+                    disabled={!newPoForm.poNumber.trim() || createProjectPOMutation.isPending}
+                    onClick={() => createProjectPOMutation.mutate()}
+                    data-testid="button-create-project-po"
+                  >
+                    {createProjectPOMutation.isPending ? 'Saving...' : 'Save P2 PO'}
+                  </Button>
+                </CardContent>
+              </Card>
+
+              {!project.poId && (
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="flex items-center gap-2 text-base">
+                      <LinkIcon className="h-4 w-4" /> Link Existing P2 PO
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {suggestedPo && !showManualLink ? (
+                      <div className="space-y-3">
+                        <div className="rounded-md border border-blue-200 bg-blue-50 p-3 space-y-1">
+                          <p className="text-xs font-medium text-blue-700 uppercase">Suggested PO</p>
+                          <p className="font-mono font-semibold text-blue-950">{suggestedPo.poNumber}</p>
+                          <p className="text-sm text-blue-800">{suggestedPo.customerName}</p>
+                        </div>
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            onClick={() => linkPoMutation.mutate({ poId: suggestedPo.id })}
+                            disabled={linkPoMutation.isPending}
+                          >
+                            {linkPoMutation.isPending ? 'Linking...' : 'Accept'}
+                          </Button>
+                          <Button size="sm" variant="outline" onClick={() => setShowManualLink(true)}>
+                            Choose Different
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="space-y-3">
+                        {showManualLink && suggestedPo && (
+                          <Button variant="ghost" size="sm" className="text-muted-foreground -mb-1" onClick={() => setShowManualLink(false)}>
+                            Back to suggestion
+                          </Button>
+                        )}
+                        <div className="space-y-2">
+                          <Label>Search POs</Label>
+                          <Input
+                            placeholder="Filter by PO number or customer..."
+                            value={linkPoSearch}
+                            onChange={(event) => setLinkPoSearch(event.target.value)}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>Purchase Order</Label>
+                          <Select value={linkPoId} onValueChange={setLinkPoId}>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select a purchase order" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {p2PurchaseOrders
+                                .filter(po => !po.projectId || po.projectId === project.id)
+                                .filter(po => {
+                                  const q = linkPoSearch.toLowerCase();
+                                  return !q || po.poNumber?.toLowerCase().includes(q) || po.customerName?.toLowerCase().includes(q);
+                                })
+                                .map(po => (
+                                  <SelectItem key={po.id} value={po.id.toString()}>
+                                    {po.poNumber} - {po.customerName}
+                                  </SelectItem>
+                                ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <Button
+                          disabled={!linkPoId || linkPoMutation.isPending}
+                          onClick={() => linkPoMutation.mutate({ poId: parseInt(linkPoId, 10) })}
+                        >
+                          {linkPoMutation.isPending ? 'Linking...' : 'Link PO'}
+                        </Button>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          </div>
+        </TabsContent>
+
         {/* ── TRACEABILITY TAB ── */}
         <TabsContent value="revisions" className="space-y-4">
           <Card>
@@ -2445,7 +2687,7 @@ export default function ProjectDetailPage() {
                       <div>
                         <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">PO Number</p>
                         <button
-                          onClick={() => setLocation(`/p2-control-center?tab=pos`)}
+                          onClick={() => setLocation(`/projects/${project.id}?tab=po`)}
                           className="font-mono font-semibold text-sm text-primary hover:underline cursor-pointer"
                         >
                           {traceability.po?.po_number || `PO ID ${project.poId}`}

--- a/migrations/0116_po_project_links.sql
+++ b/migrations/0116_po_project_links.sql
@@ -1,0 +1,15 @@
+-- Link P2 purchase orders directly to projects.
+
+ALTER TABLE p2_purchase_orders
+  ADD COLUMN IF NOT EXISTS project_id uuid REFERENCES projects(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS p2_purchase_orders_project_id_idx
+  ON p2_purchase_orders(project_id);
+
+-- Backfill from projects already hard-linked by P2 PO id.
+UPDATE p2_purchase_orders p2po
+SET project_id = p.id,
+    project_name = COALESCE(p2po.project_name, p.project_code || ' - ' || p.project_name)
+FROM projects p
+WHERE p2po.project_id IS NULL
+  AND p.po_id = p2po.id;

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -5237,7 +5237,8 @@ export const p2PurchaseOrders = pgTable('p2_purchase_orders', {
   productionLeadId: integer('production_lead_id').references(() => employees.id), // Production lead for this PO
   productionLeadName: text('production_lead_name'), // Denormalized for display
   
-  // Project association — free-text field for internal project name or number
+  // Project association for PM/P2 continuity
+  projectId: uuid('project_id').references((): AnyPgColumn => projects.id, { onDelete: 'set null' }),
   projectName: text('project_name'),
   securityClassification: text('security_classification').notNull().default('internal'), // public | internal | cui | itar
   cuiCategory: text('cui_category'),
@@ -6827,6 +6828,7 @@ export const insertP2PurchaseOrderSchema = createInsertSchema(p2PurchaseOrders)
     notes: z.string().optional().nullable(),
     sourceQuoteId: z.string().uuid().optional().nullable(),
     contractReviewRole: z.enum(['primary', 'secondary']).default('secondary'),
+    projectId: z.string().uuid().optional().nullable(),
   });
 
 export const insertP2PurchaseOrderItemSchema = createInsertSchema(

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2864,7 +2864,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         toleranceAuthorizerId, toleranceAuthorizerName, toleranceNotes, notes, lineItems,
         assignedToId, assignedToName, productionLeadId, productionLeadName,
         customerName: bodyCustomerName, poDate: bodyPoDate, status: bodyStatus,
-        sourceQuoteId, projectName, contractReviewRole,
+        sourceQuoteId, projectId, projectName, contractReviewRole,
       } = req.body;
       
       // Use the customer-provided PO number — accept either field name
@@ -2901,6 +2901,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         productionLeadName: productionLeadName || null,
         sourceQuoteId: sourceQuoteId || null,
         contractReviewRole: contractReviewRole === 'primary' ? 'primary' : 'secondary',
+        projectId: projectId || null,
         projectName: projectName || null,
       };
       
@@ -3989,7 +3990,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           scrappedItems,
           pendingItems,
           hasBOMsNeeded: !po.bomConfigured,
-          projectId: linkedProject?.projectId ?? null,
+          projectId: po.projectId ?? linkedProject?.projectId ?? null,
           projectCode: linkedProject?.projectCode ?? null,
           projectName: linkedProject?.projectName ?? po.projectName ?? null,
           ...wadContext,

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -699,12 +699,15 @@ router.post('/:id/link-po', async (req, res) => {
       return res.status(400).json({ message: 'A revision reason is required when changing the linked PO' });
     }
 
-    // Validate PO exists
-    const poRows = await pool.query<{ id: number; po_number: string }>(
-      `SELECT id, po_number FROM p2_purchase_orders WHERE id = $1`,
+    // Validate PO exists and is not already assigned to another project
+    const poRows = await pool.query<{ id: number; po_number: string; project_id: string | null }>(
+      `SELECT id, po_number, project_id::text FROM p2_purchase_orders WHERE id = $1`,
       [poId]
     );
     if (poRows.length === 0) return res.status(404).json({ message: 'PO not found' });
+    if (poRows[0].project_id && poRows[0].project_id !== id) {
+      return res.status(409).json({ message: 'This PO is already assigned to another project' });
+    }
 
     // Ensure no other project already uses this poId
     const conflictRows = await pool.query<{ id: string }>(
@@ -723,6 +726,7 @@ router.post('/:id/link-po', async (req, res) => {
     const revisionSummary = isRelink
       ? `Changed linked P2 PO to ${poRows[0].po_number}`
       : `Linked project to P2 PO ${poRows[0].po_number}`;
+    const projectPoLabel = `${project.projectCode} - ${project.projectName}`;
 
     // Task #258: link-po writes + WAD supersede must be atomic. If any step
     // fails (including the supersede helper), the entire link is rolled back
@@ -745,6 +749,14 @@ router.post('/:id/link-po', async (req, res) => {
         UPDATE project_steps
            SET linked_p2_order_id = ${poId}, updated_at = NOW()
          WHERE project_id = ${id}::uuid AND step_type = 'p2_order'
+      `);
+
+      await tx.execute(sql`
+        UPDATE p2_purchase_orders
+           SET project_id = ${id}::uuid,
+               project_name = COALESCE(project_name, ${projectPoLabel}),
+               updated_at = NOW()
+         WHERE id = ${poId}
       `);
 
       await tx.execute(sql`

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -15412,6 +15412,7 @@ export class DatabaseStorage implements IStorage {
         bom_owner_name as "bomOwnerName", scheduled_by_id as "scheduledById",
         scheduled_by_name as "scheduledByName", production_lead_id as "productionLeadId",
         production_lead_name as "productionLeadName",
+        project_id as "projectId",
         project_name as "projectName"
       FROM p2_purchase_orders 
       ORDER BY created_at DESC
@@ -15456,7 +15457,7 @@ export class DatabaseStorage implements IStorage {
         tolerance_notes, bom_configured, source_quote_id, contract_review_role,
         created_by_id, created_by_name, assigned_to_id, assigned_to_name, bom_owner_id, bom_owner_name,
         scheduled_by_id, scheduled_by_name, production_lead_id, production_lead_name,
-        project_name
+        project_id, project_name
       ) VALUES (
         $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25
       )
@@ -15474,6 +15475,7 @@ export class DatabaseStorage implements IStorage {
         bom_owner_name as "bomOwnerName", scheduled_by_id as "scheduledById",
         scheduled_by_name as "scheduledByName", production_lead_id as "productionLeadId",
         production_lead_name as "productionLeadName",
+        project_id as "projectId",
         project_name as "projectName",
         created_at as "createdAt", updated_at as "updatedAt"
     `, [
@@ -15501,6 +15503,7 @@ export class DatabaseStorage implements IStorage {
       data.scheduledByName || null,
       data.productionLeadId || null,
       data.productionLeadName || null,
+      data.projectId || null,
       data.projectName || null,
     ]);
     return result[0] as P2PurchaseOrder;


### PR DESCRIPTION
## Summary
- remove the P2 Control Center POs tab
- add a project-level PO tab for entering and viewing P2 POs assigned to that project
- store P2 PO project linkage with `p2_purchase_orders.project_id` and backfill existing project `po_id` links
- update project PO linking so the P2 PO record also records its project

## Validation
- `git diff --check`
- `node --experimental-strip-types --check server/storage.ts`
- `node --experimental-strip-types --check server/src/routes/index.ts`
- `node --experimental-strip-types --check server/src/routes/projects.ts`
- `node --experimental-strip-types --check server/schema.ts`

Note: full `npm run check` could not run locally because `npm` was not available on PATH in this session.