### PR TITLE
Handle array query results in db adapter

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -106,14 +106,19 @@ export type CompatibleQueryResult<T extends QueryResultRow = any> =
 function toCompatibleQueryResult<T extends QueryResultRow>(
   result: QueryResult<T>,
 ): CompatibleQueryResult<T> {
-  const rows = [...result.rows] as CompatibleQueryResult<T>;
+  const rawRows = Array.isArray((result as any)?.rows)
+    ? (result as any).rows
+    : Array.isArray(result)
+      ? result
+      : [];
+  const rows = [...rawRows] as CompatibleQueryResult<T>;
 
   Object.defineProperties(rows, {
     rows: { value: rows, enumerable: false },
-    rowCount: { value: result.rowCount, enumerable: false },
+    rowCount: { value: result.rowCount ?? rows.length, enumerable: false },
     command: { value: result.command, enumerable: false },
     oid: { value: result.oid, enumerable: false },
-    fields: { value: result.fields, enumerable: false },
+    fields: { value: result.fields ?? [], enumerable: false },
   });
 
   return rows;


### PR DESCRIPTION
## Summary
- harden the database compatibility adapter so it accepts either native pg `{ rows }` results or already-array row results
- default `rowCount` and `fields` safely when the query result does not include native pg metadata
- prevents shipment creation from failing with `rows is not iterable` when a query result is already row-array shaped

## Validation
- `git -c core.fscache=false -c gc.auto=0 diff --check -- server/db.ts`
- `C:\Users\glenn\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --experimental-strip-types --check server\db.ts`