### PR TITLE
Show shipping notification delivery errors

### DIFF
--- a/client/src/components/BulkShippingActions.tsx
+++ b/client/src/components/BulkShippingActions.tsx
@@ -37,6 +37,20 @@ interface ReceiverAccount {
   zipCode: string;
 }
 
+function getNotificationErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as any;
+    const details = Array.isArray(data?.details)
+      ? data.details.filter(Boolean).join('; ')
+      : typeof data?.details === 'string'
+        ? data.details
+        : '';
+    return [data?.error || error.message, details].filter(Boolean).join(': ');
+  }
+
+  return error instanceof Error ? error.message : 'Notification could not be delivered.';
+}
+
 export function BulkShippingActions({
   selectedOrders,
   onClearSelection,
@@ -278,7 +292,7 @@ export function BulkShippingActions({
           console.error("Auto notification failed:", err);
           toast({
             title: "Notification Error",
-            description: "Label created but notification could not be delivered.",
+            description: `Label created but notification could not be delivered: ${getNotificationErrorMessage(err)}`,
             variant: "destructive",
           });
         }

--- a/client/src/pages/ShippingTracker.tsx
+++ b/client/src/pages/ShippingTracker.tsx
@@ -120,6 +120,18 @@ interface NotificationHistoryResponse {
   notifications: NotificationHistoryItem[];
 }
 
+function formatNotificationFailure(result: any): string {
+  const details = Array.isArray(result?.details)
+    ? result.details.filter(Boolean).join('; ')
+    : typeof result?.details === 'string'
+      ? result.details
+      : '';
+
+  return [result?.error || 'Failed to send notification', details]
+    .filter(Boolean)
+    .join(': ');
+}
+
 type DateRangeMode = 'week' | 'month' | 'quarter';
 
 const MONTH_NAMES = [
@@ -297,7 +309,7 @@ export default function ShippingTracker() {
 
       if (!response.ok) {
         console.error('[NOTIFY FAIL RESULT]', result);
-        throw new Error(result.error || 'Failed to send notification');
+        throw new Error(formatNotificationFailure(result));
       }
 
       return result;
@@ -315,7 +327,7 @@ export default function ShippingTracker() {
       console.error('[UI ERROR] Failed notification for order:', orderId, error);
       toast({
         title: 'Failed to Send Notification',
-        description: error.message + ' — see browser console for details',
+        description: error.message,
         variant: 'destructive',
       });
     },


### PR DESCRIPTION
## Summary
- Show backend notification failure details directly in the Shipping Tracker resend toast
- Surface the same delivery details when bulk label auto-notification fails
- Remove the operator dead-end that only said to inspect the browser console

## Validation
- `git diff --check`
- Confirmed changed call sites reference the new failure formatters

Note: full `npm run check` was not run in the clean worktree because `node_modules` is not installed there.