### PR TITLE
[codex] Fix P2 PO revision work transfer

### DIFF
--- a/migrations/0174_repair_p2_po_revision_work_transfer.sql
+++ b/migrations/0174_repair_p2_po_revision_work_transfer.sql
@@ -1,0 +1,372 @@
+-- Repair P2 PO revision work transfer.
+--
+-- When a PO revision is created after production has started, the current
+-- revision should carry the serialized units and P2 production orders from
+-- the superseded PO. If a full fresh set was already generated on the current
+-- revision, remove only the matching unstarted duplicates first. Quantity
+-- increases remain as pending rows on the new revision.
+
+BEGIN;
+
+WITH revision_families AS (
+  SELECT
+    current_po.id AS new_po_id,
+    current_po.po_number AS new_po_number,
+    COALESCE(current_po.parent_po_id, current_po.id) AS root_po_id
+  FROM p2_purchase_orders current_po
+  WHERE current_po.is_current_revision IS TRUE
+    AND current_po.parent_po_id IS NOT NULL
+),
+old_pos AS (
+  SELECT
+    old_po.id AS old_po_id,
+    rf.new_po_id,
+    rf.new_po_number
+  FROM revision_families rf
+  JOIN p2_purchase_orders old_po
+    ON old_po.id = rf.root_po_id
+    OR old_po.parent_po_id = rf.root_po_id
+  WHERE old_po.id <> rf.new_po_id
+    AND old_po.is_current_revision IS FALSE
+),
+old_items AS (
+  SELECT
+    op.old_po_id,
+    op.new_po_id,
+    op.new_po_number,
+    poi.id AS old_item_id,
+    LOWER(TRIM(poi.part_number)) AS part_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY op.old_po_id, LOWER(TRIM(poi.part_number))
+      ORDER BY poi.id
+    ) AS part_rank
+  FROM old_pos op
+  JOIN p2_purchase_order_items poi ON poi.po_id = op.old_po_id
+),
+new_items AS (
+  SELECT
+    rf.new_po_id,
+    poi.id AS new_item_id,
+    LOWER(TRIM(poi.part_number)) AS part_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY rf.new_po_id, LOWER(TRIM(poi.part_number))
+      ORDER BY poi.id
+    ) AS part_rank
+  FROM revision_families rf
+  JOIN p2_purchase_order_items poi ON poi.po_id = rf.new_po_id
+),
+item_map AS (
+  SELECT
+    oi.old_po_id,
+    oi.new_po_id,
+    oi.new_po_number,
+    oi.old_item_id,
+    ni.new_item_id
+  FROM old_items oi
+  JOIN new_items ni
+    ON ni.new_po_id = oi.new_po_id
+   AND ni.part_key = oi.part_key
+   AND ni.part_rank = oi.part_rank
+),
+old_serialized AS (
+  SELECT
+    psi.id,
+    psi.sequence_number,
+    im.old_po_id,
+    im.new_po_id,
+    im.new_po_number,
+    im.old_item_id,
+    im.new_item_id
+  FROM item_map im
+  JOIN p2_serialized_items psi
+    ON psi.po_id = im.old_po_id
+   AND psi.po_item_id = im.old_item_id
+),
+deleted_new_serialized AS (
+  DELETE FROM p2_serialized_items new_psi
+  USING old_serialized old_psi
+  WHERE new_psi.po_id = old_psi.new_po_id
+    AND new_psi.po_item_id = old_psi.new_item_id
+    AND new_psi.sequence_number = old_psi.sequence_number
+    AND COALESCE(UPPER(new_psi.status), '') = 'ACTIVE'
+    AND COALESCE(new_psi.current_stage_index, 0) = 0
+    AND LOWER(TRIM(COALESCE(new_psi.current_department, ''))) = 'pending layup'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM travelers t
+      WHERE t.serial_number IS NOT NULL
+        AND LOWER(TRIM(t.serial_number)) = LOWER(TRIM(new_psi.serial_number))
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM p2_serialized_item_events e
+      WHERE e.serialized_item_id = new_psi.id
+        AND COALESCE(UPPER(e.event_type), '') NOT IN ('', 'GENERATED')
+    )
+  RETURNING new_psi.id
+)
+UPDATE p2_serialized_items psi
+SET po_id = old_psi.new_po_id,
+    po_item_id = old_psi.new_item_id,
+    po_number = old_psi.new_po_number,
+    updated_at = NOW()
+FROM old_serialized old_psi
+WHERE psi.id = old_psi.id
+  AND psi.po_id = old_psi.old_po_id
+  AND psi.po_item_id = old_psi.old_item_id;
+
+WITH revision_families AS (
+  SELECT
+    current_po.id AS new_po_id,
+    COALESCE(current_po.parent_po_id, current_po.id) AS root_po_id
+  FROM p2_purchase_orders current_po
+  WHERE current_po.is_current_revision IS TRUE
+    AND current_po.parent_po_id IS NOT NULL
+),
+old_pos AS (
+  SELECT old_po.id AS old_po_id, rf.new_po_id
+  FROM revision_families rf
+  JOIN p2_purchase_orders old_po
+    ON old_po.id = rf.root_po_id
+    OR old_po.parent_po_id = rf.root_po_id
+  WHERE old_po.id <> rf.new_po_id
+    AND old_po.is_current_revision IS FALSE
+),
+old_items AS (
+  SELECT
+    op.old_po_id,
+    op.new_po_id,
+    poi.id AS old_item_id,
+    LOWER(TRIM(poi.part_number)) AS part_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY op.old_po_id, LOWER(TRIM(poi.part_number))
+      ORDER BY poi.id
+    ) AS part_rank
+  FROM old_pos op
+  JOIN p2_purchase_order_items poi ON poi.po_id = op.old_po_id
+),
+new_items AS (
+  SELECT
+    rf.new_po_id,
+    poi.id AS new_item_id,
+    LOWER(TRIM(poi.part_number)) AS part_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY rf.new_po_id, LOWER(TRIM(poi.part_number))
+      ORDER BY poi.id
+    ) AS part_rank
+  FROM revision_families rf
+  JOIN p2_purchase_order_items poi ON poi.po_id = rf.new_po_id
+),
+item_map AS (
+  SELECT
+    oi.old_po_id,
+    oi.new_po_id,
+    oi.old_item_id,
+    ni.new_item_id
+  FROM old_items oi
+  JOIN new_items ni
+    ON ni.new_po_id = oi.new_po_id
+   AND ni.part_key = oi.part_key
+   AND ni.part_rank = oi.part_rank
+),
+old_orders AS (
+  SELECT
+    p2po.id,
+    im.old_po_id,
+    im.new_po_id,
+    im.old_item_id,
+    im.new_item_id,
+    p2po.sku,
+    p2po.department,
+    p2po.bom_definition_id,
+    p2po.bom_item_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY im.old_po_id, im.old_item_id, p2po.sku, p2po.department,
+                   p2po.bom_definition_id, p2po.bom_item_id
+      ORDER BY p2po.id
+    ) AS work_rank
+  FROM item_map im
+  JOIN p2_production_orders p2po
+    ON p2po.p2_po_id = im.old_po_id
+   AND p2po.p2_po_item_id = im.old_item_id
+),
+new_unstarted_orders AS (
+  SELECT
+    p2po.id,
+    im.new_po_id,
+    im.new_item_id,
+    p2po.sku,
+    p2po.department,
+    p2po.bom_definition_id,
+    p2po.bom_item_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY im.new_po_id, im.new_item_id, p2po.sku, p2po.department,
+                   p2po.bom_definition_id, p2po.bom_item_id
+      ORDER BY p2po.id
+    ) AS work_rank
+  FROM item_map im
+  JOIN p2_production_orders p2po
+    ON p2po.p2_po_id = im.new_po_id
+   AND p2po.p2_po_item_id = im.new_item_id
+  WHERE COALESCE(UPPER(p2po.status), '') = 'PENDING'
+    AND COALESCE(p2po.quantity_manufactured, 0) = 0
+    AND p2po.started_at IS NULL
+    AND p2po.completed_at IS NULL
+),
+deleted_new_orders AS (
+  DELETE FROM p2_production_orders new_p2po
+  USING old_orders old_p2po
+  JOIN new_unstarted_orders new_match
+    ON new_match.new_po_id = old_p2po.new_po_id
+   AND new_match.new_item_id = old_p2po.new_item_id
+   AND COALESCE(new_match.sku, '') = COALESCE(old_p2po.sku, '')
+   AND COALESCE(new_match.department, '') = COALESCE(old_p2po.department, '')
+   AND COALESCE(new_match.bom_definition_id::text, '') = COALESCE(old_p2po.bom_definition_id::text, '')
+   AND COALESCE(new_match.bom_item_id::text, '') = COALESCE(old_p2po.bom_item_id::text, '')
+   AND new_match.work_rank = old_p2po.work_rank
+  WHERE new_p2po.id = new_match.id
+  RETURNING new_p2po.id
+)
+UPDATE p2_production_orders p2po
+SET p2_po_id = old_p2po.new_po_id,
+    p2_po_item_id = old_p2po.new_item_id,
+    updated_at = NOW()
+FROM old_orders old_p2po
+WHERE p2po.id = old_p2po.id
+  AND p2po.p2_po_id = old_p2po.old_po_id
+  AND p2po.p2_po_item_id = old_p2po.old_item_id;
+
+WITH current_revisions AS (
+  SELECT
+    current_po.id AS new_po_id,
+    COALESCE(current_po.parent_po_id, current_po.id) AS root_po_id
+  FROM p2_purchase_orders current_po
+  WHERE current_po.is_current_revision IS TRUE
+    AND current_po.parent_po_id IS NOT NULL
+),
+old_pos AS (
+  SELECT
+    old_po.id AS old_po_id,
+    cr.new_po_id
+  FROM current_revisions cr
+  JOIN p2_purchase_orders old_po
+    ON old_po.id = cr.root_po_id
+    OR old_po.parent_po_id = cr.root_po_id
+  WHERE old_po.id <> cr.new_po_id
+    AND old_po.is_current_revision IS FALSE
+),
+old_items AS (
+  SELECT
+    op.old_po_id,
+    op.new_po_id,
+    poi.id AS old_item_id,
+    LOWER(TRIM(poi.part_number)) AS part_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY op.old_po_id, LOWER(TRIM(poi.part_number))
+      ORDER BY poi.id
+    ) AS part_rank
+  FROM old_pos op
+  JOIN p2_purchase_order_items poi ON poi.po_id = op.old_po_id
+),
+new_items AS (
+  SELECT
+    cr.new_po_id,
+    poi.id AS new_item_id,
+    LOWER(TRIM(poi.part_number)) AS part_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY cr.new_po_id, LOWER(TRIM(poi.part_number))
+      ORDER BY poi.id
+    ) AS part_rank
+  FROM current_revisions cr
+  JOIN p2_purchase_order_items poi ON poi.po_id = cr.new_po_id
+),
+item_map AS (
+  SELECT
+    oi.old_po_id,
+    oi.new_po_id,
+    oi.old_item_id,
+    ni.new_item_id
+  FROM old_items oi
+  JOIN new_items ni
+    ON ni.new_po_id = oi.new_po_id
+   AND ni.part_key = oi.part_key
+   AND ni.part_rank = oi.part_rank
+)
+UPDATE manufacturing_queue mq
+SET p2_po_id = item_map.new_po_id,
+    p2_po_item_id = item_map.new_item_id,
+    updated_at = NOW()
+FROM item_map
+WHERE mq.p2_po_id = item_map.old_po_id
+  AND mq.p2_po_item_id = item_map.old_item_id;
+
+WITH current_revisions AS (
+  SELECT
+    current_po.id AS new_po_id,
+    current_po.po_number AS new_po_number,
+    COALESCE(current_po.parent_po_id, current_po.id) AS root_po_id
+  FROM p2_purchase_orders current_po
+  WHERE current_po.is_current_revision IS TRUE
+    AND current_po.parent_po_id IS NOT NULL
+),
+old_pos AS (
+  SELECT
+    old_po.id AS old_po_id,
+    cr.new_po_id,
+    cr.new_po_number
+  FROM current_revisions cr
+  JOIN p2_purchase_orders old_po
+    ON old_po.id = cr.root_po_id
+    OR old_po.parent_po_id = cr.root_po_id
+  WHERE old_po.id <> cr.new_po_id
+    AND old_po.is_current_revision IS FALSE
+),
+old_items AS (
+  SELECT
+    op.old_po_id,
+    op.new_po_id,
+    op.new_po_number,
+    poi.id AS old_item_id,
+    LOWER(TRIM(poi.part_number)) AS part_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY op.old_po_id, LOWER(TRIM(poi.part_number))
+      ORDER BY poi.id
+    ) AS part_rank
+  FROM old_pos op
+  JOIN p2_purchase_order_items poi ON poi.po_id = op.old_po_id
+),
+new_items AS (
+  SELECT
+    cr.new_po_id,
+    poi.id AS new_item_id,
+    LOWER(TRIM(poi.part_number)) AS part_key,
+    ROW_NUMBER() OVER (
+      PARTITION BY cr.new_po_id, LOWER(TRIM(poi.part_number))
+      ORDER BY poi.id
+    ) AS part_rank
+  FROM current_revisions cr
+  JOIN p2_purchase_order_items poi ON poi.po_id = cr.new_po_id
+),
+item_map AS (
+  SELECT
+    oi.old_po_id,
+    oi.new_po_id,
+    oi.new_po_number,
+    oi.old_item_id,
+    ni.new_item_id
+  FROM old_items oi
+  JOIN new_items ni
+    ON ni.new_po_id = oi.new_po_id
+   AND ni.part_key = oi.part_key
+   AND ni.part_rank = oi.part_rank
+)
+UPDATE p2_lot_numbers lot
+SET po_id = item_map.new_po_id,
+    po_item_id = item_map.new_item_id,
+    po_number = item_map.new_po_number,
+    updated_at = NOW()
+FROM item_map
+WHERE lot.po_id = item_map.old_po_id
+  AND lot.po_item_id = item_map.old_item_id;
+
+COMMIT;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3299,10 +3299,54 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
         const newPO = insertResult.rows[0];
 
