### PR TITLE
[codex] Fix P1 shipping rollback tracking

### DIFF
--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -66,6 +66,9 @@ const READY_FOR_SHIPPING_STATUSES = new Set([
   'ready to ship',
 ]);
 
+const FULFILLED_STATUSES = new Set(['fulfilled', 'shipped']);
+const READY_FOR_SHIPPING_STATUS = 'Ready for Shipping';
+
 function shouldResetReadyForShippingToInProgress(
   currentDepartment: string | null | undefined,
   targetDepartment: string | null | undefined,
@@ -77,6 +80,23 @@ function shouldResetReadyForShippingToInProgress(
 
   const normalizedStatus = String(currentStatus || '').trim().toLowerCase();
   return READY_FOR_SHIPPING_STATUSES.has(normalizedStatus);
+}
+
+function shouldResetFulfilledToReadyForShipping(
+  currentDepartment: string | null | undefined,
+  targetDepartment: string | null | undefined,
+  currentStatus: string | null | undefined
+): boolean {
+  if (targetDepartment !== 'Shipping') {
+    return false;
+  }
+
+  const normalizedStatus = String(currentStatus || '').trim().toLowerCase();
+  return (
+    FULFILLED_STATUSES.has(normalizedStatus) ||
+    currentDepartment === 'Shipping Management' ||
+    currentDepartment === 'Fulfilled'
+  );
 }
 
 async function requiresP1PaymentAccountingApproval(paymentDate: Date, user: any): Promise<{ required: boolean; period: any }> {
@@ -2894,6 +2914,17 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
       ) {
         updateData.status = 'IN_PROGRESS';
       }
+      if (
+        shouldResetFulfilledToReadyForShipping(
+          existingOrder.currentDepartment,
+          targetDepartment,
+          existingOrder.status
+        )
+      ) {
+        updateData.status = READY_FOR_SHIPPING_STATUS;
+        updateData.shippedDate = null;
+        updateData.shippingCompletedAt = null;
+      }
     }
 
     // Build actor from authenticated user
@@ -3855,6 +3886,11 @@ router.patch(
       department,
       existingOrder?.status ?? existingOrder?.productionStatus
     );
+    const shouldResetStatusToReadyForShipping = shouldResetFulfilledToReadyForShipping(
+      previousDepartment,
+      department,
+      existingOrder?.status ?? existingOrder?.productionStatus
+    );
 
     // Try to find and update the order
     let updatedOrder;
