### PR TITLE
Add cutting queue summary rollups

### DIFF
--- a/client/src/components/cutting/CuttingQueueFilterBar.tsx
+++ b/client/src/components/cutting/CuttingQueueFilterBar.tsx
@@ -32,6 +32,8 @@ const filterLabels: Record<CuttingQueueFilterValue, string> = {
   trace_review: "Trace review",
 };
 
+export { filterLabels as cuttingQueueFilterLabels };
+
 function numberValue(value: number | null | undefined): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
@@ -81,8 +83,8 @@ export function filterCuttingQueueItems<T extends CuttingQueueFilterItem>(items:
   return items;
 }
 
-export function CuttingQueueFilterBar<T extends CuttingQueueFilterItem>({ items, value, onChange }: Props<T>) {
-  const counts = {
+export function getCuttingQueueFilterCounts<T extends CuttingQueueFilterItem>(items: T[]): Record<CuttingQueueFilterValue, number> {
+  return {
     all: items.length,
     needs_bom: filterCuttingQueueItems(items, "needs_bom").length,
     needs_labels: filterCuttingQueueItems(items, "needs_labels").length,
@@ -90,6 +92,10 @@ export function CuttingQueueFilterBar<T extends CuttingQueueFilterItem>({ items,
     in_production: filterCuttingQueueItems(items, "in_production").length,
     trace_review: filterCuttingQueueItems(items, "trace_review").length,
   };
+}
+
+export function CuttingQueueFilterBar<T extends CuttingQueueFilterItem>({ items, value, onChange }: Props<T>) {
+  const counts = getCuttingQueueFilterCounts(items);
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">

--- a/client/src/components/cutting/CuttingQueueSummaryStrip.tsx
+++ b/client/src/components/cutting/CuttingQueueSummaryStrip.tsx
@@ -1,0 +1,46 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  cuttingQueueFilterLabels,
+  getCuttingQueueFilterCounts,
+  type CuttingQueueFilterItem,
+  type CuttingQueueFilterValue,
+} from "@/components/cutting/CuttingQueueFilterBar";
+
+type Props<T extends CuttingQueueFilterItem> = {
+  items: T[];
+};
+
+const summaryOrder: CuttingQueueFilterValue[] = [
+  "all",
+  "ready_to_cut",
+  "needs_labels",
+  "needs_bom",
+  "in_production",
+  "trace_review",
+];
+
+function summaryVariant(filter: CuttingQueueFilterValue): "default" | "secondary" | "destructive" | "outline" {
+  if (filter === "ready_to_cut") return "secondary";
+  if (filter === "needs_bom") return "destructive";
+  return "outline";
+}
+
+export function CuttingQueueSummaryStrip<T extends CuttingQueueFilterItem>({ items }: Props<T>) {
+  const counts = getCuttingQueueFilterCounts(items);
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {summaryOrder.map((filter) => (
+        <Badge
+          key={filter}
+          variant={summaryVariant(filter)}
+          className="h-7 gap-1 px-2 text-xs"
+          data-testid={`cutting-queue-summary-${filter}`}
+        >
+          <span>{cuttingQueueFilterLabels[filter]}</span>
+          <span className="font-mono font-semibold">{counts[filter]}</span>
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -36,6 +36,7 @@ import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealt
 import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge";
 import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNextActionBadge";
 import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
+import { CuttingQueueSummaryStrip } from "@/components/cutting/CuttingQueueSummaryStrip";
 import {
   CuttingQueueFilterBar,
   filterCuttingQueueItems,
@@ -1367,6 +1368,9 @@ export default function CuttingOperatorDashboard() {
             Operator Dashboard
           </h2>
           <p className="text-muted-foreground text-sm">Cutting workflow, fabric selection, and label printing</p>
+          <div className="mt-2">
+            <CuttingQueueSummaryStrip items={mfgQueueItems} />
+          </div>
         </div>
         <div className="flex items-center gap-3">
           <div className="flex gap-2 text-sm">

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -25,6 +25,7 @@ import { CuttingQueueHealthBadges } from "@/components/cutting/CuttingQueueHealt
 import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge";
 import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNextActionBadge";
 import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
+import { CuttingQueueSummaryStrip } from "@/components/cutting/CuttingQueueSummaryStrip";
 import {
   CuttingQueueFilterBar,
   filterCuttingQueueItems,
@@ -963,6 +964,9 @@ export default function CuttingWeeklySchedule() {
             <Calendar className="h-5 w-5" />
             Currently Scheduled for Cutting
           </CardTitle>
+          {activeScheduledRows.length > 0 && (
+            <CuttingQueueSummaryStrip items={activeScheduledRows} />
+          )}
         </CardHeader>
         <CardContent>
           {activeScheduledRows.length === 0 ? (


### PR DESCRIPTION
## Summary
- Add a shared read-only cutting queue summary strip
- Reuse the same queue filter counts for scheduled, ready, labels, BOM, production, and trace-review rollups
- Show the summary in Weekly Scheduling and Operator Dashboard without changing queue state

## Validation
- `git diff --cached --check`

## Notes
- This is stacked on PR #1044 (`codex/cutting-queue-filters`) and only adds read-only summary counts.
- It does not mutate existing production packets or add new action paths.
- `npm run check` could not be run locally because `npm` is not available in this shell.