### PR TITLE
Use P2 PO line description in shipment buckets

### DIFF
--- a/client/src/components/p2/ShipmentSummaryModal.tsx
+++ b/client/src/components/p2/ShipmentSummaryModal.tsx
@@ -63,6 +63,8 @@ type PoItem = {
   partName: string | null;
   quantity: number | null;
   unitPrice: string | number | null;
+  specifications?: string | null;
+  notes?: string | null;
 };
 
 interface ShipmentSummaryModalProps {
@@ -126,6 +128,7 @@ export default function ShipmentSummaryModal({
         partNumber: item.partNumber,
         itemName: item.partNumber || `PO Item #${item.id}`,
         partName: item.partName ?? group?.partName ?? '',
+        lineDescription: item.specifications || item.notes || item.partName || group?.partName || '',
         quantity: Number(item.quantity) || group?.units.length || 0,
         unitPrice: Number(item.unitPrice) || 0,
         units: group?.units ?? [],
@@ -140,6 +143,7 @@ export default function ShipmentSummaryModal({
         partNumber: group.partNumber,
         itemName: group.itemName || `PO Item #${group.poItemId}`,
         partName: group.partName,
+        lineDescription: group.partName,
         quantity: group.units.length,
         unitPrice: 0,
         units: group.units,
@@ -158,6 +162,7 @@ export default function ShipmentSummaryModal({
           partNumber: poItemGroups[0].partNumber,
           itemName: poItemGroups[0].itemName || `PO Item #${poItemGroups[0].poItemId}`,
           partName: poItemGroups[0].partName,
+          lineDescription: poItemGroups[0].partName,
           quantity: poItemGroups[0].units.length,
           unitPrice: 0,
           units: poItemGroups[0].units,
@@ -185,6 +190,7 @@ export default function ShipmentSummaryModal({
     : '';
   const combinedBucketDescription = selectedPoItemOption
     ? combinedBucketOverride.description.trim() ||
+      selectedPoItemOption.lineDescription ||
       selectedPoItemOption.partName ||
       ''
     : '';
@@ -352,7 +358,7 @@ export default function ShipmentSummaryModal({
                   <SelectContent>
                     {poItemOptions.map((item) => (
                       <SelectItem key={item.poItemId} value={String(item.poItemId)}>
-                        {item.itemName || `PO Item #${item.poItemId}`} - {item.partName || item.partNumber}
+                        {item.itemName || `PO Item #${item.poItemId}`} - {item.lineDescription || item.partName || item.partNumber}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -383,9 +389,9 @@ export default function ShipmentSummaryModal({
                   <Label className="text-xs">Description</Label>
                   <Input
                     className="h-9"
-                    value={combinedBucketOverride.description}
+                    value={combinedBucketOverride.description || selectedPoItemOption?.lineDescription || ''}
                     onChange={(e) => updateCombinedBucketOverride('description', e.target.value)}
-                    placeholder={selectedPoItemOption?.partName || 'Shipment line description'}
+                    placeholder="Shipment line description"
                   />
                 </div>
                 <div className="space-y-1">

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2931,6 +2931,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             quantity: item.quantity,
             dueDate: item.dueDate || null,
             unitPrice: item.unitPrice || 0,
+            specifications: item.description || item.specifications || null,
+            notes: item.notes || null,
           });
         }
       }
@@ -3047,6 +3049,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
             quantity: Number(item.quantity) || 1,
             dueDate: item.dueDate || null,
             unitPrice: Number(item.unitPrice) || 0,
+            specifications: item.description || item.specifications || null,
+            notes: item.notes || null,
           };
 
           if (itemId && existingById.has(itemId)) {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -809,7 +809,15 @@ router.get('/:id/po-link-options', async (req, res) => {
     }
 
     const poItems = await pool.query(
-      `SELECT id, po_id AS "poId", part_number AS "partNumber", part_name AS "partName", quantity, unit_price AS "unitPrice"
+      `SELECT id,
+              po_id AS "poId",
+              part_number AS "partNumber",
+              part_name AS "partName",
+              COALESCE(NULLIF(specifications, ''), NULLIF(notes, ''), part_name) AS description,
+              quantity,
+              unit_price AS "unitPrice",
+              specifications,
+              notes
          FROM p2_purchase_order_items
         WHERE po_id = $1
         ORDER BY id`,


### PR DESCRIPTION
## Summary
- populate the shipment modal Description field from the selected P2 PO line description
- prefer PO item `specifications`/`notes` before falling back to `partName` in shipment bucket descriptions
- preserve incoming PO line `description` into P2 PO item `specifications` when creating or updating P2 purchase orders
- expose PO item description/specification fields through project PO link options

## Validation
- `git -c core.fscache=false -c gc.auto=0 diff --check -- client/src/components/p2/ShipmentSummaryModal.tsx server/src/routes/index.ts server/src/routes/projects.ts`
- `C:\Users\glenn\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --experimental-strip-types --check server\src\routes\index.ts`
- `C:\Users\glenn\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --experimental-strip-types --check server\src\routes\projects.ts`

Note: full frontend build was not run because this isolated worktree does not have `node_modules` installed.