### PR TITLE
[codex] Route P2 PO revisions through wizard updates

### DIFF
--- a/client/src/components/p2/P2POCreationWizard.tsx
+++ b/client/src/components/p2/P2POCreationWizard.tsx
@@ -82,6 +82,7 @@ interface P2POCreationWizardProps {
   initialProjectId?: string | null;
   initialCustomerId?: string | null;
   sourcePO?: SourcePO | null;
+  existingPoId?: number | null;
 }
 
 const NO_PROJECT_VALUE = '__no_project__';
@@ -125,8 +126,10 @@ export default function P2POCreationWizard({
   initialProjectId,
   initialCustomerId,
   sourcePO,
+  existingPoId,
 }: P2POCreationWizardProps) {
-  const isReviseMode = !!sourcePO;
+  const isReviseMode = !!sourcePO || !!existingPoId;
+  const activeSourcePoId = existingPoId ?? sourcePO?.id ?? null;
   const [currentStep, setCurrentStep] = useState(0);
   const [selectedCustomer, setSelectedCustomer] = useState<any>(null);
   const [poDetails, setPODetails] = useState<z.infer<typeof detailsSchema> | null>(null);
@@ -165,10 +168,20 @@ export default function P2POCreationWizard({
     queryKey: ['/api/projects'],
   });
 
+  const { data: loadedRevisionPO } = useQuery<any>({
+    queryKey: ['/api/p2-purchase-orders', existingPoId],
+    queryFn: () => fetch(`/api/p2-purchase-orders/${existingPoId}`, { credentials: 'include' }).then((r) => {
+      if (!r.ok) throw new Error('Failed to load revised PO');
+      return r.json();
+    }),
+    enabled: !!existingPoId,
+  });
+  const editableSourcePO = loadedRevisionPO || sourcePO || null;
+
   // Fetch source PO items when in revise mode
   const { data: sourcePOItems = [] } = useQuery<any[]>({
-    queryKey: ['/api/p2-purchase-order-items', sourcePO?.id],
-    enabled: !!sourcePO?.id,
+    queryKey: ['/api/p2-purchase-order-items', activeSourcePoId],
+    enabled: !!activeSourcePoId && !loadedRevisionPO?.lineItems,
   });
 
   const openProjects = projects.filter((project) =>
@@ -256,44 +269,45 @@ export default function P2POCreationWizard({
 
   // Pre-populate from sourcePO (revise mode) — wait for all data to load
   useEffect(() => {
-    if (!sourcePO || sourcePrefilled || p2Customers.length === 0 || employees.length === 0) return;
+    if (!editableSourcePO || sourcePrefilled || p2Customers.length === 0 || employees.length === 0) return;
 
     // Customer
-    const customer = p2Customers.find((c: any) => c.customerId === sourcePO.customerId);
+    const customer = p2Customers.find((c: any) => c.customerId === editableSourcePO.customerId);
     if (customer) {
       customerForm.setValue('customerId', customer.id.toString());
       setSelectedCustomer(customer);
     }
 
     // PO Details — strip any -RX revision suffix from PO number for the new revision
-    const basePONumber = sourcePO.poNumber.replace(/-R[A-Z]+$/, '');
+    const basePONumber = existingPoId ? editableSourcePO.poNumber : editableSourcePO.poNumber.replace(/-R[A-Z]+$/, '');
     detailsForm.setValue('customerPONumber', basePONumber);
-    if (sourcePO.expectedDelivery) {
-      detailsForm.setValue('dueDate', sourcePO.expectedDelivery.split('T')[0]);
+    if (editableSourcePO.expectedDelivery) {
+      detailsForm.setValue('dueDate', editableSourcePO.expectedDelivery.split('T')[0]);
     }
-    if (sourcePO.toleranceAuthorizerId) {
-      detailsForm.setValue('toleranceAuthorizer', sourcePO.toleranceAuthorizerId.toString());
+    if (editableSourcePO.toleranceAuthorizerId) {
+      detailsForm.setValue('toleranceAuthorizer', editableSourcePO.toleranceAuthorizerId.toString());
     }
-    if (sourcePO.notes) {
-      detailsForm.setValue('notes', sourcePO.notes);
+    if (editableSourcePO.notes) {
+      detailsForm.setValue('notes', editableSourcePO.notes);
     }
-    if (sourcePO.assignedToId) {
-      detailsForm.setValue('assignedTo', sourcePO.assignedToId.toString());
+    if (editableSourcePO.assignedToId) {
+      detailsForm.setValue('assignedTo', editableSourcePO.assignedToId.toString());
     }
-    if (sourcePO.productionLeadId) {
-      detailsForm.setValue('productionLead', sourcePO.productionLeadId.toString());
+    if (editableSourcePO.productionLeadId) {
+      detailsForm.setValue('productionLead', editableSourcePO.productionLeadId.toString());
     }
-    if (sourcePO.projectId) {
-      detailsForm.setValue('projectId', sourcePO.projectId);
+    if (editableSourcePO.projectId) {
+      detailsForm.setValue('projectId', editableSourcePO.projectId);
     }
 
     setSourcePrefilled(true);
-  }, [sourcePO, p2Customers, employees, sourcePrefilled]);
+  }, [detailsForm, editableSourcePO, existingPoId, p2Customers, employees, sourcePrefilled]);
 
   // Pre-populate line items from source PO items
   useEffect(() => {
-    if (!sourcePO || sourcePOItems.length === 0) return;
-    const items: LineItem[] = sourcePOItems.map((item: any) => {
+    const sourceItems = loadedRevisionPO?.lineItems || loadedRevisionPO?.items || sourcePOItems;
+    if (!editableSourcePO || sourceItems.length === 0) return;
+    const items: LineItem[] = sourceItems.map((item: any) => {
       const revMatch = String(item.partNumber || '').match(/ Rev (.+)$/);
       const sku = String(item.partNumber || '').replace(/ Rev .+$/, '') || '';
       const revision = revMatch?.[1] || 'A';
@@ -309,7 +323,7 @@ export default function P2POCreationWizard({
       };
     });
     setLineItems(items);
-  }, [sourcePO, sourcePOItems]);
+  }, [editableSourcePO, loadedRevisionPO, sourcePOItems]);
 
   const createPOMutation = useMutation({
     mutationFn: async (data: any) => {
@@ -343,29 +357,25 @@ export default function P2POCreationWizard({
 
   const revisePOMutation = useMutation({
     mutationFn: async (data: any) => {
-      const po = await apiRequest(`/api/p2-purchase-orders-bypass/${sourcePO!.id}/revise`, {
-        method: 'POST',
+      if (!activeSourcePoId) throw new Error('No revised PO selected');
+      return apiRequest(`/api/p2-purchase-orders-bypass/${activeSourcePoId}`, {
+        method: 'PUT',
         body: data,
       });
-      await apiRequest(`/api/p2-purchase-orders/${po.id}/lock`, {
-        method: 'POST',
-        body: { employeeId: data.toleranceAuthorizerId || null },
-      });
-      return po;
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['/api/p2-purchase-orders-bypass'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center'] });
       toast({
-        title: 'PO Revision Created & Locked',
-        description: `Revision ${data.poNumber} has been issued and locked.`,
+        title: 'PO Revision Updated',
+        description: `Revision ${data.poNumber} has been updated.`,
       });
       onComplete(data.id);
     },
     onError: (error: Error) => {
       toast({
         title: 'Error',
-        description: error.message || 'Failed to create revision',
+        description: error.message || 'Failed to update revision',
         variant: 'destructive',
       });
     },
@@ -468,6 +478,7 @@ export default function P2POCreationWizard({
       projectId: poDetails?.projectId && poDetails.projectId !== NO_PROJECT_VALUE ? poDetails.projectId : null,
       projectName: poDetails?.projectName || null,
       lineItems: lineItems.map((item) => ({
+        id: Number(item.id) || undefined,
         partNumber: `${item.sku}${item.revision ? ` Rev ${item.revision}` : ''}`,
         description: item.description,
         quantity: item.quantity,
@@ -501,7 +512,7 @@ export default function P2POCreationWizard({
           <div>
             <CardTitle className="flex items-center gap-2">
               {isReviseMode && <GitBranch className="h-5 w-5 text-blue-600" />}
-              {isReviseMode ? 'Revise PO' : 'Create New P2 Order'}
+              {isReviseMode ? 'Edit PO Revision' : 'Create New P2 Order'}
             </CardTitle>
             <CardDescription>
               Step {currentStep + 1} of {steps.length}: {steps[currentStep].title}
@@ -516,11 +527,11 @@ export default function P2POCreationWizard({
           <Alert className="mt-2 border-blue-200 bg-blue-50 dark:bg-blue-950/20">
             <GitBranch className="h-4 w-4 text-blue-600" />
             <AlertDescription className="text-blue-800 dark:text-blue-200">
-              Issuing a new revision of <strong>{sourcePO.poNumber}</strong>
-              {sourcePO.revisionNumber !== undefined && sourcePO.revisionNumber > 0
-                ? ` (Rev ${sourcePO.revisionNumber})`
+              Editing PO revision <strong>{editableSourcePO?.poNumber}</strong>
+              {editableSourcePO?.revisionNumber !== undefined && editableSourcePO.revisionNumber > 0
+                ? ` (Rev ${editableSourcePO.revisionNumber})`
                 : ' (Rev 0 — original)'}
-              . The previous revision will be marked superseded and a new locked revision will be created.
+              . Changes update this revision and keep existing production work tied to it.
             </AlertDescription>
           </Alert>
         )}
@@ -905,11 +916,11 @@ export default function P2POCreationWizard({
                 }
                 <div>
                   <h4 className={`font-medium ${isReviseMode ? 'text-blue-800 dark:text-blue-200' : 'text-amber-800 dark:text-amber-200'}`}>
-                    {isReviseMode ? 'Ready to Issue Revision' : 'Ready to Create Order'}
+                    {isReviseMode ? 'Ready to Update Revision' : 'Ready to Create Order'}
                   </h4>
                   <p className={`text-sm mt-1 ${isReviseMode ? 'text-blue-700 dark:text-blue-300' : 'text-amber-700 dark:text-amber-300'}`}>
                     {isReviseMode
-                      ? `This will create a new locked revision of ${sourcePO.poNumber}. The previous revision will be marked superseded.`
+                      ? `This will update ${editableSourcePO?.poNumber}. Existing project work orders stay attached to this PO revision.`
                       : "Once created, the order will be locked and you'll be prompted to set up BOMs for each part."}
                   </p>
                 </div>
@@ -937,7 +948,7 @@ export default function P2POCreationWizard({
                   {isReviseMode && (
                     <p><span className="text-muted-foreground">New Revision:</span>{' '}
                       <Badge variant="outline" className="border-blue-500 text-blue-700 text-xs">
-                        Rev {(sourcePO.revisionNumber ?? 0) + 1}
+                        Rev {editableSourcePO?.revisionNumber ?? 0}
                       </Badge>
                     </p>
                   )}
@@ -997,8 +1008,8 @@ export default function P2POCreationWizard({
                 className={isReviseMode ? 'bg-blue-600 hover:bg-blue-700' : ''}
               >
                 {isPending
-                  ? (isReviseMode ? 'Issuing Revision...' : 'Creating...')
-                  : (isReviseMode ? 'Issue Revision & Lock' : 'Create Order & Setup BOMs')}
+                  ? (isReviseMode ? 'Updating Revision...' : 'Creating...')
+                  : (isReviseMode ? 'Update Revised PO' : 'Create Order & Setup BOMs')}
                 {isReviseMode ? <GitBranch className="ml-2 h-4 w-4" /> : <Check className="ml-2 h-4 w-4" />}
               </Button>
             </div>

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -102,6 +102,7 @@ export default function P2ControlCenter() {
   const tabFromUrl = urlParams.get('tab');
   const poFromUrl = urlParams.get('po') || undefined;
   const poIdFromUrl = urlParams.get('poId') ? Number(urlParams.get('poId')) : null;
+  const editPoIdFromUrl = urlParams.get('editPoId') ? Number(urlParams.get('editPoId')) : null;
   const unitsFromUrl = urlParams.get('units') || undefined;
   // Project context: passed from PM/WAD project workflow cards
   const wadProjectId = urlParams.get('projectId') || '';
@@ -122,6 +123,7 @@ export default function P2ControlCenter() {
   const [showBOMWizard, setShowBOMWizard] = useState(false);
   const [selectedPOForBOM, setSelectedPOForBOM] = useState<number | null>(null);
   const [selectedPOIds, setSelectedPOIds] = useState<number[]>([]);
+  const [editingPOId, setEditingPOId] = useState<number | null>(editPoIdFromUrl);
 
   const { data: stats } = useQuery<P2Stats>({
     queryKey: ['/api/p2/control-center/stats'],
@@ -216,8 +218,24 @@ export default function P2ControlCenter() {
     setSelectedPOIds([]);
   };
 
+  useEffect(() => {
+    if (!editPoIdFromUrl || !Number.isFinite(editPoIdFromUrl)) return;
+    setEditingPOId(editPoIdFromUrl);
+    setShowBOMWizard(false);
+    setSelectedPOForBOM(null);
+    setShowPOWizard(true);
+  }, [editPoIdFromUrl]);
+
   const handlePOCreated = (poId: number) => {
     setShowPOWizard(false);
+    if (editingPOId) {
+      setEditingPOId(null);
+      setSelectedPOIds([poId]);
+      queryClient.invalidateQueries({ queryKey: ['/api/p2-purchase-orders-bypass'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/po-statuses'] });
+      setActiveTab('setup');
+      return;
+    }
     setSelectedPOForBOM(poId);
     setShowBOMWizard(true);
   };
@@ -266,8 +284,12 @@ export default function P2ControlCenter() {
     return (
       <div className="container mx-auto p-6">
         <P2POCreationWizard 
+          existingPoId={editingPOId}
           onComplete={handlePOCreated}
-          onCancel={() => setShowPOWizard(false)}
+          onCancel={() => {
+            setShowPOWizard(false);
+            setEditingPOId(null);
+          }}
         />
       </div>
     );

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -662,7 +662,7 @@ export default function ProjectDetailPage() {
           createdByDisplayName: currentUser?.username,
         },
       }),
-    onSuccess: () => {
+    onSuccess: (createdRevision: ProjectRevision) => {
       queryClient.invalidateQueries({ queryKey: ['/api/projects', id] });
       queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'revisions'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2-purchase-orders-bypass'] });
@@ -676,6 +676,9 @@ export default function ProjectDetailPage() {
         revisedLineItems: [],
       });
       toast({ title: 'Revision created', description: 'Project revision history was updated.' });
+      if (createdRevision?.has_po_change && createdRevision.new_po_id) {
+        setLocation(`/p2-control-center?tab=setup&projectId=${encodeURIComponent(id || '')}&editPoId=${encodeURIComponent(String(createdRevision.new_po_id))}`);
+      }
     },
     onError: (err: any) => toast({ title: 'Revision failed', description: err?.message || 'Could not create revision.', variant: 'destructive' }),
   });
@@ -3216,7 +3219,7 @@ export default function ProjectDetailPage() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => setLocation(`/p2-control-center?tab=pos&search=${encodeURIComponent(revision.new_po_number || String(revision.new_po_id))}`)}
+                          onClick={() => setLocation(`/p2-control-center?tab=setup&projectId=${encodeURIComponent(project.id)}&editPoId=${encodeURIComponent(String(revision.new_po_id))}`)}
                         >
                           <Edit className="h-4 w-4 mr-2" />
                           Edit Revised PO

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2956,22 +2956,24 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   // SECURITY: softAuth enforces authentication in production
   app.put('/api/p2-purchase-orders-bypass/:id', softAuth, async (req, res) => {
     try {
-      console.log('🔧 P2 PURCHASE ORDER UPDATE BYPASS ROUTE CALLED');
+      console.log('P2 PURCHASE ORDER UPDATE BYPASS ROUTE CALLED');
       const { storage } = await import('../../storage');
       const { id } = req.params;
-      const poData = req.body;
-      if (poData.contractReviewRole && !['primary', 'secondary'].includes(poData.contractReviewRole)) {
+      const poId = parseInt(id, 10);
+      const body = req.body || {};
+
+      if (body.contractReviewRole && !['primary', 'secondary'].includes(body.contractReviewRole)) {
         return res.status(400).json({
           error: 'contractReviewRole must be primary or secondary',
         });
       }
-      
-      const existingPO = await storage.getP2PurchaseOrder(parseInt(id));
+
+      const existingPO = await storage.getP2PurchaseOrder(poId);
       if (!existingPO) {
         return res.status(404).json({ error: 'PO not found' });
       }
-      
-      // STATE GUARD: Superseded revisions are permanent audit history — read-only
+
+      // STATE GUARD: Superseded revisions are permanent audit history - read-only
       if (existingPO.isCurrentRevision === false) {
         return res.status(403).json({
           error: 'This PO has been superseded by a newer revision and cannot be modified',
@@ -2984,36 +2986,95 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         return res.status(403).json({
           error: 'This PO has been locked and cannot be modified',
           lockedAt: existingPO.lockedAt,
-          lockedBy: existingPO.lockedBy
+          lockedBy: existingPO.lockedBy,
         });
       }
-      
+
       // STATE GUARD: Cannot modify CLOSED or CANCELED POs
       if (existingPO.status === 'CLOSED' || existingPO.status === 'CANCELED') {
         return res.status(400).json({
           error: `Cannot modify a ${existingPO.status} PO`,
-          currentStatus: existingPO.status
+          currentStatus: existingPO.status,
         });
       }
-      
+
       // STATE GUARD: Cannot move to CLOSED unless BOM is configured
-      if (poData.status === 'CLOSED' && !existingPO.bomConfigured) {
+      if (body.status === 'CLOSED' && !existingPO.bomConfigured) {
         return res.status(400).json({
           error: 'Cannot close PO - BOM has not been configured',
-          guard: 'BOM_REQUIRED'
+          guard: 'BOM_REQUIRED',
         });
       }
-      
-      const po = await storage.updateP2PurchaseOrder(parseInt(id), poData);
-      console.log('🔧 Updated P2 purchase order:', po.id);
+
+      const customerId = body.customerId || existingPO.customerId;
+      const customer = customerId ? await storage.getP2CustomerByCustomerId(customerId) : null;
+      const poData = {
+        poNumber: body.customerPONumber || body.poNumber || existingPO.poNumber,
+        customerId: customer?.customerId || customerId,
+        customerName: customer?.customerName || body.customerName || existingPO.customerName,
+        poDate: body.poDate || existingPO.poDate || new Date().toISOString().split('T')[0],
+        expectedDelivery: body.dueDate || body.expectedDelivery || existingPO.expectedDelivery || null,
+        status: body.status || existingPO.status || 'OPEN',
+        notes: body.notes ?? body.toleranceNotes ?? existingPO.notes ?? null,
+        toleranceAuthorizerId: body.toleranceAuthorizerId || null,
+        toleranceAuthorizerName: body.toleranceAuthorizerName || null,
+        toleranceNotes: body.toleranceNotes ?? body.notes ?? null,
+        assignedToId: body.assignedToId && body.assignedToId !== 'none' ? parseInt(String(body.assignedToId)) : null,
+        assignedToName: body.assignedToName || null,
+        productionLeadId: body.productionLeadId && body.productionLeadId !== 'none' ? parseInt(String(body.productionLeadId)) : null,
+        productionLeadName: body.productionLeadName || null,
+        sourceQuoteId: body.sourceQuoteId || existingPO.sourceQuoteId || null,
+        contractReviewRole: body.contractReviewRole === 'primary' ? 'primary' : 'secondary',
+        projectId: body.projectId || null,
+        projectName: body.projectName || null,
+      };
+
+      const po = await storage.updateP2PurchaseOrder(poId, poData);
+
+      if (Array.isArray(body.lineItems)) {
+        const existingItems = await storage.getP2PurchaseOrderItems(poId);
+        const existingById = new Map(existingItems.map((item: any) => [Number(item.id), item]));
+        const seenItemIds = new Set<number>();
+
+        for (const item of body.lineItems) {
+          const itemId = Number(item.id);
+          const itemData = {
+            poId,
+            inventoryItemId: item.inventoryItemId || null,
+            partNumber: item.partNumber,
+            partName: item.description || item.partName || item.partNumber,
+            quantity: Number(item.quantity) || 1,
+            unitPrice: Number(item.unitPrice) || 0,
+          };
+
+          if (itemId && existingById.has(itemId)) {
+            seenItemIds.add(itemId);
+            await storage.updateP2PurchaseOrderItem(itemId, itemData);
+          } else {
+            const created = await storage.createP2PurchaseOrderItem(itemData);
+            seenItemIds.add(created.id);
+          }
+        }
+
+        for (const existingItem of existingItems) {
+          if (!seenItemIds.has(Number(existingItem.id))) {
+            try {
+              await storage.deleteP2PurchaseOrderItem(existingItem.id);
+            } catch (deleteError) {
+              console.warn('Skipped deleting revised PO item with downstream references:', existingItem.id, deleteError);
+            }
+          }
+        }
+      }
+
+      console.log('Updated P2 purchase order:', po.id);
       res.json(po);
     } catch (_error) {
-      console.error('🔧 P2 purchase order update bypass _error:', _error);
-      res
-        .status(500)
-        .json({
-          _error: 'Failed to update P2 purchase order via bypass route',
-        });
+      console.error('P2 purchase order update bypass error:', _error);
+      res.status(500).json({
+        _error: 'Failed to update P2 purchase order via bypass route',
+        message: _error instanceof Error ? _error.message : 'Unknown error',
+      });
     }
   });
 

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -663,6 +663,7 @@ router.post('/:id/revisions', async (req, res) => {
       revisedPoNumber: z.string().trim().min(1).optional(),
       revisedDueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
       revisedLineItems: z.array(z.object({
+        id: z.union([z.number().int().positive(), z.string()]).optional(),
         inventoryItemId: z.number().int().positive().nullable().optional(),
         partNumber: z.string().trim().min(1),
         partName: z.string().trim().min(1),
@@ -722,7 +723,10 @@ router.post('/:id/revisions', async (req, res) => {
         {
           poNumber: data.revisedPoNumber,
           expectedDelivery: data.revisedDueDate,
-          lineItems: data.revisedLineItems,
+          lineItems: data.revisedLineItems.map((item) => ({
+            ...item,
+            sourceItemId: Number.isFinite(Number(item.id)) ? Number(item.id) : undefined,
+          })),
         }
       );
       newPoId = revisedPo.id;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1893,6 +1893,7 @@ export interface IStorage {
       poNumber?: string;
       expectedDelivery?: string;
       lineItems?: Array<{
+        sourceItemId?: number;
         inventoryItemId?: number | null;
         partNumber: string;
         partName: string;
@@ -15621,6 +15622,7 @@ export class DatabaseStorage implements IStorage {
       poNumber?: string;
       expectedDelivery?: string;
       lineItems?: Array<{
+        sourceItemId?: number;
         inventoryItemId?: number | null;
         partNumber: string;
         partName: string;
@@ -15723,6 +15725,7 @@ export class DatabaseStorage implements IStorage {
       const revisedItems = overrides?.lineItems?.length
         ? overrides.lineItems
         : originalItems.map((item) => ({
+            sourceItemId: item.id,
             inventoryItemId: item.inventoryItemId,
             partNumber: item.partNumber,
             partName: item.partName,
@@ -15732,10 +15735,11 @@ export class DatabaseStorage implements IStorage {
             notes: item.notes,
           }));
 
+      const itemIdMap = new Map<number, number>();
       for (const item of revisedItems) {
         const quantity = Number(item.quantity) || 1;
         const unitPrice = Number(item.unitPrice) || 0;
-        await tx.insert(p2PurchaseOrderItems).values({
+        const [copiedItem] = await tx.insert(p2PurchaseOrderItems).values({
           poId: newRevision.id,
           inventoryItemId: item.inventoryItemId ?? null,
           partNumber: item.partNumber,
@@ -15745,8 +15749,46 @@ export class DatabaseStorage implements IStorage {
           totalPrice: quantity * unitPrice,
           specifications: item.specifications ?? null,
           notes: item.notes ?? null,
-        });
+        }).returning({ id: p2PurchaseOrderItems.id });
+
+        if (item.sourceItemId) {
+          itemIdMap.set(item.sourceItemId, copiedItem.id);
+        }
       }
+
+      for (const [oldItemId, newItemId] of itemIdMap.entries()) {
+        await tx
+          .update(p2ProductionOrders)
+          .set({ p2PoId: newRevision.id, p2PoItemId: newItemId, updatedAt: new Date() })
+          .where(and(
+            eq(p2ProductionOrders.p2PoId, originalPO.id),
+            eq(p2ProductionOrders.p2PoItemId, oldItemId)
+          ));
+
+        await tx
+          .update(p2SerializedItems)
+          .set({ poId: newRevision.id, poItemId: newItemId, updatedAt: new Date() })
+          .where(and(
+            eq(p2SerializedItems.poId, originalPO.id),
+            eq(p2SerializedItems.poItemId, oldItemId)
+          ));
+
+        await tx.execute(sql`
+          UPDATE manufacturing_queue
+             SET p2_po_id = ${newRevision.id},
+                 p2_po_item_id = ${newItemId},
+                 updated_at = NOW()
+           WHERE p2_po_id = ${originalPO.id}
+             AND p2_po_item_id = ${oldItemId}
+        `);
+      }
+
+      await tx.execute(sql`
+        UPDATE program_builds
+           SET p2_purchase_order_id = ${newRevision.id},
+               updated_at = NOW()
+         WHERE p2_purchase_order_id = ${originalPO.id}
+      `);
 
       return newRevision;
     });


### PR DESCRIPTION
## Summary
- Routes PO-change project revisions directly into the P2 PO wizard using the copied revision PO id.
- Converts the wizard revision flow from creating another revision to updating the already-created revised PO and its line items.
- Relinks existing P2 production, serialized item, manufacturing queue, and program build records from the previous PO/item ids to the copied revision PO/item ids.

## Why
When a P2 project PO needed revision, users were sent back to PO search/listing and the wizard revision path could create another PO/work-order path. The intended flow is: create the project revision, open that revised PO in the wizard, and have changes modify the existing project production work rather than creating duplicate work.

## Validation
- `git diff --check`
- Source review of changed P2 project revision, PO wizard, PO update route, and revision storage paths

Full `npm run check` was not available because this shell/worktree does not have `npm`, `tsc`, or local `node_modules` on PATH.