### PR TITLE
[codex] Retire customer signature order flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -197,7 +197,6 @@ const BOMAdministration = React.lazy(() => import('./pages/BOMAdministration').t
 const RobustBOMAdministration = React.lazy(() => import('./pages/RobustBOMAdministration'));
 const AGBottomMetalReport = React.lazy(() => import('./pages/AGBottomMetalReport'));
 const ShippingTracker = React.lazy(() => import('./pages/ShippingTracker'));
-const AwaitingSignaturePage = React.lazy(() => import('./pages/AwaitingSignaturePage'));
 const EmployeeDashboard = React.lazy(() => import('./pages/EmployeeDashboard'));
 const EmployeeDetail = React.lazy(() => import('./pages/EmployeeDetail'));
 const EmployeePortal = React.lazy(() => import('./pages/EmployeePortal'));
@@ -1338,7 +1337,6 @@ function App() {
                   />
                   <Route path="/shipping-tracker" component={ShippingTracker} />
                   <Route path="/weekly-shipments" component={RedirectToShippingTracker} />
-                  <Route path="/awaiting-signature" component={AwaitingSignaturePage} />
                   <Route path="/gateway-reports" component={GatewayReports} />
                   <Route path="/metrics-sandbox" component={MetricsSandbox} />
                   <Route path="/metric-directory" component={MetricDirectory} />

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -10,7 +10,6 @@ import {
   Plus,
   Settings,
   Package,
-  FilePenLine,
   ClipboardList,
   BarChart,
   BarChart3,
@@ -741,12 +740,6 @@ export default function Navigation() {
       label: 'Calendar',
       icon: Calendar,
       description: 'Multi-user calendar system',
-    },
-    {
-      path: '/awaiting-signature',
-      label: 'Awaiting Signature',
-      icon: FilePenLine,
-      description: 'Orders pending customer signature',
     },
     {
       path: '/shipping-tracker',

--- a/client/src/components/OrderActionsDrawer.tsx
+++ b/client/src/components/OrderActionsDrawer.tsx
@@ -27,10 +27,8 @@ import {
   ArrowRight,
   FileText,
   AlertTriangle,
-  RefreshCw,
   FileDown,
   XCircle,
-  Mail,
   Download,
   Link2,
   Copy,
@@ -39,7 +37,6 @@ import {
   Zap,
   History,
   Clock,
-  FileCheck,
 } from 'lucide-react';
 import { useOrderActions } from '@/hooks/useOrderActions';
 import { duplicateOrder } from '@/lib/queryClient';
@@ -110,8 +107,6 @@ export function OrderActionsDrawer({
     progressOrderMutation,
     cancelOrderMutation,
     undoCancelMutation,
-    resendSignatureEmailMutation,
-    sendUpdatedOrderMutation,
     emailPdfCopyMutation,
     setUrgencyMutation,
   } = useOrderActions({
@@ -127,8 +122,6 @@ export function OrderActionsDrawer({
   const isScrapped = orderStatus === 'SCRAPPED';
   const isFulfilled = orderStatus === 'FULFILLED';
   const isInShipping = currentDepartment === 'Shipping';
-  const isPendingSignature = orderStatus?.toUpperCase() === 'PENDING_SIGNATURE';
-  const isFinalized = orderStatus?.toUpperCase() === 'FINALIZED';
   const isUrgent = urgency === 'high' || urgency === 'critical';
 
   const handleProgressOrder = () => {
@@ -208,23 +201,6 @@ export function OrderActionsDrawer({
 
   const handleViewTimeline = () => {
     setLocation(`/order-timeline/p1_order/${orderId}`);
-    setOpen(false);
-  };
-
-  const handleViewSignedConfirmation = async () => {
-    try {
-      const response = await fetch(`/api/followup-orders/signature-info/${orderId}`);
-      const data = await response.json();
-      if (data.hasSignature && data.signedPdfAvailable) {
-        window.open(`/api/followup-orders/signed-pdf/${orderId}`, '_blank');
-      } else if (data.hasSignature) {
-        toast.error('Signed PDF file not found on server');
-      } else {
-        toast.error('Order has not been signed by customer yet');
-      }
-    } catch (error) {
-      toast.error('Failed to check signature status');
-    }
     setOpen(false);
   };
 
@@ -340,17 +316,6 @@ export function OrderActionsDrawer({
 
             <div className="space-y-2">
               <h4 className="text-sm font-medium text-muted-foreground">Email Actions</h4>
-              {(isPendingSignature || isFinalized) && (
-                <Button
-                  variant="outline"
-                  className="w-full justify-start gap-2 text-blue-600 hover:text-blue-700"
-                  onClick={() => sendUpdatedOrderMutation.mutate(orderId)}
-                  disabled={sendUpdatedOrderMutation.isPending}
-                >
-                  <RefreshCw className={`h-4 w-4 ${sendUpdatedOrderMutation.isPending ? 'animate-spin' : ''}`} />
-                  {sendUpdatedOrderMutation.isPending ? 'Sending...' : 'Send Updated Order Email'}
-                </Button>
-              )}
               <Button
                 variant="outline"
                 className="w-full justify-start gap-2 text-green-600 hover:text-green-700"
@@ -360,17 +325,6 @@ export function OrderActionsDrawer({
                 <FileDown className={`h-4 w-4 ${emailPdfCopyMutation.isPending ? 'animate-pulse' : ''}`} />
                 {emailPdfCopyMutation.isPending ? 'Sending...' : 'Email PDF Copy'}
               </Button>
-              {isPendingSignature && (
-                <Button
-                  variant="outline"
-                  className="w-full justify-start gap-2"
-                  onClick={() => resendSignatureEmailMutation.mutate(orderId)}
-                  disabled={resendSignatureEmailMutation.isPending}
-                >
-                  <Mail className={`h-4 w-4 ${resendSignatureEmailMutation.isPending ? 'animate-pulse' : ''}`} />
-                  {resendSignatureEmailMutation.isPending ? 'Sending...' : 'Resend Signature Email'}
-                </Button>
-              )}
             </div>
 
             <Separator />
@@ -445,14 +399,6 @@ export function OrderActionsDrawer({
               >
                 <Clock className="h-4 w-4" />
                 View Timeline
-              </Button>
-              <Button
-                variant="outline"
-                className="w-full justify-start gap-2"
-                onClick={handleViewSignedConfirmation}
-              >
-                <FileCheck className="h-4 w-4" />
-                View Signed Confirmation
               </Button>
             </div>
 

--- a/client/src/components/OrderEntry.tsx
+++ b/client/src/components/OrderEntry.tsx
@@ -3335,8 +3335,6 @@ export default function OrderEntry() {
                         className={`text-xs px-2 py-0.5 ${
                           orderStatus === 'HOLDING' || orderStatus === 'DRAFT'
                             ? 'bg-yellow-100 text-yellow-800 border-yellow-300'
-                            : orderStatus === 'PENDING_SIGNATURE'
-                            ? 'bg-orange-100 text-orange-800 border-orange-300'
                             : orderStatus === 'FINALIZED'
                             ? 'bg-blue-100 text-blue-800 border-blue-300'
                             : orderStatus === 'IN_PROGRESS'

--- a/client/src/hooks/useOrderActions.ts
+++ b/client/src/hooks/useOrderActions.ts
@@ -95,50 +95,6 @@ export function useOrderActions(options: UseOrderActionsOptions = {}) {
     },
   });
 
-  const resendSignatureEmailMutation = useMutation({
-    mutationFn: async (orderId: string) => {
-      return apiRequest(`/api/followup-orders/${orderId}/resend-email`, {
-        method: 'POST',
-      });
-    },
-    onSuccess: () => {
-      toast({
-        title: 'Email Sent',
-        description: 'Review and sign email has been resent to the customer.',
-      });
-      options.onSuccess?.();
-    },
-    onError: (error: any) => {
-      toast({
-        title: 'Error',
-        description: 'Failed to send email: ' + (error.message || 'Unknown error'),
-        variant: 'destructive',
-      });
-    },
-  });
-
-  const sendUpdatedOrderMutation = useMutation({
-    mutationFn: async (orderId: string) => {
-      return apiRequest(`/api/followup-orders/${orderId}/send-updated-order`, {
-        method: 'POST',
-      });
-    },
-    onSuccess: () => {
-      toast({
-        title: 'Updated Order Sent',
-        description: 'A new signature request with the updated order has been sent.',
-      });
-      options.onSuccess?.();
-    },
-    onError: (error: any) => {
-      toast({
-        title: 'Error',
-        description: 'Failed to send updated order: ' + (error.message || 'Unknown error'),
-        variant: 'destructive',
-      });
-    },
-  });
-
   const emailPdfCopyMutation = useMutation({
     mutationFn: async (orderId: string) => {
       return apiRequest(`/api/orders/${orderId}/email-pdf-copy`, {
@@ -189,16 +145,12 @@ export function useOrderActions(options: UseOrderActionsOptions = {}) {
     progressOrderMutation,
     cancelOrderMutation,
     undoCancelMutation,
-    resendSignatureEmailMutation,
-    sendUpdatedOrderMutation,
     emailPdfCopyMutation,
     setUrgencyMutation,
     isAnyPending:
       progressOrderMutation.isPending ||
       cancelOrderMutation.isPending ||
       undoCancelMutation.isPending ||
-      resendSignatureEmailMutation.isPending ||
-      sendUpdatedOrderMutation.isPending ||
       emailPdfCopyMutation.isPending ||
       setUrgencyMutation.isPending,
   };

--- a/client/src/pages/AdminPanelPage.tsx
+++ b/client/src/pages/AdminPanelPage.tsx
@@ -589,7 +589,6 @@ export default function AdminPanelPage() {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="ALL">All Departments</SelectItem>
-                <SelectItem value="Awaiting Customer Signature">Awaiting Customer Signature</SelectItem>
                 <SelectItem value="Layup">Layup</SelectItem>
                 <SelectItem value="Finish">Finish</SelectItem>
                 <SelectItem value="Gunsmith">Gunsmith</SelectItem>

--- a/client/src/pages/AllOrdersPage.tsx
+++ b/client/src/pages/AllOrdersPage.tsx
@@ -73,7 +73,6 @@ import {
   Mail,
   MessageSquare,
   Eye,
-  RefreshCw,
   FileDown,
   Paperclip,
   Image as ImageIcon,
@@ -350,7 +349,6 @@ export default function AllOrdersPage() {
 
   // Department progression flow (Shipping is final department)
   const departments = [
-    'Awaiting Customer Signature',
     'P1 Production Queue',
     'Layup/Plugging',
     'Barcode',
@@ -516,52 +514,6 @@ export default function AllOrdersPage() {
     },
   });
 
-  // Resend signature email mutation
-  const resendSignatureEmailMutation = useMutation({
-    mutationFn: async (orderId: string) => {
-      return apiRequest(`/api/followup-orders/${orderId}/resend-email`, {
-        method: 'POST',
-      });
-    },
-    onSuccess: () => {
-      toast({
-        title: 'Email Sent',
-        description: 'Review and sign email has been resent to the customer.',
-      });
-    },
-    onError: (error: any) => {
-      toast({
-        title: 'Error',
-        description:
-          'Failed to send email: ' + (error.message || 'Unknown error'),
-        variant: 'destructive',
-      });
-    },
-  });
-
-  // Send updated order email mutation (creates new snapshot with current order data)
-  const sendUpdatedOrderMutation = useMutation({
-    mutationFn: async (orderId: string) => {
-      return apiRequest(`/api/followup-orders/${orderId}/send-updated-order`, {
-        method: 'POST',
-      });
-    },
-    onSuccess: () => {
-      toast({
-        title: 'Updated Order Sent',
-        description: 'A new signature request with the updated order has been sent.',
-      });
-    },
-    onError: (error: any) => {
-      toast({
-        title: 'Error',
-        description:
-          'Failed to send updated order: ' + (error.message || 'Unknown error'),
-        variant: 'destructive',
-      });
-    },
-  });
-
   // Email PDF Copy mutation (no signature workflow, just sends PDF attachment)
   const emailPdfCopyMutation = useMutation({
     mutationFn: async (orderId: string) => {
@@ -580,29 +532,6 @@ export default function AllOrdersPage() {
         title: 'Error',
         description:
           'Failed to email PDF: ' + (error.message || 'Unknown error'),
-        variant: 'destructive',
-      });
-    },
-  });
-
-  // Test reminder mutation - manually triggers the 5-day reminder check
-  const testReminderMutation = useMutation({
-    mutationFn: async () => {
-      return apiRequest(`/api/followup-orders/test-reminder`, {
-        method: 'POST',
-      });
-    },
-    onSuccess: (data: any) => {
-      toast({
-        title: 'Reminder Check Complete',
-        description: data.message || 'Reminder check finished.',
-      });
-    },
-    onError: (error: any) => {
-      toast({
-        title: 'Error',
-        description:
-          'Failed to run reminder check: ' + (error.message || 'Unknown error'),
         variant: 'destructive',
       });
     },
@@ -733,8 +662,6 @@ export default function AllOrdersPage() {
         return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
       case 'DRAFT':
         return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
-      case 'PENDING_SIGNATURE':
-        return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300';
       case 'FINALIZED':
         return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
       case 'IN_PROGRESS':
@@ -1020,7 +947,6 @@ export default function AllOrdersPage() {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="all">All Statuses</SelectItem>
-                  <SelectItem value="PENDING_SIGNATURE">Pending Signature</SelectItem>
                   <SelectItem value="FINALIZED">Finalized</SelectItem>
                   <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
                   <SelectItem value="FULFILLED">Fulfilled</SelectItem>
@@ -1038,20 +964,6 @@ export default function AllOrdersPage() {
                   title={statusFilterMode === 'include' ? 'Click to exclude this status instead' : 'Click to include this status instead'}
                 >
                   {statusFilterMode === 'include' ? 'Include' : 'Exclude'}
-                </Button>
-              )}
-              {/* Test Reminder Button - visible when filtering for PENDING_SIGNATURE or for admin */}
-              {((selectedStatus === 'PENDING_SIGNATURE' && statusFilterMode === 'include') || currentUser?.role === 'ADMIN') && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => testReminderMutation.mutate()}
-                  disabled={testReminderMutation.isPending}
-                  title="Manually run the 5-day reminder check for unsigned orders"
-                  data-testid="button-test-reminder"
-                >
-                  <Mail className="h-4 w-4 mr-1" />
-                  {testReminderMutation.isPending ? 'Checking...' : 'Test Reminder'}
                 </Button>
               )}
             </div>
@@ -1160,33 +1072,6 @@ export default function AllOrdersPage() {
                             >
                               {order.status}
                             </Badge>
-                          )}
-                          {/* Resend Email Button - Show on hover for PENDING_SIGNATURE (any user) or FINALIZED (admin only) */}
-                          {(order.status?.toUpperCase() === 'PENDING_SIGNATURE' || 
-                            (order.status?.toUpperCase() === 'FINALIZED' && currentUser?.role === 'ADMIN')) && (
-                            <div className="absolute left-full top-0 ml-2 opacity-0 group-hover/status:opacity-100 pointer-events-none group-hover/status:pointer-events-auto transition-opacity z-20">
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className={`h-7 px-2 bg-white ${
-                                  order.status?.toUpperCase() === 'PENDING_SIGNATURE'
-                                    ? 'hover:bg-orange-50 border-orange-300 text-orange-700'
-                                    : 'hover:bg-blue-50 border-blue-300 text-blue-700'
-                                }`}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  resendSignatureEmailMutation.mutate(order.orderId);
-                                }}
-                                disabled={resendSignatureEmailMutation.isPending}
-                                title={order.status?.toUpperCase() === 'PENDING_SIGNATURE' 
-                                  ? "Resend Review and Sign Email" 
-                                  : "Resend Review and Confirm Email"}
-                                data-testid={`button-resend-email-${order.orderId}`}
-                              >
-                                <Mail className="h-3 w-3 mr-1" />
-                                Resend Email
-                              </Button>
-                            </div>
                           )}
                         </div>
                       )}
@@ -1423,18 +1308,6 @@ export default function AllOrdersPage() {
                             <AlertTriangle className="mr-2 h-4 w-4" />
                             Report Kickback
                           </DropdownMenuItem>
-                          {/* Send Updated Order Email - for orders that need customer to sign updated version */}
-                          {(order.status?.toUpperCase() === 'PENDING_SIGNATURE' || 
-                            order.status?.toUpperCase() === 'FINALIZED') && (
-                            <DropdownMenuItem
-                              onClick={() => sendUpdatedOrderMutation.mutate(order.orderId)}
-                              disabled={sendUpdatedOrderMutation.isPending}
-                              className="text-blue-600"
-                            >
-                              <RefreshCw className={`mr-2 h-4 w-4 ${sendUpdatedOrderMutation.isPending ? 'animate-spin' : ''}`} />
-                              {sendUpdatedOrderMutation.isPending ? 'Sending...' : 'Send Updated Order Email'}
-                            </DropdownMenuItem>
-                          )}
                           {/* Email PDF Copy - sends PDF without signature workflow, available for all orders */}
                           <DropdownMenuItem
                             onClick={() => emailPdfCopyMutation.mutate(order.orderId)}

--- a/client/src/pages/OrdersList.tsx
+++ b/client/src/pages/OrdersList.tsx
@@ -100,7 +100,7 @@ import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { getDisplayOrderId } from '@/lib/orderUtils';
 import AuditDrawer from '@/components/AuditDrawer';
-import { History, Clock, CopyPlus, Eraser, RefreshCw, FileDown, BookOpen } from 'lucide-react';
+import { History, Clock, CopyPlus, Eraser, FileDown, BookOpen } from 'lucide-react';
 import {
   Sheet,
   SheetContent,
@@ -639,52 +639,6 @@ export default function OrdersList() {
     },
   });
 
-  // Resend signature email mutation
-  const resendSignatureEmailMutation = useMutation({
-    mutationFn: async (orderId: string) => {
-      return apiRequest(`/api/followup-orders/${orderId}/resend-email`, {
-        method: 'POST',
-      });
-    },
-    onSuccess: () => {
-      showToast({
-        title: 'Email Sent',
-        description: 'Review and sign email has been resent successfully.',
-      });
-    },
-    onError: (error: any) => {
-      showToast({
-        title: 'Error',
-        description:
-          'Failed to resend email: ' + (error.message || 'Unknown error'),
-        variant: 'destructive',
-      });
-    },
-  });
-
-  // Send updated order email mutation (creates new snapshot with current order data)
-  const sendUpdatedOrderMutation = useMutation({
-    mutationFn: async (orderId: string) => {
-      return apiRequest(`/api/followup-orders/${orderId}/send-updated-order`, {
-        method: 'POST',
-      });
-    },
-    onSuccess: () => {
-      showToast({
-        title: 'Updated Order Sent',
-        description: 'A new signature request with the updated order has been sent.',
-      });
-    },
-    onError: (error: any) => {
-      showToast({
-        title: 'Error',
-        description:
-          'Failed to send updated order: ' + (error.message || 'Unknown error'),
-        variant: 'destructive',
-      });
-    },
-  });
-
   // Email PDF Copy mutation (no signature workflow, just sends PDF attachment)
   const emailPdfCopyMutation = useMutation({
     mutationFn: async (orderId: string) => {
@@ -1059,7 +1013,6 @@ export default function OrdersList() {
 
     // Fixed list of valid departments based on production flow
     const availableDepartments = [
-      'Awaiting Customer Signature',
       'P1 Production Queue',
       'Layup/Plugging',
       'Barcode',
@@ -1075,7 +1028,6 @@ export default function OrdersList() {
     // Fixed list of valid statuses
     const availableStatuses = [
       'HOLDING',
-      'PENDING_SIGNATURE',
       'FINALIZED',
       'IN_PROGRESS',
       'FULFILLED',
@@ -1243,8 +1195,6 @@ export default function OrdersList() {
           return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
         case 'DRAFT':
           return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
-        case 'PENDING_SIGNATURE':
-          return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300';
         case 'FINALIZED':
           return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
         case 'IN_PROGRESS':
@@ -1635,33 +1585,6 @@ export default function OrdersList() {
                                 >
                                   {order.status}
                                 </Badge>
-                              )}
-                              {/* Resend Email Button - Show on hover for PENDING_SIGNATURE (any user) or FINALIZED (admin only) */}
-                              {(order.status?.toUpperCase() === 'PENDING_SIGNATURE' || 
-                                (order.status?.toUpperCase() === 'FINALIZED' && currentUser?.role === 'ADMIN')) && (
-                                <div className="absolute left-full top-0 ml-2 opacity-0 group-hover/status:opacity-100 pointer-events-none group-hover/status:pointer-events-auto transition-opacity z-20">
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className={`h-7 px-2 bg-white ${
-                                      order.status?.toUpperCase() === 'PENDING_SIGNATURE'
-                                        ? 'hover:bg-orange-50 border-orange-300 text-orange-700'
-                                        : 'hover:bg-blue-50 border-blue-300 text-blue-700'
-                                    }`}
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      resendSignatureEmailMutation.mutate(order.orderId);
-                                    }}
-                                    disabled={resendSignatureEmailMutation.isPending}
-                                    title={order.status?.toUpperCase() === 'PENDING_SIGNATURE' 
-                                      ? "Resend Review and Sign Email" 
-                                      : "Resend Review and Confirm Email"}
-                                    data-testid={`button-resend-email-${order.orderId}`}
-                                  >
-                                    <Mail className="h-3 w-3 mr-1" />
-                                    Resend Email
-                                  </Button>
-                                </div>
                               )}
                             </div>
                           )}
@@ -2099,19 +2022,6 @@ export default function OrdersList() {
                                   Reassign Department
                                 </DropdownMenuItem>
                               )}
-                              {/* Send Updated Order Email - for orders that need customer to sign updated version */}
-                              {(order.status?.toUpperCase() === 'PENDING_SIGNATURE' || 
-                                order.status?.toUpperCase() === 'FINALIZED') && (
-                                <DropdownMenuItem
-                                  onClick={() => sendUpdatedOrderMutation.mutate(order.orderId)}
-                                  disabled={sendUpdatedOrderMutation.isPending}
-                                  className="text-blue-600"
-                                  data-testid={`button-send-updated-order-${order.orderId}`}
-                                >
-                                  <RefreshCw className={`mr-2 h-4 w-4 ${sendUpdatedOrderMutation.isPending ? 'animate-spin' : ''}`} />
-                                  {sendUpdatedOrderMutation.isPending ? 'Sending...' : 'Send Updated Order Email'}
-                                </DropdownMenuItem>
-                              )}
                               {/* Email PDF Copy - sends PDF without signature workflow, available for all orders */}
                               <DropdownMenuItem
                                 onClick={() => emailPdfCopyMutation.mutate(order.orderId)}
@@ -2121,28 +2031,6 @@ export default function OrdersList() {
                               >
                                 <FileDown className={`mr-2 h-4 w-4 ${emailPdfCopyMutation.isPending ? 'animate-pulse' : ''}`} />
                                 {emailPdfCopyMutation.isPending ? 'Sending...' : 'Email PDF Copy'}
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={async () => {
-                                  try {
-                                    // First check if signed PDF is available
-                                    const response = await fetch(`/api/followup-orders/signature-info/${order.orderId}`);
-                                    const data = await response.json();
-                                    if (data.hasSignature && data.signedPdfAvailable) {
-                                      window.open(`/api/followup-orders/signed-pdf/${order.orderId}`, '_blank');
-                                    } else if (data.hasSignature) {
-                                      toast.error('Signed PDF file not found on server');
-                                    } else {
-                                      toast.error('Order has not been signed by customer yet');
-                                    }
-                                  } catch (error) {
-                                    toast.error('Failed to check signature status');
-                                  }
-                                }}
-                                data-testid={`button-view-signed-pdf-${order.orderId}`}
-                              >
-                                <FileText className="mr-2 h-4 w-4" />
-                                View Signed Confirmation
                               </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>

--- a/migrations/0163_retire_customer_signature_queue.sql
+++ b/migrations/0163_retire_customer_signature_queue.sql
@@ -1,0 +1,27 @@
+-- Retire the customer-signature hold queue without deleting any orders.
+-- Existing affected P1 orders are released into the normal production queue.
+
+UPDATE all_orders
+SET
+  status = 'FINALIZED',
+  current_department = 'P1 Production Queue',
+  barcode = CASE
+    WHEN barcode IS NULL OR barcode = '' OR barcode LIKE 'PENDING-%'
+      THEN 'P1-' || order_id
+    ELSE barcode
+  END,
+  updated_at = NOW()
+WHERE
+  status = 'PENDING_SIGNATURE'
+  OR current_department = 'Awaiting Customer Signature';
+
+UPDATE production_orders po
+SET
+  current_department = 'P1 Production Queue',
+  updated_at = NOW()
+FROM all_orders ao
+WHERE
+  po.order_id = ao.order_id
+  AND ao.status = 'FINALIZED'
+  AND ao.current_department = 'P1 Production Queue'
+  AND po.current_department = 'Awaiting Customer Signature';

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -196,6 +196,7 @@ const safeFiles = [
   '0160_po_project_links_safe.sql',
   '0161_employee_termination_access_controls.sql',
   '0162_p2_project_revision_type_po_change.sql',
+  '0163_retire_customer_signature_queue.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/followupOrders.ts
+++ b/server/src/routes/followupOrders.ts
@@ -250,6 +250,11 @@ async function calculateOrderPricing(
 
 // POST /api/followup-orders - Create and send a follow-up order
 router.post('/', async (req, res) => {
+  return res.status(410).json({
+    error: 'Customer signature requests have been retired. Orders are finalized directly and sent to P1 Production Queue.',
+    code: 'CUSTOMER_SIGNATURE_RETIRED',
+  });
+
   try {
     const { orderId } = req.body;
 
@@ -1130,6 +1135,11 @@ router.get('/:id', async (req, res) => {
 // POST /api/followup-orders/:id/sign - Submit signature for follow-up order
 // Accepts EITHER publicSignatureId (new) OR signatureToken (legacy)
 router.post('/:id/sign', async (req, res) => {
+  return res.status(410).json({
+    error: 'Customer signatures have been retired. Orders are finalized directly and sent to P1 Production Queue.',
+    code: 'CUSTOMER_SIGNATURE_RETIRED',
+  });
+
   try {
     const id = parseInt(req.params.id);
     console.log(`📝 Sign request received for followup order ID: ${id}`);
@@ -1334,6 +1344,11 @@ router.post('/:id/sign', async (req, res) => {
 // If the order has changed since the snapshot was created, this will REFUSE to resend
 // Use sendUpdatedOrderForSignature instead for changed orders
 router.post('/:orderId/resend-email', async (req, res) => {
+  return res.status(410).json({
+    error: 'Customer signature emails have been retired. Use the sales order PDF email flow instead.',
+    code: 'CUSTOMER_SIGNATURE_RETIRED',
+  });
+
   try {
     const { orderId } = req.params;
     console.log(`📧 [RESEND] Starting resend-email for order ${orderId}`);
@@ -1588,6 +1603,11 @@ router.post('/:orderId/resend-email', async (req, res) => {
 // Supersedes any existing unsigned followup order for this order
 // Use this when order data has changed and customer must re-approve
 router.post('/:orderId/send-updated-order', async (req, res) => {
+  return res.status(410).json({
+    error: 'Customer signature requests have been retired. Use the sales order PDF email flow instead.',
+    code: 'CUSTOMER_SIGNATURE_RETIRED',
+  });
+
   try {
     const { orderId } = req.params;
     console.log(`📧 [UPDATED-ORDER] Starting send-updated-order for order ${orderId}`);

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -835,7 +835,7 @@ router.get('/draft/:id', async (req: Request, res: Response) => {
 // each blocked attempt is written to order_activity_events for observability.
 const ordersBeingFinalized = new Set<string>();
 
-// Create order - with or without signature requirement based on whether stock is selected
+// Create order directly into production and email the customer a Sales Order PDF.
 router.post('/finalized', async (req: Request, res: Response) => {
   // Declare outside try so finally can release the guard reliably
   let incomingOrderId: string | null = null;
@@ -862,16 +862,8 @@ router.post('/finalized', async (req: Request, res: Response) => {
     }
     if (incomingOrderId) ordersBeingFinalized.add(incomingOrderId);
     
-    // Determine if stock is selected (has modelId and it's not "no_stock" or similar)
-    // Normalize the modelId for checking (trim whitespace and convert to lowercase)
-    const normalizedModelId = orderData.modelId?.trim().toLowerCase() || '';
-    const noStockIdentifiers = ['', 'no_stock', 'no stock', 'none'];
-    const hasStock: boolean = !noStockIdentifiers.includes(normalizedModelId);
-    
-    // If has stock: PENDING_SIGNATURE status, awaiting customer signature
-    // If no stock: IN_PROGRESS status, skip production pipeline, go directly to Shipping QC
-    const orderStatus = hasStock ? 'PENDING_SIGNATURE' : 'IN_PROGRESS';
-    const orderDepartment = hasStock ? 'Awaiting Customer Signature' : 'Shipping QC';
+    const orderStatus = 'FINALIZED';
+    const orderDepartment = 'P1 Production Queue';
     
     // Compute bottomMetalSource upfront to set it on creation (no interim incorrect state)
     const bottomMetalSource = computeBottomMetalSource(orderData.features as Record<string, any>);
@@ -905,11 +897,7 @@ router.post('/finalized', async (req: Request, res: Response) => {
       console.warn('⚠️ reconcileRailDemand skipped on order create:', railErr?.message);
     }
     
-    if (hasStock) {
-      console.log(`📧 Order ${order.orderId} created with PENDING_SIGNATURE status - sending confirmation email to customer...`);
-    } else {
-      console.log(`📧 Order ${order.orderId} created as IN_PROGRESS (no stock) - skipping production, going to Shipping QC - sending thank you email to customer...`);
-    }
+    console.log(`Order ${order.orderId} created as FINALIZED and routed to P1 Production Queue - sending Sales Order PDF to customer...`);
     
     // Track email outcome for API response (declared outside inner try block for scoping)
     let emailOutcome: OrderConfirmationOutcome | undefined;
@@ -917,9 +905,6 @@ router.post('/finalized', async (req: Request, res: Response) => {
     
     // Automatically create followup order and send email
     try {
-      // Import dependencies
-      const { nanoid } = await import('nanoid');
-      const { sendFollowupOrderEmail } = await import('../../utils/followupOrderEmail');
       const { sendThankYouOrderEmail } = await import('../../utils/thankYouOrderEmail');
       const fs = await import('fs');
       const path = await import('path');
@@ -953,7 +938,70 @@ router.post('/finalized', async (req: Request, res: Response) => {
           emailError,
         });
       }
-      
+
+      const pdfResult = await generateOrderPdf(order.orderId, PdfIntent.CUSTOMER_VIEW);
+      const pdfDir = path.join(process.cwd(), 'uploads', 'order-confirmations');
+      fs.mkdirSync(pdfDir, { recursive: true });
+      const safeOrderId = order.orderId.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const pdfPath = path.join(pdfDir, `sales_order_${safeOrderId}_${Date.now()}.pdf`);
+      fs.writeFileSync(pdfPath, pdfResult.buffer);
+
+      const thankYouResult = await sendThankYouOrderEmail(
+        {
+          orderId: order.orderId,
+          customerName: customer.name,
+          customerEmail: customer.email,
+          customerPO: order.customerPO || '',
+          orderDate: new Date(order.orderDate).toISOString().split('T')[0],
+          dueDate: new Date(order.dueDate).toISOString().split('T')[0],
+          notes: order.notes || '',
+        },
+        pdfPath
+      );
+
+      if (thankYouResult.success) {
+        emailOutcome = 'sent';
+        console.log(`Sales Order PDF email sent for order ${order.orderId}`);
+
+        await db.insert(communicationLogs).values({
+          orderId: order.orderId,
+          customerId: order.customerId || '',
+          messageType: 'transactional',
+          method: 'email',
+          type: 'order-confirmation',
+          context: 'initial',
+          recipient: customer.email,
+          status: 'sent',
+          signatureToken: null,
+          externalId: thankYouResult.messageId,
+          message: `Sales Order PDF emailed for ${order.orderId}`,
+          sentAt: new Date(),
+        });
+      } else {
+        emailOutcome = 'failed';
+        emailError = thankYouResult.error;
+        console.error(`Failed to send Sales Order PDF email for order ${order.orderId}: ${thankYouResult.error}`);
+
+        await db.insert(communicationLogs).values({
+          orderId: order.orderId,
+          customerId: order.customerId || '',
+          messageType: 'transactional',
+          method: 'email',
+          type: 'order-confirmation',
+          context: 'initial',
+          recipient: customer.email,
+          status: 'failed',
+          signatureToken: null,
+          error: thankYouResult.error,
+          message: `Failed Sales Order PDF email for ${order.orderId}: ${thankYouResult.error}`,
+          sentAt: new Date(),
+        });
+      }
+
+      /*
+       * Legacy signature follow-up workflow intentionally disabled.
+       * New orders now enter production immediately and only receive the Sales Order PDF.
+       *
       // Get customer address
       const addresses = await storage.getCustomerAddresses(String(customer.id));
       const defaultAddress = addresses.find(addr => addr.isDefault) || addresses[0];
@@ -1332,6 +1380,7 @@ router.post('/finalized', async (req: Request, res: Response) => {
           // Continue to success response with emailOutcome='failed' for frontend to display warning
         }
       }
+      */
     } catch (sendError: any) {
       // MANDATORY OUTCOME: Any thrown error results in 'failed' outcome
       // NOTE: sendOrderConfirmationNotification handles its own logging internally
@@ -1355,7 +1404,7 @@ router.post('/finalized', async (req: Request, res: Response) => {
             context: 'initial',
             recipient: 'N/A - exception during preparation',
             status: 'failed',
-            signatureToken: signatureToken || null, // May be null if exception occurred before token generation
+            signatureToken: null,
             error: errorMessage,
             message: `Order confirmation failed for ${order.orderId}: ${errorMessage}`,
             sentAt: new Date(),
@@ -1473,19 +1522,19 @@ router.post('/pending-payment', async (req: Request, res: Response) => {
   }
 });
 
-// Create draft order (legacy method - now creates PENDING_SIGNATURE orders)
+// Create draft order (legacy method - now creates finalized production orders)
 router.post('/draft', requirePermission('orders.create'), async (req: Request, res: Response) => {
   try {
     const orderData = insertAllOrderSchema.parse(req.body);
 
-    // Create as PENDING_SIGNATURE or FINALIZED based on status
-    const finalStatus = orderData.status === 'FINALIZED' ? 'FINALIZED' : 'PENDING_SIGNATURE';
+    const finalStatus = 'FINALIZED';
     
     console.log(`🔄 Creating order ${orderData.orderId} with status: ${finalStatus}`);
     
     const order = await storage.createFinalizedOrder({
       ...orderData,
-      status: finalStatus
+      status: finalStatus,
+      currentDepartment: 'P1 Production Queue',
     }, req.body.finalizedBy);
     
     res.status(201).json(order);
@@ -1947,7 +1996,7 @@ router.get('/:id', async (req: Request, res: Response, next: Function) => {
     const orderId = req.params.id;
     
     // Skip static routes that should be handled by other handlers defined later
-    const staticRoutes = ['heat-map', 'stats', 'all', 'generate-id', 'last-id', 'reference', 'awaiting-signature'];
+    const staticRoutes = ['heat-map', 'stats', 'all', 'generate-id', 'last-id', 'reference'];
     if (staticRoutes.some(route => orderId === route || orderId.startsWith(route + '/'))) {
       return next('route');
     }
@@ -5137,74 +5186,6 @@ router.post('/:orderId/email-pdf-copy', authenticateToken, async (req: Request, 
       error: 'Failed to send PDF copy',
       details: error instanceof Error ? error.message : 'Unknown error',
     });
-  }
-});
-
-// GET /api/orders/awaiting-signature - All orders in Awaiting Customer Signature department
-router.get('/awaiting-signature', async (req: Request, res: Response) => {
-  try {
-    const { search, sort = 'due_date', dir = 'asc' } = req.query as Record<string, string>;
-
-    const allowedSorts: Record<string, string> = {
-      due_date: 'ao.due_date',
-      order_date: 'ao.order_date',
-      order_id: 'ao.order_id',
-      customer: 'c.name',
-      days_waiting: 'ao.created_at',
-    };
-    const sortCol = allowedSorts[sort] || 'ao.due_date';
-    const sortDir = dir === 'desc' ? 'DESC' : 'ASC';
-
-    let searchClause = '';
-    const params: any[] = [];
-
-    if (search && search.trim()) {
-      params.push(`%${search.trim().toLowerCase()}%`);
-      searchClause = `AND (LOWER(ao.order_id) LIKE $${params.length} OR LOWER(c.name) LIKE $${params.length} OR LOWER(ao.model_id) LIKE $${params.length})`;
-    }
-
-    const query = `
-      SELECT
-        ao.order_id AS "orderId",
-        ao.order_date AS "orderDate",
-        ao.due_date AS "dueDate",
-        ao.status,
-        ao.model_id AS "modelId",
-        ao.handedness,
-        ao.notes,
-        ao.urgency,
-        ao.customer_id AS "customerId",
-        ao.created_at AS "createdAt",
-        ao.signature_data IS NOT NULL AND ao.signature_data != '' AS "hasSigned",
-        ao.signed_at AS "signedAt",
-        ao.is_replacement AS "isReplacement",
-        c.name AS "customerName",
-        c.email AS "customerEmail",
-        NOW() - ao.created_at AS "waitingDuration",
-        EXTRACT(EPOCH FROM (NOW() - ao.created_at)) / 86400 AS "daysWaiting"
-      FROM all_orders ao
-      LEFT JOIN customers c ON c.id::text = ao.customer_id
-      WHERE ao.current_department = 'Awaiting Customer Signature'
-        AND ao.status != 'CANCELLED'
-        ${searchClause}
-      ORDER BY ${sortCol} ${sortDir}
-    `;
-
-    const rows = await pool.query(query, params);
-
-    const orders = (Array.isArray(rows) ? rows : (rows as any).rows || rows).map((r: any) => ({
-      ...r,
-      daysWaiting: Math.floor(Number(r.daysWaiting) || 0),
-    }));
-
-    const total = orders.length;
-    const overdue = orders.filter((o: any) => new Date(o.dueDate) < new Date()).length;
-    const signed = orders.filter((o: any) => o.hasSigned).length;
-
-    res.json({ orders, total, overdue, signed });
-  } catch (error) {
-    console.error('Error fetching awaiting-signature orders:', error);
-    res.status(500).json({ error: 'Failed to fetch awaiting-signature orders' });
   }
 });
 

--- a/server/src/routes/reports.ts
+++ b/server/src/routes/reports.ts
@@ -918,7 +918,7 @@ router.get('/po-production-orders', async (req, res) => {
 // Due Date Capacity Report - Shows FINALIZED and IN_PROGRESS orders grouped by week
 router.get('/due-date-capacity', async (req, res) => {
   try {
-    // Query orders with FINALIZED, IN_PROGRESS, or PENDING_SIGNATURE status, joined with customer info
+    // Query active production orders joined with customer info.
     const ordersResult = await db.execute(sql`
       SELECT 
         o.id,
@@ -934,7 +934,7 @@ router.get('/due-date-capacity', async (req, res) => {
         WHEN o.customer_id ~ '^[0-9]+$' THEN o.customer_id::integer 
         ELSE NULL 
       END = c.id
-      WHERE o.status IN ('FINALIZED', 'IN_PROGRESS', 'PENDING_SIGNATURE')
+      WHERE o.status IN ('FINALIZED', 'IN_PROGRESS')
         AND o.is_cancelled = false
         AND o.due_date IS NOT NULL
       ORDER BY o.due_date ASC

--- a/server/src/services/orderTransitionValidator.ts
+++ b/server/src/services/orderTransitionValidator.ts
@@ -46,8 +46,6 @@ export class TransitionValidationError extends Error {
  * so that future statuses or edge-case legacy rows do not hard-block.
  */
 export const STATUS_TRANSITIONS: Readonly<Record<string, readonly string[]>> = {
-  // New orders start here (website import, manual entry)
-  PENDING_SIGNATURE: ['FINALIZED', 'CANCELLED'],
   // Finalized order enters production
   FINALIZED:         ['IN_PROGRESS', 'CANCELLED'],
   // Active production paths

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -22052,8 +22052,8 @@ export class DatabaseStorage implements IStorage {
     orderData: InsertOrderDraft,
     finalizedBy?: string
   ): Promise<AllOrder> {
-    // If status is PENDING_SIGNATURE, don't auto-route to production
-    const isPendingSignature = orderData.status === 'PENDING_SIGNATURE';
+    // PENDING_SIGNATURE is retired for new P1 orders.
+    const requestedStatus = orderData.status === 'PENDING_SIGNATURE' ? 'FINALIZED' : orderData.status;
     
     // Special handling for orders with no stock model - route directly to Shipping QC (unless pending signature)
     const hasNoStockModel =
@@ -22065,27 +22065,27 @@ export class DatabaseStorage implements IStorage {
     let barcode: string;
     let status: string;
 
-    if (isPendingSignature) {
+    if (orderData.currentDepartment) {
       console.log(
-        `📝 Order ${orderData.orderId} created with PENDING_SIGNATURE status - awaiting customer confirmation`
+        `Order ${orderData.orderId} created with status "${requestedStatus || 'FINALIZED'}" in department "${orderData.currentDepartment}"`
       );
-      currentDepartment = orderData.currentDepartment || 'Awaiting Customer Signature';
-      barcode = orderData.barcode || `PENDING-${orderData.orderId}`;
-      status = 'PENDING_SIGNATURE';
+      currentDepartment = orderData.currentDepartment;
+      barcode = orderData.barcode || `P1-${orderData.orderId}`;
+      status = requestedStatus || 'FINALIZED';
     } else if (hasNoStockModel) {
       console.log(
-        `🚀 CREATE APPROVED: Order ${orderData.orderId} has no stock model - routing directly to Shipping QC`
+        `CREATE APPROVED: Order ${orderData.orderId} has no stock model - routing to P1 Production Queue`
       );
-      currentDepartment = 'Shipping QC';
-      barcode = orderData.barcode || `NOSTOCK-${orderData.orderId}`;
-      status = 'FINALIZED';
+      currentDepartment = 'P1 Production Queue';
+      barcode = orderData.barcode || `P1-${orderData.orderId}`;
+      status = requestedStatus || 'FINALIZED';
     } else {
       console.log(
         `✅ CREATE APPROVED: Order ${orderData.orderId} has valid stock model "${orderData.modelId}" - going directly to P1 Production Queue`
       );
       currentDepartment = 'P1 Production Queue';
       barcode = orderData.barcode || `P1-${orderData.orderId}`;
-      status = 'FINALIZED';
+      status = requestedStatus || 'FINALIZED';
     }
 
     // Create the finalized order data directly - exclude id field explicitly
@@ -22229,21 +22229,6 @@ export class DatabaseStorage implements IStorage {
       `🎯 AUTO-ADDED TO P1 PRODUCTION QUEUE: Order ${orderData.orderId} with stock model "${orderData.modelId}"`
     );
 
-    // Check if this order needs a signature email (no stock model + no review)
-    if (hasNoStockModel && orderData.isCustomOrder === 'no') {
-      console.log(
-        `📧 Order ${orderData.orderId} has no stock model and no review needed - triggering signature email`
-      );
-      
-      // Trigger signature email in the background
-      this.sendSignatureEmailForOrder(finalizedOrder.orderId).catch((error) => {
-        console.error(
-          `❌ Failed to send signature email for order ${finalizedOrder.orderId}:`,
-          error
-        );
-      });
-    }
-
     return finalizedOrder;
   }
 
@@ -22273,10 +22258,10 @@ export class DatabaseStorage implements IStorage {
 
     if (hasNoStockModel) {
       console.log(
-        `🚀 FINALIZE APPROVED: Order ${orderId} has no stock model - routing directly to Shipping QC (ready-to-sell product)`
+        `CREATE APPROVED: Order ${orderId} has no stock model - routing to P1 Production Queue`
       );
-      currentDepartment = 'Shipping QC';
-      barcode = `NOSTOCK-${orderId}`; // Force NOSTOCK barcode for ready-to-sell products
+      currentDepartment = 'P1 Production Queue';
+      barcode = draft.barcode || `P1-${orderId}`;
     } else {
       console.log(
         `✅ FINALIZE APPROVED: Order ${orderId} has valid stock model "${draft.modelId}" - proceeding to P1 Production Queue`
@@ -22393,31 +22378,7 @@ export class DatabaseStorage implements IStorage {
     // Remove from order_drafts table
     await db.delete(orderDrafts).where(eq(orderDrafts.orderId, orderId));
 
-    // Log the finalization result based on department
-    if (hasNoStockModel) {
-      console.log(
-        `🚀 FINALIZED TO SHIPPING QC: Order ${orderId} (ready-to-sell product) sent to Shipping QC department`
-      );
-    } else {
-      console.log(
-        `🎯 FINALIZED TO PRODUCTION: Order ${orderId} sent to P1 Production Queue for manufacturing`
-      );
-    }
-
-    // Check if this order needs a signature email (no stock model + no review)
-    if (hasNoStockModel && draft.isCustomOrder === 'no') {
-      console.log(
-        `📧 Order ${orderId} has no stock model and no review needed - triggering signature email`
-      );
-      
-      // Trigger signature email in the background
-      this.sendSignatureEmailForOrder(finalizedOrder.orderId).catch((error) => {
-        console.error(
-          `❌ Failed to send signature email for order ${finalizedOrder.orderId}:`,
-          error
-        );
-      });
-    }
+    console.log(`FINALIZED TO PRODUCTION: Order ${orderId} sent to P1 Production Queue`);
 
     return finalizedOrder;
   }
@@ -24238,18 +24199,6 @@ export class DatabaseStorage implements IStorage {
       sortOrder: index + 1,
       isActive: true
     }));
-
-    // Ensure "Awaiting Customer Signature" is always available as an option
-    const awaitingSignature = 'Awaiting Customer Signature';
-    if (!departments.some((d: any) => d.name === awaitingSignature)) {
-      departments.push({
-        id: departments.length + 1,
-        name: awaitingSignature,
-        displayName: awaitingSignature,
-        sortOrder: departments.length + 1,
-        isActive: true
-      });
-    }
 
     return departments;
   }


### PR DESCRIPTION
## Summary
- Route new All Orders creation directly to `FINALIZED` / `P1 Production Queue` and email the customer a Sales Order PDF instead of a signature link.
- Remove visible Awaiting Signature/customer-signature controls from order list surfaces, navigation, and shared order actions.
- Add safe migration `0163_retire_customer_signature_queue.sql` to correct existing `PENDING_SIGNATURE` / `Awaiting Customer Signature` orders without deleting records.
- Return `410 CUSTOMER_SIGNATURE_RETIRED` from legacy customer signature create/sign/resend/update endpoints.

## Validation
- `git diff --cached --check` passed before commit.
- `npm run check` could not run in this environment because `npm` is not installed/available; local `node_modules` TypeScript/Vite/tsx bins are also absent.