### PR TITLE
[codex] Fix All Orders creation routing

### DIFF
--- a/migrations/0171_all_orders_finalize_to_p1_queue.sql
+++ b/migrations/0171_all_orders_finalize_to_p1_queue.sql
@@ -1,0 +1,27 @@
+-- Ensure newly created All Orders no longer remain in retired initial states.
+-- Existing downstream production departments are intentionally left untouched.
+
+UPDATE all_orders
+SET
+  status = 'FINALIZED',
+  current_department = 'P1 Production Queue',
+  barcode = CASE
+    WHEN barcode IS NULL OR barcode = '' OR barcode LIKE 'NOSTOCK-%' OR barcode LIKE 'PENDING-%'
+      THEN 'P1-' || order_id
+    ELSE barcode
+  END,
+  updated_at = NOW()
+WHERE
+  current_department IN ('Awaiting Customer Signature', 'P1 Production Queue', 'Shipping QC')
+  AND status IN ('PENDING_SIGNATURE', 'IN_PROGRESS');
+
+UPDATE production_orders po
+SET
+  current_department = 'P1 Production Queue',
+  updated_at = NOW()
+FROM all_orders ao
+WHERE
+  po.order_id = ao.order_id
+  AND ao.status = 'FINALIZED'
+  AND ao.current_department = 'P1 Production Queue'
+  AND po.current_department = 'Awaiting Customer Signature';

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -198,6 +198,7 @@ const safeFiles = [
   '0161_employee_termination_access_controls.sql',
   '0162_p2_project_revision_type_po_change.sql',
   '0166_p2_packing_slip_invoice_number.sql',
+  '0171_all_orders_finalize_to_p1_queue.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -835,7 +835,7 @@ router.get('/draft/:id', async (req: Request, res: Response) => {
 // each blocked attempt is written to order_activity_events for observability.
 const ordersBeingFinalized = new Set<string>();
 
-// Create order - with or without signature requirement based on whether stock is selected
+// Create order directly into the P1 production queue.
 router.post('/finalized', async (req: Request, res: Response) => {
   // Declare outside try so finally can release the guard reliably
   let incomingOrderId: string | null = null;
@@ -862,16 +862,9 @@ router.post('/finalized', async (req: Request, res: Response) => {
     }
     if (incomingOrderId) ordersBeingFinalized.add(incomingOrderId);
     
-    // Determine if stock is selected (has modelId and it's not "no_stock" or similar)
-    // Normalize the modelId for checking (trim whitespace and convert to lowercase)
-    const normalizedModelId = orderData.modelId?.trim().toLowerCase() || '';
-    const noStockIdentifiers = ['', 'no_stock', 'no stock', 'none'];
-    const hasStock: boolean = !noStockIdentifiers.includes(normalizedModelId);
-    
-    // If has stock: PENDING_SIGNATURE status, awaiting customer signature
-    // If no stock: IN_PROGRESS status, skip production pipeline, go directly to Shipping QC
-    const orderStatus = hasStock ? 'PENDING_SIGNATURE' : 'IN_PROGRESS';
-    const orderDepartment = hasStock ? 'Awaiting Customer Signature' : 'Shipping QC';
+    const orderStatus = 'FINALIZED';
+    const orderDepartment = 'P1 Production Queue';
+    const requiresCustomerSignature = false;
     
     // Compute bottomMetalSource upfront to set it on creation (no interim incorrect state)
     const bottomMetalSource = computeBottomMetalSource(orderData.features as Record<string, any>);
@@ -905,11 +898,7 @@ router.post('/finalized', async (req: Request, res: Response) => {
       console.warn('⚠️ reconcileRailDemand skipped on order create:', railErr?.message);
     }
     
-    if (hasStock) {
-      console.log(`📧 Order ${order.orderId} created with PENDING_SIGNATURE status - sending confirmation email to customer...`);
-    } else {
-      console.log(`📧 Order ${order.orderId} created as IN_PROGRESS (no stock) - skipping production, going to Shipping QC - sending thank you email to customer...`);
-    }
+    console.log(`Order ${order.orderId} created as FINALIZED and routed to P1 Production Queue - sending order confirmation email to customer...`);
     
     // Track email outcome for API response (declared outside inner try block for scoping)
     let emailOutcome: OrderConfirmationOutcome | undefined;
@@ -1152,7 +1141,7 @@ router.post('/finalized', async (req: Request, res: Response) => {
       // Declare signatureToken outside the if block for error handling access
       let signatureToken: string | undefined;
       
-      if (hasStock) {
+      if (requiresCustomerSignature) {
         // Generate PDF via unified service with frozen snapshot for signature workflow
         const pdfResult = await generateOrderPdf(order.orderId, PdfIntent.SIGNATURE_EMAIL);
         const pdfPath = pdfResult.filePath!;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -22061,40 +22061,25 @@ export class DatabaseStorage implements IStorage {
     orderData: InsertOrderDraft,
     finalizedBy?: string
   ): Promise<AllOrder> {
-    // If status is PENDING_SIGNATURE, don't auto-route to production
-    const isPendingSignature = orderData.status === 'PENDING_SIGNATURE';
+    // New All Orders always enter the P1 production queue as finalized.
+    const status = 'FINALIZED';
+    const currentDepartment = 'P1 Production Queue';
+    const barcode = orderData.barcode || `P1-${orderData.orderId}`;
     
-    // Special handling for orders with no stock model - route directly to Shipping QC (unless pending signature)
+    // Retained only for creation diagnostics.
     const hasNoStockModel =
       !orderData.modelId ||
       orderData.modelId.toLowerCase() === 'none' ||
       orderData.modelId.toLowerCase().trim() === '';
 
-    let currentDepartment: string;
-    let barcode: string;
-    let status: string;
-
-    if (isPendingSignature) {
+    if (hasNoStockModel) {
       console.log(
-        `📝 Order ${orderData.orderId} created with PENDING_SIGNATURE status - awaiting customer confirmation`
+        `CREATE APPROVED: Order ${orderData.orderId} has no stock model - routing to P1 Production Queue`
       );
-      currentDepartment = orderData.currentDepartment || 'Awaiting Customer Signature';
-      barcode = orderData.barcode || `PENDING-${orderData.orderId}`;
-      status = 'PENDING_SIGNATURE';
-    } else if (hasNoStockModel) {
-      console.log(
-        `🚀 CREATE APPROVED: Order ${orderData.orderId} has no stock model - routing directly to Shipping QC`
-      );
-      currentDepartment = 'Shipping QC';
-      barcode = orderData.barcode || `NOSTOCK-${orderData.orderId}`;
-      status = 'FINALIZED';
     } else {
       console.log(
         `✅ CREATE APPROVED: Order ${orderData.orderId} has valid stock model "${orderData.modelId}" - going directly to P1 Production Queue`
       );
-      currentDepartment = 'P1 Production Queue';
-      barcode = orderData.barcode || `P1-${orderData.orderId}`;
-      status = 'FINALIZED';
     }
 
     // Create the finalized order data directly - exclude id field explicitly


### PR DESCRIPTION
## Summary

- Route newly created All Orders directly to `P1 Production Queue` with `FINALIZED` status.
- Stop the create route from taking the retired customer-signature branch for new finalized orders.
- Add a safe boot migration to repair existing initial-state rows that were left in `PENDING_SIGNATURE`, `IN_PROGRESS`, `Awaiting Customer Signature`, or `Shipping QC`.

## Root Cause

The finalized-order create route still derived status and department from stock/no-stock state, and `createFinalizedOrder` honored those legacy values. That allowed new orders to land in the retired customer-signature queue or in non-finalized initial states instead of entering the P1 queue as finalized.

## Validation

- `node --experimental-strip-types --check server/src/routes/orders.ts` using bundled Codex Node runtime
- `node --experimental-strip-types --check server/storage.ts` using bundled Codex Node runtime
- `git diff --check`
- `git diff --cached --check`