### PR TITLE
[codex] Group consolidated needs by visible vendor label

### DIFF
--- a/client/src/pages/ConsolidatedNeedsListPage.tsx
+++ b/client/src/pages/ConsolidatedNeedsListPage.tsx
@@ -525,6 +525,15 @@ export default function ConsolidatedNeedsListPage() {
     return null;
   }, [vendorMap, vendorNameMap, normalizeVendorName]);
 
+  const getRequestVendorLabel = useCallback((request: PartsRequest): string => {
+    return (
+      request.inventoryItem?.vendorName ||
+      request.inventoryItem?.source ||
+      request.supplier ||
+      ''
+    ).trim();
+  }, []);
+
   const openLinkPoDialog = (request: PartsRequest) => {
     setLinkPoRequest(request);
     setSelectedVendorPoId(request.vendorPoId ? String(request.vendorPoId) : '');
@@ -557,6 +566,7 @@ export default function ConsolidatedNeedsListPage() {
 
     for (const request of activeRequests) {
       const vendor = getResolvedVendorForRequest(request);
+      const vendorLabel = getRequestVendorLabel(request);
 
       if (vendor) {
         // Has a resolved vendor record — group under that vendor regardless of order method
@@ -568,6 +578,24 @@ export default function ConsolidatedNeedsListPage() {
             vendorName: vendor.name,
             orderMethod: request.orderMethod || null,
             websiteUrl: vendor.website || null,
+            requests: [],
+            totalQuantity: 0,
+            totalEstimatedCost: 0,
+          };
+        }
+        groups[key].requests.push(request);
+        groups[key].totalQuantity += request.quantity;
+        groups[key].totalEstimatedCost += request.estimatedCost || 0;
+      } else if (vendorLabel) {
+        const sourceKey = normalizeVendorName(vendorLabel);
+        const key = `source-${sourceKey || vendorLabel.toLowerCase()}`;
+        if (!groups[key]) {
+          groups[key] = {
+            key,
+            vendorId: null,
+            vendorName: vendorLabel,
+            orderMethod: request.orderMethod || null,
+            websiteUrl: null,
             requests: [],
             totalQuantity: 0,
             totalEstimatedCost: 0,
@@ -613,7 +641,7 @@ export default function ConsolidatedNeedsListPage() {
         if (b.vendorName === 'Website Orders') return -1;
         return a.vendorName.localeCompare(b.vendorName);
       });
-  }, [filteredRequests, getResolvedVendorForRequest]);
+  }, [filteredRequests, getRequestVendorLabel, getResolvedVendorForRequest, normalizeVendorName]);
 
   const filteredVendorGroups = useMemo(() => {
     if (vendorFilterTab === 'po') {


### PR DESCRIPTION
## Summary

- Groups Consolidated Needs rows by the visible vendor/source label when no vendor record is resolved.
- Keeps true vendor-record matches grouped by vendor id, but stops rows showing labels like `Vendor: Uline` or `Vendor: McMaster Carr` from staying under `Unassigned`.
- Leaves rows with no vendor id and no visible vendor/source text in the existing Unassigned bucket.

## Root Cause

The page display already showed fallback vendor text from `inventoryItem.vendorName`, `inventoryItem.source`, or request `supplier`, but the group builder only used resolved vendor records, with a special website fallback. PO requests with source text but no matched vendor record were therefore displayed as having a vendor while still grouped under `Unassigned`.

## Validation

- `git diff --check`
- `git diff --cached --check`

Note: full frontend TypeScript/npm validation was not available because `npm` is not on PATH in this PowerShell session.