### PR TITLE
Add COA metadata editing and employee termination controls

### DIFF
--- a/client/src/pages/EmployeeDashboard.tsx
+++ b/client/src/pages/EmployeeDashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plus, Search, User, Shield, Calendar, FileText } from 'lucide-react';
+import { AlertTriangle, Plus, Search, User, Shield, Calendar, FileText } from 'lucide-react';
 import { Link } from 'wouter';
 
 import { Button } from '@/components/ui/button';
@@ -13,6 +13,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -33,11 +34,17 @@ interface Employee {
   department: string;
   employmentType: string;
   isActive: boolean;
+  employmentStatus?: string;
+  terminationDate?: string | null;
+  userIsActive?: boolean | null;
+  accessExceptionExpiresAt?: string | null;
+  terminatedWithAccess?: boolean;
   createdAt: string;
 }
 
 export default function EmployeeDashboard() {
   const [searchTerm, setSearchTerm] = useState('');
+  const [includeSeparated, setIncludeSeparated] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -47,9 +54,11 @@ export default function EmployeeDashboard() {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['/api/employees'],
+    queryKey: ['/api/employees', includeSeparated],
     queryFn: async () => {
-      const response = await fetch('/api/employees');
+      const response = await fetch(
+        `/api/employees${includeSeparated ? '?includeInactive=true' : ''}`
+      );
       if (!response.ok) throw new Error('Failed to fetch employees');
       return response.json();
     },
@@ -64,6 +73,9 @@ export default function EmployeeDashboard() {
   );
 
   const activeEmployees = employees.filter((emp: Employee) => emp.isActive);
+  const separatedWithAccess = employees.filter(
+    (emp: Employee) => emp.terminatedWithAccess
+  );
   const totalDepartments = [
     ...new Set(employees.map((emp: Employee) => emp.department)),
   ].length;
@@ -173,7 +185,7 @@ export default function EmployeeDashboard() {
       </div>
 
       {/* Search */}
-      <div className="flex items-center space-x-2">
+      <div className="flex flex-wrap items-center gap-4">
         <div className="relative flex-1 max-w-sm">
           <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
@@ -183,6 +195,19 @@ export default function EmployeeDashboard() {
             className="pl-8"
           />
         </div>
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Checkbox
+            checked={includeSeparated}
+            onCheckedChange={(checked) => setIncludeSeparated(Boolean(checked))}
+          />
+          Include inactive / terminated
+        </label>
+        {separatedWithAccess.length > 0 && (
+          <Badge variant="destructive" className="gap-1">
+            <AlertTriangle className="h-3 w-3" />
+            {separatedWithAccess.length} terminated with access
+          </Badge>
+        )}
       </div>
 
       {/* Employee List */}
@@ -250,13 +275,36 @@ export default function EmployeeDashboard() {
                     </div>
                     <div className="flex items-center space-x-2">
                       <Badge
-                        variant={employee.isActive ? 'default' : 'secondary'}
+                        variant={
+                          employee.employmentStatus === 'TERMINATED'
+                            ? 'destructive'
+                            : employee.isActive
+                              ? 'default'
+                              : 'secondary'
+                        }
                         className={
-                          employee.isActive ? 'bg-green-100 text-green-800' : ''
+                          employee.employmentStatus === 'TERMINATED'
+                            ? ''
+                            : employee.isActive
+                              ? 'bg-green-100 text-green-800'
+                              : ''
                         }
                       >
-                        {employee.isActive ? 'Active' : 'Inactive'}
+                        {employee.employmentStatus === 'TERMINATED'
+                          ? 'Terminated'
+                          : employee.isActive
+                            ? 'Active'
+                            : 'Inactive'}
                       </Badge>
+                      {employee.terminatedWithAccess && (
+                        <Badge variant="destructive" className="gap-1">
+                          <AlertTriangle className="h-3 w-3" />
+                          Access until{' '}
+                          {employee.accessExceptionExpiresAt
+                            ? new Date(employee.accessExceptionExpiresAt).toLocaleDateString()
+                            : 'review'}
+                        </Badge>
+                      )}
                       {employee.userRole && (
                         <Badge
                           variant="outline"

--- a/client/src/pages/EmployeeDetail.tsx
+++ b/client/src/pages/EmployeeDetail.tsx
@@ -60,11 +60,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import AddCertificationModal from '@/components/employee/AddCertificationModal';
 import CertificationFormModal from '@/components/employee/CertificationFormModal';
@@ -89,6 +92,19 @@ interface Employee {
   salary: number;
   hourlyRate: number;
   isActive: boolean;
+  employmentStatus?: string;
+  terminationDate?: string | null;
+  terminationReasonCode?: string | null;
+  terminationReason?: string | null;
+  eligibleForRehire?: boolean | null;
+  finalPaycheckDate?: string | null;
+  terminationNotes?: string | null;
+  userIsActive?: boolean | null;
+  accessExceptionReason?: string | null;
+  accessExceptionApprovedByName?: string | null;
+  accessExceptionApprovedAt?: string | null;
+  accessExceptionExpiresAt?: string | null;
+  terminatedWithAccess?: boolean;
   portalToken: string;
   portalTokenExpiry: string;
   createdAt: string;
@@ -531,6 +547,17 @@ export default function EmployeeDetail() {
   const [selectedAssignUserId, setSelectedAssignUserId] = useState<string>('');
   const [showAssignUser, setShowAssignUser] = useState(false);
   const [selectedChargeCodeIds, setSelectedChargeCodeIds] = useState<number[]>([]);
+  const [showTerminateDialog, setShowTerminateDialog] = useState(false);
+  const [terminationForm, setTerminationForm] = useState({
+    terminationDate: new Date().toISOString().split('T')[0],
+    terminationReasonCode: '',
+    terminationReason: '',
+    eligibleForRehire: false,
+    finalPaycheckDate: '',
+    terminationNotes: '',
+    retainAccess: false,
+    accessExceptionReason: '',
+  });
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
@@ -721,6 +748,44 @@ export default function EmployeeDetail() {
     },
   });
 
+  const terminateEmployeeMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(`/api/employees/${id}/terminate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...terminationForm,
+          finalPaycheckDate: terminationForm.finalPaycheckDate || null,
+          terminationNotes: terminationForm.terminationNotes || null,
+          accessExceptionReason: terminationForm.accessExceptionReason || null,
+        }),
+      });
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(error.error || 'Failed to complete termination');
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/employees', id] });
+      queryClient.invalidateQueries({ queryKey: ['/api/employees'] });
+      setShowTerminateDialog(false);
+      toast({
+        title: 'Termination recorded',
+        description: terminationForm.retainAccess
+          ? 'Employment ended and EPOCH access was retained for 90 days.'
+          : 'Employment ended and EPOCH access was disabled.',
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Termination failed',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
   const updateChargeCodesMutation = useMutation({
     mutationFn: async () => {
       const response = await fetch(`/api/employees/${id}/charge-codes`, {
@@ -748,6 +813,22 @@ export default function EmployeeDetail() {
   const activeChargeCodes = allChargeCodes
     .filter((code) => code.active !== false)
     .sort((a, b) => a.code.localeCompare(b.code));
+
+  const isTerminated = employee?.employmentStatus === 'TERMINATED' || employee?.isActive === false;
+  const retainedAccessExpires = terminationForm.terminationDate
+    ? (() => {
+        const date = new Date(`${terminationForm.terminationDate}T00:00:00`);
+        date.setDate(date.getDate() + 90);
+        return date;
+      })()
+    : null;
+  const canTerminate =
+    Boolean(terminationForm.terminationDate) &&
+    Boolean(terminationForm.terminationReasonCode) &&
+    Boolean(terminationForm.terminationReason.trim()) &&
+    (!terminationForm.retainAccess ||
+      Boolean(terminationForm.accessExceptionReason.trim())) &&
+    !terminateEmployeeMutation.isPending;
 
   const toggleChargeCode = (chargeCodeId: number) => {
     setSelectedChargeCodeIds((current) =>
@@ -1310,6 +1391,16 @@ export default function EmployeeDetail() {
           </div>
         </div>
         <div className="flex items-center space-x-2">
+          {!isEditing && !isTerminated && (
+            <Button
+              variant="outline"
+              className="border-red-200 text-red-700 hover:bg-red-50"
+              onClick={() => setShowTerminateDialog(true)}
+            >
+              <Ban className="w-4 h-4 mr-2" />
+              Terminate
+            </Button>
+          )}
           {isEditing ? (
             <>
               <Button variant="outline" onClick={handleCancel}>
@@ -1332,6 +1423,25 @@ export default function EmployeeDetail() {
           )}
         </div>
       </div>
+
+      {employee.terminatedWithAccess && (
+        <Card className="border-red-200 bg-red-50">
+          <CardContent className="flex flex-wrap items-center gap-3 pt-6 text-red-800">
+            <AlertTriangle className="h-5 w-5" />
+            <div className="text-sm">
+              <span className="font-semibold">Terminated employee retains EPOCH access.</span>{' '}
+              Access expires{' '}
+              {employee.accessExceptionExpiresAt
+                ? new Date(employee.accessExceptionExpiresAt).toLocaleDateString()
+                : 'after review'}
+              {employee.accessExceptionApprovedByName
+                ? `, approved by ${employee.accessExceptionApprovedByName}`
+                : ''}
+              .
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Employee Profile Card */}
@@ -1357,6 +1467,19 @@ export default function EmployeeDetail() {
                 >
                   {employee.isActive ? 'Active' : 'Inactive'}
                 </Badge>
+                {employee.employmentStatus === 'TERMINATED' && (
+                  <div className="mt-2 space-y-1 text-xs text-red-700">
+                    <div>
+                      Terminated{' '}
+                      {employee.terminationDate
+                        ? formatDate(employee.terminationDate)
+                        : ''}
+                    </div>
+                    {employee.terminationReasonCode && (
+                      <div>{employee.terminationReasonCode}</div>
+                    )}
+                  </div>
+                )}
               </div>
 
               <div className="space-y-3 text-sm">
@@ -3345,6 +3468,180 @@ export default function EmployeeDetail() {
               </Card>
             </TabsContent>
           </Tabs>
+
+          <Dialog open={showTerminateDialog} onOpenChange={setShowTerminateDialog}>
+            <DialogContent className="sm:max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>Terminate Employee</DialogTitle>
+                <DialogDescription>
+                  Record the employment termination separately from EPOCH access. Historical records will remain intact.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-5">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="termination-date">Termination Date</Label>
+                    <Input
+                      id="termination-date"
+                      type="date"
+                      value={terminationForm.terminationDate}
+                      onChange={(event) =>
+                        setTerminationForm((current) => ({
+                          ...current,
+                          terminationDate: event.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="termination-reason-code">Reason Code</Label>
+                    <Select
+                      value={terminationForm.terminationReasonCode}
+                      onValueChange={(value) =>
+                        setTerminationForm((current) => ({
+                          ...current,
+                          terminationReasonCode: value,
+                        }))
+                      }
+                    >
+                      <SelectTrigger id="termination-reason-code">
+                        <SelectValue placeholder="Select reason" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="voluntary">Voluntary</SelectItem>
+                        <SelectItem value="involuntary">Involuntary</SelectItem>
+                        <SelectItem value="layoff">Layoff</SelectItem>
+                        <SelectItem value="retirement">Retirement</SelectItem>
+                        <SelectItem value="other">Other</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="termination-reason">Reason / Notes for Audit</Label>
+                  <Textarea
+                    id="termination-reason"
+                    value={terminationForm.terminationReason}
+                    onChange={(event) =>
+                      setTerminationForm((current) => ({
+                        ...current,
+                        terminationReason: event.target.value,
+                      }))
+                    }
+                    placeholder="Document the business reason for the employment status change."
+                    rows={3}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="final-paycheck-date">Final Paycheck Date</Label>
+                    <Input
+                      id="final-paycheck-date"
+                      type="date"
+                      value={terminationForm.finalPaycheckDate}
+                      onChange={(event) =>
+                        setTerminationForm((current) => ({
+                          ...current,
+                          finalPaycheckDate: event.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+
+                  <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                    <Checkbox
+                      checked={terminationForm.eligibleForRehire}
+                      onCheckedChange={(checked) =>
+                        setTerminationForm((current) => ({
+                          ...current,
+                          eligibleForRehire: checked === true,
+                        }))
+                      }
+                    />
+                    Eligible for rehire
+                  </label>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="termination-notes">Additional Termination Notes</Label>
+                  <Textarea
+                    id="termination-notes"
+                    value={terminationForm.terminationNotes}
+                    onChange={(event) =>
+                      setTerminationForm((current) => ({
+                        ...current,
+                        terminationNotes: event.target.value,
+                      }))
+                    }
+                    rows={2}
+                  />
+                </div>
+
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-4 space-y-3">
+                  <label className="flex items-start gap-3 text-sm font-medium text-amber-950">
+                    <Checkbox
+                      checked={terminationForm.retainAccess}
+                      onCheckedChange={(checked) =>
+                        setTerminationForm((current) => ({
+                          ...current,
+                          retainAccess: checked === true,
+                        }))
+                      }
+                    />
+                    Retain EPOCH access after employment termination
+                  </label>
+
+                  {terminationForm.retainAccess && (
+                    <div className="space-y-3 pl-7">
+                      <p className="text-sm text-amber-900">
+                        Current role and capabilities stay in place until manually changed. This exception expires on{' '}
+                        <span className="font-semibold">
+                          {retainedAccessExpires ? formatDate(retainedAccessExpires.toISOString()) : 'the 90-day review date'}
+                        </span>
+                        .
+                      </p>
+                      <div className="space-y-2">
+                        <Label htmlFor="access-exception-reason">Access Exception Reason</Label>
+                        <Textarea
+                          id="access-exception-reason"
+                          value={terminationForm.accessExceptionReason}
+                          onChange={(event) =>
+                            setTerminationForm((current) => ({
+                              ...current,
+                              accessExceptionReason: event.target.value,
+                            }))
+                          }
+                          placeholder="Document owner/admin approval and why access is being retained."
+                          rows={3}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setShowTerminateDialog(false)}
+                  disabled={terminateEmployeeMutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => terminateEmployeeMutation.mutate()}
+                  disabled={!canTerminate}
+                >
+                  {terminateEmployeeMutation.isPending ? 'Recording...' : 'Record Termination'}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </div>
       </div>
     </div>

--- a/migrations/0161_employee_termination_access_controls.sql
+++ b/migrations/0161_employee_termination_access_controls.sql
@@ -1,0 +1,37 @@
+-- 0161_employee_termination_access_controls.sql
+-- Separate employment lifecycle status from EPOCH login access.
+
+ALTER TABLE employees
+  ADD COLUMN IF NOT EXISTS employment_status TEXT NOT NULL DEFAULT 'ACTIVE',
+  ADD COLUMN IF NOT EXISTS termination_date DATE,
+  ADD COLUMN IF NOT EXISTS termination_reason_code TEXT,
+  ADD COLUMN IF NOT EXISTS termination_reason TEXT,
+  ADD COLUMN IF NOT EXISTS eligible_for_rehire BOOLEAN,
+  ADD COLUMN IF NOT EXISTS final_paycheck_date DATE,
+  ADD COLUMN IF NOT EXISTS termination_notes TEXT,
+  ADD COLUMN IF NOT EXISTS terminated_by_user_id INTEGER REFERENCES users(id),
+  ADD COLUMN IF NOT EXISTS terminated_by_name TEXT,
+  ADD COLUMN IF NOT EXISTS terminated_at TIMESTAMP;
+
+UPDATE employees
+SET employment_status = CASE WHEN COALESCE(is_active, true) THEN 'ACTIVE' ELSE 'TERMINATED' END
+WHERE employment_status IS NULL OR employment_status = '';
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS access_status TEXT NOT NULL DEFAULT 'ACTIVE',
+  ADD COLUMN IF NOT EXISTS access_exception_reason TEXT,
+  ADD COLUMN IF NOT EXISTS access_exception_approved_by_user_id INTEGER REFERENCES users(id),
+  ADD COLUMN IF NOT EXISTS access_exception_approved_by_name TEXT,
+  ADD COLUMN IF NOT EXISTS access_exception_approved_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS access_exception_expires_at TIMESTAMP;
+
+UPDATE users
+SET access_status = CASE WHEN COALESCE(is_active, true) THEN 'ACTIVE' ELSE 'DISABLED' END
+WHERE access_status IS NULL OR access_status = '';
+
+CREATE INDEX IF NOT EXISTS employees_employment_status_idx
+  ON employees(employment_status);
+
+CREATE INDEX IF NOT EXISTS users_access_exception_expires_at_idx
+  ON users(access_exception_expires_at)
+  WHERE access_exception_expires_at IS NOT NULL;

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -1089,6 +1089,16 @@ export const employees = pgTable('employees', {
   buildingKeyAccess: boolean('building_key_access').default(false),
   tciAccess: boolean('tci_access').default(false),
   employmentType: text('employment_type').default('FULL_TIME'), // FULL_TIME, PART_TIME, CONTRACT
+  employmentStatus: text('employment_status').notNull().default('ACTIVE'), // ACTIVE, TERMINATED, LEAVE, CONTRACTOR
+  terminationDate: date('termination_date'),
+  terminationReasonCode: text('termination_reason_code'),
+  terminationReason: text('termination_reason'),
+  eligibleForRehire: boolean('eligible_for_rehire'),
+  finalPaycheckDate: date('final_paycheck_date'),
+  terminationNotes: text('termination_notes'),
+  terminatedByUserId: integer('terminated_by_user_id').references((): AnyPgColumn => users.id),
+  terminatedByName: text('terminated_by_name'),
+  terminatedAt: timestamp('terminated_at'),
   payType: text('pay_type'), // 'HOURLY' | 'SALARY'
   hourlyRate: numeric('hourly_rate', { precision: 12, scale: 2 }),
   salary: numeric('salary', { precision: 12, scale: 2 }),
@@ -1663,6 +1673,12 @@ export const users = pgTable('users', {
   canOverridePrices: boolean('can_override_prices').default(false),
   isFinishTechnician: boolean('is_finish_technician').default(false),
   isActive: boolean('is_active').default(true),
+  accessStatus: text('access_status').notNull().default('ACTIVE'), // ACTIVE, DISABLED, LIMITED, EMERGENCY_ONLY
+  accessExceptionReason: text('access_exception_reason'),
+  accessExceptionApprovedByUserId: integer('access_exception_approved_by_user_id').references(() => users.id),
+  accessExceptionApprovedByName: text('access_exception_approved_by_name'),
+  accessExceptionApprovedAt: timestamp('access_exception_approved_at'),
+  accessExceptionExpiresAt: timestamp('access_exception_expires_at'),
   lastLogin: timestamp('last_login'),
   failedLoginAttempts: integer('failed_login_attempts').default(0),
   accountLockedUntil: timestamp('account_locked_until'),

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -193,6 +193,7 @@ const safeFiles = [
   '0158_inventory_receipt_grni_accounting.sql',
   '0159_epoch_copilot_phase1.sql',
   '0160_po_project_links_safe.sql',
+  '0161_employee_termination_access_controls.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -37,6 +37,7 @@ function buildDeviceFingerprint(ipAddress: string | null | undefined, userAgent:
 
 // ─── Session Audit Helper ─────────────────────────────────────────────────────
 let userSessionsLoginSchemaReady: Promise<void> | null = null;
+let employeeAccessExceptionSchemaReady: Promise<void> | null = null;
 
 function ensureUserSessionsLoginSchema(): Promise<void> {
   if (!userSessionsLoginSchemaReady) {
@@ -54,6 +55,28 @@ function ensureUserSessionsLoginSchema(): Promise<void> {
     });
   }
   return userSessionsLoginSchemaReady;
+}
+
+function ensureEmployeeAccessExceptionSchema(): Promise<void> {
+  if (!employeeAccessExceptionSchemaReady) {
+    employeeAccessExceptionSchemaReady = pool.query(`
+      ALTER TABLE employees
+        ADD COLUMN IF NOT EXISTS employment_status TEXT NOT NULL DEFAULT 'ACTIVE',
+        ADD COLUMN IF NOT EXISTS termination_date DATE;
+
+      ALTER TABLE users
+        ADD COLUMN IF NOT EXISTS access_status TEXT NOT NULL DEFAULT 'ACTIVE',
+        ADD COLUMN IF NOT EXISTS access_exception_reason TEXT,
+        ADD COLUMN IF NOT EXISTS access_exception_approved_by_user_id INTEGER REFERENCES users(id),
+        ADD COLUMN IF NOT EXISTS access_exception_approved_by_name TEXT,
+        ADD COLUMN IF NOT EXISTS access_exception_approved_at TIMESTAMP,
+        ADD COLUMN IF NOT EXISTS access_exception_expires_at TIMESTAMP;
+    `).then(() => undefined).catch((err) => {
+      employeeAccessExceptionSchemaReady = null;
+      throw err;
+    });
+  }
+  return employeeAccessExceptionSchemaReady;
 }
 
 async function ensureHardcodedLoginUser(user: {
@@ -731,6 +754,8 @@ router.post('/login', loginRateLimiter, async (req, res) => {
         .json({ error: 'Username and password are required' });
     }
 
+    await ensureEmployeeAccessExceptionSchema();
+
     // Try to find user in database first using Drizzle ORM
     const dbUserResult = await db.select({
       id: users.id,
@@ -738,6 +763,8 @@ router.post('/login', loginRateLimiter, async (req, res) => {
       passwordHash: users.passwordHash,
       role: users.role,
       isActive: users.isActive,
+      employeeId: users.employeeId,
+      accessExceptionExpiresAt: users.accessExceptionExpiresAt,
     }).from(users).where(sql`LOWER(${users.username}) = LOWER(${username})`);
 
     let user: any;
@@ -751,6 +778,37 @@ router.post('/login', loginRateLimiter, async (req, res) => {
       const devAuthBypass = process.env.DEV_AUTH_BYPASS === 'true';
       if (dbUser.isActive === false && !devAuthBypass) {
         return res.status(401).json({ error: 'Account is inactive' });
+      }
+
+      if (dbUser.employeeId && dbUser.accessExceptionExpiresAt && new Date(dbUser.accessExceptionExpiresAt) <= new Date()) {
+        await pool.query(
+          `UPDATE users
+           SET is_active = false,
+               access_status = 'DISABLED',
+               updated_at = NOW()
+           WHERE id = $1`,
+          [dbUser.id]
+        );
+        await recordAuditEvent({
+          eventType: 'TERMINATED_EMPLOYEE_ACCESS_EXPIRED',
+          subjectType: 'user',
+          subjectId: String(dbUser.id),
+          sourceService: 'auth.route',
+          actor: { id: dbUser.id, username: dbUser.username, role: dbUser.role },
+          reason: 'Retained access expired 90 days after termination date',
+          fieldsChanged: {
+            isActive: { before: true, after: false },
+            accessStatus: { before: 'ACTIVE', after: 'DISABLED' },
+          },
+          payload: {
+            userId: dbUser.id,
+            employeeId: dbUser.employeeId,
+            accessExceptionExpiresAt: new Date(dbUser.accessExceptionExpiresAt).toISOString(),
+          },
+          ipAddress: req.ip ?? null,
+          userAgent: req.headers['user-agent'] ?? null,
+        });
+        return res.status(401).json({ error: 'Account access exception has expired' });
       }
 
       // Verify password against database hash
@@ -837,6 +895,48 @@ router.post('/login', loginRateLimiter, async (req, res) => {
       ipAddress ?? undefined,
       userAgent ?? undefined
     );
+
+    const terminatedAccessRows = await pool.query(
+      `SELECT
+         e.id AS "employeeId",
+         e.name AS "employeeName",
+         e.termination_date AS "terminationDate",
+         u.access_exception_expires_at AS "accessExceptionExpiresAt"
+       FROM users u
+       JOIN employees e ON e.id = u.employee_id
+       WHERE u.id = $1
+         AND e.employment_status = 'TERMINATED'
+         AND u.is_active = true
+       LIMIT 1`,
+      [user.id]
+    );
+    const terminatedAccess = terminatedAccessRows.rows?.[0] ?? terminatedAccessRows[0];
+    if (terminatedAccess) {
+      await recordAuditEvent({
+        eventType: 'TERMINATED_EMPLOYEE_LOGIN',
+        subjectType: 'user',
+        subjectId: String(user.id),
+        sourceService: 'auth.route',
+        actor: { id: user.id, username: user.username, role: user.role },
+        reason: 'Terminated employee retained EPOCH access',
+        payload: {
+          userId: user.id,
+          username: user.username,
+          employeeId: terminatedAccess.employeeId,
+          employeeName: terminatedAccess.employeeName,
+          terminationDate: terminatedAccess.terminationDate,
+          accessExceptionExpiresAt: terminatedAccess.accessExceptionExpiresAt,
+          sessionId: newSessionId,
+        },
+        meta: {
+          employeeId: terminatedAccess.employeeId,
+          employeeName: terminatedAccess.employeeName,
+          sessionId: newSessionId,
+        },
+        ipAddress: ipAddress ?? null,
+        userAgent: userAgent ?? null,
+      });
+    }
 
     console.log('✅ Session saved to database for user:', user.username);
 

--- a/server/src/routes/employees.ts
+++ b/server/src/routes/employees.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import bcrypt from 'bcrypt';
+import { z } from 'zod';
 import { storage } from '../../storage';
 import { pool, pgPool } from '../../db';
 import { authenticateToken, requireRole } from '../../middleware/auth';
@@ -31,6 +32,73 @@ import {
 const router = Router();
 
 let chargeCodeAssignmentTableReady: Promise<void> | null = null;
+let employeeTerminationSchemaReady: Promise<void> | null = null;
+
+function rows<T = any>(result: any): T[] {
+  return Array.isArray(result) ? result : (result?.rows ?? []);
+}
+
+function requireAdminOrOwner(req: Request, res: Response): boolean {
+  const role = String(req.user?.role ?? '').toUpperCase();
+  if (role === 'ADMIN' || role === 'OWNER') return true;
+  res.status(403).json({ error: 'Admin or owner access required' });
+  return false;
+}
+
+function actor(req: Request) {
+  return {
+    id: req.user?.id ?? null,
+    username: req.user?.username ?? 'unknown',
+    role: req.user?.role ?? null,
+  };
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function ensureEmployeeTerminationSchema(): Promise<void> {
+  if (!employeeTerminationSchemaReady) {
+    employeeTerminationSchemaReady = pool.query(`
+      ALTER TABLE employees
+        ADD COLUMN IF NOT EXISTS employment_status TEXT NOT NULL DEFAULT 'ACTIVE',
+        ADD COLUMN IF NOT EXISTS termination_date DATE,
+        ADD COLUMN IF NOT EXISTS termination_reason_code TEXT,
+        ADD COLUMN IF NOT EXISTS termination_reason TEXT,
+        ADD COLUMN IF NOT EXISTS eligible_for_rehire BOOLEAN,
+        ADD COLUMN IF NOT EXISTS final_paycheck_date DATE,
+        ADD COLUMN IF NOT EXISTS termination_notes TEXT,
+        ADD COLUMN IF NOT EXISTS terminated_by_user_id INTEGER REFERENCES users(id),
+        ADD COLUMN IF NOT EXISTS terminated_by_name TEXT,
+        ADD COLUMN IF NOT EXISTS terminated_at TIMESTAMP;
+
+      ALTER TABLE users
+        ADD COLUMN IF NOT EXISTS access_status TEXT NOT NULL DEFAULT 'ACTIVE',
+        ADD COLUMN IF NOT EXISTS access_exception_reason TEXT,
+        ADD COLUMN IF NOT EXISTS access_exception_approved_by_user_id INTEGER REFERENCES users(id),
+        ADD COLUMN IF NOT EXISTS access_exception_approved_by_name TEXT,
+        ADD COLUMN IF NOT EXISTS access_exception_approved_at TIMESTAMP,
+        ADD COLUMN IF NOT EXISTS access_exception_expires_at TIMESTAMP;
+    `).then(() => undefined).catch((error) => {
+      employeeTerminationSchemaReady = null;
+      throw error;
+    });
+  }
+  return employeeTerminationSchemaReady;
+}
+
+const terminationSchema = z.object({
+  terminationDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  terminationReasonCode: z.string().trim().min(1),
+  terminationReason: z.string().trim().min(1),
+  eligibleForRehire: z.boolean().nullable().optional(),
+  finalPaycheckDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
+  terminationNotes: z.string().trim().nullable().optional(),
+  retainAccess: z.boolean().default(false),
+  accessExceptionReason: z.string().trim().optional().nullable(),
+});
 
 function ensureChargeCodeAssignmentTable(): Promise<void> {
   if (!chargeCodeAssignmentTableReady) {
@@ -117,17 +185,38 @@ async function generateNextEmployeeCode(): Promise<string> {
 // Employee Management Routes
 router.get('/', async (req: Request, res: Response) => {
   try {
-    const employees = await storage.getAllEmployees();
+    await ensureEmployeeTerminationSchema();
+    const includeInactive =
+      req.query.includeInactive === 'true' ||
+      req.query.includeTerminated === 'true' ||
+      req.query.isActive === 'false';
+    const allEmployees = await storage.getAllEmployees();
+    const employees = includeInactive
+      ? allEmployees
+      : allEmployees.filter((employee: any) =>
+          employee.isActive !== false &&
+          String(employee.employmentStatus ?? 'ACTIVE').toUpperCase() !== 'TERMINATED'
+        );
     // Enrich each employee with the linked auth user's integer ID so that
     // callers can map ownerUserId (auth user ID) → employee name.
-    let userIdByEmployeeId: Record<number, number> = {};
+    let userByEmployeeId: Record<number, any> = {};
     try {
-      const rows = await pool.query(
-        `SELECT id AS "userId", employee_id AS "employeeId" FROM users WHERE employee_id IS NOT NULL AND is_active = true`
+      const userRows = await pool.query(
+        `SELECT
+           id AS "userId",
+           employee_id AS "employeeId",
+           is_active AS "userIsActive",
+           access_status AS "accessStatus",
+           access_exception_reason AS "accessExceptionReason",
+           access_exception_approved_by_name AS "accessExceptionApprovedByName",
+           access_exception_approved_at AS "accessExceptionApprovedAt",
+           access_exception_expires_at AS "accessExceptionExpiresAt"
+         FROM users
+         WHERE employee_id IS NOT NULL`
       );
-      for (const row of rows) {
+      for (const row of rows<any>(userRows)) {
         if (row.employeeId) {
-          userIdByEmployeeId[row.employeeId] = row.userId;
+          userByEmployeeId[row.employeeId] = row;
         }
       }
     } catch (e) {
@@ -135,9 +224,19 @@ router.get('/', async (req: Request, res: Response) => {
     }
     const enriched = employees.map((emp) => {
       const { timekeeperPin, ...rest } = emp;
+      const linkedUser = userByEmployeeId[emp.id] ?? null;
       return {
         ...rest,
-        userId: userIdByEmployeeId[emp.id] ?? null,
+        userId: linkedUser?.userId ?? null,
+        userIsActive: linkedUser?.userIsActive ?? null,
+        accessStatus: linkedUser?.accessStatus ?? null,
+        accessExceptionReason: linkedUser?.accessExceptionReason ?? null,
+        accessExceptionApprovedByName: linkedUser?.accessExceptionApprovedByName ?? null,
+        accessExceptionApprovedAt: linkedUser?.accessExceptionApprovedAt ?? null,
+        accessExceptionExpiresAt: linkedUser?.accessExceptionExpiresAt ?? null,
+        terminatedWithAccess:
+          String((emp as any).employmentStatus ?? '').toUpperCase() === 'TERMINATED' &&
+          linkedUser?.userIsActive === true,
         hasPin: timekeeperPin !== null && timekeeperPin !== undefined,
       };
     });
@@ -1366,14 +1465,231 @@ router.get('/:id/training-matrix', async (req: Request, res: Response) => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Parametric routes MUST come after all specific routes
+router.post('/:id/terminate', authenticateToken, async (req: Request, res: Response) => {
+  if (!requireAdminOrOwner(req, res)) return;
+
+  const employeeId = Number(req.params.id);
+  if (!Number.isInteger(employeeId) || employeeId <= 0) {
+    res.status(400).json({ error: 'Invalid employee id' });
+    return;
+  }
+
+  const parsed = terminationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid termination data', details: parsed.error.flatten() });
+    return;
+  }
+
+  if (parsed.data.retainAccess && !parsed.data.accessExceptionReason?.trim()) {
+    res.status(400).json({ error: 'Retained access requires an access exception reason.' });
+    return;
+  }
+
+  try {
+    await ensureEmployeeTerminationSchema();
+    const currentEmployee = await storage.getEmployee(employeeId);
+    if (!currentEmployee) {
+      res.status(404).json({ error: 'Employee not found' });
+      return;
+    }
+
+    const termDate = new Date(`${parsed.data.terminationDate}T00:00:00`);
+    const accessExpiresAt = addDays(termDate, 90);
+    const currentActor = actor(req);
+
+    const client = await pgPool.connect();
+    let updatedEmployee: any = null;
+    let linkedUser: any = null;
+    try {
+      await client.query('BEGIN');
+      const employeeResult = await client.query(
+        `UPDATE employees
+         SET employment_status = 'TERMINATED',
+             is_active = false,
+             termination_date = $1,
+             termination_reason_code = $2,
+             termination_reason = $3,
+             eligible_for_rehire = $4,
+             final_paycheck_date = $5,
+             termination_notes = $6,
+             terminated_by_user_id = $7,
+             terminated_by_name = $8,
+             terminated_at = NOW(),
+             updated_at = NOW()
+         WHERE id = $9
+         RETURNING *`,
+        [
+          parsed.data.terminationDate,
+          parsed.data.terminationReasonCode,
+          parsed.data.terminationReason,
+          parsed.data.eligibleForRehire ?? null,
+          parsed.data.finalPaycheckDate ?? null,
+          parsed.data.terminationNotes ?? null,
+          currentActor.id,
+          currentActor.username,
+          employeeId,
+        ]
+      );
+      updatedEmployee = rows(employeeResult)[0];
+
+      const userResult = await client.query(
+        `UPDATE users
+         SET is_active = $1,
+             access_status = $2,
+             access_exception_reason = $3,
+             access_exception_approved_by_user_id = $4,
+             access_exception_approved_by_name = $5,
+             access_exception_approved_at = CASE WHEN $1 THEN NOW() ELSE NULL END,
+             access_exception_expires_at = $6,
+             updated_at = NOW()
+         WHERE employee_id = $7
+         RETURNING id, username, role, is_active AS "userIsActive",
+                   access_status AS "accessStatus",
+                   access_exception_reason AS "accessExceptionReason",
+                   access_exception_approved_by_name AS "accessExceptionApprovedByName",
+                   access_exception_approved_at AS "accessExceptionApprovedAt",
+                   access_exception_expires_at AS "accessExceptionExpiresAt"`,
+        [
+          parsed.data.retainAccess,
+          parsed.data.retainAccess ? 'ACTIVE' : 'DISABLED',
+          parsed.data.retainAccess ? parsed.data.accessExceptionReason : null,
+          parsed.data.retainAccess ? currentActor.id : null,
+          parsed.data.retainAccess ? currentActor.username : null,
+          parsed.data.retainAccess ? accessExpiresAt : null,
+          employeeId,
+        ]
+      );
+      linkedUser = rows(userResult)[0] ?? null;
+
+      if (!parsed.data.retainAccess) {
+        await client.query(
+          `UPDATE user_sessions
+           SET is_active = false
+           WHERE user_id IN (SELECT id FROM users WHERE employee_id = $1)`,
+          [employeeId]
+        );
+      }
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+
+    await recordAuditEvent({
+      eventType: 'EMPLOYEE_TERMINATED',
+      subjectType: 'employee',
+      subjectId: String(employeeId),
+      sourceService: 'employees.routes',
+      actor: currentActor,
+      reason: parsed.data.terminationReason,
+      fieldsChanged: {
+        employmentStatus: { before: (currentEmployee as any).employmentStatus ?? 'ACTIVE', after: 'TERMINATED' },
+        isActive: { before: currentEmployee.isActive, after: false },
+        terminationDate: { before: (currentEmployee as any).terminationDate ?? null, after: parsed.data.terminationDate },
+      },
+      meta: { employeeName: currentEmployee.name, retainAccess: parsed.data.retainAccess },
+      payload: {
+        employeeId,
+        employeeName: currentEmployee.name,
+        terminationDate: parsed.data.terminationDate,
+        terminationReasonCode: parsed.data.terminationReasonCode,
+        eligibleForRehire: parsed.data.eligibleForRehire ?? null,
+        finalPaycheckDate: parsed.data.finalPaycheckDate ?? null,
+        retainAccess: parsed.data.retainAccess,
+        accessExceptionExpiresAt: parsed.data.retainAccess ? accessExpiresAt.toISOString() : null,
+      },
+      ipAddress: req.ip ?? null,
+      userAgent: req.headers['user-agent'] ?? null,
+    });
+
+    if (parsed.data.retainAccess && linkedUser) {
+      await recordAuditEvent({
+        eventType: 'TERMINATED_EMPLOYEE_ACCESS_RETAINED',
+        subjectType: 'user',
+        subjectId: String(linkedUser.id),
+        sourceService: 'employees.routes',
+        actor: currentActor,
+        reason: parsed.data.accessExceptionReason,
+        fieldsChanged: {
+          userIsActive: { before: null, after: true },
+          accessExceptionExpiresAt: { before: null, after: accessExpiresAt.toISOString() },
+        },
+        meta: { employeeId, employeeName: currentEmployee.name },
+        payload: {
+          employeeId,
+          employeeName: currentEmployee.name,
+          username: linkedUser.username,
+          role: linkedUser.role,
+          accessExceptionExpiresAt: accessExpiresAt.toISOString(),
+        },
+        ipAddress: req.ip ?? null,
+        userAgent: req.headers['user-agent'] ?? null,
+      });
+    }
+
+    res.json({
+      ...updatedEmployee,
+      userId: linkedUser?.id ?? null,
+      userIsActive: linkedUser?.userIsActive ?? null,
+      accessStatus: linkedUser?.accessStatus ?? null,
+      accessExceptionReason: linkedUser?.accessExceptionReason ?? null,
+      accessExceptionApprovedByName: linkedUser?.accessExceptionApprovedByName ?? null,
+      accessExceptionApprovedAt: linkedUser?.accessExceptionApprovedAt ?? null,
+      accessExceptionExpiresAt: linkedUser?.accessExceptionExpiresAt ?? null,
+      terminatedWithAccess: Boolean(linkedUser?.userIsActive),
+    });
+  } catch (error) {
+    console.error('Terminate employee error:', error);
+    res.status(500).json({ error: 'Failed to terminate employee' });
+  }
+});
+
 router.get('/:id', async (req: Request, res: Response) => {
   try {
+    await ensureEmployeeTerminationSchema();
     const raw = await storage.getEmployee(parseInt(req.params.id));
     if (!raw) {
       return res.status(404).json({ error: 'Employee not found' });
     }
     const { timekeeperPin, ...employee } = raw;
-    res.json({ ...employee, hasPin: timekeeperPin !== null && timekeeperPin !== undefined });
+    let linkedUser: any = null;
+    try {
+      const userResult = await pool.query(
+        `SELECT
+           id AS "userId",
+           is_active AS "userIsActive",
+           access_status AS "accessStatus",
+           access_exception_reason AS "accessExceptionReason",
+           access_exception_approved_by_name AS "accessExceptionApprovedByName",
+           access_exception_approved_at AS "accessExceptionApprovedAt",
+           access_exception_expires_at AS "accessExceptionExpiresAt"
+         FROM users
+         WHERE employee_id = $1
+         ORDER BY id DESC
+         LIMIT 1`,
+        [employee.id]
+      );
+      linkedUser = rows(userResult)[0] ?? null;
+    } catch (error) {
+      console.error('Error fetching employee linked user:', error);
+    }
+    res.json({
+      ...employee,
+      userId: linkedUser?.userId ?? null,
+      userIsActive: linkedUser?.userIsActive ?? null,
+      accessStatus: linkedUser?.accessStatus ?? null,
+      accessExceptionReason: linkedUser?.accessExceptionReason ?? null,
+      accessExceptionApprovedByName: linkedUser?.accessExceptionApprovedByName ?? null,
+      accessExceptionApprovedAt: linkedUser?.accessExceptionApprovedAt ?? null,
+      accessExceptionExpiresAt: linkedUser?.accessExceptionExpiresAt ?? null,
+      terminatedWithAccess:
+        String((employee as any).employmentStatus ?? '').toUpperCase() === 'TERMINATED' &&
+        linkedUser?.userIsActive === true,
+      hasPin: timekeeperPin !== null && timekeeperPin !== undefined,
+    });
   } catch (error) {
     console.error('Get employee error:', error);
     res.status(500).json({ error: 'Failed to fetch employee' });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -800,7 +800,7 @@ import {
 const VENDOR_DATE_COLUMNS = ['evaluationDate', 'startRenewalDate', 'approvalExpiration'] as const;
 
 // Employee date columns that must be normalised to "YYYY-MM-DD" strings.
-const EMPLOYEE_DATE_COLUMNS = ['hireDate', 'dateOfBirth', 'driversLicenseExpiration'] as const;
+const EMPLOYEE_DATE_COLUMNS = ['hireDate', 'dateOfBirth', 'driversLicenseExpiration', 'terminationDate', 'finalPaycheckDate'] as const;
 
 // Vendor PO date columns that must be normalised to "YYYY-MM-DD" strings.
 const VENDOR_PO_DATE_COLUMNS = ['orderDate', 'expectedDeliveryDate', 'actualDeliveryDate'] as const;
@@ -7418,6 +7418,12 @@ export class DatabaseStorage implements IStorage {
     if (insertData.hireDate instanceof Date) {
       insertData.hireDate = insertData.hireDate.toISOString().split('T')[0];
     }
+    if (insertData.terminationDate instanceof Date) {
+      insertData.terminationDate = insertData.terminationDate.toISOString().split('T')[0];
+    }
+    if (insertData.finalPaycheckDate instanceof Date) {
+      insertData.finalPaycheckDate = insertData.finalPaycheckDate.toISOString().split('T')[0];
+    }
 
     const [employee] = await db
       .insert(employees)
@@ -7447,6 +7453,12 @@ export class DatabaseStorage implements IStorage {
     }
     if (updateData.driversLicenseExpiration instanceof Date) {
       updateData.driversLicenseExpiration = updateData.driversLicenseExpiration.toISOString().split('T')[0];
+    }
+    if (updateData.terminationDate instanceof Date) {
+      updateData.terminationDate = updateData.terminationDate.toISOString().split('T')[0];
+    }
+    if (updateData.finalPaycheckDate instanceof Date) {
+      updateData.finalPaycheckDate = updateData.finalPaycheckDate.toISOString().split('T')[0];
     }
 
     // Convert portalTokenExpiry string → Date for Drizzle's timestamp column


### PR DESCRIPTION
## Summary
- add audited chart-of-accounts metadata editing and sticky COA header from the earlier fixes in this branch
- add employee termination fields, migration, and safe boot migration registration
- add termination workflow that separates employment status from EPOCH access, supports owner/admin retained-access exceptions, audits changes/logins, and expires exceptions after 90 days

## Verification
- git diff --check passed with only Windows line-ending warnings
- npm run check could not complete because this workspace is missing the local TypeScript binary (`tsc` is not recognized)
