### PR TITLE
[codex] Group consolidated needs by inventory vendor

### DIFF
--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -1479,32 +1479,46 @@ router.post('/parts-requests', async (req: Request, res: Response) => {
       },
     ];
 
-    if (requestData.agPartNumber) {
+    const requestedPartNumbers = Array.from(
+      new Set(
+        [requestData.agPartNumber, requestData.partNumber]
+          .filter((part): part is string => typeof part === 'string' && part.trim().length > 0)
+          .map((part) => part.trim())
+      )
+    );
+
+    if (requestedPartNumbers.length > 0) {
       const { inventoryItems } = await import('../../schema');
       const [item] = await db
         .select({
+          agPartNumber: inventoryItems.agPartNumber,
           vendorId: inventoryItems.vendorId,
           source: inventoryItems.source,
           defaultOrderMethod: inventoryItems.defaultOrderMethod,
         })
         .from(inventoryItems)
-        .where(eq(inventoryItems.agPartNumber, requestData.agPartNumber))
+        .where(inArray(inventoryItems.agPartNumber, requestedPartNumbers))
         .limit(1);
 
       if (item) {
+        requestData.agPartNumber = requestData.agPartNumber || item.agPartNumber;
+        requestData.partNumber = requestData.partNumber || item.agPartNumber;
+
         // Auto-set orderMethod from item default if not provided
         if (!requestData.orderMethod && item.defaultOrderMethod) {
           requestData.orderMethod = item.defaultOrderMethod as 'PO' | 'WEBSITE';
         }
 
-        // Auto-assign vendor from source or item vendor if not provided.
+        // Auto-assign vendor from the inventory item first; source is legacy display text.
         // Future improvement: a supplier_items table or source_vendor_id FK would replace this lookup.
         if (!requestData.vendorId) {
-          const sourceVendorId = await resolveSourceVendorId(item.source, db);
-          if (sourceVendorId) {
-            requestData.vendorId = sourceVendorId;
-          } else if (item.vendorId) {
+          if (item.vendorId) {
             requestData.vendorId = item.vendorId;
+          } else {
+            const sourceVendorId = await resolveSourceVendorId(item.source, db);
+            if (sourceVendorId) {
+              requestData.vendorId = sourceVendorId;
+            }
           }
         }
       }
@@ -1853,8 +1867,9 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
       }
 
       let vendorId = request.vendorId;
-      if (!vendorId && request.agPartNumber) {
-        vendorId = itemVendorMap.get(request.agPartNumber) || null;
+      const requestPartNumber = request.agPartNumber || request.partNumber;
+      if (!vendorId && requestPartNumber) {
+        vendorId = itemVendorMap.get(requestPartNumber) || null;
       }
       
       if (vendorId && vendorMap.has(vendorId)) {
@@ -2262,7 +2277,37 @@ router.post(
           throw Object.assign(new Error(`Parts request(s) not found: ${missing.join(', ')}`), { status: 404 });
         }
 
-        const badStatus = selected.filter((r) => r.status !== 'APPROVED');
+        const selectedPartNumbers = Array.from(
+          new Set(
+            selected
+              .flatMap((request) => [request.agPartNumber, request.partNumber])
+              .filter((part): part is string => typeof part === 'string' && part.trim().length > 0)
+              .map((part) => part.trim())
+          )
+        );
+        const inventoryVendorRows = selectedPartNumbers.length > 0
+          ? await tx
+            .select({
+              agPartNumber: inventoryItems.agPartNumber,
+              vendorId: inventoryItems.vendorId,
+            })
+            .from(inventoryItems)
+            .where(dInArray(inventoryItems.agPartNumber, selectedPartNumbers))
+          : [];
+        const vendorByPartNumber = new Map(
+          inventoryVendorRows
+            .filter((row) => typeof row.vendorId === 'number')
+            .map((row) => [row.agPartNumber, row.vendorId as number])
+        );
+        const selectedWithResolvedVendors = selected.map((request) => {
+          const resolvedVendorId = request.vendorId
+            ?? (request.agPartNumber ? vendorByPartNumber.get(request.agPartNumber) : undefined)
+            ?? (request.partNumber ? vendorByPartNumber.get(request.partNumber) : undefined)
+            ?? null;
+          return { ...request, vendorId: resolvedVendorId };
+        });
+
+        const badStatus = selectedWithResolvedVendors.filter((r) => r.status !== 'APPROVED');
         if (badStatus.length > 0) {
           throw Object.assign(
             new Error(`Only APPROVED parts requests can start RFQ/PO flow. Invalid request id(s): ${badStatus.map((r) => `${r.id} (${r.status})`).join(', ')}`),
@@ -2270,7 +2315,7 @@ router.post(
           );
         }
 
-        const websiteRequests = selected.filter((r) => r.orderMethod === 'WEBSITE');
+        const websiteRequests = selectedWithResolvedVendors.filter((r) => r.orderMethod === 'WEBSITE');
         if (websiteRequests.length > 0) {
           throw Object.assign(
             new Error(`Website-order request(s) cannot be used to create a Vendor PO: ${websiteRequests.map((r) => r.id).join(', ')}`),
@@ -2278,7 +2323,7 @@ router.post(
           );
         }
 
-        const alreadyLinked = selected.filter((r) => r.vendorPoId != null);
+        const alreadyLinked = selectedWithResolvedVendors.filter((r) => r.vendorPoId != null);
         if (alreadyLinked.length > 0) {
           throw Object.assign(
             new Error(`Request(s) already linked to a Vendor PO: ${alreadyLinked.map((r) => `${r.id} -> PO ${r.vendorPoId}`).join(', ')}`),
@@ -2286,12 +2331,12 @@ router.post(
           );
         }
 
-        const vendorIds = Array.from(new Set(selected.map((r) => r.vendorId).filter((v): v is number => typeof v === 'number')));
+        const vendorIds = Array.from(new Set(selectedWithResolvedVendors.map((r) => r.vendorId).filter((v): v is number => typeof v === 'number')));
         if (vendorIds.length !== 1) {
           throw Object.assign(new Error('All selected requests must have the same assigned vendor before creating a Vendor PO draft.'), { status: 422 });
         }
 
-        const wrongCategory = selected.filter((r) => {
+        const wrongCategory = selectedWithResolvedVendors.filter((r) => {
           const requestCategory = normalizePartsRequestCategory(r.productionLine);
           return requestCategory != null && requestCategory !== payload.purchasingCategory;
         });
@@ -2303,8 +2348,8 @@ router.post(
         }
 
         const vendorId = vendorIds[0];
-        const estimatedTotal = selected.reduce((sum, r) => sum + Number(r.estimatedCost || 0), 0);
-        const requestSummary = selected.map((r) => `PR-${r.id}`).join(', ');
+        const estimatedTotal = selectedWithResolvedVendors.reduce((sum, r) => sum + Number(r.estimatedCost || 0), 0);
+        const requestSummary = selectedWithResolvedVendors.map((r) => `PR-${r.id}`).join(', ');
         const [vendorPO] = await tx
           .insert(vendorPOs)
           .values({
@@ -2323,8 +2368,8 @@ router.post(
           })
           .returning();
 
-        const grouped = new Map<string, typeof selected>();
-        for (const request of selected) {
+        const grouped = new Map<string, typeof selectedWithResolvedVendors>();
+        for (const request of selectedWithResolvedVendors) {
           const key = `${request.agPartNumber || ''}|${request.partNumber}|${request.partName}`;
           grouped.set(key, [...(grouped.get(key) || []), request]);
         }
@@ -2375,7 +2420,7 @@ router.post(
           .where(dAnd(dInArray(partsRequests.id, uniqueRequestIds), dEq(partsRequests.status, 'APPROVED')));
 
         await tx.insert(partsRequestStatusHistory).values(
-          selected.map((request) => ({
+          selectedWithResolvedVendors.map((request) => ({
             partsRequestId: request.id,
             fromStatus: request.status,
             toStatus: request.status,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7112,6 +7112,7 @@ export class DatabaseStorage implements IStorage {
       .select({
         request: partsRequests,
         invId: inventoryItems.id,
+        invAgPartNumber: inventoryItems.agPartNumber,
         invName: inventoryItems.name,
         invSource: inventoryItems.source,
         invVendorId: inventoryItems.vendorId,
@@ -7123,7 +7124,13 @@ export class DatabaseStorage implements IStorage {
         vendorPoStatus: vendorPOs.status,
       })
       .from(partsRequests)
-      .leftJoin(inventoryItems, eq(inventoryItems.agPartNumber, partsRequests.agPartNumber))
+      .leftJoin(
+        inventoryItems,
+        eq(
+          inventoryItems.agPartNumber,
+          sql`COALESCE(NULLIF(${partsRequests.agPartNumber}, ''), NULLIF(${partsRequests.partNumber}, ''))`
+        )
+      )
       .leftJoin(projects, eq(projects.id, partsRequests.projectId))
       .leftJoin(vendorPOs, eq(vendorPOs.id, partsRequests.vendorPoId))
       .where(eq(partsRequests.isActive, true))
@@ -7133,7 +7140,7 @@ export class DatabaseStorage implements IStorage {
       ...r.request,
       inventoryItem: r.invId ? {
         id: r.invId,
-        agPartNumber: r.request.agPartNumber,
+        agPartNumber: r.invAgPartNumber ?? r.request.agPartNumber ?? r.request.partNumber,
         name: r.invName,
         source: r.invSource,
         vendorName: r.invSource,
@@ -7275,7 +7282,13 @@ export class DatabaseStorage implements IStorage {
         projectName: projects.projectName,
       })
       .from(partsRequests)
-      .leftJoin(inventoryItems, eq(partsRequests.agPartNumber, inventoryItems.agPartNumber))
+      .leftJoin(
+        inventoryItems,
+        eq(
+          inventoryItems.agPartNumber,
+          sql`COALESCE(NULLIF(${partsRequests.agPartNumber}, ''), NULLIF(${partsRequests.partNumber}, ''))`
+        )
+      )
       .leftJoin(departments, eq(partsRequests.departmentId, departments.id))
       .leftJoin(projects, eq(projects.id, partsRequests.projectId))
       .where(and(


### PR DESCRIPTION
## Summary

- Resolves inventory items for parts requests using either `ag_part_number` or `part_number`, so existing requests can inherit the inventory vendor instead of falling into Unassigned.
- Auto-assigns new parts requests from the inventory item `vendorId` before falling back to legacy source text.
- Uses the same inventory-vendor fallback when creating a Vendor PO draft from approved parts requests.

## Validation

- `git diff --check`
- `git diff --cached --check` before cherry-picking to the clean PR branch
- `git diff --check origin/main...HEAD`

Full TypeScript validation was not available locally because `npm` is not on PATH and this worktree has no local `node_modules`.