@@ -3867,6 +3903,11 @@ router.patch(
       if (shouldResetStatusToInProgress) {
         finalizedUpdates.status = 'IN_PROGRESS';
       }
+      if (shouldResetStatusToReadyForShipping) {
+        finalizedUpdates.status = READY_FOR_SHIPPING_STATUS;
+        finalizedUpdates.shippedDate = null;
+        finalizedUpdates.shippingCompletedAt = null;
+      }
       updatedOrder = await storage.updateFinalizedOrder(orderId, finalizedUpdates);
       orderType = 'finalized';
       console.log(`✅ Updated finalized order ${orderId} to ${department}`);
@@ -3877,6 +3918,11 @@ router.patch(
         };
         if (shouldResetStatusToInProgress) {
           draftUpdates.status = 'IN_PROGRESS';
+        }
+        if (shouldResetStatusToReadyForShipping) {
+          draftUpdates.status = READY_FOR_SHIPPING_STATUS;
+          draftUpdates.shippedDate = null;
+          draftUpdates.shippingCompletedAt = null;
         }
         updatedOrder = await storage.updateOrderDraft(orderId, draftUpdates);
         orderType = 'draft';

--- a/server/src/routes/shipping.ts
+++ b/server/src/routes/shipping.ts
@@ -20,6 +20,23 @@ import {
 
 const router = Router();
 
+function getUpsPackageResults(shipmentResults: any): any {
+  const packageResults = shipmentResults?.PackageResults;
+  return Array.isArray(packageResults) ? packageResults[0] : packageResults;
+}
+
+function getUpsTrackingNumber(shipmentResults: any): string | undefined {
+  const packageResults = getUpsPackageResults(shipmentResults);
+  const packageTracking = packageResults?.TrackingNumber;
+  if (typeof packageTracking === 'string' && packageTracking.trim()) {
+    return packageTracking;
+  }
+  if (typeof packageTracking?.Value === 'string' && packageTracking.Value.trim()) {
+    return packageTracking.Value;
+  }
+  return shipmentResults?.ShipmentIdentificationNumber;
+}
+
 // Helper function to normalize country names to ISO country codes for UPS API
 function getCountryCode(country: string | undefined): string {
   if (!country) return 'US';
@@ -1042,7 +1059,7 @@ router.post('/create-label', requirePermission('shipping.create_label'), async (
     const labelBase64 =
       shipmentResults?.PackageResults?.[0]?.ShippingLabel?.GraphicImage ||
       shipmentResults?.PackageResults?.ShippingLabel?.GraphicImage;
-    const trackingNumber = shipmentResults?.ShipmentIdentificationNumber;
+    const trackingNumber = getUpsTrackingNumber(shipmentResults);
     // Use negotiated rate if available, otherwise use retail rate
     const negotiatedCost = shipmentResults?.NegotiatedRateCharges?.TotalCharge?.MonetaryValue;
     const retailCost = shipmentResults?.ShipmentCharges?.TotalCharges?.MonetaryValue;
@@ -1060,6 +1077,7 @@ router.post('/create-label', requirePermission('shipping.create_label'), async (
             shippingMethod: getServiceName(serviceType || '03'),
             shippingCost: shipmentCost ? parseFloat(shipmentCost) : null,
             labelGenerated: true,
+            shippingLabelGenerated: true,
             labelGeneratedAt: new Date(),
             shippedDate: new Date(),
           };
@@ -2025,7 +2043,7 @@ router.post('/bulk/create-consolidated-label', async (req: Request, res: Respons
     const labelBase64 =
       shipmentResults?.PackageResults?.[0]?.ShippingLabel?.GraphicImage ||
       shipmentResults?.PackageResults?.ShippingLabel?.GraphicImage;
-    const trackingNumber = shipmentResults?.ShipmentIdentificationNumber;
+    const trackingNumber = getUpsTrackingNumber(shipmentResults);
     // Use negotiated rate if available, otherwise use retail rate
     const negotiatedCost = shipmentResults?.NegotiatedRateCharges?.TotalCharge?.MonetaryValue;
     const retailCost = shipmentResults?.ShipmentCharges?.TotalCharges?.MonetaryValue;
@@ -2479,7 +2497,7 @@ router.post('/bulk/create-labels', async (req: Request, res: Response) => {
 
           const shipmentResults = shipResponse.data?.ShipmentResponse?.ShipmentResults;
           const labelBase64 = shipmentResults?.PackageResults?.[0]?.ShippingLabel?.GraphicImage;
-          const trackingNumber = shipmentResults?.ShipmentIdentificationNumber;
+          const trackingNumber = getUpsTrackingNumber(shipmentResults);
 
           if (labelBase64 && trackingNumber) {
             // Update NCR with tracking number (instead of order)
@@ -2659,7 +2677,7 @@ router.post('/bulk/create-labels', async (req: Request, res: Response) => {
 
         const shipmentResults = shipResponse.data?.ShipmentResponse?.ShipmentResults;
         const labelBase64 = shipmentResults?.PackageResults?.[0]?.ShippingLabel?.GraphicImage;
-        const trackingNumber = shipmentResults?.ShipmentIdentificationNumber;
+        const trackingNumber = getUpsTrackingNumber(shipmentResults);
 
         if (labelBase64 && trackingNumber) {
           // Update order with tracking number


### PR DESCRIPTION
## Summary
- Reset fulfilled P1 orders moved back to Shipping to `Ready for Shipping`.
- Clear fulfilled shipment timestamps on that rollback so the order leaves completed-shipment views until it is fulfilled again.
- Use the UPS package tracking number returned by label creation paths, with shipment ID fallback, and set the canonical single-label generated flag.

## Root Cause
Fulfilled P1 orders could be moved back into Shipping without resetting their fulfilled status/timestamps, leaving them treated as completed shipments. Label creation also relied only on the shipment-level UPS ID instead of preferring the package tracking number.

## Validation
- `git diff --check -- server/src/routes/orders.ts server/src/routes/shipping.ts` passed with only CRLF warnings.
- `npm` is not installed in this environment.
- Node syntax checks were not runnable because the WindowsApps `node.exe` is blocked with `Access is denied`.