### PR TITLE
[codex] Link vendor POs to parts requests

### DIFF
--- a/client/src/components/inventory/PartsRequestsCard.tsx
+++ b/client/src/components/inventory/PartsRequestsCard.tsx
@@ -103,6 +103,12 @@ type PartsRequestWithProject = PartsRequest & {
     projectCode: string | null;
     projectName: string | null;
   };
+  vendorPO?: {
+    id: number | null;
+    poNumber: string | null;
+    externalPoNumber: string | null;
+    status: string | null;
+  };
 };
 
 const NONE_VALUE = '__none__';
@@ -1023,6 +1029,17 @@ export default function PartsRequestsCard() {
                               {new Date(
                                 request.expectedDelivery
                               ).toLocaleDateString()}
+                            </span>
+                          </div>
+                        )}
+
+                        {request.vendorPO && (
+                          <div className="flex items-center gap-2 text-xs text-blue-700 bg-blue-50 px-2 py-1 rounded">
+                            <Package className="h-3 w-3" />
+                            <span>
+                              Vendor PO:{' '}
+                              {request.vendorPO.poNumber || `Draft #${request.vendorPO.id}`}
+                              {request.vendorPO.status ? ` (${request.vendorPO.status})` : ''}
                             </span>
                           </div>
                         )}

