### PR TITLE
[codex] Scope part routings by project

### DIFF
--- a/client/src/components/PartRoutingWizard.tsx
+++ b/client/src/components/PartRoutingWizard.tsx
@@ -102,6 +102,13 @@ interface InventoryItem {
   description?: string;
 }
 
+interface ProjectOption {
+  id: string;
+  projectCode: string;
+  projectName: string;
+  status?: string;
+}
+
 interface MaterialRequirement {
   partId: string;
   partNumber: string;
@@ -224,6 +231,7 @@ interface DepartmentConfiguration {
 interface PartRouting {
   id: string;
   inventoryItemId: string;
+  projectId?: string | null;
   partNumber: string;  // This comes from backend, keep as is for routing data
   partName: string;    // This comes from backend, keep as is for routing data
   departmentSequence: string[];
@@ -307,6 +315,7 @@ interface PartRoutingWizardProps {
 export default function PartRoutingWizard({ open, onOpenChange, editRouting, poId }: PartRoutingWizardProps) {
   const [step, setStep] = useState(1);
   const [selectedItemId, setSelectedItemId] = useState<string>(editRouting?.inventoryItemId || '');
+  const [selectedProjectId, setSelectedProjectId] = useState<string>(editRouting?.projectId || '');
   const [selectedDepartments, setSelectedDepartments] = useState<string[]>(editRouting?.departmentSequence || []);
   const [searchTerm, setSearchTerm] = useState('');
   
@@ -392,12 +401,14 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
   useEffect(() => {
     if (open && editRouting) {
       setSelectedItemId(editRouting.inventoryItemId || '');
+      setSelectedProjectId(editRouting.projectId || '');
       setSelectedDepartments(editRouting.departmentSequence || []);
       setDepartmentConfig(editRouting.departmentConfig || {});
       setStep(1);
     } else if (open && !editRouting) {
       // Reset for new routing
       setSelectedItemId('');
+      setSelectedProjectId('');
       setSelectedDepartments([]);
       setDepartmentConfig({});
       setStep(1);
@@ -442,6 +453,11 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
       })),
   });
 
+  const { data: projectsList = [] } = useQuery<ProjectOption[]>({
+    queryKey: ['/api/projects'],
+    enabled: open && step === 1,
+  });
+
   // Fetch inventory items for step 3 (materials selection)
   const { data: inventoryItems = [] } = useQuery<InventoryItem[]>({
     queryKey: ['/api/inventory'],
@@ -461,6 +477,11 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
 
   // Use inventory parts list directly for step 1 display
   const displayItems: InventoryItem[] = inventoryPartsList;
+  const displayProjects = [...projectsList].sort((a, b) => {
+    const aLabel = `${a.projectCode || ''} ${a.projectName || ''}`.trim();
+    const bLabel = `${b.projectCode || ''} ${b.projectName || ''}`.trim();
+    return aLabel.localeCompare(bLabel);
+  });
 
   // Fetch employees for technician assignment
   const { data: employees = [] } = useQuery<Employee[]>({
@@ -565,6 +586,7 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
           description: undefined,
         }
       : undefined);
+  const selectedProject = displayProjects.find(project => project.id === selectedProjectId);
 
   // Create/Update mutation
   const saveMutation = useMutation({
@@ -601,6 +623,7 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
   const resetState = () => {
     setStep(1);
     setSelectedItemId('');
+    setSelectedProjectId('');
     setSelectedDepartments([]);
     setDepartmentConfig({});
     setSearchTerm('');
@@ -641,6 +664,14 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
       toast({
         title: 'Selection Required',
         description: 'Please select an inventory part',
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (step === 1 && !editRouting && !selectedProjectId) {
+      toast({
+        title: 'Project Required',
+        description: 'Please select the project this routing applies to',
         variant: 'destructive',
       });
       return;
@@ -696,6 +727,7 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
 
     const data = {
       inventoryItemId: String(selectedItem.id), // Ensure inventoryItemId is string
+      projectId: selectedProjectId || null,
       partNumber: selectedItem.agPartNumber,
       partName: selectedItem.name,
       departmentSequence: selectedDepartments,
@@ -1636,6 +1668,36 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
                 </Select>
               </div>
 
+              <div>
+                <Label htmlFor="project-select">Project</Label>
+                <Select
+                  value={selectedProjectId}
+                  onValueChange={(value) => setSelectedProjectId(value)}
+                >
+                  <SelectTrigger id="project-select" data-testid="select-routing-project">
+                    <SelectValue placeholder={editRouting ? 'No project assigned yet' : 'Select a project...'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {displayProjects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        <span className="flex items-center gap-2">
+                          <span className="font-mono">{project.projectCode}</span>
+                          <span>{project.projectName}</span>
+                          {project.status && (
+                            <Badge variant="outline" className="text-xs shrink-0">{project.status}</Badge>
+                          )}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {editRouting && !selectedProjectId && (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Existing routings can stay unassigned until the project is known.
+                  </p>
+                )}
+              </div>
+
               {selectedItem && (
                 <Card className="bg-muted/30">
                   <CardContent className="p-4">
@@ -1647,6 +1709,19 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
                     {selectedItem.description && (
                       <p className="text-xs text-muted-foreground mt-2">{selectedItem.description}</p>
                     )}
+                    <div className="flex items-center gap-2 text-sm mt-2">
+                      <FolderOpen className="h-4 w-4 text-muted-foreground" />
+                      {selectedProject ? (
+                        <>
+                          <span className="font-mono font-medium">{selectedProject.projectCode}</span>
+                          <span>{selectedProject.projectName}</span>
+                        </>
+                      ) : (
+                        <span className="text-muted-foreground">
+                          {editRouting ? 'No project assigned' : 'Select a project for this routing'}
+                        </span>
+                      )}
+                    </div>
                     {itemsWithRoutings.has(selectedItem.id) && (
                       <p className="text-xs text-amber-600 dark:text-amber-400 mt-2 flex items-center gap-1">
                         <AlertCircle className="h-3 w-3 shrink-0" />

--- a/migrations/0176_part_routings_project_id.sql
+++ b/migrations/0176_part_routings_project_id.sql
@@ -1,0 +1,8 @@
+-- Link part routings to the project they apply to.
+-- Existing routings intentionally remain NULL so users can assign the project later.
+
+ALTER TABLE part_routings
+  ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES projects(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS part_routings_project_idx
+  ON part_routings(project_id);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -5480,6 +5480,7 @@ export const routingTypeEnum = pgEnum('routing_type', [
 export const partRoutings = pgTable('part_routings', {
   id: uuid('id').defaultRandom().primaryKey(),
   inventoryItemId: text('inventory_item_id').notNull(), // Reference to inventory item
+  projectId: uuid('project_id').references(() => projects.id, { onDelete: 'set null' }), // Nullable for legacy routings
   partNumber: text('part_number').notNull(), // Denormalized for display
   partName: text('part_name').notNull(), // Denormalized for display
   routingName: text('routing_name').default('Default').notNull(), // AS9100 routing name for revision control
@@ -5503,6 +5504,7 @@ export const partRoutings = pgTable('part_routings', {
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (table) => ({
   inventoryItemIdx: index('part_routings_inventory_item_idx').on(table.inventoryItemId),
+  projectIdx: index('part_routings_project_idx').on(table.projectId),
 }));
 
 // Routing Operations - Step-by-step operations within a part routing

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -202,6 +202,7 @@ const safeFiles = [
   '0171_all_orders_finalize_to_p1_queue.sql',
   '0173_nonconformance_records_runtime_alignment.sql',
   '0175_repair_remaining_ff_signature_queue_orders.sql',
+  '0176_part_routings_project_id.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -6605,9 +6605,9 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
               .where(eq(p2PurchaseOrders.id, poItem.poId));
             
             // Create serialized items for scheduling when BOM is complete
-            const { p2SerializedItems, partRoutings: partRoutingsTable } = await import('../../schema');
+            const { p2SerializedItems, partRoutings: partRoutingsTable, projects: projectsTable } = await import('../../schema');
             const { v4: uuidv4 } = await import('uuid');
-            const { and: andOp, eq: eqOp, ilike: ilikeOp } = await import('drizzle-orm');
+            const { and: andOp, eq: eqOp, ilike: ilikeOp, isNull: isNullOp } = await import('drizzle-orm');
             
             // Get the PO for additional info
             const [po] = await db
@@ -6627,12 +6627,54 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
               console.log(`Creating serialized items for PO ${po?.poNumber} with ${allItems.length} line items`);
               
               for (const lineItem of allItems) {
-                let itemRouting = await db.query.partRoutings.findFirst({
-                  where: andOp(eqOp(partRoutingsTable.partNumber, lineItem.partNumber), eqOp(partRoutingsTable.isActive, true)),
-                });
+                const [projectForPoItem] = await db
+                  .select({ id: projectsTable.id })
+                  .from(projectsTable)
+                  .where(andOp(eqOp(projectsTable.poId, poItem.poId), eqOp(projectsTable.p2PoItemId, lineItem.id)))
+                  .limit(1);
+                const [projectForPo] = projectForPoItem
+                  ? [projectForPoItem]
+                  : await db
+                      .select({ id: projectsTable.id })
+                      .from(projectsTable)
+                      .where(eqOp(projectsTable.poId, poItem.poId))
+                      .limit(1);
+                const projectId = projectForPo?.id ?? null;
+
+                let itemRouting = projectId
+                  ? await db.query.partRoutings.findFirst({
+                      where: andOp(
+                        eqOp(partRoutingsTable.projectId, projectId),
+                        eqOp(partRoutingsTable.partNumber, lineItem.partNumber),
+                        eqOp(partRoutingsTable.isActive, true)
+                      ),
+                    })
+                  : null;
+                if (!itemRouting && projectId) {
+                  itemRouting = await db.query.partRoutings.findFirst({
+                    where: andOp(
+                      eqOp(partRoutingsTable.projectId, projectId),
+                      ilikeOp(partRoutingsTable.partNumber, lineItem.partNumber),
+                      eqOp(partRoutingsTable.isActive, true)
+                    ),
+                  });
+                }
                 if (!itemRouting) {
                   itemRouting = await db.query.partRoutings.findFirst({
-                    where: andOp(ilikeOp(partRoutingsTable.partNumber, lineItem.partNumber), eqOp(partRoutingsTable.isActive, true)),
+                    where: andOp(
+                      isNullOp(partRoutingsTable.projectId),
+                      eqOp(partRoutingsTable.partNumber, lineItem.partNumber),
+                      eqOp(partRoutingsTable.isActive, true)
+                    ),
+                  });
+                }
+                if (!itemRouting) {
+                  itemRouting = await db.query.partRoutings.findFirst({
+                    where: andOp(
+                      isNullOp(partRoutingsTable.projectId),
+                      ilikeOp(partRoutingsTable.partNumber, lineItem.partNumber),
+                      eqOp(partRoutingsTable.isActive, true)
+                    ),
                   });
                 }
                 const baseMatch = lineItem.partNumber.match(/^(.+?)\s*Rev\s*\w+$/i);

--- a/server/src/routes/p2LayupSchedules.ts
+++ b/server/src/routes/p2LayupSchedules.ts
@@ -7,9 +7,10 @@ import {
   p2PurchaseOrderItems,
   p2ProductionOrders,
   partRoutings,
+  projects,
   insertP2LayupScheduleSchema 
 } from '../../schema';
-import { eq, and, gte, lte, desc, inArray, ilike, max } from 'drizzle-orm';
+import { eq, and, gte, lte, desc, inArray, ilike, max, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
 import JsBarcode from 'jsbarcode';
@@ -663,12 +664,54 @@ router.post('/layup-schedules/generate-serialized-items/:poItemId', async (req: 
       .where(eq(p2SerializedItems.poId, po.id));
     const startSeq = (maxSeqResult[0]?.maxSeq ?? 0) + 1;
 
-    let itemRouting = await db.query.partRoutings.findFirst({
-      where: and(eq(partRoutings.partNumber, poItem.partNumber), eq(partRoutings.isActive, true)),
-    });
+    const [projectForPoItem] = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(and(eq(projects.poId, po.id), eq(projects.p2PoItemId, poItem.id)))
+      .limit(1);
+    const [projectForPo] = projectForPoItem
+      ? [projectForPoItem]
+      : await db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(eq(projects.poId, po.id))
+          .limit(1);
+    const projectId = projectForPo?.id ?? null;
+
+    let itemRouting = projectId
+      ? await db.query.partRoutings.findFirst({
+          where: and(
+            eq(partRoutings.projectId, projectId),
+            eq(partRoutings.partNumber, poItem.partNumber),
+            eq(partRoutings.isActive, true)
+          ),
+        })
+      : null;
+    if (!itemRouting && projectId) {
+      itemRouting = await db.query.partRoutings.findFirst({
+        where: and(
+          eq(partRoutings.projectId, projectId),
+          ilike(partRoutings.partNumber, poItem.partNumber),
+          eq(partRoutings.isActive, true)
+        ),
+      });
+    }
     if (!itemRouting) {
       itemRouting = await db.query.partRoutings.findFirst({
-        where: and(ilike(partRoutings.partNumber, poItem.partNumber), eq(partRoutings.isActive, true)),
+        where: and(
+          isNull(partRoutings.projectId),
+          eq(partRoutings.partNumber, poItem.partNumber),
+          eq(partRoutings.isActive, true)
+        ),
+      });
+    }
+    if (!itemRouting) {
+      itemRouting = await db.query.partRoutings.findFirst({
+        where: and(
+          isNull(partRoutings.projectId),
+          ilike(partRoutings.partNumber, poItem.partNumber),
+          eq(partRoutings.isActive, true)
+        ),
       });
     }
     const baseMatch = poItem.partNumber.match(/^(.+?)\s*Rev\s*\w+$/i);

--- a/server/src/routes/partRoutings.ts
+++ b/server/src/routes/partRoutings.ts
@@ -33,6 +33,7 @@ async function ensureTablesExist() {
       CREATE TABLE IF NOT EXISTS part_routings (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         inventory_item_id TEXT NOT NULL,
+        project_id UUID,
         part_number TEXT NOT NULL,
         part_name TEXT NOT NULL,
         routing_name TEXT NOT NULL DEFAULT 'Default',
@@ -50,6 +51,8 @@ async function ensureTablesExist() {
         updated_at TIMESTAMP DEFAULT NOW()
       )
     `);
+    await pool.query(`ALTER TABLE part_routings ADD COLUMN IF NOT EXISTS project_id UUID`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS part_routings_project_idx ON part_routings(project_id)`);
     await pool.query(`
       CREATE TABLE IF NOT EXISTS routing_documents (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16461,12 +16461,54 @@ export class DatabaseStorage implements IStorage {
       .where(eq(p2SerializedItems.poId, po.id));
     const startSeq = (maxSeqResult[0]?.maxSeq ?? 0) + 1;
 
-    let itemRouting = await dbClient.query.partRoutings.findFirst({
-      where: and(eq(partRoutings.partNumber, poItem.partNumber), eq(partRoutings.isActive, true)),
-    });
+    const [projectForPoItem] = await dbClient
+      .select({ id: projects.id })
+      .from(projects)
+      .where(and(eq(projects.poId, po.id), eq(projects.p2PoItemId, poItem.id)))
+      .limit(1);
+    const [projectForPo] = projectForPoItem
+      ? [projectForPoItem]
+      : await dbClient
+          .select({ id: projects.id })
+          .from(projects)
+          .where(eq(projects.poId, po.id))
+          .limit(1);
+    const projectId = projectForPo?.id ?? null;
+
+    let itemRouting = projectId
+      ? await dbClient.query.partRoutings.findFirst({
+          where: and(
+            eq(partRoutings.projectId, projectId),
+            eq(partRoutings.partNumber, poItem.partNumber),
+            eq(partRoutings.isActive, true)
+          ),
+        })
+      : null;
+    if (!itemRouting && projectId) {
+      itemRouting = await dbClient.query.partRoutings.findFirst({
+        where: and(
+          eq(partRoutings.projectId, projectId),
+          ilike(partRoutings.partNumber, poItem.partNumber),
+          eq(partRoutings.isActive, true)
+        ),
+      });
+    }
     if (!itemRouting) {
       itemRouting = await dbClient.query.partRoutings.findFirst({
-        where: and(ilike(partRoutings.partNumber, poItem.partNumber), eq(partRoutings.isActive, true)),
+        where: and(
+          isNull(partRoutings.projectId),
+          eq(partRoutings.partNumber, poItem.partNumber),
+          eq(partRoutings.isActive, true)
+        ),
+      });
+    }
+    if (!itemRouting) {
+      itemRouting = await dbClient.query.partRoutings.findFirst({
+        where: and(
+          isNull(partRoutings.projectId),
+          ilike(partRoutings.partNumber, poItem.partNumber),
+          eq(partRoutings.isActive, true)
+        ),
       });
     }
     const baseMatch = poItem.partNumber.match(/^(.+?)\s*Rev\s*\w+$/i);


### PR DESCRIPTION
## Summary

- Add nullable `project_id` support for part routings so the same part can have different routings by project.
- Require project selection when creating a new part routing in the wizard, while allowing existing routings to remain unassigned until updated.
- Prefer project-specific routings when creating serialized P2 items, with fallback to legacy unassigned routings.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Bundled Node syntax checks with `--experimental-strip-types --check` for touched server `.ts` files:
  - `server/schema.ts`
  - `server/src/routes/partRoutings.ts`
  - `server/src/routes/p2LayupSchedules.ts`
  - `server/src/routes/index.ts`
  - `server/storage.ts`
  - `server/scripts/migrations/runSafeBootMigrations.ts`

Note: `npm` and local `node_modules/typescript` were unavailable in this Windows shell, so a full `npm run check` could not be run locally.