### PR TITLE
Add cutting queue CSV export

### DIFF
--- a/client/src/components/cutting/CuttingQueueExportButton.tsx
+++ b/client/src/components/cutting/CuttingQueueExportButton.tsx
@@ -1,0 +1,83 @@
+import { Button } from "@/components/ui/button";
+import { Download } from "lucide-react";
+
+type CuttingQueueExportItem = {
+  id?: number | string | null;
+  partNumber?: string | null;
+  partName?: string | null;
+  displayName?: string | null;
+  packetName?: string | null;
+  materialType?: string | null;
+  status?: string | null;
+  quantityRequested?: number | null;
+  quantityOrdered?: number | null;
+  quantityCompleted?: number | null;
+  printableBarcodeCount?: number | null;
+  builtPacketCount?: number | null;
+  allocatedPacketCount?: number | null;
+  productionProtected?: boolean | null;
+  productionProtectionReason?: string | null;
+  bomMatchReason?: string | null;
+  bomMatchConfidence?: string | null;
+};
+
+type Props<T extends CuttingQueueExportItem> = {
+  items: T[];
+  filenamePrefix: string;
+};
+
+const columns: Array<{ header: string; value: (item: CuttingQueueExportItem) => unknown }> = [
+  { header: "Queue ID", value: (item) => item.id ?? "" },
+  { header: "Part Number", value: (item) => item.partNumber ?? "" },
+  { header: "Description", value: (item) => item.displayName ?? item.packetName ?? item.partName ?? "" },
+  { header: "Material Type", value: (item) => item.materialType ?? "" },
+  { header: "Status", value: (item) => item.status ?? "" },
+  { header: "Quantity Requested", value: (item) => item.quantityRequested ?? item.quantityOrdered ?? 0 },
+  { header: "Quantity Completed", value: (item) => item.quantityCompleted ?? 0 },
+  { header: "Printable Labels", value: (item) => item.printableBarcodeCount ?? 0 },
+  { header: "Built Packets", value: (item) => item.builtPacketCount ?? 0 },
+  { header: "Trace/Allocated Packets", value: (item) => item.allocatedPacketCount ?? 0 },
+  { header: "Production Protected", value: (item) => item.productionProtected ? "Yes" : "No" },
+  { header: "Protection Reason", value: (item) => item.productionProtectionReason ?? "" },
+  { header: "BOM Match", value: (item) => item.bomMatchReason ?? "" },
+  { header: "BOM Confidence", value: (item) => item.bomMatchConfidence ?? "" },
+];
+
+function csvCell(value: unknown): string {
+  const text = String(value ?? "");
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+function exportRows(items: CuttingQueueExportItem[], filenamePrefix: string) {
+  const header = columns.map((column) => csvCell(column.header)).join(",");
+  const rows = items.map((item) => columns.map((column) => csvCell(column.value(item))).join(","));
+  const csv = [header, ...rows].join("\r\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  const stamp = new Date().toISOString().slice(0, 10);
+
+  link.href = url;
+  link.download = `${filenamePrefix}-${stamp}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function CuttingQueueExportButton<T extends CuttingQueueExportItem>({ items, filenamePrefix }: Props<T>) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-8 gap-1.5 px-2"
+      onClick={() => exportRows(items, filenamePrefix)}
+      disabled={items.length === 0}
+      data-testid={`button-export-${filenamePrefix}`}
+    >
+      <Download className="h-3.5 w-3.5" />
+      Export view
+    </Button>
+  );
+}

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -37,6 +37,7 @@ import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge"
 import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNextActionBadge";
 import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
 import { CuttingQueueSummaryStrip } from "@/components/cutting/CuttingQueueSummaryStrip";
+import { CuttingQueueExportButton } from "@/components/cutting/CuttingQueueExportButton";
 import {
   CuttingQueueFilterBar,
   filterCuttingQueueItems,
@@ -2239,7 +2240,10 @@ export default function CuttingOperatorDashboard() {
             </div>
           ) : filteredMfgQueueItems.length === 0 ? (
             <div className="space-y-3">
-              <CuttingQueueFilterBar items={mfgQueueItems} value={queueFilter} onChange={setQueueFilter} />
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <CuttingQueueFilterBar items={mfgQueueItems} value={queueFilter} onChange={setQueueFilter} />
+                <CuttingQueueExportButton items={filteredMfgQueueItems} filenamePrefix="cutting-operator-queue" />
+              </div>
               <div className="text-center py-10 text-muted-foreground border-2 border-dashed rounded-lg">
                 <Scissors className="h-8 w-8 mx-auto mb-2 opacity-30" />
                 <p>No queue rows match this filter</p>
@@ -2247,7 +2251,10 @@ export default function CuttingOperatorDashboard() {
             </div>
           ) : (
             <div className="space-y-3">
-              <CuttingQueueFilterBar items={mfgQueueItems} value={queueFilter} onChange={setQueueFilter} />
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <CuttingQueueFilterBar items={mfgQueueItems} value={queueFilter} onChange={setQueueFilter} />
+                <CuttingQueueExportButton items={filteredMfgQueueItems} filenamePrefix="cutting-operator-queue" />
+              </div>
               <div className="rounded-lg border overflow-x-auto">
                 <Table>
                   <TableHeader className="bg-muted/50">

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -26,6 +26,7 @@ import { CuttingBomMatchBadge } from "@/components/cutting/CuttingBomMatchBadge"
 import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNextActionBadge";
 import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
 import { CuttingQueueSummaryStrip } from "@/components/cutting/CuttingQueueSummaryStrip";
+import { CuttingQueueExportButton } from "@/components/cutting/CuttingQueueExportButton";
 import {
   CuttingQueueFilterBar,
   filterCuttingQueueItems,
@@ -975,14 +976,20 @@ export default function CuttingWeeklySchedule() {
             </div>
           ) : filteredScheduledRows.length === 0 ? (
             <div className="space-y-3">
-              <CuttingQueueFilterBar items={activeScheduledRows} value={queueFilter} onChange={setQueueFilter} />
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <CuttingQueueFilterBar items={activeScheduledRows} value={queueFilter} onChange={setQueueFilter} />
+                <CuttingQueueExportButton items={filteredScheduledRows} filenamePrefix="cutting-weekly-schedule" />
+              </div>
               <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
                 No scheduled packets match this filter
               </div>
             </div>
           ) : (
             <div className="space-y-3">
-              <CuttingQueueFilterBar items={activeScheduledRows} value={queueFilter} onChange={setQueueFilter} />
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <CuttingQueueFilterBar items={activeScheduledRows} value={queueFilter} onChange={setQueueFilter} />
+                <CuttingQueueExportButton items={filteredScheduledRows} filenamePrefix="cutting-weekly-schedule" />
+              </div>
               <Table>
                 <TableHeader>
                   <TableRow>


### PR DESCRIPTION
## Summary
- Add a shared client-side CSV export button for cutting queue views
- Export the currently filtered Weekly Scheduling and Operator Dashboard rows
- Include traceability fields like BOM match, printable labels, built packets, allocated packets, and production protection reason

## Validation
- `git diff --cached --check`

## Notes
- This is stacked on PR #1046 (`codex/cutting-queue-rollups`) and only exports already-loaded client data.
- It does not mutate existing production packets or add new action paths.
- `npm run check` could not be run locally because `npm` is not available in this shell.