### PR TITLE
[codex] Remove P2 customer tab from control center

### DIFF
--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -33,8 +33,7 @@ import {
   ChevronRight,
   Filter,
   X,
-  Lock,
-  Users
+  Lock
 } from 'lucide-react';
 import { Link, useLocation } from 'wouter';
 import P2POCreationWizard from '@/components/p2/P2POCreationWizard';
@@ -48,7 +47,6 @@ import RoutingDocumentManagement from './RoutingDocumentManagement';
 import P2ChangesTab from '@/components/p2/P2ChangesTab';
 import P2ShippingTab from '@/components/p2/P2ShippingTab';
 import P2NonconformingTab from '@/components/p2/P2ScrappedItemsTab';
-import P2CustomersPage from './P2CustomersPage';
 import { TravelerCapturedDataById } from '@/components/p2/TravelerCapturedData';
 import ProgramManufacturingOrchestration from '@/components/p2/ProgramManufacturingOrchestration';
 import { queryClient, apiRequest } from '@/lib/queryClient';
@@ -109,12 +107,15 @@ export default function P2ControlCenter() {
   const wadProjectId = urlParams.get('projectId') || '';
   const wadProjectName = urlParams.get('projectName') || '';
   const wadPoId = urlParams.get('poId') || '';
-  const [activeTab, setActiveTab] = useState(tabFromUrl === 'pos' ? 'status' : tabFromUrl || 'status');
+  const resolveControlCenterTab = (tab: string | null) => {
+    return tab === 'pos' || tab === 'customers' ? 'status' : tab || 'status';
+  };
+  const [activeTab, setActiveTab] = useState(resolveControlCenterTab(tabFromUrl));
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const tab = params.get('tab');
-    if (tab) setActiveTab(tab === 'pos' ? 'status' : tab);
+    if (tab) setActiveTab(resolveControlCenterTab(tab));
   }, [location]);
 
   const [showPOWizard, setShowPOWizard] = useState(false);
@@ -703,10 +704,6 @@ export default function P2ControlCenter() {
             <BarChart3 className="h-4 w-4" />
             Status
           </TabsTrigger>
-          <TabsTrigger value="customers" className="flex items-center gap-2" data-testid="tab-customers">
-            <Users className="h-4 w-4" />
-            Customers
-          </TabsTrigger>
           <TabsTrigger value="setup" className="flex items-center gap-2" data-testid="tab-setup">
             <Settings className="h-4 w-4" />
             Setup
@@ -773,10 +770,6 @@ export default function P2ControlCenter() {
             }}
             selectedPOIds={selectedPOIds}
           />
-        </TabsContent>
-
-        <TabsContent value="customers">
-          <P2CustomersPage />
         </TabsContent>
 
         <TabsContent value="setup">


### PR DESCRIPTION
## Summary

- Removes the Customers tab from the P2 Control Center tab list.
- Removes the embedded Customers tab content panel from the P2 Control Center.
- Redirects legacy `?tab=customers` links to Status, matching the existing hidden-tab fallback behavior.

## Impact

P2 customer management remains available through its standalone page and backend routes. The P2 Control Center no longer exposes that customer management surface as an in-page tab.

## Validation

- `git diff --check origin/main..HEAD`
- Confirmed the PR compare is scoped to `client/src/pages/P2ControlCenter.tsx`

Full `npm run check` could not be run locally because `npm` is not available on PATH in this environment, and this clean worktree does not have `node_modules/.bin/tsc.cmd`.