### PR TITLE
Let P2 shipments select PO line buckets

### DIFF
--- a/client/src/components/p2/ShipmentSummaryModal.tsx
+++ b/client/src/components/p2/ShipmentSummaryModal.tsx
@@ -1,6 +1,7 @@
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -11,6 +12,8 @@ import { Separator } from '@/components/ui/separator';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { apiRequest } from '@/lib/queryClient';
+import { useQuery } from '@tanstack/react-query';
 import { Truck, Package, CalendarClock, Receipt, Plus, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
@@ -46,6 +49,14 @@ type BucketOverrideDraft = {
   unitPrice: string;
 };
 
+type PoItem = {
+  id: number;
+  part_number: string;
+  part_name: string | null;
+  quantity: number | null;
+  unit_price: string | number | null;
+};
+
 interface ShipmentSummaryModalProps {
   serials: SerializedUnit[];
   onConfirm: (
@@ -62,9 +73,16 @@ export default function ShipmentSummaryModal({
 }: ShipmentSummaryModalProps) {
   const customer = serials[0]?.customerName ?? '-';
   const poNumber = serials[0]?.poNumber ?? '-';
+  const poId = serials[0]?.poId;
   const [bucketMode, setBucketMode] = useState<'combined' | 'split'>('combined');
   const [selectedPoItemId, setSelectedPoItemId] = useState<number | null>(null);
   const [bucketOverrides, setBucketOverrides] = useState<Record<number, BucketOverrideDraft>>({});
+
+  const { data: allocationData } = useQuery<{ poItems: PoItem[] }>({
+    queryKey: ['/api/p2/billing-allocations', poId],
+    queryFn: async () => apiRequest(`/api/p2/billing-allocations?poId=${encodeURIComponent(String(poId))}`),
+    enabled: !!poId,
+  });
 
   const poItemGroups = useMemo(() => {
     const groups = new Map<number, SerializedUnit[]>();
@@ -84,8 +102,53 @@ export default function ShipmentSummaryModal({
       .sort((a, b) => a.poItemId - b.poItemId);
   }, [serials]);
 
-  const effectiveSelectedPoItemId = selectedPoItemId ?? poItemGroups[0]?.poItemId ?? null;
-  const selectedPoItemGroup = poItemGroups.find((group) => group.poItemId === effectiveSelectedPoItemId) ?? poItemGroups[0];
+  const poItemOptions = useMemo(() => {
+    const groupByPoItemId = new Map(poItemGroups.map((group) => [group.poItemId, group]));
+    const fetchedItems = allocationData?.poItems ?? [];
+    const fetchedOptions = fetchedItems.map((item) => {
+      const group = groupByPoItemId.get(item.id);
+      return {
+        poItemId: item.id,
+        partNumber: item.part_number,
+        itemName: item.part_number || `PO Item #${item.id}`,
+        partName: item.part_name ?? group?.partName ?? '',
+        quantity: Number(item.quantity) || group?.units.length || 0,
+        unitPrice: Number(item.unit_price) || 0,
+        units: group?.units ?? [],
+      };
+    });
+
+    const fetchedIds = new Set(fetchedOptions.map((option) => option.poItemId));
+    const serialOnlyOptions = poItemGroups
+      .filter((group) => !fetchedIds.has(group.poItemId))
+      .map((group) => ({
+        poItemId: group.poItemId,
+        partNumber: group.partNumber,
+        itemName: group.itemName || `PO Item #${group.poItemId}`,
+        partName: group.partName,
+        quantity: group.units.length,
+        unitPrice: 0,
+        units: group.units,
+      }));
+
+    return [...fetchedOptions, ...serialOnlyOptions].sort((a, b) => a.poItemId - b.poItemId);
+  }, [allocationData?.poItems, poItemGroups]);
+
+  const effectiveSelectedPoItemId = selectedPoItemId ?? poItemOptions[0]?.poItemId ?? poItemGroups[0]?.poItemId ?? null;
+  const selectedPoItemOption =
+    poItemOptions.find((option) => option.poItemId === effectiveSelectedPoItemId) ??
+    poItemOptions[0] ??
+    (poItemGroups[0]
+      ? {
+          poItemId: poItemGroups[0].poItemId,
+          partNumber: poItemGroups[0].partNumber,
+          itemName: poItemGroups[0].itemName || `PO Item #${poItemGroups[0].poItemId}`,
+          partName: poItemGroups[0].partName,
+          quantity: poItemGroups[0].units.length,
+          unitPrice: 0,
+          units: poItemGroups[0].units,
+        }
+      : null);
 
   const enabledBucketOverrides: BillingBucketOverride[] = poItemGroups.flatMap((group) => {
     const override = bucketOverrides[group.poItemId];
@@ -102,13 +165,14 @@ export default function ShipmentSummaryModal({
   });
 
   const shipmentBucketOverrides: BillingBucketOverride[] =
-    bucketMode === 'combined' && selectedPoItemGroup
+    bucketMode === 'combined' && selectedPoItemOption
       ? [{
-          poItemId: selectedPoItemGroup.poItemId,
-          bucketLabel: selectedPoItemGroup.itemName || `PO Item #${selectedPoItemGroup.poItemId}`,
-          description: selectedPoItemGroup.partName || undefined,
-          customerPoLine: String(selectedPoItemGroup.poItemId),
+          poItemId: selectedPoItemOption.poItemId,
+          bucketLabel: selectedPoItemOption.itemName || `PO Item #${selectedPoItemOption.poItemId}`,
+          description: selectedPoItemOption.partName || undefined,
+          customerPoLine: String(selectedPoItemOption.poItemId),
           quantityAuthorized: serials.length,
+          unitPrice: selectedPoItemOption.unitPrice || undefined,
           serialIds: serials.map((serial) => serial.id),
         }]
       : enabledBucketOverrides;
@@ -162,6 +226,9 @@ export default function ShipmentSummaryModal({
             <Truck className="h-5 w-5 text-blue-600" />
             Shipment Summary
           </DialogTitle>
+          <DialogDescription>
+            Confirm the PO line item bucket for the selected serialized units.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="grid grid-cols-3 gap-3 text-sm">
@@ -226,7 +293,7 @@ export default function ShipmentSummaryModal({
                 onValueChange={(value) => setSelectedPoItemId(Number(value))}
                 className="space-y-2"
               >
-                {poItemGroups.map((group) => (
+                {poItemOptions.map((group) => (
                   <Label
                     key={group.poItemId}
                     htmlFor={`ship-po-item-${group.poItemId}`}
@@ -241,7 +308,7 @@ export default function ShipmentSummaryModal({
                       <span className="flex items-center gap-2">
                         <span className="font-mono text-sm font-semibold">{group.itemName || `PO Item #${group.poItemId}`}</span>
                         <Badge variant="secondary" className="text-xs">
-                          {group.units.length} unit{group.units.length !== 1 ? 's' : ''}
+                          {group.units.length > 0 ? `${group.units.length} selected` : `${group.quantity} on PO`}
                         </Badge>
                       </span>
                       <span className="block text-xs text-muted-foreground truncate">

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -1333,6 +1333,9 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
   } catch (err: any) {
     if (err instanceof z.ZodError)
       return res.status(400).json({ error: err.errors[0].message });
+    if (typeof err?.message === 'string' && /PO item|PO line|Serial .*missing/i.test(err.message)) {
+      return res.status(400).json({ error: err.message });
+    }
     console.error('Create lot error:', err);
     return res.status(500).json({ error: 'Failed to create lot' });
   }
@@ -1347,7 +1350,6 @@ router.get('/lots/existing-shipments', async (req: Request, res: Response) => {
   try {
     const rows = await pool.query<{
       po_id: number;
-      po_item_id: number | null;
       lot_id: string;
       lot_number: string;
       slip_id: string;
@@ -1364,30 +1366,21 @@ router.get('/lots/existing-shipments', async (req: Request, res: Response) => {
     }>(`
       SELECT
         l.po_id,
-        l.po_item_id,
         l.id           AS lot_id,
         l.lot_number,
         ps.id          AS slip_id,
         ps.packing_slip_number AS slip_number,
-        cc.id          AS cert_id,
-        cc.certificate_number  AS cert_number,
-        inv.id AS invoice_id,
-        inv.invoice_number,
-        inv.status AS invoice_status,
-        inv.total_amount AS invoice_total_amount,
+        NULL::uuid AS cert_id,
+        NULL::text AS cert_number,
+        NULL::uuid AS invoice_id,
+        NULL::text AS invoice_number,
+        NULL::text AS invoice_status,
+        NULL::numeric AS invoice_total_amount,
         NULL::integer AS journal_entry_id,
         NULL::text AS journal_entry_status,
         0::int AS journal_line_count
       FROM p2_lot_numbers l
       JOIN p2_packing_slips ps ON ps.id = l.packing_slip_id
-      LEFT JOIN p2_certificates_of_conformance cc ON cc.id = l.certificate_id
-      LEFT JOIN LATERAL (
-        SELECT id, invoice_number, status, total_amount
-        FROM ar_invoices
-        WHERE packing_slip_id = ps.id OR lot_id = l.id
-        ORDER BY created_at DESC
-        LIMIT 1
-      ) inv ON true
       WHERE l.po_id IS NOT NULL
         AND l.packing_slip_id IS NOT NULL
         AND COALESCE(l.status, '') <> 'VOID'


### PR DESCRIPTION
## Summary
- Fetch the selected PO's real line items in the P2 shipment confirmation modal so users can choose the PO line item/bucket associated with the project work order, even when that line is not represented by the selected serials' stored `po_item_id`.
- Send the selected PO line as the full-shipment bucket override so `/api/p2/lots` assigns selected serialized units to that line bucket.
- Harden `/api/p2/lots/existing-shipments` by removing AR invoice and certificate joins from the primary Shipping tab list load; those optional details should not block shipment history or lot creation.
- Return specific PO line/serial association errors from `/api/p2/lots` instead of only the generic `Failed to create lot` response.

## Validation
- `git diff --check origin/main..HEAD -- client/src/components/p2/ShipmentSummaryModal.tsx server/src/routes/p2Shipping.ts`
- `C:\Users\glenn\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --experimental-strip-types --check server\src\routes\p2Shipping.ts`

## Production Signal
User still sees 500s for `/api/p2/lots/existing-shipments` and `/api/p2/lots`, and cannot select the PO line item associated with the project work order during shipment creation.