### PR TITLE
Connect timer station traveler scans to oven cure logs

### DIFF
--- a/client/src/components/StartProductionTimerModal.tsx
+++ b/client/src/components/StartProductionTimerModal.tsx
@@ -31,6 +31,46 @@ interface ProductionProgram {
   isActive: boolean;
 }
 
+interface TravelerScanResolution {
+  scannedTravelerBarcode: string;
+  traveler: {
+    id: string;
+    travelerNumber: string;
+    serialNumber: string | null;
+    lotNumber: string | null;
+    partNumber: string | null;
+    partName: string | null;
+    status: string;
+  } | null;
+  serializedItem: {
+    id: string;
+    barcode: string;
+    travelerBarcode: string | null;
+    serialNumber: string | null;
+    partNumber: string | null;
+    partName: string | null;
+    currentDepartment: string | null;
+    status: string;
+    mandrelNumber: number | null;
+  } | null;
+  routing: {
+    id: string;
+    ovenCureDepartment: string | null;
+    timerConfig: {
+      enabled?: boolean;
+      defaultProgramId?: string;
+      defaultProgramName?: string;
+    } | null;
+  } | null;
+  timerDefaults: {
+    serialNumber: string;
+    mandrelNumber: number | null;
+    programId: string | null;
+    programName: string | null;
+    departmentName: string | null;
+  };
+}
+
 
 interface StartProductionTimerModalProps {
   open: boolean;
@@ -44,6 +84,7 @@ interface StartProductionTimerModalProps {
   travelerStepId?: string;
   travelerTaskId?: string;
   departmentName?: string;
+  enableTravelerScan?: boolean;
 }
 
 export default function StartProductionTimerModal({
@@ -58,13 +99,17 @@ export default function StartProductionTimerModal({
   travelerStepId,
   travelerTaskId,
   departmentName,
+  enableTravelerScan = false,
 }: StartProductionTimerModalProps) {
   const [, setLocation] = useLocation();
   const { toast } = useToast();
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const travelerInputRef = useRef<HTMLInputElement>(null);
   const serialInputRef = useRef<HTMLInputElement>(null);
 
+  const [travelerBarcode, setTravelerBarcode] = useState('');
+  const [resolvedTraveler, setResolvedTraveler] = useState<TravelerScanResolution | null>(null);
   const [programId, setProgramId] = useState('');
   const [serialNumber, setSerialNumber] = useState('');
   const [description, setDescription] = useState('');
@@ -75,6 +120,7 @@ export default function StartProductionTimerModal({
   const [scannedBy, setScannedBy] = useState('');
   const [isScanning, setIsScanning] = useState(false);
   const [barcodeSupported, setBarcodeSupported] = useState(false);
+  const [isResolvingTraveler, setIsResolvingTraveler] = useState(false);
 
   const { data: programs, isLoading: programsLoading } = useQuery<ProductionProgram[]>({
     queryKey: ['/api/production/timers/programs'],
@@ -96,13 +142,17 @@ export default function StartProductionTimerModal({
         setProgramId(defaultProgramId);
       }
       setTimeout(() => {
-        if (!defaultSerialNumber) {
+        if (enableTravelerScan && !defaultSerialNumber) {
+          travelerInputRef.current?.focus();
+        } else if (!defaultSerialNumber) {
           serialInputRef.current?.focus();
         }
       }, 100);
     } else {
       stopScanning();
       setProgramId('');
+      setTravelerBarcode('');
+      setResolvedTraveler(null);
       setSerialNumber('');
       setDescription('');
       setMandrelNumber('');
@@ -111,7 +161,43 @@ export default function StartProductionTimerModal({
       setNotes('');
       setScannedBy('');
     }
-  }, [open, defaultSerialNumber, defaultProgramId]);
+  }, [open, defaultSerialNumber, defaultProgramId, enableTravelerScan]);
+
+  const applyTravelerResolution = (resolution: TravelerScanResolution) => {
+    setResolvedTraveler(resolution);
+    setTravelerBarcode(resolution.scannedTravelerBarcode);
+    setSerialNumber(resolution.timerDefaults.serialNumber || '');
+    if (resolution.timerDefaults.mandrelNumber) {
+      setMandrelNumber(String(resolution.timerDefaults.mandrelNumber));
+    }
+    if (resolution.timerDefaults.programId) {
+      setProgramId(resolution.timerDefaults.programId);
+    }
+  };
+
+  const resolveTravelerScan = async (scanValue: string) => {
+    const trimmed = scanValue.trim();
+    if (!trimmed) return;
+
+    setIsResolvingTraveler(true);
+    try {
+      const resolution = await apiRequest(`/api/production/timers/traveler-scan/${encodeURIComponent(trimmed)}`);
+      applyTravelerResolution(resolution);
+      toast({
+        title: 'Traveler loaded',
+        description: resolution.traveler?.travelerNumber || resolution.serializedItem?.barcode || trimmed,
+      });
+    } catch (error: any) {
+      setResolvedTraveler(null);
+      toast({
+        title: 'Traveler not found',
+        description: error.message || 'Scan a traveler or serialized item barcode.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsResolvingTraveler(false);
+    }
+  };
 
   const startMutation = useMutation({
     mutationFn: async () => {
@@ -124,11 +210,14 @@ export default function StartProductionTimerModal({
           mandrelNumber: parseInt(mandrelNumber, 10),
           ovenNumber: parseInt(ovenNumber, 10),
           ovenSlot,
+          ...(resolvedTraveler?.scannedTravelerBarcode || travelerBarcode.trim()
+            ? { scannedTravelerBarcode: resolvedTraveler?.scannedTravelerBarcode || travelerBarcode.trim() }
+            : {}),
           ...(scannedBy.trim() ? { badgeId: scannedBy.trim() } : badgeId ? { badgeId } : {}),
-          ...(travelerId ? { travelerId } : {}),
+          ...(travelerId || resolvedTraveler?.traveler?.id ? { travelerId: travelerId || resolvedTraveler?.traveler?.id } : {}),
           ...(travelerStepId ? { travelerStepId } : {}),
           ...(travelerTaskId ? { travelerTaskId } : {}),
-          ...(departmentName ? { departmentName } : {}),
+          ...(departmentName || resolvedTraveler?.timerDefaults.departmentName ? { departmentName: departmentName || resolvedTraveler?.timerDefaults.departmentName } : {}),
         }),
       });
     },
@@ -178,7 +267,11 @@ export default function StartProductionTimerModal({
             const barcodes = await detector.detect(videoRef.current);
             if (barcodes.length > 0) {
               const scannedValue = barcodes[0].rawValue;
-              setSerialNumber(scannedValue);
+              if (enableTravelerScan) {
+                await resolveTravelerScan(scannedValue);
+              } else {
+                setSerialNumber(scannedValue);
+              }
               toast({ title: 'Barcode scanned', description: scannedValue });
               stopScanning();
               return;
@@ -245,6 +338,59 @@ export default function StartProductionTimerModal({
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {enableTravelerScan && (
+            <div className="space-y-2">
+              <Label htmlFor="travelerBarcode">Traveler Scan</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="travelerBarcode"
+                  ref={travelerInputRef}
+                  value={travelerBarcode}
+                  onChange={(e) => setTravelerBarcode(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      resolveTravelerScan(travelerBarcode);
+                    }
+                  }}
+                  placeholder="Scan traveler barcode"
+                  className="flex-1 font-mono"
+                  autoComplete="off"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => resolveTravelerScan(travelerBarcode)}
+                  disabled={!travelerBarcode.trim() || isResolvingTraveler}
+                >
+                  {isResolvingTraveler ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <ScanBarcode className="w-4 h-4" />
+                  )}
+                </Button>
+              </div>
+              {resolvedTraveler && (
+                <div className="rounded-md border bg-slate-50 p-3 text-sm space-y-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="font-medium">
+                      {resolvedTraveler.traveler?.travelerNumber || resolvedTraveler.serializedItem?.barcode}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {resolvedTraveler.timerDefaults.departmentName || resolvedTraveler.serializedItem?.currentDepartment || 'No department'}
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    <span>Serial: {resolvedTraveler.timerDefaults.serialNumber || '-'}</span>
+                    <span>Part: {resolvedTraveler.serializedItem?.partNumber || resolvedTraveler.traveler?.partNumber || '-'}</span>
+                    <span>Mandrel: {resolvedTraveler.timerDefaults.mandrelNumber || 'Enter below'}</span>
+                    <span>Program: {resolvedTraveler.timerDefaults.programName || 'Select below'}</span>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
           <div className="space-y-2">
             <Label htmlFor="program">Program *</Label>
             <Select value={programId} onValueChange={setProgramId}>

--- a/client/src/pages/ProductionStationDashboard.tsx
+++ b/client/src/pages/ProductionStationDashboard.tsx
@@ -750,6 +750,7 @@ export default function ProductionStationDashboard() {
         <StartProductionTimerModal
           open={startModalOpen}
           onOpenChange={setStartModalOpen}
+          enableTravelerScan
         />
 
         {detailedRuns.length === 0 ? (

--- a/server/src/routes/productionTimers.ts
+++ b/server/src/routes/productionTimers.ts
@@ -13,21 +13,52 @@ import {
   p2FinalInspectionResults,
   p2SerializedItems,
   travelers,
+  partRoutings,
 } from '../../schema';
-import { eq, and, desc, or, inArray } from 'drizzle-orm';
+import { eq, and, desc, or, inArray, ilike } from 'drizzle-orm';
 import { z } from 'zod';
 import { authenticateToken, optionalAuth } from '../../middleware/auth';
 import { validateActionToken } from '../../middleware/actionToken';
 
 // ── Auto-logging helpers ──────────────────────────────────────────────────────
 // Resolves serialized item from run serial number / sku for log creation
-async function lookupSerializedItem(serialNumber: string | null, sku: string | null) {
+async function lookupSerializedItem(serialNumber: string | null, sku: string | null, travelerId?: string | null) {
+  if (travelerId) {
+    const [traveler] = await db
+      .select({ serialNumber: travelers.serialNumber, lotNumber: travelers.lotNumber })
+      .from(travelers)
+      .where(eq(travelers.id, travelerId))
+      .limit(1);
+
+    const travelerSerial = traveler?.serialNumber || traveler?.lotNumber || null;
+    if (travelerSerial) {
+      const [item] = await db
+        .select()
+        .from(p2SerializedItems)
+        .where(
+          or(
+            ilike(p2SerializedItems.serialNumber, travelerSerial),
+            ilike(p2SerializedItems.barcode, travelerSerial),
+            ilike(p2SerializedItems.travelerBarcode, travelerSerial)
+          )
+        )
+        .limit(1);
+      if (item) return item;
+    }
+  }
+
   if (!serialNumber) return null;
   try {
     const [item] = await db
       .select()
       .from(p2SerializedItems)
-      .where(eq(p2SerializedItems.serialNumber, serialNumber))
+      .where(
+        or(
+          ilike(p2SerializedItems.serialNumber, serialNumber),
+          ilike(p2SerializedItems.barcode, serialNumber),
+          ilike(p2SerializedItems.travelerBarcode, serialNumber)
+        )
+      )
       .limit(1);
     return item || null;
   } catch {
@@ -44,14 +75,28 @@ async function autoCreateLinkedLog(
   const logType: string = program.logType || 'none';
   if (logType === 'none') return { linkedLogId: null, linkedLogType: null };
 
-  const item = await lookupSerializedItem(run.serialNumber, run.sku);
+  const item = await lookupSerializedItem(run.serialNumber, run.sku, run.travelerId || null);
   if (!item) {
     console.warn(`[ProductionTimer] No serialized item found for serial=${run.serialNumber} — skipping auto-log`);
     return { linkedLogId: null, linkedLogType: null };
   }
 
   const dept = run.departmentName || item.currentDepartment || 'Unknown';
-
+  const scannedTravelerBarcode = run.scannedTravelerBarcode || null;
+  const runMetadata = {
+    source: 'timer_station',
+    timerRunId: run.id,
+    timerProgramId: run.programId,
+    timerProgramName: program.name,
+    scannedTravelerBarcode,
+    travelerId: run.travelerId || null,
+    travelerStepId: run.travelerStepId || null,
+    travelerTaskId: run.travelerTaskId || null,
+    serialNumber: run.serialNumber || item.serialNumber || null,
+    mandrelNumber: run.mandrelNumber || null,
+    ovenNumber: run.ovenNumber || null,
+    ovenSlot: run.ovenSlot || null,
+  };
   try {
     if (logType === 'oven_cure') {
       const [log] = await db.insert(p2OvenCureLogs).values({
@@ -66,6 +111,7 @@ async function autoCreateLinkedLog(
         result: 'PENDING',
         operatorId: null,
         operatorName: null,
+        metadata: runMetadata,
         notes: `Auto-logged from timer run ${run.id} — program: ${program.name}`,
       }).returning();
       return { linkedLogId: log.id, linkedLogType: 'oven_cure' };
@@ -82,6 +128,7 @@ async function autoCreateLinkedLog(
         result: 'PENDING',
         operatorId: null,
         operatorName: null,
+        metadata: runMetadata,
         notes: `Auto-logged from timer run ${run.id} — program: ${program.name}`,
       }).returning();
       return { linkedLogId: log.id, linkedLogType: 'vacuum_leak_test' };
@@ -233,6 +280,7 @@ function buildRunSnapshot(run: any, itemIdentity: Awaited<ReturnType<typeof reso
     status: field(run, 'status', 'status'),
     currentStepIndex: field(run, 'currentStepIndex', 'current_step_index'),
     departmentName: field(run, 'departmentName', 'department_name'),
+    scannedTravelerBarcode: field(run, 'scannedTravelerBarcode', 'scanned_traveler_barcode'),
     startedAt: field(run, 'startedAt', 'started_at'),
     completedAt: field(run, 'completedAt', 'completed_at'),
     totalElapsedSeconds: field(run, 'totalElapsedSeconds', 'total_elapsed_seconds'),
@@ -286,6 +334,174 @@ const startRunSchema = z.object({
   travelerStepId: z.string().optional(),
   travelerTaskId: z.string().optional(),
   departmentName: z.string().optional(),
+  scannedTravelerBarcode: z.string().optional(),
+});
+
+function extractMandrelNumber(...sources: any[]): number | null {
+  const keys = ['mandrelNumber', 'mandrel_number', 'mandrel', 'mandrelNo', 'mandrel_no', 'mandrelId', 'mandrel_id'];
+  for (const source of sources) {
+    if (!source || typeof source !== 'object') continue;
+    for (const key of keys) {
+      const value = source[key];
+      const parsed = typeof value === 'number' ? value : parseInt(String(value ?? '').replace(/[^0-9]/g, ''), 10);
+      if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 3) return parsed;
+    }
+  }
+  return null;
+}
+
+function isOvenCureDepartment(name?: string | null): boolean {
+  return /oven|cure/i.test(name || '');
+}
+
+function getDepartmentTimerConfig(routing: any, preferredDepartment?: string | null) {
+  const departmentConfig = routing?.departmentConfig && typeof routing.departmentConfig === 'object'
+    ? routing.departmentConfig as Record<string, any>
+    : {};
+
+  if (preferredDepartment && departmentConfig[preferredDepartment]?.timerConfig?.enabled) {
+    return { departmentName: preferredDepartment, timerConfig: departmentConfig[preferredDepartment].timerConfig };
+  }
+
+  const ovenDept = Object.keys(departmentConfig).find((dept) =>
+    isOvenCureDepartment(dept) && departmentConfig[dept]?.timerConfig?.enabled
+  );
+  if (ovenDept) {
+    return { departmentName: ovenDept, timerConfig: departmentConfig[ovenDept].timerConfig };
+  }
+
+  const anyTimerDept = Object.keys(departmentConfig).find((dept) => departmentConfig[dept]?.timerConfig?.enabled);
+  if (anyTimerDept) {
+    return { departmentName: anyTimerDept, timerConfig: departmentConfig[anyTimerDept].timerConfig };
+  }
+
+  return { departmentName: preferredDepartment || null, timerConfig: null };
+}
+
+async function resolveTimerTravelerScan(scanValue: string) {
+  const scannedTravelerBarcode = scanValue.trim();
+
+  let traveler = await db.query.travelers.findFirst({
+    where: or(
+      ilike(travelers.travelerNumber, scannedTravelerBarcode),
+      ilike(travelers.id, scannedTravelerBarcode),
+      ilike(travelers.serialNumber, scannedTravelerBarcode),
+      ilike(travelers.lotNumber, scannedTravelerBarcode)
+    ),
+  });
+
+  let serializedItem = await db.query.p2SerializedItems.findFirst({
+    where: or(
+      ilike(p2SerializedItems.barcode, scannedTravelerBarcode),
+      ilike(p2SerializedItems.travelerBarcode, scannedTravelerBarcode),
+      ilike(p2SerializedItems.serialNumber, scannedTravelerBarcode)
+    ),
+  });
+
+  if (!serializedItem && traveler) {
+    const travelerSerial = traveler.serialNumber || traveler.lotNumber || traveler.travelerNumber;
+    serializedItem = await db.query.p2SerializedItems.findFirst({
+      where: or(
+        ilike(p2SerializedItems.serialNumber, travelerSerial),
+        ilike(p2SerializedItems.barcode, travelerSerial),
+        ilike(p2SerializedItems.travelerBarcode, travelerSerial)
+      ),
+    });
+  }
+
+  if (!traveler && serializedItem) {
+    traveler = await db.query.travelers.findFirst({
+      where: or(
+        ilike(travelers.serialNumber, serializedItem.serialNumber || serializedItem.barcode),
+        ilike(travelers.lotNumber, serializedItem.serialNumber || serializedItem.barcode)
+      ),
+    });
+  }
+
+  if (!serializedItem && !traveler) return null;
+
+  let routing: any = null;
+  const routingId = traveler?.partRoutingId || (serializedItem as any)?.partRoutingId || null;
+  if (routingId) {
+    routing = await db.query.partRoutings.findFirst({
+      where: and(eq(partRoutings.id, routingId), eq(partRoutings.isActive, true)),
+    });
+  }
+
+  if (!routing) {
+    const partNumber = traveler?.partNumber || serializedItem?.partNumber || '';
+    if (partNumber) {
+      routing = await db.query.partRoutings.findFirst({
+        where: and(eq(partRoutings.partNumber, partNumber), eq(partRoutings.isActive, true)),
+      });
+    }
+  }
+
+  const departmentSequence = Array.isArray(routing?.departmentSequence) ? routing.departmentSequence as string[] : [];
+  const currentDepartment = serializedItem?.currentDepartment
+    || departmentSequence[serializedItem?.currentStageIndex || 0]
+    || null;
+  const timerMatch = getDepartmentTimerConfig(routing, currentDepartment);
+  const mandrelNumber = extractMandrelNumber(serializedItem?.metadata, (traveler as any)?.metadata);
+
+  return {
+    scannedTravelerBarcode,
+    traveler: traveler ? {
+      id: traveler.id,
+      travelerNumber: traveler.travelerNumber,
+      serialNumber: traveler.serialNumber,
+      lotNumber: traveler.lotNumber,
+      partNumber: traveler.partNumber,
+      partName: traveler.partName,
+      status: traveler.status,
+    } : null,
+    serializedItem: serializedItem ? {
+      id: serializedItem.id,
+      barcode: serializedItem.barcode,
+      travelerBarcode: serializedItem.travelerBarcode,
+      serialNumber: serializedItem.serialNumber,
+      partNumber: serializedItem.partNumber,
+      partName: serializedItem.partName,
+      currentDepartment: serializedItem.currentDepartment,
+      currentStageIndex: serializedItem.currentStageIndex,
+      status: serializedItem.status,
+      mandrelNumber,
+    } : null,
+    routing: routing ? {
+      id: routing.id,
+      partNumber: routing.partNumber,
+      partName: routing.partName,
+      departmentSequence,
+      ovenCureDepartment: timerMatch.departmentName,
+      timerConfig: timerMatch.timerConfig,
+    } : null,
+    timerDefaults: {
+      serialNumber: serializedItem?.serialNumber || traveler?.serialNumber || traveler?.lotNumber || scannedTravelerBarcode,
+      mandrelNumber,
+      programId: timerMatch.timerConfig?.defaultProgramId || null,
+      programName: timerMatch.timerConfig?.defaultProgramName || null,
+      departmentName: timerMatch.departmentName || currentDepartment || null,
+    },
+  };
+}
+
+router.get('/traveler-scan/:barcode', async (req: Request, res: Response) => {
+  try {
+    const scanValue = decodeURIComponent(req.params.barcode || '').trim();
+    if (!scanValue) {
+      return res.status(400).json({ error: 'Traveler barcode is required' });
+    }
+
+    const resolved = await resolveTimerTravelerScan(scanValue);
+    if (!resolved) {
+      return res.status(404).json({ error: 'Traveler or serialized item not found for scanned barcode' });
+    }
+
+    return res.json(resolved);
+  } catch (error: any) {
+    console.error('[ProductionTimer] Error resolving traveler scan:', error);
+    return res.status(500).json({ error: 'Failed to resolve traveler scan' });
+  }
 });
 
 router.post('/runs/start', async (req: Request, res: Response) => {
@@ -301,7 +517,7 @@ router.post('/runs/start', async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Invalid payload', details: parseResult.error.issues });
     }
 
-    const { programId, instanceName, sku, serialNumber, inventoryItemId, mandrelNumber, ovenNumber, ovenSlot, travelerId, travelerStepId, travelerTaskId, departmentName } = parseResult.data;
+    const { programId, instanceName, sku, serialNumber, inventoryItemId, mandrelNumber, ovenNumber, ovenSlot, travelerId, travelerStepId, travelerTaskId, departmentName, scannedTravelerBarcode } = parseResult.data;
 
     const [program] = await db
       .select()
@@ -346,14 +562,15 @@ router.post('/runs/start', async (req: Request, res: Response) => {
     });
 
     // Auto-create linked AS9100 log entry if this program type requires it
-    const { linkedLogId, linkedLogType } = await autoCreateLinkedLog(run, program, userId);
+    const runWithScan = { ...run, scannedTravelerBarcode: scannedTravelerBarcode || null };
+    const { linkedLogId, linkedLogType } = await autoCreateLinkedLog(runWithScan, program, userId);
     if (linkedLogId && linkedLogType) {
       await db.update(productionProgramRuns)
         .set({ linkedLogId, linkedLogType })
         .where(eq(productionProgramRuns.id, run.id));
     }
 
-    await recordItemAudit({ ...run, linkedLogId, linkedLogType }, 'started', userId, program);
+    await recordItemAudit({ ...runWithScan, linkedLogId, linkedLogType }, 'started', userId, program);
 
     console.log(`[ProductionTimer] Run started: ${run.id} for program ${program.name}${linkedLogType ? ` (auto-linked ${linkedLogType} log ${linkedLogId})` : ''}`);
 


### PR DESCRIPTION
## Summary
- add a timer-station traveler scan resolver that links scanned traveler or serialized-item barcodes to traveler, routing, timer config, serial number, and mandrel defaults
- make the Timer Station start modal support traveler scanning while keeping existing traveler-execution timer launches unchanged
- preserve scanned traveler context in timer run audit snapshots and linked oven cure/vacuum log metadata

## Validation
- `git diff --check`
- `git diff --cached --check`
- bundled Node syntax check: `node --experimental-strip-types --check server/src/routes/productionTimers.ts`

## Notes
- `node_modules` is not present in the clean worktree, so I could not run the full app TypeScript/Vite test suite locally.