### PR TITLE
[codex] Add PCF signer role assignments

### DIFF
--- a/client/src/components/p2/P2ChangesTab.tsx
+++ b/client/src/components/p2/P2ChangesTab.tsx
@@ -271,7 +271,7 @@ export default function P2ChangesTab() {
                     New PCF
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="max-w-2xl">
+                <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
                   <DialogHeader>
                     <DialogTitle>Create Production Change Form</DialogTitle>
                     <DialogDescription>
@@ -596,7 +596,7 @@ export default function P2ChangesTab() {
                     New Deviation
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="max-w-2xl">
+                <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
                   <DialogHeader>
                     <DialogTitle>Create Traveler Deviation</DialogTitle>
                     <DialogDescription>
@@ -882,7 +882,7 @@ export default function P2ChangesTab() {
 
       {/* Approval Dialog */}
       <Dialog open={!!showApproveDialog} onOpenChange={() => setShowApproveDialog(null)}>
-        <DialogContent>
+        <DialogContent className="max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Approve Production Change</DialogTitle>
             <DialogDescription>Select the approving authority for this change.</DialogDescription>
@@ -926,7 +926,7 @@ export default function P2ChangesTab() {
 
       {/* Rejection Dialog */}
       <Dialog open={!!showRejectDialog} onOpenChange={() => setShowRejectDialog(null)}>
-        <DialogContent>
+        <DialogContent className="max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Reject Production Change</DialogTitle>
             <DialogDescription>Provide a reason for rejection and select the rejecting authority.</DialogDescription>
@@ -981,7 +981,7 @@ export default function P2ChangesTab() {
 
       {/* Deviation Authorization Dialog */}
       <Dialog open={!!showAuthorizeDeviationDialog} onOpenChange={() => { setShowAuthorizeDeviationDialog(null); setSelectedApprover(''); }}>
-        <DialogContent>
+        <DialogContent className="max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Authorize Traveler Deviation</DialogTitle>
             <DialogDescription>

--- a/client/src/components/p2/P2ChangesTab.tsx
+++ b/client/src/components/p2/P2ChangesTab.tsx
@@ -30,9 +30,32 @@ const productionChangeSchema = z.object({
   riskAssessment: z.string().optional(),
   affectedDocuments: z.array(z.string()).default([]),
   requiredActions: z.array(z.string()).default([]),
-  approverEmployeeId: z.string().min(1, 'Assigned signer is required'),
+  approvalAssignments: z.array(z.object({
+    roleKey: z.string(),
+    roleLabel: z.string(),
+    required: z.boolean(),
+    employeeId: z.string().optional(),
+  })).default([]),
   implementationRequired: z.boolean().default(false),
   requiresCustomerApproval: z.boolean().default(false),
+}).superRefine((data, ctx) => {
+  const requiredAssignments = data.approvalAssignments.filter((assignment) => assignment.required);
+  if (requiredAssignments.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'At least one required signer is needed',
+      path: ['approvalAssignments'],
+    });
+  }
+  requiredAssignments.forEach((assignment, index) => {
+    if (!assignment.employeeId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${assignment.roleLabel} must be assigned to a user`,
+        path: ['approvalAssignments', index, 'employeeId'],
+      });
+    }
+  });
 });
 
 const travelerChangeSchema = z.object({
@@ -79,6 +102,13 @@ const REQUIRED_ACTION_OPTIONS = [
   { value: 'TRAINING_REQUIRED', label: 'Assign operator training' },
 ];
 
+const PCF_APPROVAL_ROLES = [
+  { roleKey: 'BUSINESS_MANAGER', roleLabel: 'Business Manager' },
+  { roleKey: 'PURCHASING_QUALITY_MANAGER', roleLabel: 'Purchasing / Quality Manager' },
+  { roleKey: 'PRODUCTION_MANAGER', roleLabel: 'Production Manager' },
+  { roleKey: 'CUSTOMER', roleLabel: 'Customer' },
+];
+
 export default function P2ChangesTab() {
   const [activeSection, setActiveSection] = useState('production');
   const [showNewPCFDialog, setShowNewPCFDialog] = useState(false);
@@ -119,7 +149,11 @@ export default function P2ChangesTab() {
       riskAssessment: '',
       affectedDocuments: [],
       requiredActions: [],
-      approverEmployeeId: '',
+      approvalAssignments: PCF_APPROVAL_ROLES.map((role) => ({
+        ...role,
+        required: role.roleKey === 'PURCHASING_QUALITY_MANAGER' || role.roleKey === 'PRODUCTION_MANAGER',
+        employeeId: '',
+      })),
       implementationRequired: false,
       requiresCustomerApproval: false,
     },
@@ -127,6 +161,7 @@ export default function P2ChangesTab() {
 
   const affectedDocuments = pcfForm.watch('affectedDocuments') || [];
   const requiredActions = pcfForm.watch('requiredActions') || [];
+  const approvalAssignments = pcfForm.watch('approvalAssignments') || [];
 
   const deviationForm = useForm({
     resolver: zodResolver(travelerChangeSchema),
@@ -214,7 +249,10 @@ export default function P2ChangesTab() {
     pcfForm.handleSubmit((data) => {
       createPCFMutation.mutate({
         ...data,
-        approverEmployeeId: Number(data.approverEmployeeId),
+        approvalAssignments: data.approvalAssignments.map((assignment) => ({
+          ...assignment,
+          employeeId: assignment.employeeId ? Number(assignment.employeeId) : null,
+        })),
         status: 'SUBMITTED',
         submittedAt: new Date(),
       });
@@ -226,6 +264,20 @@ export default function P2ChangesTab() {
     pcfForm.setValue(
       field,
       current.includes(value) ? current.filter((item: string) => item !== value) : [...current, value],
+      { shouldDirty: true, shouldValidate: true },
+    );
+  };
+
+  const updateApprovalAssignment = (
+    roleKey: string,
+    patch: Partial<{ required: boolean; employeeId: string }>,
+  ) => {
+    const current = pcfForm.getValues('approvalAssignments') || [];
+    pcfForm.setValue(
+      'approvalAssignments',
+      current.map((assignment: any) =>
+        assignment.roleKey === roleKey ? { ...assignment, ...patch } : assignment,
+      ),
       { shouldDirty: true, shouldValidate: true },
     );
   };
@@ -414,31 +466,53 @@ export default function P2ChangesTab() {
                         )}
                       />
 
-                      <FormField
-                        control={pcfForm.control}
-                        name="approverEmployeeId"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Assigned Signer *</FormLabel>
-                            <Select onValueChange={field.onChange} defaultValue={field.value}>
-                              <FormControl>
+                      <div className="rounded-md border p-3 space-y-3">
+                        <div>
+                          <p className="text-sm font-medium">Required signatures</p>
+                          <p className="text-xs text-muted-foreground">Mark each signer required or not required, then assign required signatures to EPOCH users.</p>
+                        </div>
+                        <div className="space-y-3">
+                          {approvalAssignments.map((assignment: any) => (
+                            <div key={assignment.roleKey} className="grid grid-cols-[minmax(0,1fr)_180px_minmax(180px,1fr)] gap-3 items-center">
+                              <div>
+                                <p className="text-sm font-medium">{assignment.roleLabel}</p>
+                                <p className="text-xs text-muted-foreground">
+                                  {assignment.required ? 'Signature required' : 'Not required for this PCF'}
+                                </p>
+                              </div>
+                              <label className="flex items-center gap-2 text-sm">
+                                <Switch
+                                  checked={assignment.required}
+                                  onCheckedChange={(checked) => updateApprovalAssignment(assignment.roleKey, { required: checked === true })}
+                                />
+                                Required
+                              </label>
+                              <Select
+                                value={assignment.employeeId || ''}
+                                onValueChange={(employeeId) => updateApprovalAssignment(assignment.roleKey, { employeeId })}
+                                disabled={!assignment.required}
+                              >
                                 <SelectTrigger>
-                                  <SelectValue placeholder="Send signature task to..." />
+                                  <SelectValue placeholder="Assign user..." />
                                 </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {employees.filter((e: any) => e.isActive !== false && e.userId).map((emp: any) => (
-                                  <SelectItem key={emp.id} value={emp.id.toString()}>
-                                    {emp.name || `${emp.firstName || ''} ${emp.lastName || ''}`.trim()}
-                                    {emp.department ? ` (${emp.department})` : ''}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
+                                <SelectContent>
+                                  {employees.filter((e: any) => e.isActive !== false && e.userId).map((emp: any) => (
+                                    <SelectItem key={emp.id} value={emp.id.toString()}>
+                                      {emp.name || `${emp.firstName || ''} ${emp.lastName || ''}`.trim()}
+                                      {emp.department ? ` (${emp.department})` : ''}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                          ))}
+                        </div>
+                        {pcfForm.formState.errors.approvalAssignments && (
+                          <p className="text-sm font-medium text-destructive">
+                            {pcfForm.formState.errors.approvalAssignments.message?.toString() || 'Required signers must be assigned.'}
+                          </p>
                         )}
-                      />
+                      </div>
 
                       <div className="rounded-md border p-3 space-y-3">
                         <div>
@@ -556,7 +630,22 @@ export default function P2ChangesTab() {
                           <TableCell>
                             <Badge className={STATUS_COLORS[change.status]}>{change.status}</Badge>
                           </TableCell>
-                          <TableCell>{change.approverEmployeeName || '-'}</TableCell>
+                          <TableCell>
+                            {Array.isArray(change.approvalAssignments) && change.approvalAssignments.length > 0 ? (
+                              <div className="space-y-1">
+                                {change.approvalAssignments
+                                  .filter((assignment: any) => assignment.required)
+                                  .map((assignment: any) => (
+                                    <div key={assignment.roleKey} className="text-xs">
+                                      <span className="font-medium">{assignment.roleLabel}:</span>{' '}
+                                      {assignment.employeeName || 'Unassigned'}
+                                    </div>
+                                  ))}
+                              </div>
+                            ) : (
+                              change.approverEmployeeName || '-'
+                            )}
+                          </TableCell>
                           <TableCell>
                             {change.submittedAt ? new Date(change.submittedAt).toLocaleDateString() : '-'}
                           </TableCell>

--- a/client/src/pages/ApprovalsInbox.tsx
+++ b/client/src/pages/ApprovalsInbox.tsx
@@ -141,6 +141,7 @@ function ProductionChangeApprovalSummary({ payload }: { payload: Record<string, 
   const requiredActions: string[] = Array.isArray(payload.requiredActions) ? payload.requiredActions : [];
   const rows: Array<[string, React.ReactNode]> = [
     ['PCF #', <span className="font-mono">{payload.changeNumber ?? 'Pending number'}</span>],
+    ['Signature role', payload.approvalRoleLabel ?? 'Production change approver'],
     ['Type', <Badge variant="outline">{payload.changeType ?? 'Production change'}</Badge>],
     ['Scope', payload.scope ?? '-'],
   ];

--- a/migrations/0136_p2_production_change_form_approvals.sql
+++ b/migrations/0136_p2_production_change_form_approvals.sql
@@ -5,6 +5,8 @@ ALTER TABLE p2_production_changes
   ADD COLUMN IF NOT EXISTS approver_employee_id INTEGER REFERENCES employees(id),
   ADD COLUMN IF NOT EXISTS approver_employee_name TEXT,
   ADD COLUMN IF NOT EXISTS approval_request_id UUID,
+  ADD COLUMN IF NOT EXISTS approval_request_ids JSONB DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS approval_assignments JSONB DEFAULT '[]'::jsonb,
   ADD COLUMN IF NOT EXISTS implementation_required BOOLEAN DEFAULT false;
 
 CREATE INDEX IF NOT EXISTS p2_prod_changes_approval_request_idx

--- a/server/index.ts
+++ b/server/index.ts
@@ -5182,6 +5182,8 @@ async function initializeBackgroundServices() {
             approver_employee_id       INTEGER REFERENCES employees(id),
             approver_employee_name     TEXT,
             approval_request_id        UUID,
+            approval_request_ids       JSONB DEFAULT '[]'::jsonb,
+            approval_assignments       JSONB DEFAULT '[]'::jsonb,
             implementation_required    BOOLEAN DEFAULT false,
             requires_customer_approval BOOLEAN DEFAULT false,
             status                     TEXT NOT NULL DEFAULT 'DRAFT',
@@ -5211,6 +5213,8 @@ async function initializeBackgroundServices() {
         await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS approver_employee_id INTEGER REFERENCES employees(id)`);
         await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS approver_employee_name TEXT`);
         await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS approval_request_id UUID`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS approval_request_ids JSONB DEFAULT '[]'::jsonb`);
+        await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS approval_assignments JSONB DEFAULT '[]'::jsonb`);
         await pool.query(`ALTER TABLE p2_production_changes ADD COLUMN IF NOT EXISTS implementation_required BOOLEAN DEFAULT false`);
         await pool.query(`CREATE INDEX IF NOT EXISTS p2_prod_changes_approval_request_idx ON p2_production_changes(approval_request_id)`);
         await pool.query(`

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -11144,6 +11144,15 @@ export const p2ProductionChanges = pgTable('p2_production_changes', {
   approverEmployeeId: integer('approver_employee_id').references(() => employees.id),
   approverEmployeeName: text('approver_employee_name'),
   approvalRequestId: uuid('approval_request_id'),
+  approvalRequestIds: jsonb('approval_request_ids').$type<string[]>().default(sql`'[]'::jsonb`),
+  approvalAssignments: jsonb('approval_assignments').$type<Array<{
+    roleKey: string;
+    roleLabel: string;
+    required: boolean;
+    employeeId: number | null;
+    employeeName: string | null;
+    userId: number | null;
+  }>>().default(sql`'[]'::jsonb`),
   implementationRequired: boolean('implementation_required').default(false),
   requiresCustomerApproval: boolean('requires_customer_approval').default(false),
   status: text('status').notNull().default('DRAFT'), // DRAFT | SUBMITTED | APPROVED | REJECTED | IMPLEMENTED

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -28,7 +28,7 @@ import {
 } from '../services/inventoryApprovalExecutor';
 import { db } from '../../db';
 import { approvalRequestHistory, approvalRequests, employees, p2ProductionChanges, users } from '../../schema';
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, eq, sql } from 'drizzle-orm';
 
 export const approvalsRouter = Router();
 export const escalationPoliciesRouter = Router();
@@ -126,7 +126,7 @@ approvalsRouter.get('/my-tasks/:employeeId', async (req: Request, res: Response)
         and(
           eq(p2ProductionChanges.status, 'APPROVED'),
           eq(p2ProductionChanges.implementationRequired, true),
-          eq(p2ProductionChanges.approverEmployeeId, employeeId),
+          sql`${p2ProductionChanges.approvalAssignments} @> ${JSON.stringify([{ required: true, employeeId }])}::jsonb`,
         ),
       )
       .limit(100);
@@ -404,16 +404,31 @@ approvalsRouter.post('/:id/approve', async (req: Request, res: Response) => {
     }
 
     if (result.requestType === 'PRODUCTION_CHANGE_FORM') {
-      await db
-        .update(p2ProductionChanges)
-        .set({
-          status: 'APPROVED',
-          approvedById: (req.user as any)?.employeeId ?? null,
-          approvedByName: actor.displayName,
-          approvedAt: new Date(),
-          updatedAt: new Date(),
-        } as any)
-        .where(eq(p2ProductionChanges.approvalRequestId, result.id));
+      const pendingSiblings = await db
+        .select({ id: approvalRequests.id })
+        .from(approvalRequests)
+        .where(
+          and(
+            eq(approvalRequests.requestType, 'PRODUCTION_CHANGE_FORM'),
+            eq(approvalRequests.subjectType, result.subjectType ?? ''),
+            eq(approvalRequests.subjectId, result.subjectId ?? ''),
+            eq(approvalRequests.status, 'PENDING'),
+          ),
+        )
+        .limit(1);
+
+      if (pendingSiblings.length === 0) {
+        await db
+          .update(p2ProductionChanges)
+          .set({
+            status: 'APPROVED',
+            approvedById: (req.user as any)?.employeeId ?? null,
+            approvedByName: actor.displayName,
+            approvedAt: new Date(),
+            updatedAt: new Date(),
+          } as any)
+          .where(eq(p2ProductionChanges.id, result.subjectId ?? ''));
+      }
     }
 
     res.json({ ...result, executor });
@@ -454,7 +469,7 @@ approvalsRouter.post('/:id/reject', async (req: Request, res: Response) => {
           rejectionReason: body.notes ?? body.reasonCode ?? 'Rejected through approval inbox',
           updatedAt: new Date(),
         } as any)
-        .where(eq(p2ProductionChanges.approvalRequestId, result.id));
+        .where(eq(p2ProductionChanges.id, result.subjectId ?? ''));
     }
     res.json(result);
   } catch (err: any) {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3170,34 +3170,77 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { and, eq } = await import('drizzle-orm');
       const { cancel, openRequest } = await import('../services/escalationService');
       const { notificationManager } = await import('../services/notificationManager');
-      const approverEmployeeId = Number(req.body?.approverEmployeeId);
-      let approverEmployeeName: string | null = null;
-      let approverUserId: number | null = null;
+      const roleLabels: Record<string, string> = {
+        BUSINESS_MANAGER: 'Business Manager',
+        PURCHASING_QUALITY_MANAGER: 'Purchasing / Quality Manager',
+        PRODUCTION_MANAGER: 'Production Manager',
+        CUSTOMER: 'Customer',
+      };
+      const rawAssignments = Array.isArray(req.body?.approvalAssignments)
+        ? req.body.approvalAssignments
+        : [];
+      const requiredRawAssignments = rawAssignments.filter((assignment: any) => assignment?.required === true);
 
-      if (!Number.isInteger(approverEmployeeId) || approverEmployeeId <= 0) {
-        return res.status(400).json({ error: 'An assigned approver is required for a production change form.' });
+      if (requiredRawAssignments.length === 0) {
+        return res.status(400).json({ error: 'At least one required signer must be selected for a production change form.' });
       }
 
-      const [approver] = await db
-        .select({
-          employeeId: employees.id,
-          employeeName: employees.name,
-          userId: users.id,
-        })
-        .from(employees)
-        .leftJoin(users, and(eq(users.employeeId, employees.id), eq(users.isActive, true)))
-        .where(eq(employees.id, approverEmployeeId))
-        .limit(1);
+      const normalizedAssignments: Array<{
+        roleKey: string;
+        roleLabel: string;
+        required: boolean;
+        employeeId: number | null;
+        employeeName: string | null;
+        userId: number | null;
+      }> = [];
 
-      if (!approver) {
-        return res.status(404).json({ error: 'Assigned approver not found.' });
-      }
-      if (approver.userId == null) {
-        return res.status(400).json({ error: 'Assigned approver does not have an active user account.' });
+      for (const raw of rawAssignments) {
+        const roleKey = String(raw?.roleKey ?? '').trim();
+        if (!roleLabels[roleKey]) continue;
+        const employeeId = raw?.employeeId == null ? null : Number(raw.employeeId);
+        const normalized = {
+          roleKey,
+          roleLabel: roleLabels[roleKey],
+          required: raw?.required === true,
+          employeeId: Number.isInteger(employeeId) && employeeId > 0 ? employeeId : null,
+          employeeName: null as string | null,
+          userId: null as number | null,
+        };
+
+        if (normalized.required && normalized.employeeId == null) {
+          return res.status(400).json({ error: `${normalized.roleLabel} must be assigned to an active EPOCH user.` });
+        }
+
+        if (normalized.employeeId != null) {
+          const [assignee] = await db
+            .select({
+              employeeId: employees.id,
+              employeeName: employees.name,
+              userId: users.id,
+            })
+            .from(employees)
+            .leftJoin(users, and(eq(users.employeeId, employees.id), eq(users.isActive, true)))
+            .where(eq(employees.id, normalized.employeeId))
+            .limit(1);
+
+          if (!assignee) {
+            return res.status(404).json({ error: `${normalized.roleLabel} assignee not found.` });
+          }
+          if (normalized.required && assignee.userId == null) {
+            return res.status(400).json({ error: `${normalized.roleLabel} assignee does not have an active EPOCH user account.` });
+          }
+          normalized.employeeName = assignee.employeeName;
+          normalized.userId = assignee.userId ?? null;
+        }
+
+        normalizedAssignments.push(normalized);
       }
 
-      approverEmployeeName = approver.employeeName;
-      approverUserId = approver.userId;
+      const requiredAssignments = normalizedAssignments.filter((assignment) => assignment.required);
+      if (requiredAssignments.length === 0) {
+        return res.status(400).json({ error: 'At least one valid required signer must be selected for a production change form.' });
+      }
+      const primaryApprover = requiredAssignments[0];
       const actor = (req as any).user;
       const requestedByDisplayName =
         actor?.username ||
@@ -3207,89 +3250,106 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
       const change = await storage.createP2ProductionChange({
         ...req.body,
-        approverEmployeeId,
-        approverEmployeeName,
+        approverEmployeeId: primaryApprover.employeeId,
+        approverEmployeeName: primaryApprover.employeeName,
+        approvalAssignments: normalizedAssignments,
       });
 
-      let approvalIdToCancel: string | null = null;
+      const approvalIdsToCancel: string[] = [];
       try {
         const requiredActions = Array.isArray((change as any).requiredActions) ? (change as any).requiredActions : [];
-        const approval = await openRequest({
-          requestType: 'PRODUCTION_CHANGE_FORM',
-          payload: {
-            changeId: change.id,
-            changeNumber: change.changeNumber,
-            changeType: change.changeType,
-            scope: change.scope,
-            partNumber: change.partNumber,
-            poId: change.poId,
-            routingId: change.routingId,
-            currentRevision: change.currentRevision,
-            proposedRevision: (change as any).proposedRevision,
-            proposedChange: change.proposedChange,
-            reason: change.reason,
-            riskAssessment: change.riskAssessment,
-            affectedDocuments: (change as any).affectedDocuments ?? [],
-            requiredActions,
-            requiresCustomerApproval: change.requiresCustomerApproval,
-            implementationRequired: (change as any).implementationRequired ?? false,
-          },
-          subjectType: 'p2_production_change',
-          subjectId: change.id,
-          requestedByUserId: actor?.id ?? null,
-          requestedByDisplayName,
-          summary: `${change.changeNumber} ${change.changeType} change needs signature review.`,
-        });
-        approvalIdToCancel = approval.id;
+        const assignedApprovals = [];
 
-        const [assignedApproval] = await db
-          .update(approvalRequests)
-          .set({
-            currentApproverUserId: approverUserId,
-            updatedAt: new Date(),
-          })
-          .where(eq(approvalRequests.id, approval.id))
-          .returning();
-
-        await db.insert(approvalRequestHistory).values({
-          approvalRequestId: approval.id,
-          event: 'ASSIGNED',
-          fromLevel: approval.escalationLevel,
-          toLevel: approval.escalationLevel,
-          fromStatus: approval.status,
-          toStatus: approval.status,
-          actorUserId: actor?.id ?? null,
-          actorDisplayName: requestedByDisplayName,
-          notes: `Production change signature assigned to ${approverEmployeeName}`,
-          metadata: {
-            assignedEmployeeId: approverEmployeeId,
-            assignedUserId: approverUserId,
-            assignedEmployeeName: approverEmployeeName,
-            changeNumber: change.changeNumber,
-          },
-        });
-
-        notificationManager.sendToUsers([approverUserId], {
-          type: 'APPROVAL_REQUEST',
-          title: `Production change signature needed: ${change.changeNumber}`,
-          message: `${requestedByDisplayName} assigned you to review and sign ${change.changeNumber}.`,
-          data: {
-            approvalRequestId: approval.id,
+        for (const assignment of requiredAssignments) {
+          if (assignment.userId == null) {
+            throw new Error(`${assignment.roleLabel} must be assigned to an active EPOCH user.`);
+          }
+          const approval = await openRequest({
             requestType: 'PRODUCTION_CHANGE_FORM',
+            payload: {
+              changeId: change.id,
+              changeNumber: change.changeNumber,
+              changeType: change.changeType,
+              scope: change.scope,
+              partNumber: change.partNumber,
+              poId: change.poId,
+              routingId: change.routingId,
+              currentRevision: change.currentRevision,
+              proposedRevision: (change as any).proposedRevision,
+              proposedChange: change.proposedChange,
+              reason: change.reason,
+              riskAssessment: change.riskAssessment,
+              affectedDocuments: (change as any).affectedDocuments ?? [],
+              requiredActions,
+              approvalRoleKey: assignment.roleKey,
+              approvalRoleLabel: assignment.roleLabel,
+              approvalAssignments: normalizedAssignments,
+              requiresCustomerApproval: change.requiresCustomerApproval,
+              implementationRequired: (change as any).implementationRequired ?? false,
+            },
             subjectType: 'p2_production_change',
             subjectId: change.id,
-            changeNumber: change.changeNumber,
-          },
-          timestamp: new Date().toISOString(),
-        });
+            requestedByUserId: actor?.id ?? null,
+            requestedByDisplayName,
+            summary: `${change.changeNumber} ${assignment.roleLabel} signature review needed.`,
+          });
+          approvalIdsToCancel.push(approval.id);
+
+          const [assignedApproval] = await db
+            .update(approvalRequests)
+            .set({
+              currentApproverUserId: assignment.userId,
+              updatedAt: new Date(),
+            })
+            .where(eq(approvalRequests.id, approval.id))
+            .returning();
+          assignedApprovals.push(assignedApproval);
+
+          await db.insert(approvalRequestHistory).values({
+            approvalRequestId: approval.id,
+            event: 'ASSIGNED',
+            fromLevel: approval.escalationLevel,
+            toLevel: approval.escalationLevel,
+            fromStatus: approval.status,
+            toStatus: approval.status,
+            actorUserId: actor?.id ?? null,
+            actorDisplayName: requestedByDisplayName,
+            notes: `${assignment.roleLabel} production change signature assigned to ${assignment.employeeName}`,
+            metadata: {
+              roleKey: assignment.roleKey,
+              roleLabel: assignment.roleLabel,
+              assignedEmployeeId: assignment.employeeId,
+              assignedUserId: assignment.userId,
+              assignedEmployeeName: assignment.employeeName,
+              changeNumber: change.changeNumber,
+            },
+          });
+
+          notificationManager.sendToUsers([assignment.userId], {
+            type: 'APPROVAL_REQUEST',
+            title: `${assignment.roleLabel} signature needed: ${change.changeNumber}`,
+            message: `${requestedByDisplayName} assigned you to review and sign ${change.changeNumber}.`,
+            data: {
+              approvalRequestId: approval.id,
+              requestType: 'PRODUCTION_CHANGE_FORM',
+              subjectType: 'p2_production_change',
+              subjectId: change.id,
+              changeNumber: change.changeNumber,
+              roleKey: assignment.roleKey,
+              roleLabel: assignment.roleLabel,
+            },
+            timestamp: new Date().toISOString(),
+          });
+        }
 
         const updatedChange = await storage.updateP2ProductionChange(change.id, {
-          approvalRequestId: approval.id,
+          approvalRequestId: approvalIdsToCancel[0] ?? null,
+          approvalRequestIds: approvalIdsToCancel,
           status: 'SUBMITTED',
         } as any);
-        return res.status(201).json({ ...updatedChange, approvalRequest: assignedApproval });
+        return res.status(201).json({ ...updatedChange, approvalRequests: assignedApprovals });
       } catch (approvalError) {
-        if (approvalIdToCancel) {
+        for (const approvalIdToCancel of approvalIdsToCancel) {
           try {
             await cancel(
               approvalIdToCancel,


### PR DESCRIPTION
## Summary
- Make all P2 change-tab dialogs viewport-bounded and scrollable so form actions remain reachable.
- Replace the single PCF signer with role-based signer slots for Business Manager, Purchasing / Quality Manager, Production Manager, and Customer.
- Let each signer role be marked required or not required, and require every selected signer to be assigned to an active EPOCH user.
- Create a separate approval/signature task and notification for every required signer, and only mark the PCF approved after all required signatures are complete.
- Show the signer role in the approval summary and preserve signer assignment metadata on the PCF for audit traceability.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Bundled Node syntax checks with `--experimental-strip-types --check` for:
  - `server/src/routes/approvals.ts`
  - `server/src/routes/index.ts`
  - `server/schema.ts`

## Notes
- This follows up merged PR #1027, which merged before these requested refinements were added to the branch.
- `npm` and `gh` are not available on PATH in this local environment, so full `npm run check` and GitHub CLI PR creation were not run.