### PR TITLE
Fix shipping label customer notification preferences

### DIFF
--- a/server/src/routes/shipping.ts
+++ b/server/src/routes/shipping.ts
@@ -1092,15 +1092,15 @@ router.post('/create-label', requirePermission('shipping.create_label'), async (
 
             if (customer && (customer.email || customer.phone)) {
               // Send notification respecting customer preference (ONE channel only)
-              const { sendCustomerNotification } = await import(
+              const { normalizeNotificationMethods, sendCustomerNotification } = await import(
                 '../../utils/notifications'
               );
               
               // Use customer's preferred communication method - NOT all available channels
-              const customerPreference = (customer.preferredCommunicationMethod as string[]) || [];
-              const preferredMethods: string[] = customerPreference.length > 0 
-                ? customerPreference 
-                : (customer.email ? ['email'] : (customer.phone ? ['sms'] : []));
+              const preferredMethods = normalizeNotificationMethods(
+                customer.preferredCommunicationMethod,
+                { email: customer.email, phone: customer.phone }
+              );
               
               console.log(`[LABEL-NOTIFY] Order ${orderId} - Customer preference: ${preferredMethods.join(', ')}`);
               

--- a/server/utils/notifications.ts
+++ b/server/utils/notifications.ts
@@ -37,14 +37,14 @@ export function normalizeNotificationMethods(
   const rawMethods = Array.isArray(preferredMethods)
     ? preferredMethods
     : typeof preferredMethods === 'string'
-      ? preferredMethods.split(/[,\s]+/)
+      ? preferredMethods.split(/[\s,;|/]+/)
       : [];
 
   const normalized = rawMethods
-    .map((method) => String(method).trim().toLowerCase())
+    .map((method) => String(method || '').trim().toLowerCase())
     .map((method) => {
-      if (method === 'text' || method === 'phone') return 'sms';
-      if (method === 'e-mail') return 'email';
+      if (['text', 'txt', 'phone', 'mobile'].includes(method)) return 'sms';
+      if (['e-mail', 'mail'].includes(method)) return 'email';
       return method;
     })
     .filter((method): method is 'email' | 'sms' => method === 'email' || method === 'sms');


### PR DESCRIPTION
## Summary
- Route UPS label-created customer notifications through the shared notification preference normalizer
- Harden notification preference parsing for string values separated by spaces, commas, semicolons, pipes, or slashes
- Preserve fallback to available customer email/phone when no valid preference is stored

## Validation
- `node --experimental-strip-types --check server/utils/notifications.ts`
- `node --experimental-strip-types --check server/src/routes/shipping.ts`
- `node --experimental-strip-types --check server/src/routes/orders.ts`
- `git diff --check`