### PR TITLE
[codex] Preserve P2 shipment PO item line

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2052,15 +2052,33 @@ async function initializeBackgroundServices() {
           ADD COLUMN IF NOT EXISTS po_id INTEGER REFERENCES p2_purchase_orders(id)
         `);
         await db.execute(sqlLot`
+          ALTER TABLE p2_lot_numbers
+          ADD COLUMN IF NOT EXISTS po_item_id INTEGER REFERENCES p2_purchase_order_items(id)
+        `);
+        await db.execute(sqlLot`
           UPDATE p2_lot_numbers l
           SET po_id = po.id
           FROM p2_purchase_orders po
           WHERE l.po_number = po.po_number
             AND l.po_id IS NULL
         `);
-        console.log('✅ Ensured p2_lot_numbers has po_id FK (backfilled from po_number)');
+        await db.execute(sqlLot`
+          UPDATE p2_lot_numbers l
+          SET po_item_id = matched.po_item_id
+          FROM (
+            SELECT l2.id AS lot_id, MIN(si.po_item_id) AS po_item_id
+            FROM p2_lot_numbers l2
+            JOIN p2_serialized_items si
+              ON l2.serialized_item_ids ? si.id::text
+            WHERE l2.po_item_id IS NULL
+            GROUP BY l2.id
+            HAVING COUNT(DISTINCT si.po_item_id) = 1
+          ) matched
+          WHERE l.id = matched.lot_id
+        `);
+        console.log('✅ Ensured p2_lot_numbers has PO FK columns (backfilled from po_number/serials)');
       } catch (lotPoIdError: any) {
-        console.warn('⚠️ p2_lot_numbers po_id migration warning:', lotPoIdError?.message);
+        console.warn('⚠️ p2_lot_numbers PO FK migration warning:', lotPoIdError?.message);
       }
 
       // GIN index on serialized_item_ids for fast JSONB containment lookups

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -6481,6 +6481,7 @@ export const p2LotNumbers = pgTable('p2_lot_numbers', {
   customerName: text('customer_name'),
   poNumber: text('po_number'), // Kept as denormalized text for display/legacy
   poId: integer('po_id').references(() => p2PurchaseOrders.id), // Hard FK — replaces fragile text join
+  poItemId: integer('po_item_id').references(() => p2PurchaseOrderItems.id),
   quantity: integer('quantity').default(1),
   serializedItemIds: jsonb('serialized_item_ids'), // Array of serialized item UUIDs in this lot
   barcodes: jsonb('barcodes'), // Array of barcodes in this lot for easy reference

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -1090,6 +1090,8 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
     }
 
     const first = serials[0];
+    const poItemIds = Array.from(new Set(serials.map((serial) => serial.poItemId)));
+    const lotPoItemId = poItemIds.length === 1 ? poItemIds[0] : null;
     const lotNumber = await generateSequentialId('LOT', 'p2_lot_numbers', 'lot_number');
 
     const manufacturingDate =
@@ -1107,6 +1109,7 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
         customerName: first.customerName,
         poNumber: first.poNumber, // kept for display/legacy
         poId: first.poId,         // hard FK — serial already carries the integer po_id
+        poItemId: lotPoItemId,
         quantity: serials.length,
         serializedItemIds: input.serialIds,
         barcodes: serials.map((s) => s.barcode),
@@ -1142,6 +1145,7 @@ router.get('/lots/existing-shipments', async (req: Request, res: Response) => {
   try {
     const rows = await pool.query<{
       po_id: number;
+      po_item_id: number | null;
       lot_id: string;
       lot_number: string;
       slip_id: string;
@@ -1158,6 +1162,7 @@ router.get('/lots/existing-shipments', async (req: Request, res: Response) => {
     }>(`
       SELECT
         l.po_id,
+        l.po_item_id,
         l.id           AS lot_id,
         l.lot_number,
         ps.id          AS slip_id,


### PR DESCRIPTION
## Summary

- Adds nullable `po_item_id` support to `p2_lot_numbers` so P2 shipment lots can retain the selected PO item line when a shipment contains one canonical line.
- Backfills existing single-line lots from serialized item membership during startup migration.
- Returns `po_item_id` from the existing P2 shipment list endpoint for downstream shipment/document consumers.

## Root Cause

The current P2 shipment flow now captures billing bucket assignments, but the shipment lot record itself only persisted the PO header. When shipment confirmation created the lot, the selected PO item line context could be lost at the lot level, which makes shipment summaries/documents depend on downstream assignment rows instead of carrying the canonical line when one exists.

## Validation

- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/p2Shipping.ts`
- `node --experimental-strip-types --check server/index.ts`
- `node --experimental-strip-types --check server/schema.ts`

`npm run check` was not available in this clean worktree because `npm`/`node_modules` are not present on this machine path.