### PR TITLE
[codex] Fix P2 PO view action

### DIFF
--- a/client/src/components/p2/P2StatusDashboard.tsx
+++ b/client/src/components/p2/P2StatusDashboard.tsx
@@ -14,7 +14,6 @@ import {
   CheckCircle,
   Clock,
   AlertCircle,
-  ArrowRight,
   Layers,
   Factory,
   TrendingUp,
@@ -395,7 +394,7 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                           onClick={() => onViewPO?.(po.id)}
                           data-testid={`button-view-po-${po.id}`}
                         >
-                          Schedule <ArrowRight className="h-4 w-4 ml-1" />
+                          View PO <FileText className="h-4 w-4 ml-1" />
                         </Button>
                       </div>
                     </div>
@@ -456,7 +455,7 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                             onClick={() => onViewPO?.(po.id)}
                             data-testid={`button-view-completed-po-${po.id}`}
                           >
-                            View <ArrowRight className="h-4 w-4 ml-1" />
+                            View PO <FileText className="h-4 w-4 ml-1" />
                           </Button>
                         </div>
                       </TableCell>

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -794,8 +794,7 @@ export default function P2ControlCenter() {
               setShowBOMWizard(true);
             }} 
             onViewPO={(poId) => {
-              setSelectedPOForBOM(poId);
-              setActiveTab('schedule');
+              navigate(`/p2/purchase-orders/${poId}/preview`);
             }}
             selectedPOIds={selectedPOIds}
           />


### PR DESCRIPTION
## Summary
- Route P2 status dashboard View PO actions to the existing purchase order preview page
- Rename the active/completed PO card actions to View PO so the label matches the behavior

## Root cause
The P2 status dashboard wired `onViewPO` into schedule/BOM state in `P2ControlCenter`, so selecting a PO from the status cards opened the P2 workflow surface instead of a read-only purchase order summary.

## Validation
- `git diff --check -- client/src/pages/P2ControlCenter.tsx client/src/components/p2/P2StatusDashboard.tsx`
- `git diff --cached --check`

Full `tsc` was not run because `npm` and local TypeScript tooling are not available in this PowerShell environment.