### PR TITLE
Add cutting queue view filters

### DIFF
--- a/client/src/components/cutting/CuttingQueueFilterBar.tsx
+++ b/client/src/components/cutting/CuttingQueueFilterBar.tsx
@@ -1,0 +1,114 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export type CuttingQueueFilterValue = "all" | "needs_bom" | "needs_labels" | "ready_to_cut" | "in_production" | "trace_review";
+
+export type CuttingQueueFilterItem = {
+  status?: string | null;
+  packetBomId?: string | null;
+  bomPartNumber?: string | null;
+  bomMatchConfidence?: string | null;
+  quantityRequested?: number | null;
+  quantityOrdered?: number | null;
+  quantityCompleted?: number | null;
+  builtPacketCount?: number | null;
+  allocatedPacketCount?: number | null;
+  printableBarcodeCount?: number | null;
+  productionProtected?: boolean | null;
+};
+
+type Props<T extends CuttingQueueFilterItem> = {
+  items: T[];
+  value: CuttingQueueFilterValue;
+  onChange: (value: CuttingQueueFilterValue) => void;
+};
+
+const filterLabels: Record<CuttingQueueFilterValue, string> = {
+  all: "All",
+  needs_bom: "Needs BOM",
+  needs_labels: "Needs labels",
+  ready_to_cut: "Ready to cut",
+  in_production: "In production",
+  trace_review: "Trace review",
+};
+
+function numberValue(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function isCuttingQueueProductionProtected(item: CuttingQueueFilterItem): boolean {
+  return Boolean(
+    item.productionProtected ||
+    numberValue(item.quantityCompleted) > 0 ||
+    numberValue(item.builtPacketCount) > 0 ||
+    numberValue(item.allocatedPacketCount) > 0
+  );
+}
+
+function hasBomMatch(item: CuttingQueueFilterItem): boolean {
+  return Boolean(item.packetBomId || item.bomPartNumber || (item.bomMatchConfidence && item.bomMatchConfidence !== "none"));
+}
+
+function hasPrintableLabels(item: CuttingQueueFilterItem): boolean {
+  const status = item.status || "PENDING";
+  return (status === "PENDING" || status === "IN_PROGRESS")
+    && !isCuttingQueueProductionProtected(item)
+    && numberValue(item.printableBarcodeCount) > 0;
+}
+
+function isReadyToCut(item: CuttingQueueFilterItem): boolean {
+  const status = item.status || "PENDING";
+  return status === "PENDING"
+    && hasBomMatch(item)
+    && !isCuttingQueueProductionProtected(item)
+    && !hasPrintableLabels(item);
+}
+
+function needsTraceReview(item: CuttingQueueFilterItem): boolean {
+  const requested = numberValue(item.quantityRequested ?? item.quantityOrdered);
+  const completed = numberValue(item.quantityCompleted);
+  const protectedRow = isCuttingQueueProductionProtected(item);
+  return protectedRow && item.status !== "COMPLETED" && (requested === 0 || completed < requested);
+}
+
+export function filterCuttingQueueItems<T extends CuttingQueueFilterItem>(items: T[], filter: CuttingQueueFilterValue): T[] {
+  if (filter === "all") return items;
+  if (filter === "needs_bom") return items.filter((item) => !hasBomMatch(item));
+  if (filter === "needs_labels") return items.filter(hasPrintableLabels);
+  if (filter === "ready_to_cut") return items.filter(isReadyToCut);
+  if (filter === "in_production") return items.filter(isCuttingQueueProductionProtected);
+  if (filter === "trace_review") return items.filter(needsTraceReview);
+  return items;
+}
+
+export function CuttingQueueFilterBar<T extends CuttingQueueFilterItem>({ items, value, onChange }: Props<T>) {
+  const counts = {
+    all: items.length,
+    needs_bom: filterCuttingQueueItems(items, "needs_bom").length,
+    needs_labels: filterCuttingQueueItems(items, "needs_labels").length,
+    ready_to_cut: filterCuttingQueueItems(items, "ready_to_cut").length,
+    in_production: filterCuttingQueueItems(items, "in_production").length,
+    trace_review: filterCuttingQueueItems(items, "trace_review").length,
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {(Object.keys(filterLabels) as CuttingQueueFilterValue[]).map((filter) => (
+        <Button
+          key={filter}
+          type="button"
+          variant={value === filter ? "default" : "outline"}
+          size="sm"
+          className="h-8 gap-1.5 px-2"
+          onClick={() => onChange(filter)}
+          data-testid={`cutting-queue-filter-${filter}`}
+        >
+          <span>{filterLabels[filter]}</span>
+          <Badge variant={value === filter ? "secondary" : "outline"} className="h-5 px-1.5 text-[10px]">
+            {counts[filter]}
+          </Badge>
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -36,6 +36,12 @@ import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealt
 import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge";
 import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNextActionBadge";
 import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
+import {
+  CuttingQueueFilterBar,
+  filterCuttingQueueItems,
+  isCuttingQueueProductionProtected,
+  type CuttingQueueFilterValue,
+} from "@/components/cutting/CuttingQueueFilterBar";
 import { useToast } from "@/hooks/use-toast";
 import {
   Accordion,
@@ -238,12 +244,7 @@ function getPrintableBarcodeCount(item: ManufacturingQueueItem): number {
 }
 
 function isQueueProductionProtected(item: ManufacturingQueueItem): boolean {
-  return Boolean(
-    item.productionProtected ||
-    item.quantityCompleted > 0 ||
-    (item.builtPacketCount || 0) > 0 ||
-    (item.allocatedPacketCount || 0) > 0
-  );
+  return isCuttingQueueProductionProtected(item);
 }
 
 function isPacketBarcodePrintable(item: ManufacturingQueueItem): boolean {
@@ -261,6 +262,7 @@ export default function CuttingOperatorDashboard() {
   const isAdmin = useIsAdmin();
   
   const [selectedStatus, setSelectedStatus] = useState<string>("ACTIVE");
+  const [queueFilter, setQueueFilter] = useState<CuttingQueueFilterValue>("all");
   const [selectedMfgItem, setSelectedMfgItem] = useState<ManufacturingQueueItem | null>(null);
   const [isProductionDialogOpen, setIsProductionDialogOpen] = useState(false);
   const [isCuttingWorkflowOpen, setIsCuttingWorkflowOpen] = useState(false);
@@ -1346,7 +1348,11 @@ export default function CuttingOperatorDashboard() {
   const pendingReceiving = freezerAssignmentQueue.length;
   const inProgressCount = mfgQueueItems.filter(i => i.status === 'IN_PROGRESS').length;
   const pendingCount = mfgQueueItems.filter(i => i.status === 'PENDING').length;
-  const printableQueueItems = mfgQueueItems.filter(isPacketBarcodePrintable);
+  const filteredMfgQueueItems = useMemo(
+    () => filterCuttingQueueItems(mfgQueueItems, queueFilter),
+    [mfgQueueItems, queueFilter]
+  );
+  const printableQueueItems = filteredMfgQueueItems.filter(isPacketBarcodePrintable);
   const printableQueueIds = printableQueueItems.map(i => i.id);
   const selectedPrintableIds = selectedPrintIds.filter(id => printableQueueIds.includes(id));
   const printTargetIds = selectedPrintableIds.length > 0 ? selectedPrintableIds : printableQueueIds;
@@ -2227,35 +2233,45 @@ export default function CuttingOperatorDashboard() {
               <p>No items in the queue</p>
               <p className="text-sm">Schedule packets from the Weekly Scheduling page</p>
             </div>
+          ) : filteredMfgQueueItems.length === 0 ? (
+            <div className="space-y-3">
+              <CuttingQueueFilterBar items={mfgQueueItems} value={queueFilter} onChange={setQueueFilter} />
+              <div className="text-center py-10 text-muted-foreground border-2 border-dashed rounded-lg">
+                <Scissors className="h-8 w-8 mx-auto mb-2 opacity-30" />
+                <p>No queue rows match this filter</p>
+              </div>
+            </div>
           ) : (
-            <div className="rounded-lg border overflow-x-auto">
-              <Table>
-                <TableHeader className="bg-muted/50">
-                  <TableRow>
-                    <TableHead className="w-10">
-                      <input
-                        type="checkbox"
-                        checked={selectedPrintableIds.length > 0 && selectedPrintableIds.length === printableQueueItems.length}
-                        onChange={selectAllPendingForPrint}
-                        className="h-4 w-4 rounded border-gray-300"
-                        title="Select all for printing"
-                        disabled={printableQueueItems.length === 0}
-                      />
-                    </TableHead>
-                    <TableHead>Part Number</TableHead>
-                    <TableHead>Name</TableHead>
-                    <TableHead className="text-center">Progress</TableHead>
-                    <TableHead className="text-center">Cuts</TableHead>
-                    <TableHead className="text-center w-24"># to Print</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Next</TableHead>
-                    <TableHead className="text-center">Priority</TableHead>
-                    <TableHead>Due Date</TableHead>
-                    <TableHead className="w-48 text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {mfgQueueItems.map((item) => {
+            <div className="space-y-3">
+              <CuttingQueueFilterBar items={mfgQueueItems} value={queueFilter} onChange={setQueueFilter} />
+              <div className="rounded-lg border overflow-x-auto">
+                <Table>
+                  <TableHeader className="bg-muted/50">
+                    <TableRow>
+                      <TableHead className="w-10">
+                        <input
+                          type="checkbox"
+                          checked={selectedPrintableIds.length > 0 && selectedPrintableIds.length === printableQueueItems.length}
+                          onChange={selectAllPendingForPrint}
+                          className="h-4 w-4 rounded border-gray-300"
+                          title="Select all for printing"
+                          disabled={printableQueueItems.length === 0}
+                        />
+                      </TableHead>
+                      <TableHead>Part Number</TableHead>
+                      <TableHead>Name</TableHead>
+                      <TableHead className="text-center">Progress</TableHead>
+                      <TableHead className="text-center">Cuts</TableHead>
+                      <TableHead className="text-center w-24"># to Print</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Next</TableHead>
+                      <TableHead className="text-center">Priority</TableHead>
+                      <TableHead>Due Date</TableHead>
+                      <TableHead className="w-48 text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredMfgQueueItems.map((item) => {
                     const isProductionProtected = isQueueProductionProtected(item);
 
                     return (
@@ -2405,8 +2421,9 @@ export default function CuttingOperatorDashboard() {
                     </TableRow>
                     );
                   })}
-                </TableBody>
-              </Table>
+                  </TableBody>
+                </Table>
+              </div>
             </div>
           )}
         </CardContent>

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -26,6 +26,11 @@ import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge"
 import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNextActionBadge";
 import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
 import {
+  CuttingQueueFilterBar,
+  filterCuttingQueueItems,
+  type CuttingQueueFilterValue,
+} from "@/components/cutting/CuttingQueueFilterBar";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -107,6 +112,7 @@ export default function CuttingWeeklySchedule() {
   const { toast } = useToast();
   
   const [currentWeek] = useState(getMondayOfWeek(new Date()));
+  const [queueFilter, setQueueFilter] = useState<CuttingQueueFilterValue>("all");
   const [scheduleQuantities, setScheduleQuantities] = useState<Record<string, number>>({});
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({ p1: true, p2: true });
   const [customDemand, setCustomDemand] = useState({
@@ -296,6 +302,15 @@ export default function CuttingWeeklySchedule() {
     });
     return result;
   }, [mfgQueueData]);
+
+  const activeScheduledRows = useMemo(
+    () => (mfgQueueData || []).filter((item: any) => item.status !== 'COMPLETED'),
+    [mfgQueueData]
+  );
+  const filteredScheduledRows = useMemo(
+    () => filterCuttingQueueItems(activeScheduledRows, queueFilter),
+    [activeScheduledRows, queueFilter]
+  );
 
   const schedulePacketsMutation = useMutation({
     mutationFn: async (data: { packetType: string; quantity: number; materialType: string; description?: string; poNumber?: string; suppressToast?: boolean }) => {
@@ -950,24 +965,33 @@ export default function CuttingWeeklySchedule() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          {(mfgQueueData || []).filter((item: any) => item.status !== 'COMPLETED').length === 0 ? (
+          {activeScheduledRows.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               No packets currently scheduled for cutting
             </div>
+          ) : filteredScheduledRows.length === 0 ? (
+            <div className="space-y-3">
+              <CuttingQueueFilterBar items={activeScheduledRows} value={queueFilter} onChange={setQueueFilter} />
+              <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
+                No scheduled packets match this filter
+              </div>
+            </div>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Description</TableHead>
-                  <TableHead className="text-center">Qty</TableHead>
-                  <TableHead className="text-center">Done</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Next</TableHead>
-                  <TableHead className="w-24"></TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {(mfgQueueData || []).filter((item: any) => item.status !== 'COMPLETED').slice(0, 15).map((item: any) => {
+            <div className="space-y-3">
+              <CuttingQueueFilterBar items={activeScheduledRows} value={queueFilter} onChange={setQueueFilter} />
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Description</TableHead>
+                    <TableHead className="text-center">Qty</TableHead>
+                    <TableHead className="text-center">Done</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Next</TableHead>
+                    <TableHead className="w-24"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredScheduledRows.slice(0, 15).map((item: any) => {
                   let notes: any = {};
                   let rawNotes = item.notes || '';
                   try { notes = JSON.parse(item.notes || '{}'); } catch {
@@ -1089,8 +1113,9 @@ export default function CuttingWeeklySchedule() {
                     </TableRow>
                   );
                 })}
-              </TableBody>
-            </Table>
+                </TableBody>
+              </Table>
+            </div>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Add a shared read-only cutting queue filter bar with counts for key queue views
- Filter Weekly Scheduling and Operator Dashboard rows by Needs BOM, Needs labels, Ready to cut, In production, and Trace review
- Keep production-protected rows read-only while making them easier to find

## Validation
- `git diff --cached --check`

## Notes
- This is stacked on PR #1042 (`codex/cutting-production-lock-visibility`) and only changes client-side filtering/presentation.
- It does not mutate existing production packets or add new action paths.
- `npm run check` could not be run locally because `npm` is not available in this shell.