### PR TITLE
[codex] Add draft BOM wizard flow

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -1,13 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useLocation } from 'wouter';
 import {
-  Archive,
   Calculator,
   Check,
-  Copy,
   FileSpreadsheet,
   Filter,
+  Layers,
   PackagePlus,
   Plus,
   Save,
@@ -39,7 +38,6 @@ import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import { cn } from '@/lib/utils';
 
-type BomAction = 'Order / Quote' | 'Use in RFQ' | 'Do Not Order' | 'Hold';
 type BomStatus = 'Needs Review' | 'Needs Quote' | 'RFQ Sent' | 'On Order' | 'On Hand' | 'ETA / Inbound' | 'Hold';
 
 type BomLine = PrivateerDraftBomLine & {
@@ -47,8 +45,43 @@ type BomLine = PrivateerDraftBomLine & {
   inventoryItemId?: number | null;
   inventoryItemName?: string | null;
   isDraftPart?: boolean;
+  isManufactured?: boolean;
+  firstDepartment?: string;
+  childDraftBoms?: DraftPartBom[];
   actualCost?: number | '';
   service?: boolean;
+};
+type DraftBomSource = 'draft-part' | 'inventory-item' | 'new-part';
+type DraftBomComponent = {
+  id: string;
+  source: DraftBomSource;
+  sourceLineId?: string | null;
+  inventoryItemId?: number | null;
+  partNumber: string;
+  description: string;
+  quantity: number;
+  isManufactured: boolean;
+  firstDepartment: string;
+};
+type DraftBomPart = {
+  id: string;
+  source: DraftBomSource;
+  sourceLineId?: string | null;
+  inventoryItemId?: number | null;
+  partNumber: string;
+  description: string;
+  quantity: number;
+  bomItems: DraftBomComponent[];
+  hasBOM: boolean;
+};
+type DraftPartBom = {
+  id: string;
+  name: string;
+  revision: string;
+  createdAt: string;
+  updatedAt: string;
+  rootPart: DraftBomPart;
+  parts: DraftBomPart[];
 };
 type BuiltInWorkspaceTabId = 'po-draft' | 'parts-request' | 'bom-wizard' | 'assembly-tree';
 type CustomWorkspaceTabId = `custom:${string}`;
@@ -104,6 +137,10 @@ type InventoryItemOption = {
   manufacturerPartNumber?: string | null;
   manufacturer?: string | null;
   isActive?: boolean | null;
+  itemType?: string | null;
+  type?: string | null;
+  isPacket?: boolean | null;
+  manufacturedCategory?: string | null;
 };
 
 const STORAGE_KEY = 'epoch:draft-boms';
@@ -112,9 +149,7 @@ const PRIVATEER_DRAFT_ID = 'privateer';
 const NEW_DRAFT_VALUE = '__new_draft__';
 const R_AND_D_PROJECT_VALUE = '__r_and_d__';
 
-const actions: BomAction[] = ['Order / Quote', 'Use in RFQ', 'Do Not Order', 'Hold'];
 const statuses: BomStatus[] = ['Needs Review', 'Needs Quote', 'RFQ Sent', 'On Order', 'On Hand', 'ETA / Inbound', 'Hold'];
-const defaultFilterNames = ['Avionics/Sensors', 'Electrical', 'Propulsion/Mechanical', 'Structural', 'Hardware/Misc.', 'Tooling'];
 const defaultWorkspaceTabs: BuiltInWorkspaceTabId[] = ['po-draft', 'parts-request', 'bom-wizard', 'assembly-tree'];
 const workspaceTabLabels: Record<BuiltInWorkspaceTabId, string> = {
   'po-draft': 'PO draft',
@@ -135,6 +170,18 @@ const poColumnLabels: Record<PoColumnId, string> = {
   source: 'Source',
 };
 const defaultPoColumns: PoColumnId[] = ['agPartNumber', 'qtyNeeded', 'unitCost', 'extCost', 'status', 'source'];
+const defaultDepartment = 'layup';
+const departmentOptions = [
+  { value: 'cutting_table', label: 'Cutting Table' },
+  { value: 'core_department', label: 'Core Department' },
+  { value: 'layup', label: 'Layup' },
+  { value: 'assembly', label: 'Assembly' },
+  { value: 'disassembly', label: 'Disassembly' },
+  { value: 'cnc', label: 'CNC' },
+  { value: 'finish', label: 'Finish' },
+  { value: 'paint', label: 'Paint' },
+  { value: 'final_qc', label: 'Final QC' },
+];
 
 function newLine(): BomLine {
   return {
@@ -158,8 +205,88 @@ function newLine(): BomLine {
     inventoryItemId: null,
     inventoryItemName: null,
     isDraftPart: true,
+    isManufactured: false,
+    firstDepartment: defaultDepartment,
+    childDraftBoms: [],
     actualCost: '',
     service: false,
+  };
+}
+
+function isInventoryManufactured(item?: InventoryItemOption | null) {
+  if (!item) return false;
+  return item.itemType === 'MANUFACTURED' || item.type === 'Manufactured' || item.isPacket === true || !!item.manufacturedCategory;
+}
+
+function inventoryPartNumber(item: InventoryItemOption) {
+  return item.agPartNumber || item.manufacturerPartNumber || item.supplierPartNumber || `INV-${item.id}`;
+}
+
+function inventoryDescription(item: InventoryItemOption) {
+  return item.name || item.description || inventoryPartNumber(item);
+}
+
+function linePartNumber(line: BomLine) {
+  return line.agPartNumber || line.supplierItemId || `DRAFT-${line.id.slice(0, 8).toUpperCase()}`;
+}
+
+function lineDescription(line: BomLine) {
+  return line.description || line.inventoryItemName || linePartNumber(line);
+}
+
+function draftLineToPart(line: BomLine): DraftBomPart {
+  return {
+    id: `draft-line-${line.id}`,
+    source: line.inventoryItemId ? 'inventory-item' : 'draft-part',
+    sourceLineId: line.id,
+    inventoryItemId: line.inventoryItemId ?? null,
+    partNumber: linePartNumber(line),
+    description: lineDescription(line),
+    quantity: asNumber(line.qtyNeeded) || 1,
+    bomItems: [],
+    hasBOM: false,
+  };
+}
+
+function inventoryItemToPart(item: InventoryItemOption): DraftBomPart {
+  return {
+    id: `inventory-${item.id}`,
+    source: 'inventory-item',
+    sourceLineId: null,
+    inventoryItemId: item.id,
+    partNumber: inventoryPartNumber(item),
+    description: inventoryDescription(item),
+    quantity: 1,
+    bomItems: [],
+    hasBOM: false,
+  };
+}
+
+function newWizardPart(partNumber: string, description: string): DraftBomPart {
+  const cleanPartNumber = partNumber.trim() || `DRAFT-${Date.now()}`;
+  return {
+    id: `new-${crypto.randomUUID()}`,
+    source: 'new-part',
+    sourceLineId: null,
+    inventoryItemId: null,
+    partNumber: cleanPartNumber,
+    description: description.trim() || cleanPartNumber,
+    quantity: 1,
+    bomItems: [],
+    hasBOM: false,
+  };
+}
+
+function createDraftPartBom(rootPart: DraftBomPart, existingCount = 0): DraftPartBom {
+  const now = new Date().toISOString();
+  return {
+    id: crypto.randomUUID(),
+    name: `${rootPart.partNumber} Draft BOM`,
+    revision: `Draft ${String.fromCharCode(65 + Math.min(existingCount, 25))}`,
+    createdAt: now,
+    updatedAt: now,
+    rootPart,
+    parts: [{ ...rootPart, bomItems: rootPart.bomItems ?? [], hasBOM: false }],
   };
 }
 
@@ -176,7 +303,13 @@ function createPrivateerDraft(): BomDraft {
     projectType: null,
     notes: 'First draft sourcing BOM modeled after the Google Sheet layout.',
     updatedAt: new Date().toISOString(),
-    lines: privateerDraftBomLines,
+    lines: privateerDraftBomLines.map((line) => ({
+      ...line,
+      isDraftPart: true,
+      isManufactured: false,
+      firstDepartment: defaultDepartment,
+      childDraftBoms: [],
+    })),
     poVisibleColumns: defaultPoColumns,
     customPoColumns: [],
     workspaceTabs: defaultWorkspaceTabs,
@@ -194,6 +327,13 @@ function normalizeDraft(draft: BomDraft): BomDraft {
     projectCode: draft.projectCode ?? null,
     projectName: draft.projectName ?? draft.project ?? null,
     projectType: draft.projectType ?? null,
+    lines: (draft.lines ?? []).map((line) => ({
+      ...line,
+      isDraftPart: line.isDraftPart ?? !line.inventoryItemId,
+      isManufactured: line.isManufactured ?? false,
+      firstDepartment: line.firstDepartment ?? defaultDepartment,
+      childDraftBoms: line.childDraftBoms ?? [],
+    })),
     poVisibleColumns: draft.poVisibleColumns ?? defaultPoColumns,
     customPoColumns: draft.customPoColumns ?? [],
     workspaceTabs: draft.workspaceTabs ?? defaultWorkspaceTabs,
@@ -236,8 +376,6 @@ export default function DraftBOMBuilderPage() {
   const [savedDrafts, setSavedDrafts] = useState<BomDraft[]>(() => loadDrafts());
   const [selectedDraftId, setSelectedDraftId] = useState<string>(PRIVATEER_DRAFT_ID);
   const [draft, setDraft] = useState<BomDraft>(() => loadDrafts()[0] ?? createPrivateerDraft());
-  const [categoryFilter, setCategoryFilter] = useState<string>('all');
-  const [statusFilter, setStatusFilter] = useState<string>('all');
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [visibleWorkspaceTabs, setVisibleWorkspaceTabs] = useState<WorkspaceTabId[]>(() => draft.workspaceTabs ?? defaultWorkspaceTabs);
   const [activeWorkspaceTab, setActiveWorkspaceTab] = useState<WorkspaceTabId>('po-draft');
@@ -248,6 +386,7 @@ export default function DraftBOMBuilderPage() {
   const [customPoColumns, setCustomPoColumns] = useState<string[]>(() => draft.customPoColumns ?? []);
   const [newPoColumnName, setNewPoColumnName] = useState('');
   const [newWorkspaceTabName, setNewWorkspaceTabName] = useState('');
+  const [wizardSeedLineId, setWizardSeedLineId] = useState<string | null>(null);
 
   const { data: projects = [], isLoading: projectsLoading } = useQuery<ProjectOption[]>({
     queryKey: ['/api/projects'],
@@ -263,22 +402,11 @@ export default function DraftBOMBuilderPage() {
   }, [projects]);
   const selectedProjectValue = draft.projectType === 'R_AND_D' ? R_AND_D_PROJECT_VALUE : draft.projectId ?? '';
 
-  const visibleLines = useMemo(() => {
-    return draft.lines.filter((line) => {
-      const categoryMatch = categoryFilter === 'all' || line.category === categoryFilter;
-      const statusMatch = statusFilter === 'all' || line.status === statusFilter;
-      return categoryMatch && statusMatch;
-    });
-  }, [categoryFilter, draft.lines, statusFilter]);
-
   const selectedLines = useMemo(() => draft.lines.filter((line) => line.include), [draft.lines]);
   const orderableLines = useMemo(
     () => draft.lines.filter((line) => line.action !== 'Do Not Order' && !line.finalized),
     [draft.lines],
   );
-  const filterOptions = useMemo(() => {
-    return [...new Set([...defaultFilterNames, ...draft.lines.map((line) => line.category).filter(Boolean)])].sort();
-  }, [draft.lines]);
   const activeInventoryItems = useMemo(
     () => inventoryItems.filter((item) => item.isActive !== false),
     [inventoryItems],
@@ -373,17 +501,6 @@ export default function DraftBOMBuilderPage() {
     }));
   }
 
-  function updateNumberLine(id: string, field: 'unitCost' | 'qtyNeeded', value: string) {
-    updateLine(id, { [field]: value === '' ? '' : Number(value) } as Partial<BomLine>);
-  }
-
-  function setAllIncluded(include: boolean) {
-    setDraft((current) => ({
-      ...current,
-      lines: current.lines.map((line) => ({ ...line, include })),
-    }));
-  }
-
   function selectOrderable() {
     setDraft((current) => ({
       ...current,
@@ -394,8 +511,70 @@ export default function DraftBOMBuilderPage() {
     }));
   }
 
-  function addLine() {
-    setDraft((current) => ({ ...current, lines: [...current.lines, newLine()] }));
+  function startDraftBomForLine(lineId: string) {
+    setWizardSeedLineId(lineId);
+    if (!visibleWorkspaceTabs.includes('bom-wizard')) {
+      setVisibleWorkspaceTabs((current) => (current.includes('bom-wizard') ? current : [...current, 'bom-wizard']));
+    }
+    setActiveWorkspaceTab('bom-wizard');
+  }
+
+  function saveWizardBom(part: DraftBomPart, bom: DraftPartBom) {
+    setDraft((current) => {
+      const sourceLine = part.sourceLineId ? current.lines.find((line) => line.id === part.sourceLineId) : null;
+      const rootLine =
+        sourceLine ??
+        ({
+          ...newLine(),
+          id: crypto.randomUUID(),
+          include: true,
+          action: 'Hold',
+          category: 'Hardware/Misc.',
+          agPartNumber: part.partNumber,
+          description: part.description,
+          qtyNeeded: part.quantity || 1,
+          status: part.source === 'inventory-item' ? 'Needs Review' : 'Needs Quote',
+          note: part.source === 'inventory-item' ? `Draft BOM built from inventory item #${part.inventoryItemId}` : 'Draft BOM built from new part',
+          inventoryItemId: part.inventoryItemId ?? null,
+          inventoryItemName: part.source === 'inventory-item' ? part.description : null,
+          isDraftPart: part.source !== 'inventory-item',
+          isManufactured: true,
+          firstDepartment: defaultDepartment,
+          childDraftBoms: [],
+        } as BomLine);
+
+      const linkedPart = { ...part, sourceLineId: rootLine.id };
+      const linkedBom: DraftPartBom = {
+        ...bom,
+        rootPart: linkedPart,
+        parts: bom.parts.map((queuedPart, index) =>
+          index === 0 ? { ...queuedPart, sourceLineId: rootLine.id } : queuedPart,
+        ),
+        updatedAt: new Date().toISOString(),
+      };
+
+      const nextLines = sourceLine ? current.lines : [rootLine, ...current.lines];
+      return {
+        ...current,
+        lines: nextLines.map((line) => {
+          if (line.id !== rootLine.id) return line;
+          const childDraftBoms = line.childDraftBoms ?? [];
+          const withoutCurrentBom = childDraftBoms.filter((item) => item.id !== linkedBom.id);
+          return {
+            ...line,
+            isManufactured: true,
+            firstDepartment: line.firstDepartment ?? defaultDepartment,
+            childDraftBoms: [linkedBom, ...withoutCurrentBom],
+          };
+        }),
+      };
+    });
+
+    setWizardSeedLineId(null);
+    toast({
+      title: 'Draft BOM saved',
+      description: `${bom.name} ${bom.revision} is linked to ${part.partNumber}.`,
+    });
   }
 
   function createLineFromPoDescription(item?: InventoryItemOption) {
@@ -424,6 +603,9 @@ export default function DraftBOMBuilderPage() {
       inventoryItemId: item?.id ?? null,
       inventoryItemName: item?.name || item?.description || null,
       isDraftPart: !item,
+      isManufactured: isInventoryManufactured(item),
+      firstDepartment: defaultDepartment,
+      childDraftBoms: [],
       customFields: {},
     };
 
@@ -464,6 +646,9 @@ export default function DraftBOMBuilderPage() {
       inventoryItemId: item?.id ?? null,
       inventoryItemName: item?.name || item?.description || null,
       isDraftPart: !item,
+      isManufactured: isInventoryManufactured(item),
+      firstDepartment: defaultDepartment,
+      childDraftBoms: [],
       customFields: {},
     };
 
@@ -496,20 +681,6 @@ export default function DraftBOMBuilderPage() {
         [columnName]: value,
       },
     });
-  }
-
-  function duplicateSelected() {
-    const copies = selectedLines.map((line) => ({
-      ...line,
-      id: crypto.randomUUID(),
-      finalized: false,
-      note: line.note ? `${line.note} | copied` : 'copied',
-    }));
-    setDraft((current) => ({ ...current, lines: [...current.lines, ...copies] }));
-  }
-
-  function removeSelected() {
-    setDraft((current) => ({ ...current, lines: current.lines.filter((line) => !line.include) }));
   }
 
   function saveDraft() {
@@ -951,32 +1122,6 @@ export default function DraftBOMBuilderPage() {
                     </div>
                   </DropdownMenuContent>
                 </DropdownMenu>
-                <Select value={categoryFilter} onValueChange={setCategoryFilter}>
-                  <SelectTrigger className="w-[190px]">
-                    <SelectValue placeholder="Filters" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All filters</SelectItem>
-                    {filterOptions.map((filterName) => (
-                      <SelectItem key={filterName} value={filterName}>
-                        {filterName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Select value={statusFilter} onValueChange={setStatusFilter}>
-                  <SelectTrigger className="w-[170px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All statuses</SelectItem>
-                    {statuses.map((status) => (
-                      <SelectItem key={status} value={status}>
-                        {status}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
               </div>
             </div>
 
@@ -1002,6 +1147,7 @@ export default function DraftBOMBuilderPage() {
                   onAddCustomColumn={addCustomPoColumn}
                   onUpdateCustomField={updateLineCustomField}
                   onGeneratePoDraft={() => showHandoffToast('PO draft')}
+                  onCreateDraftBom={startDraftBomForLine}
                 />
               </TabsContent>
             ) : null}
@@ -1026,34 +1172,13 @@ export default function DraftBOMBuilderPage() {
 
             {visibleWorkspaceTabs.includes('bom-wizard') ? (
               <TabsContent value="bom-wizard" className="mt-4">
-              <div className="mb-3 flex flex-wrap gap-2">
-                <Button variant="outline" onClick={addLine}>
-                  <Plus className="mr-2 h-4 w-4" />
-                  Add line
-                </Button>
-                <Button variant="outline" onClick={() => setAllIncluded(true)}>
-                  <Archive className="mr-2 h-4 w-4" />
-                  Select all
-                </Button>
-                <Button variant="outline" onClick={() => setAllIncluded(false)}>
-                  Clear selection
-                </Button>
-                <Button variant="outline" onClick={duplicateSelected} disabled={selectedLines.length === 0}>
-                  <Copy className="mr-2 h-4 w-4" />
-                  Duplicate selected
-                </Button>
-                <Button variant="destructive" onClick={removeSelected} disabled={selectedLines.length === 0}>
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Remove selected
-                </Button>
-              </div>
-
-              <BomLineGrid
-                lines={visibleLines}
-                filterOptions={filterOptions}
-                updateLine={updateLine}
-                updateNumberLine={updateNumberLine}
-              />
+                <DraftBomWizardWorkspace
+                  draftLines={draft.lines}
+                  inventoryItems={activeInventoryItems}
+                  seedLineId={wizardSeedLineId}
+                  onSeedLineConsumed={() => setWizardSeedLineId(null)}
+                  onSaveWizardBom={saveWizardBom}
+                />
               </TabsContent>
             ) : null}
 
@@ -1126,6 +1251,7 @@ function PoDraftWorkspace({
   onAddCustomColumn,
   onUpdateCustomField,
   onGeneratePoDraft,
+  onCreateDraftBom,
 }: {
   lines: BomLine[];
   description: string;
@@ -1140,9 +1266,10 @@ function PoDraftWorkspace({
   onAddCustomColumn: () => void;
   onUpdateCustomField: (lineId: string, columnName: string, value: string) => void;
   onGeneratePoDraft: () => void;
+  onCreateDraftBom: (lineId: string) => void;
 }) {
   const typedDescription = description.trim();
-  const totalColumns = 2 + visibleColumns.length + customColumns.length;
+  const totalColumns = 3 + visibleColumns.length + customColumns.length;
 
   return (
     <section className="space-y-4">
@@ -1264,6 +1391,7 @@ function PoDraftWorkspace({
                   </TableHead>
                 ))}
                 <TableHead className="w-[110px]">Part type</TableHead>
+                <TableHead className="w-[120px]">BOMs</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -1293,6 +1421,12 @@ function PoDraftWorkspace({
                       <Badge variant={line.inventoryItemId ? 'outline' : 'secondary'}>
                         {line.inventoryItemId ? 'Inventory' : 'Draft part'}
                       </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Button type="button" variant="outline" size="sm" onClick={() => onCreateDraftBom(line.id)}>
+                        <Layers className="mr-2 h-4 w-4" />
+                        {line.childDraftBoms?.length ? `${line.childDraftBoms.length} BOM` : 'BOM'}
+                      </Button>
                     </TableCell>
                   </TableRow>
                 ))
@@ -1540,6 +1674,486 @@ function PartsRequestWorkspace({
   );
 }
 
+function DraftBomWizardWorkspace({
+  draftLines,
+  inventoryItems,
+  seedLineId,
+  onSeedLineConsumed,
+  onSaveWizardBom,
+}: {
+  draftLines: BomLine[];
+  inventoryItems: InventoryItemOption[];
+  seedLineId: string | null;
+  onSeedLineConsumed: () => void;
+  onSaveWizardBom: (part: DraftBomPart, bom: DraftPartBom) => void;
+}) {
+  const [sourceMode, setSourceMode] = useState<DraftBomSource>('draft-part');
+  const [selectedLineId, setSelectedLineId] = useState('');
+  const [inventorySearch, setInventorySearch] = useState('');
+  const [selectedInventoryId, setSelectedInventoryId] = useState('');
+  const [newPartNumber, setNewPartNumber] = useState('');
+  const [newPartDescription, setNewPartDescription] = useState('');
+  const [activeBom, setActiveBom] = useState<DraftPartBom | null>(null);
+  const [currentPartIndex, setCurrentPartIndex] = useState(0);
+  const [componentSource, setComponentSource] = useState<DraftBomSource>('draft-part');
+  const [componentLineId, setComponentLineId] = useState('');
+  const [componentInventorySearch, setComponentInventorySearch] = useState('');
+  const [componentInventoryId, setComponentInventoryId] = useState('');
+  const [componentPartNumber, setComponentPartNumber] = useState('');
+  const [componentDescription, setComponentDescription] = useState('');
+  const [componentQuantity, setComponentQuantity] = useState('1');
+  const [componentManufactured, setComponentManufactured] = useState(false);
+  const [componentDepartment, setComponentDepartment] = useState(defaultDepartment);
+
+  const draftPartLines = useMemo(
+    () => draftLines.filter((line) => line.isDraftPart !== false || line.inventoryItemId || line.description || line.agPartNumber),
+    [draftLines],
+  );
+  const inventoryMatches = useMemo(() => searchInventoryItems(inventoryItems, inventorySearch), [inventoryItems, inventorySearch]);
+  const componentInventoryMatches = useMemo(
+    () => searchInventoryItems(inventoryItems, componentInventorySearch),
+    [componentInventorySearch, inventoryItems],
+  );
+  const selectedInventoryItem = inventoryItems.find((item) => String(item.id) === selectedInventoryId);
+  const componentInventoryItem = inventoryItems.find((item) => String(item.id) === componentInventoryId);
+  const selectedLine = draftLines.find((line) => line.id === selectedLineId);
+  const currentPart = activeBom?.parts[currentPartIndex] ?? null;
+  const queuedManufacturedParts = activeBom?.parts.filter((part, index) => index > currentPartIndex && !part.hasBOM) ?? [];
+
+  useEffect(() => {
+    if (!seedLineId) return;
+    const line = draftLines.find((item) => item.id === seedLineId);
+    if (!line) {
+      onSeedLineConsumed();
+      return;
+    }
+    setSourceMode('draft-part');
+    setSelectedLineId(line.id);
+    setActiveBom(createDraftPartBom(draftLineToPart(line), line.childDraftBoms?.length ?? 0));
+    setCurrentPartIndex(0);
+    onSeedLineConsumed();
+  }, [draftLines, onSeedLineConsumed, seedLineId]);
+
+  function startNewBom() {
+    let rootPart: DraftBomPart | null = null;
+    let existingCount = 0;
+
+    if (sourceMode === 'draft-part' && selectedLine) {
+      rootPart = draftLineToPart(selectedLine);
+      existingCount = selectedLine.childDraftBoms?.length ?? 0;
+    } else if (sourceMode === 'inventory-item' && selectedInventoryItem) {
+      rootPart = inventoryItemToPart(selectedInventoryItem);
+    } else if (sourceMode === 'new-part') {
+      rootPart = newWizardPart(newPartNumber, newPartDescription);
+    }
+
+    if (!rootPart) return;
+    setActiveBom(createDraftPartBom(rootPart, existingCount));
+    setCurrentPartIndex(0);
+  }
+
+  function loadExistingBom(line: BomLine, bom: DraftPartBom) {
+    setSourceMode('draft-part');
+    setSelectedLineId(line.id);
+    setActiveBom(bom);
+    setCurrentPartIndex(0);
+  }
+
+  function resetComponentForm() {
+    setComponentLineId('');
+    setComponentInventoryId('');
+    setComponentInventorySearch('');
+    setComponentPartNumber('');
+    setComponentDescription('');
+    setComponentQuantity('1');
+    setComponentManufactured(false);
+    setComponentDepartment(defaultDepartment);
+  }
+
+  function syncComponentFromDraftLine(lineId: string) {
+    const line = draftLines.find((item) => item.id === lineId);
+    setComponentLineId(lineId);
+    if (!line) return;
+    setComponentPartNumber(linePartNumber(line));
+    setComponentDescription(lineDescription(line));
+    setComponentManufactured(line.isManufactured === true);
+    setComponentDepartment(line.firstDepartment ?? defaultDepartment);
+  }
+
+  function syncComponentFromInventory(itemId: string) {
+    const item = inventoryItems.find((entry) => String(entry.id) === itemId);
+    setComponentInventoryId(itemId);
+    if (!item) return;
+    setComponentPartNumber(inventoryPartNumber(item));
+    setComponentDescription(inventoryDescription(item));
+    setComponentManufactured(isInventoryManufactured(item));
+    setComponentDepartment(defaultDepartment);
+  }
+
+  function addComponent() {
+    if (!activeBom || !currentPart || !componentPartNumber.trim()) return;
+    const quantity = Number(componentQuantity);
+    const component: DraftBomComponent = {
+      id: crypto.randomUUID(),
+      source: componentSource,
+      sourceLineId: componentSource === 'draft-part' ? componentLineId || null : null,
+      inventoryItemId: componentSource === 'inventory-item' ? Number(componentInventoryId) || componentInventoryItem?.id || null : null,
+      partNumber: componentPartNumber.trim(),
+      description: componentDescription.trim() || componentPartNumber.trim(),
+      quantity: Number.isFinite(quantity) && quantity > 0 ? quantity : 1,
+      isManufactured: componentManufactured,
+      firstDepartment: componentDepartment || defaultDepartment,
+    };
+
+    setActiveBom((current) => {
+      if (!current) return current;
+      const parts = current.parts.map((part, index) =>
+        index === currentPartIndex ? { ...part, bomItems: [...part.bomItems, component] } : part,
+      );
+
+      if (component.isManufactured && !parts.some((part) => part.partNumber === component.partNumber)) {
+        parts.splice(currentPartIndex + 1, 0, {
+          id: `mfg-${component.id}`,
+          source: component.source,
+          sourceLineId: component.sourceLineId ?? null,
+          inventoryItemId: component.inventoryItemId ?? null,
+          partNumber: component.partNumber,
+          description: component.description,
+          quantity: component.quantity,
+          bomItems: [],
+          hasBOM: false,
+        });
+      }
+
+      return { ...current, parts, updatedAt: new Date().toISOString() };
+    });
+    resetComponentForm();
+  }
+
+  function removeComponent(componentId: string) {
+    setActiveBom((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        parts: current.parts.map((part, index) =>
+          index === currentPartIndex
+            ? { ...part, bomItems: part.bomItems.filter((component) => component.id !== componentId) }
+            : part,
+        ),
+        updatedAt: new Date().toISOString(),
+      };
+    });
+  }
+
+  function saveAndAdvance() {
+    if (!activeBom || !currentPart) return;
+    const nextBom = {
+      ...activeBom,
+      parts: activeBom.parts.map((part, index) => (index === currentPartIndex ? { ...part, hasBOM: true } : part)),
+      updatedAt: new Date().toISOString(),
+    };
+
+    if (currentPartIndex < nextBom.parts.length - 1) {
+      setActiveBom(nextBom);
+      setCurrentPartIndex(currentPartIndex + 1);
+      resetComponentForm();
+      return;
+    }
+
+    onSaveWizardBom(nextBom.rootPart, nextBom);
+    setActiveBom(null);
+    setCurrentPartIndex(0);
+    resetComponentForm();
+  }
+
+  return (
+    <section className="grid gap-4 xl:grid-cols-[360px_minmax(0,1fr)]">
+      <div className="space-y-4">
+        <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex items-center gap-2">
+            <Layers className="h-4 w-4 text-teal-700" />
+            <h2 className="font-semibold text-slate-950">BOM Wizard</h2>
+          </div>
+          <p className="mt-1 text-sm text-slate-600">
+            Create another draft BOM from a draft part, inventory item, or new part.
+          </p>
+
+          <div className="mt-4 grid gap-3">
+            <Select value={sourceMode} onValueChange={(value) => setSourceMode(value as DraftBomSource)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="draft-part">Draft parts list</SelectItem>
+                <SelectItem value="inventory-item">Inventory items</SelectItem>
+                <SelectItem value="new-part">Create new part</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {sourceMode === 'draft-part' ? (
+              <Select value={selectedLineId} onValueChange={setSelectedLineId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select draft part" />
+                </SelectTrigger>
+                <SelectContent>
+                  {draftPartLines.map((line) => (
+                    <SelectItem key={line.id} value={line.id}>
+                      {linePartNumber(line)} - {lineDescription(line)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : null}
+
+            {sourceMode === 'inventory-item' ? (
+              <div className="grid gap-2">
+                <Input value={inventorySearch} onChange={(event) => setInventorySearch(event.target.value)} placeholder="Search inventory" />
+                <Select value={selectedInventoryId} onValueChange={setSelectedInventoryId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select inventory item" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {inventoryMatches.map((item) => (
+                      <SelectItem key={item.id} value={String(item.id)}>
+                        {inventoryPartNumber(item)} - {inventoryDescription(item)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : null}
+
+            {sourceMode === 'new-part' ? (
+              <div className="grid gap-2">
+                <Input value={newPartNumber} onChange={(event) => setNewPartNumber(event.target.value)} placeholder="Part number" />
+                <Input value={newPartDescription} onChange={(event) => setNewPartDescription(event.target.value)} placeholder="Description" />
+              </div>
+            ) : null}
+
+            <Button type="button" onClick={startNewBom}>
+              <Plus className="mr-2 h-4 w-4" />
+              Start draft BOM
+            </Button>
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">Existing draft BOMs</h3>
+          <div className="mt-3 space-y-2">
+            {draftLines.flatMap((line) =>
+              (line.childDraftBoms ?? []).map((bom) => (
+                <button
+                  key={bom.id}
+                  type="button"
+                  className="block w-full rounded-md border border-slate-200 p-3 text-left text-sm hover:border-teal-300 hover:bg-teal-50"
+                  onClick={() => loadExistingBom(line, bom)}
+                >
+                  <span className="block font-medium text-slate-950">{bom.name} {bom.revision}</span>
+                  <span className="mt-1 block text-xs text-slate-500">
+                    {linePartNumber(line)} - {bom.parts.length} configured part{bom.parts.length === 1 ? '' : 's'}
+                  </span>
+                </button>
+              )),
+            )}
+            {draftLines.every((line) => !line.childDraftBoms?.length) ? (
+              <p className="text-sm text-slate-500">No child draft BOMs have been saved yet.</p>
+            ) : null}
+          </div>
+        </section>
+      </div>
+
+      <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
+        {!activeBom || !currentPart ? (
+          <div className="p-8 text-center text-sm text-slate-500">
+            Choose a source part to begin a draft BOM.
+          </div>
+        ) : (
+          <div className="space-y-4 p-4">
+            <div className="flex flex-col gap-3 border-b border-slate-200 pb-4 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-950">{activeBom.name}</h3>
+                <p className="text-sm text-slate-600">
+                  Part {currentPartIndex + 1} of {activeBom.parts.length}: {currentPart.partNumber} - {currentPart.description}
+                </p>
+              </div>
+              <Badge variant="outline">{activeBom.revision}</Badge>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {activeBom.parts.map((part, index) => (
+                <Button
+                  key={part.id}
+                  type="button"
+                  variant={index === currentPartIndex ? 'default' : part.hasBOM ? 'outline' : 'secondary'}
+                  size="sm"
+                  onClick={() => {
+                    setCurrentPartIndex(index);
+                    resetComponentForm();
+                  }}
+                >
+                  {part.hasBOM ? <Check className="mr-1 h-3 w-3" /> : null}
+                  {part.partNumber}
+                </Button>
+              ))}
+            </div>
+
+            {queuedManufacturedParts.length > 0 ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                Manufactured sub-parts queued next: {queuedManufacturedParts.map((part) => part.partNumber).join(', ')}
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 rounded-md border border-slate-200 bg-slate-50 p-3">
+              <div className="grid gap-3 lg:grid-cols-[160px_minmax(180px,1fr)_minmax(180px,1fr)_100px_150px_auto]">
+                <Select value={componentSource} onValueChange={(value) => setComponentSource(value as DraftBomSource)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="draft-part">Draft part</SelectItem>
+                    <SelectItem value="inventory-item">Inventory</SelectItem>
+                    <SelectItem value="new-part">New part</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                {componentSource === 'draft-part' ? (
+                  <Select value={componentLineId} onValueChange={syncComponentFromDraftLine}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Draft part" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {draftPartLines.map((line) => (
+                        <SelectItem key={line.id} value={line.id}>
+                          {linePartNumber(line)} - {lineDescription(line)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : componentSource === 'inventory-item' ? (
+                  <div className="grid gap-2">
+                    <Input
+                      value={componentInventorySearch}
+                      onChange={(event) => setComponentInventorySearch(event.target.value)}
+                      placeholder="Search inventory"
+                    />
+                    <Select value={componentInventoryId} onValueChange={syncComponentFromInventory}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Inventory item" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {componentInventoryMatches.map((item) => (
+                          <SelectItem key={item.id} value={String(item.id)}>
+                            {inventoryPartNumber(item)} - {inventoryDescription(item)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ) : (
+                  <Input value={componentPartNumber} onChange={(event) => setComponentPartNumber(event.target.value)} placeholder="Part number" />
+                )}
+
+                <Input value={componentDescription} onChange={(event) => setComponentDescription(event.target.value)} placeholder="Description" />
+                <Input
+                  type="number"
+                  min="0.001"
+                  step="0.001"
+                  value={componentQuantity}
+                  onChange={(event) => setComponentQuantity(event.target.value)}
+                  placeholder="Qty"
+                />
+                <Select value={componentDepartment} onValueChange={setComponentDepartment}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {departmentOptions.map((department) => (
+                      <SelectItem key={department.value} value={department.value}>
+                        {department.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button type="button" onClick={addComponent} disabled={!componentPartNumber.trim()}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add
+                </Button>
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <Checkbox checked={componentManufactured} onCheckedChange={(checked) => setComponentManufactured(checked === true)} />
+                Manufactured component
+              </label>
+            </div>
+
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Part number</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead className="text-right">Qty</TableHead>
+                    <TableHead>First department</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead className="w-[70px]"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {currentPart.bomItems.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={6} className="h-24 text-center text-slate-500">
+                        Add components for this draft BOM part.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    currentPart.bomItems.map((component) => (
+                      <TableRow key={component.id}>
+                        <TableCell className="font-medium">{component.partNumber}</TableCell>
+                        <TableCell>{component.description}</TableCell>
+                        <TableCell className="text-right tabular-nums">{component.quantity}</TableCell>
+                        <TableCell>{departmentOptions.find((department) => department.value === component.firstDepartment)?.label ?? component.firstDepartment}</TableCell>
+                        <TableCell>
+                          <Badge variant={component.isManufactured ? 'secondary' : 'outline'}>
+                            {component.isManufactured ? 'Manufactured' : 'Purchased'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <Button type="button" variant="ghost" size="sm" onClick={() => removeComponent(component.id)}>
+                            <Trash2 className="h-4 w-4 text-destructive" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="flex justify-end">
+              <Button type="button" onClick={saveAndAdvance}>
+                {currentPartIndex < activeBom.parts.length - 1 ? 'Save & Next' : 'Save Draft BOM'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </section>
+    </section>
+  );
+}
+
+function searchInventoryItems(items: InventoryItemOption[], query: string) {
+  const normalized = query.trim().toLowerCase();
+  const source = normalized.length >= 2
+    ? items.filter((item) =>
+        [item.name, item.description, item.agPartNumber, item.supplierPartNumber, item.manufacturerPartNumber, item.manufacturer]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase()
+          .includes(normalized),
+      )
+    : items;
+  return source.slice(0, 50);
+}
+
 function SourcingLineTable({ lines, emptyMessage }: { lines: BomLine[]; emptyMessage: string }) {
   return (
     <div className="overflow-x-auto">
@@ -1589,161 +2203,6 @@ function SourcingLineTable({ lines, emptyMessage }: { lines: BomLine[]; emptyMes
         </TableBody>
       </Table>
     </div>
-  );
-}
-
-function BomLineGrid({
-  lines,
-  filterOptions,
-  updateLine,
-  updateNumberLine,
-}: {
-  lines: BomLine[];
-  filterOptions: string[];
-  updateLine: (id: string, patch: Partial<BomLine>) => void;
-  updateNumberLine: (id: string, field: 'unitCost' | 'qtyNeeded', value: string) => void;
-}) {
-  return (
-    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
-      <datalist id="draft-bom-filter-options">
-        {filterOptions.map((filterName) => (
-          <option key={filterName} value={filterName} />
-        ))}
-      </datalist>
-      <div className="overflow-x-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[56px]">Use</TableHead>
-              <TableHead className="w-[150px]">Order Action</TableHead>
-              <TableHead className="w-[180px]">Filter</TableHead>
-              <TableHead className="w-[150px]">Supplier</TableHead>
-              <TableHead className="w-[150px]">Manufacturer</TableHead>
-              <TableHead className="w-[150px]">Supplier Item ID</TableHead>
-              <TableHead className="w-[120px]">AG Part #</TableHead>
-              <TableHead className="min-w-[320px]">Description</TableHead>
-              <TableHead className="w-[80px]">Unit</TableHead>
-              <TableHead className="w-[110px] text-right">Unit Cost</TableHead>
-              <TableHead className="w-[100px] text-right">Qty</TableHead>
-              <TableHead className="w-[120px] text-right">Ext Cost</TableHead>
-              <TableHead className="w-[140px]">Status</TableHead>
-              <TableHead className="w-[150px]">Need Date</TableHead>
-              <TableHead className="w-[92px]">Final</TableHead>
-              <TableHead className="min-w-[260px]">Note / Link</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {lines.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={16} className="h-24 text-center text-slate-500">
-                  No BOM lines match the active filters.
-                </TableCell>
-              </TableRow>
-            ) : (
-              lines.map((line) => {
-                const extCost = asNumber(line.unitCost) * asNumber(line.qtyNeeded);
-                return (
-                  <TableRow key={line.id} className={cn(line.finalized && 'bg-emerald-50/60')}>
-                    <TableCell>
-                      <Checkbox
-                        checked={line.include}
-                        onCheckedChange={(checked) => updateLine(line.id, { include: checked === true })}
-                        aria-label={`Select ${line.description || 'BOM line'}`}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Select value={line.action} onValueChange={(value) => updateLine(line.id, { action: value as BomAction })}>
-                        <SelectTrigger className="h-9">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {actions.map((action) => (
-                            <SelectItem key={action} value={action}>
-                              {action}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </TableCell>
-                    <TableCell>
-                      <Input
-                        className="h-9"
-                        list="draft-bom-filter-options"
-                        value={line.category}
-                        onChange={(event) => updateLine(line.id, { category: event.target.value })}
-                        placeholder="Filter name"
-                      />
-                    </TableCell>
-                    <EditableCell value={line.supplier} onChange={(value) => updateLine(line.id, { supplier: value })} />
-                    <EditableCell value={line.manufacturer} onChange={(value) => updateLine(line.id, { manufacturer: value })} />
-                    <EditableCell value={line.supplierItemId} onChange={(value) => updateLine(line.id, { supplierItemId: value })} />
-                    <EditableCell value={line.agPartNumber} onChange={(value) => updateLine(line.id, { agPartNumber: value })} />
-                    <EditableCell value={line.description} onChange={(value) => updateLine(line.id, { description: value })} wide />
-                    <EditableCell value={line.unit} onChange={(value) => updateLine(line.id, { unit: value })} />
-                    <TableCell>
-                      <Input
-                        className="h-9 text-right"
-                        type="number"
-                        min="0"
-                        step="0.01"
-                        value={line.unitCost}
-                        onChange={(event) => updateNumberLine(line.id, 'unitCost', event.target.value)}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Input
-                        className="h-9 text-right"
-                        type="number"
-                        min="0"
-                        step="0.001"
-                        value={line.qtyNeeded}
-                        onChange={(event) => updateNumberLine(line.id, 'qtyNeeded', event.target.value)}
-                      />
-                    </TableCell>
-                    <TableCell className="text-right font-medium tabular-nums">{money(extCost)}</TableCell>
-                    <TableCell>
-                      <Select value={line.status} onValueChange={(value) => updateLine(line.id, { status: value as BomStatus })}>
-                        <SelectTrigger className="h-9">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {statuses.map((status) => (
-                            <SelectItem key={status} value={status}>
-                              {status}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </TableCell>
-                    <TableCell>
-                      <Input
-                        className="h-9"
-                        type="date"
-                        value={line.targetNeedDate}
-                        onChange={(event) => updateLine(line.id, { targetNeedDate: event.target.value })}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Checkbox
-                        checked={line.finalized}
-                        onCheckedChange={(checked) => updateLine(line.id, { finalized: checked === true })}
-                        aria-label={`Finalize ${line.description || 'BOM line'}`}
-                      />
-                    </TableCell>
-                    <EditableCell value={line.note} onChange={(value) => updateLine(line.id, { note: value })} wide />
-                  </TableRow>
-                );
-              })
-            )}
-          </TableBody>
-        </Table>
-      </div>
-      <Separator />
-      <div className="flex flex-wrap items-center justify-between gap-2 p-3 text-xs text-slate-500">
-        <span>Columns follow the working Google Sheet: supplier, manufacturer, item, AG part, cost, quantity, status, and notes.</span>
-        <span>Drafts save locally until backend draft persistence is wired.</span>
-      </div>
-    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- Replaces the Draft Builder BOM wizard tab with a real draft BOM creation workflow.
- Allows users to start draft BOMs from draft part lines, inventory items, or newly entered parts.
- Adds per-line PO draft BOM actions and stores multiple child draft BOMs on the source draft line.
- Queues manufactured components for follow-up sub-BOM configuration, matching the recursive P2 BOM wizard behavior.

## Validation
- `git diff --check`
- `git diff --cached --check`

Note: `npm run check` could not be run locally because `npm` and a local TypeScript install are not available in this worktree.