### PR TITLE
Run production change approval migration at boot

### DIFF
--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -174,6 +174,7 @@ const safeFiles = [
   '0133_voice_notes_persistence.sql',
   '0134_conversational_rfq_risk_sessions.sql',
   '0135_pto_balances_and_schedules.sql',
+  '0136_p2_production_change_form_approvals.sql',
   '0142_punch_correction_requests.sql',
   '0143_internal_messages_nullable_sender.sql',
   '0144_rename_10300_customer_payment_clearing.sql',


### PR DESCRIPTION
## Summary
- Include `0136_p2_production_change_form_approvals.sql` in the safe boot migration list
- Ensures `p2_production_changes.proposed_revision` and related approval fields are applied during deployment/startup
- Addresses production `/api/approvals/my-tasks/:employeeId` failures caused by missing `proposed_revision`

## Validation
- `node --experimental-strip-types --check server/scripts/migrations/runSafeBootMigrations.ts`
- `git diff --check`