### PR TITLE
Use P2 PO line items as shipment buckets

### DIFF
--- a/client/src/components/p2/P2ShippingTab.tsx
+++ b/client/src/components/p2/P2ShippingTab.tsx
@@ -407,13 +407,22 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
     poNumber: string,
     serialIds: string[],
     billingAssignments: { serializedItemId: string; allocationId: string }[] = [],
+    billingBucketOverrides: {
+      poItemId: number;
+      bucketLabel: string;
+      description?: string;
+      customerPoLine?: string;
+      quantityAuthorized?: number;
+      unitPrice?: number;
+      serialIds?: string[];
+    }[] = [],
   ) => {
     if (serialIds.length === 0) return;
     setCreatingShipmentFor(poNumber);
     try {
       const lot = await apiRequest('/api/p2/lots', {
         method: 'POST',
-        body: JSON.stringify({ serialIds, createdBy: 'shipping', billingAssignments }),
+        body: JSON.stringify({ serialIds, createdBy: 'shipping', billingAssignments, billingBucketOverrides }),
       });
       const slip = await apiRequest('/api/p2/packing-slips', {
         method: 'POST',
@@ -556,12 +565,12 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
       {summaryModalPO && (
         <ShipmentSummaryModal
           serials={summaryModalSerials}
-          onConfirm={(billingAssignments) => {
+          onConfirm={(billingAssignments, billingBucketOverrides) => {
             const po = summaryModalPO!;
             const ids = summaryModalSerials.map((s) => s.id);
             setSummaryModalPO(null);
             setSummaryModalSerials([]);
-            handleCreateShipment(po, ids, billingAssignments);
+            handleCreateShipment(po, ids, billingAssignments, billingBucketOverrides);
           }}
           onCancel={() => {
             setSummaryModalPO(null);

--- a/client/src/components/p2/ShipmentSummaryModal.tsx
+++ b/client/src/components/p2/ShipmentSummaryModal.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   Dialog,
   DialogContent,
@@ -12,8 +10,8 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { queryClient, apiRequest } from '@/lib/queryClient';
-import { Truck, Package, CalendarClock, Plus, DollarSign } from 'lucide-react';
+import { Truck, Package, CalendarClock, Receipt, Plus, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 type SerializedUnit = {
   id: string;
@@ -27,29 +25,31 @@ type SerializedUnit = {
   customerName: string;
 };
 
-type BillingAllocation = {
-  id: string;
-  po_item_id: number;
-  part_number: string;
-  bucket_label: string;
-  description: string | null;
-  customer_po_line: string | null;
-  quantity_authorized: number;
-  unit_price: string;
-  assigned_quantity: number;
+type BillingBucketOverride = {
+  poItemId: number;
+  bucketLabel: string;
+  description?: string;
+  customerPoLine?: string;
+  quantityAuthorized?: number;
+  unitPrice?: number;
+  serialIds?: string[];
 };
 
-type PoItem = {
-  id: number;
-  part_number: string;
-  part_name: string;
-  quantity: number;
-  unit_price: number | null;
+type BucketOverrideDraft = {
+  enabled: boolean;
+  bucketLabel: string;
+  description: string;
+  customerPoLine: string;
+  quantityAuthorized: string;
+  unitPrice: string;
 };
 
 interface ShipmentSummaryModalProps {
   serials: SerializedUnit[];
-  onConfirm: (assignments: { serializedItemId: string; allocationId: string }[]) => void;
+  onConfirm: (
+    assignments?: { serializedItemId: string; allocationId: string }[],
+    bucketOverrides?: BillingBucketOverride[],
+  ) => void;
   onCancel: () => void;
 }
 
@@ -60,116 +60,83 @@ export default function ShipmentSummaryModal({
 }: ShipmentSummaryModalProps) {
   const customer = serials[0]?.customerName ?? '-';
   const poNumber = serials[0]?.poNumber ?? '-';
-  const poId = serials[0]?.poId;
-  const [assignments, setAssignments] = useState<Record<string, string>>({});
-  const [newBucket, setNewBucket] = useState({
-    poItemId: serials[0]?.poItemId ? String(serials[0].poItemId) : '',
-    bucketLabel: '',
-    description: '',
-    customerPoLine: '',
-    quantityAuthorized: String(serials.length || 1),
-    unitPrice: '',
-    notes: '',
-  });
+  const [bucketOverrides, setBucketOverrides] = useState<Record<number, BucketOverrideDraft>>({});
 
-  const { data: allocationData, isLoading: loadingAllocations } = useQuery<{ poItems: PoItem[]; allocations: BillingAllocation[] }>({
-    queryKey: ['/api/p2/billing-allocations', poId],
-    queryFn: async () => apiRequest(`/api/p2/billing-allocations?poId=${encodeURIComponent(String(poId))}`),
-    enabled: !!poId,
-  });
-
-  const poItems = allocationData?.poItems ?? [];
-  const allocations = allocationData?.allocations ?? [];
-  const serialPoItems = useMemo(() => {
-    const byPoItemId = new Map<number, PoItem>();
+  const poItemGroups = useMemo(() => {
+    const groups = new Map<number, SerializedUnit[]>();
     for (const serial of serials) {
-      if (!serial.poItemId || byPoItemId.has(serial.poItemId)) continue;
-      byPoItemId.set(serial.poItemId, {
-        id: serial.poItemId,
-        part_number: serial.partNumber,
-        part_name: serial.partName,
-        quantity: serials.filter((candidate) => candidate.poItemId === serial.poItemId).length,
-        unit_price: null,
-      });
+      const existing = groups.get(serial.poItemId) ?? [];
+      groups.set(serial.poItemId, [...existing, serial]);
     }
-    return Array.from(byPoItemId.values()).sort((a, b) => a.id - b.id);
+
+    return Array.from(groups.entries())
+      .map(([poItemId, units]) => ({
+        poItemId,
+        units: units.sort((a, b) => a.sequenceNumber - b.sequenceNumber),
+        partNumber: units[0]?.partNumber ?? '',
+        partName: units[0]?.partName ?? '',
+      }))
+      .sort((a, b) => a.poItemId - b.poItemId);
   }, [serials]);
-  const selectablePoItems = poItems.length > 0 ? poItems : serialPoItems;
 
-  useEffect(() => {
-    if (newBucket.poItemId || selectablePoItems.length === 0) return;
-    setNewBucket((prev) => ({ ...prev, poItemId: String(selectablePoItems[0].id) }));
-  }, [newBucket.poItemId, selectablePoItems]);
+  const enabledBucketOverrides: BillingBucketOverride[] = poItemGroups.flatMap((group) => {
+    const override = bucketOverrides[group.poItemId];
+    if (!override?.enabled || !override.bucketLabel.trim()) return [];
+    return [{
+      poItemId: group.poItemId,
+      bucketLabel: override.bucketLabel.trim(),
+      description: override.description.trim() || undefined,
+      customerPoLine: override.customerPoLine.trim() || undefined,
+      quantityAuthorized: Number(override.quantityAuthorized) || group.units.length,
+      unitPrice: Number(override.unitPrice) || 0,
+      serialIds: group.units.map((serial) => serial.id),
+    }];
+  });
 
-  useEffect(() => {
-    if (!allocations.length || !serials.length) return;
-    setAssignments((current) => {
-      const next = { ...current };
-      const remainingByAllocation = new Map(
-        allocations.map((allocation) => [
-          allocation.id,
-          Math.max(0, Number(allocation.quantity_authorized) - Number(allocation.assigned_quantity || 0)),
-        ]),
-      );
-
-      for (const serial of [...serials].sort((a, b) => a.sequenceNumber - b.sequenceNumber)) {
-        if (next[serial.id]) continue;
-        const allocation = allocations.find((candidate) =>
-          candidate.po_item_id === serial.poItemId &&
-          (remainingByAllocation.get(candidate.id) ?? 0) > 0
-        );
-        if (!allocation) continue;
-        next[serial.id] = allocation.id;
-        remainingByAllocation.set(allocation.id, (remainingByAllocation.get(allocation.id) ?? 0) - 1);
+  const toggleBucketOverride = (group: (typeof poItemGroups)[number]) => {
+    setBucketOverrides((prev) => {
+      const current = prev[group.poItemId];
+      if (current?.enabled) {
+        return { ...prev, [group.poItemId]: { ...current, enabled: false } };
       }
 
-      return next;
-    });
-  }, [allocations, serials]);
-
-  const createAllocationMutation = useMutation({
-    mutationFn: () => apiRequest('/api/p2/billing-allocations', {
-      method: 'POST',
-      body: {
-        poId,
-        poItemId: Number(newBucket.poItemId),
-        bucketLabel: newBucket.bucketLabel,
-        description: newBucket.description,
-        customerPoLine: newBucket.customerPoLine,
-        quantityAuthorized: Number(newBucket.quantityAuthorized),
-        unitPrice: Number(newBucket.unitPrice),
-        notes: newBucket.notes,
-      },
-    }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/p2/billing-allocations', poId] });
-      setNewBucket((prev) => ({
+      return {
         ...prev,
+        [group.poItemId]: {
+          enabled: true,
+          bucketLabel: current?.bucketLabel || `Pending revised PO item #${group.poItemId}`,
+          description: current?.description || group.partName,
+          customerPoLine: current?.customerPoLine || '',
+          quantityAuthorized: current?.quantityAuthorized || String(group.units.length),
+          unitPrice: current?.unitPrice || '',
+        },
+      };
+    });
+  };
+
+  const updateBucketOverride = (
+    poItemId: number,
+    field: keyof Omit<BucketOverrideDraft, 'enabled'>,
+    value: string,
+  ) => {
+    setBucketOverrides((prev) => ({
+      ...prev,
+      [poItemId]: {
+        enabled: true,
         bucketLabel: '',
         description: '',
         customerPoLine: '',
-        quantityAuthorized: '1',
+        quantityAuthorized: '',
         unitPrice: '',
-        notes: '',
-      }));
-    },
-  });
-
-  const grouped: Record<string, SerializedUnit[]> = {};
-  for (const serial of serials) {
-    if (!grouped[serial.partNumber]) grouped[serial.partNumber] = [];
-    grouped[serial.partNumber].push(serial);
-  }
-
-  const missingAssignments = serials.filter((serial) => !assignments[serial.id]);
-  const confirmAssignments = serials.map((serial) => ({
-    serializedItemId: serial.id,
-    allocationId: assignments[serial.id],
-  }));
+        ...prev[poItemId],
+        [field]: value,
+      },
+    }));
+  };
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onCancel(); }}>
-      <DialogContent className="max-w-4xl max-h-[86vh] flex flex-col">
+      <DialogContent className="max-w-3xl max-h-[84vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Truck className="h-5 w-5 text-blue-600" />
@@ -194,156 +161,96 @@ export default function ShipmentSummaryModal({
 
         <Separator />
 
-        <div className="overflow-y-auto flex-1 space-y-4 pr-1">
-          <div className="space-y-3">
-            <div className="flex items-center gap-2">
-              <DollarSign className="h-4 w-4 text-emerald-600" />
-              <div className="font-medium text-sm">Billing Bucket / CLIN Assignment</div>
-              {missingAssignments.length > 0 && (
-                <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-200">
-                  {missingAssignments.length} unassigned
-                </Badge>
-              )}
-            </div>
-
-            <div className="border rounded-md p-3 space-y-3">
-              <div className="grid grid-cols-6 gap-2">
-                <div className="space-y-1 col-span-2">
-                  <Label className="text-xs">PO Item</Label>
-                  <select
-                    className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-                    value={newBucket.poItemId}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, poItemId: e.target.value }))}
-                  >
-                    {selectablePoItems.map((item) => (
-                      <option key={item.id} value={String(item.id)}>
-                        {item.part_number} - {item.part_name}
-                      </option>
-                    ))}
-                  </select>
+        <div className="overflow-y-auto flex-1 space-y-3 pr-1">
+          {poItemGroups.map((group) => (
+            <div key={group.poItemId} className="border rounded-md p-3 space-y-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Receipt className="h-4 w-4 text-emerald-600 shrink-0" />
+                    <span className="text-xs text-muted-foreground">Bucket</span>
+                    <span className="font-mono text-sm font-semibold">PO Item #{group.poItemId}</span>
+                    <Badge variant="secondary" className="text-xs">
+                      {group.units.length} unit{group.units.length !== 1 ? 's' : ''}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                    <Package className="h-3.5 w-3.5 shrink-0" />
+                    <span className="font-mono text-foreground">{group.partNumber}</span>
+                    <span className="truncate">{group.partName}</span>
+                  </div>
                 </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">CLIN/Bucket</Label>
-                  <Input
-                    className="h-9"
-                    value={newBucket.bucketLabel}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, bucketLabel: e.target.value }))}
-                    placeholder="CLIN 0001"
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">Qty</Label>
-                  <Input
-                    className="h-9"
-                    type="number"
-                    min="1"
-                    value={newBucket.quantityAuthorized}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, quantityAuthorized: e.target.value }))}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">Unit Price</Label>
-                  <Input
-                    className="h-9"
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    value={newBucket.unitPrice}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, unitPrice: e.target.value }))}
-                    placeholder="0.00"
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">PO Line Ref</Label>
-                  <Input
-                    className="h-9"
-                    value={newBucket.customerPoLine}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, customerPoLine: e.target.value }))}
-                    placeholder="optional"
-                  />
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <Input
-                  className="h-9"
-                  value={newBucket.description}
-                  onChange={(e) => setNewBucket((prev) => ({ ...prev, description: e.target.value }))}
-                  placeholder="Bucket description or pricing note"
-                />
                 <Button
                   type="button"
                   variant="outline"
-                  disabled={!newBucket.poItemId || !newBucket.bucketLabel.trim() || !newBucket.unitPrice || createAllocationMutation.isPending}
-                  onClick={() => createAllocationMutation.mutate()}
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => toggleBucketOverride(group)}
                 >
