### PR TITLE
[codex] Fix back navigation redirects

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -447,7 +447,7 @@ function RootRedirect() {
     if (isLoading) return;
 
     if (!currentUser) {
-      setLocation('/login');
+      setLocation('/login', { replace: true });
       return;
     }
 
@@ -455,7 +455,7 @@ function RootRedirect() {
       const personalizedRoute = getDashboardRoute(currentUser.username);
       if (personalizedRoute !== '/') {
         console.log(`Redirecting ${currentUser.username} to ${personalizedRoute}`);
-        setLocation(personalizedRoute);
+        setLocation(personalizedRoute, { replace: true });
       }
     }
   }, [isLoading, currentUser, setLocation]);
@@ -525,7 +525,7 @@ function SessionAwareMessageNotificationPopup() {
 function RedirectToShippingTracker() {
   const [, setLocation] = useLocation();
   React.useEffect(() => {
-    setLocation('/shipping-tracker');
+    setLocation('/shipping-tracker', { replace: true });
   }, [setLocation]);
   return null;
 }

--- a/client/src/components/auth/ProtectedRoute.tsx
+++ b/client/src/components/auth/ProtectedRoute.tsx
@@ -128,9 +128,9 @@ export default function ProtectedRoute({
 
   useEffect(() => {
     if (accessState === 'unauthenticated') {
-      setLocation('/login');
+      setLocation('/login', { replace: true });
     } else if (accessState === 'denied') {
-      setLocation('/access-denied');
+      setLocation('/access-denied', { replace: true });
     }
   }, [accessState, setLocation]);
 

--- a/client/src/components/auth/RouteGuard.tsx
+++ b/client/src/components/auth/RouteGuard.tsx
@@ -187,7 +187,7 @@ export default function RouteGuard({ children }: RouteGuardProps) {
   // performing navigation during render, which avoids React strict-mode warnings.
   useEffect(() => {
     if (!isLoading && !isPublicRoute(location) && currentUser === null) {
-      setLocation('/login');
+      setLocation('/login', { replace: true });
     }
   }, [isLoading, currentUser, location, setLocation]);
 


### PR DESCRIPTION
## Summary
- Change automatic root/auth redirects to replace the current history entry instead of pushing a new entry.
- Change the legacy weekly shipments redirect to replace history as well.

## Root cause
Back navigation could land on an automatic redirect route, such as `/`, `/weekly-shipments`, or an auth guard path. Those redirects were pushing a new history entry, which could bounce the user forward again and make the Back button feel like it was jumping around.

## Validation
- `git diff --check -- client/src/App.tsx client/src/components/auth/RouteGuard.tsx client/src/components/auth/ProtectedRoute.tsx`
- `git diff --cached --check`

Full TypeScript checks were not run because local `npm` is not available in this shell and `node_modules/typescript` is absent.