### PR TITLE
[codex] Add P2 production change form approvals

### DIFF
--- a/client/src/components/p2/P2ChangesTab.tsx
+++ b/client/src/components/p2/P2ChangesTab.tsx
@@ -23,9 +23,15 @@ const productionChangeSchema = z.object({
   changeType: z.string().min(1, 'Change type is required'),
   scope: z.string().default('PO'),
   partNumber: z.string().optional(),
+  currentRevision: z.string().optional(),
+  proposedRevision: z.string().optional(),
   proposedChange: z.string().min(1, 'Proposed change description is required'),
   reason: z.string().min(1, 'Reason is required'),
   riskAssessment: z.string().optional(),
+  affectedDocuments: z.array(z.string()).default([]),
+  requiredActions: z.array(z.string()).default([]),
+  approverEmployeeId: z.string().min(1, 'Assigned signer is required'),
+  implementationRequired: z.boolean().default(false),
   requiresCustomerApproval: z.boolean().default(false),
 });
 
@@ -54,6 +60,24 @@ const CHANGE_TYPE_ICONS: Record<string, any> = {
   BOM: ClipboardList,
   INSPECTION: CheckCircle2,
 };
+
+const AFFECTED_DOCUMENT_OPTIONS = [
+  { value: 'ROUTING', label: 'Routing' },
+  { value: 'BOM', label: 'BOM' },
+  { value: 'TRAVELER', label: 'Traveler' },
+  { value: 'WORK_INSTRUCTION', label: 'Work instruction' },
+  { value: 'INSPECTION_PLAN', label: 'Inspection plan' },
+  { value: 'CUSTOMER_SPEC', label: 'Customer specification' },
+];
+
+const REQUIRED_ACTION_OPTIONS = [
+  { value: 'UPDATE_ROUTING', label: 'Update routing' },
+  { value: 'UPDATE_BOM', label: 'Update BOM' },
+  { value: 'UPDATE_TRAVELER', label: 'Revise traveler or instructions' },
+  { value: 'UPDATE_INSPECTION', label: 'Revise inspection requirements' },
+  { value: 'CUSTOMER_APPROVAL', label: 'Obtain customer approval' },
+  { value: 'TRAINING_REQUIRED', label: 'Assign operator training' },
+];
 
 export default function P2ChangesTab() {
   const [activeSection, setActiveSection] = useState('production');
@@ -88,12 +112,21 @@ export default function P2ChangesTab() {
       changeType: '',
       scope: 'PO',
       partNumber: '',
+      currentRevision: '',
+      proposedRevision: '',
       proposedChange: '',
       reason: '',
       riskAssessment: '',
+      affectedDocuments: [],
+      requiredActions: [],
+      approverEmployeeId: '',
+      implementationRequired: false,
       requiresCustomerApproval: false,
     },
   });
+
+  const affectedDocuments = pcfForm.watch('affectedDocuments') || [];
+  const requiredActions = pcfForm.watch('requiredActions') || [];
 
   const deviationForm = useForm({
     resolver: zodResolver(travelerChangeSchema),
@@ -118,7 +151,7 @@ export default function P2ChangesTab() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/p2/changes'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/changes/impact'] });
-      toast({ title: 'Production Change Created', description: 'The PCF has been created and is pending review.' });
+      toast({ title: 'Production Change Created', description: 'The assigned signer has a new dashboard approval task.' });
       setShowNewPCFDialog(false);
       pcfForm.reset();
     },
@@ -181,10 +214,20 @@ export default function P2ChangesTab() {
     pcfForm.handleSubmit((data) => {
       createPCFMutation.mutate({
         ...data,
+        approverEmployeeId: Number(data.approverEmployeeId),
         status: 'SUBMITTED',
         submittedAt: new Date(),
       });
     })();
+  };
+
+  const togglePcfArrayValue = (field: 'affectedDocuments' | 'requiredActions', value: string) => {
+    const current = pcfForm.getValues(field) || [];
+    pcfForm.setValue(
+      field,
+      current.includes(value) ? current.filter((item: string) => item !== value) : [...current, value],
+      { shouldDirty: true, shouldValidate: true },
+    );
   };
 
   return (
@@ -300,6 +343,35 @@ export default function P2ChangesTab() {
                         )}
                       />
 
