### PR TITLE
Improve cutting queue empty states

### DIFF
--- a/client/src/components/cutting/CuttingQueueEmptyState.tsx
+++ b/client/src/components/cutting/CuttingQueueEmptyState.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { ClipboardList, FilterX, Scissors } from "lucide-react";
+import { cuttingQueueFilterLabels, type CuttingQueueFilterValue } from "@/components/cutting/CuttingQueueFilterBar";
+
+type Props = {
+  mode: "empty" | "filtered";
+  filter?: CuttingQueueFilterValue;
+  onClearFilter?: () => void;
+  className?: string;
+};
+
+const filterMessages: Partial<Record<CuttingQueueFilterValue, string>> = {
+  needs_bom: "Every visible row has an active BOM match.",
+  needs_labels: "No visible rows currently need packet labels.",
+  ready_to_cut: "No visible rows are ready to start cutting.",
+  in_production: "No visible rows are locked by production trace.",
+  trace_review: "No visible rows need trace review.",
+};
+
+export function CuttingQueueEmptyState({ mode, filter = "all", onClearFilter, className = "" }: Props) {
+  if (mode === "empty") {
+    return (
+      <div className={`text-center py-12 text-muted-foreground border-2 border-dashed rounded-lg ${className}`}>
+        <Scissors className="h-8 w-8 mx-auto mb-2 opacity-30" />
+        <p>No packets are scheduled for cutting</p>
+        <p className="text-sm">New demand will appear here after scheduling.</p>
+      </div>
+    );
+  }
+
+  const label = cuttingQueueFilterLabels[filter] || "selected";
+  const message = filterMessages[filter] || "No visible rows match this filter.";
+
+  return (
+    <div className={`text-center py-10 text-muted-foreground border-2 border-dashed rounded-lg ${className}`}>
+      <FilterX className="h-8 w-8 mx-auto mb-2 opacity-30" />
+      <p>No rows in {label}</p>
+      <p className="text-sm">{message}</p>
+      {onClearFilter && filter !== "all" && (
+        <Button type="button" variant="outline" size="sm" className="mt-3 gap-1.5" onClick={onClearFilter}>
+          <ClipboardList className="h-3.5 w-3.5" />
+          Show all rows
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -38,6 +38,7 @@ import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNe
 import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
 import { CuttingQueueSummaryStrip } from "@/components/cutting/CuttingQueueSummaryStrip";
 import { CuttingQueueExportButton } from "@/components/cutting/CuttingQueueExportButton";
+import { CuttingQueueEmptyState } from "@/components/cutting/CuttingQueueEmptyState";
 import {
   CuttingQueueFilterBar,
   filterCuttingQueueItems,
@@ -2233,21 +2234,14 @@ export default function CuttingOperatorDashboard() {
               Loading queue...
             </div>
           ) : mfgQueueItems.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground border-2 border-dashed rounded-lg">
-              <Scissors className="h-8 w-8 mx-auto mb-2 opacity-30" />
-              <p>No items in the queue</p>
-              <p className="text-sm">Schedule packets from the Weekly Scheduling page</p>
-            </div>
+            <CuttingQueueEmptyState mode="empty" />
           ) : filteredMfgQueueItems.length === 0 ? (
             <div className="space-y-3">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <CuttingQueueFilterBar items={mfgQueueItems} value={queueFilter} onChange={setQueueFilter} />
                 <CuttingQueueExportButton items={filteredMfgQueueItems} filenamePrefix="cutting-operator-queue" />
               </div>
-              <div className="text-center py-10 text-muted-foreground border-2 border-dashed rounded-lg">
-                <Scissors className="h-8 w-8 mx-auto mb-2 opacity-30" />
-                <p>No queue rows match this filter</p>
-              </div>
+              <CuttingQueueEmptyState mode="filtered" filter={queueFilter} onClearFilter={() => setQueueFilter("all")} />
             </div>
           ) : (
             <div className="space-y-3">

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -27,6 +27,7 @@ import { CuttingQueueNextActionBadge } from "@/components/cutting/CuttingQueueNe
 import { CuttingQueueProductionLockNotice } from "@/components/cutting/CuttingQueueProductionLockNotice";
 import { CuttingQueueSummaryStrip } from "@/components/cutting/CuttingQueueSummaryStrip";
 import { CuttingQueueExportButton } from "@/components/cutting/CuttingQueueExportButton";
+import { CuttingQueueEmptyState } from "@/components/cutting/CuttingQueueEmptyState";
 import {
   CuttingQueueFilterBar,
   filterCuttingQueueItems,
@@ -971,18 +972,14 @@ export default function CuttingWeeklySchedule() {
         </CardHeader>
         <CardContent>
           {activeScheduledRows.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">
-              No packets currently scheduled for cutting
-            </div>
+            <CuttingQueueEmptyState mode="empty" className="py-8" />
           ) : filteredScheduledRows.length === 0 ? (
             <div className="space-y-3">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <CuttingQueueFilterBar items={activeScheduledRows} value={queueFilter} onChange={setQueueFilter} />
                 <CuttingQueueExportButton items={filteredScheduledRows} filenamePrefix="cutting-weekly-schedule" />
               </div>
-              <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
-                No scheduled packets match this filter
-              </div>
+              <CuttingQueueEmptyState mode="filtered" filter={queueFilter} onClearFilter={() => setQueueFilter("all")} className="py-8" />
             </div>
           ) : (
             <div className="space-y-3">


### PR DESCRIPTION
## Summary
- Add a shared cutting queue empty-state component
- Give filtered no-match states filter-specific context and a quick return to all rows
- Use the improved empty states in Weekly Scheduling and Operator Dashboard

## Validation
- `git diff --cached --check`

## Notes
- This is stacked on PR #1047 (`codex/cutting-queue-export`) and only changes read-only presentation.
- It does not mutate existing production packets or add new action paths.
- `npm run check` could not be run locally because `npm` is not available in this shell.