### PR TITLE
[codex] Keep P2 packing slips viewable

### DIFF
--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -271,7 +271,6 @@ async function logP2DocumentAccess(
     );
   } catch (err) {
     console.error('[P2Shipping] Failed to write document access log:', { entityType, entityId, actor, err });
-    throw err;
   }
 }
 
@@ -905,14 +904,22 @@ router.get('/packing-slips/:id/pdf', async (req: Request, res: Response) => {
       sku: string | null;
       drawing_name: string | null;
     };
-    const serialRows: PackingSlipSerialIdentity[] = lineItemSerialNumbers.length > 0
-      ? await pool.query<PackingSlipSerialIdentity>(
+    let serialRows: PackingSlipSerialIdentity[] = [];
+    if (lineItemSerialNumbers.length > 0) {
+      try {
+        serialRows = await pool.query<PackingSlipSerialIdentity>(
           `SELECT serial_number, sku, drawing_name
              FROM p2_serialized_items
             WHERE serial_number = ANY($1::text[])`,
           [lineItemSerialNumbers]
-        )
-      : [];
+        );
+      } catch (err) {
+        console.warn('[P2Shipping] Packing slip serial identity enrichment unavailable:', {
+          packingSlipId: slip.id,
+          err,
+        });
+      }
+    }
     const serialIdentityByNumber = new Map<string, PackingSlipSerialIdentity>(
       serialRows.map((row) => [row.serial_number, row])
     );


### PR DESCRIPTION
## Summary
- Make P2 document access audit logging non-blocking so a logging-table failure cannot break packing slip PDF viewing.
- Keep packing slip PDF generation resilient when optional serial identity enrichment is unavailable.

## Root Cause
The reported production failure is on `/p2/packing-slip/:id`, which loads the persisted packing slip and its generated PDF. Optional backend lookups in the PDF path could still throw a 500 even when the saved packing slip itself exists.

## Validation
- `git -c core.fscache=false -c gc.auto=0 diff --check -- server/src/routes/p2Shipping.ts`
- bundled Node `--experimental-strip-types --check server/src/routes/p2Shipping.ts`

Note: `npm` is not available on this machine's PATH, so repo-wide npm checks were not run.