-        // 5. Determine line items: use wizard payload if provided, otherwise copy source items
-        let itemsToInsert: Array<{ partNumber: string; partName: string; quantity: number; unitPrice: number; inventoryItemId: number | null }> = [];
+        // 5. Determine line items: use wizard payload if provided, otherwise copy source items.
+        // Preserve the source item id when possible so existing P2 production rows
+        // move to the new revision instead of looking "missing" and being generated again.
+        let itemsToInsert: Array<{
+          sourceItemId: number | null;
+          partNumber: string;
+          partName: string;
+          quantity: number;
+          unitPrice: number;
+          inventoryItemId: number | null;
+        }> = [];
+        const sourceItemsResult = await client.query(
+          `SELECT id, part_number, part_name, quantity, unit_price, inventory_item_id
+           FROM p2_purchase_order_items WHERE po_id = $1
+           ORDER BY id`,
+          [sourceId]
+        );
+        const sourceItems = sourceItemsResult.rows;
         if (lineItems && Array.isArray(lineItems) && lineItems.length > 0) {
-          itemsToInsert = lineItems.map((item: any) => ({
+          const unusedSourceIndexes = new Set(sourceItems.map((_: any, index: number) => index));
+          const takeSourceMatch = (item: any, index: number) => {
+            const explicitId = Number(item.sourceItemId ?? item.source_item_id ?? item.id);
+            if (Number.isInteger(explicitId) && sourceItems.some((source: any) => Number(source.id) === explicitId)) {
+              const matchedIndex = sourceItems.findIndex((source: any) => Number(source.id) === explicitId);
+              unusedSourceIndexes.delete(matchedIndex);
+              return explicitId;
+            }
+
+            const partNumber = String(item.partNumber || item.sku || '').trim().toLowerCase();
+            const matchingIndex = sourceItems.findIndex((source: any, sourceIndex: number) =>
+              unusedSourceIndexes.has(sourceIndex) &&
+              String(source.part_number || '').trim().toLowerCase() === partNumber
+            );
+            if (matchingIndex >= 0) {
+              unusedSourceIndexes.delete(matchingIndex);
+              return Number(sourceItems[matchingIndex].id);
+            }
+
+            if (unusedSourceIndexes.has(index)) {
+              unusedSourceIndexes.delete(index);
+              return Number(sourceItems[index].id);
+            }
+
+            return null;
+          };
+
+          itemsToInsert = lineItems.map((item: any, index: number) => ({
+            sourceItemId: takeSourceMatch(item, index),
             partNumber: item.partNumber,
             partName: item.description || item.partName || item.partNumber,
             quantity: item.quantity,
@@ -3311,12 +3355,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           }));
         } else {
           // Fall back to copying source PO's items exactly
-          const sourceItemsResult = await client.query(
-            `SELECT part_number, part_name, quantity, unit_price, inventory_item_id
-             FROM p2_purchase_order_items WHERE po_id = $1`,
-            [sourceId]
-          );
-          itemsToInsert = sourceItemsResult.rows.map((row: any) => ({
+          itemsToInsert = sourceItems.map((row: any) => ({
+            sourceItemId: Number(row.id),
             partNumber: row.part_number,
             partName: row.part_name,
             quantity: row.quantity,
@@ -3326,12 +3366,72 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         }
 
         // Insert line items within the same transaction using the dedicated client
+        const itemIdMap = new Map<number, number>();
         for (const item of itemsToInsert) {
           const totalPrice = item.quantity * item.unitPrice;
-          await client.query(
+          const insertedItem = await client.query(
             `INSERT INTO p2_purchase_order_items (po_id, part_number, part_name, quantity, unit_price, total_price, inventory_item_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             RETURNING id`,
             [newPO.id, item.partNumber, item.partName, item.quantity, item.unitPrice, totalPrice, item.inventoryItemId]
+          );
+          const newItemId = Number(insertedItem.rows[0]?.id);
+          if (item.sourceItemId && Number.isInteger(newItemId)) {
+            itemIdMap.set(item.sourceItemId, newItemId);
+          }
+        }
+
+        for (const [oldItemId, newItemId] of itemIdMap.entries()) {
+          await client.query(
+            `UPDATE p2_production_orders
+                SET p2_po_id = $1,
+                    p2_po_item_id = $2,
+                    updated_at = NOW()
+              WHERE p2_po_id = $3
+                AND p2_po_item_id = $4`,
+            [newPO.id, newItemId, sourcePO.id, oldItemId]
+          );
+
+          await client.query(
+            `UPDATE p2_serialized_items
+                SET po_id = $1,
+                    po_item_id = $2,
+                    po_number = $3,
+                    updated_at = NOW()
+              WHERE po_id = $4
+                AND po_item_id = $5`,
+            [newPO.id, newItemId, newPONumber, sourcePO.id, oldItemId]
+          );
+
+          await client.query(
+            `UPDATE manufacturing_queue
+                SET p2_po_id = $1,
+                    p2_po_item_id = $2,
+                    updated_at = NOW()
+              WHERE p2_po_id = $3
+                AND p2_po_item_id = $4`,
+            [newPO.id, newItemId, sourcePO.id, oldItemId]
+          );
+        }
+
+        if (resolvedProjectId) {
+          await client.query(
+            `UPDATE projects
+                SET po_id = $1,
+                    updated_at = NOW()
+              WHERE id = $2::uuid
+                AND (po_id = $3 OR po_id IS NULL)`,
+            [newPO.id, resolvedProjectId, sourcePO.id]
+          );
+
+          await client.query(
+            `UPDATE project_steps
+                SET linked_p2_order_id = $1,
+                    updated_at = NOW()
+              WHERE project_id = $2::uuid
+                AND step_type = 'p2_order'
+                AND (linked_p2_order_id = $3 OR linked_p2_order_id IS NULL)`,
+            [newPO.id, resolvedProjectId, sourcePO.id]
           );
         }
 
@@ -4278,6 +4378,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
            )
            WHERE po.project_name IS NOT NULL
              AND TRIM(po.project_name) <> ''
+             AND po.is_current_revision IS NOT FALSE
          ),
          work_order_quantities AS (
            SELECT
@@ -4347,11 +4448,14 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         legacyProjectProductionRows.map((row: any) => [Number(row.poId), row])
       );
       const poIdsWithLegacyProjectProduction = new Set<number>(legacyProjectStatsByPoId.keys());
-      const pos = allPos.filter((po: any) =>
-        P2_GATED_STATUSES.has(normalizeP2Status(po.status)) ||
-        poIdsWithSerializedUnits.has(Number(po.id)) ||
-        poIdsWithLegacyProjectProduction.has(Number(po.id))
-      );
+      const pos = allPos.filter((po: any) => {
+        if (po.isCurrentRevision === false) return false;
+        return (
+          P2_GATED_STATUSES.has(normalizeP2Status(po.status)) ||
+          poIdsWithSerializedUnits.has(Number(po.id)) ||
+          poIdsWithLegacyProjectProduction.has(Number(po.id))
+        );
+      });
 
       // Look up projects linked to these POs. PM Control Center resolves the
       // same relationship through either projects.po_id or the p2_order step.
@@ -4395,6 +4499,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                )
                WHERE po.project_name IS NOT NULL
                  AND TRIM(po.project_name) <> ''
+                 AND po.is_current_revision IS NOT FALSE
              )
              SELECT DISTINCT ON (linked_po_id)
                linked_po_id AS "poId",
@@ -4807,6 +4912,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
            )
            WHERE po.project_name IS NOT NULL
              AND TRIM(po.project_name) <> ''
+             AND po.is_current_revision IS NOT FALSE
          )
          SELECT DISTINCT ON (wo.id)
            wo.id,
@@ -4929,6 +5035,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                )
                WHERE po.project_name IS NOT NULL
                  AND TRIM(po.project_name) <> ''
+                 AND po.is_current_revision IS NOT FALSE
              )
              SELECT DISTINCT ON (linked_po_id)
                linked_po_id AS "poId",

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -462,6 +462,7 @@ async function getProjectLinkedP2PoIds(projectId: string): Promise<number[]> {
       WHERE p.id = $1
         AND po.project_name IS NOT NULL
         AND TRIM(po.project_name) <> ''
+        AND po.is_current_revision IS NOT FALSE
     )
     SELECT DISTINCT po_id::text AS "poId" FROM project_po_link WHERE po_id IS NOT NULL
   `, [projectId]);
@@ -538,6 +539,7 @@ async function getProjectP2PoStatusSummaries(projectId: string): Promise<P2PoSta
     LEFT JOIN ordered_qty oq ON oq.po_id = po.id
     LEFT JOIN item_state psi ON psi.po_id = po.id
     WHERE po.id = ANY($1::int[])
+      AND po.is_current_revision IS NOT FALSE
     GROUP BY po.id, po.po_number, po.customer_name, po.expected_delivery, po.status, oq.ordered_qty
     ORDER BY po.po_number ASC
   `, [linkedPoIds]);

--- a/server/src/routes/workOrders.ts
+++ b/server/src/routes/workOrders.ts
@@ -106,6 +106,7 @@ async function getWadStatusP2Demand(projectIds: string[]): Promise<Map<string, W
       WHERE p.id = ANY($1::uuid[])
         AND po.project_name IS NOT NULL
         AND TRIM(po.project_name) <> ''
+        AND po.is_current_revision IS NOT FALSE
     ),
     distinct_links AS (
       SELECT DISTINCT project_id, po_id
@@ -683,6 +684,7 @@ router.get('/production/wad-status', authenticateToken, requirePermission('work_
             FROM p2_purchase_orders po
             WHERE po.project_name IS NOT NULL
               AND TRIM(po.project_name) <> ''
+              AND po.is_current_revision IS NOT FALSE
               AND LOWER(TRIM(po.project_name)) IN (
                 LOWER(TRIM(${projects.projectCode})),
                 LOWER(TRIM(${projects.projectName})),


### PR DESCRIPTION
## Summary
- Transfer existing P2 production orders, serialized units, manufacturing queue rows, and project PO links when creating a P2 PO revision.
- Hide superseded PO revisions from active PM/P2/WAD status surfaces.
- Add an idempotent repair migration to move already-split revision work from superseded POs onto the current revision while preserving revised-quantity pending rows.

## Root Cause
PO revision creation could copy line items into a new PO without preserving the old PO item to new PO item mapping. Existing work stayed attached to the superseded PO, while the new revision looked empty enough for fresh work to be generated. Project-name based read paths also continued surfacing superseded POs as active cards.

## Validation
- `git diff --cached --check` passed.
- Full TypeScript checks were not run because this worktree has no local `node_modules` and `npm` is not on PATH in this shell.