-                  <Plus className="h-4 w-4 mr-2" />
-                  Add Bucket
+                  {bucketOverrides[group.poItemId]?.enabled ? (
+                    <><X className="h-3.5 w-3.5 mr-1" />Use PO Line</>
+                  ) : (
+                    <><Plus className="h-3.5 w-3.5 mr-1" />Add Bucket</>
+                  )}
                 </Button>
               </div>
-              {createAllocationMutation.isError && (
-                <p className="text-xs text-red-600">{(createAllocationMutation.error as any)?.message || 'Failed to add bucket'}</p>
-              )}
-            </div>
 
-            <div className="border rounded-md overflow-hidden">
-              <table className="w-full text-sm">
-                <thead className="bg-muted/50">
-                  <tr>
-                    <th className="text-left px-3 py-2 font-medium text-xs">Serial</th>
-                    <th className="text-left px-3 py-2 font-medium text-xs">Part</th>
-                    <th className="text-left px-3 py-2 font-medium text-xs">Billing Bucket</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {serials.map((serial) => {
-                    const matchingAllocations = allocations.filter((allocation) => allocation.po_item_id === serial.poItemId);
-                    return (
-                      <tr key={serial.id}>
-                        <td className="px-3 py-2 font-mono text-xs">{serial.serialNumber}</td>
-                        <td className="px-3 py-2 text-xs">
-                          <div className="font-mono">{serial.partNumber}</div>
-                          <div className="text-muted-foreground">{serial.partName}</div>
-                        </td>
-                        <td className="px-3 py-2">
-                          <select
-                            className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-                            value={assignments[serial.id] || ''}
-                            onChange={(e) => setAssignments((prev) => ({ ...prev, [serial.id]: e.target.value }))}
-                            disabled={loadingAllocations}
-                          >
-                            <option value="">Select bucket...</option>
-                            {matchingAllocations.map((allocation) => (
-                              <option key={allocation.id} value={allocation.id}>
-                                {allocation.bucket_label} - ${Number(allocation.unit_price).toFixed(2)}
-                                {' '}({allocation.assigned_quantity}/{allocation.quantity_authorized} assigned)
-                              </option>
-                            ))}
-                          </select>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          <Separator />
-
-          {Object.entries(grouped).map(([partNumber, group]) => (
-            <div key={partNumber} className="border rounded-md p-3 space-y-2">
-              <div className="flex items-start justify-between gap-2">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <Package className="h-4 w-4 text-muted-foreground shrink-0" />
-                    <span className="font-mono text-sm font-semibold">{partNumber}</span>
-                    <Badge variant="secondary" className="text-xs">{group.length} unit{group.length !== 1 ? 's' : ''}</Badge>
+              {bucketOverrides[group.poItemId]?.enabled && (
+                <div className="grid grid-cols-6 gap-2 rounded-md border bg-muted/20 p-3">
+                  <div className="space-y-1 col-span-2">
+                    <Label className="text-xs">Bucket</Label>
+                    <Input
+                      className="h-9"
+                      value={bucketOverrides[group.poItemId]?.bucketLabel || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'bucketLabel', e.target.value)}
+                      placeholder="Pending revised PO item"
+                    />
                   </div>
-                  <div className="text-xs text-muted-foreground mt-0.5 ml-6">{group[0].partName}</div>
+                  <div className="space-y-1 col-span-2">
+                    <Label className="text-xs">Description</Label>
+                    <Input
+                      className="h-9"
+                      value={bucketOverrides[group.poItemId]?.description || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'description', e.target.value)}
+                      placeholder={group.partName}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Qty</Label>
+                    <Input
+                      className="h-9"
+                      type="number"
+                      min="1"
+                      value={bucketOverrides[group.poItemId]?.quantityAuthorized || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'quantityAuthorized', e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Unit Price</Label>
+                    <Input
+                      className="h-9"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={bucketOverrides[group.poItemId]?.unitPrice || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'unitPrice', e.target.value)}
+                      placeholder="0.00"
+                    />
+                  </div>
+                  <div className="space-y-1 col-span-6">
+                    <Label className="text-xs">Revised PO Line Reference</Label>
+                    <Input
+                      className="h-9"
+                      value={bucketOverrides[group.poItemId]?.customerPoLine || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'customerPoLine', e.target.value)}
+                      placeholder="optional"
+                    />
+                  </div>
                 </div>
-              </div>
-              <div className="ml-6 flex flex-wrap gap-1.5">
-                {group.map((serial) => (
+              )}
+
+              <div className="flex flex-wrap gap-1.5">
+                {group.units.map((serial) => (
                   <span
                     key={serial.id}
                     className="font-mono text-[11px] bg-muted px-1.5 py-0.5 rounded border"
@@ -360,7 +267,7 @@ export default function ShipmentSummaryModal({
 
         <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/30 rounded-md px-3 py-2">
           <CalendarClock className="h-3.5 w-3.5 shrink-0" />
-          Lot number will be generated upon confirmation (format: YYMMDD-XX)
+          Each unit will be assigned to its PO item line unless a pending revised-PO bucket is added.
         </div>
 
         <DialogFooter className="gap-2">
@@ -369,8 +276,8 @@ export default function ShipmentSummaryModal({
           </Button>
           <Button
             className="bg-blue-600 hover:bg-blue-700 text-white"
-            disabled={missingAssignments.length > 0}
-            onClick={() => onConfirm(confirmAssignments)}
+            disabled={serials.length === 0}
+            onClick={() => onConfirm([], enabledBucketOverrides)}
           >
             <Truck className="h-4 w-4 mr-2" />
             Confirm Shipment ({serials.length} unit{serials.length !== 1 ? 's' : ''})

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -604,6 +604,15 @@ const createLotSchema = z.object({
     serializedItemId: z.string().uuid(),
     allocationId: z.string().uuid(),
   })).optional(),
+  billingBucketOverrides: z.array(z.object({
+    poItemId: z.coerce.number().int().positive(),
+    bucketLabel: z.string().trim().min(1, 'Bucket label is required'),
+    description: z.string().trim().optional(),
+    customerPoLine: z.string().trim().optional(),
+    quantityAuthorized: z.coerce.number().int().positive().optional(),
+    unitPrice: z.coerce.number().min(0).optional(),
+    serialIds: z.array(z.string().uuid()).optional(),
+  })).optional(),
 });
 
 const voidShipmentSchema = z.object({
@@ -888,6 +897,127 @@ router.post('/billing-allocations', authenticateToken, requirePermission('shippi
   }
 });
 
+type BillingBucketOverride = NonNullable<z.infer<typeof createLotSchema>['billingBucketOverrides']>[number];
+
+async function assignSerialsToPoItemBuckets(
+  serials: any[],
+  actor: string,
+  bucketOverrides: BillingBucketOverride[] = [],
+): Promise<void> {
+  const serialsByPoItemId = new Map<number, any[]>();
+  for (const serial of serials) {
+    const poItemId = Number(serial.poItemId);
+    if (!Number.isInteger(poItemId) || poItemId <= 0) {
+      throw new Error(`Serial ${serial.serialNumber} is missing a PO item line`);
+    }
+    serialsByPoItemId.set(poItemId, [...(serialsByPoItemId.get(poItemId) ?? []), serial]);
+  }
+
+  const overrideByPoItemId = new Map(bucketOverrides.map((override) => [override.poItemId, override]));
+
+  for (const [poItemId, group] of serialsByPoItemId.entries()) {
+    const first = group[0];
+    const override = overrideByPoItemId.get(poItemId);
+    const poItemResult = await pool.query<{
+      id: number;
+      po_id: number;
+      part_number: string;
+      part_name: string | null;
+      quantity: number | null;
+      unit_price: string | number | null;
+    }>(
+      `SELECT id, po_id, part_number, part_name, quantity, unit_price
+         FROM p2_purchase_order_items
+        WHERE id = $1 AND po_id = $2`,
+      [poItemId, first.poId],
+    );
+    const poItem = poItemResult.rows[0];
+    if (!poItem) throw new Error(`PO item ${poItemId} was not found for PO ${first.poNumber}`);
+
+    const authorizedQuantity = Math.max(
+      Number(override?.quantityAuthorized) || 0,
+      Number(poItem.quantity) || 0,
+      group.length,
+    );
+    const unitPrice = Number(override?.unitPrice ?? poItem.unit_price) || 0;
+    const bucketLabel = override?.bucketLabel || `PO Item #${poItem.id}`;
+    const description = override?.description || poItem.part_name || first.partName || null;
+    const customerPoLine = override?.customerPoLine || String(poItem.id);
+
+    const existingAllocationResult = await pool.query<{ id: string }>(
+      `SELECT id
+         FROM p2_billing_allocations
+        WHERE po_id = $1
+          AND po_item_id = $2
+          AND bucket_label = $3
+          AND active = true
+        ORDER BY created_at
+        LIMIT 1`,
+      [poItem.po_id, poItem.id, bucketLabel],
+    );
+
+    let allocationId = existingAllocationResult.rows[0]?.id;
+    if (allocationId) {
+      await pool.query(
+        `UPDATE p2_billing_allocations
+            SET bucket_label = $1,
+                description = COALESCE(description, $2),
+                customer_po_line = COALESCE(customer_po_line, $6),
+                quantity_authorized = GREATEST(quantity_authorized, $3),
+                unit_price = $4,
+                updated_at = now()
+          WHERE id = $5`,
+        [bucketLabel, description, authorizedQuantity, unitPrice.toFixed(2), allocationId, customerPoLine],
+      );
+    } else {
+      const createdAllocationResult = await pool.query<{ id: string }>(
+        `INSERT INTO p2_billing_allocations (
+           po_id, po_item_id, po_number, part_number, bucket_label, description,
+           customer_po_line, quantity_authorized, unit_price, notes, created_by
+         )
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+         RETURNING id`,
+        [
+          poItem.po_id,
+          poItem.id,
+          first.poNumber,
+          poItem.part_number || first.partNumber,
+          bucketLabel,
+          description,
+          customerPoLine,
+          authorizedQuantity,
+          unitPrice.toFixed(2),
+          override
+            ? 'Pending revised PO bucket created during shipment creation'
+            : 'Auto-created from PO item line during shipment creation',
+          actor,
+        ],
+      );
+      allocationId = createdAllocationResult.rows[0].id;
+    }
+
+    for (const serial of group) {
+      await pool.query(
+        `INSERT INTO p2_serial_billing_assignments (
+           allocation_id, serialized_item_id, po_id, po_item_id, assigned_by, assignment_source
+         )
+         VALUES ($1,$2,$3,$4,$5,'po_item_shipment_create')
+         ON CONFLICT (serialized_item_id)
+         DO UPDATE SET
+           allocation_id = EXCLUDED.allocation_id,
+           po_id = EXCLUDED.po_id,
+           po_item_id = EXCLUDED.po_item_id,
+           assigned_at = now(),
+           assigned_by = EXCLUDED.assigned_by,
+           assignment_source = EXCLUDED.assignment_source,
+           updated_at = now()
+         WHERE p2_serial_billing_assignments.locked_at IS NULL`,
+        [allocationId, serial.id, serial.poId, serial.poItemId, actor],
+      );
+    }
+  }
+}
+
 router.post('/lots', authenticateToken, requirePermission('shipping.release_shipment'), async (req: Request, res: Response) => {
   try {
     await ensureP2BillingAllocationSchema();
@@ -925,6 +1055,10 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
     const incomingAssignmentBySerialId = new Map(
       incomingAssignments.map((assignment) => [assignment.serializedItemId, assignment.allocationId]),
     );
+    if (incomingAssignments.length === 0) {
+      await assignSerialsToPoItemBuckets(serials, actor, input.billingBucketOverrides ?? []);
+    }
+
     if (incomingAssignments.length > 0) {
       const missingIncoming = input.serialIds.filter((serialId) => !incomingAssignmentBySerialId.has(serialId));
       const outsideShipment = incomingAssignments.filter((assignment) => !selectedSerialIdSet.has(assignment.serializedItemId));


### PR DESCRIPTION
## Summary
- Make the P2 shipment confirmation modal group selected serials by PO item line instead of requiring a pre-existing billing bucket dropdown selection.
- Default shipment bucket creation to the PO item line during lot creation so users can confirm shipments when no manual buckets exist yet.
- Add an optional per-line Add Bucket path for pending revised PO cases, carrying revised bucket metadata into the shipment create request.

## Validation
- `git diff --check -- client/src/components/p2/ShipmentSummaryModal.tsx client/src/components/p2/P2ShippingTab.tsx server/src/routes/p2Shipping.ts`
- `C:\Users\glenn\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --experimental-strip-types --check server\src\routes\p2Shipping.ts`

## Note
PR #1189 had already been merged, so this is a fresh follow-up branch from current `origin/main`.