### PR TITLE
[codex] Fix stale chunk recovery

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,7 +1,5 @@
-const CACHE_NAME = 'epoch-v8-cache-v1';
+const CACHE_NAME = 'epoch-v8-runtime-v2';
 const urlsToCache = [
-  '/',
-  '/index.html',
   '/manifest.json',
   '/icons/icon-192.svg',
   '/icons/icon-512.svg',
@@ -28,19 +26,22 @@ self.addEventListener('fetch', (event) => {
   if (event.request.mode === 'navigate') {
     event.respondWith(
       fetch(event.request).catch(() => {
-        return caches.match('/index.html');
+        return new Response(
+          '<!doctype html><title>EPOCH Offline</title><p>EPOCH is offline. Please reconnect and reload.</p>',
+          {
+            headers: { 'Content-Type': 'text/html' },
+          }
+        );
       })
     );
     return;
   }
 
-  const isStaticAsset =
-    url.pathname.startsWith('/assets/') ||
-    url.pathname.startsWith('/static/') ||
+  const isCacheableStaticAsset =
     url.pathname.startsWith('/icons/') ||
     url.pathname === '/manifest.json';
 
-  if (!isStaticAsset) {
+  if (!isCacheableStaticAsset) {
     return;
   }
 

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { recoverFromChunkLoadError } from '@/utils/chunkLoadRecovery';
 
 interface Props {
   children: ReactNode;
@@ -50,6 +51,8 @@ class ErrorBoundary extends Component<Props, State> {
       error,
       errorInfo,
     });
+
+    recoverFromChunkLoadError(error);
   }
 
   render() {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,6 @@
 // Import React refresh fix FIRST before any other imports
 import './react-refresh-fix';
+import { recoverFromChunkLoadError } from './utils/chunkLoadRecovery';
 
 // Suppress Vite HMR WebSocket errors in the Replit proxied environment.
 // When accessed via HTTPS proxy, `location.port` resolves to empty/undefined,
@@ -15,6 +16,16 @@ window.addEventListener('unhandledrejection', (event) => {
   ) {
     event.preventDefault();
   }
+
+  if (recoverFromChunkLoadError(event.reason)) {
+    event.preventDefault();
+  }
+});
+
+window.addEventListener('error', (event) => {
+  if (recoverFromChunkLoadError(event.error ?? event.message)) {
+    event.preventDefault();
+  }
 });
 
 import React from 'react';
@@ -24,6 +35,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'react-hot-toast';
 import App from './App.tsx';
 import './index.css';
+import ErrorBoundary from './components/ErrorBoundary';
 import { registerServiceWorker, setupInstallPrompt } from './utils/pwa';
 import { startSyncEngine } from './offline/syncEngine';
 
@@ -73,7 +85,9 @@ root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
         <Toaster position="top-right" />
       </BrowserRouter>
     </QueryClientProvider>

--- a/client/src/utils/chunkLoadRecovery.ts
+++ b/client/src/utils/chunkLoadRecovery.ts
@@ -1,0 +1,60 @@
+const RECOVERY_KEY = 'epoch:chunk-load-recovery-at';
+const RECOVERY_COOLDOWN_MS = 60_000;
+let inMemoryRecoveryAt = 0;
+
+export function isChunkLoadError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? `${error.name} ${error.message} ${error.stack ?? ''}`
+      : String(error ?? '');
+
+  return [
+    'failed to fetch dynamically imported module',
+    'error loading dynamically imported module',
+    'importing a module script failed',
+    'chunkloaderror',
+    'loading chunk',
+  ].some((needle) => message.toLowerCase().includes(needle));
+}
+
+export async function clearStaleAppCaches(): Promise<void> {
+  if ('caches' in window) {
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
+  }
+
+  if ('serviceWorker' in navigator) {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((registration) => registration.update()));
+  }
+}
+
+export function recoverFromChunkLoadError(error: unknown): boolean {
+  if (!isChunkLoadError(error)) {
+    return false;
+  }
+
+  let lastRecoveryAt = inMemoryRecoveryAt;
+  try {
+    lastRecoveryAt = Number(sessionStorage.getItem(RECOVERY_KEY) ?? 0);
+  } catch {
+    // Some locked-down browser modes block sessionStorage; keep recovery alive.
+  }
+
+  if (Date.now() - lastRecoveryAt < RECOVERY_COOLDOWN_MS) {
+    return false;
+  }
+
+  inMemoryRecoveryAt = Date.now();
+  try {
+    sessionStorage.setItem(RECOVERY_KEY, String(inMemoryRecoveryAt));
+  } catch {
+    // In-memory cooldown still prevents a tight reload loop for this runtime.
+  }
+
+  void clearStaleAppCaches().finally(() => {
+    window.location.reload();
+  });
+
+  return true;
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -93,7 +93,22 @@ export function serveStatic(app: Express) {
     console.error(`[serveStatic] index.html not found at ${indexPath} — build may have failed`);
   }
 
-  app.use(express.static(distPath));
+  app.use(
+    express.static(distPath, {
+      setHeaders(res, filePath) {
+        if (filePath.endsWith('.html') || filePath.endsWith('sw.js')) {
+          res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+          res.setHeader('Pragma', 'no-cache');
+          res.setHeader('Expires', '0');
+          return;
+        }
+
+        if (filePath.includes(`${path.sep}assets${path.sep}`)) {
+          res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        }
+      },
+    })
+  );
 
   // fall through to index.html if the file doesn't exist
   app.use('*', (req, res, next) => {
@@ -111,6 +126,11 @@ export function serveStatic(app: Express) {
         '<body><p>Application starting up, please refresh in a moment.</p></body></html>'
       );
     }
+    res.set({
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      Pragma: 'no-cache',
+      Expires: '0',
+    });
     res.sendFile(indexPath, (err) => {
       if (err) {
         console.error(`[serveStatic] sendFile error for ${req.path}:`, err);


### PR DESCRIPTION
## Summary

Fixes the deployed application error where an older browser session tries to lazy-load a removed hashed chunk such as `PurchaseOrders-*.js` after a new deploy.

## Root Cause

The app registered a service worker that cached `index.html` and Vite-built `/assets/*` files cache-first. After a deployment removed old hashed chunks, a stale browser or service worker cache could keep an old module graph that referenced chunk URLs no longer present on the server.

## Changes

- Add a chunk-load recovery helper that detects dynamic import failures, clears browser caches, updates service workers, and performs one guarded reload.
- Wire the recovery path into global `error` / `unhandledrejection` listeners and the app error boundary.
- Stop the service worker from caching `index.html` and built JS/CSS chunks.
- Mark production `index.html` and `sw.js` responses as non-cacheable while keeping hashed `/assets/*` immutable.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Bundled Node `--check client/public/sw.js`
- Bundled Node `--experimental-strip-types --check client/src/utils/chunkLoadRecovery.ts`
- Bundled Node `--experimental-strip-types --check server/vite.ts`

Note: full `npm run check` was not available because `npm` is not installed on PATH in this local shell.