### PR TITLE
Add cutting queue health badges

### DIFF
--- a/client/src/components/cutting/CuttingQueueHealthBadges.tsx
+++ b/client/src/components/cutting/CuttingQueueHealthBadges.tsx
@@ -1,0 +1,92 @@
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle, CheckCircle2, Layers, PackageCheck, Printer, Route } from "lucide-react";
+
+export type CuttingQueueHealthItem = {
+  status?: string | null;
+  packetBomId?: string | null;
+  bomPartNumber?: string | null;
+  poNumbers?: Array<unknown> | null;
+  quantityRequested?: number | null;
+  quantityOrdered?: number | null;
+  quantityCompleted?: number | null;
+  allocatedPacketCount?: number | null;
+  printableBarcodeCount?: number | null;
+};
+
+type Props = {
+  item: CuttingQueueHealthItem;
+  compact?: boolean;
+};
+
+function numberValue(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function CuttingQueueHealthBadges({ item, compact = false }: Props) {
+  const quantityRequested = numberValue(item.quantityRequested ?? item.quantityOrdered);
+  const quantityCompleted = numberValue(item.quantityCompleted);
+  const allocatedPacketCount = numberValue(item.allocatedPacketCount);
+  const printableBarcodeCount = numberValue(item.printableBarcodeCount);
+  const hasBom = Boolean(item.packetBomId || item.bomPartNumber);
+  const groupedPoCount = Array.isArray(item.poNumbers) ? item.poNumbers.length : 0;
+  const status = item.status || "PENDING";
+  const isActive = status === "PENDING" || status === "IN_PROGRESS";
+  const isPartial = quantityCompleted > 0 && quantityCompleted < quantityRequested;
+  const hasTrace = allocatedPacketCount > 0 || quantityCompleted > 0;
+  const traceComplete = quantityRequested > 0 && quantityCompleted >= quantityRequested && hasTrace;
+  const needsLabels = isActive && printableBarcodeCount > 0;
+
+  const className = compact ? "h-6 gap-1 px-1.5 text-[11px]" : "gap-1";
+  const iconClassName = "h-3 w-3";
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {hasBom ? (
+        <Badge variant="secondary" className={className} title="Active BOM matched">
+          <CheckCircle2 className={iconClassName} />
+          BOM OK
+        </Badge>
+      ) : (
+        <Badge variant="destructive" className={className} title="No active BOM matched this queue row">
+          <AlertTriangle className={iconClassName} />
+          No BOM
+        </Badge>
+      )}
+
+      {groupedPoCount > 0 && (
+        <Badge variant="outline" className={className} title="Grouped demand from multiple PO contributors">
+          <Route className={iconClassName} />
+          {groupedPoCount} PO{groupedPoCount === 1 ? "" : "s"}
+        </Badge>
+      )}
+
+      {needsLabels && (
+        <Badge variant="outline" className={className} title={`${printableBarcodeCount} packet barcode(s) still printable`}>
+          <Printer className={iconClassName} />
+          {printableBarcodeCount} labels
+        </Badge>
+      )}
+
+      {isPartial && (
+        <Badge variant="secondary" className={className} title="Some packet trace records have been completed">
+          <Layers className={iconClassName} />
+          Partial
+        </Badge>
+      )}
+
+      {hasTrace && !traceComplete && !isPartial && (
+        <Badge variant="outline" className={className} title="Trace records or allocations exist for this work order">
+          <PackageCheck className={iconClassName} />
+          Trace started
+        </Badge>
+      )}
+
+      {traceComplete && (
+        <Badge className={className} title="Completed quantity has packet trace records">
+          <PackageCheck className={iconClassName} />
+          Trace complete
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/dialog";
 import { GroupedPOsBadge } from "@/components/cutting/GroupedPOsBadge";
 import { CuttingQueueTraceSheet } from "@/components/cutting/CuttingQueueTraceSheet";
+import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealthBadges";
 import { useToast } from "@/hooks/use-toast";
 import {
   Accordion,
@@ -2265,6 +2266,9 @@ export default function CuttingOperatorDashboard() {
                             poNumbers={item.poNumbers}
                             testIdPrefix={`pos-${item.id}`}
                           />
+                        </div>
+                        <div className="mt-1">
+                          <CuttingQueueHealthBadges item={item} compact />
                         </div>
                       </TableCell>
                       <TableCell className="text-center">

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -21,6 +21,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { GroupedPOsBadge, type GroupedPOEntry } from "@/components/cutting/GroupedPOsBadge";
 import { CuttingQueueTraceSheet } from "@/components/cutting/CuttingQueueTraceSheet";
+import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealthBadges";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1013,6 +1014,13 @@ export default function CuttingWeeklySchedule() {
                           <GroupedPOsBadge
                             poNumbers={poEntries}
                             testIdPrefix={`weekly-pos-${item.id}`}
+                          />
+                          <CuttingQueueHealthBadges
+                            item={{
+                              ...item,
+                              poNumbers: poEntries,
+                            }}
+                            compact
                           />
                         </div>
                       </TableCell>


### PR DESCRIPTION
## Summary
- Add a shared cutting queue health badge component for quick work-order readiness/status signals
- Show BOM readiness, grouped demand count, printable label count, partial progress, and trace completion badges in Weekly Scheduling
- Show the same compact health signals in the Operator Dashboard scheduled packet rows

## Validation
- `git diff --cached --check`

## Notes
- `npm run check` could not be run locally because `npm` is not available in this shell.