### PR TITLE
[codex] Reopen stale P1 POs with active items

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -9437,10 +9437,11 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       let purchaseOrderReopened = false;
       if (order.poId) {
         const parentPO = await storage.getPurchaseOrder(order.poId);
-        if (parentPO?.status === 'CLOSED') {
+        const parentStatus = String(parentPO?.status || '').trim().toUpperCase();
+        if (['CLOSED', 'COMPLETE', 'COMPLETED'].includes(parentStatus)) {
           await storage.updatePurchaseOrder(order.poId, { status: 'OPEN' });
           purchaseOrderReopened = true;
-          console.log(`🔄 Reopened CLOSED PO ${order.poId} after reactivating production order ${orderId}`);
+          console.log(`🔄 Reopened ${parentStatus} PO ${order.poId} after reactivating production order ${orderId}`);
         }
       }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1771,6 +1771,7 @@ export interface IStorage {
 
   // Module 12: Purchase Orders CRUD
   getAllPurchaseOrders(): Promise<PurchaseOrder[]>;
+  reopenClosedP1PurchaseOrdersWithActiveProductionItems(): Promise<number>;
   getPurchaseOrder(
     id: number,
     options?: { includeItems?: boolean; includeOrderCount?: boolean }
@@ -12273,7 +12274,30 @@ export class DatabaseStorage implements IStorage {
   }
 
   // Module 12: Purchase Orders CRUD
+  async reopenClosedP1PurchaseOrdersWithActiveProductionItems(): Promise<number> {
+    const result = await pool.query(`
+      UPDATE purchase_orders po
+         SET status = 'OPEN',
+             updated_at = NOW()
+       WHERE UPPER(COALESCE(po.status, '')) IN ('CLOSED', 'COMPLETE', 'COMPLETED')
+         AND EXISTS (
+           SELECT 1
+             FROM production_orders prod
+            WHERE prod.po_id = po.id
+              AND COALESCE(UPPER(prod.production_status), '') NOT IN ('SHIPPED', 'CANCELLED', 'CANCELED', 'SCRAPPED')
+         )
+    `);
+
+    const reopenedCount = result.rowCount ?? 0;
+    if (reopenedCount > 0) {
+      console.log(`📦 Reopened ${reopenedCount} P1 purchase order(s) with active production items`);
+    }
+    return reopenedCount;
+  }
+
   async getAllPurchaseOrders(): Promise<PurchaseOrder[]> {
+    await this.reopenClosedP1PurchaseOrdersWithActiveProductionItems();
+
     const rows = await db
       .select()
       .from(purchaseOrders)


### PR DESCRIPTION
## Summary
- Reopen closed/complete P1 purchase orders when they still have active production items.
- Repair existing stale PO records before returning the P1 PO manager list so previously reactivated items move their parent PO back to Active.
- Broaden the reactivation reopen check to handle `CLOSED`, `COMPLETE`, and `COMPLETED` parent PO statuses.

## Validation
- `git diff --check -- server/storage.ts server/src/routes/index.ts`
- `git diff --cached --check`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/routes/index.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/storage.ts`

Full TypeScript validation was not run because `npm` is not available in this shell and this worktree does not have a local TypeScript binary in `node_modules`.