### PR TITLE
[codex] Add P2 project PO view action

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -2757,14 +2757,25 @@ export default function ProjectDetailPage() {
                         <p className="text-sm text-muted-foreground truncate">{po.customerName}</p>
                         {po.projectName && <p className="text-xs text-muted-foreground truncate">{po.projectName}</p>}
                       </div>
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant={po.status === 'OPEN' ? 'secondary' : 'default'}>{po.status}</Badge>
-                        {project.poId === po.id && <Badge variant="outline">Primary</Badge>}
-                        {po.expectedDelivery && (
-                          <span className="text-xs text-muted-foreground">
-                            Due {format(new Date(po.expectedDelivery), 'MMM d, yyyy')}
-                          </span>
-                        )}
+                      <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant={po.status === 'OPEN' ? 'secondary' : 'default'}>{po.status}</Badge>
+                          {project.poId === po.id && <Badge variant="outline">Primary</Badge>}
+                          {po.expectedDelivery && (
+                            <span className="text-xs text-muted-foreground">
+                              Due {format(new Date(po.expectedDelivery), 'MMM d, yyyy')}
+                            </span>
+                          )}
+                        </div>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setLocation(`/p2-control-center?tab=setup&projectId=${encodeURIComponent(project.id)}&editPoId=${encodeURIComponent(String(po.id))}`)}
+                          data-testid={`button-view-project-po-${po.id}`}
+                        >
+                          <Eye className="h-4 w-4 mr-1.5" />
+                          View PO
+                        </Button>
                       </div>
                     </div>
                   ))


### PR DESCRIPTION
## Summary
- Adds a `View PO` action to each PO listed on the P2 Project PO tab.
- Routes users directly into the existing P2 Control Center PO wizard/detail surface for the selected PO.

## Why
The P2 Project PO tab showed assigned POs, but users could not open/view a PO directly from that list.

## Validation
- `git diff --check`
- `git diff --cached --check`

Full `npm run check` was not available because this shell/worktree does not have `npm`/`tsc` available.