### PR TITLE
Show cutting queue production lock reasons

### DIFF
--- a/client/src/components/cutting/CuttingQueueProductionLockNotice.tsx
+++ b/client/src/components/cutting/CuttingQueueProductionLockNotice.tsx
@@ -1,0 +1,56 @@
+import { Badge } from "@/components/ui/badge";
+import { LockKeyhole, PackageCheck } from "lucide-react";
+
+export type CuttingQueueProductionLockItem = {
+  productionProtected?: boolean | null;
+  productionProtectionReason?: string | null;
+  builtPacketCount?: number | null;
+  allocatedPacketCount?: number | null;
+  quantityCompleted?: number | null;
+};
+
+type Props = {
+  item: CuttingQueueProductionLockItem;
+  compact?: boolean;
+};
+
+function numberValue(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function lockReasonLabel(reason: string | null | undefined): string {
+  if (reason === "built_packets_exist") return "built packets exist";
+  if (reason === "quantity_completed") return "completed quantity recorded";
+  return "production trace exists";
+}
+
+export function CuttingQueueProductionLockNotice({ item, compact = false }: Props) {
+  const builtPacketCount = numberValue(item.builtPacketCount);
+  const allocatedPacketCount = numberValue(item.allocatedPacketCount);
+  const quantityCompleted = numberValue(item.quantityCompleted);
+  const isProtected = Boolean(item.productionProtected || builtPacketCount > 0 || allocatedPacketCount > 0 || quantityCompleted > 0);
+
+  if (!isProtected) return null;
+
+  const className = compact
+    ? "mt-1 flex flex-wrap items-center gap-1 text-[11px] text-muted-foreground"
+    : "mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground";
+
+  return (
+    <div className={className}>
+      <Badge variant="outline" className="h-6 gap-1 px-1.5 text-[11px]" title="This queue row is read-only because production trace already exists">
+        <LockKeyhole className="h-3 w-3" />
+        Production locked
+      </Badge>
+      <span>{lockReasonLabel(item.productionProtectionReason)}.</span>
+      {builtPacketCount > 0 && (
+        <span className="inline-flex items-center gap-1">
+          <PackageCheck className="h-3 w-3" />
+          {builtPacketCount} built
+        </span>
+      )}
+      {allocatedPacketCount > 0 && <span>{allocatedPacketCount} traced</span>}
+      {quantityCompleted > 0 && <span>{quantityCompleted} completed</span>}
+    </div>
+  );
+}

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -35,6 +35,7 @@ import { CuttingQueueTraceSheet } from "@/components/cutting/CuttingQueueTraceSh
 import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealthBadges";
 import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge";
 import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNextActionBadge";
+import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
 import { useToast } from "@/hooks/use-toast";
 import {
   Accordion,
@@ -2297,6 +2298,7 @@ export default function CuttingOperatorDashboard() {
                         <div className="mt-1">
                           <CuttingQueueHealthBadges item={item} compact />
                         </div>
+                        <CuttingQueueProductionLockNotice item={item} compact />
                       </TableCell>
                       <TableCell className="text-center">
                         <div className="flex items-center justify-center gap-1">

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -24,6 +24,7 @@ import { CuttingQueueTraceSheet } from "@/components/cutting/CuttingQueueTraceSh
 import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealthBadges";
 import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge";
 import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNextActionBadge";
+import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1037,6 +1038,7 @@ export default function CuttingWeeklySchedule() {
                             compact
                           />
                         </div>
+                        <CuttingQueueProductionLockNotice item={item} compact />
                       </TableCell>
                       <TableCell className="text-center">{item.quantityRequested}</TableCell>
                       <TableCell className="text-center">{item.quantityCompleted || 0}</TableCell>


### PR DESCRIPTION
## Summary
- Add a read-only production lock notice for protected cutting queue rows
- Show why actions are unavailable using the existing production protection reason and trace counts
- Surface the notice in Weekly Scheduling and Operator Dashboard without changing queue state

## Validation
- `git diff --cached --check`

## Notes
- This is stacked on PR #1041 (`codex/cutting-production-lock`) and only adds visibility for protected rows.
- It does not mutate existing production packets or add new action paths.
- `npm run check` could not be run locally because `npm` is not available in this shell.