### PR TITLE
[codex] Fix Twilio credential precedence

### DIFF
--- a/server/config/notifications.ts
+++ b/server/config/notifications.ts
@@ -7,11 +7,33 @@
  */
 
 // ============== TWILIO (SMS) ==============
-export const getTwilioConfig = () => ({
-  accountSid: process.env.TWILIO_SID || process.env.TWILIO_ACCOUNT_SID || '',
-  authToken: process.env.TWILIO_AUTH_TOKEN || '',
-  fromNumber: process.env.TWILIO_NUMBER || process.env.TWILIO_FROM_NUMBER || process.env.TWILIO_PHONE_NUMBER || '',
-});
+const firstPresentEnv = (entries) => {
+  const found = entries.find(([, value]) => Boolean(value?.trim()));
+  return {
+    value: found?.[1]?.trim() || '',
+    source: found?.[0] || null,
+  };
+};
+
+export const getTwilioConfig = () => {
+  const accountSid = firstPresentEnv([
+    ['TWILIO_ACCOUNT_SID', process.env.TWILIO_ACCOUNT_SID],
+    ['TWILIO_SID', process.env.TWILIO_SID],
+  ]);
+  const fromNumber = firstPresentEnv([
+    ['TWILIO_FROM_NUMBER', process.env.TWILIO_FROM_NUMBER],
+    ['TWILIO_NUMBER', process.env.TWILIO_NUMBER],
+    ['TWILIO_PHONE_NUMBER', process.env.TWILIO_PHONE_NUMBER],
+  ]);
+
+  return {
+    accountSid: accountSid.value,
+    accountSidSource: accountSid.source,
+    authToken: process.env.TWILIO_AUTH_TOKEN?.trim() || '',
+    fromNumber: fromNumber.value,
+    fromNumberSource: fromNumber.source,
+  };
+};
 
 export const isTwilioConfigured = (): boolean => {
   const config = getTwilioConfig();
@@ -34,6 +56,7 @@ export const getNotificationStatus = () => ({
   sms: {
     enabled: isTwilioConfigured(),
     fromNumber: getTwilioConfig().fromNumber || 'NOT SET',
+    accountSidSource: getTwilioConfig().accountSidSource || 'NOT SET',
   },
   email: {
     enabled: isSendGridConfigured(),
@@ -48,6 +71,7 @@ export const logNotificationConfig = (prefix: string = '📡') => {
     sms: {
       enabled: status.sms.enabled ? '✔' : '❌',
       from: status.sms.fromNumber,
+      accountSidSource: status.sms.accountSidSource,
     },
     email: {
       enabled: status.email.enabled ? '✔' : '❌', 

--- a/server/src/routes/communications.ts
+++ b/server/src/routes/communications.ts
@@ -271,16 +271,15 @@ router.get('/sms-status/:messageId', async (req, res) => {
   try {
     const { messageId } = req.params;
 
-    const accountSid = process.env.TWILIO_SID || process.env.TWILIO_ACCOUNT_SID;
-    const authToken = process.env.TWILIO_AUTH_TOKEN;
+    const twilioConfig = getTwilioConfig();
 
-    if (!accountSid || !authToken) {
+    if (!twilioConfig.accountSid || !twilioConfig.authToken) {
       return res
         .status(500)
         .json({ error: 'Twilio credentials not configured' });
     }
 
-    const twilioClient = twilio(accountSid, authToken);
+    const twilioClient = twilio(twilioConfig.accountSid, twilioConfig.authToken);
     const message = await twilioClient.messages(messageId).fetch();
 
     res.json({

--- a/server/utils/healthCheckService.ts
+++ b/server/utils/healthCheckService.ts
@@ -225,8 +225,10 @@ async function checkTwilioSMS(checkType: HealthCheckType): Promise<HealthCheckRe
         message: 'Twilio credentials not configured',
         details: { 
           accountSidSet: !!twilioConfig.accountSid, 
+          accountSidSource: twilioConfig.accountSidSource || 'NOT SET',
           authTokenSet: !!twilioConfig.authToken, 
-          fromNumberSet: !!twilioConfig.fromNumber 
+          fromNumberSet: !!twilioConfig.fromNumber,
+          fromNumberSource: twilioConfig.fromNumberSource || 'NOT SET',
         },
         executionTimeMs: Date.now() - startTime,
       };
@@ -259,6 +261,8 @@ async function checkTwilioSMS(checkType: HealthCheckType): Promise<HealthCheckRe
       details: { 
         messageSid: message.sid, 
         recipient: testPhone,
+        accountSidSource: twilioConfig.accountSidSource || 'NOT SET',
+        fromNumberSource: twilioConfig.fromNumberSource || 'NOT SET',
         sentAt: now.toISOString()
       },
       executionTimeMs: Date.now() - startTime,
@@ -394,6 +398,8 @@ async function checkTrackingNotificationPipeline(checkType: HealthCheckType): Pr
     smsSuccess,
     smsMessageId,
     smsError,
+    smsAccountSidSource: smsTwilioConfig.accountSidSource || 'NOT SET',
+    smsFromNumberSource: smsTwilioConfig.fromNumberSource || 'NOT SET',
     lastTestTimestamp: timestamp,
   };
   

--- a/server/utils/notifications.ts
+++ b/server/utils/notifications.ts
@@ -180,7 +180,7 @@ export async function sendCustomerNotification(
   if (prefersSms && !allowSms) {
     console.warn(
       `[NOTIFY] SMS preferred for order ${data.orderId} but Twilio is not configured ` +
-      `(missing TWILIO_SID/TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, or TWILIO_NUMBER). ` +
+      `(missing TWILIO_ACCOUNT_SID/TWILIO_SID, TWILIO_AUTH_TOKEN, or TWILIO_FROM_NUMBER/TWILIO_NUMBER/TWILIO_PHONE_NUMBER). ` +
       `SMS will be skipped${email ? ' and email used as fallback' : ' and no SMS will be sent'}.`
     );
   }


### PR DESCRIPTION
## Summary
- Prefer `TWILIO_ACCOUNT_SID` over the legacy `TWILIO_SID` when resolving Twilio credentials.
- Keep SMS status checks on the centralized Twilio config path instead of reading env vars directly.
- Add non-secret health-check details showing which Twilio SID/from-number env var was selected.

## Root Cause
P1 shipping notifications were reaching Twilio but failing with `Authenticate`. The code previously preferred `TWILIO_SID` before `TWILIO_ACCOUNT_SID`, so a stale legacy SID could shadow the correct account SID in production and cause Twilio authentication failure.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/config/notifications.ts`
- `node --experimental-strip-types --check server/src/routes/communications.ts`
- `node --experimental-strip-types --check server/utils/healthCheckService.ts`
- `node --experimental-strip-types --check server/utils/notifications.ts`

## Follow-up After Deploy
Run `/admin/health-checks` -> `Twilio SMS Service`. The details should show `accountSidSource: TWILIO_ACCOUNT_SID` if production is using the canonical SID variable.