### PR TITLE
[codex] Resolve unassigned consolidated need vendors

### DIFF
--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -1811,18 +1811,42 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
     // Get all vendors for lookup
     const allVendors = await db.select().from(vendors);
     const vendorMap = new Map(allVendors.map(v => [v.id, v]));
+    const normalizeVendorName = (value?: string | null) =>
+      (value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    const vendorNameMap = new Map(
+      allVendors
+        .map((vendor) => [normalizeVendorName(vendor.name), vendor] as const)
+        .filter(([key]) => key.length > 0)
+    );
+    const resolveVendorByName = (value?: string | null) => {
+      const sourceKey = normalizeVendorName(value);
+      if (!sourceKey) return null;
+      if (vendorNameMap.has(sourceKey)) return vendorNameMap.get(sourceKey)!;
+      for (const [vendorKey, vendor] of vendorNameMap) {
+        if (vendorKey.includes(sourceKey) || sourceKey.includes(vendorKey)) {
+          return vendor;
+        }
+      }
+      return null;
+    };
     
-    // Get inventory items with vendor assignments for auto-suggest
+    // Get inventory items for vendor resolution by either request part-number field.
     const itemsWithVendors = await db
       .select({
         agPartNumber: inventoryItems.agPartNumber,
         vendorId: inventoryItems.vendorId,
+        source: inventoryItems.source,
         name: inventoryItems.name,
       })
       .from(inventoryItems)
-      .where(isNotNull(inventoryItems.vendorId));
+      .where(
+        or(
+          isNotNull(inventoryItems.vendorId),
+          isNotNull(inventoryItems.source)
+        )
+      );
     
-    const itemVendorMap = new Map(itemsWithVendors.map(i => [i.agPartNumber, i.vendorId]));
+    const itemByPartNumber = new Map(itemsWithVendors.map(i => [i.agPartNumber, i]));
     
     // Group requests by vendor
     const vendorGroups: Record<string, {
@@ -1830,7 +1854,16 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
       vendorName: string;
       orderMethod: string | null;
       websiteUrl: string | null;
-      requests: typeof requests;
+      requests: Array<typeof requests[number] & {
+        supplier?: string | null;
+        inventoryItem?: {
+          agPartNumber: string;
+          name: string;
+          source: string | null;
+          vendorId: number | null;
+          vendorName: string | null;
+        };
+      }>;
       totalQuantity: number;
       totalEstimatedCost: number;
     }> = {};
@@ -1847,7 +1880,28 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
     };
     
     for (const request of requests) {
-      if (request.orderMethod === 'WEBSITE') {
+      const requestPartNumber = request.agPartNumber || request.partNumber;
+      const inventoryItem = requestPartNumber ? itemByPartNumber.get(requestPartNumber) : null;
+      const sourceVendor = resolveVendorByName(inventoryItem?.source || request.supplier);
+      const resolvedVendor = request.vendorId
+        ? vendorMap.get(request.vendorId)
+        : inventoryItem?.vendorId
+          ? vendorMap.get(inventoryItem.vendorId)
+          : sourceVendor;
+      const vendorId = request.vendorId ?? resolvedVendor?.id ?? inventoryItem?.vendorId ?? null;
+      const vendorName = resolvedVendor?.name ?? request.supplier ?? inventoryItem?.source ?? null;
+      const enrichedRequest = {
+        ...request,
+        vendorId,
+        supplier: vendorName,
+        inventoryItem: inventoryItem ? {
+          ...inventoryItem,
+          vendorId: inventoryItem.vendorId ?? vendorId,
+          vendorName,
+        } : undefined,
+      };
+
+      if (!resolvedVendor && request.orderMethod === 'WEBSITE') {
         const key = 'WEBSITE';
         if (!vendorGroups[key]) {
           vendorGroups[key] = {
@@ -1860,16 +1914,10 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
             totalEstimatedCost: 0,
           };
         }
-        vendorGroups[key].requests.push(request);
+        vendorGroups[key].requests.push(enrichedRequest);
         vendorGroups[key].totalQuantity += request.quantity;
         vendorGroups[key].totalEstimatedCost += request.estimatedCost || 0;
         continue;
-      }
-
-      let vendorId = request.vendorId;
-      const requestPartNumber = request.agPartNumber || request.partNumber;
-      if (!vendorId && requestPartNumber) {
-        vendorId = itemVendorMap.get(requestPartNumber) || null;
       }
       
       if (vendorId && vendorMap.has(vendorId)) {
@@ -1888,11 +1936,11 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
           };
         }
         
-        vendorGroups[key].requests.push(request);
+        vendorGroups[key].requests.push(enrichedRequest);
         vendorGroups[key].totalQuantity += request.quantity;
         vendorGroups[key].totalEstimatedCost += request.estimatedCost || 0;
       } else {
-        vendorGroups['unassigned'].requests.push(request);
+        vendorGroups['unassigned'].requests.push(enrichedRequest);
         vendorGroups['unassigned'].totalQuantity += request.quantity;
         vendorGroups['unassigned'].totalEstimatedCost += request.estimatedCost || 0;
       }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7300,17 +7300,67 @@ export class DatabaseStorage implements IStorage {
         eq(partsRequests.isActive, true)
       ))
       .orderBy(desc(partsRequests.urgency), desc(partsRequests.requestDate));
