### PR TITLE
[codex] Link parts requests to vendor POs

### DIFF
--- a/client/src/components/inventory/InventoryItemsCard.tsx
+++ b/client/src/components/inventory/InventoryItemsCard.tsx
@@ -646,13 +646,13 @@ const InventoryForm = ({
           />
         </div>
         <div>
-          <Label htmlFor="source">Source</Label>
+          <Label htmlFor="source">Vendor Name</Label>
           <Input
             id="source"
             name="source"
             value={formData.source}
             onChange={onChange}
-            placeholder="Enter source"
+            placeholder="Enter vendor name"
             data-testid="input-source"
           />
         </div>
@@ -1478,6 +1478,11 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
   });
 
   const vendors = vendorsResponse?.data || [];
+  const vendorById = React.useMemo(() => {
+    const map = new Map<number, VendorOption>();
+    vendors.forEach((vendor) => map.set(vendor.id, vendor));
+    return map;
+  }, [vendors]);
 
   const { data: assets = [] } = useQuery<{ id: string; assetTag: string; name: string; status: string }[]>({
     queryKey: ['/api/assets'],
@@ -2022,8 +2027,19 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
   );
 
   const handleSelectChange = useCallback((name: string, value: string) => {
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  }, []);
+    setFormData((prev) => {
+      if (name !== 'vendorId') {
+        return { ...prev, [name]: value };
+      }
+
+      const selectedVendor = vendors.find((vendor) => vendor.id.toString() === value);
+      return {
+        ...prev,
+        vendorId: value,
+        source: selectedVendor && !prev.source.trim() ? selectedVendor.name : prev.source,
+      };
+    });
+  }, [vendors]);
 
   const handleMultiSelectChange = useCallback((name: string, values: string[]) => {
     setFormData((prev) => ({ ...prev, [name]: values }));
@@ -2561,7 +2577,7 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
             <div className="text-sm text-gray-500 space-y-1">
               <p className="font-semibold">Expected columns:</p>
               <p>
-                AG Part#, SKU, Name, Source, Supplier Part #, Cost per, Order
+                AG Part#, SKU, Name, Vendor, Supplier Part #, Cost per, Order
                 Date, Notes, Utilized, Secondary Source
               </p>
               <p className="text-xs italic mt-2">
@@ -2786,7 +2802,7 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
                   data-testid="header-source"
                 >
                   <div className="flex items-center gap-2">
-                    Source
+                    Vendor
                     {sortColumn === 'source' ? (
                       sortDirection === 'asc' ? (
                         <ArrowUp className="h-4 w-4" />
@@ -2953,7 +2969,7 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
                       {item.name}
                     </td>
                     <td className="border border-gray-200 dark:border-gray-700 px-4 py-2">
-                      {item.source || '-'}
+                      {(item.vendorId && vendorById.get(item.vendorId)?.name) || item.source || '-'}
                     </td>
                     <td className="border border-gray-200 dark:border-gray-700 px-4 py-2">
                       {item.costPer ? `$${item.costPer.toFixed(2)}` : '-'}

--- a/client/src/pages/ConsolidatedNeedsListPage.tsx
+++ b/client/src/pages/ConsolidatedNeedsListPage.tsx
@@ -49,6 +49,7 @@ type InventoryItem = {
   agPartNumber: string;
   name: string;
   source?: string | null;
+  vendorName?: string | null;
   vendorId?: number | null;
   currentBalance?: number;
   minStock?: number;
@@ -509,7 +510,10 @@ export default function ConsolidatedNeedsListPage() {
     if (request.vendorId && vendorMap.has(request.vendorId)) {
       return vendorMap.get(request.vendorId)!;
     }
-    const sourceKey = normalizeVendorName(request.inventoryItem?.source || request.supplier);
+    if (request.inventoryItem?.vendorId && vendorMap.has(request.inventoryItem.vendorId)) {
+      return vendorMap.get(request.inventoryItem.vendorId)!;
+    }
+    const sourceKey = normalizeVendorName(request.inventoryItem?.vendorName || request.inventoryItem?.source || request.supplier);
     if (sourceKey && vendorNameMap.has(sourceKey)) {
       return vendorNameMap.get(sourceKey)!;
     }
@@ -573,11 +577,11 @@ export default function ConsolidatedNeedsListPage() {
         groups[key].totalQuantity += request.quantity;
         groups[key].totalEstimatedCost += request.estimatedCost || 0;
       } else if (request.orderMethod === 'WEBSITE') {
-        // WEBSITE order with no resolved vendor — group by source text so buyers see per-site buckets.
+        // WEBSITE order with no resolved vendor — group by vendor text so buyers see per-site buckets.
         // Future improvement: once source_vendor_id FK exists, all WEBSITE items will resolve to a vendor and this fallback will be rarely needed.
-        const source = request.inventoryItem?.source?.trim();
-        const key = source ? `website-${source.toLowerCase()}` : 'website-unresolved';
-        const groupName = source || 'Website Orders';
+        const vendorName = (request.inventoryItem?.vendorName || request.inventoryItem?.source || '').trim();
+        const key = vendorName ? `website-${vendorName.toLowerCase()}` : 'website-unresolved';
+        const groupName = vendorName || 'Website Orders';
         if (!groups[key]) {
           groups[key] = {
             key,
@@ -1233,14 +1237,9 @@ export default function ConsolidatedNeedsListPage() {
                               </div>
                               <div className="text-xs text-gray-500 dark:text-gray-400">{request.partNumber}</div>
                             </button>
-                            {request.inventoryItem?.source && (
+                            {(getResolvedVendorForRequest(request) || request.inventoryItem?.vendorName || request.inventoryItem?.source) && (
                               <div className="text-xs text-blue-600 dark:text-blue-400 mt-0.5">
-                                Source: {request.inventoryItem.source}
-                              </div>
-                            )}
-                            {request.inventoryItem?.vendorId && vendorMap.has(request.inventoryItem.vendorId) && (
-                              <div className="text-xs text-gray-400 dark:text-gray-500">
-                                Mfr: {vendorMap.get(request.inventoryItem.vendorId)!.name}
+                                Vendor: {getResolvedVendorForRequest(request)?.name || request.inventoryItem?.vendorName || request.inventoryItem?.source}
                               </div>
                             )}
                           </td>
@@ -1618,9 +1617,9 @@ export default function ConsolidatedNeedsListPage() {
                   <div className="font-medium">{detailRequest.requestedBy}</div>
                 </div>
                 <div>
-                  <div className="text-muted-foreground">Source / Vendor</div>
+                  <div className="text-muted-foreground">Vendor</div>
                   <div className="font-medium">
-                    {getResolvedVendorForRequest(detailRequest)?.name || detailRequest.inventoryItem?.source || detailRequest.supplier || 'Unassigned'}
+                    {getResolvedVendorForRequest(detailRequest)?.name || detailRequest.inventoryItem?.vendorName || detailRequest.inventoryItem?.source || detailRequest.supplier || 'Unassigned'}
                   </div>
                 </div>
                 <div>
@@ -1705,7 +1704,7 @@ export default function ConsolidatedNeedsListPage() {
                   Part #{linkPoRequest.partNumber} | Qty {linkPoRequest.quantity} | {linkPoRequest.department || 'No department'}
                 </div>
                 <div className="text-muted-foreground">
-                  Resolved vendor: {linkRequestVendor?.name || linkPoRequest.inventoryItem?.source || linkPoRequest.supplier || 'Unassigned'}
+                  Resolved vendor: {linkRequestVendor?.name || linkPoRequest.inventoryItem?.vendorName || linkPoRequest.inventoryItem?.source || linkPoRequest.supplier || 'Unassigned'}
                 </div>
               </div>
 

--- a/client/src/pages/NewInventoryManagerPage.tsx
+++ b/client/src/pages/NewInventoryManagerPage.tsx
@@ -91,7 +91,7 @@ function InventorySplitView() {
               <tr className="border-b bg-muted/50">
                 <th className="h-10 px-4 text-left font-medium">AG Part #</th>
                 <th className="h-10 px-4 text-left font-medium">Name</th>
-                <th className="h-10 px-4 text-left font-medium">Source</th>
+                <th className="h-10 px-4 text-left font-medium">Vendor</th>
                 <th className="h-10 px-4 text-left font-medium">Cost Per</th>
                 <th className="h-10 px-4 text-left font-medium">Supplier Part #</th>
               </tr>

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -2177,7 +2177,7 @@ router.post(
     try {
       const payload = createVendorPoFromPartsRequestsSchema.parse(req.body);
       const actor = String((req as any).user?.username ?? (req as any).user?.id ?? 'unknown');
-      const { partsRequests, partsRequestStatusHistory, vendorPOs, vendorPOItems } = await import('../../schema');
+      const { partsRequests, partsRequestStatusHistory, vendorPOs, vendorPOItems, inventoryItems } = await import('../../schema');
       const { eq: dEq, inArray: dInArray, and: dAnd, sql: dSql } = await import('drizzle-orm');
 
       const uniqueRequestIds = Array.from(new Set(payload.requestIds));


### PR DESCRIPTION
## Summary

- Adds a parts request to Vendor PO handoff so approved requests can create or link to vendor PO drafts.
- Resolves request vendors from the inventory item vendor before falling back to legacy source text.
- Renames the Inventory Items source surface to Vendor in the relevant request and inventory views.
- Fixes the vendor PO draft route import so the inventory vendor fallback can run when request vendor_id is empty.

## Why

Parts List / Parts Request rows were showing vendor-like source text, but PO creation needs the actual vendor record. When a part already has an inventory vendor selected, the request workflow should use that vendor for grouping, linking, and draft PO creation.

## Validation

- `git diff --check`
- `git diff --cached --check`

Full TypeScript validation was not available locally because `npm` is not on PATH and this worktree has no local `node_modules`.