### PR TITLE
[codex] Use inventory departments in BOM wizards

### DIFF
--- a/client/src/components/p2/P2BOMWizard.tsx
+++ b/client/src/components/p2/P2BOMWizard.tsx
@@ -53,6 +53,16 @@ interface BOMItem {
   firstDepartment: string;
 }
 
+interface InventoryDepartment {
+  id: number;
+  name: string;
+}
+
+interface DepartmentOption {
+  value: string;
+  label: string;
+}
+
 interface PartNeedingBOM {
   id: string;
   partNumber: string;
@@ -62,17 +72,43 @@ interface PartNeedingBOM {
   bomItems: BOMItem[];
 }
 
-const DEPARTMENT_OPTIONS = [
-  { value: 'cutting_table', label: 'Cutting Table' },
-  { value: 'core_department', label: 'Core Department' },
-  { value: 'layup', label: 'Layup' },
-  { value: 'assembly', label: 'Assembly' },
-  { value: 'disassembly', label: 'Disassembly' },
-  { value: 'cnc', label: 'CNC' },
-  { value: 'finish', label: 'Finish' },
-  { value: 'paint', label: 'Paint' },
-  { value: 'final_qc', label: 'Final QC' },
+const DEFAULT_DEPARTMENT = 'Layup';
+const FALLBACK_DEPARTMENT_OPTIONS: DepartmentOption[] = [
+  { value: 'Production Queue', label: 'Production Queue' },
+  { value: 'Layup', label: 'Layup' },
+  { value: 'Barcode', label: 'Barcode' },
+  { value: 'CNC', label: 'CNC' },
+  { value: 'Gunsmith', label: 'Gunsmith' },
+  { value: 'Paint', label: 'Paint' },
+  { value: 'Finish', label: 'Finish' },
+  { value: 'Finish QC', label: 'Finish QC' },
+  { value: 'Shipping QC', label: 'Shipping QC' },
+  { value: 'Shipping', label: 'Shipping' },
+  { value: 'Cutting Table', label: 'Cutting Table' },
+  { value: 'Office', label: 'Office' },
+  { value: 'Assembly', label: 'Assembly' },
 ];
+const LEGACY_DEPARTMENT_LABELS: Record<string, string> = {
+  cutting_table: 'Cutting Table',
+  core_department: 'Core Department',
+  layup: 'Layup',
+  assembly: 'Assembly',
+  disassembly: 'Disassembly',
+  cnc: 'CNC',
+  finish: 'Finish',
+  paint: 'Paint',
+  final_qc: 'Final QC',
+};
+
+function getDepartmentLabel(value: string | undefined, options: DepartmentOption[]) {
+  if (!value) return '';
+  return options.find((department) => department.value === value)?.label ?? LEGACY_DEPARTMENT_LABELS[value] ?? value;
+}
+
+function departmentOptionsWithCurrent(options: DepartmentOption[], value: string | undefined) {
+  if (!value || options.some((department) => department.value === value)) return options;
+  return [...options, { value, label: getDepartmentLabel(value, options) }];
+}
 
 export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardProps) {
   const [currentPartIndex, setCurrentPartIndex] = useState(0);
@@ -93,6 +129,18 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
   const { data: inventoryItems = [] } = useQuery<any[]>({
     queryKey: ['/api/inventory/items'],
   });
+
+  const { data: inventoryDepartments = [] } = useQuery<InventoryDepartment[]>({
+    queryKey: ['/api/inventory/departments'],
+  });
+
+  const departmentOptions = useMemo<DepartmentOption[]>(() => {
+    if (inventoryDepartments.length === 0) return FALLBACK_DEPARTMENT_OPTIONS;
+    return inventoryDepartments.map((department) => ({
+      value: department.name,
+      label: department.name,
+    }));
+  }, [inventoryDepartments]);
 
   const saveBOMMutation = useMutation({
     mutationFn: async (data: { partId: string; bomItems: BOMItem[]; poItemId?: string; partNumber?: string }) => {
@@ -140,7 +188,7 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
         description: item.notes || item.description || '',
         quantity: item.quantity || 1,
         isManufactured: item.isManufactured === true || item.itemType === 'manufactured',
-        firstDepartment: item.firstDept || item.firstDepartment || 'layup',
+        firstDepartment: item.firstDept || item.firstDepartment || DEFAULT_DEPARTMENT,
       }));
     } catch (error) {
       console.error('Error fetching existing BOM items:', error);
@@ -210,7 +258,7 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
       description: newItem.description || '',
       quantity: newItem.quantity || 1,
       isManufactured: newItem.isManufactured || false,
-      firstDepartment: newItem.firstDepartment || 'layup',
+      firstDepartment: newItem.firstDepartment || DEFAULT_DEPARTMENT,
     };
 
     setCurrentBOMItems([...currentBOMItems, item]);
@@ -522,7 +570,7 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
                   <SelectValue placeholder="Dept..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {DEPARTMENT_OPTIONS.map((dept) => (
+                  {departmentOptionsWithCurrent(departmentOptions, newItem.firstDepartment).map((dept) => (
                     <SelectItem key={dept.value} value={dept.value}>
                       {dept.label}
                     </SelectItem>
@@ -578,7 +626,7 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
                   <TableCell className="text-center">{item.quantity}</TableCell>
                   <TableCell>
                     <Badge variant="outline">
-                      {DEPARTMENT_OPTIONS.find(d => d.value === item.firstDepartment)?.label || item.firstDepartment}
+                      {getDepartmentLabel(item.firstDepartment, departmentOptions)}
                     </Badge>
                   </TableCell>
                   <TableCell>
@@ -660,7 +708,7 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {DEPARTMENT_OPTIONS.map((dept) => (
+                      {departmentOptionsWithCurrent(departmentOptions, editingItem.firstDepartment).map((dept) => (
                         <SelectItem key={dept.value} value={dept.value}>
                           {dept.label}
                         </SelectItem>

--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -201,6 +201,16 @@ type InventoryItemOption = {
   manufacturedCategory?: string | null;
 };
 
+type InventoryDepartmentOption = {
+  id: number;
+  name: string;
+};
+
+type DepartmentOption = {
+  value: string;
+  label: string;
+};
+
 type AssemblyStockState = 'on-hand' | 'low-stock' | 'blocked';
 type AssemblyManufactureState = 'ready' | 'waiting' | 'needs-plan';
 type AssemblyTreeNode = {
@@ -318,6 +328,46 @@ const departmentOptions = [
   { value: 'paint', label: 'Paint' },
   { value: 'final_qc', label: 'Final QC' },
 ];
+const fallbackBomDepartmentOptions: DepartmentOption[] = [
+  { value: 'Production Queue', label: 'Production Queue' },
+  { value: 'Layup', label: 'Layup' },
+  { value: 'Barcode', label: 'Barcode' },
+  { value: 'CNC', label: 'CNC' },
+  { value: 'Gunsmith', label: 'Gunsmith' },
+  { value: 'Paint', label: 'Paint' },
+  { value: 'Finish', label: 'Finish' },
+  { value: 'Finish QC', label: 'Finish QC' },
+  { value: 'Shipping QC', label: 'Shipping QC' },
+  { value: 'Shipping', label: 'Shipping' },
+  { value: 'Cutting Table', label: 'Cutting Table' },
+  { value: 'Office', label: 'Office' },
+  { value: 'Assembly', label: 'Assembly' },
+];
+const legacyDepartmentLabels: Record<string, string> = {
+  cutting_table: 'Cutting Table',
+  core_department: 'Core Department',
+  layup: 'Layup',
+  assembly: 'Assembly',
+  disassembly: 'Disassembly',
+  cnc: 'CNC',
+  finish: 'Finish',
+  paint: 'Paint',
+  final_qc: 'Final QC',
+};
+
+function bomDepartmentLabel(value: string | undefined, options: DepartmentOption[]) {
+  if (!value) return '';
+  return options.find((department) => department.value === value)?.label ?? legacyDepartmentLabels[value] ?? value;
+}
+
+function bomDepartmentOptionsWithCurrent(options: DepartmentOption[], value: string | undefined) {
+  if (!value || options.some((department) => department.value === value)) return options;
+  return [...options, { value, label: bomDepartmentLabel(value, options) }];
+}
+
+function defaultBomDepartment(options: DepartmentOption[]) {
+  return options.find((department) => department.value === 'Layup')?.value ?? options[0]?.value ?? 'Layup';
+}
 const employeeRoleOptions = [
   'Operator',
   'Technician',
@@ -1152,6 +1202,18 @@ export default function DraftBOMBuilderPage() {
     queryKey: ['/api/inventory'],
     queryFn: () => apiRequest('/api/inventory'),
   });
+
+  const { data: inventoryDepartments = [] } = useQuery<InventoryDepartmentOption[]>({
+    queryKey: ['/api/inventory/departments'],
+  });
+
+  const bomDepartmentOptions = useMemo<DepartmentOption[]>(() => {
+    if (inventoryDepartments.length === 0) return fallbackBomDepartmentOptions;
+    return inventoryDepartments.map((department) => ({
+      value: department.name,
+      label: department.name,
+    }));
+  }, [inventoryDepartments]);
 
   const projectOptions = useMemo(() => {
     return [...projects].sort((a, b) => projectLabel(a).localeCompare(projectLabel(b)));
@@ -2464,6 +2526,7 @@ export default function DraftBOMBuilderPage() {
                   draftLines={draft.lines}
                   savedDraftBoms={draft.savedDraftBoms ?? []}
                   inventoryItems={activeInventoryItems}
+                  departmentOptions={bomDepartmentOptions}
                   seedLineId={wizardSeedLineId}
                   onSeedLineConsumed={() => setWizardSeedLineId(null)}
                   onSaveWizardBom={saveWizardBom}
@@ -3405,6 +3468,7 @@ function DraftBomWizardWorkspace({
   draftLines,
   savedDraftBoms,
   inventoryItems,
+  departmentOptions,
   seedLineId,
   onSeedLineConsumed,
   onSaveWizardBom,
@@ -3414,6 +3478,7 @@ function DraftBomWizardWorkspace({
   draftLines: BomLine[];
   savedDraftBoms: DraftPartBom[];
   inventoryItems: InventoryItemOption[];
+  departmentOptions: DepartmentOption[];
   seedLineId: string | null;
   onSeedLineConsumed: () => void;
   onSaveWizardBom: (part: DraftBomPart, bom: DraftPartBom) => void;
@@ -3436,7 +3501,8 @@ function DraftBomWizardWorkspace({
   const [componentDescription, setComponentDescription] = useState('');
   const [componentQuantity, setComponentQuantity] = useState('1');
   const [componentManufactured, setComponentManufactured] = useState(false);
-  const [componentDepartment, setComponentDepartment] = useState(defaultDepartment);
+  const currentDefaultDepartment = defaultBomDepartment(departmentOptions);
+  const [componentDepartment, setComponentDepartment] = useState(currentDefaultDepartment);
 
   const draftPartLines = useMemo(
     () => draftLines.filter((line) => line.isDraftPart !== false || line.inventoryItemId || line.description || line.agPartNumber),
@@ -3507,7 +3573,7 @@ function DraftBomWizardWorkspace({
     setComponentDescription('');
     setComponentQuantity('1');
     setComponentManufactured(false);
-    setComponentDepartment(defaultDepartment);
+    setComponentDepartment(currentDefaultDepartment);
   }
 
   function syncComponentFromDraftLine(lineId: string) {
@@ -3517,7 +3583,7 @@ function DraftBomWizardWorkspace({
     setComponentPartNumber(linePartNumber(line));
     setComponentDescription(lineDescription(line));
     setComponentManufactured(line.isManufactured === true);
-    setComponentDepartment(line.firstDepartment ?? defaultDepartment);
+    setComponentDepartment(line.firstDepartment ?? currentDefaultDepartment);
   }
 
   function syncComponentFromInventory(itemId: string) {
@@ -3527,7 +3593,7 @@ function DraftBomWizardWorkspace({
     setComponentPartNumber(inventoryPartNumber(item));
     setComponentDescription(inventoryDescription(item));
     setComponentManufactured(isInventoryManufactured(item));
-    setComponentDepartment(defaultDepartment);
+    setComponentDepartment(currentDefaultDepartment);
   }
 
   function addComponent() {
@@ -3542,7 +3608,7 @@ function DraftBomWizardWorkspace({
       description: componentDescription.trim() || componentPartNumber.trim(),
       quantity: Number.isFinite(quantity) && quantity > 0 ? quantity : 1,
       isManufactured: componentManufactured,
-      firstDepartment: componentDepartment || defaultDepartment,
+      firstDepartment: componentDepartment || currentDefaultDepartment,
     };
 
     setActiveBom((current) => {
@@ -3885,7 +3951,7 @@ function DraftBomWizardWorkspace({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {departmentOptions.map((department) => (
+                    {bomDepartmentOptionsWithCurrent(departmentOptions, componentDepartment).map((department) => (
                       <SelectItem key={department.value} value={department.value}>
                         {department.label}
                       </SelectItem>
@@ -3960,7 +4026,7 @@ function DraftBomWizardWorkspace({
                         </TableCell>
                         <TableCell className="min-w-[160px]">
                           <Select
-                            value={component.firstDepartment || defaultDepartment}
+                            value={component.firstDepartment || currentDefaultDepartment}
                             onValueChange={(value) => updateComponent(component.id, { firstDepartment: value })}
                             disabled={!isEditMode}
                           >
@@ -3968,7 +4034,7 @@ function DraftBomWizardWorkspace({
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              {departmentOptions.map((department) => (
+                              {bomDepartmentOptionsWithCurrent(departmentOptions, component.firstDepartment).map((department) => (
                                 <SelectItem key={department.value} value={department.value}>
                                   {department.label}
                                 </SelectItem>


### PR DESCRIPTION
## Summary
- Load BOM Wizard department choices from `/api/inventory/departments` so they match Inventory Item assigned departments.
- Keep inventory-style fallback departments for initial render/API failure.
- Preserve legacy saved values like `layup`/`final_qc` so existing draft BOMs remain visible while new selections store inventory department names.

## Root Cause
The Draft Builder BOM Wizard and standalone P2 BOM Wizard used hard-coded department option arrays, so departments present in Inventory Items could be missing from BOM component selection.

## Validation
- `git diff --check` passed.
- `git diff --cached --check` passed.
- Compare audit confirmed one commit touching only the two BOM wizard files.

Note: full TypeScript validation was not available locally because this clean worktree has no `node_modules`, `npm` is not on PATH, and the bundled Node syntax check does not support `.tsx` files in this environment.