### PR TITLE
Make tracking notification sender configurable

### DIFF
--- a/server/utils/notifications.ts
+++ b/server/utils/notifications.ts
@@ -388,11 +388,20 @@ Phone: 256-723-8381
     subject,
   });
 
+  const trackingFromEmail =
+    process.env.TRACKING_NOTIFICATION_FROM_EMAIL ||
+    process.env.CUSTOMER_NOTIFICATION_FROM_EMAIL ||
+    undefined;
+  const trackingReplyTo =
+    process.env.TRACKING_NOTIFICATION_REPLY_TO ||
+    trackingFromEmail ||
+    undefined;
+
   const result = await sendEmailViaSendGrid({
     to: data.email,
-    fromEmail: 'sales@agadvanced.com',
+    ...(trackingFromEmail ? { fromEmail: trackingFromEmail } : {}),
     fromName: 'AG Composites Sales',
-    replyTo: 'sales@agadvanced.com',
+    ...(trackingReplyTo ? { replyTo: trackingReplyTo } : {}),
     subject,
     text: message,
     html: message.replace(/\n/g, '<br>'),


### PR DESCRIPTION
## Summary
- Stop hardcoding `sales@agadvanced.com` as the customer tracking email sender
- Use `TRACKING_NOTIFICATION_FROM_EMAIL` or `CUSTOMER_NOTIFICATION_FROM_EMAIL` when configured
- Fall back to the existing verified shared SendGrid sender when no tracking sender override is configured
- Keep the visible display name as `AG Composites Sales`

## Why
Production showed SendGrid rejecting `sales@agadvanced.com` because it is not a verified Sender Identity yet. This lets tracking emails send through the already verified sender immediately, while still allowing `sales@agadvanced.com` after it is verified and configured.

## Operational setup
To show customer tracking emails from `sales@agadvanced.com`, first verify that sender or authenticate the `agadvanced.com` domain in SendGrid. Then set:

- `TRACKING_NOTIFICATION_FROM_EMAIL=sales@agadvanced.com`
- optional: `TRACKING_NOTIFICATION_REPLY_TO=sales@agadvanced.com`

## Validation
- `node --experimental-strip-types --check server/utils/notifications.ts`
- `git diff --check`