### PR TITLE
[codex] Normalize P1 PO production status transitions

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -148,6 +148,10 @@ import digitalSignaturesRoutes from './digitalSignatures';
 import traceabilityRoutes from './traceability';
 import cycleCountsRoutes from './cycleCounts';
 import { auditService } from '../services/auditService';
+import {
+  deriveP1ProductionStatus,
+  isClosedP1PurchaseOrderStatus,
+} from '../utils/p1ProductionStatus';
 import mediaRoutes from './media';
 import voiceNotesRoutes from './voiceNotes';
 import epochCopilotRoutes from './epochCopilot';
@@ -9270,7 +9274,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
               const today = new Date();
               return expectedDue > today ? expectedDue : today;
             })(),
-            productionStatus: 'PENDING' as const,
+            productionStatus: deriveP1ProductionStatus({
+              currentDepartment: initialDepartment,
+            }),
             currentDepartment: initialDepartment,
             poId: poId,
             poItemId: item.id,
@@ -9406,7 +9412,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     }
   });
 
-  // Reactivate a cancelled production order (sets status back to PENDING)
+  // Reactivate a cancelled production order into the status implied by its department.
   app.post('/api/production-orders/:orderId/reactivate', async (req, res) => {
     try {
       const { storage } = await import('../../storage');
@@ -9421,15 +9427,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       }
 
       const reactivatedDepartment = order.currentDepartment || 'P1 Production Queue';
-      const normalizedDepartment = reactivatedDepartment.trim().toLowerCase();
-      const reactivatedStatus =
-        normalizedDepartment === 'p1 production queue'
-          ? 'PENDING'
-          : normalizedDepartment === 'fulfilled' ||
-            normalizedDepartment === 'shipped' ||
-            (order as any).isFulfilled
-            ? 'SHIPPED'
-            : 'LAID_UP';
+      const reactivatedStatus = deriveP1ProductionStatus({
+        currentDepartment: reactivatedDepartment,
+        isFulfilled: (order as any).isFulfilled,
+        currentStatus: order.productionStatus,
+        preserveCancelled: false,
+      });
 
       const updated = await storage.updateProductionOrder(order.id, {
         productionStatus: reactivatedStatus,
@@ -9439,8 +9442,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       let purchaseOrderReopened = false;
       if (order.poId) {
         const parentPO = await storage.getPurchaseOrder(order.poId);
-        const parentStatus = String(parentPO?.status || '').trim().toUpperCase();
-        if (['CLOSED', 'COMPLETE', 'COMPLETED'].includes(parentStatus)) {
+        const parentStatus = parentPO?.status;
+        if (isClosedP1PurchaseOrderStatus(parentStatus)) {
           await storage.updatePurchaseOrder(order.poId, { status: 'OPEN' });
           purchaseOrderReopened = true;
           console.log(`🔄 Reopened ${parentStatus} PO ${order.poId} after reactivating production order ${orderId}`);
@@ -11494,6 +11497,13 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             updatedAt: currentTimestamp,
             departmentHistory,
           };
+          if (isProductionOrder) {
+            updateData.productionStatus = deriveP1ProductionStatus({
+              currentDepartment: toDepartment,
+              isFulfilled: (order as any).isFulfilled,
+              currentStatus: (order as any).productionStatus,
+            });
+          }
 
           // Set completion timestamp for previous department
           if (currentDept === 'Barcode') {

--- a/server/src/routes/poShippingQC.ts
+++ b/server/src/routes/poShippingQC.ts
@@ -16,6 +16,7 @@ import {
   reverseP1ShipmentRevenueDraftOrEntry,
 } from '../services/p1ShipmentRevenueService';
 import { buildRevenueDimensionTags } from '../services/productionLineAccounting';
+import { deriveP1ProductionStatus } from '../utils/p1ProductionStatus';
 
 const router = Router();
 
@@ -2610,7 +2611,7 @@ router.post(
       const updateResult = await pool.query(
         `
       UPDATE production_orders 
-      SET production_status = 'QC_PASSED',
+      SET production_status = 'LAID_UP',
           current_department = 'Shipping QC',
           shipped_at = NULL,
           is_fulfilled = false,
@@ -2770,10 +2771,19 @@ router.post('/toggle-fulfilled', authenticateToken, async (req, res) => {
         continue;
       }
 
-      // Update production status to SHIPPED or back to previous status
+      const nextProductionStatus = deriveP1ProductionStatus({
+        currentDepartment: order.currentDepartment,
+        isFulfilled: shouldFulfill,
+        currentStatus: order.productionStatus,
+        preserveCancelled: true,
+      });
+
+      // Update production status to SHIPPED or back to the status implied by its department.
       await storage.updateProductionOrder(order.id, {
-        productionStatus: shouldFulfill ? 'SHIPPED' : 'PENDING',
+        productionStatus: nextProductionStatus,
         shippedAt: shouldFulfill ? shippedAt : null,
+        isFulfilled: shouldFulfill,
+        fulfilledDate: shouldFulfill ? shippedAt : null,
       });
 
       if (shouldFulfill && order.poId) shippedPoIds.add(order.poId);
@@ -2905,13 +2915,13 @@ router.post('/reset-fulfilled', authenticateToken, async (req, res) => {
     let updateQuery = `
       UPDATE production_orders 
       SET 
-        production_status = 'QC_PASSED',
+        production_status = 'LAID_UP',
         current_department = 'Shipping QC',
         shipped_at = NULL,
         is_fulfilled = false,
         fulfilled_date = NULL,
         updated_at = NOW()
-      WHERE (production_status = 'Shipped' OR is_fulfilled = true)
+      WHERE (UPPER(production_status) = 'SHIPPED' OR is_fulfilled = true)
     `;
 
     const params: any[] = [];
@@ -2924,13 +2934,13 @@ router.post('/reset-fulfilled', authenticateToken, async (req, res) => {
       updateQuery = `
         UPDATE production_orders 
         SET 
-          production_status = 'QC_PASSED',
+          production_status = 'LAID_UP',
           current_department = 'Shipping QC',
           shipped_at = NULL,
           is_fulfilled = false,
           fulfilled_date = NULL,
           updated_at = NOW()
-        WHERE (production_status = 'Shipped' OR is_fulfilled = true)
+        WHERE (UPPER(production_status) = 'SHIPPED' OR is_fulfilled = true)
         AND po_item_id IN (
           SELECT poi.id FROM purchase_order_items poi
           JOIN purchase_orders po ON poi.po_id = po.id
@@ -3724,6 +3734,8 @@ router.post('/process-shipment', authenticateToken, async (req, res) => {
           await storage.updateProductionOrder(detail.order.id, {
             productionStatus: 'SHIPPED',
             shippedAt,
+            isFulfilled: true,
+            fulfilledDate: shippedAt,
           });
           console.log(`✅ Order ${detail.order.orderId} marked as SHIPPED`);
           const poId = detail.order?.poId ?? (detail.order as any)?.po_id;

--- a/server/src/utils/p1ProductionStatus.ts
+++ b/server/src/utils/p1ProductionStatus.ts
@@ -1,0 +1,54 @@
+export type P1ProductionStatus = 'PENDING' | 'LAID_UP' | 'SHIPPED' | 'CANCELLED';
+
+type DeriveP1ProductionStatusInput = {
+  currentDepartment?: string | null;
+  isFulfilled?: boolean | null;
+  currentStatus?: string | null;
+  preserveCancelled?: boolean;
+};
+
+const CLOSED_PO_STATUSES = new Set(['CLOSED', 'COMPLETE', 'COMPLETED']);
+
+function normalizeStatus(value?: string | null): string {
+  return String(value || '').trim().toUpperCase();
+}
+
+function normalizeDepartment(value?: string | null): string {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function deriveP1ProductionStatus({
+  currentDepartment,
+  isFulfilled,
+  currentStatus,
+  preserveCancelled = true,
+}: DeriveP1ProductionStatusInput): P1ProductionStatus {
+  if (preserveCancelled && normalizeStatus(currentStatus) === 'CANCELLED') {
+    return 'CANCELLED';
+  }
+
+  const department = normalizeDepartment(currentDepartment);
+
+  if (department === 'p1 production queue') {
+    return 'PENDING';
+  }
+
+  if (!department) {
+    return isFulfilled ? 'SHIPPED' : 'PENDING';
+  }
+
+  if (department === 'fulfilled' || department === 'shipped') {
+    return 'SHIPPED';
+  }
+
+  return 'LAID_UP';
+}
+
+export function isClosedP1PurchaseOrderStatus(status?: string | null): boolean {
+  return CLOSED_PO_STATUSES.has(normalizeStatus(status));
+}
+
+export function isActiveP1ProductionStatus(status?: string | null): boolean {
+  const normalized = normalizeStatus(status);
+  return normalized !== '' && !['SHIPPED', 'CANCELLED', 'CANCELED', 'SCRAPPED'].includes(normalized);
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -771,6 +771,7 @@ import {
 import { DEFAULT_SESSIONS_LIMIT } from './src/constants/sessions';
 import { userHasScopedCapability as _userHasScopedCapability } from './src/services/permissionService';
 import { formatDates } from './utils/formatDates';
+import { deriveP1ProductionStatus } from './src/utils/p1ProductionStatus';
 import { ensureP2PurchaseOrderReadSchema } from './src/lib/p2PurchaseOrderReadiness';
 import {
   laborEntryDraftsTable,
@@ -13209,6 +13210,7 @@ export class DatabaseStorage implements IStorage {
       'productionStatus', 'laidUpAt', 'shippedAt', 'notes', 'createdAt', 'updatedAt',
       'priorityScore', 'currentPipelineConfig', 'hasP1Priority', 'currentDepartment',
       'materialCanonical', 'sourceSnapshot',
+      'isFulfilled', 'fulfilledDate',
       'finishAcceptedAt', 'finishAcceptedBy',
       'status', 'assignedTechnician', 'finishCompletedAt',
     ]);
@@ -14691,17 +14693,11 @@ export class DatabaseStorage implements IStorage {
           departmentHistory: updatedHistory,
           updatedAt: now,
         };
-        const normalizedNextDepartment = String(nextDept).trim().toLowerCase();
-        if (normalizedNextDepartment === 'p1 production queue') {
-          productionCompletionUpdates.productionStatus = 'PENDING';
-        } else if (
-          normalizedNextDepartment === 'fulfilled' ||
-          normalizedNextDepartment === 'shipped'
-        ) {
-          productionCompletionUpdates.productionStatus = 'SHIPPED';
-        } else {
-          productionCompletionUpdates.productionStatus = 'LAID_UP';
-        }
+        productionCompletionUpdates.productionStatus = deriveP1ProductionStatus({
+          currentDepartment: nextDept,
+          isFulfilled: (productionOrderRecord as any).isFulfilled,
+          currentStatus: productionOrderRecord.productionStatus,
+        });
         
         // Map completion timestamps for production orders (using schema column names)
         // Schema columns: barcodeCompletedAt, layupCompletedAt, cncCompletedAt, 


### PR DESCRIPTION
## Summary
- Add a shared P1 PO production-status helper for the canonical workflow: P1 Production Queue = `PENDING`, active pre-shipment departments = `LAID_UP`, fulfilled/shipped = `SHIPPED`, cancelled stays cancelled unless explicitly reactivated.
- Apply the helper when generating P1 PO production orders, reactivating cancelled production orders, progressing departments, and completing storage-level department moves.
- Replace old `QC_PASSED` reset/return-to-QC writes with `LAID_UP` and make fulfilled reset filters handle uppercase `SHIPPED`.
- Persist `isFulfilled` and `fulfilledDate` through `updateProductionOrder` so shipment and fulfillment state stays aligned with `productionStatus`.

## Why
This is step 2 of the P1 PO cleanup: enforce the future-facing status rules without bulk rewriting historical rows or losing the actual current department/order state.

## Validation
- `git diff --check -- server/src/routes/index.ts server/src/routes/poShippingQC.ts server/storage.ts server/src/utils/p1ProductionStatus.ts`
- `git diff --cached --check`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/routes/index.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/routes/poShippingQC.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/storage.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/utils/p1ProductionStatus.ts`

Full TypeScript validation was not run because `npm` is not available in this shell.