### PR TITLE
[codex] Mark Shipping QC fulfilled P1 items as shipped

### DIFF
--- a/client/src/components/POManager.tsx
+++ b/client/src/components/POManager.tsx
@@ -136,6 +136,11 @@ function isP1InProgressStatus(status?: string | null): boolean {
   return ['IN_PROGRESS', 'LAID_UP'].includes(String(status || '').toUpperCase());
 }
 
+function getP1EffectiveStatus(order: any): string {
+  if (order?.isFulfilled) return 'SHIPPED';
+  return String(order?.productionStatus || '');
+}
+
 function getStatusLabel(filter: StatusFilter): string {
   switch (filter) {
     case 'ALL': return 'All Orders';
@@ -171,10 +176,10 @@ function ProductionStatusBadge({ productionOrders, totalPoQuantity, poNumber }: 
   }
 
   const total = productionOrders.length;
-  const pending = productionOrders.filter((o: any) => o.productionStatus === 'PENDING').length;
-  const inProgress = productionOrders.filter((o: any) => isP1InProgressStatus(o.productionStatus)).length;
-  const shipped = productionOrders.filter((o: any) => o.productionStatus === 'SHIPPED').length;
-  const cancelled = productionOrders.filter((o: any) => o.productionStatus === 'CANCELLED').length;
+  const pending = productionOrders.filter((o: any) => getP1EffectiveStatus(o) === 'PENDING').length;
+  const inProgress = productionOrders.filter((o: any) => isP1InProgressStatus(getP1EffectiveStatus(o))).length;
+  const shipped = productionOrders.filter((o: any) => getP1EffectiveStatus(o) === 'SHIPPED').length;
+  const cancelled = productionOrders.filter((o: any) => getP1EffectiveStatus(o) === 'CANCELLED').length;
   const active = total - cancelled;
   // Flag when orders outnumber the PO quantity — likely indicates duplicate generation
   const hasDuplicates = totalPoQuantity > 0 && total > totalPoQuantity;
@@ -182,8 +187,8 @@ function ProductionStatusBadge({ productionOrders, totalPoQuantity, poNumber }: 
   const filteredOrders = selectedFilter === null ? [] : selectedFilter === 'ALL'
     ? productionOrders
     : selectedFilter === 'IN_PROGRESS'
-      ? productionOrders.filter((o: any) => isP1InProgressStatus(o.productionStatus))
-      : productionOrders.filter((o: any) => o.productionStatus === selectedFilter);
+      ? productionOrders.filter((o: any) => isP1InProgressStatus(getP1EffectiveStatus(o)))
+      : productionOrders.filter((o: any) => getP1EffectiveStatus(o) === selectedFilter);
 
   const modalTitle = selectedFilter
     ? `${poNumber} — ${getStatusLabel(selectedFilter)} (${filteredOrders.length})`
@@ -300,7 +305,7 @@ function ProductionStatusBadge({ productionOrders, totalPoQuantity, poNumber }: 
                       </td>
                       <td className="p-3">{order.itemName || '—'}</td>
                       <td className="p-3 text-muted-foreground">{order.itemCode || order.materialCanonical || '—'}</td>
-                      <td className="p-3">{getOrderStatusBadge(order.productionStatus)}</td>
+                      <td className="p-3">{getOrderStatusBadge(getP1EffectiveStatus(order))}</td>
                       <td className="p-3 text-muted-foreground">{order.currentDepartment || '—'}</td>
                       <td className="p-3 text-muted-foreground">{order.operatorName || order.operator || order.assignedOperator || '—'}</td>
                       <td className="p-3 text-muted-foreground">
@@ -364,7 +369,7 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
     // Group orders by linked PO line, excluding cancelled orders.
     const groups = new Map<string, any[]>();
     for (const order of productionOrders) {
-      if (order.productionStatus === 'CANCELLED') continue;
+      if (getP1EffectiveStatus(order) === 'CANCELLED') continue;
       const key = order.poItemId
         ? `item:${order.poItemId}`
         : `name:${normalizeLineName(order.itemName || order.itemCode)}`;
@@ -383,8 +388,8 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
   }, [productionOrders, poItems]);
 
   const duplicateCount = duplicateOrderIds.size;
-  const activeOrders = (productionOrders as any[]).filter((order: any) => order.productionStatus !== 'CANCELLED');
-  const cancelledOrders = (productionOrders as any[]).filter((order: any) => order.productionStatus === 'CANCELLED');
+  const activeOrders = (productionOrders as any[]).filter((order: any) => getP1EffectiveStatus(order) !== 'CANCELLED');
+  const cancelledOrders = (productionOrders as any[]).filter((order: any) => getP1EffectiveStatus(order) === 'CANCELLED');
   const visibleProductionOrders =
     visibilityFilter === 'all'
       ? (productionOrders as any[])
@@ -636,13 +641,13 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
                     </div>
                   </td>
                   <td className="p-3">{order.materialCanonical || '—'}</td>
-                  <td className="p-3">{getStatusBadge(order.productionStatus)}</td>
+                  <td className="p-3">{getStatusBadge(getP1EffectiveStatus(order))}</td>
                   <td className="p-3 text-muted-foreground">{order.currentDepartment || '—'}</td>
                   <td className="p-3 text-muted-foreground">
                     {order.createdAt ? formatDate(new Date(order.createdAt), 'M/d/yy') : '—'}
                   </td>
                   <td className="p-3 flex items-center gap-1">
-                    {order.productionStatus === 'CANCELLED' ? (
+                    {getP1EffectiveStatus(order) === 'CANCELLED' ? (
                       <Button
                         variant="outline"
                         size="sm"
@@ -656,7 +661,7 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
                           : <RotateCcw className="h-3.5 w-3.5 mr-1" />}
                         Reactivate
                       </Button>
-                    ) : order.productionStatus !== 'SHIPPED' && (
+                    ) : getP1EffectiveStatus(order) !== 'SHIPPED' && (
                       <>
                       <Button
                         variant="outline"

--- a/server/__tests__/p1ProductionStatus.test.ts
+++ b/server/__tests__/p1ProductionStatus.test.ts
@@ -38,7 +38,7 @@ describe('deriveP1ProductionStatus', () => {
     })).toBe('SHIPPED');
   });
 
-  it('uses the fulfilled flag only when the department is blank', () => {
+  it('maps fulfilled items to shipped regardless of department', () => {
     expect(deriveP1ProductionStatus({
       currentDepartment: null,
       currentStatus: 'PENDING',
@@ -49,7 +49,7 @@ describe('deriveP1ProductionStatus', () => {
       currentDepartment: 'Shipping QC',
       currentStatus: 'SHIPPED',
       isFulfilled: true,
-    })).toBe('IN_PROGRESS');
+    })).toBe('SHIPPED');
   });
 
   it('preserves cancelled status unless the caller is explicitly reactivating', () => {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -30,10 +30,12 @@ const p1ProductionStatusExpectationSql = `
   CASE
     WHEN UPPER(COALESCE(NULLIF(TRIM(production_status), ''), '')) = 'CANCELLED'
       THEN 'CANCELLED'
+    WHEN COALESCE(is_fulfilled, false)
+      THEN 'SHIPPED'
     WHEN LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) = 'p1 production queue'
       THEN 'PENDING'
     WHEN COALESCE(NULLIF(TRIM(current_department), ''), '') = ''
-      THEN CASE WHEN COALESCE(is_fulfilled, false) THEN 'SHIPPED' ELSE 'PENDING' END
+      THEN 'PENDING'
     WHEN LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) IN ('fulfilled', 'shipped')
       THEN 'SHIPPED'
     ELSE 'IN_PROGRESS'

--- a/server/src/routes/poShippingQC.ts
+++ b/server/src/routes/poShippingQC.ts
@@ -2819,10 +2819,17 @@ router.post('/toggle-fulfilled', authenticateToken, async (req, res) => {
         currentStatus: order.productionStatus,
         preserveCancelled: true,
       });
+      const nextDepartment =
+        shouldFulfill
+          ? 'Shipped'
+          : ['shipped', 'fulfilled'].includes(String(order.currentDepartment || '').trim().toLowerCase())
+            ? 'Shipping QC'
+            : order.currentDepartment;
 
       // Update production status to SHIPPED or back to the status implied by its department.
       await storage.updateProductionOrder(order.id, {
         productionStatus: nextProductionStatus,
+        currentDepartment: nextDepartment,
         shippedAt: shouldFulfill ? shippedAt : null,
         isFulfilled: shouldFulfill,
         fulfilledDate: shouldFulfill ? shippedAt : null,
@@ -3775,6 +3782,7 @@ router.post('/process-shipment', authenticateToken, async (req, res) => {
         } else if (detail.order.id) {
           await storage.updateProductionOrder(detail.order.id, {
             productionStatus: 'SHIPPED',
+            currentDepartment: 'Shipped',
             shippedAt,
             isFulfilled: true,
             fulfilledDate: shippedAt,

--- a/server/src/utils/p1ProductionStatus.ts
+++ b/server/src/utils/p1ProductionStatus.ts
@@ -27,15 +27,17 @@ export function deriveP1ProductionStatus({
     return 'CANCELLED';
   }
 
+  if (isFulfilled) {
+    return 'SHIPPED';
+  }
+
   const department = normalizeDepartment(currentDepartment);
 
   if (department === 'p1 production queue') {
     return 'PENDING';
   }
 
-  if (!department) {
-    return isFulfilled ? 'SHIPPED' : 'PENDING';
-  }
+  if (!department) return 'PENDING';
 
   if (department === 'fulfilled' || department === 'shipped') {
     return 'SHIPPED';

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -12661,6 +12661,8 @@ export class DatabaseStorage implements IStorage {
           prod.order_id as "orderId",
           prod.current_department as "currentDepartment",
           prod.production_status as "productionStatus",
+          COALESCE(prod.is_fulfilled, false) as "isFulfilled",
+          prod.fulfilled_date as "fulfilledDate",
           pp.customer_product_number as "customerProductNumber"
         FROM purchase_orders po
         INNER JOIN purchase_order_items poi ON po.id = poi.po_id
@@ -12710,6 +12712,8 @@ export class DatabaseStorage implements IStorage {
           prod.order_id as "orderId",
           prod.current_department as "currentDepartment",
           prod.production_status as "productionStatus",
+          COALESCE(prod.is_fulfilled, false) as "isFulfilled",
+          prod.fulfilled_date as "fulfilledDate",
           pp.customer_product_number as "customerProductNumber"
         FROM production_orders prod
         INNER JOIN purchase_orders po ON prod.po_id = po.id
@@ -12776,6 +12780,8 @@ export class DatabaseStorage implements IStorage {
       orderId: string | null;
       currentDepartment: string | null;
       productionStatus: string | null;
+      isFulfilled: boolean;
+      fulfilledDate: Date | string | null;
       customerProductNumber: string | null;
     };
     const rows = (result.rows || []) as P1PORow[];
@@ -12849,7 +12855,7 @@ export class DatabaseStorage implements IStorage {
         // poi.stock_status can be stale (e.g. marked SHIPPED at the item level while individual
         // production orders are still LAID_UP in Shipping QC), which would incorrectly hide
         // those units from the queue (bug: PO002612 / RFPO-002612).
-        const isShipped = row.productionStatus === 'SHIPPED';
+        const isShipped = row.isFulfilled || row.productionStatus === 'SHIPPED';
         const isInShippingDept = row.currentDepartment === 'Shipping QC' || row.currentDepartment === 'Shipping';
 
         poItem.productionOrders.push({
@@ -12857,8 +12863,8 @@ export class DatabaseStorage implements IStorage {
           unitNumber,
           currentDepartment: row.currentDepartment,
           productionStatus: row.productionStatus,
-          isFulfilled: isShipped,
-          fulfilledDate: null,
+          isFulfilled: row.isFulfilled || isShipped,
+          fulfilledDate: row.fulfilledDate ? String(row.fulfilledDate) : null,
           fulfilledBy: null,
           isReadyToShip: isInShippingDept && !isShipped,
         });
@@ -12925,9 +12931,12 @@ export class DatabaseStorage implements IStorage {
               const isShippedProdOrder = prodOrder.isFulfilled || prodOrder.productionStatus === 'SHIPPED';
               let effectiveDepartment = prodOrder.currentDepartment;
               let effectiveStatus = prodOrder.productionStatus;
-              if (isMetalAccessoryWithProdOrder) {
-                effectiveDepartment = isShippedProdOrder ? 'Shipped' : 'Shipping QC';
-                effectiveStatus = isShippedProdOrder ? 'SHIPPED' : 'IN_SHIPPING_QC';
+              if (isShippedProdOrder) {
+                effectiveDepartment = 'Shipped';
+                effectiveStatus = 'SHIPPED';
+              } else if (isMetalAccessoryWithProdOrder) {
+                effectiveDepartment = 'Shipping QC';
+                effectiveStatus = 'IN_SHIPPING_QC';
               }
               allItems.push({
                 orderId: prodOrder.orderId,


### PR DESCRIPTION
## Summary
- Make the Shipping QC `Mark Fulfilled` action set P1 production orders to `SHIPPED`, move them to the `Shipped` department, and write fulfilled timestamps.
- Treat `isFulfilled=true` as shipped in P1 PO Manage Items > Production so fulfilled rows count/display as shipped even if older data still has a stale raw status.
- Update the P1 status derivation and repair expectation so fulfilled always maps to shipped before department-based in-progress logic.

## Validation
- `git diff --check`
- Bundled Node parse checks for touched backend `.ts` files
- Full `npm run check` was not available because `npm` is not on PATH in this checkout.