### PR TITLE
[codex] Normalize P1 PO status on department changes

### DIFF
--- a/client/src/components/POManager.tsx
+++ b/client/src/components/POManager.tsx
@@ -400,10 +400,16 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
     onSuccess: (data: any, orderId) => {
       queryClient.invalidateQueries({ queryKey: [`/api/production-orders/by-po/${poId}`] });
       queryClient.invalidateQueries({ queryKey: ['/api/pos'] });
+      const statusLabel =
+        data?.order?.productionStatus === 'LAID_UP'
+          ? 'In Progress'
+          : data?.order?.productionStatus === 'SHIPPED'
+            ? 'Shipped'
+            : 'Pending';
       toast.success(
         data?.purchaseOrderReopened
           ? `Order ${orderId} reactivated — PO reopened as active.`
-          : `Order ${orderId} reactivated — status reset to Pending.`
+          : `Order ${orderId} reactivated — status reset to ${statusLabel}.`
       );
     },
     onError: (error: any) => {
@@ -442,7 +448,7 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
       case 'ACTIVE':
         return <Badge className="bg-yellow-100 text-yellow-800">Active</Badge>;
       case 'LAID_UP':
-        return <Badge className="bg-orange-100 text-orange-800">Laid Up</Badge>;
+        return <Badge className="bg-orange-100 text-orange-800">In Progress</Badge>;
       case 'SHIPPED':
         return <Badge className="bg-green-100 text-green-800">Shipped</Badge>;
       case 'CANCELLED':

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -9418,9 +9418,20 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         return res.status(400).json({ _error: `Order ${orderId} is not cancelled (current status: ${order.productionStatus})` });
       }
 
+      const reactivatedDepartment = order.currentDepartment || 'P1 Production Queue';
+      const normalizedDepartment = reactivatedDepartment.trim().toLowerCase();
+      const reactivatedStatus =
+        normalizedDepartment === 'p1 production queue'
+          ? 'PENDING'
+          : normalizedDepartment === 'fulfilled' ||
+            normalizedDepartment === 'shipped' ||
+            (order as any).isFulfilled
+            ? 'SHIPPED'
+            : 'LAID_UP';
+
       const updated = await storage.updateProductionOrder(order.id, {
-        productionStatus: 'PENDING',
-        currentDepartment: order.currentDepartment || 'P1 Production Queue',
+        productionStatus: reactivatedStatus,
+        currentDepartment: reactivatedDepartment,
       });
 
       let purchaseOrderReopened = false;
@@ -9433,7 +9444,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         }
       }
 
-      console.log(`🔄 Reactivated production order ${orderId} → PENDING`);
+      console.log(`🔄 Reactivated production order ${orderId} → ${reactivatedStatus}`);
       res.json({ success: true, order: updated, purchaseOrderReopened });
     } catch (_error) {
       console.error('🔄 Reactivate production order error:', _error);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -13911,6 +13911,17 @@ export class DatabaseStorage implements IStorage {
       const resolvedStatus = INITIAL_QUEUE_DEPARTMENTS.includes(department)
         ? status
         : 'IN_PROGRESS';
+      const normalizedDepartment = department.trim().toLowerCase();
+      const normalizedStatus = status.trim().toUpperCase();
+      const resolvedProductionStatus =
+        normalizedDepartment === 'p1 production queue'
+          ? 'PENDING'
+          : normalizedDepartment === 'fulfilled' ||
+            normalizedDepartment === 'shipped' ||
+            normalizedStatus === 'FULFILLED' ||
+            normalizedStatus === 'SHIPPED'
+            ? 'SHIPPED'
+            : 'LAID_UP';
 
       console.log(
         ` প্রক্র PRODUCTION FLOW: Updating order ${orderId} to department ${department} with status ${resolvedStatus}`
@@ -13948,7 +13959,7 @@ export class DatabaseStorage implements IStorage {
         .update(productionOrders)
         .set({
           currentDepartment: department,
-          productionStatus: resolvedStatus,
+          productionStatus: resolvedProductionStatus,
           updatedAt: new Date(),
         })
         .where(eq(productionOrders.orderId, orderId))
@@ -13960,7 +13971,7 @@ export class DatabaseStorage implements IStorage {
         );
         return {
           success: true,
-          message: `Production order ${orderId} updated to ${resolvedStatus} status`,
+          message: `Production order ${orderId} updated to ${resolvedProductionStatus} status`,
         };
       }
 
@@ -14656,6 +14667,17 @@ export class DatabaseStorage implements IStorage {
           departmentHistory: updatedHistory,
           updatedAt: now,
         };
+        const normalizedNextDepartment = String(nextDept).trim().toLowerCase();
+        if (normalizedNextDepartment === 'p1 production queue') {
+          productionCompletionUpdates.productionStatus = 'PENDING';
+        } else if (
+          normalizedNextDepartment === 'fulfilled' ||
+          normalizedNextDepartment === 'shipped'
+        ) {
+          productionCompletionUpdates.productionStatus = 'SHIPPED';
+        } else {
+          productionCompletionUpdates.productionStatus = 'LAID_UP';
+        }
         
         // Map completion timestamps for production orders (using schema column names)
         // Schema columns: barcodeCompletedAt, layupCompletedAt, cncCompletedAt, 
@@ -14667,7 +14689,6 @@ export class DatabaseStorage implements IStorage {
           case 'Layup/Plugging':
             productionCompletionUpdates.layupCompletedAt = now;
             productionCompletionUpdates.laidUpAt = now;
-            productionCompletionUpdates.productionStatus = 'LAID_UP';
             break;
           case 'CNC':
             productionCompletionUpdates.cncCompletedAt = now;
@@ -14689,7 +14710,6 @@ export class DatabaseStorage implements IStorage {
             break;
           case 'Shipping':
             productionCompletionUpdates.shippingCompletedAt = now;
-            productionCompletionUpdates.productionStatus = 'SHIPPED';
             productionCompletionUpdates.shippedAt = now;
             break;
         }


### PR DESCRIPTION
## Summary
- Normalize P1 purchase-order production item statuses whenever their department changes.
- Keep P1 Production Queue items as Pending, pre-fulfillment departments as In Progress (`LAID_UP`), and fulfilled/shipped items as Shipped.
- Reactivate cancelled P1 PO items back into the status that matches their current department instead of always forcing Pending.
- Keep the Manage Items production tab showing `LAID_UP` as In Progress so it matches the P1 PO workflow language.

## Validation
- `git diff --check -- client/src/components/POManager.tsx server/src/routes/index.ts server/storage.ts`
- `git diff --cached --check`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/routes/index.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/storage.ts`

Full TypeScript validation was not run because `npm` is not available in this shell and this worktree does not have a local TypeScript binary in `node_modules`.