### PR TITLE
[codex] Keep travelers immutable during P2 PO revision sync

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3138,15 +3138,6 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
               ]
             );
 
-            await dbPool.query(
-              `UPDATE travelers
-               SET production_work_order_id = $1::uuid,
-                   updated_at = NOW()
-               WHERE project_id = $2::uuid
-                 AND (production_work_order_id IS NULL OR production_work_order_id <> $1::uuid)`,
-              [canonicalWad.id, revisionProjectId]
-            );
-
             if (revisedPartNumbers.length > 0) {
               const duplicateRows = await dbPool.query(
                 `UPDATE production_work_orders wo


### PR DESCRIPTION
## Summary
- Removes the traveler mutation from the P2 PO revision sync path.
- Keeps traveler rows immutable as audit records; revision sync now reconciles WAD/work-order state around travelers instead of rewriting traveler work-order links.
- Leaves the Control Center traveler rollup read-only through travelers.project_id.

## Why
Travelers are audit records and should never be changed by a PO revision. The revised PO should update the project WAD/work-order and dashboard state, while travelers remain immutable evidence associated to the project.

## Validation
- `git diff --check`
- Verified the touched revision/dashboard routes contain no traveler mutation statement

Full `npm run check` was not available because this shell/worktree does not have `npm`, `tsc`, or local `node_modules` on PATH.