### PR TITLE
Fix P2 shipping PO filter options

### DIFF
--- a/client/src/components/p2/ShipmentSummaryModal.tsx
+++ b/client/src/components/p2/ShipmentSummaryModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   Dialog,
@@ -80,6 +80,26 @@ export default function ShipmentSummaryModal({
 
   const poItems = allocationData?.poItems ?? [];
   const allocations = allocationData?.allocations ?? [];
+  const serialPoItems = useMemo(() => {
+    const byPoItemId = new Map<number, PoItem>();
+    for (const serial of serials) {
+      if (!serial.poItemId || byPoItemId.has(serial.poItemId)) continue;
+      byPoItemId.set(serial.poItemId, {
+        id: serial.poItemId,
+        part_number: serial.partNumber,
+        part_name: serial.partName,
+        quantity: serials.filter((candidate) => candidate.poItemId === serial.poItemId).length,
+        unit_price: null,
+      });
+    }
+    return Array.from(byPoItemId.values()).sort((a, b) => a.id - b.id);
+  }, [serials]);
+  const selectablePoItems = poItems.length > 0 ? poItems : serialPoItems;
+
+  useEffect(() => {
+    if (newBucket.poItemId || selectablePoItems.length === 0) return;
+    setNewBucket((prev) => ({ ...prev, poItemId: String(selectablePoItems[0].id) }));
+  }, [newBucket.poItemId, selectablePoItems]);
 
   useEffect(() => {
     if (!allocations.length || !serials.length) return;
@@ -195,7 +215,7 @@ export default function ShipmentSummaryModal({
                     value={newBucket.poItemId}
                     onChange={(e) => setNewBucket((prev) => ({ ...prev, poItemId: e.target.value }))}
                   >
-                    {poItems.map((item) => (
+                    {selectablePoItems.map((item) => (
                       <option key={item.id} value={String(item.id)}>
                         {item.part_number} - {item.part_name}
                       </option>

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -179,7 +179,14 @@ export default function P2ControlCenter() {
     refetchInterval: 30000,
   });
 
-  const openPOs = allPOStatuses.filter((po) => po.status !== 'completed');
+  const openPOs = useMemo(
+    () => allPOStatuses.filter((po) => po.status !== 'completed'),
+    [allPOStatuses]
+  );
+  const poFilterOptions = useMemo(
+    () => activeTab === 'shipping' ? allPOStatuses : openPOs,
+    [activeTab, allPOStatuses, openPOs]
+  );
 
   useEffect(() => {
     if (selectedPOIds.length === 0) return;
@@ -617,7 +624,7 @@ export default function P2ControlCenter() {
       )}
 
       {/* PO Filter Bar */}
-      {openPOs.length > 1 && (
+      {poFilterOptions.length > 1 && (
         <div className="space-y-2">
           <div className="flex items-center gap-3 flex-wrap">
             <div className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
@@ -658,7 +665,7 @@ export default function P2ControlCenter() {
                   <div className="h-px bg-border my-1" />
 
                   {/* Individual PO options */}
-                  {openPOs.map((po) => {
+                  {poFilterOptions.map((po) => {
                     const isChecked = selectedPOIds.includes(po.id);
                     return (
                       <div
@@ -697,7 +704,7 @@ export default function P2ControlCenter() {
           {selectedPOIds.length > 0 && (
             <div className="flex items-center gap-2 flex-wrap">
               <span className="text-xs text-muted-foreground">Showing:</span>
-              {openPOs.filter((po) => selectedPOIds.includes(po.id)).map((po) => (
+              {poFilterOptions.filter((po) => selectedPOIds.includes(po.id)).map((po) => (
                 <Badge
                   key={po.id}
                   variant="secondary"


### PR DESCRIPTION
## Summary
- allow the P2 Control Center PO picker to use all POs while the Shipping tab is active
- keep non-shipping tabs limited to open POs
- populate the confirm-shipment modal PO Item selector from selected serials when the billing allocation lookup returns no PO items
- ensure completed/shipping-ready POs can still be selected and shipments can create billing buckets from valid selected PO item IDs

## Validation
- `git diff --check -- client/src/pages/P2ControlCenter.tsx`
- `git diff --check -- client/src/components/p2/ShipmentSummaryModal.tsx client/src/pages/P2ControlCenter.tsx`
- `git diff --cached --check`

Note: full TypeScript/build validation was not run because this clean worktree has no `node_modules` and `npm` is not available on PATH.