### PR TITLE
[codex] Let P2 shipments survive packing slip PDF snapshot failures

### DIFF
--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -961,17 +961,14 @@ router.post('/packing-slips', authenticateToken, requirePermission('shipping.rel
       const snapshot = await persistP2PackingSlipPdfSnapshot(slip);
       slip = snapshot.slip;
     } catch (snapshotErr) {
-      await db.delete(p2PackingSlips).where(eq(p2PackingSlips.id, slip.id)).catch((cleanupErr) => {
-        console.error('[P2Shipping] Failed to clean up packing slip after PDF snapshot failure:', {
-          packingSlipId: slip.id,
-          cleanupErr,
-        });
-      });
-      console.error('[P2Shipping] Packing slip PDF snapshot failed; creation aborted:', {
+      console.warn('[P2Shipping] Packing slip PDF snapshot failed; continuing with persisted slip:', {
         packingSlipId: slip.id,
         snapshotErr,
       });
-      return res.status(500).json({ error: 'Failed to create durable packing slip PDF' });
+      slip = {
+        ...slip,
+        pdfSnapshotWarning: 'Packing slip was created, but the frozen PDF snapshot could not be stored. It will be regenerated on view.',
+      };
     }
 
     if (input.replacesPackingSlipId) {


### PR DESCRIPTION
## Summary
- Keep the P2 packing slip record when the frozen PDF snapshot upload/generation fails.
- Return the created slip with a warning instead of deleting it and returning `Failed to create durable packing slip PDF`.
- Leave PDF rendering recoverable through the existing view/download fallback path.

## Root Cause
Production logs showed `/api/p2/lots` succeeding, followed by `/api/p2/packing-slips` returning 500 with `Failed to create durable packing slip PDF`. The route inserted a packing slip, attempted to persist a frozen PDF snapshot, then deleted the slip and aborted the shipment when that snapshot step failed. That left a created lot with no linked slip, so the shipment stayed hidden.

## Validation
- `node --experimental-strip-types --check server/src/routes/p2Shipping.ts`
- `node --experimental-strip-types --check server/index.ts`
- `git diff --check origin/main..HEAD`
- Verified compare range: one commit, `server/src/routes/p2Shipping.ts` only