### PR TITLE
[codex] Require PO item and bucket on project PO links

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -117,6 +117,8 @@ interface Project {
   currentRevisionNumber: number;
   currentRevisionLabel: string;
   poId: number | null;
+  p2PoItemId: number | null;
+  p2BillingAllocationId: string | null;
   projectManagerId: number | null;
   reminderDays: number;
   notes: string | null;
@@ -145,6 +147,31 @@ interface P2PurchaseOrder {
   poDate?: string | null;
   expectedDelivery?: string | null;
   createdAt?: string;
+}
+
+interface P2PoItemOption {
+  id: number;
+  poId: number;
+  partNumber: string;
+  partName: string;
+  quantity: number;
+  unitPrice: number | null;
+}
+
+interface P2BillingBucketOption {
+  id: string;
+  poId: number;
+  poItemId: number | null;
+  bucketLabel: string;
+  description: string | null;
+  customerPoLine: string | null;
+  quantityAuthorized: number;
+  unitPrice: string | number;
+}
+
+interface P2PoLinkOptions {
+  poItems: P2PoItemOption[];
+  billingBuckets: P2BillingBucketOption[];
 }
 
 interface ProjectRevision {
@@ -419,6 +446,8 @@ export default function ProjectDetailPage() {
   const p2PurchaseOrderOptions = Array.isArray(p2PurchaseOrders) ? p2PurchaseOrders : [];
 
   const [linkPoId, setLinkPoId] = useState<string>('');
+  const [linkPoItemId, setLinkPoItemId] = useState<string>('');
+  const [linkBillingBucketId, setLinkBillingBucketId] = useState<string>('');
   const [linkPoSearch, setLinkPoSearch] = useState('');
   const [showManualLink, setShowManualLink] = useState(false);
   const [linkPoReason, setLinkPoReason] = useState('');
@@ -453,12 +482,38 @@ export default function ProjectDetailPage() {
       });
   }, [project, p2PurchaseOrders]);
 
