### PR TITLE
[codex] Include NCR schema alignment in safe migrations

### DIFF
--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -169,6 +169,7 @@ const safeFiles = [
   '0129_receiving_inspection_plans.sql',
   '0130_vendor_po_support_tables_safe.sql',
   '0130_audit_dcaa_security_section11.sql',
+  '0131_nonconformance_schema_alignment.sql',
   '0131_user_sessions_login_compatibility.sql',
   '0132_daily_time_certifications.sql',
   '0133_voice_notes_persistence.sql',


### PR DESCRIPTION
## Summary
- Include `0131_nonconformance_schema_alignment.sql` in the safe boot migration runner
- Ensures legacy `nonconformance_records` tables get the P1 NCR/RMA columns required by create, update, and resolve flows

## Root cause
- The migration file existed, but it was not listed in `safeFiles`, so production-like environments could still miss columns used by `/api/nonconformance` writes.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Verified PR range after rebase: one commit, one changed file

Note: full TypeScript checks were not run because `npm` is not available on PATH in this environment.