### PR TITLE
Fix P2 PO wizard employee selectors

### DIFF
--- a/client/src/components/p2/P2POCreationWizard.tsx
+++ b/client/src/components/p2/P2POCreationWizard.tsx
@@ -52,6 +52,15 @@ interface Project {
   customerName?: string | null;
 }
 
+interface EmployeeOption {
+  id: number | string;
+  name?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  employeeCode?: string | null;
+  isActive?: boolean | null;
+}
+
 interface P2POCreationWizardProps {
   onComplete: (poId: number) => void;
   onCancel: () => void;
@@ -150,6 +159,16 @@ export default function P2POCreationWizard({
 
   const renderProjectLabel = (project: Project) =>
     `${project.projectCode} - ${project.projectName}${project.customerName ? ` (${project.customerName})` : ''}`;
+
+  const employeeOptions = employees.filter((emp: EmployeeOption) => emp.isActive !== false);
+  const getEmployeeName = (emp: EmployeeOption | null | undefined) =>
+    emp
+      ? emp.name || `${emp.firstName || ''} ${emp.lastName || ''}`.trim() || emp.employeeCode || `Employee ${emp.id}`
+      : null;
+  const findEmployeeById = (employeeId: string | undefined) =>
+    employeeId && employeeId !== 'none'
+      ? employeeOptions.find((emp: EmployeeOption) => String(emp.id) === employeeId)
+      : null;
 
   const createProductMutation = useMutation({
     mutationFn: async (data: typeof newProductForm) => {
@@ -323,18 +342,11 @@ export default function P2POCreationWizard({
 
   const handleCreateOrder = () => {
     // Find the selected tolerance authorizer employee
-    const selectedAuthorizerId = poDetails?.toleranceAuthorizer;
-    const selectedAuthorizer = selectedAuthorizerId 
-      ? employees.find((emp: any) => emp.id.toString() === selectedAuthorizerId)
-      : null;
+    const selectedAuthorizer = findEmployeeById(poDetails?.toleranceAuthorizer);
 
     // Find assigned employee and production lead for ownership fields
-    const assignedEmployee = poDetails?.assignedTo 
-      ? employees.find((e: any) => e.id.toString() === poDetails.assignedTo)
-      : null;
-    const productionLeadEmployee = poDetails?.productionLead
-      ? employees.find((e: any) => e.id.toString() === poDetails.productionLead)
-      : null;
+    const assignedEmployee = findEmployeeById(poDetails?.assignedTo);
+    const productionLeadEmployee = findEmployeeById(poDetails?.productionLead);
 
     const orderData = {
       customerId: selectedCustomer.customerId,
@@ -342,20 +354,14 @@ export default function P2POCreationWizard({
       dueDate: poDetails?.dueDate,
       // Properly map tolerance authorizer fields
       toleranceAuthorizerId: selectedAuthorizer?.id || null,
-      toleranceAuthorizerName: selectedAuthorizer 
-        ? `${selectedAuthorizer.firstName} ${selectedAuthorizer.lastName}` 
-        : null,
+      toleranceAuthorizerName: getEmployeeName(selectedAuthorizer),
       toleranceNotes: poDetails?.notes,
       notes: poDetails?.notes,
       // Ownership fields for accountability
       assignedToId: assignedEmployee?.id || null,
-      assignedToName: assignedEmployee 
-        ? `${assignedEmployee.firstName} ${assignedEmployee.lastName}` 
-        : null,
+      assignedToName: getEmployeeName(assignedEmployee),
       productionLeadId: productionLeadEmployee?.id || null,
-      productionLeadName: productionLeadEmployee
-        ? `${productionLeadEmployee.firstName} ${productionLeadEmployee.lastName}`
-        : null,
+      productionLeadName: getEmployeeName(productionLeadEmployee),
       projectId: poDetails?.projectId && poDetails.projectId !== NO_PROJECT_VALUE ? poDetails.projectId : null,
       projectName: poDetails?.projectName || null,
       lineItems: lineItems.map((item) => ({
@@ -517,12 +523,10 @@ export default function P2POCreationWizard({
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        <SelectItem value="none">None</SelectItem>
-                        {employees
-                          .filter((emp: any) => emp.isActive !== false)
-                          .map((emp: any) => (
+                        {employeeOptions
+                          .map((emp: EmployeeOption) => (
                             <SelectItem key={emp.id} value={emp.id.toString()}>
-                              {emp.name || `${emp.firstName || ''} ${emp.lastName || ''}`.trim() || `Employee ${emp.id}`}
+                              {getEmployeeName(emp)}
                             </SelectItem>
                           ))}
                       </SelectContent>
@@ -550,11 +554,10 @@ export default function P2POCreationWizard({
                           </FormControl>
                           <SelectContent>
                             <SelectItem value="none">Unassigned</SelectItem>
-                            {employees
-                              .filter((emp: any) => emp.isActive !== false)
-                              .map((emp: any) => (
+                            {employeeOptions
+                              .map((emp: EmployeeOption) => (
                                 <SelectItem key={emp.id} value={emp.id.toString()}>
-                                  {emp.name || `${emp.firstName || ''} ${emp.lastName || ''}`.trim() || `Employee ${emp.id}`}
+                                  {getEmployeeName(emp)}
                                 </SelectItem>
                               ))}
                           </SelectContent>
@@ -578,11 +581,10 @@ export default function P2POCreationWizard({
                           </FormControl>
                           <SelectContent>
                             <SelectItem value="none">Unassigned</SelectItem>
-                            {employees
-                              .filter((emp: any) => emp.isActive !== false)
-                              .map((emp: any) => (
+                            {employeeOptions
+                              .map((emp: EmployeeOption) => (
                                 <SelectItem key={emp.id} value={emp.id.toString()}>
-                                  {emp.name || `${emp.firstName || ''} ${emp.lastName || ''}`.trim() || `Employee ${emp.id}`}
+                                  {getEmployeeName(emp)}
                                 </SelectItem>
                               ))}
                           </SelectContent>

--- a/server/src/routes/employees.ts
+++ b/server/src/routes/employees.ts
@@ -34,10 +34,6 @@ const router = Router();
 let chargeCodeAssignmentTableReady: Promise<void> | null = null;
 let employeeTerminationSchemaReady: Promise<void> | null = null;
 
-function rows<T = any>(result: any): T[] {
-  return Array.isArray(result) ? result : (result?.rows ?? []);
-}
-
 const employeeListColumns = [
   ['id', 'id'],
   ['employee_code', 'employeeCode'],
@@ -94,6 +90,10 @@ const employeeListColumns = [
   ['created_at', 'createdAt'],
   ['updated_at', 'updatedAt'],
 ] as const;
+
+function rows<T = any>(result: any): T[] {
+  return Array.isArray(result) ? result : (result?.rows ?? []);
+}
 
 async function getEmployeesWithAvailableColumns() {
   const availableRows = await pool.query(
@@ -265,7 +265,11 @@ async function generateNextEmployeeCode(): Promise<string> {
 // Employee Management Routes
 router.get('/', async (req: Request, res: Response) => {
   try {
-    await ensureEmployeeTerminationSchema();
+    try {
+      await ensureEmployeeTerminationSchema();
+    } catch (error) {
+      console.warn('[Employees] Continuing list response after optional schema maintenance failed:', error);
+    }
     const includeInactive =
       req.query.includeInactive === 'true' ||
       req.query.includeTerminated === 'true' ||
@@ -273,14 +277,8 @@ router.get('/', async (req: Request, res: Response) => {
     let allEmployees;
     try {
       allEmployees = await storage.getAllEmployees();
-    } catch (error: any) {
-      if (error?.code !== '42703') {
-        throw error;
-      }
-      console.warn(
-        '[Employees] Falling back to available-column employee list after schema drift:',
-        error?.message
-      );
+    } catch (error) {
+      console.warn('[Employees] Falling back to available-column employee list:', error);
       allEmployees = await getEmployeesWithAvailableColumns();
     }
     const employees = includeInactive

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -15482,7 +15482,7 @@ export class DatabaseStorage implements IStorage {
         scheduled_by_id, scheduled_by_name, production_lead_id, production_lead_name,
         project_id, project_name
       ) VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26
       )
       RETURNING id, po_number as "poNumber", customer_id as "customerId",
         customer_name as "customerName", po_date as "poDate",


### PR DESCRIPTION
## Summary
- Populate the P2 PO wizard tolerance authorizer, assigned-to, and production lead selectors from the active employee list with one shared name resolver
- Remove the invalid `None` option from the required tolerance authorizer selector while keeping `Unassigned` for optional ownership fields
- Fix P2 PO creation by matching the insert placeholder count to the target columns
- Make `/api/employees` resilient to optional employee schema drift so the wizard can still load employee dropdown options

## Validation
- `git diff --cached --check` before commit
- `git diff --check` on touched files

Note: TypeScript/build validation could not be run locally because `node.exe` is blocked with `Access is denied` in this worktree.