### PR TITLE
Send customer tracking emails from sales address

### DIFF
--- a/server/utils/notifications.ts
+++ b/server/utils/notifications.ts
@@ -390,6 +390,9 @@ Phone: 256-723-8381
 
   const result = await sendEmailViaSendGrid({
     to: data.email,
+    fromEmail: 'sales@agadvanced.com',
+    fromName: 'AG Composites Sales',
+    replyTo: 'sales@agadvanced.com',
     subject,
     text: message,
     html: message.replace(/\n/g, '<br>'),

--- a/server/utils/sendgrid.ts
+++ b/server/utils/sendgrid.ts
@@ -110,6 +110,7 @@ export async function sendEmailViaSendGrid(options: {
   text: string;
   html?: string;
   replyTo?: string;
+  fromEmail?: string;
   fromName?: string;
   cc?: string | string[];
   attachments?: Array<{
@@ -121,10 +122,15 @@ export async function sendEmailViaSendGrid(options: {
 }): Promise<{ success: boolean; messageId?: string; error?: string }> {
   try {
     const { client, fromEmail } = await getUncachableSendGridClient();
+    const sender = options.fromEmail
+      ? { email: options.fromEmail, name: options.fromName || fromEmail.name }
+      : options.fromName
+        ? { ...fromEmail, name: options.fromName }
+        : fromEmail;
 
     const msg: any = {
       to: options.to,
-      from: options.fromName ? { ...fromEmail, name: options.fromName } : fromEmail,
+      from: sender,
       replyTo: options.replyTo || { email: 'laurie.tandy@agadvanced.com', name: 'Laurie Tandy' },
       subject: options.subject,
       text: options.text,
@@ -144,7 +150,7 @@ export async function sendEmailViaSendGrid(options: {
     console.log('📧 Sending email via SendGrid:', {
       to: options.to,
       cc: options.cc,
-      from: fromEmail,
+      from: sender,
       replyTo: msg.replyTo,
       subject: options.subject,
       hasText: !!options.text,
@@ -157,10 +163,10 @@ export async function sendEmailViaSendGrid(options: {
 
     // DIAGNOSTIC: Log runtime configuration before send
     console.log('[Email Debug] Provider: SendGrid');
-    console.log('[Email Debug] From:', fromEmail.email);
+    console.log('[Email Debug] From:', sender.email);
     console.log('[Email Debug] Using Key:', process.env.SENDGRID_API_KEY ? 'present' : 'missing');
     console.log('[Compare] HealthCheck From vs Notification From');
-    console.log('[Compare] Notification From:', fromEmail.email);
+    console.log('[Compare] Notification From:', sender.email);
     console.log('[Compare] ENV SENDGRID_FROM_EMAIL:', process.env.SENDGRID_FROM_EMAIL || 'NOT SET');
 
     try {


### PR DESCRIPTION
## Summary
- Add a narrow `fromEmail` override to the shared SendGrid helper
- Send customer tracking notification emails from `sales@agadvanced.com` with display name `AG Composites Sales`
- Set tracking email replies to `sales@agadvanced.com`

## Notes
This requires `sales@agadvanced.com` to be a verified SendGrid sender or domain-authenticated sender. If it is not verified in SendGrid, SendGrid will reject the send.

## Validation
- `node --experimental-strip-types --check server/utils/notifications.ts`
- `node --experimental-strip-types --check server/utils/sendgrid.ts`
- `git diff --check HEAD~1..HEAD`