+                      <div className="grid grid-cols-2 gap-4">
+                        <FormField
+                          control={pcfForm.control}
+                          name="currentRevision"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Current Revision</FormLabel>
+                              <FormControl>
+                                <Input {...field} placeholder="Rev A, routing rev 3..." />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={pcfForm.control}
+                          name="proposedRevision"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Proposed Revision</FormLabel>
+                              <FormControl>
+                                <Input {...field} placeholder="Rev B, routing rev 4..." />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </div>
+
                       <FormField
                         control={pcfForm.control}
                         name="proposedChange"
@@ -344,6 +416,68 @@ export default function P2ChangesTab() {
 
                       <FormField
                         control={pcfForm.control}
+                        name="approverEmployeeId"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Assigned Signer *</FormLabel>
+                            <Select onValueChange={field.onChange} defaultValue={field.value}>
+                              <FormControl>
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Send signature task to..." />
+                                </SelectTrigger>
+                              </FormControl>
+                              <SelectContent>
+                                {employees.filter((e: any) => e.isActive !== false && e.userId).map((emp: any) => (
+                                  <SelectItem key={emp.id} value={emp.id.toString()}>
+                                    {emp.name || `${emp.firstName || ''} ${emp.lastName || ''}`.trim()}
+                                    {emp.department ? ` (${emp.department})` : ''}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <div className="rounded-md border p-3 space-y-3">
+                        <div>
+                          <p className="text-sm font-medium">Affected controlled records</p>
+                          <p className="text-xs text-muted-foreground">Select every record that may need revision or verification.</p>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                          {AFFECTED_DOCUMENT_OPTIONS.map((option) => (
+                            <label key={option.value} className="flex items-center gap-2 text-sm">
+                              <Switch
+                                checked={affectedDocuments.includes(option.value)}
+                                onCheckedChange={() => togglePcfArrayValue('affectedDocuments', option.value)}
+                              />
+                              {option.label}
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+
+                      <div className="rounded-md border p-3 space-y-3">
+                        <div>
+                          <p className="text-sm font-medium">Required follow-up tasks</p>
+                          <p className="text-xs text-muted-foreground">These prompts stay on the PCF summary for implementation follow-through.</p>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                          {REQUIRED_ACTION_OPTIONS.map((option) => (
+                            <label key={option.value} className="flex items-center gap-2 text-sm">
+                              <Switch
+                                checked={requiredActions.includes(option.value)}
+                                onCheckedChange={() => togglePcfArrayValue('requiredActions', option.value)}
+                              />
+                              {option.label}
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+
+                      <FormField
+                        control={pcfForm.control}
                         name="requiresCustomerApproval"
                         render={({ field }) => (
                           <FormItem className="flex items-center gap-2">
@@ -351,6 +485,20 @@ export default function P2ChangesTab() {
                               <Switch checked={field.value} onCheckedChange={field.onChange} />
                             </FormControl>
                             <FormLabel className="!mt-0">Requires Customer Approval</FormLabel>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={pcfForm.control}
+                        name="implementationRequired"
+                        render={({ field }) => (
+                          <FormItem className="flex items-center gap-2">
+                            <FormControl>
+                              <Switch checked={field.value} onCheckedChange={field.onChange} />
+                            </FormControl>
+                            <FormLabel className="!mt-0">Implementation task required after signature</FormLabel>
                             <FormMessage />
                           </FormItem>
                         )}
@@ -386,6 +534,7 @@ export default function P2ChangesTab() {
                       <TableHead>Description</TableHead>
                       <TableHead>Scope</TableHead>
                       <TableHead>Status</TableHead>
+                      <TableHead>Signer</TableHead>
                       <TableHead>Submitted</TableHead>
                       <TableHead>Actions</TableHead>
                     </TableRow>
@@ -407,36 +556,20 @@ export default function P2ChangesTab() {
                           <TableCell>
                             <Badge className={STATUS_COLORS[change.status]}>{change.status}</Badge>
                           </TableCell>
+                          <TableCell>{change.approverEmployeeName || '-'}</TableCell>
                           <TableCell>
                             {change.submittedAt ? new Date(change.submittedAt).toLocaleDateString() : '-'}
                           </TableCell>
                           <TableCell>
-                            {change.status === 'SUBMITTED' && (
-                              <div className="flex gap-2">
-                                <Button 
-                                  size="sm" 
-                                  variant="outline"
-                                  onClick={() => {
-                                    setSelectedApprover('');
-                                    setShowApproveDialog(change.id);
-                                  }}
-                                >
-                                  <CheckCircle2 className="h-4 w-4 mr-1" />
-                                  Approve
-                                </Button>
-                                <Button 
-                                  size="sm" 
-                                  variant="outline"
-                                  onClick={() => {
-                                    setRejectionReason('');
-                                    setSelectedApprover('');
-                                    setShowRejectDialog(change.id);
-                                  }}
-                                >
-                                  <XCircle className="h-4 w-4 mr-1" />
-                                  Reject
-                                </Button>
-                              </div>
+                            {change.status === 'SUBMITTED' && change.approvalRequestId ? (
+                              <Button size="sm" variant="outline" onClick={() => window.location.href = `/approvals?requestId=${change.approvalRequestId}`}>
+                                <Clock className="h-4 w-4 mr-1" />
+                                Signature Task
+                              </Button>
+                            ) : change.status === 'APPROVED' && change.implementationRequired ? (
+                              <Badge variant="outline">Implement follow-ups</Badge>
+                            ) : (
+                              <span className="text-muted-foreground">-</span>
                             )}
                           </TableCell>
                         </TableRow>

--- a/client/src/pages/ApprovalsInbox.tsx
+++ b/client/src/pages/ApprovalsInbox.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Link } from 'wouter';
 import { apiRequest, queryClient } from '@/lib/queryClient';
@@ -57,6 +57,24 @@ const INVENTORY_REQUEST_LABELS: Record<string, string> = {
   INV_ALLOCATION_OVERRIDE: 'Allocation override',
   INV_EXPIRED_USE: 'Expired material use',
   INV_QUARANTINE_RELEASE: 'Quarantine release',
+};
+
+const PRODUCTION_CHANGE_ACTION_LABELS: Record<string, string> = {
+  UPDATE_ROUTING: 'Update routing',
+  UPDATE_BOM: 'Update BOM',
+  UPDATE_TRAVELER: 'Revise traveler or instructions',
+  UPDATE_INSPECTION: 'Revise inspection requirements',
+  CUSTOMER_APPROVAL: 'Obtain customer approval',
+  TRAINING_REQUIRED: 'Assign operator training',
+};
+
+const PRODUCTION_CHANGE_DOCUMENT_LABELS: Record<string, string> = {
+  ROUTING: 'Routing',
+  BOM: 'BOM',
+  TRAVELER: 'Traveler',
+  WORK_INSTRUCTION: 'Work instruction',
+  INSPECTION_PLAN: 'Inspection plan',
+  CUSTOMER_SPEC: 'Customer specification',
 };
 
 function InventoryApprovalSummary({
@@ -118,6 +136,79 @@ function InventoryApprovalSummary({
   );
 }
 
+function ProductionChangeApprovalSummary({ payload }: { payload: Record<string, any> }) {
+  const affectedDocuments: string[] = Array.isArray(payload.affectedDocuments) ? payload.affectedDocuments : [];
+  const requiredActions: string[] = Array.isArray(payload.requiredActions) ? payload.requiredActions : [];
+  const rows: Array<[string, React.ReactNode]> = [
+    ['PCF #', <span className="font-mono">{payload.changeNumber ?? 'Pending number'}</span>],
+    ['Type', <Badge variant="outline">{payload.changeType ?? 'Production change'}</Badge>],
+    ['Scope', payload.scope ?? '-'],
+  ];
+  if (payload.partNumber) rows.push(['Part #', payload.partNumber]);
+  if (payload.poId) rows.push(['PO ID', payload.poId]);
+  if (payload.currentRevision) rows.push(['Current revision', payload.currentRevision]);
+  if (payload.proposedRevision) rows.push(['Proposed revision', payload.proposedRevision]);
+
+  return (
+    <div className="border rounded p-4 bg-muted/30 space-y-3" data-testid="production-change-approval-summary">
+      <div className="flex items-center gap-2">
+        <Badge className="bg-blue-600">AS9100 PCF</Badge>
+        <span className="font-semibold text-sm">Production Change Form</span>
+      </div>
+      <table className="text-xs w-full">
+        <tbody>
+          {rows.map(([k, v]) => (
+            <tr key={k} className="border-t border-muted-foreground/20">
+              <td className="py-1 pr-3 text-muted-foreground font-medium">{k}</td>
+              <td className="py-1">{v}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="grid gap-3 md:grid-cols-2">
+        <div>
+          <div className="text-xs font-semibold text-muted-foreground">Proposed Change</div>
+          <p className="text-sm whitespace-pre-wrap">{payload.proposedChange ?? '-'}</p>
+        </div>
+        <div>
+          <div className="text-xs font-semibold text-muted-foreground">Reason</div>
+          <p className="text-sm whitespace-pre-wrap">{payload.reason ?? '-'}</p>
+        </div>
+      </div>
+      {payload.riskAssessment && (
+        <div>
+          <div className="text-xs font-semibold text-muted-foreground">Risk Assessment</div>
+          <p className="text-sm whitespace-pre-wrap">{payload.riskAssessment}</p>
+        </div>
+      )}
+      <div className="grid gap-3 md:grid-cols-2">
+        <div>
+          <div className="text-xs font-semibold text-muted-foreground mb-1">Affected Records</div>
+          <div className="flex flex-wrap gap-1">
+            {affectedDocuments.length > 0
+              ? affectedDocuments.map((item) => <Badge key={item} variant="outline">{PRODUCTION_CHANGE_DOCUMENT_LABELS[item] ?? item}</Badge>)
+              : <span className="text-xs text-muted-foreground">None selected</span>}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs font-semibold text-muted-foreground mb-1">Follow-Up Tasks</div>
+          <div className="flex flex-wrap gap-1">
+            {requiredActions.length > 0
+              ? requiredActions.map((item) => <Badge key={item} variant="secondary">{PRODUCTION_CHANGE_ACTION_LABELS[item] ?? item}</Badge>)
+              : <span className="text-xs text-muted-foreground">No extra tasks selected</span>}
+          </div>
+        </div>
+      </div>
+      {(payload.requiresCustomerApproval || payload.implementationRequired) && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+          {payload.requiresCustomerApproval && <div>Customer approval must be verified before implementation.</div>}
+          {payload.implementationRequired && <div>Implementation follow-up is required after signature.</div>}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function ApprovalsInbox() {
   const { toast } = useToast();
   const [selected, setSelected] = useState<ApprovalRequest | null>(null);
@@ -127,6 +218,13 @@ export default function ApprovalsInbox() {
     queryKey: ['/api/approvals'],
     refetchInterval: 30000,
   });
+
+  useEffect(() => {
+    const requestId = new URLSearchParams(window.location.search).get('requestId');
+    if (!requestId || selected || rows.length === 0) return;
+    const match = rows.find((row) => row.id === requestId);
+    if (match) setSelected(match);
+  }, [rows, selected]);
 
   const { data: employees = [] } = useQuery<EmployeeOption[]>({
     queryKey: ['/api/employees'],
@@ -331,7 +429,9 @@ export default function ApprovalsInbox() {
                   </p>
                 </div>
 
-                {INVENTORY_REQUEST_TYPES.has(selectedRequest.requestType) ? (
+                {selectedRequest.requestType === 'PRODUCTION_CHANGE_FORM' ? (
+                  <ProductionChangeApprovalSummary payload={selectedRequest.requestPayload ?? {}} />
+                ) : INVENTORY_REQUEST_TYPES.has(selectedRequest.requestType) ? (
                   <InventoryApprovalSummary
                     requestType={selectedRequest.requestType}
                     payload={selectedRequest.requestPayload ?? {}}

--- a/migrations/0136_p2_production_change_form_approvals.sql
+++ b/migrations/0136_p2_production_change_form_approvals.sql
@@ -1,0 +1,30 @@
+ALTER TABLE p2_production_changes
+  ADD COLUMN IF NOT EXISTS proposed_revision TEXT,
+  ADD COLUMN IF NOT EXISTS affected_documents JSONB DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS required_actions JSONB DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS approver_employee_id INTEGER REFERENCES employees(id),
+  ADD COLUMN IF NOT EXISTS approver_employee_name TEXT,
+  ADD COLUMN IF NOT EXISTS approval_request_id UUID,
+  ADD COLUMN IF NOT EXISTS implementation_required BOOLEAN DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS p2_prod_changes_approval_request_idx
+  ON p2_production_changes(approval_request_id);
+
+INSERT INTO escalation_policies (request_type, display_name, description, chain, requires_signature, reason_codes, is_active)
+VALUES (
+  'PRODUCTION_CHANGE_FORM',
+  'Production Change Form',
+  'AS9100 production change form approval for routing, BOM, material, process, or inspection changes.',
+  '[{"role":"Quality Manager","slaSeconds":14400},{"role":"Production Manager","slaSeconds":28800},{"role":"Director of Operations","slaSeconds":86400,"isBackstop":true}]'::jsonb,
+  true,
+  '["ROUTING_VERIFIED","BOM_VERIFIED","CUSTOMER_APPROVAL_VERIFIED","RISK_ACCEPTED","OTHER"]'::jsonb,
+  true
+)
+ON CONFLICT (request_type) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  description = EXCLUDED.description,
+  chain = EXCLUDED.chain,
+  requires_signature = EXCLUDED.requires_signature,
+  reason_codes = EXCLUDED.reason_codes,
+  is_active = EXCLUDED.is_active,
+  updated_at = NOW();

--- a/server/index.ts
+++ b/server/index.ts
@@ -5173,9 +5173,16 @@ async function initializeBackgroundServices() {
             po_id                      INTEGER REFERENCES p2_purchase_orders(id),
             routing_id                 UUID,
             current_revision           TEXT,
+            proposed_revision          TEXT,
             proposed_change            TEXT NOT NULL,
             reason                     TEXT NOT NULL,
             risk_assessment            TEXT,
+            affected_documents         JSONB DEFAULT '[]'::jsonb,
+            required_actions           JSONB DEFAULT '[]'::jsonb,
+            approver_employee_id       INTEGER REFERENCES employees(id),
+            approver_employee_name     TEXT,
+            approval_request_id        UUID,
+            implementation_required    BOOLEAN DEFAULT false,
             requires_customer_approval BOOLEAN DEFAULT false,
             status                     TEXT NOT NULL DEFAULT 'DRAFT',
             submitted_by_id            INTEGER REFERENCES employees(id),
@@ -5198,6 +5205,34 @@ async function initializeBackgroundServices() {
         await pool.query(`CREATE INDEX IF NOT EXISTS p2_prod_changes_po_id_idx ON p2_production_changes(po_id)`);
         await pool.query(`CREATE INDEX IF NOT EXISTS p2_prod_changes_status_idx ON p2_production_changes(status)`);
         await pool.query(`CREATE INDEX IF NOT EXISTS p2_prod_changes_type_idx ON p2_production_changes(change_type)`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS proposed_revision TEXT`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS affected_documents JSONB DEFAULT '[]'::jsonb`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS required_actions JSONB DEFAULT '[]'::jsonb`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS approver_employee_id INTEGER REFERENCES employees(id)`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS approver_employee_name TEXT`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS approval_request_id UUID`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS implementation_required BOOLEAN DEFAULT false`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS p2_prod_changes_approval_request_idx ON p2_production_changes(approval_request_id)`);
+        await pool.query(`
+          INSERT INTO escalation_policies (request_type, display_name, description, chain, requires_signature, reason_codes, is_active)
+          VALUES (
+            'PRODUCTION_CHANGE_FORM',
+            'Production Change Form',
+            'AS9100 production change form approval for routing, BOM, material, process, or inspection changes.',
+            '[{"role":"Quality Manager","slaSeconds":14400},{"role":"Production Manager","slaSeconds":28800},{"role":"Director of Operations","slaSeconds":86400,"isBackstop":true}]'::jsonb,
+            true,
+            '["ROUTING_VERIFIED","BOM_VERIFIED","CUSTOMER_APPROVAL_VERIFIED","RISK_ACCEPTED","OTHER"]'::jsonb,
+            true
+          )
+          ON CONFLICT (request_type) DO UPDATE SET
+            display_name = EXCLUDED.display_name,
+            description = EXCLUDED.description,
+            chain = EXCLUDED.chain,
+            requires_signature = EXCLUDED.requires_signature,
+            reason_codes = EXCLUDED.reason_codes,
+            is_active = EXCLUDED.is_active,
+            updated_at = NOW()
+        `);
 
         await pool.query(`
           CREATE TABLE IF NOT EXISTS p2_traveler_changes (

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -11135,9 +11135,16 @@ export const p2ProductionChanges = pgTable('p2_production_changes', {
   poId: integer('po_id').references(() => p2PurchaseOrders.id),
   routingId: uuid('routing_id'), // References routing document if applicable
   currentRevision: text('current_revision'),
+  proposedRevision: text('proposed_revision'),
   proposedChange: text('proposed_change').notNull(),
   reason: text('reason').notNull(),
   riskAssessment: text('risk_assessment'),
+  affectedDocuments: jsonb('affected_documents').$type<string[]>().default(sql`'[]'::jsonb`),
+  requiredActions: jsonb('required_actions').$type<string[]>().default(sql`'[]'::jsonb`),
+  approverEmployeeId: integer('approver_employee_id').references(() => employees.id),
+  approverEmployeeName: text('approver_employee_name'),
+  approvalRequestId: uuid('approval_request_id'),
+  implementationRequired: boolean('implementation_required').default(false),
   requiresCustomerApproval: boolean('requires_customer_approval').default(false),
   status: text('status').notNull().default('DRAFT'), // DRAFT | SUBMITTED | APPROVED | REJECTED | IMPLEMENTED
   submittedById: integer('submitted_by_id').references(() => employees.id),

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -27,7 +27,7 @@ import {
   InventoryExecutorError,
 } from '../services/inventoryApprovalExecutor';
 import { db } from '../../db';
-import { approvalRequestHistory, approvalRequests, employees, users } from '../../schema';
+import { approvalRequestHistory, approvalRequests, employees, p2ProductionChanges, users } from '../../schema';
 import { and, asc, eq } from 'drizzle-orm';
 
 export const approvalsRouter = Router();
@@ -119,15 +119,33 @@ approvalsRouter.get('/my-tasks/:employeeId', async (req: Request, res: Response)
       .orderBy(asc(approvalRequests.currentLevelDeadline))
       .limit(100);
 
+    const approvedFollowUps = await db
+      .select()
+      .from(p2ProductionChanges)
+      .where(
+        and(
+          eq(p2ProductionChanges.status, 'APPROVED'),
+          eq(p2ProductionChanges.implementationRequired, true),
+          eq(p2ProductionChanges.approverEmployeeId, employeeId),
+        ),
+      )
+      .limit(100);
+
     const now = Date.now();
     const tasks = rows.map((row) => {
       const deadlineMs = row.currentLevelDeadline ? new Date(row.currentLevelDeadline).getTime() : null;
       const overdue = deadlineMs != null && deadlineMs <= now;
+      const payload = (row.requestPayload ?? {}) as Record<string, any>;
+      const isProductionChange = row.requestType === 'PRODUCTION_CHANGE_FORM';
       return {
         id: `approval-${row.id}`,
         type: 'approval_request',
-        title: `Approval required: ${row.requestType}`,
-        description: row.subjectType && row.subjectId
+        title: isProductionChange
+          ? `Sign production change ${payload.changeNumber ?? ''}`.trim()
+          : `Approval required: ${row.requestType}`,
+        description: isProductionChange
+          ? `${payload.changeType ?? 'Production'} change: ${payload.proposedChange ?? row.subjectId ?? row.id}`
+          : row.subjectType && row.subjectId
           ? `${row.subjectType} #${row.subjectId}`
           : `Requested by ${row.requestedByDisplayName}`,
         requestType: row.requestType,
@@ -138,7 +156,26 @@ approvalsRouter.get('/my-tasks/:employeeId', async (req: Request, res: Response)
         actionUrl: `/approvals?requestId=${row.id}`,
         sourceId: row.id,
       };
-    });
+    }).concat(approvedFollowUps.map((change) => {
+      const requiredActions = Array.isArray((change as any).requiredActions)
+        ? ((change as any).requiredActions as string[])
+        : [];
+      return {
+        id: `p2-change-followup-${change.id}`,
+        type: 'p2_production_change_followup',
+        title: `Implement production change ${change.changeNumber}`,
+        description: requiredActions.length > 0
+          ? requiredActions.join(', ')
+          : change.proposedChange,
+        requestType: 'PRODUCTION_CHANGE_FORM',
+        requestedByDisplayName: change.submittedByName ?? 'P2 Control Center',
+        createdAt: change.approvedAt ?? change.createdAt,
+        dueAt: change.effectiveDate ?? null,
+        priority: 'normal',
+        actionUrl: `/p2-control-center?tab=changes`,
+        sourceId: change.id,
+      };
+    }));
 
     res.json({
       tasks,
@@ -366,6 +403,19 @@ approvalsRouter.post('/:id/approve', async (req: Request, res: Response) => {
       }
     }
 
+    if (result.requestType === 'PRODUCTION_CHANGE_FORM') {
+      await db
+        .update(p2ProductionChanges)
+        .set({
+          status: 'APPROVED',
+          approvedById: (req.user as any)?.employeeId ?? null,
+          approvedByName: actor.displayName,
+          approvedAt: new Date(),
+          updatedAt: new Date(),
+        } as any)
+        .where(eq(p2ProductionChanges.approvalRequestId, result.id));
+    }
+
     res.json({ ...result, executor });
   } catch (err: any) {
     handleEscalationError(err, res);
@@ -393,6 +443,19 @@ approvalsRouter.post('/:id/reject', async (req: Request, res: Response) => {
       linkedObjectId: body.linkedObjectId ?? null,
       digitalSignatureId: body.digitalSignatureId ?? null,
     });
+    if (result.requestType === 'PRODUCTION_CHANGE_FORM') {
+      await db
+        .update(p2ProductionChanges)
+        .set({
+          status: 'REJECTED',
+          rejectedById: (req.user as any)?.employeeId ?? null,
+          rejectedByName: actor.displayName,
+          rejectedAt: new Date(),
+          rejectionReason: body.notes ?? body.reasonCode ?? 'Rejected through approval inbox',
+          updatedAt: new Date(),
+        } as any)
+        .where(eq(p2ProductionChanges.approvalRequestId, result.id));
+    }
     res.json(result);
   } catch (err: any) {
     handleEscalationError(err, res);

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3165,9 +3165,148 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   app.post('/api/p2/changes', softAuth, async (req, res) => {
     try {
       const { storage } = await import('../../storage');
-      const change = await storage.createP2ProductionChange(req.body);
-      res.status(201).json(change);
+      const { db } = await import('../../db');
+      const { approvalRequestHistory, approvalRequests, employees, p2ProductionChanges, users } = await import('../../schema');
+      const { and, eq } = await import('drizzle-orm');
+      const { cancel, openRequest } = await import('../services/escalationService');
+      const { notificationManager } = await import('../services/notificationManager');
+      const approverEmployeeId = Number(req.body?.approverEmployeeId);
+      let approverEmployeeName: string | null = null;
+      let approverUserId: number | null = null;
+
+      if (!Number.isInteger(approverEmployeeId) || approverEmployeeId <= 0) {
+        return res.status(400).json({ error: 'An assigned approver is required for a production change form.' });
+      }
+
+      const [approver] = await db
+        .select({
+          employeeId: employees.id,
+          employeeName: employees.name,
+          userId: users.id,
+        })
+        .from(employees)
+        .leftJoin(users, and(eq(users.employeeId, employees.id), eq(users.isActive, true)))
+        .where(eq(employees.id, approverEmployeeId))
+        .limit(1);
+
+      if (!approver) {
+        return res.status(404).json({ error: 'Assigned approver not found.' });
+      }
+      if (approver.userId == null) {
+        return res.status(400).json({ error: 'Assigned approver does not have an active user account.' });
+      }
+
+      approverEmployeeName = approver.employeeName;
+      approverUserId = approver.userId;
+      const actor = (req as any).user;
+      const requestedByDisplayName =
+        actor?.username ||
+        actor?.email ||
+        req.body?.submittedByName ||
+        'P2 Control Center';
+
+      const change = await storage.createP2ProductionChange({
+        ...req.body,
+        approverEmployeeId,
+        approverEmployeeName,
+      });
+
+      let approvalIdToCancel: string | null = null;
+      try {
+        const requiredActions = Array.isArray((change as any).requiredActions) ? (change as any).requiredActions : [];
+        const approval = await openRequest({
+          requestType: 'PRODUCTION_CHANGE_FORM',
+          payload: {
+            changeId: change.id,
+            changeNumber: change.changeNumber,
+            changeType: change.changeType,
+            scope: change.scope,
+            partNumber: change.partNumber,
+            poId: change.poId,
+            routingId: change.routingId,
+            currentRevision: change.currentRevision,
+            proposedRevision: (change as any).proposedRevision,
+            proposedChange: change.proposedChange,
+            reason: change.reason,
+            riskAssessment: change.riskAssessment,
+            affectedDocuments: (change as any).affectedDocuments ?? [],
+            requiredActions,
+            requiresCustomerApproval: change.requiresCustomerApproval,
+            implementationRequired: (change as any).implementationRequired ?? false,
+          },
+          subjectType: 'p2_production_change',
+          subjectId: change.id,
+          requestedByUserId: actor?.id ?? null,
+          requestedByDisplayName,
+          summary: `${change.changeNumber} ${change.changeType} change needs signature review.`,
+        });
+        approvalIdToCancel = approval.id;
+
+        const [assignedApproval] = await db
+          .update(approvalRequests)
+          .set({
+            currentApproverUserId: approverUserId,
+            updatedAt: new Date(),
+          })
+          .where(eq(approvalRequests.id, approval.id))
+          .returning();
+
+        await db.insert(approvalRequestHistory).values({
+          approvalRequestId: approval.id,
+          event: 'ASSIGNED',
+          fromLevel: approval.escalationLevel,
+          toLevel: approval.escalationLevel,
+          fromStatus: approval.status,
+          toStatus: approval.status,
+          actorUserId: actor?.id ?? null,
+          actorDisplayName: requestedByDisplayName,
+          notes: `Production change signature assigned to ${approverEmployeeName}`,
+          metadata: {
+            assignedEmployeeId: approverEmployeeId,
+            assignedUserId: approverUserId,
+            assignedEmployeeName: approverEmployeeName,
+            changeNumber: change.changeNumber,
+          },
+        });
+
+        notificationManager.sendToUsers([approverUserId], {
+          type: 'APPROVAL_REQUEST',
+          title: `Production change signature needed: ${change.changeNumber}`,
+          message: `${requestedByDisplayName} assigned you to review and sign ${change.changeNumber}.`,
+          data: {
+            approvalRequestId: approval.id,
+            requestType: 'PRODUCTION_CHANGE_FORM',
+            subjectType: 'p2_production_change',
+            subjectId: change.id,
+            changeNumber: change.changeNumber,
+          },
+          timestamp: new Date().toISOString(),
+        });
+
+        const updatedChange = await storage.updateP2ProductionChange(change.id, {
+          approvalRequestId: approval.id,
+          status: 'SUBMITTED',
+        } as any);
+        return res.status(201).json({ ...updatedChange, approvalRequest: assignedApproval });
+      } catch (approvalError) {
+        if (approvalIdToCancel) {
+          try {
+            await cancel(
+              approvalIdToCancel,
+              { userId: actor?.id ?? null, displayName: requestedByDisplayName, isPrivilegedOverride: true },
+              `Cancelled because PCF ${change.changeNumber} creation did not complete.`,
+            );
+          } catch (cancelError: any) {
+            console.warn('Failed to cancel incomplete PCF approval request:', cancelError?.message ?? cancelError);
+          }
+        }
+        await db.delete(p2ProductionChanges).where(eq(p2ProductionChanges.id, change.id));
+        throw approvalError;
+      }
     } catch (error: any) {
+      if (error?.code === 'NO_POLICY') {
+        return res.status(500).json({ error: 'Production change approval policy is not installed. Run migrations and try again.' });
+      }
       console.error('Error creating production change:', error);
       res.status(500).json({ error: 'Failed to create production change' });
     }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16802,9 +16802,13 @@ export class DatabaseStorage implements IStorage {
   async createP2ProductionChange(data: InsertP2ProductionChange): Promise<P2ProductionChange> {
     // Generate change number: PCF-YYYY-NNN
     const year = new Date().getFullYear();
-    const existingChanges = await db.select().from(p2ProductionChanges);
-    const yearChanges = existingChanges.filter(c => c.changeNumber?.startsWith(`PCF-${year}`));
-    const nextNum = yearChanges.length + 1;
+    const [{ lastNumber } = { lastNumber: null }] = await db
+      .select({
+        lastNumber: sql<number | null>`MAX(NULLIF(SUBSTRING(${p2ProductionChanges.changeNumber} FROM ${`^PCF-${year}-(\\d+)$`}), '')::int)`,
+      })
+      .from(p2ProductionChanges)
+      .where(like(p2ProductionChanges.changeNumber, `PCF-${year}-%`));
+    const nextNum = (lastNumber ?? 0) + 1;
     const changeNumber = `PCF-${year}-${String(nextNum).padStart(3, '0')}`;
     
     const [change] = await db.insert(p2ProductionChanges).values({ ...data, changeNumber }).returning();


### PR DESCRIPTION
## Summary
- Upgrade the P2 Control Center change tab into an AS9100-oriented production change form workflow with assigned signer selection, controlled-record impact prompts, revision fields, and implementation follow-up prompts.
- Add durable PCF fields, a migration, and a seeded `PRODUCTION_CHANGE_FORM` approval policy requiring signatures.
- Wire PCF creation to auto-number from the latest `PCF-YYYY-NNN`, create and assign an approval request, notify the signer, show a production-change summary in My Approvals, and stamp the PCF when approved or rejected.
- Keep approved PCFs with implementation work visible as dashboard follow-up tasks until they are marked implemented.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Bundled Node syntax checks with `--experimental-strip-types --check` for:
  - `server/src/routes/approvals.ts`
  - `server/src/routes/index.ts`
  - `server/storage.ts`
  - `server/schema.ts`

## Notes
- `npm` and `gh` were not available on PATH in this local environment, so full `npm run check` and GitHub CLI PR creation were not run.
- The exact Google Doc template could not be read through the available connector path in this session; this implements the system workflow and PCF model so labels can be tuned later if the template wording differs.