### PR TITLE
[codex] Mark shipped Shipping QC P1 rows fulfilled

### DIFF
--- a/client/src/pages/admin/P1POStatusRepairPage.tsx
+++ b/client/src/pages/admin/P1POStatusRepairPage.tsx
@@ -198,7 +198,7 @@ export default function P1POStatusRepairPage() {
       setLastApplied(data);
       toast({
         title: 'P1 PO repair applied',
-        description: `${data.productionStatusRepairs.appliedCount} production statuses updated, ${data.fulfilledDepartmentRepairs?.appliedCount ?? 0} fulfilled rows moved to Shipped, ${data.purchaseOrderReopens.appliedCount} POs reopened.`,
+        description: `${data.productionStatusRepairs.appliedCount} production statuses updated, ${data.fulfilledDepartmentRepairs?.appliedCount ?? 0} shipped rows marked fulfilled, ${data.purchaseOrderReopens.appliedCount} POs reopened.`,
       });
       query.refetch();
     },
@@ -291,7 +291,7 @@ export default function P1POStatusRepairPage() {
                 <AlertDialogHeader>
                   <AlertDialogTitle>Apply P1 PO Status Repair</AlertDialogTitle>
                   <AlertDialogDescription>
-                    This will update up to {maxApply} drifted production statuses, move fulfilled P1 rows that are still in active departments to Shipped, and reopen up to {maxApply} closed or complete POs with active production items.
+                    This will update up to {maxApply} drifted production statuses, mark shipped P1 rows as fulfilled and move them to Shipped, and reopen up to {maxApply} closed or complete POs with active production items.
                     Item descriptions, item stock fields, and shipment records will not be changed.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
@@ -328,7 +328,7 @@ export default function P1POStatusRepairPage() {
         </Card>
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm text-muted-foreground">Fulfilled Rows To Ship</CardTitle>
+            <CardTitle className="text-sm text-muted-foreground">Shipped Rows In QC</CardTitle>
           </CardHeader>
           <CardContent className="text-3xl font-semibold">{fulfilledDepartmentRepairCount}</CardContent>
         </Card>
@@ -346,7 +346,7 @@ export default function P1POStatusRepairPage() {
             {lastApplied ? (
               <div className="space-y-1">
                 <div>{lastApplied.productionStatusRepairs.appliedCount} statuses</div>
-                <div>{lastApplied.fulfilledDepartmentRepairs?.appliedCount ?? 0} fulfilled rows shipped</div>
+                <div>{lastApplied.fulfilledDepartmentRepairs?.appliedCount ?? 0} shipped rows fulfilled</div>
                 <div>{lastApplied.purchaseOrderReopens.appliedCount} POs reopened</div>
               </div>
             ) : (
@@ -438,8 +438,8 @@ export default function P1POStatusRepairPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Fulfilled Rows Still In Active Departments</CardTitle>
-          <CardDescription>Fulfilled P1 production rows should be in Shipped and display as SHIPPED in P1 PO Manage Items.</CardDescription>
+          <CardTitle className="text-base">Shipped Rows Still In Shipping QC</CardTitle>
+          <CardDescription>SHIPPED P1 production rows in Shipping QC should be marked fulfilled, moved to Shipped, and display as SHIPPED in P1 PO Manage Items.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-5">
           <Table>
@@ -447,7 +447,7 @@ export default function P1POStatusRepairPage() {
               <TableRow>
                 <TableHead>Current Department</TableHead>
                 <TableHead>Production Status</TableHead>
-                <TableHead>Expected Department</TableHead>
+                <TableHead>Repair Department</TableHead>
                 <TableHead className="text-right">Count</TableHead>
               </TableRow>
             </TableHeader>
@@ -462,7 +462,7 @@ export default function P1POStatusRepairPage() {
               ))}
               {!query.isFetching && (data?.fulfilledDepartmentRepairs?.summary ?? []).length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={4} className="text-center text-muted-foreground py-6">No fulfilled rows are stuck in active departments.</TableCell>
+                  <TableCell colSpan={4} className="text-center text-muted-foreground py-6">No shipped rows are still in Shipping QC.</TableCell>
                 </TableRow>
               )}
             </TableBody>

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -32,6 +32,9 @@ const p1ProductionStatusExpectationSql = `
       THEN 'CANCELLED'
     WHEN COALESCE(is_fulfilled, false)
       THEN 'SHIPPED'
+    WHEN UPPER(COALESCE(NULLIF(TRIM(production_status), ''), '')) = 'SHIPPED'
+      AND LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) = 'shipping qc'
+      THEN 'SHIPPED'
     WHEN LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) = 'p1 production queue'
       THEN 'PENDING'
     WHEN COALESCE(NULLIF(TRIM(current_department), ''), '') = ''
@@ -76,8 +79,8 @@ const p1FulfilledDepartmentCandidateSql = `
     updated_at
   FROM production_orders
   WHERE po_id IS NOT NULL
-    AND COALESCE(is_fulfilled, false)
-    AND LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) NOT IN ('shipped', 'fulfilled')
+    AND UPPER(COALESCE(NULLIF(TRIM(production_status), ''), '')) = 'SHIPPED'
+    AND LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) = 'shipping qc'
 `;
 
 router.post(
@@ -1477,6 +1480,7 @@ router.post(
             UPDATE production_orders prod
             SET current_department = mismatches.expected_department,
                 production_status = 'SHIPPED',
+                is_fulfilled = true,
                 shipped_at = COALESCE(prod.shipped_at, prod.fulfilled_date, NOW()),
                 fulfilled_date = COALESCE(prod.fulfilled_date, prod.shipped_at, NOW()),
                 updated_at = NOW()


### PR DESCRIPTION
## Summary
- Narrow the P1 PO Status Repair fulfilled-row fix to rows where `production_status = SHIPPED` and `current_department = Shipping QC`.
- Keep those rows expected as `SHIPPED` instead of repairing them backward to `IN_PROGRESS`.
- When applied, mark those shipped Shipping QC rows as fulfilled, move them to `Shipped`, and backfill shipped/fulfilled timestamps only when missing.

## Validation
- `git diff --check`
- Bundled Node parse check for `server/src/routes/admin.ts`
- Full frontend/TypeScript check was not available because `npm`/`node_modules` are not available in this checkout.