### PR TITLE
[codex] Repair finalized awaiting-signature orders

### DIFF
--- a/migrations/0171_all_orders_finalize_to_p1_queue.sql
+++ b/migrations/0171_all_orders_finalize_to_p1_queue.sql
@@ -12,8 +12,11 @@ SET
   END,
   updated_at = NOW()
 WHERE
-  current_department IN ('Awaiting Customer Signature', 'P1 Production Queue', 'Shipping QC')
-  AND status IN ('PENDING_SIGNATURE', 'IN_PROGRESS');
+  current_department = 'Awaiting Customer Signature'
+  OR (
+    current_department IN ('P1 Production Queue', 'Shipping QC')
+    AND status IN ('PENDING_SIGNATURE', 'IN_PROGRESS')
+  );
 
 UPDATE production_orders po
 SET


### PR DESCRIPTION
## Summary

- Update the All Orders repair migration so any row still in `Awaiting Customer Signature` is moved to `P1 Production Queue` with `FINALIZED` status.
- Keep the `P1 Production Queue` / `Shipping QC` repair limited to rows with retired initial statuses.

## Root Cause

The first migration repaired `PENDING_SIGNATURE` and `IN_PROGRESS` initial states, but the screenshot shows rows that are already `FINALIZED` while still stuck in the retired `Awaiting Customer Signature` department. Those need to be repaired based on department alone.

## Validation

- `git diff --check`
- `git diff --cached --check`