--- a/client/src/components/inventory/VendorPOItemSelector.tsx
+++ b/client/src/components/inventory/VendorPOItemSelector.tsx
@@ -4,6 +4,7 @@ import { apiRequest } from '@/lib/queryClient';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import {
@@ -164,6 +165,27 @@ type InventoryItem = {
   supplierPartNumber?: string;
 };
 
+type PartsRequest = {
+  id: number;
+  agPartNumber?: string | null;
+  partNumber: string;
+  partName: string;
+  requestedBy: string;
+  department?: string | null;
+  quantity: number;
+  qtyOrdered?: number | null;
+  vendorPoId?: number | null;
+  status: string;
+  urgency: string;
+  requestDate?: string;
+};
+
+type PartsRequestVendorGroup = {
+  vendorId: number | null;
+  vendorName: string;
+  requests: PartsRequest[];
+};
+
 type NewItemState = {
   agPartNumber: string;
   description: string;
@@ -294,6 +316,7 @@ export default function VendorPOItemSelector({
     productionWorkOrderId?: string | null;
     chargeCodeId?: number | null;
   }>({});
+  const [linkedPartsRequestIds, setLinkedPartsRequestIds] = useState<number[]>([]);
 
   const { data: items = [], isLoading } = useQuery<VendorPOItem[]>({
     queryKey: ['/api/vendor-pos', vendorPoId, 'items'],
@@ -310,6 +333,11 @@ export default function VendorPOItemSelector({
 
   const { data: p2PurchaseOrders = [] } = useQuery<P2PurchaseOrder[]>({
     queryKey: ['/api/p2-purchase-orders-bypass'],
+  });
+
+  const { data: partsRequestGroups = [] } = useQuery<PartsRequestVendorGroup[]>({
+    queryKey: ['/api/inventory/parts-requests/by-vendor'],
+    queryFn: () => apiRequest('/api/inventory/parts-requests/by-vendor'),
   });
 
   const { data: traceabilityOptions } = useQuery<{
@@ -339,6 +367,33 @@ export default function VendorPOItemSelector({
     return productionWorkOrders.filter((wo) => wo.projectId === editedItem.projectId);
   }, [editedItem.projectId, productionWorkOrders]);
 
+  const matchingPartsRequests = useMemo(() => {
+    if (!newItem.agPartNumber && !newItem.description) return [];
+    const normalizedPart = newItem.agPartNumber.trim().toLowerCase();
+    const vendorGroup = partsRequestGroups.find((group) => group.vendorId === vendorId);
+    if (!vendorGroup) return [];
+
+    return vendorGroup.requests
+      .filter((request) => {
+        const requestPart = String(request.agPartNumber || request.partNumber || '').trim().toLowerCase();
+        const remaining = Number(request.quantity || 0) - Number(request.qtyOrdered || 0);
+        return requestPart === normalizedPart && remaining > 0 && !request.vendorPoId;
+      })
+      .sort((a, b) => {
+        const urgencyOrder: Record<string, number> = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 };
+        return (urgencyOrder[a.urgency] ?? 4) - (urgencyOrder[b.urgency] ?? 4);
+      });
+  }, [newItem.agPartNumber, newItem.description, partsRequestGroups, vendorId]);
+
+  const selectedPartsRequestQuantities = useMemo(() => {
+    return linkedPartsRequestIds.reduce<Record<number, number>>((acc, requestId) => {
+      const request = matchingPartsRequests.find((item) => item.id === requestId);
+      if (!request) return acc;
+      acc[requestId] = Math.max(0, Number(request.quantity || 0) - Number(request.qtyOrdered || 0));
+      return acc;
+    }, {});
+  }, [linkedPartsRequestIds, matchingPartsRequests]);
+
   const hasUnitConversion = useMemo(() => {
     return selectedInventoryItem?.vendorUnit && 
            selectedInventoryItem?.purchaseUnit && 
@@ -367,6 +422,7 @@ export default function VendorPOItemSelector({
 
   const handlePartSelect = async (partId: string) => {
     setSelectedPartId(partId);
+    setLinkedPartsRequestIds([]);
     const selectedPart = vendorParts.find(p => p.id.toString() === partId);
     
     if (selectedPart) {
@@ -472,6 +528,9 @@ export default function VendorPOItemSelector({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/vendor-pos', vendorPoId, 'items'] });
       queryClient.invalidateQueries({ queryKey: ['/api/vendor-pos'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/inventory/parts-requests'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/inventory/parts-requests/my'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/inventory/parts-requests/by-vendor'] });
       toast.success('Item added successfully');
       resetForm();
       if (onTotalChange) {
@@ -547,6 +606,7 @@ export default function VendorPOItemSelector({
     });
     setSelectedPartId('');
     setSelectedInventoryItem(null);
+    setLinkedPartsRequestIds([]);
   };
 
   const handleAddItem = () => {
@@ -585,6 +645,8 @@ export default function VendorPOItemSelector({
         chargeCodeId: newItem.chargeCodeId || null,
         otherIdentifier: newItem.otherIdentifier || null,
         notes: newItem.notes || null,
+        partsRequestIds: linkedPartsRequestIds,
+        partsRequestQuantities: selectedPartsRequestQuantities,
       };
     } else {
       if (newItem.quantity <= 0 || newItem.unitPrice < 0) {
@@ -605,6 +667,8 @@ export default function VendorPOItemSelector({
         chargeCodeId: newItem.chargeCodeId || null,
         otherIdentifier: newItem.otherIdentifier || null,
         notes: newItem.notes || null,
+        partsRequestIds: linkedPartsRequestIds,
+        partsRequestQuantities: selectedPartsRequestQuantities,
       };
     }
     
@@ -797,7 +861,10 @@ export default function VendorPOItemSelector({
                   <Input
                     id="agPartNumber"
                     value={newItem.agPartNumber}
-                    onChange={(e) => setNewItem({ ...newItem, agPartNumber: e.target.value })}
+                    onChange={(e) => {
+                      setNewItem({ ...newItem, agPartNumber: e.target.value });
+                      setLinkedPartsRequestIds([]);
+                    }}
                     data-testid="input-ag-part-number"
                     placeholder="Auto-filled or manual"
                   />
@@ -838,6 +905,61 @@ export default function VendorPOItemSelector({
                 </div>
               </div>
               <p className="text-xs text-amber-700 dark:text-amber-300 mt-2">💡 Tip: Set up vendorUnit, purchaseUnit, and conversion factor in inventory items for automatic unit conversion</p>
+            </div>
+          )}
+
+          {matchingPartsRequests.length > 0 && (
+            <div className="border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30 rounded-lg p-4">
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <div>
+                  <p className="font-medium text-sm text-blue-900 dark:text-blue-100">
+                    Link User Part Requests
+                  </p>
+                  <p className="text-xs text-blue-700 dark:text-blue-300">
+                    Selected requests will be marked ordered and linked to this vendor PO.
+                  </p>
+                </div>
+                <Badge variant="outline" className="bg-white dark:bg-blue-950">
+                  {linkedPartsRequestIds.length} selected
+                </Badge>
+              </div>
+
+              <div className="space-y-2">
+                {matchingPartsRequests.map((request) => {
+                  const remaining = Math.max(0, Number(request.quantity || 0) - Number(request.qtyOrdered || 0));
+                  const checked = linkedPartsRequestIds.includes(request.id);
+                  return (
+                    <label
+                      key={request.id}
+                      className="flex items-start gap-3 rounded-md border bg-white dark:bg-gray-900 px-3 py-2 text-sm cursor-pointer"
+                    >
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={(value) => {
+                          setLinkedPartsRequestIds((current) =>
+                            value === true
+                              ? Array.from(new Set([...current, request.id]))
+                              : current.filter((id) => id !== request.id)
+                          );
+                        }}
+                        data-testid={`checkbox-link-parts-request-${request.id}`}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium">Request #{request.id}</span>
+                          <Badge variant="secondary">{request.urgency}</Badge>
+                          <span className="text-xs text-muted-foreground">
+                            {request.department || 'No department'}
+                          </span>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {request.requestedBy} requested {remaining} of {request.quantity} remaining
+                        </p>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
             </div>
           )}
 

--- a/client/src/pages/DepartmentPartsRequestPage.tsx
+++ b/client/src/pages/DepartmentPartsRequestPage.tsx
@@ -50,6 +50,8 @@ type PartsRequest = {
   department: string;
   departmentId: number;
   quantity: number;
+  qtyOrdered?: number;
+  qtyReceived?: number;
   quantityOrdered?: number;
   quantityReceived?: number;
   urgency: string;
@@ -63,6 +65,12 @@ type PartsRequest = {
   cancelReason?: string;
   catalogFixNeeded?: boolean;
   outOfDeptReason?: string;
+  vendorPO?: {
+    id: number | null;
+    poNumber: string | null;
+    externalPoNumber: string | null;
+    status: string | null;
+  };
 };
 
 type User = {
@@ -370,8 +378,8 @@ export default function DepartmentPartsRequestPage() {
 
   const getProgressIndicator = (request: PartsRequest) => {
     const requested = request.quantity || 0;
-    const ordered = request.quantityOrdered || 0;
-    const received = request.quantityReceived || 0;
+    const ordered = request.quantityOrdered ?? request.qtyOrdered ?? 0;
+    const received = request.quantityReceived ?? request.qtyReceived ?? 0;
     if (requested === 0) return null;
 
     const orderedPct = Math.min((ordered / requested) * 100, 100);
@@ -690,10 +698,10 @@ export default function DepartmentPartsRequestPage() {
                         {request.quantity}
                       </td>
                       <td className="px-4 py-3 text-sm text-center text-gray-900 dark:text-gray-100" data-testid={`text-request-qty-ordered-${request.id}`}>
-                        {request.quantityOrdered ?? '—'}
+                        {request.quantityOrdered ?? request.qtyOrdered ?? '—'}
                       </td>
                       <td className="px-4 py-3 text-sm text-center text-gray-900 dark:text-gray-100" data-testid={`text-request-qty-received-${request.id}`}>
-                        {request.quantityReceived ?? '—'}
+                        {request.quantityReceived ?? request.qtyReceived ?? '—'}
                       </td>
                       <td className="px-4 py-3 text-sm min-w-[120px]">
                         {getProgressIndicator(request)}
@@ -713,6 +721,11 @@ export default function DepartmentPartsRequestPage() {
                             <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
                               Reason: {request.cancelReason}
                             </p>
+                          )}
+                          {request.vendorPO && (
+                            <Badge className="bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300">
+                              PO {request.vendorPO.poNumber || `Draft #${request.vendorPO.id}`}
+                            </Badge>
                           )}
                         </div>
                       </td>

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -1715,7 +1715,7 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
     const { eq, and, inArray, isNotNull, isNull } = await import('drizzle-orm');
     
     // Get all active parts requests that are not yet delivered
-    const activeStatuses = ['PENDING', 'APPROVED', 'ORDERED', 'RECEIVED'];
+    const activeStatuses = ['PENDING', 'APPROVED', 'ORDERED_PARTIAL', 'ORDERED', 'RECEIVED_PARTIAL', 'RECEIVED'];
     const requests = await db
       .select()
       .from(partsRequests)

--- a/server/src/routes/vendorPOs.ts
+++ b/server/src/routes/vendorPOs.ts
@@ -5,6 +5,8 @@ import {
   insertVendorPOSettingsSchema,
   insertOptionalSettingSchema,
   insertPOOptionalSettingSchema,
+  partsRequests,
+  partsRequestStatusHistory,
   procurementComplianceEffectiveDates,
   auditEvents,
 } from '@shared/schema';
@@ -13,7 +15,7 @@ import { storage } from '../../storage';
 import { requirePermission } from '../../middleware/requirePermission';
 import { sendCommunication } from '../../communication/send';
 import { db, queryRows } from '../../db';
-import { and, desc, eq, or, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, or, sql } from 'drizzle-orm';
 import {
   appendUniqueEmail,
   DEFAULT_VENDOR_PO_RETURN_EMAIL,
@@ -30,6 +32,91 @@ import { sendApiError } from '../../utils/apiErrors';
 import { generateVendorPoPdf } from '../../utils/pdf/vendorPoPdf';
 
 const router = Router();
+
+function parseLinkedPartsRequestIds(raw: unknown): number[] {
+  if (!Array.isArray(raw)) return [];
+  return Array.from(new Set(
+    raw
+      .map((value) => Number(value))
+      .filter((value) => Number.isInteger(value) && value > 0)
+  ));
+}
+
+function parsePartsRequestQuantities(raw: unknown): Map<number, number> {
+  const quantities = new Map<number, number>();
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return quantities;
+
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    const requestId = Number(key);
+    const quantity = Number(value);
+    if (Number.isInteger(requestId) && requestId > 0 && Number.isFinite(quantity) && quantity > 0) {
+      quantities.set(requestId, Math.ceil(quantity));
+    }
+  }
+
+  return quantities;
+}
+
+async function linkPartsRequestsToVendorPO(params: {
+  requestIds: number[];
+  quantitiesByRequestId: Map<number, number>;
+  vendorPoId: number;
+  vendorId: number;
+  orderedQuantityFallback: number;
+  changedBy: string;
+}) {
+  const { requestIds, quantitiesByRequestId, vendorPoId, vendorId, orderedQuantityFallback, changedBy } = params;
+  if (requestIds.length === 0) return;
+
+  const linkedRequests = await db
+    .select()
+    .from(partsRequests)
+    .where(inArray(partsRequests.id, requestIds));
+
+  let fallbackRemaining = Math.max(0, Math.ceil(orderedQuantityFallback || 0));
+
+  for (const request of linkedRequests) {
+    if (!request.isActive || (request.vendorId != null && request.vendorId !== vendorId)) {
+      continue;
+    }
+
+    const remainingRequested = Math.max(0, Number(request.quantity || 0) - Number(request.qtyOrdered || 0));
+    const explicitQty = quantitiesByRequestId.get(request.id);
+    const allocatedQty = explicitQty ?? (remainingRequested > 0 ? remainingRequested : 0);
+    const qtyFromFallback = explicitQty == null && fallbackRemaining > 0
+      ? Math.min(remainingRequested || fallbackRemaining, fallbackRemaining)
+      : allocatedQty;
+    const qtyToApply = Math.max(0, Math.ceil(qtyFromFallback));
+    if (explicitQty == null && fallbackRemaining > 0) {
+      fallbackRemaining = Math.max(0, fallbackRemaining - qtyToApply);
+    }
+
+    const nextQtyOrdered = Number(request.qtyOrdered || 0) + qtyToApply;
+    const shouldMoveStatus = ['PENDING', 'APPROVED', 'ORDERED_PARTIAL', 'ORDERED'].includes(request.status);
+    const nextStatus = nextQtyOrdered >= Number(request.quantity || 0) ? 'ORDERED' : 'ORDERED_PARTIAL';
+
+    await db
+      .update(partsRequests)
+      .set({
+        vendorPoId,
+        vendorId,
+        orderMethod: request.orderMethod || 'PO',
+        qtyOrdered: nextQtyOrdered,
+        status: shouldMoveStatus ? nextStatus : request.status,
+        orderDate: request.orderDate || new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(partsRequests.id, request.id));
+
+    await db.insert(partsRequestStatusHistory).values({
+      partsRequestId: request.id,
+      fromStatus: request.status,
+      toStatus: shouldMoveStatus ? nextStatus : request.status,
+      changedBy,
+      reason: `Linked to vendor PO #${vendorPoId}${qtyToApply > 0 ? ` - ${qtyToApply} ordered` : ''}`,
+    });
+  }
+}
 
 // Temporary operational override: purchasing leadership is transitioning, so
 // vendor PO issuance must not be blocked by procurement/compliance gates.
@@ -1679,8 +1766,19 @@ router.post('/:id/items', async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Invalid vendor PO ID' });
     }
 
+    const vendorPOForLink = await storage.getVendorPO(vendorPoId);
+    if (!vendorPOForLink) {
+      return res.status(404).json({ error: 'Vendor PO not found' });
+    }
+
+    const linkedPartsRequestIds = parseLinkedPartsRequestIds(req.body?.partsRequestIds);
+    const linkedPartsRequestQuantities = parsePartsRequestQuantities(req.body?.partsRequestQuantities);
+    const sanitizedBody = { ...(req.body ?? {}) };
+    delete sanitizedBody.partsRequestIds;
+    delete sanitizedBody.partsRequestQuantities;
+
     const data = insertVendorPOItemSchema.parse({
-      ...req.body,
+      ...sanitizedBody,
       vendorPoId,
     });
 
@@ -1688,9 +1786,21 @@ router.post('/:id/items', async (req: Request, res: Response) => {
     await requireP2ComplianceBeforeProjectAllocation(vendorPoId, data);
 
     const item = await storage.createVendorPOItem(data);
+    await linkPartsRequestsToVendorPO({
+      requestIds: linkedPartsRequestIds,
+      quantitiesByRequestId: linkedPartsRequestQuantities,
+      vendorPoId,
+      vendorId: vendorPOForLink.vendorId,
+      orderedQuantityFallback: Number(data.purchaseQty ?? data.quantity ?? 0),
+      changedBy: (req as any).user?.username ?? (req as any).user?.email ?? 'system',
+    });
     await recordVendorPoAudit(req, vendorPoId, 'VENDOR_PO_ITEM_CREATED', {
       after: item,
-      meta: { itemId: item?.id ?? null, lineNumber: item?.lineNumber ?? null },
+      meta: {
+        itemId: item?.id ?? null,
+        lineNumber: item?.lineNumber ?? null,
+        linkedPartsRequestIds,
+      },
     });
     res.status(201).json(item);
   } catch (error) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7118,10 +7118,14 @@ export class DatabaseStorage implements IStorage {
         invUsageUnit: inventoryItems.usageUnit,
         projectCode: projects.projectCode,
         projectName: projects.projectName,
+        vendorPoNumber: vendorPOs.poNumber,
+        vendorPoExternalNumber: vendorPOs.externalPoNumber,
+        vendorPoStatus: vendorPOs.status,
       })
       .from(partsRequests)
       .leftJoin(inventoryItems, eq(inventoryItems.agPartNumber, partsRequests.agPartNumber))
       .leftJoin(projects, eq(projects.id, partsRequests.projectId))
+      .leftJoin(vendorPOs, eq(vendorPOs.id, partsRequests.vendorPoId))
       .where(eq(partsRequests.isActive, true))
       .orderBy(desc(partsRequests.requestDate));
 
@@ -7132,6 +7136,7 @@ export class DatabaseStorage implements IStorage {
         agPartNumber: r.request.agPartNumber,
         name: r.invName,
         source: r.invSource,
+        vendorName: r.invSource,
         vendorId: r.invVendorId,
         usageUnit: r.invUsageUnit,
       } : undefined,
@@ -7139,6 +7144,12 @@ export class DatabaseStorage implements IStorage {
         id: r.request.projectId,
         projectCode: r.projectCode,
         projectName: r.projectName,
+      } : undefined,
+      vendorPO: r.request.vendorPoId ? {
+        id: r.request.vendorPoId,
+        poNumber: r.vendorPoNumber,
+        externalPoNumber: r.vendorPoExternalNumber,
+        status: r.vendorPoStatus,
       } : undefined,
     }));
   }
@@ -7227,14 +7238,30 @@ export class DatabaseStorage implements IStorage {
       }
     }
 
-    return await db
-      .select()
+    const results = await db
+      .select({
+        request: partsRequests,
+        vendorPoNumber: vendorPOs.poNumber,
+        vendorPoExternalNumber: vendorPOs.externalPoNumber,
+        vendorPoStatus: vendorPOs.status,
+      })
       .from(partsRequests)
+      .leftJoin(vendorPOs, eq(vendorPOs.id, partsRequests.vendorPoId))
       .where(and(
         or(...participantFilters),
         eq(partsRequests.isActive, true)
       ))
       .orderBy(desc(partsRequests.requestDate));
+
+    return results.map((r) => ({
+      ...r.request,
+      vendorPO: r.request.vendorPoId ? {
+        id: r.request.vendorPoId,
+        poNumber: r.vendorPoNumber,
+        externalPoNumber: r.vendorPoExternalNumber,
+        status: r.vendorPoStatus,
+      } : undefined,
+    } as PartsRequest));
   }
 
   async getConsolidatedPartsNeeds(): Promise<any[]> {


### PR DESCRIPTION
## Summary
- allow vendor PO line creation to link selected user parts requests and update request order state/history
- show matching open user requests in the vendor PO line-item flow
- surface linked vendor PO details on inventory manager and requester parts-request views

## Validation
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/vendorPOs.ts`
- `node --experimental-strip-types --check server/src/routes/inventory.ts`
- `node --experimental-strip-types --check server/storage.ts`

Note: `npm`/local TypeScript tooling was not available in this PowerShell session, so TSX files were reviewed and included in the staged diff but not full-compiled locally.