### PR TITLE
Show cutting queue BOM match reasons

### DIFF
--- a/client/src/components/cutting/CuttingBomMatchBadge.tsx
+++ b/client/src/components/cutting/CuttingBomMatchBadge.tsx
@@ -1,0 +1,57 @@
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle2, HelpCircle, Link2, Search } from "lucide-react";
+
+type Props = {
+  reason?: string | null;
+  confidence?: "strong" | "medium" | "fallback" | "none" | string | null;
+  compact?: boolean;
+};
+
+const labels: Record<string, string> = {
+  notes_bom_id: "BOM ID",
+  inventory_item: "Item link",
+  part_number: "Part #",
+  material_type: "Material",
+  packet_name: "Name",
+  item_name: "Item name",
+};
+
+export function CuttingBomMatchBadge({ reason, confidence, compact = false }: Props) {
+  const normalizedConfidence = confidence || "none";
+  const label = reason ? labels[reason] || reason.replace(/_/g, " ") : "No BOM";
+  const className = compact ? "h-6 gap-1 px-1.5 text-[11px]" : "gap-1";
+
+  if (normalizedConfidence === "strong") {
+    return (
+      <Badge variant="secondary" className={className} title={`BOM matched by ${label}`}>
+        <CheckCircle2 className="h-3 w-3" />
+        {label}
+      </Badge>
+    );
+  }
+
+  if (normalizedConfidence === "medium") {
+    return (
+      <Badge variant="outline" className={className} title={`BOM matched by ${label}`}>
+        <Link2 className="h-3 w-3" />
+        {label}
+      </Badge>
+    );
+  }
+
+  if (normalizedConfidence === "fallback") {
+    return (
+      <Badge variant="outline" className={className} title={`Fallback BOM match by ${label}`}>
+        <Search className="h-3 w-3" />
+        {label}
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="destructive" className={className} title="No active BOM matched this queue row">
+      <HelpCircle className="h-3 w-3" />
+      No BOM
+    </Badge>
+  );
+}

--- a/client/src/components/cutting/CuttingQueueTraceSheet.tsx
+++ b/client/src/components/cutting/CuttingQueueTraceSheet.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { History, PackageCheck, Route, ScanLine, Layers, AlertTriangle } from "lucide-react";
+import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge";
 
 type TraceContributor = {
   poNumber: string;
@@ -90,6 +91,7 @@ type CuttingQueueTrace = {
     squareMetersPerCut: number;
     noPlySchedule: boolean | null;
     matchReason: string | null;
+    matchConfidence?: string | null;
     materials: Array<{ id: string; fabricType: string | null; commonName: string | null; rollsRequired: number | null }>;
     parts: Array<{ id: string; partNumber: string; partDescription: string | null; fabricType: string | null; commonName: string | null; yieldPerCut: number | null }>;
   } | null;
@@ -249,7 +251,7 @@ export function CuttingQueueTraceSheet({ queueId, label = "Trace", variant = "gh
                       <div className="flex flex-wrap gap-2">
                         <Badge>{data.bom.packetType}</Badge>
                         <Badge variant="outline">{data.bom.partNumber}</Badge>
-                        <Badge variant="secondary">Matched by {data.bom.matchReason || "fallback"}</Badge>
+                        <CuttingBomMatchBadge reason={data.bom.matchReason} confidence={data.bom.matchConfidence} compact />
                       </div>
                       <DetailRow label="Yield per cut" value={data.bom.yieldPerCut} />
                       <DetailRow label="Sq m per cut" value={data.bom.squareMetersPerCut} />

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -33,6 +33,7 @@ import {
 import { GroupedPOsBadge } from "@/components/cutting/GroupedPOsBadge";
 import { CuttingQueueTraceSheet } from "@/components/cutting/CuttingQueueTraceSheet";
 import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealthBadges";
+import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge";
 import { useToast } from "@/hooks/use-toast";
 import {
   Accordion,
@@ -151,6 +152,8 @@ type ManufacturingQueueItem = {
   dueDate: string | null;
   estimatedCuts: number;
   packetBomId: string | null;
+  bomMatchReason?: string | null;
+  bomMatchConfidence?: string | null;
   poNumbers?: GroupedPO[] | null;
   allocatedPacketCount?: number;
   printableBarcodeCount?: number;
@@ -519,6 +522,8 @@ export default function CuttingOperatorDashboard() {
         estimatedCuts,
         displayName,
         packetBomId: bomId || matchingBOM?.id,
+        bomMatchReason: item.bomMatchReason || (bomId || matchingBOM?.id ? 'client_fallback' : null),
+        bomMatchConfidence: item.bomMatchConfidence || (bomId ? 'strong' : matchingBOM?.id ? 'fallback' : 'none'),
         poNumbers,
       };
     });
@@ -2265,6 +2270,11 @@ export default function CuttingOperatorDashboard() {
                           <GroupedPOsBadge
                             poNumbers={item.poNumbers}
                             testIdPrefix={`pos-${item.id}`}
+                          />
+                          <CuttingBomMatchBadge
+                            reason={item.bomMatchReason}
+                            confidence={item.bomMatchConfidence}
+                            compact
                           />
                         </div>
                         <div className="mt-1">

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -22,6 +22,7 @@ import { useToast } from "@/hooks/use-toast";
 import { GroupedPOsBadge, type GroupedPOEntry } from "@/components/cutting/GroupedPOsBadge";
 import { CuttingQueueTraceSheet } from "@/components/cutting/CuttingQueueTraceSheet";
 import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealthBadges";
+import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1020,6 +1021,11 @@ export default function CuttingWeeklySchedule() {
                               ...item,
                               poNumbers: poEntries,
                             }}
+                            compact
+                          />
+                          <CuttingBomMatchBadge
+                            reason={item.bomMatchReason}
+                            confidence={item.bomMatchConfidence}
                             compact
                           />
                         </div>

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -52,6 +52,74 @@ function parseQueueNotes(notes: string | null): Record<string, any> {
   }
 }
 
+type QueueBomMatch = {
+  bom: any | null;
+  reason: 'notes_bom_id' | 'inventory_item' | 'part_number' | 'material_type' | 'packet_name' | 'item_name' | null;
+  confidence: 'strong' | 'medium' | 'fallback' | 'none';
+};
+
+function resolveQueueBomMatch(params: {
+  allActiveBoms: Array<{ id: string; partNumber: string; inventoryItemId: number | null; packetType?: string | null }>;
+  bomId?: string | null;
+  inventoryItemId?: number | null;
+  itemPartNumber?: string | null;
+  materialType?: string | null;
+  packetName?: string | null;
+  itemName?: string | null;
+}): QueueBomMatch {
+  const { allActiveBoms, bomId, inventoryItemId, itemPartNumber, materialType, packetName, itemName } = params;
+
+  const byBomId = bomId ? allActiveBoms.find((b) => b.id === bomId) : null;
+  if (byBomId) return { bom: byBomId, reason: 'notes_bom_id', confidence: 'strong' };
+
+  const byInventoryItem = inventoryItemId
+    ? allActiveBoms.find((b) => b.inventoryItemId != null && b.inventoryItemId === inventoryItemId)
+    : null;
+  if (byInventoryItem) return { bom: byInventoryItem, reason: 'inventory_item', confidence: 'strong' };
+
+  const byPartNumber = itemPartNumber ? allActiveBoms.find((b) => b.partNumber === itemPartNumber) : null;
+  if (byPartNumber) return { bom: byPartNumber, reason: 'part_number', confidence: 'medium' };
+
+  const materialToPacketType: Record<string, string> = {
+    carbon_fiber: 'carbon fiber packet',
+    fiberglass: 'fiberglass packet',
+    mesa: 'mesa packet',
+    p2_disruptor: 'disruptor',
+    p2_disruptor_packet: 'disruptor packet',
+    p2_antenna: 'antenna cover',
+    p2_antenna_cover: 'antenna cover packet',
+  };
+
+  const materialTarget = materialType ? materialToPacketType[materialType] : null;
+  const byMaterialType = materialTarget
+    ? allActiveBoms.find((b) => {
+        const packetType = String(b.packetType || '').toLowerCase();
+        return packetType === materialTarget || packetType.includes(materialTarget) || materialTarget.includes(packetType);
+      })
+    : null;
+  if (byMaterialType) return { bom: byMaterialType, reason: 'material_type', confidence: 'fallback' };
+
+  const normalizedPacketName = packetName ? packetName.toLowerCase() : null;
+  const byPacketName = normalizedPacketName
+    ? allActiveBoms.find((b) => {
+        const packetType = String(b.packetType || '').toLowerCase();
+        return packetType === normalizedPacketName || packetType.includes(normalizedPacketName) || normalizedPacketName.includes(packetType);
+      })
+    : null;
+  if (byPacketName) return { bom: byPacketName, reason: 'packet_name', confidence: 'fallback' };
+
+  const normalizedItemName = itemName ? itemName.toLowerCase() : null;
+  const byItemName = normalizedItemName
+    ? allActiveBoms.find((b) => {
+        const packetType = String(b.packetType || '').toLowerCase();
+        return packetType === normalizedItemName || packetType.includes(normalizedItemName) || normalizedItemName.includes(packetType);
+      })
+    : null;
+  if (byItemName) return { bom: byItemName, reason: 'item_name', confidence: 'fallback' };
+
+  return { bom: null, reason: null, confidence: 'none' };
+}
+
 async function ensureBuiltPacketsForCompletedQueueRows(): Promise<void> {
   const cuttingTableDept = supplySourceDashboardToLegacyDept('CUTTING_TABLE')!;
   const cuttingTableCategories = getDashboardCategories('CUTTING_TABLE');
@@ -188,13 +256,14 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
       .limit(CUTTING_QUEUE_MAX_ROWS);
 
     // Fetch all active BOMs once for efficient lookup. Selecting only the
-    // columns we use downstream (id, partNumber, inventoryItemId) so the BOM
+    // columns we use downstream so the BOM
     // table doesn't have to be fully materialised in memory.
     const allActiveBoms = await db
       .select({
         id: cuttingPacketBOMs.id,
         partNumber: cuttingPacketBOMs.partNumber,
         inventoryItemId: cuttingPacketBOMs.inventoryItemId,
+        packetType: cuttingPacketBOMs.packetType,
       })
       .from(cuttingPacketBOMs)
       .where(eq(cuttingPacketBOMs.isActive, true));
@@ -244,12 +313,16 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
         // Notes might not be JSON, that's ok
       }
 
-      // Find the BOM linked to this queue item (by bomId, inventoryItemId, or partNumber)
-      const linkedBom = 
-        (packetBomId && allActiveBoms.find(b => b.id === packetBomId)) ||
-        (row.queue.inventoryItemId && allActiveBoms.find(b => b.inventoryItemId != null && b.inventoryItemId === row.queue.inventoryItemId)) ||
-        (row.item?.agPartNumber && allActiveBoms.find(b => b.partNumber === row.item!.agPartNumber)) ||
-        null;
+      const bomMatch = resolveQueueBomMatch({
+        allActiveBoms,
+        bomId: packetBomId,
+        inventoryItemId: row.queue.inventoryItemId,
+        itemPartNumber: row.item?.agPartNumber ?? null,
+        materialType,
+        packetName,
+        itemName: row.item?.name ?? null,
+      });
+      const linkedBom = bomMatch.bom;
 
       const displayName = packetName || userNotes || row.item?.name || orderId || null;
       const quantityRequested = row.queue.quantityRequested || 0;
@@ -264,8 +337,10 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
         partName: row.item?.name,
         displayName,
         inventoryItem: row.item,
-        packetBomId,
+        packetBomId: linkedBom?.id || packetBomId,
         bomPartNumber: linkedBom?.partNumber || null,
+        bomMatchReason: bomMatch.reason,
+        bomMatchConfidence: bomMatch.confidence,
         materialType,
         source,
         orderId,
@@ -340,32 +415,16 @@ router.get('/:id/trace', async (req: Request, res: Response) => {
       .from(cuttingPacketBOMs)
       .where(eq(cuttingPacketBOMs.isActive, true));
 
-    let bomMatchReason: string | null = null;
-    let packetBom =
-      notes.bomId
-        ? allActiveBoms.find((b) => b.id === notes.bomId) ?? null
-        : null;
-    if (packetBom) bomMatchReason = 'notes.bomId';
-
-    if (!packetBom && row.queue.inventoryItemId) {
-      packetBom = allActiveBoms.find((b) => b.inventoryItemId != null && b.inventoryItemId === row.queue.inventoryItemId) ?? null;
-      if (packetBom) bomMatchReason = 'inventory item';
-    }
-
-    if (!packetBom && row.item?.agPartNumber) {
-      packetBom = allActiveBoms.find((b) => b.partNumber === row.item!.agPartNumber) ?? null;
-      if (packetBom) bomMatchReason = 'part number';
-    }
-
-    if (!packetBom && (notes.packetName || row.item?.name)) {
-      const name = String(notes.packetName || row.item?.name || '').toLowerCase();
-      packetBom = allActiveBoms.find((b) =>
-        b.packetType.toLowerCase() === name ||
-        b.packetType.toLowerCase().includes(name) ||
-        name.includes(b.packetType.toLowerCase())
-      ) ?? null;
-      if (packetBom) bomMatchReason = 'packet name';
-    }
+    const bomMatch = resolveQueueBomMatch({
+      allActiveBoms,
+      bomId: notes.bomId || null,
+      inventoryItemId: row.queue.inventoryItemId,
+      itemPartNumber: row.item?.agPartNumber ?? null,
+      materialType: notes.materialType || null,
+      packetName: notes.packetName || null,
+      itemName: row.item?.name ?? null,
+    });
+    const packetBom = bomMatch.bom;
 
     const bomMaterials = packetBom
       ? await db.select().from(cuttingPacketBOMMaterials).where(eq(cuttingPacketBOMMaterials.packetBomId, packetBom.id))
@@ -463,7 +522,8 @@ router.get('/:id/trace', async (req: Request, res: Response) => {
         squareMetersPerCut: packetBom.squareMetersPerCut,
         wasteFactor: packetBom.wasteFactor,
         noPlySchedule: packetBom.noPlySchedule,
-        matchReason: bomMatchReason,
+        matchReason: bomMatch.reason,
+        matchConfidence: bomMatch.confidence,
         materials: bomMaterials,
         parts: bomParts,
       } : null,


### PR DESCRIPTION
## Summary
- Add explicit BOM match reason/confidence fields to the cutting-table queue API
- Reuse the same BOM match reason in the trace drawer payload
- Add a shared BOM match badge and show match strength in Weekly Scheduling and Operator Dashboard rows

## Validation
- `git diff --cached --check`

## Notes
- `npm run check` could not be run locally because `npm` is not available in this shell.