### PR TITLE
[codex] Fix P1 PO in-progress status and OEM shipment actions

### DIFF
--- a/client/src/components/POManager.tsx
+++ b/client/src/components/POManager.tsx
@@ -129,13 +129,17 @@ function POQuantityDisplay({ poId }: { poId: number }) {
   );
 }
 
-type StatusFilter = 'ALL' | 'LAID_UP' | 'PENDING' | 'SHIPPED' | 'CANCELLED';
+type StatusFilter = 'ALL' | 'IN_PROGRESS' | 'PENDING' | 'SHIPPED' | 'CANCELLED';
 type ProductionItemVisibilityFilter = 'active' | 'all' | 'cancelled';
+
+function isP1InProgressStatus(status?: string | null): boolean {
+  return ['IN_PROGRESS', 'LAID_UP'].includes(String(status || '').toUpperCase());
+}
 
 function getStatusLabel(filter: StatusFilter): string {
   switch (filter) {
     case 'ALL': return 'All Orders';
-    case 'LAID_UP': return 'In Progress';
+    case 'IN_PROGRESS': return 'In Progress';
     case 'PENDING': return 'Pending';
     case 'SHIPPED': return 'Shipped';
     case 'CANCELLED': return 'Cancelled';
@@ -145,6 +149,7 @@ function getStatusLabel(filter: StatusFilter): string {
 function getOrderStatusBadge(status: string) {
   switch (status) {
     case 'PENDING': return <Badge className="bg-blue-100 text-blue-800 text-xs">Pending</Badge>;
+    case 'IN_PROGRESS': return <Badge className="bg-yellow-100 text-yellow-800 text-xs">In Progress</Badge>;
     case 'LAID_UP': return <Badge className="bg-yellow-100 text-yellow-800 text-xs">In Progress</Badge>;
     case 'ACTIVE': return <Badge className="bg-orange-100 text-orange-800 text-xs">Active</Badge>;
     case 'SHIPPED': return <Badge className="bg-green-100 text-green-800 text-xs">Shipped</Badge>;
@@ -167,7 +172,7 @@ function ProductionStatusBadge({ productionOrders, totalPoQuantity, poNumber }: 
 
   const total = productionOrders.length;
   const pending = productionOrders.filter((o: any) => o.productionStatus === 'PENDING').length;
-  const inProgress = productionOrders.filter((o: any) => o.productionStatus === 'LAID_UP').length;
+  const inProgress = productionOrders.filter((o: any) => isP1InProgressStatus(o.productionStatus)).length;
   const shipped = productionOrders.filter((o: any) => o.productionStatus === 'SHIPPED').length;
   const cancelled = productionOrders.filter((o: any) => o.productionStatus === 'CANCELLED').length;
   const active = total - cancelled;
@@ -176,7 +181,9 @@ function ProductionStatusBadge({ productionOrders, totalPoQuantity, poNumber }: 
 
   const filteredOrders = selectedFilter === null ? [] : selectedFilter === 'ALL'
     ? productionOrders
-    : productionOrders.filter((o: any) => o.productionStatus === selectedFilter);
+    : selectedFilter === 'IN_PROGRESS'
+      ? productionOrders.filter((o: any) => isP1InProgressStatus(o.productionStatus))
+      : productionOrders.filter((o: any) => o.productionStatus === selectedFilter);
 
   const modalTitle = selectedFilter
     ? `${poNumber} — ${getStatusLabel(selectedFilter)} (${filteredOrders.length})`
@@ -209,7 +216,7 @@ function ProductionStatusBadge({ productionOrders, totalPoQuantity, poNumber }: 
         {inProgress > 0 && (
           <Badge
             className="bg-yellow-100 text-yellow-800 text-xs cursor-pointer hover:bg-yellow-200 transition-colors"
-            onClick={(e) => handleBadgeClick(e, 'LAID_UP')}
+            onClick={(e) => handleBadgeClick(e, 'IN_PROGRESS')}
             title="Click to view in-progress orders"
           >
             {inProgress} In Progress
@@ -401,7 +408,7 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
       queryClient.invalidateQueries({ queryKey: [`/api/production-orders/by-po/${poId}`] });
       queryClient.invalidateQueries({ queryKey: ['/api/pos'] });
       const statusLabel =
-        data?.order?.productionStatus === 'LAID_UP'
+        isP1InProgressStatus(data?.order?.productionStatus)
           ? 'In Progress'
           : data?.order?.productionStatus === 'SHIPPED'
             ? 'Shipped'
@@ -414,6 +421,24 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
     },
     onError: (error: any) => {
       toast.error('Failed to reactivate order: ' + (error.message || 'Unknown error'));
+    },
+  });
+
+  const fulfillMutation = useMutation({
+    mutationFn: async (orderId: string) => {
+      return apiRequest('/api/po-orders/toggle-fulfilled', {
+        method: 'POST',
+        body: { orderId, isFulfilled: true },
+      });
+    },
+    onSuccess: (_data: any, orderId) => {
+      queryClient.invalidateQueries({ queryKey: [`/api/production-orders/by-po/${poId}`] });
+      queryClient.invalidateQueries({ queryKey: ['/api/pos'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/po-orders/oem-shipments'] });
+      toast.success(`Order ${orderId} marked fulfilled.`);
+    },
+    onError: (error: any) => {
+      toast.error('Failed to mark fulfilled: ' + (error.message || 'Unknown error'));
     },
   });
 
@@ -447,6 +472,8 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
         return <Badge className="bg-blue-100 text-blue-800">Pending</Badge>;
       case 'ACTIVE':
         return <Badge className="bg-yellow-100 text-yellow-800">Active</Badge>;
+      case 'IN_PROGRESS':
+        return <Badge className="bg-orange-100 text-orange-800">In Progress</Badge>;
       case 'LAID_UP':
         return <Badge className="bg-orange-100 text-orange-800">In Progress</Badge>;
       case 'SHIPPED':
@@ -595,6 +622,24 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
                         Reactivate
                       </Button>
                     ) : order.productionStatus !== 'SHIPPED' && (
+                      <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-green-700 hover:text-green-800 hover:bg-green-50 border-green-300 h-7 px-2"
+                        disabled={fulfillMutation.isPending}
+                        onClick={() => {
+                          if (window.confirm(`Mark ${order.orderId} as fulfilled/shipped off-system?`)) {
+                            fulfillMutation.mutate(order.orderId);
+                          }
+                        }}
+                        title="Mark this item as fulfilled because it was shipped outside EPOCH"
+                      >
+                        {fulfillMutation.isPending && fulfillMutation.variables === order.orderId
+                          ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+                          : <Check className="h-3.5 w-3.5 mr-1" />}
+                        Fulfilled
+                      </Button>
                       <Button
                         variant={isDuplicate ? 'destructive' : 'ghost'}
                         size="sm"
@@ -608,6 +653,7 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
                         <X className="h-3.5 w-3.5 mr-1" />
                         {isDuplicate ? 'Cancel Duplicate' : 'Cancel'}
                       </Button>
+                      </>
                     )}
                   </td>
                 </tr>

--- a/client/src/lib/productionUtils.ts
+++ b/client/src/lib/productionUtils.ts
@@ -16,7 +16,7 @@ export interface ProductionOrder {
   sourceSnapshot?: any;
   orderDate: string;
   dueDate: string;
-  productionStatus: 'PENDING' | 'LAID_UP' | 'SHIPPED';
+  productionStatus: 'PENDING' | 'IN_PROGRESS' | 'LAID_UP' | 'SHIPPED' | 'CANCELLED';
   currentDepartment?: string | null;
   laidUpAt?: string;
   shippedAt?: string;
@@ -26,7 +26,7 @@ export interface ProductionOrder {
 }
 
 export interface ProductionOrderUpdate {
-  productionStatus?: 'PENDING' | 'LAID_UP' | 'SHIPPED';
+  productionStatus?: 'PENDING' | 'IN_PROGRESS' | 'LAID_UP' | 'SHIPPED' | 'CANCELLED';
   laidUpAt?: string;
   shippedAt?: string;
   notes?: string;
@@ -78,6 +78,7 @@ export function getProductionSummary(orders: ProductionOrder[]) {
       case 'PENDING':
         summary.pending++;
         break;
+      case 'IN_PROGRESS':
       case 'LAID_UP':
         summary.laidUp++;
         break;
@@ -133,6 +134,7 @@ export function getProductionSummaryByPO(orders: ProductionOrder[]) {
       case 'PENDING':
         summary.pending++;
         break;
+      case 'IN_PROGRESS':
       case 'LAID_UP':
         summary.laidUp++;
         break;

--- a/client/src/pages/OEMShipmentsPage.tsx
+++ b/client/src/pages/OEMShipmentsPage.tsx
@@ -61,13 +61,14 @@ import { queryClient, apiRequest } from '@/lib/queryClient';
 import { Plus } from 'lucide-react';
 
 interface ShipmentItem {
-  id: number;
+  id: string;
   poItemId: number;
   orderId: string;
   quantity: number;
   description: string;
   poNumber: string;
   hasPackingSlip: boolean;
+  packingSlipItemId?: string | null;
   itemType: 'stock_model' | 'custom_model' | string;
   unitPrice?: number | null;
   lineTotal?: number | null;
@@ -78,7 +79,7 @@ interface ShipmentItem {
 }
 
 interface Shipment {
-  id: number;
+  id: string;
   customer_id: number;
   customer_name: string;
   customer_address: string;
@@ -139,11 +140,11 @@ export default function OEMShipmentsPage() {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [page, setPage] = useState(0);
-  const [expandedShipments, setExpandedShipments] = useState<Set<number>>(new Set());
+  const [expandedShipments, setExpandedShipments] = useState<Set<string>>(new Set());
   const [viewMode, setViewMode] = useState<'date' | 'po'>('date');
   const [expandedDates, setExpandedDates] = useState<Set<string>>(new Set());
   const [expandedPOs, setExpandedPOs] = useState<Set<string>>(new Set());
-  const [editingTrackingId, setEditingTrackingId] = useState<number | null>(null);
+  const [editingTrackingId, setEditingTrackingId] = useState<string | null>(null);
   const [editingTrackingValue, setEditingTrackingValue] = useState('');
   const [addItemDialogOpen, setAddItemDialogOpen] = useState(false);
   const [addItemShipmentId, setAddItemShipmentId] = useState<string | null>(null);
@@ -366,7 +367,7 @@ export default function OEMShipmentsPage() {
     );
   };
 
-  const toggleExpanded = (shipmentId: number) => {
+  const toggleExpanded = (shipmentId: string) => {
     const newExpanded = new Set(expandedShipments);
     if (newExpanded.has(shipmentId)) {
       newExpanded.delete(shipmentId);
@@ -376,7 +377,7 @@ export default function OEMShipmentsPage() {
     setExpandedShipments(newExpanded);
   };
 
-  const downloadShippingLabel = async (shipmentId: number, trackingNumber: string) => {
+  const downloadShippingLabel = async (shipmentId: string, trackingNumber: string) => {
     const newTab = window.open('', '_blank');
     try {
       const response = await fetch(`/api/po-orders/oem-shipments/${shipmentId}/label`, {
@@ -418,7 +419,15 @@ export default function OEMShipmentsPage() {
     }
   };
 
-  const downloadPackingSlip = async (itemId: number, poNumber: string, orderId: string) => {
+  const getAttachedPackingSlipItemId = (item: ShipmentItem) =>
+    item.packingSlipItemId || item.id;
+
+  const getPackingSlipItemForGroup = (items: ShipmentItem[]) =>
+    items.find((item) => item.packingSlipItemId) ||
+    items.find((item) => item.hasPackingSlip) ||
+    items[0];
+
+  const downloadPackingSlip = async (itemId: string, poNumber: string, orderId: string) => {
     const newTab = window.open('', '_blank');
     try {
       const response = await fetch(`/api/po-orders/oem-shipments/packing-slip/${itemId}`, {
@@ -466,7 +475,7 @@ export default function OEMShipmentsPage() {
   };
 
   const updateTrackingMutation = useMutation({
-    mutationFn: async ({ shipmentId, trackingNumber }: { shipmentId: number; trackingNumber: string }) => {
+    mutationFn: async ({ shipmentId, trackingNumber }: { shipmentId: string; trackingNumber: string }) => {
       return await apiRequest(`/api/po-orders/oem-shipments/${shipmentId}/tracking`, { 
         method: 'PATCH', 
         body: { trackingNumber } 
@@ -487,12 +496,12 @@ export default function OEMShipmentsPage() {
     },
   });
 
-  const startEditingTracking = (shipmentId: number, currentValue: string) => {
+  const startEditingTracking = (shipmentId: string, currentValue: string) => {
     setEditingTrackingId(shipmentId);
     setEditingTrackingValue(currentValue);
   };
 
-  const saveTrackingNumber = (shipmentId: number) => {
+  const saveTrackingNumber = (shipmentId: string) => {
     if (editingTrackingValue.trim()) {
       updateTrackingMutation.mutate({ shipmentId, trackingNumber: editingTrackingValue.trim() });
     }
@@ -640,7 +649,7 @@ export default function OEMShipmentsPage() {
       });
     });
     return acc;
-  }, {} as Record<string, { poNumber: string; customerName: string; customerId: number; items: Array<ShipmentItem & { trackingNumber: string; shippedDate: string; shipmentId: number; hasLabel: boolean }> }>);
+  }, {} as Record<string, { poNumber: string; customerName: string; customerId: number; items: Array<ShipmentItem & { trackingNumber: string; shippedDate: string; shipmentId: string; hasLabel: boolean }> }>);
 
   return (
     <div className="p-6 space-y-6">
@@ -1042,7 +1051,7 @@ export default function OEMShipmentsPage() {
                                               <Button
                                                 size="sm"
                                                 variant="outline"
-                                                onClick={() => { const slipItem = items.find(i => i.hasPackingSlip) || items[0]; downloadPackingSlip(slipItem.id, poNumber, slipItem.orderId); }}
+                                                onClick={() => { const slipItem = getPackingSlipItemForGroup(items); downloadPackingSlip(getAttachedPackingSlipItemId(slipItem), poNumber, slipItem.orderId); }}
                                               >
                                                 <FileText className="h-4 w-4 mr-2" />
                                                 View Packing Slip
@@ -1076,7 +1085,7 @@ export default function OEMShipmentsPage() {
                                                 <TooltipTrigger asChild>
                                                   <div>
                                                     <DropdownMenuItem
-                                                      onClick={() => { const slipItem = items.find(i => i.hasPackingSlip) || items[0]; downloadPackingSlip(slipItem.id, poNumber, slipItem.orderId); }}
+                                                      onClick={() => { const slipItem = getPackingSlipItemForGroup(items); downloadPackingSlip(getAttachedPackingSlipItemId(slipItem), poNumber, slipItem.orderId); }}
                                                     >
                                                       <Printer className="h-3 w-3 mr-2 flex-shrink-0" />
                                                       <div className="flex flex-col">
@@ -1387,7 +1396,7 @@ export default function OEMShipmentsPage() {
                                     <Button
                                       size="sm"
                                       variant="outline"
-                                      onClick={() => downloadPackingSlip(item.id, item.poNumber, item.orderId)}
+                                      onClick={() => downloadPackingSlip(getAttachedPackingSlipItemId(item), item.poNumber, item.orderId)}
                                     >
                                       <Printer className="h-3 w-3 mr-1" />
                                       View Packing Slip

--- a/client/src/pages/ProductionOrderInspector.tsx
+++ b/client/src/pages/ProductionOrderInspector.tsx
@@ -87,6 +87,7 @@ export default function ProductionOrderInspector() {
         return <Badge className="bg-blue-100 text-blue-800">Pending</Badge>;
       case 'ACTIVE':
         return <Badge className="bg-yellow-100 text-yellow-800">Active</Badge>;
+      case 'IN_PROGRESS':
       case 'LAID_UP':
         return <Badge className="bg-orange-100 text-orange-800">Laid Up</Badge>;
       case 'SHIPPED':

--- a/client/src/pages/admin/P1POStatusRepairPage.tsx
+++ b/client/src/pages/admin/P1POStatusRepairPage.tsx
@@ -114,7 +114,7 @@ function StatusBadge({ value }: { value: string | null | undefined }) {
         ? 'bg-red-100 text-red-800'
         : upper === 'PENDING'
           ? 'bg-blue-100 text-blue-800'
-          : upper === 'LAID_UP'
+          : upper === 'IN_PROGRESS' || upper === 'LAID_UP'
             ? 'bg-yellow-100 text-yellow-800'
             : '';
 

--- a/server/__tests__/p1ProductionStatus.test.ts
+++ b/server/__tests__/p1ProductionStatus.test.ts
@@ -20,7 +20,7 @@ describe('deriveP1ProductionStatus', () => {
         currentDepartment,
         currentStatus: 'PENDING',
         isFulfilled: false,
-      })).toBe('LAID_UP');
+      })).toBe('IN_PROGRESS');
     }
   });
 
@@ -49,7 +49,7 @@ describe('deriveP1ProductionStatus', () => {
       currentDepartment: 'Shipping QC',
       currentStatus: 'SHIPPED',
       isFulfilled: true,
-    })).toBe('LAID_UP');
+    })).toBe('IN_PROGRESS');
   });
 
   it('preserves cancelled status unless the caller is explicitly reactivating', () => {
@@ -64,7 +64,7 @@ describe('deriveP1ProductionStatus', () => {
       currentStatus: 'CANCELLED',
       isFulfilled: false,
       preserveCancelled: false,
-    })).toBe('LAID_UP');
+    })).toBe('IN_PROGRESS');
   });
 });
 
@@ -78,6 +78,7 @@ describe('P1 PO status helpers', () => {
 
   it('treats pending and in-progress production statuses as active', () => {
     expect(isActiveP1ProductionStatus('PENDING')).toBe(true);
+    expect(isActiveP1ProductionStatus('IN_PROGRESS')).toBe(true);
     expect(isActiveP1ProductionStatus('LAID_UP')).toBe(true);
     expect(isActiveP1ProductionStatus('QC_PASSED')).toBe(true);
     expect(isActiveP1ProductionStatus('SHIPPED')).toBe(false);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -6674,7 +6674,7 @@ export const productionOrders = pgTable('production_orders', {
   orderDate: timestamp('order_date').notNull(),
   dueDate: timestamp('due_date').notNull(),
   // Production tracking fields
-  productionStatus: text('production_status').notNull().default('PENDING'), // PENDING, LAID_UP, SHIPPED
+  productionStatus: text('production_status').notNull().default('PENDING'), // PENDING, IN_PROGRESS, SHIPPED
   currentDepartment: text('current_department').default('Barcode'), // Department progression tracking
   departmentHistory: jsonb('department_history').default('[]'), // History of department movements
   barcodeCompletedAt: timestamp('barcode_completed_at'),
@@ -7009,7 +7009,7 @@ export const insertProductionOrderSchema = createInsertSchema(productionOrders)
     orderDate: z.coerce.date(),
     dueDate: z.coerce.date(),
     productionStatus: z
-      .enum(['PENDING', 'LAID_UP', 'SHIPPED'])
+      .enum(['PENDING', 'IN_PROGRESS', 'LAID_UP', 'SHIPPED', 'CANCELLED'])
       .default('PENDING'),
     laidUpAt: z.coerce.date().optional().nullable(),
     shippedAt: z.coerce.date().optional().nullable(),

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -36,7 +36,7 @@ const p1ProductionStatusExpectationSql = `
       THEN CASE WHEN COALESCE(is_fulfilled, false) THEN 'SHIPPED' ELSE 'PENDING' END
     WHEN LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) IN ('fulfilled', 'shipped')
       THEN 'SHIPPED'
-    ELSE 'LAID_UP'
+    ELSE 'IN_PROGRESS'
   END
 `;
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -7823,7 +7823,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const updatedOrders = [];
       const skippedOrders = [];
       for (const orderId of orderIds) {
-        // Update production orders status to LAID_UP
+        // Update production orders status to IN_PROGRESS
         const productionOrder =
           await storage.getProductionOrderByOrderId(orderId);
         if (productionOrder) {
@@ -7847,12 +7847,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             const updated = await storage.updateProductionOrder(
               productionOrder.id,
               {
-                productionStatus: 'LAID_UP',
+                productionStatus: 'IN_PROGRESS',
                 laidUpAt: new Date(),
               }
             );
             updatedOrders.push(updated);
-            console.log(`✅ Production order ${orderId} moved to LAID_UP status`);
+            console.log(`✅ Production order ${orderId} moved to IN_PROGRESS status`);
           }
         }
 

--- a/server/src/routes/p1POQueue.ts
+++ b/server/src/routes/p1POQueue.ts
@@ -754,11 +754,11 @@ router.post('/progress', async (req: Request, res: Response) => {
               created_at, updated_at
             ) VALUES (
               $1, $2, $3, $4, $5, $6, 'stock', $7, $8, $9,
-              NOW(), $10, 'LAID_UP', 'Barcode', NOW(), NOW()
+              NOW(), $10, 'IN_PROGRESS', 'Barcode', NOW(), NOW()
             )
             ON CONFLICT (order_id) DO UPDATE
             SET current_department = 'Barcode',
-                production_status = 'LAID_UP',
+                production_status = 'IN_PROGRESS',
                 updated_at = NOW()
           `;
           await pool.query(insertProdQuery, [

--- a/server/src/routes/poShippingQC.ts
+++ b/server/src/routes/poShippingQC.ts
@@ -1524,7 +1524,30 @@ router.get('/oem-shipments', authenticateToken, async (req, res) => {
               'quantity', si.quantity,
               'description', COALESCE(NULLIF(si.description, ''), COALESCE(poi.stock_model_name, poi.item_name), prod_ord.item_name),
               'poNumber', COALESCE(NULLIF(si.po_number, ''), prod_ord.po_number, po.po_number),
-              'hasPackingSlip', si.packing_slip_base64 IS NOT NULL,
+              'hasPackingSlip', EXISTS (
+                SELECT 1
+                FROM shipment_items slip_si
+                LEFT JOIN production_orders slip_prod_ord ON slip_si.order_id = slip_prod_ord.order_id
+                LEFT JOIN purchase_order_items slip_poi ON slip_poi.id = slip_si.po_item_id
+                LEFT JOIN purchase_orders slip_po ON slip_poi.po_id = slip_po.id
+                WHERE slip_si.shipment_id = sr.id
+                  AND COALESCE(NULLIF(slip_si.po_number, ''), slip_prod_ord.po_number, slip_po.po_number) =
+                    COALESCE(NULLIF(si.po_number, ''), prod_ord.po_number, po.po_number)
+                  AND slip_si.packing_slip_base64 IS NOT NULL
+              ),
+              'packingSlipItemId', (
+                SELECT slip_si.id::text
+                FROM shipment_items slip_si
+                LEFT JOIN production_orders slip_prod_ord ON slip_si.order_id = slip_prod_ord.order_id
+                LEFT JOIN purchase_order_items slip_poi ON slip_poi.id = slip_si.po_item_id
+                LEFT JOIN purchase_orders slip_po ON slip_poi.po_id = slip_po.id
+                WHERE slip_si.shipment_id = sr.id
+                  AND COALESCE(NULLIF(slip_si.po_number, ''), slip_prod_ord.po_number, slip_po.po_number) =
+                    COALESCE(NULLIF(si.po_number, ''), prod_ord.po_number, po.po_number)
+                  AND slip_si.packing_slip_base64 IS NOT NULL
+                ORDER BY (slip_si.id = si.id) DESC, slip_si.created_at DESC
+                LIMIT 1
+              ),
               'itemType', COALESCE(poi.item_type, 'stock_model'),
               'unitPrice', CASE WHEN $${paramIndex + 2}::boolean THEN poi.unit_price ELSE NULL END,
               'lineTotal', CASE WHEN $${paramIndex + 2}::boolean THEN COALESCE(poi.unit_price, 0) * COALESCE(si.quantity, 1) ELSE NULL END,
@@ -2406,11 +2429,29 @@ router.post('/oem-shipments/:id/items', authenticateToken, async (req, res) => {
         .json({ _error: `Item ${orderId} already exists in this shipment` });
     }
 
+    const inheritedSlipRows = rowsOf<{ packing_slip_base64: string | null }>(
+      await pool.query(
+        `SELECT existing_si.packing_slip_base64
+         FROM shipment_items existing_si
+         LEFT JOIN production_orders existing_prod_ord ON existing_si.order_id = existing_prod_ord.order_id
+         LEFT JOIN purchase_order_items existing_poi ON existing_poi.id = existing_si.po_item_id
+         LEFT JOIN purchase_orders existing_po ON existing_poi.po_id = existing_po.id
+         WHERE existing_si.shipment_id = $1
+           AND COALESCE(NULLIF(existing_si.po_number, ''), existing_prod_ord.po_number, existing_po.po_number) = $2
+           AND existing_si.packing_slip_base64 IS NOT NULL
+         ORDER BY existing_si.created_at DESC
+         LIMIT 1`,
+        [id, poNumber]
+      )
+    );
+    const inheritedPackingSlipBase64 =
+      inheritedSlipRows[0]?.packing_slip_base64 || null;
+
     // Insert the new shipment item
     const insertQuery = `
-      INSERT INTO shipment_items (id, shipment_id, po_item_id, order_id, quantity, description, po_number)
-      VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6)
-      RETURNING id, shipment_id, po_item_id, order_id, quantity
+      INSERT INTO shipment_items (id, shipment_id, po_item_id, order_id, quantity, description, po_number, packing_slip_base64)
+      VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7)
+      RETURNING id, shipment_id, po_item_id, order_id, quantity, packing_slip_base64 IS NOT NULL AS has_packing_slip
     `;
 
     const result = await pool.query(insertQuery, [
@@ -2420,6 +2461,7 @@ router.post('/oem-shipments/:id/items', authenticateToken, async (req, res) => {
       quantity,
       description,
       poNumber,
+      inheritedPackingSlipBase64,
     ]);
     const newItem = (result.rows || result)[0];
 
@@ -2611,7 +2653,7 @@ router.post(
       const updateResult = await pool.query(
         `
       UPDATE production_orders 
-      SET production_status = 'LAID_UP',
+      SET production_status = 'IN_PROGRESS',
           current_department = 'Shipping QC',
           shipped_at = NULL,
           is_fulfilled = false,
@@ -2915,7 +2957,7 @@ router.post('/reset-fulfilled', authenticateToken, async (req, res) => {
     let updateQuery = `
       UPDATE production_orders 
       SET 
-        production_status = 'LAID_UP',
+        production_status = 'IN_PROGRESS',
         current_department = 'Shipping QC',
         shipped_at = NULL,
         is_fulfilled = false,
@@ -2934,7 +2976,7 @@ router.post('/reset-fulfilled', authenticateToken, async (req, res) => {
       updateQuery = `
         UPDATE production_orders 
         SET 
-          production_status = 'LAID_UP',
+          production_status = 'IN_PROGRESS',
           current_department = 'Shipping QC',
           shipped_at = NULL,
           is_fulfilled = false,
@@ -3158,7 +3200,7 @@ router.post('/process-shipment', authenticateToken, async (req, res) => {
           if (!order) {
             throw new Error(`Order ${item.orderId} not found`);
           }
-          // P1 PO orders use productionStatus (PENDING, LAID_UP, SHIPPED) not currentDepartment
+          // P1 PO orders use productionStatus (PENDING, IN_PROGRESS, SHIPPED) not currentDepartment
           const isDevMode = process.env.NODE_ENV === 'development';
           if (order.productionStatus === 'SHIPPED' && !isDevMode) {
             throw new Error(`Order ${item.orderId} has already been shipped`);

--- a/server/src/utils/p1ProductionStatus.ts
+++ b/server/src/utils/p1ProductionStatus.ts
@@ -1,4 +1,4 @@
-export type P1ProductionStatus = 'PENDING' | 'LAID_UP' | 'SHIPPED' | 'CANCELLED';
+export type P1ProductionStatus = 'PENDING' | 'IN_PROGRESS' | 'SHIPPED' | 'CANCELLED';
 
 type DeriveP1ProductionStatusInput = {
   currentDepartment?: string | null;
@@ -41,7 +41,7 @@ export function deriveP1ProductionStatus({
     return 'SHIPPED';
   }
 
-  return 'LAID_UP';
+  return 'IN_PROGRESS';
 }
 
 export function isClosedP1PurchaseOrderStatus(status?: string | null): boolean {


### PR DESCRIPTION
## Summary
- Use `IN_PROGRESS` as the canonical P1 PO production status for active departments while still recognizing legacy `LAID_UP` rows in UI counts and filters.
- Attach PO-level packing slip references to OEM shipment items so shipped rows can open the associated packing list even when the row itself did not store the PDF.
- Add a per-item Fulfilled action in Manage Items > Production Orders for orders shipped off-system.

## Validation
- `git diff --check`
- Bundled Node parse checks for touched backend `.ts` files and `client/src/lib/productionUtils.ts`
- Could not run `npm run check` because `npm` is not available on PATH in this checkout.