### PR TITLE
Decouple P2 shipment line selection from billing buckets

### DIFF
--- a/client/src/components/p2/ShipmentSummaryModal.tsx
+++ b/client/src/components/p2/ShipmentSummaryModal.tsx
@@ -51,10 +51,11 @@ type BucketOverrideDraft = {
 
 type PoItem = {
   id: number;
-  part_number: string;
-  part_name: string | null;
+  poId?: number;
+  partNumber: string;
+  partName: string | null;
   quantity: number | null;
-  unit_price: string | number | null;
+  unitPrice: string | number | null;
 };
 
 interface ShipmentSummaryModalProps {
@@ -78,9 +79,9 @@ export default function ShipmentSummaryModal({
   const [selectedPoItemId, setSelectedPoItemId] = useState<number | null>(null);
   const [bucketOverrides, setBucketOverrides] = useState<Record<number, BucketOverrideDraft>>({});
 
-  const { data: allocationData } = useQuery<{ poItems: PoItem[] }>({
-    queryKey: ['/api/p2/billing-allocations', poId],
-    queryFn: async () => apiRequest(`/api/p2/billing-allocations?poId=${encodeURIComponent(String(poId))}`),
+  const { data: poItems = [] } = useQuery<PoItem[]>({
+    queryKey: ['/api/p2-purchase-order-items', poId],
+    queryFn: async () => apiRequest(`/api/p2-purchase-order-items/${encodeURIComponent(String(poId))}`),
     enabled: !!poId,
   });
 
@@ -104,16 +105,15 @@ export default function ShipmentSummaryModal({
 
   const poItemOptions = useMemo(() => {
     const groupByPoItemId = new Map(poItemGroups.map((group) => [group.poItemId, group]));
-    const fetchedItems = allocationData?.poItems ?? [];
-    const fetchedOptions = fetchedItems.map((item) => {
+    const fetchedOptions = poItems.map((item) => {
       const group = groupByPoItemId.get(item.id);
       return {
         poItemId: item.id,
-        partNumber: item.part_number,
-        itemName: item.part_number || `PO Item #${item.id}`,
-        partName: item.part_name ?? group?.partName ?? '',
+        partNumber: item.partNumber,
+        itemName: item.partNumber || `PO Item #${item.id}`,
+        partName: item.partName ?? group?.partName ?? '',
         quantity: Number(item.quantity) || group?.units.length || 0,
-        unitPrice: Number(item.unit_price) || 0,
+        unitPrice: Number(item.unitPrice) || 0,
         units: group?.units ?? [],
       };
     });
@@ -132,7 +132,7 @@ export default function ShipmentSummaryModal({
       }));
 
     return [...fetchedOptions, ...serialOnlyOptions].sort((a, b) => a.poItemId - b.poItemId);
-  }, [allocationData?.poItems, poItemGroups]);
+  }, [poItems, poItemGroups]);
 
   const effectiveSelectedPoItemId = selectedPoItemId ?? poItemOptions[0]?.poItemId ?? poItemGroups[0]?.poItemId ?? null;
   const selectedPoItemOption =

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -689,9 +689,15 @@ function ensureP2BillingAllocationSchema(): Promise<void> {
       );
 
       ALTER TABLE p2_billing_allocations
+        ADD COLUMN IF NOT EXISTS po_id integer,
         ADD COLUMN IF NOT EXISTS po_item_id integer REFERENCES p2_purchase_order_items(id),
+        ADD COLUMN IF NOT EXISTS po_number text,
+        ADD COLUMN IF NOT EXISTS part_number text,
+        ADD COLUMN IF NOT EXISTS bucket_label text,
         ADD COLUMN IF NOT EXISTS description text,
         ADD COLUMN IF NOT EXISTS customer_po_line text,
+        ADD COLUMN IF NOT EXISTS quantity_authorized integer,
+        ADD COLUMN IF NOT EXISTS unit_price numeric(12,2),
         ADD COLUMN IF NOT EXISTS notes text,
         ADD COLUMN IF NOT EXISTS active boolean NOT NULL DEFAULT true,
         ADD COLUMN IF NOT EXISTS created_by text,
@@ -700,12 +706,22 @@ function ensureP2BillingAllocationSchema(): Promise<void> {
 
       ALTER TABLE p2_billing_allocations
         ALTER COLUMN active SET DEFAULT true,
+        ALTER COLUMN quantity_authorized SET DEFAULT 0,
+        ALTER COLUMN unit_price SET DEFAULT 0,
         ALTER COLUMN created_at SET DEFAULT now(),
         ALTER COLUMN updated_at SET DEFAULT now();
 
       UPDATE p2_billing_allocations
          SET active = true
        WHERE active IS NULL;
+
+      UPDATE p2_billing_allocations
+         SET quantity_authorized = 0
+       WHERE quantity_authorized IS NULL;
+
+      UPDATE p2_billing_allocations
+         SET unit_price = 0
+       WHERE unit_price IS NULL;
 
       CREATE INDEX IF NOT EXISTS p2_billing_allocations_po_idx
         ON p2_billing_allocations(po_id)
@@ -732,6 +748,9 @@ function ensureP2BillingAllocationSchema(): Promise<void> {
       );
 
       ALTER TABLE p2_serial_billing_assignments
+        ADD COLUMN IF NOT EXISTS allocation_id uuid,
+        ADD COLUMN IF NOT EXISTS serialized_item_id uuid,
+        ADD COLUMN IF NOT EXISTS po_id integer,
         ADD COLUMN IF NOT EXISTS po_item_id integer REFERENCES p2_purchase_order_items(id),
         ADD COLUMN IF NOT EXISTS lot_id uuid REFERENCES p2_lot_numbers(id),
         ADD COLUMN IF NOT EXISTS packing_slip_id uuid REFERENCES p2_packing_slips(id),


### PR DESCRIPTION
## Summary
- Change the P2 shipment confirmation modal to load PO line item choices from `/api/p2-purchase-order-items/:poId` instead of `/api/p2/billing-allocations`, so users can select the PO line item even when billing bucket/allocation schema is unhealthy.
- Keep the selected PO line flowing into the shipment bucket override used by `/api/p2/lots`.
- Harden the P2 shipping billing-allocation schema guard so older partial `p2_billing_allocations` and `p2_serial_billing_assignments` tables get missing base columns repaired before the route reads or creates bucket assignments.

## Validation
- `git diff --check origin/main..HEAD -- client/src/components/p2/ShipmentSummaryModal.tsx server/src/routes/p2Shipping.ts`
- `C:\Users\glenn\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --experimental-strip-types --check server\src\routes\p2Shipping.ts`

## Production Signal
User reported:
- `/api/p2/billing-allocations?poId=14` 500ing with `Failed to fetch P2 billing allocations`
- `/api/p2/lots` still returning `Failed to create lot`
- shipment creation still not allowing selection of the PO line item