+  const activeLinkPoId = showManualLink ? linkPoId : (suggestedPo?.id.toString() ?? linkPoId);
+
+  const { data: poLinkOptions } = useQuery<P2PoLinkOptions>({
+    queryKey: ['/api/projects', id, 'po-link-options', activeLinkPoId],
+    queryFn: () => apiRequest(`/api/projects/${id}/po-link-options?poId=${encodeURIComponent(activeLinkPoId)}`),
+    enabled: !!id && !!activeLinkPoId,
+  });
+
+  const poItemOptions = poLinkOptions?.poItems ?? [];
+  const billingBucketOptions = (poLinkOptions?.billingBuckets ?? []).filter((bucket) => {
+    if (!linkPoItemId) return true;
+    return !bucket.poItemId || bucket.poItemId === Number(linkPoItemId);
+  });
+
   const linkPoMutation = useMutation({
-    mutationFn: ({ poId, reason }: { poId: number; reason?: string }) =>
+    mutationFn: ({
+      poId,
+      poItemId,
+      billingAllocationId,
+      reason,
+    }: {
+      poId: number;
+      poItemId?: number | null;
+      billingAllocationId?: string | null;
+      reason?: string;
+    }) =>
       apiRequest(`/api/projects/${id}/link-po`, {
         method: 'POST',
         body: {
           poId,
+          poItemId,
+          billingAllocationId,
           reason,
           createdByDisplayName: currentUser?.username,
         },
@@ -470,6 +525,8 @@ export default function ProjectDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'revisions'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2-purchase-orders-bypass'] });
       setLinkPoId('');
+      setLinkPoItemId('');
+      setLinkBillingBucketId('');
       setLinkPoSearch('');
       setLinkPoReason('');
       setShowManualLink(false);
@@ -478,6 +535,16 @@ export default function ProjectDetailPage() {
       toast({ title: 'Link failed', description: err?.message || 'Failed to link PO.', variant: 'destructive' });
     },
   });
+
+  const linkSelectedPo = (poIdValue: string, reason?: string) => {
+    if (!poIdValue) return;
+    linkPoMutation.mutate({
+      poId: parseInt(poIdValue, 10),
+      poItemId: linkPoItemId ? parseInt(linkPoItemId, 10) : null,
+      billingAllocationId: linkBillingBucketId || null,
+      reason,
+    });
+  };
 
   const { data: projectRevisions = [] } = useQuery<ProjectRevision[]>({
     queryKey: ['/api/projects', id, 'revisions'],
@@ -2630,15 +2697,68 @@ export default function ProjectDetailPage() {
                           <p className="font-mono font-semibold text-blue-950">{suggestedPo.poNumber}</p>
                           <p className="text-sm text-blue-800">{suggestedPo.customerName}</p>
                         </div>
+                        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                          <div className="space-y-2">
+                            <Label>PO Item</Label>
+                            <Select
+                              value={linkPoItemId}
+                              onValueChange={(value) => {
+                                setLinkPoItemId(value);
+                                setLinkBillingBucketId('');
+                              }}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select an item from this PO" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {poItemOptions.map(item => (
+                                  <SelectItem key={item.id} value={item.id.toString()}>
+                                    {item.partNumber} - {item.partName} ({item.quantity})
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="space-y-2">
+                            <Label>CLIN / Bucket</Label>
+                            <Select
+                              value={linkBillingBucketId}
+                              onValueChange={setLinkBillingBucketId}
+                              disabled={!linkPoItemId}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder={linkPoItemId ? 'Select a bucket from this PO' : 'Choose a PO item first'} />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {billingBucketOptions.map(bucket => (
+                                  <SelectItem key={bucket.id} value={bucket.id}>
+                                    {bucket.bucketLabel}{bucket.customerPoLine ? ` - ${bucket.customerPoLine}` : ''}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            {linkPoItemId && billingBucketOptions.length === 0 && (
+                              <p className="text-xs text-amber-700">No active CLIN/bucket allocations are set up for this PO item.</p>
+                            )}
+                          </div>
+                        </div>
                         <div className="flex gap-2">
                           <Button
                             size="sm"
-                            onClick={() => linkPoMutation.mutate({ poId: suggestedPo.id })}
-                            disabled={linkPoMutation.isPending}
+                            onClick={() => linkSelectedPo(suggestedPo.id.toString())}
+                            disabled={linkPoMutation.isPending || !linkPoItemId || !linkBillingBucketId}
                           >
                             {linkPoMutation.isPending ? 'Linking...' : 'Accept'}
                           </Button>
-                          <Button size="sm" variant="outline" onClick={() => setShowManualLink(true)}>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                              setShowManualLink(true);
+                              setLinkPoItemId('');
+                              setLinkBillingBucketId('');
+                            }}
+                          >
                             Choose Different
                           </Button>
                         </div>
@@ -2646,7 +2766,17 @@ export default function ProjectDetailPage() {
                     ) : (
                       <div className="space-y-3">
                         {showManualLink && suggestedPo && (
-                          <Button variant="ghost" size="sm" className="text-muted-foreground -mb-1" onClick={() => setShowManualLink(false)}>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-muted-foreground -mb-1"
+                            onClick={() => {
+                              setShowManualLink(false);
+                              setLinkPoId('');
+                              setLinkPoItemId('');
+                              setLinkBillingBucketId('');
+                            }}
+                          >
                             Back to suggestion
                           </Button>
                         )}
@@ -2660,7 +2790,14 @@ export default function ProjectDetailPage() {
                         </div>
                         <div className="space-y-2">
                           <Label>Purchase Order</Label>
-                          <Select value={linkPoId} onValueChange={setLinkPoId}>
+                          <Select
+                            value={linkPoId}
+                            onValueChange={(value) => {
+                              setLinkPoId(value);
+                              setLinkPoItemId('');
+                              setLinkBillingBucketId('');
+                            }}
+                          >
                             <SelectTrigger>
                               <SelectValue placeholder="Select a purchase order" />
                             </SelectTrigger>
@@ -2679,9 +2816,55 @@ export default function ProjectDetailPage() {
                             </SelectContent>
                           </Select>
                         </div>
+                        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                          <div className="space-y-2">
+                            <Label>PO Item</Label>
+                            <Select
+                              value={linkPoItemId}
+                              onValueChange={(value) => {
+                                setLinkPoItemId(value);
+                                setLinkBillingBucketId('');
+                              }}
+                              disabled={!linkPoId}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder={linkPoId ? 'Select an item from this PO' : 'Choose a PO first'} />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {poItemOptions.map(item => (
+                                  <SelectItem key={item.id} value={item.id.toString()}>
+                                    {item.partNumber} - {item.partName} ({item.quantity})
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="space-y-2">
+                            <Label>CLIN / Bucket</Label>
+                            <Select
+                              value={linkBillingBucketId}
+                              onValueChange={setLinkBillingBucketId}
+                              disabled={!linkPoItemId}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder={linkPoItemId ? 'Select a bucket from this PO' : 'Choose a PO item first'} />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {billingBucketOptions.map(bucket => (
+                                  <SelectItem key={bucket.id} value={bucket.id}>
+                                    {bucket.bucketLabel}{bucket.customerPoLine ? ` - ${bucket.customerPoLine}` : ''}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            {linkPoItemId && billingBucketOptions.length === 0 && (
+                              <p className="text-xs text-amber-700">No active CLIN/bucket allocations are set up for this PO item.</p>
+                            )}
+                          </div>
+                        </div>
                         <Button
-                          disabled={!linkPoId || linkPoMutation.isPending}
-                          onClick={() => linkPoMutation.mutate({ poId: parseInt(linkPoId, 10) })}
+                          disabled={!linkPoId || !linkPoItemId || !linkBillingBucketId || linkPoMutation.isPending}
+                          onClick={() => linkSelectedPo(linkPoId)}
                         >
                           {linkPoMutation.isPending ? 'Linking...' : 'Link PO'}
                         </Button>
@@ -2862,14 +3045,66 @@ export default function ProjectDetailPage() {
                         <p className="text-xs text-blue-500 dark:text-blue-400">Matched on customer</p>
                       )}
                     </div>
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label>PO Item</Label>
+                        <Select
+                          value={linkPoItemId}
+                          onValueChange={(value) => {
+                            setLinkPoItemId(value);
+                            setLinkBillingBucketId('');
+                          }}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select an item from this PO" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {poItemOptions.map(item => (
+                              <SelectItem key={item.id} value={item.id.toString()}>
+                                {item.partNumber} - {item.partName} ({item.quantity})
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label>CLIN / Bucket</Label>
+                        <Select
+                          value={linkBillingBucketId}
+                          onValueChange={setLinkBillingBucketId}
+                          disabled={!linkPoItemId}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder={linkPoItemId ? 'Select a bucket from this PO' : 'Choose a PO item first'} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {billingBucketOptions.map(bucket => (
+                              <SelectItem key={bucket.id} value={bucket.id}>
+                                {bucket.bucketLabel}{bucket.customerPoLine ? ` - ${bucket.customerPoLine}` : ''}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        {linkPoItemId && billingBucketOptions.length === 0 && (
+                          <p className="text-xs text-amber-700">No active CLIN/bucket allocations are set up for this PO item.</p>
+                        )}
+                      </div>
+                    </div>
                     <div className="flex gap-2">
                       <Button
-                        onClick={() => linkPoMutation.mutate({ poId: suggestedPo.id })}
-                        disabled={linkPoMutation.isPending}
+                        onClick={() => linkSelectedPo(suggestedPo.id.toString())}
+                        disabled={linkPoMutation.isPending || !linkPoItemId || !linkBillingBucketId}
                       >
                         {linkPoMutation.isPending ? 'Linking…' : 'Accept'}
                       </Button>
-                      <Button variant="outline" onClick={() => setShowManualLink(true)}>
+                      <Button
+                        variant="outline"
+                        onClick={() => {
+                          setShowManualLink(true);
+                          setLinkPoItemId('');
+                          setLinkBillingBucketId('');
+                        }}
+                      >
                         Choose Different
                       </Button>
                     </div>
@@ -2877,7 +3112,17 @@ export default function ProjectDetailPage() {
                 ) : (
                   <div className="space-y-4">
                     {showManualLink && suggestedPo && (
-                      <Button variant="ghost" size="sm" className="text-muted-foreground -mb-2" onClick={() => setShowManualLink(false)}>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-muted-foreground -mb-2"
+                        onClick={() => {
+                          setShowManualLink(false);
+                          setLinkPoId('');
+                          setLinkPoItemId('');
+                          setLinkBillingBucketId('');
+                        }}
+                      >
                         ← Back to suggestion
                       </Button>
                     )}
@@ -2891,7 +3136,14 @@ export default function ProjectDetailPage() {
                     </div>
                     <div className="space-y-2">
                       <Label>Purchase Order</Label>
-                      <Select value={linkPoId} onValueChange={setLinkPoId}>
+                      <Select
+                        value={linkPoId}
+                        onValueChange={(value) => {
+                          setLinkPoId(value);
+                          setLinkPoItemId('');
+                          setLinkBillingBucketId('');
+                        }}
+                      >
                         <SelectTrigger>
                           <SelectValue placeholder="Select a purchase order" />
                         </SelectTrigger>
@@ -2909,6 +3161,52 @@ export default function ProjectDetailPage() {
                         </SelectContent>
                       </Select>
                     </div>
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label>PO Item</Label>
+                        <Select
+                          value={linkPoItemId}
+                          onValueChange={(value) => {
+                            setLinkPoItemId(value);
+                            setLinkBillingBucketId('');
+                          }}
+                          disabled={!linkPoId}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder={linkPoId ? 'Select an item from this PO' : 'Choose a PO first'} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {poItemOptions.map(item => (
+                              <SelectItem key={item.id} value={item.id.toString()}>
+                                {item.partNumber} - {item.partName} ({item.quantity})
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label>CLIN / Bucket</Label>
+                        <Select
+                          value={linkBillingBucketId}
+                          onValueChange={setLinkBillingBucketId}
+                          disabled={!linkPoItemId}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder={linkPoItemId ? 'Select a bucket from this PO' : 'Choose a PO item first'} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {billingBucketOptions.map(bucket => (
+                              <SelectItem key={bucket.id} value={bucket.id}>
+                                {bucket.bucketLabel}{bucket.customerPoLine ? ` - ${bucket.customerPoLine}` : ''}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        {linkPoItemId && billingBucketOptions.length === 0 && (
+                          <p className="text-xs text-amber-700">No active CLIN/bucket allocations are set up for this PO item.</p>
+                        )}
+                      </div>
+                    </div>
                     <div className="space-y-2">
                       <Label>Revision Reason</Label>
                       <Textarea
@@ -2918,8 +3216,8 @@ export default function ProjectDetailPage() {
                       />
                     </div>
                     <Button
-                      disabled={!linkPoId || linkPoMutation.isPending}
-                      onClick={() => linkPoMutation.mutate({ poId: parseInt(linkPoId), reason: linkPoReason })}
+                      disabled={!linkPoId || !linkPoItemId || !linkBillingBucketId || linkPoMutation.isPending}
+                      onClick={() => linkSelectedPo(linkPoId, linkPoReason)}
                     >
                       {linkPoMutation.isPending ? 'Linking…' : 'Link PO'}
                     </Button>
@@ -2986,6 +3284,8 @@ export default function ProjectDetailPage() {
                             onClick={() => {
                               setShowManualLink(false);
                               setLinkPoId('');
+                              setLinkPoItemId('');
+                              setLinkBillingBucketId('');
                               setLinkPoReason('');
                             }}
                           >
@@ -2995,7 +3295,14 @@ export default function ProjectDetailPage() {
                         <div className="grid gap-3 md:grid-cols-2">
                           <div className="space-y-2">
                             <Label>New P2 PO</Label>
-                            <Select value={linkPoId} onValueChange={setLinkPoId}>
+                            <Select
+                              value={linkPoId}
+                              onValueChange={(value) => {
+                                setLinkPoId(value);
+                                setLinkPoItemId('');
+                                setLinkBillingBucketId('');
+                              }}
+                            >
                               <SelectTrigger>
                                 <SelectValue placeholder="Select replacement PO" />
                               </SelectTrigger>
@@ -3011,6 +3318,50 @@ export default function ProjectDetailPage() {
                             </Select>
                           </div>
                           <div className="space-y-2">
+                            <Label>PO Item</Label>
+                            <Select
+                              value={linkPoItemId}
+                              onValueChange={(value) => {
+                                setLinkPoItemId(value);
+                                setLinkBillingBucketId('');
+                              }}
+                              disabled={!linkPoId}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder={linkPoId ? 'Select an item from this PO' : 'Choose a PO first'} />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {poItemOptions.map(item => (
+                                  <SelectItem key={item.id} value={item.id.toString()}>
+                                    {item.partNumber} - {item.partName} ({item.quantity})
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="space-y-2">
+                            <Label>CLIN / Bucket</Label>
+                            <Select
+                              value={linkBillingBucketId}
+                              onValueChange={setLinkBillingBucketId}
+                              disabled={!linkPoItemId}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder={linkPoItemId ? 'Select a bucket from this PO' : 'Choose a PO item first'} />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {billingBucketOptions.map(bucket => (
+                                  <SelectItem key={bucket.id} value={bucket.id}>
+                                    {bucket.bucketLabel}{bucket.customerPoLine ? ` - ${bucket.customerPoLine}` : ''}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            {linkPoItemId && billingBucketOptions.length === 0 && (
+                              <p className="text-xs text-amber-700">No active CLIN/bucket allocations are set up for this PO item.</p>
+                            )}
+                          </div>
+                          <div className="space-y-2">
                             <Label>Required Reason</Label>
                             <Textarea
                               placeholder="Why is this project moving to a different production PO?"
@@ -3020,8 +3371,8 @@ export default function ProjectDetailPage() {
                           </div>
                         </div>
                         <Button
-                          disabled={!linkPoId || linkPoReason.trim().length < 3 || linkPoMutation.isPending}
-                          onClick={() => linkPoMutation.mutate({ poId: parseInt(linkPoId), reason: linkPoReason })}
+                          disabled={!linkPoId || !linkPoItemId || !linkBillingBucketId || linkPoReason.trim().length < 3 || linkPoMutation.isPending}
+                          onClick={() => linkSelectedPo(linkPoId, linkPoReason)}
                         >
                           {linkPoMutation.isPending ? 'Saving Revision...' : 'Save PO Revision'}
                         </Button>

--- a/server/index.ts
+++ b/server/index.ts
@@ -5061,6 +5061,8 @@ async function initializeBackgroundServices() {
         await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS current_revision_number INTEGER NOT NULL DEFAULT 0`);
         await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS current_revision_label TEXT NOT NULL DEFAULT 'Rev 0'`);
         await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS po_id INTEGER REFERENCES p2_purchase_orders(id)`);
+        await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS p2_po_item_id INTEGER REFERENCES p2_purchase_order_items(id)`);
+        await db.execute(sqlProj`ALTER TABLE projects ADD COLUMN IF NOT EXISTS p2_billing_allocation_id UUID`);
         // Backfill current_stage from current_step_type for existing rows that still have the default
         await db.execute(sqlProj`
           UPDATE projects SET current_stage = CASE current_step_type

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -11661,6 +11661,8 @@ export const projects = pgTable('projects', {
   currentRevisionNumber: integer('current_revision_number').notNull().default(0),
   currentRevisionLabel: text('current_revision_label').notNull().default('Rev 0'),
   poId: integer('po_id').references(() => p2PurchaseOrders.id),
+  p2PoItemId: integer('p2_po_item_id').references(() => p2PurchaseOrderItems.id),
+  p2BillingAllocationId: uuid('p2_billing_allocation_id'),
   projectManagerId: integer('project_manager_id').references(() => employees.id),
   reminderDays: integer('reminder_days').default(3), // Days before reminder is sent for stuck steps
   lastReminderSentAt: timestamp('last_reminder_sent_at'),

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -54,6 +54,14 @@ async function ensureProjectRevisionSchema() {
       ADD COLUMN IF NOT EXISTS current_revision_label TEXT NOT NULL DEFAULT 'Rev 0'
   `);
   await pool.query(`
+    ALTER TABLE projects
+      ADD COLUMN IF NOT EXISTS p2_po_item_id INTEGER REFERENCES p2_purchase_order_items(id)
+  `);
+  await pool.query(`
+    ALTER TABLE projects
+      ADD COLUMN IF NOT EXISTS p2_billing_allocation_id UUID
+  `);
+  await pool.query(`
     CREATE TABLE IF NOT EXISTS project_revisions (
       id SERIAL PRIMARY KEY,
       project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
@@ -100,6 +108,8 @@ async function ensureProjectClinSchema() {
   await pool.query(`CREATE INDEX IF NOT EXISTS project_clins_active_idx ON project_clins(active)`);
   projectClinSchemaReady = true;
 }
+
+const uuidStringSchema = z.string().uuid();
 
 const projectClinBodySchema = z.object({
   clinNumber: z.string().trim().min(1),
@@ -751,11 +761,71 @@ router.post('/:id/revisions', async (req, res) => {
   }
 });
 
+router.get('/:id/po-link-options', async (req, res) => {
+  try {
+    const projectId = req.params.id;
+    const poId = Number(req.query.poId);
+    if (!Number.isFinite(poId) || poId <= 0) {
+      return res.status(400).json({ message: 'poId is required' });
+    }
+
+    const project = await storage.getProject(projectId);
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+
+    const poRows = await pool.query<{ id: number; project_id: string | null }>(
+      `SELECT id, project_id::text FROM p2_purchase_orders WHERE id = $1`,
+      [poId]
+    );
+    if (poRows.length === 0) return res.status(404).json({ message: 'PO not found' });
+    if (poRows[0].project_id && poRows[0].project_id !== projectId) {
+      return res.status(409).json({ message: 'This PO is already assigned to another project' });
+    }
+
+    const poItems = await pool.query(
+      `SELECT id, po_id AS "poId", part_number AS "partNumber", part_name AS "partName", quantity, unit_price AS "unitPrice"
+         FROM p2_purchase_order_items
+        WHERE po_id = $1
+        ORDER BY id`,
+      [poId]
+    );
+
+    const allocationTable = await pool.query<{ exists: string | null }>(
+      `SELECT to_regclass('public.p2_billing_allocations')::text AS exists`
+    );
+
+    let billingBuckets: any[] = [];
+    if (allocationTable[0]?.exists) {
+      billingBuckets = await pool.query(
+        `SELECT id::text,
+                po_id AS "poId",
+                po_item_id AS "poItemId",
+                bucket_label AS "bucketLabel",
+                description,
+                customer_po_line AS "customerPoLine",
+                quantity_authorized AS "quantityAuthorized",
+                unit_price AS "unitPrice"
+           FROM p2_billing_allocations
+          WHERE po_id = $1
+            AND active = true
+          ORDER BY created_at, bucket_label`,
+        [poId]
+      );
+    }
+
+    res.json({ poItems, billingBuckets });
+  } catch (error) {
+    console.error('Error fetching project PO link options:', error);
+    res.status(500).json({ message: 'Failed to fetch PO link options' });
+  }
+});
+
 router.post('/:id/link-po', async (req, res) => {
   try {
     const { id } = req.params;
     const schema = z.object({
       poId: z.number().int().positive(),
+      poItemId: z.number().int().positive().optional().nullable(),
+      billingAllocationId: uuidStringSchema.optional().nullable(),
       reason: z.string().min(3).optional(),
       createdBy: z.number().int().positive().optional(),
       createdByDisplayName: z.string().optional(),
@@ -764,7 +834,7 @@ router.post('/:id/link-po', async (req, res) => {
     if (!parsed.success) {
       return res.status(400).json({ message: 'Invalid request: poId (number) required', errors: parsed.error.errors });
     }
-    const { poId, reason, createdBy, createdByDisplayName } = parsed.data;
+    const { poId, poItemId, billingAllocationId, reason, createdBy, createdByDisplayName } = parsed.data;
 
     const project = await storage.getProject(id);
     if (!project) return res.status(404).json({ message: 'Project not found' });
@@ -785,6 +855,44 @@ router.post('/:id/link-po', async (req, res) => {
     if (poRows.length === 0) return res.status(404).json({ message: 'PO not found' });
     if (poRows[0].project_id && poRows[0].project_id !== id) {
       return res.status(409).json({ message: 'This PO is already assigned to another project' });
+    }
+
+    let poItemLabel: string | null = null;
+    if (poItemId) {
+      const itemRows = await pool.query<{ id: number; part_number: string; part_name: string }>(
+        `SELECT id, part_number, part_name FROM p2_purchase_order_items WHERE id = $1 AND po_id = $2`,
+        [poItemId, poId]
+      );
+      if (itemRows.length === 0) {
+        return res.status(400).json({ message: 'Selected PO item does not belong to this PO' });
+      }
+      poItemLabel = `${itemRows[0].part_number} - ${itemRows[0].part_name}`;
+    }
+
+    let billingBucketLabel: string | null = null;
+    if (billingAllocationId) {
+      const allocationTable = await pool.query<{ exists: string | null }>(
+        `SELECT to_regclass('public.p2_billing_allocations')::text AS exists`
+      );
+      if (!allocationTable[0]?.exists) {
+        return res.status(400).json({ message: 'No CLIN/bucket allocations exist for this PO yet' });
+      }
+
+      const bucketRows = await pool.query<{ id: string; po_item_id: number | null; bucket_label: string }>(
+        `SELECT id::text, po_item_id, bucket_label
+           FROM p2_billing_allocations
+          WHERE id = $1::uuid
+            AND po_id = $2
+            AND active = true`,
+        [billingAllocationId, poId]
+      );
+      if (bucketRows.length === 0) {
+        return res.status(400).json({ message: 'Selected CLIN/bucket does not belong to this PO' });
+      }
+      if (poItemId && bucketRows[0].po_item_id && bucketRows[0].po_item_id !== poItemId) {
+        return res.status(400).json({ message: 'Selected CLIN/bucket does not belong to this PO item' });
+      }
+      billingBucketLabel = bucketRows[0].bucket_label;
     }
 
     // Ensure no other project already uses this poId
@@ -814,6 +922,8 @@ router.post('/:id/link-po', async (req, res) => {
       const updatedRows = await tx.execute(sql`
         UPDATE projects
            SET po_id = ${poId},
+               p2_po_item_id = ${poItemId ?? null},
+               p2_billing_allocation_id = ${billingAllocationId ?? null}::uuid,
                current_revision_number = ${nextRevision},
                current_revision_label = ${revisionLabel},
                updated_at = NOW()
@@ -847,7 +957,15 @@ router.post('/:id/link-po', async (req, res) => {
           ${revisionSummary}, ${revisionReason},
           ${previousPoId}, ${poId},
           ${createdBy ?? null}, ${createdByDisplayName ?? null},
-          ${JSON.stringify({ source: 'project_po_link', previousPoId, newPoId: poId })}::jsonb
+          ${JSON.stringify({
+            source: 'project_po_link',
+            previousPoId,
+            newPoId: poId,
+            poItemId: poItemId ?? null,
+            billingAllocationId: billingAllocationId ?? null,
+            poItemLabel,
+            billingBucketLabel,
+          })}::jsonb
         )
       `);
 
@@ -870,10 +988,21 @@ router.post('/:id/link-po', async (req, res) => {
     await storage.createProjectActivityLog({
       projectId: id,
       activityType: isRelink ? 'project_po_relinked' : 'project_po_linked',
-      description: `${revisionLabel}: ${revisionSummary}`,
+      description: [
+        `${revisionLabel}: ${revisionSummary}`,
+        poItemLabel ? `item ${poItemLabel}` : null,
+        billingBucketLabel ? `bucket ${billingBucketLabel}` : null,
+      ].filter(Boolean).join(', '),
       performedBy: createdBy,
       performedByDisplayName: createdByDisplayName,
-      metadata: { revisionNumber: nextRevision, previousPoId, newPoId: poId, reason: revisionReason },
+      metadata: {
+        revisionNumber: nextRevision,
+        previousPoId,
+        newPoId: poId,
+        poItemId: poItemId ?? null,
+        billingAllocationId: billingAllocationId ?? null,
+        reason: revisionReason,
+      },
     } as any);
 
     res.json(updated);


### PR DESCRIPTION
## Summary
- Add project-level persistence for the selected P2 PO item and billing bucket/CLIN allocation.
- Add a project PO-link options endpoint that returns the selected PO's line items and active billing buckets.
- Update Project Detail PO linking and relinking flows so users choose PO Item and CLIN / Bucket from dropdowns sourced from the selected PO.

## Why
P2 project PO links could be saved with only the PO header. That left the project without the specific PO line and billing bucket context needed downstream.

## Validation
- `git diff --cached --check`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/routes/projects.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/index.ts`
- Bundled Node syntax check: `node --experimental-strip-types --check server/schema.ts`

Full TypeScript check was not available locally because this worktree has no `node_modules` and `npm` is not on PATH.