### PR TITLE
[codex] Correct P2 PO revision in-place status handling

### DIFF
--- a/client/src/components/p2/P2POCreationWizard.tsx
+++ b/client/src/components/p2/P2POCreationWizard.tsx
@@ -115,6 +115,7 @@ interface LineItem {
   revision: string;
   description: string;
   quantity: number;
+  dueDate?: string | null;
   unitPrice: number;
   internalName: string;
   inventoryItemId?: number | null;
@@ -317,6 +318,7 @@ export default function P2POCreationWizard({
         revision,
         description: item.partName || item.description || '',
         quantity: Number(item.quantity) || 1,
+        dueDate: item.dueDate?.slice(0, 10) || editableSourcePO.expectedDelivery?.slice(0, 10) || '',
         unitPrice: parseFloat(item.unitPrice) || 0,
         internalName: '',
         inventoryItemId: item.inventoryItemId ?? null,
@@ -415,6 +417,7 @@ export default function P2POCreationWizard({
       revision: newItem.revision || 'A',
       description: newItem.description || '',
       quantity: newItem.quantity || 1,
+      dueDate: newItem.dueDate || poDetails?.dueDate || '',
       unitPrice: newItem.unitPrice || 0,
       internalName: newItem.internalName || '',
       inventoryItemId: newItem.inventoryItemId ?? null,
@@ -435,6 +438,7 @@ export default function P2POCreationWizard({
           revision: product.revision || 'A',
           description: product.description,
           unitPrice: parseFloat(product.unitPrice),
+          dueDate: newItem.dueDate || poDetails?.dueDate || '',
           internalName: product.internalName || '',
           inventoryItemId: product.inventoryItemId ?? null,
         });
@@ -482,9 +486,11 @@ export default function P2POCreationWizard({
         partNumber: `${item.sku}${item.revision ? ` Rev ${item.revision}` : ''}`,
         description: item.description,
         quantity: item.quantity,
+        dueDate: item.dueDate || null,
         unitPrice: item.unitPrice,
         inventoryItemId: item.inventoryItemId ?? null,
       })),
+      isRevisionUpdate: isReviseMode,
     };
   };
 
@@ -790,7 +796,7 @@ export default function P2POCreationWizard({
         {/* Step 3: Line Items */}
         {currentStep === 2 && (
           <div className="space-y-6">
-            <div className="grid grid-cols-6 gap-2 items-end">
+            <div className="grid grid-cols-1 gap-2 items-end md:grid-cols-[2fr_1.2fr_0.7fr_0.9fr_0.8fr_auto]">
               <div className="col-span-2">
                 <Label>P2 Product Item</Label>
                 <Select onValueChange={handleProductSelect} value="">
@@ -832,6 +838,15 @@ export default function P2POCreationWizard({
                 />
               </div>
               <div>
+                <Label>Line Date</Label>
+                <Input
+                  type="date"
+                  value={newItem.dueDate || poDetails?.dueDate || ''}
+                  onChange={(e) => setNewItem({ ...newItem, dueDate: e.target.value })}
+                  data-testid="input-line-due-date"
+                />
+              </div>
+              <div>
                 <Label>Unit Price</Label>
                 <Input
                   type="number"
@@ -863,6 +878,7 @@ export default function P2POCreationWizard({
                     <TableHead>SKU / Rev</TableHead>
                     <TableHead>Description</TableHead>
                     <TableHead className="text-right">Quantity</TableHead>
+                    <TableHead>Line Date</TableHead>
                     <TableHead className="text-right">Unit Price</TableHead>
                     <TableHead className="text-right">Total</TableHead>
                     <TableHead></TableHead>
@@ -874,6 +890,7 @@ export default function P2POCreationWizard({
                       <TableCell className="font-medium">{item.sku} Rev {item.revision}</TableCell>
                       <TableCell>{item.description}</TableCell>
                       <TableCell className="text-right">{item.quantity}</TableCell>
+                      <TableCell>{item.dueDate || poDetails?.dueDate || '-'}</TableCell>
                       <TableCell className="text-right">${item.unitPrice.toFixed(2)}</TableCell>
                       <TableCell className="text-right">
                         ${(item.quantity * item.unitPrice).toFixed(2)}
@@ -970,6 +987,7 @@ export default function P2POCreationWizard({
                       <TableHead>SKU / Rev</TableHead>
                       <TableHead>Description</TableHead>
                       <TableHead className="text-right">Quantity</TableHead>
+                      <TableHead>Line Date</TableHead>
                       <TableHead className="text-right">Total</TableHead>
                     </TableRow>
                   </TableHeader>
@@ -979,6 +997,7 @@ export default function P2POCreationWizard({
                         <TableCell className="font-medium">{item.sku} Rev {item.revision}</TableCell>
                         <TableCell>{item.description}</TableCell>
                         <TableCell className="text-right">{item.quantity}</TableCell>
+                        <TableCell>{item.dueDate || poDetails?.dueDate || '-'}</TableCell>
                         <TableCell className="text-right">
                           ${(item.quantity * item.unitPrice).toFixed(2)}
                         </TableCell>

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -180,6 +180,7 @@ interface P2PurchaseOrderItem {
   partName: string;
   description?: string | null;
   quantity: number;
+  dueDate?: string | null;
   unitPrice?: number | null;
   specifications?: string | null;
   notes?: string | null;
@@ -489,7 +490,7 @@ export default function ProjectDetailPage() {
   const suggestedRevisionPoNumber = useMemo(() => {
     const base = linkedProjectPO?.poNumber?.trim();
     if (!base) return '';
-    return /-R[A-Z]+$/i.test(base) ? base.replace(/-R[A-Z]+$/i, '-RA') : `${base}-RA`;
+    return base;
   }, [linkedProjectPO?.poNumber]);
 
   useEffect(() => {
@@ -507,6 +508,7 @@ export default function ProjectDetailPage() {
               partName: item.partName || item.description || item.partNumber || '',
               quantity: Number(item.quantity) || 1,
               unitPrice: Number(item.unitPrice) || 0,
+              dueDate: item.dueDate?.slice(0, 10) || linkedProjectPO?.expectedDelivery?.slice(0, 10) || '',
               specifications: item.specifications || '',
               notes: item.notes || '',
               inventoryItemId: item.inventoryItemId ?? null,
@@ -541,6 +543,7 @@ export default function ProjectDetailPage() {
           partNumber: '',
           partName: '',
           quantity: 1,
+          dueDate: prev.revisedDueDate || '',
           unitPrice: 0,
           specifications: '',
           notes: '',
@@ -3125,7 +3128,7 @@ export default function ProjectDetailPage() {
                     ) : (
                       <div className="space-y-2">
                         {revisionForm.revisedLineItems.map((item, index) => (
-                          <div key={item.id ?? index} className="grid gap-2 rounded-md border p-3 md:grid-cols-[1fr_1.4fr_0.5fr_0.6fr_auto]">
+                          <div key={item.id ?? index} className="grid gap-2 rounded-md border p-3 md:grid-cols-[1fr_1.4fr_0.5fr_0.7fr_0.6fr_auto]">
                             <div className="space-y-1">
                               <Label className="text-xs">Part Number</Label>
                               <Input
@@ -3150,6 +3153,15 @@ export default function ProjectDetailPage() {
                                 value={item.quantity}
                                 onChange={(e) => updateRevisionLineItem(index, { quantity: parseInt(e.target.value, 10) || 0 })}
                                 data-testid={`input-revision-line-quantity-${index}`}
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label className="text-xs">Line Date</Label>
+                              <Input
+                                type="date"
+                                value={item.dueDate?.slice(0, 10) || ''}
+                                onChange={(e) => updateRevisionLineItem(index, { dueDate: e.target.value } as Partial<P2PurchaseOrderItem>)}
+                                data-testid={`input-revision-line-due-date-${index}`}
                               />
                             </div>
                             <div className="space-y-1">

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -5291,6 +5291,7 @@ export const p2PurchaseOrderItems = pgTable('p2_purchase_order_items', {
   partNumber: text('part_number').notNull(), // P2-specific part number
   partName: text('part_name').notNull(), // Display name for the part
   quantity: integer('quantity').notNull(),
+  dueDate: date('due_date'),
   unitPrice: real('unit_price').default(0), // Price per unit
   totalPrice: real('total_price').default(0), // quantity * unitPrice
   specifications: text('specifications'), // Part specifications

--- a/server/src/lib/p2PurchaseOrderReadiness.ts
+++ b/server/src/lib/p2PurchaseOrderReadiness.ts
@@ -48,6 +48,11 @@ export async function ensureP2PurchaseOrderReadSchema(): Promise<void> {
               ADD COLUMN IF NOT EXISTS scrap_rate_percent real NOT NULL DEFAULT 0;
           END IF;
 
+          IF to_regclass('public.p2_purchase_order_items') IS NOT NULL THEN
+            ALTER TABLE public.p2_purchase_order_items
+              ADD COLUMN IF NOT EXISTS due_date date;
+          END IF;
+
           IF to_regclass('public.p2_serialized_items') IS NOT NULL THEN
             ALTER TABLE public.p2_serialized_items
               ADD COLUMN IF NOT EXISTS build_family_key text,

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2837,7 +2837,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { pool } = await import('../../db');
       const rows = await pool.query(`
         SELECT id, po_id as "poId", part_number as "partNumber", part_name as "partName", 
-               quantity, unit_price as "unitPrice", total_price as "totalPrice",
+               quantity, due_date as "dueDate", unit_price as "unitPrice", total_price as "totalPrice",
                specifications, notes, created_at as "createdAt", updated_at as "updatedAt"
         FROM p2_purchase_order_items 
         ORDER BY created_at DESC
@@ -2929,6 +2929,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             partNumber: item.partNumber,
             partName: item.description || item.partName || item.partNumber,
             quantity: item.quantity,
+            dueDate: item.dueDate || null,
             unitPrice: item.unitPrice || 0,
           });
         }
@@ -2982,7 +2983,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       }
 
       // STATE GUARD: Check if PO is locked - prevent edits to locked POs
-      if (existingPO.lockedAt) {
+      if (existingPO.lockedAt && body.isRevisionUpdate !== true) {
         return res.status(403).json({
           error: 'This PO has been locked and cannot be modified',
           lockedAt: existingPO.lockedAt,
@@ -3044,6 +3045,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             partNumber: item.partNumber,
             partName: item.description || item.partName || item.partNumber,
             quantity: Number(item.quantity) || 1,
+            dueDate: item.dueDate || null,
             unitPrice: Number(item.unitPrice) || 0,
           };
 
@@ -3311,7 +3313,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           inventoryItemId: number | null;
         }> = [];
         const sourceItemsResult = await client.query(
-          `SELECT id, part_number, part_name, quantity, unit_price, inventory_item_id
+          `SELECT id, part_number, part_name, quantity, due_date, unit_price, inventory_item_id
            FROM p2_purchase_order_items WHERE po_id = $1
            ORDER BY id`,
           [sourceId]
@@ -3350,6 +3352,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             partNumber: item.partNumber,
             partName: item.description || item.partName || item.partNumber,
             quantity: item.quantity,
+            dueDate: item.dueDate || null,
             unitPrice: item.unitPrice || 0,
             inventoryItemId: item.inventoryItemId || null,
           }));
@@ -3360,6 +3363,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             partNumber: row.part_number,
             partName: row.part_name,
             quantity: row.quantity,
+            dueDate: row.due_date || null,
             unitPrice: parseFloat(row.unit_price) || 0,
             inventoryItemId: row.inventory_item_id || null,
           }));
@@ -3370,10 +3374,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         for (const item of itemsToInsert) {
           const totalPrice = item.quantity * item.unitPrice;
           const insertedItem = await client.query(
-            `INSERT INTO p2_purchase_order_items (po_id, part_number, part_name, quantity, unit_price, total_price, inventory_item_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
+            `INSERT INTO p2_purchase_order_items (po_id, part_number, part_name, quantity, due_date, unit_price, total_price, inventory_item_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
              RETURNING id`,
-            [newPO.id, item.partNumber, item.partName, item.quantity, item.unitPrice, totalPrice, item.inventoryItemId]
+            [newPO.id, item.partNumber, item.partName, item.quantity, item.dueDate || null, item.unitPrice, totalPrice, item.inventoryItemId]
           );
           const newItemId = Number(insertedItem.rows[0]?.id);
           if (item.sourceItemId && Number.isInteger(newItemId)) {
@@ -4355,8 +4359,55 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       } catch (error) {
         console.warn('P2 Control Center optional serialized item lookup skipped:', error);
       }
+      const allPoIds = allPos
+        .map((po: any) => Number(po.id))
+        .filter(Number.isFinite);
       p2StatusStage = 'loading legacy project production rows';
-      const legacyProductionRows: any[] = [];
+      const legacyProductionRows = allPoIds.length > 0
+        ? await optionalP2Rows(
+            'P2 production orders',
+            dbPool.query(
+              `SELECT
+                 p2_po_id AS "poId",
+                 COALESCE(SUM(quantity), 0)::int AS "totalQty",
+                 COALESCE(SUM(
+                   CASE
+                     WHEN COALESCE(UPPER(status), '') IN ('COMPLETE', 'COMPLETED', 'CLOSED') THEN quantity
+                     ELSE LEAST(COALESCE(quantity_manufactured, 0), quantity)
+                   END
+                 ), 0)::int AS "completedQty",
+                 COALESCE(SUM(
+                   CASE
+                     WHEN COALESCE(UPPER(status), '') NOT IN ('', 'PENDING', 'PLANNED', 'COMPLETE', 'COMPLETED', 'CLOSED', 'CANCELLED', 'CANCELED')
+                     THEN GREATEST(quantity - LEAST(COALESCE(quantity_manufactured, 0), quantity), 0)
+                     ELSE 0
+                   END
+                 ), 0)::int AS "inProductionQty"
+               FROM p2_production_orders
+               WHERE p2_po_id = ANY($1)
+                 AND COALESCE(UPPER(status), '') NOT IN ('CANCELLED', 'CANCELED')
+               GROUP BY p2_po_id`,
+              [allPoIds]
+            )
+          )
+        : [];
+      const shippedVisibilityRows = allPoIds.length > 0
+        ? await optionalP2Rows(
+            'shipped lot visibility',
+            dbPool.query(
+              `SELECT po_id AS "poId"
+               FROM p2_lot_numbers
+               WHERE po_id = ANY($1)
+                 AND (
+                   COALESCE(UPPER(status), '') IN ('SHIPPED', 'CLOSED', 'COMPLETE', 'COMPLETED')
+                   OR shipped_at IS NOT NULL
+                   OR packing_slip_id IS NOT NULL
+                 )
+               GROUP BY po_id`,
+              [allPoIds]
+            )
+          )
+        : [];
       const legacyProjectProductionRows = await optionalP2Rows(
         'legacy project production',
         dbPool.query(
@@ -4448,12 +4499,55 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         legacyProjectProductionRows.map((row: any) => [Number(row.poId), row])
       );
       const poIdsWithLegacyProjectProduction = new Set<number>(legacyProjectStatsByPoId.keys());
+      const poIdsWithShippedHistory = new Set<number>(
+        shippedVisibilityRows.map((row: any) => Number(row.poId))
+      );
+      const projectVisibilityRows = allPoIds.length > 0
+        ? await optionalP2Rows(
+            'project visibility link',
+            dbPool.query(
+              `WITH project_po_link AS (
+                 SELECT p.po_id AS linked_po_id
+                 FROM projects p
+                 WHERE p.po_id IS NOT NULL
+                 UNION
+                 SELECT ps.linked_p2_order_id AS linked_po_id
+                 FROM project_steps ps
+                 WHERE ps.step_type = 'p2_order'
+                   AND ps.linked_p2_order_id IS NOT NULL
+                 UNION
+                 SELECT po.id AS linked_po_id
+                 FROM p2_purchase_orders po
+                 JOIN projects p ON LOWER(TRIM(po.project_name)) IN (
+                   LOWER(TRIM(p.project_code)),
+                   LOWER(TRIM(p.project_name)),
+                   LOWER(TRIM(CONCAT_WS(' - ', NULLIF(p.project_code, ''), NULLIF(p.project_name, ''))))
+                 )
+                 WHERE po.project_name IS NOT NULL
+                   AND TRIM(po.project_name) <> ''
+                   AND po.is_current_revision IS NOT FALSE
+               )
+               SELECT DISTINCT linked_po_id AS "poId"
+               FROM project_po_link
+               WHERE linked_po_id = ANY($1)`,
+              [allPoIds]
+            )
+          )
+        : [];
+      const poIdsWithProjectLink = new Set<number>(
+        projectVisibilityRows.map((row: any) => Number(row.poId))
+      );
       const pos = allPos.filter((po: any) => {
-        if (po.isCurrentRevision === false) return false;
+        const poId = Number(po.id);
+        const hasProductionHistory = poIdsWithSerializedUnits.has(poId)
+          || legacyStatsByPoId.has(poId)
+          || poIdsWithLegacyProjectProduction.has(poId)
+          || poIdsWithShippedHistory.has(poId);
+        if (po.isCurrentRevision === false && !hasProductionHistory) return false;
         return (
           P2_GATED_STATUSES.has(normalizeP2Status(po.status)) ||
-          poIdsWithSerializedUnits.has(Number(po.id)) ||
-          poIdsWithLegacyProjectProduction.has(Number(po.id))
+          hasProductionHistory ||
+          poIdsWithProjectLink.has(poId)
         );
       });
 
@@ -4566,6 +4660,26 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const orderedQtyByPoId = new Map<number, number>(
         orderedQtyRows.map((r: any) => [Number(r.poId), Number(r.orderedQty) || 0])
       );
+      const shippedQtyRows = poIds.length > 0
+        ? await optionalP2Rows(
+            'shipped lot quantity',
+            dbPool.query(
+              `SELECT po_id AS "poId", COALESCE(SUM(quantity), 0)::int AS "shippedQty"
+               FROM p2_lot_numbers
+               WHERE po_id = ANY($1)
+                 AND (
+                   COALESCE(UPPER(status), '') IN ('SHIPPED', 'CLOSED', 'COMPLETE', 'COMPLETED')
+                   OR shipped_at IS NOT NULL
+                   OR packing_slip_id IS NOT NULL
+                 )
+               GROUP BY po_id`,
+              [poIds]
+            )
+          )
+        : [];
+      const shippedQtyByPoId = new Map<number, number>(
+        shippedQtyRows.map((r: any) => [Number(r.poId), Number(r.shippedQty) || 0])
+      );
       
       p2StatusStage = 'building P2 status response';
       const poStatuses = pos.map((po: any) => {
@@ -4582,9 +4696,17 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           : null;
         
         // Use actual column names: status (ACTIVE/COMPLETED/SCRAPPED/HOLD) and currentDepartment
-        const serializedCompletedItems = poItems.filter((s: any) => s.status === 'COMPLETED').length;
+        const serializedCompletedItems = poItems.filter((s: any) => {
+          const status = String(s.status || '').trim().toUpperCase();
+          const dept = String(s.currentDepartment || '').trim().toUpperCase();
+          return ['COMPLETED', 'COMPLETE', 'SHIPPED', 'CLOSED'].includes(status)
+            || ['SHIPPED', 'SHIPPING', 'CLOSED'].includes(dept)
+            || s.shippedAt
+            || s.packingSlipId;
+        }).length;
         const legacyCompletedItems = Number(legacyStats?.completedQty ?? 0);
-        const completedItems = Math.max(serializedCompletedItems, legacyCompletedItems);
+        const shippedLotCompletedItems = shippedQtyByPoId.get(poId) ?? 0;
+        const completedItems = Math.max(serializedCompletedItems, legacyCompletedItems, shippedLotCompletedItems);
 
         const scheduledItems = poItems.filter((s: any) => {
           if (s.status !== 'ACTIVE') return false;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -668,6 +668,7 @@ router.post('/:id/revisions', async (req, res) => {
         partNumber: z.string().trim().min(1),
         partName: z.string().trim().min(1),
         quantity: z.number().int().positive(),
+        dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().nullable(),
         unitPrice: z.number().nonnegative().optional().nullable(),
         specifications: z.string().optional().nullable(),
         notes: z.string().optional().nullable(),
@@ -708,30 +709,16 @@ router.post('/:id/revisions', async (req, res) => {
       if (!data.revisedLineItems?.length) {
         return res.status(400).json({ message: 'At least one revised PO line item is required.' });
       }
-      const duplicatePo = await pool.query(
-        `SELECT id FROM p2_purchase_orders WHERE LOWER(po_number) = LOWER($1) LIMIT 1`,
-        [data.revisedPoNumber]
+      const currentPo = await pool.query(
+        `SELECT id, po_number FROM p2_purchase_orders WHERE id = $1 LIMIT 1`,
+        [project.poId]
       );
-      if (duplicatePo.rows.length > 0) {
-        return res.status(409).json({ message: `PO ${data.revisedPoNumber} already exists.` });
+      if (currentPo.rows.length === 0) {
+        return res.status(404).json({ message: 'Linked PO was not found.' });
       }
 
-      const revisedPo = await storage.createP2PurchaseOrderRevision(
-        project.poId,
-        data.reason,
-        data.createdByDisplayName,
-        {
-          poNumber: data.revisedPoNumber,
-          expectedDelivery: data.revisedDueDate,
-          lineItems: data.revisedLineItems.map((item) => ({
-            ...item,
-            sourceItemId: Number.isFinite(Number(item.id)) ? Number(item.id) : undefined,
-          })),
-        }
-      );
-      newPoId = revisedPo.id;
-      newPoNumber = revisedPo.poNumber;
-      await storage.updateProject(id, { poId: revisedPo.id } as any);
+      newPoId = project.poId;
+      newPoNumber = currentPo.rows[0].po_number;
     }
 
     const rows = await pool.query(


### PR DESCRIPTION
## Summary
- Changes the P2 Projects PO-revision flow so it records the project revision and sends the user to the PO wizard for the same linked PO instead of creating/replacing a PO row.
- Adds line-level dates to P2 PO items in the project revision form, PO wizard, item schema/readiness guard, and PO create/update payloads.
- Keeps P2 Control Center status cards visible for previous/current PO rows that still own real production, serialized, or shipped history.
- Treats existing travelers as the project execution source of truth for Control Center totals/completed/in-production counts when work-order or revised-PO linkage no longer matches the travelers.

## Why
The merged revision path could split production history between a previous PO and a new copied PO. That made previous work orders disappear from the P2 Control Center and left the revised/new PO missing already completed or shipped items. In the live broken case, neither work-order linkage cleanly matches the travelers already created for the project, so the dashboard must reconcile from travelers.project_id first.

## Validation
- `git diff --check`
- Source review of P2 Projects revision creation, PO wizard update payloads, PO item schema/readiness, and P2 Control Center status aggregation

Full `npm run check` was not available because this shell/worktree does not have `npm`, `tsc`, or local `node_modules` on PATH.