### PR TITLE
Protect cutting queue rows already in production

### DIFF
--- a/client/src/components/cutting/CuttingQueueNextActionBadge.tsx
+++ b/client/src/components/cutting/CuttingQueueNextActionBadge.tsx
@@ -11,6 +11,8 @@ export type CuttingQueueNextActionItem = {
   quantityCompleted?: number | null;
   allocatedPacketCount?: number | null;
   printableBarcodeCount?: number | null;
+  productionProtected?: boolean | null;
+  productionProtectionReason?: string | null;
 };
 
 type Props = {
@@ -32,7 +34,7 @@ export function CuttingQueueNextActionBadge({ item, compact = false }: Props) {
   const quantityCompleted = numberValue(item.quantityCompleted);
   const printableBarcodeCount = numberValue(item.printableBarcodeCount);
   const allocatedPacketCount = numberValue(item.allocatedPacketCount);
-  const hasTrace = allocatedPacketCount > 0 || quantityCompleted > 0;
+  const hasTrace = allocatedPacketCount > 0 || quantityCompleted > 0 || Boolean(item.productionProtected);
   const className = compact ? "h-6 gap-1 px-1.5 text-[11px]" : "gap-1";
   const iconClassName = "h-3 w-3";
 
@@ -56,8 +58,13 @@ export function CuttingQueueNextActionBadge({ item, compact = false }: Props) {
 
   if (hasTrace) {
     const fullyAccountedFor = quantityRequested > 0 && allocatedPacketCount >= quantityRequested;
+    const reason = item.productionProtectionReason === "built_packets_exist"
+      ? "Built packet records already exist"
+      : item.productionProtectionReason === "quantity_completed"
+        ? "Completed quantity is already recorded"
+        : "Packets already have production trace or allocation";
     return (
-      <Badge variant="outline" className={className} title="Packets already have production trace or allocation; review only">
+      <Badge variant="outline" className={className} title={`${reason}; review only`}>
         <PackageCheck className={iconClassName} />
         {fullyAccountedFor ? "In production" : "Review trace"}
       </Badge>

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -156,8 +156,11 @@ type ManufacturingQueueItem = {
   bomMatchReason?: string | null;
   bomMatchConfidence?: string | null;
   poNumbers?: GroupedPO[] | null;
+  builtPacketCount?: number;
   allocatedPacketCount?: number;
   printableBarcodeCount?: number;
+  productionProtected?: boolean;
+  productionProtectionReason?: string | null;
 };
 
 type PacketBOM = {
@@ -233,8 +236,17 @@ function getPrintableBarcodeCount(item: ManufacturingQueueItem): number {
   return Math.max(0, (item.quantityOrdered || 0) - (item.quantityCompleted || 0));
 }
 
+function isQueueProductionProtected(item: ManufacturingQueueItem): boolean {
+  return Boolean(
+    item.productionProtected ||
+    item.quantityCompleted > 0 ||
+    (item.builtPacketCount || 0) > 0 ||
+    (item.allocatedPacketCount || 0) > 0
+  );
+}
+
 function isPacketBarcodePrintable(item: ManufacturingQueueItem): boolean {
-  return (item.status === 'PENDING' || item.status === 'IN_PROGRESS') && getPrintableBarcodeCount(item) > 0;
+  return (item.status === 'PENDING' || item.status === 'IN_PROGRESS') && !isQueueProductionProtected(item) && getPrintableBarcodeCount(item) > 0;
 }
 
 function useIsAdmin() {
@@ -2242,7 +2254,10 @@ export default function CuttingOperatorDashboard() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {mfgQueueItems.map((item) => (
+                  {mfgQueueItems.map((item) => {
+                    const isProductionProtected = isQueueProductionProtected(item);
+
+                    return (
                     <TableRow 
                       key={item.id} 
                       className={cn(
@@ -2253,7 +2268,7 @@ export default function CuttingOperatorDashboard() {
                       data-testid={`row-mfg-item-${item.id}`}
                     >
                       <TableCell>
-                        {isPacketBarcodePrintable(item) ? (
+                        {isPacketBarcodePrintable(item) && !isProductionProtected ? (
                           <input
                             type="checkbox"
                             checked={selectedPrintIds.includes(item.id)}
@@ -2299,7 +2314,7 @@ export default function CuttingOperatorDashboard() {
                         <Badge variant="outline" className="font-mono">{item.estimatedCuts}</Badge>
                       </TableCell>
                       <TableCell className="text-center">
-                        {isPacketBarcodePrintable(item) ? (
+                        {isPacketBarcodePrintable(item) && !isProductionProtected ? (
                           <Input
                             type="number"
                             min={1}
@@ -2338,7 +2353,7 @@ export default function CuttingOperatorDashboard() {
                       <TableCell>
                         <div className="flex gap-1 justify-end">
                           <CuttingQueueTraceSheet queueId={item.id} size="icon" iconOnly />
-                          {item.status === 'PENDING' && (
+                          {item.status === 'PENDING' && !isProductionProtected && (
                             <Button 
                               size="sm" 
                               onClick={() => handleStartCuttingWorkflow(item)}
@@ -2359,18 +2374,20 @@ export default function CuttingOperatorDashboard() {
                                 <Scissors className="h-4 w-4 mr-1" />
                                 View
                               </Button>
-                              <Button 
-                                size="sm"
-                                className="bg-green-600 hover:bg-green-700"
-                                onClick={() => { setSelectedMfgItem(item); setIsProductionDialogOpen(true); }}
-                                data-testid={`button-complete-${item.id}`}
-                              >
-                                <CheckCircle2 className="h-4 w-4 mr-1" />
-                                Complete
-                              </Button>
+                              {!isProductionProtected && (
+                                <Button
+                                  size="sm"
+                                  className="bg-green-600 hover:bg-green-700"
+                                  onClick={() => { setSelectedMfgItem(item); setIsProductionDialogOpen(true); }}
+                                  data-testid={`button-complete-${item.id}`}
+                                >
+                                  <CheckCircle2 className="h-4 w-4 mr-1" />
+                                  Complete
+                                </Button>
+                              )}
                             </>
                           )}
-                          {item.status === 'COMPLETED' && (
+                          {item.status === 'COMPLETED' && !isProductionProtected && (
                             <Button 
                               size="sm" 
                               variant="outline"
@@ -2384,7 +2401,8 @@ export default function CuttingOperatorDashboard() {
                         </div>
                       </TableCell>
                     </TableRow>
-                  ))}
+                    );
+                  })}
                 </TableBody>
               </Table>
             </div>

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -976,6 +976,12 @@ export default function CuttingWeeklySchedule() {
                   const poEntries: GroupedPOEntry[] = Array.isArray(item.poNumbers)
                     ? item.poNumbers
                     : (Array.isArray(notes.poNumbers) ? notes.poNumbers : []);
+                  const isProductionProtected = Boolean(
+                    item.productionProtected ||
+                    (item.quantityCompleted || 0) > 0 ||
+                    (item.builtPacketCount || 0) > 0 ||
+                    (item.allocatedPacketCount || 0) > 0
+                  );
 
                   const getDescription = () => {
                     if (item.displayName) return item.displayName;
@@ -1045,7 +1051,7 @@ export default function CuttingWeeklySchedule() {
                       <TableCell>
                         <div className="flex justify-end gap-1">
                           <CuttingQueueTraceSheet queueId={item.id} size="icon" iconOnly />
-                        {item.status !== 'COMPLETED' && (
+                        {item.status !== 'COMPLETED' && !isProductionProtected && (
                           <AlertDialog>
                             <AlertDialogTrigger asChild>
                               <Button

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -327,8 +327,15 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
       const displayName = packetName || userNotes || row.item?.name || orderId || null;
       const quantityRequested = row.queue.quantityRequested || 0;
       const completedQuantity = row.queue.quantityCompleted || 0;
-      const allocatedPacketCount = Math.max(completedQuantity, builtPacketCounts.get(row.queue.id) || 0);
+      const builtPacketCount = builtPacketCounts.get(row.queue.id) || 0;
+      const allocatedPacketCount = Math.max(completedQuantity, builtPacketCount);
       const printableBarcodeCount = Math.max(0, quantityRequested - allocatedPacketCount);
+      const productionProtected = completedQuantity > 0 || builtPacketCount > 0;
+      const productionProtectionReason = builtPacketCount > 0
+        ? 'built_packets_exist'
+        : completedQuantity > 0
+          ? 'quantity_completed'
+          : null;
       
       return {
         ...row.queue,
@@ -346,8 +353,11 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
         orderId,
         packetName,
         poNumbers,
+        builtPacketCount,
         allocatedPacketCount,
         printableBarcodeCount,
+        productionProtected,
+        productionProtectionReason,
       };
     });
     
@@ -1850,6 +1860,19 @@ router.delete('/:id', async (req: Request, res: Response) => {
 
     if (queueItem.status === 'IN_PROGRESS' && (queueItem.quantityCompleted || 0) > 0) {
       return res.status(400).json({ error: 'Cannot unschedule an item that has partially completed work' });
+    }
+
+    const builtPackets = await db
+      .select({ barcode: cuttingBuiltPackets.barcode })
+      .from(cuttingBuiltPackets);
+    const builtPacketCount = builtPackets.filter((packet) => parseQueueIdFromBuiltPacketBarcode(packet.barcode) === parsedId).length;
+
+    if ((queueItem.quantityCompleted || 0) > 0 || builtPacketCount > 0) {
+      return res.status(409).json({
+        error: 'Cannot unschedule a packet that is already in production',
+        productionProtected: true,
+        productionProtectionReason: builtPacketCount > 0 ? 'built_packets_exist' : 'quantity_completed',
+      });
     }
 
     // Capture the packet identity BEFORE deleting so we can preserve barcode→packet


### PR DESCRIPTION
## Summary
- Add explicit production protection fields to cutting queue rows when completed quantity or built packet records exist
- Suppress print, start, complete, and unschedule controls for protected queue rows while keeping trace review available
- Block unschedule requests server-side when a queue row already has built packets or completed quantity

## Validation
- `git diff --cached --check`

## Notes
- This is stacked on PR #1040 (`codex/cutting-next-action`) so it only contains the production protection layer.
- The change does not mutate existing production packets; it marks and protects them from new cutting-table actions.
- `npm run check` could not be run locally because `npm` is not available in this shell.