+
+    const allVendors = await db
+      .select({
+        id: vendors.id,
+        name: vendors.name,
+        website: vendors.website,
+      })
+      .from(vendors)
+      .where(eq(vendors.isActive, true));
+
+    const vendorById = new Map(allVendors.map((vendor) => [vendor.id, vendor]));
+    const normalizeVendorName = (value?: string | null) =>
+      (value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    const vendorByName = new Map(
+      allVendors
+        .map((vendor) => [normalizeVendorName(vendor.name), vendor] as const)
+        .filter(([key]) => key.length > 0)
+    );
+
+    const resolveVendorByName = (value?: string | null) => {
+      const sourceKey = normalizeVendorName(value);
+      if (!sourceKey) return null;
+      if (vendorByName.has(sourceKey)) return vendorByName.get(sourceKey)!;
+      for (const [vendorKey, vendor] of vendorByName) {
+        if (vendorKey.includes(sourceKey) || sourceKey.includes(vendorKey)) {
+          return vendor;
+        }
+      }
+      return null;
+    };
     
-    return results.map(r => ({
-      ...r.request,
-      inventoryItem: r.inventoryItem,
-      department: r.department,
-      project: r.projectCode ? {
-        id: r.request.projectId,
-        projectCode: r.projectCode,
-        projectName: r.projectName,
-      } : undefined,
-    }));
+    return results.map(r => {
+      const requestVendor = r.request.vendorId ? vendorById.get(r.request.vendorId) : null;
+      const itemVendor = r.inventoryItem?.vendorId ? vendorById.get(r.inventoryItem.vendorId) : null;
+      const sourceVendor = resolveVendorByName(r.inventoryItem?.source || r.request.supplier);
+      const resolvedVendor = requestVendor ?? itemVendor ?? sourceVendor;
+      const resolvedVendorId = r.request.vendorId ?? resolvedVendor?.id ?? r.inventoryItem?.vendorId ?? null;
+      const resolvedVendorName = resolvedVendor?.name ?? r.request.supplier ?? r.inventoryItem?.source ?? null;
+
+      return {
+        ...r.request,
+        vendorId: resolvedVendorId,
+        supplier: resolvedVendorName,
+        vendor: resolvedVendor ? {
+          id: resolvedVendor.id,
+          name: resolvedVendor.name,
+          website: resolvedVendor.website,
+        } : undefined,
+        inventoryItem: r.inventoryItem ? {
+          ...r.inventoryItem,
+          vendorId: r.inventoryItem.vendorId ?? resolvedVendorId,
+          vendorName: resolvedVendorName,
+        } : undefined,
+        department: r.department,
+        project: r.projectCode ? {
+          id: r.request.projectId,
+          projectCode: r.projectCode,
+          projectName: r.projectName,
+        } : undefined,
+      };
+    });
   }
 
   // Departments CRUD


### PR DESCRIPTION
## Summary

- Enrich consolidated parts-request needs with resolved vendor ids/names from the request, inventory item vendor, or legacy source/supplier text.
- Return the resolved vendor on each consolidated request and nested inventory item so the Consolidated Needs vendor grouping no longer falls back to Unassigned when request.vendor_id is empty.
- Apply the same vendor resolution to `/api/inventory/parts-requests/by-vendor` so Vendor PO request selection filters by the resolved vendor instead of only the raw request vendor field.

## Root Cause

The previous grouping fix improved part-number matching, but the consolidated needs payload still relied on raw request rows. Existing requests with no `parts_requests.vendor_id` could still arrive without a resolved vendor name/id even when their inventory item had a vendor or source text, leaving the UI to categorize them as Unassigned.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/storage.ts`
- `node --experimental-strip-types --check server/src/routes/inventory.ts`

Note: full TypeScript/npm validation was not available because `npm`/local project dependencies are not available in this PowerShell session.