### PR TITLE
[codex] Link P2 shipment summary to project PO

### DIFF
--- a/client/src/components/p2/P2ShippingTab.tsx
+++ b/client/src/components/p2/P2ShippingTab.tsx
@@ -63,11 +63,23 @@ type SerializedUnit = {
   completedAt: string | null;
   finalizedAt: string | null;
   finalizedBy: string | null;
+  projectId?: string | null;
+  projectCode?: string | null;
+  projectName?: string | null;
+  projectPoId?: number | null;
+  projectPoNumber?: string | null;
+  projectPoItemId?: number | null;
 };
 
 type POGroup = {
   poNumber: string;
   poId: number;
+  shipmentPoId: number;
+  shipmentPoNumber: string;
+  shipmentPoItemId: number | null;
+  projectId: string | null;
+  projectCode: string | null;
+  projectName: string | null;
   customerName: string;
   units: SerializedUnit[];
   totalUnits: number;
@@ -90,6 +102,15 @@ type CreatedShipment = {
   journalEntryId?: number;
   journalEntryStatus?: string;
   journalLineCount?: number;
+};
+
+type ShipmentPoContext = {
+  poId?: number | null;
+  poNumber?: string | null;
+  poItemId?: number | null;
+  projectId?: string | null;
+  projectCode?: string | null;
+  projectName?: string | null;
 };
 
 function invoiceStatusColor(status?: string) {
@@ -124,6 +145,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   const [generatingCertFor, setGeneratingCertFor] = useState<string | null>(null);
   const [summaryModalPO, setSummaryModalPO] = useState<string | null>(null);
   const [summaryModalSerials, setSummaryModalSerials] = useState<SerializedUnit[]>([]);
+  const [summaryModalPoContext, setSummaryModalPoContext] = useState<ShipmentPoContext | null>(null);
   const [cocModal, setCocModal] = useState<{ poNumber: string; lotId: string } | null>(null);
   const [cocSpecialProcesses, setCocSpecialProcesses] = useState('N/A');
   const [cocShipDate, setCocShipDate] = useState(() => new Date().toISOString().slice(0, 10));
@@ -136,8 +158,23 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   });
 
   const shippingUnits = selectedPOIds.length > 0
-    ? shippingUnitsRaw.filter((u) => selectedPOIds.includes(u.poId))
+    ? shippingUnitsRaw.filter((u) => selectedPOIds.includes(u.projectPoId ?? u.poId) || selectedPOIds.includes(u.poId))
     : shippingUnitsRaw;
+
+  const buildShipmentPoContext = (
+    units: SerializedUnit[],
+    fallbackPoNumber?: string | null,
+  ): ShipmentPoContext => {
+    const sample = units[0];
+    return {
+      poId: sample?.projectPoId ?? sample?.poId ?? null,
+      poNumber: sample?.projectPoNumber ?? fallbackPoNumber ?? sample?.poNumber ?? null,
+      poItemId: sample?.projectPoItemId ?? null,
+      projectId: sample?.projectId ?? null,
+      projectCode: sample?.projectCode ?? null,
+      projectName: sample?.projectName ?? null,
+    };
+  };
 
   type ExistingShipmentRow = {
     po_id: number;
@@ -165,6 +202,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
     const map: Record<number, string> = {};
     for (const u of shippingUnits) {
       if (u.poId && u.poNumber) map[u.poId] = u.poNumber;
+      if (u.projectPoId && u.projectPoNumber) map[u.projectPoId] = u.projectPoNumber;
     }
     return map;
   }, [shippingUnits]);
@@ -221,6 +259,12 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
         groups[key] = {
           poNumber: unit.poNumber,
           poId: unit.poId,
+          shipmentPoId: unit.projectPoId ?? unit.poId,
+          shipmentPoNumber: unit.projectPoNumber ?? unit.poNumber,
+          shipmentPoItemId: unit.projectPoItemId ?? null,
+          projectId: unit.projectId ?? null,
+          projectCode: unit.projectCode ?? null,
+          projectName: unit.projectName ?? null,
           customerName: unit.customerName,
           units: [],
           totalUnits: 0,
@@ -286,7 +330,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   useEffect(() => {
     if (!initialPO || autoTriggered.current || shippingUnits.length === 0) return;
     const readyForPO = shippingUnits.filter(
-      (u) => u.poNumber === initialPO &&
+      (u) => (u.poNumber === initialPO || u.projectPoNumber === initialPO) &&
              u.status === 'COMPLETED' &&
              !!(u.finalizedAt && u.sku && u.drawingName)
     );
@@ -307,6 +351,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
 
     setSelectedSerials((prev) => ({ ...prev, [initialPO]: new Set(unitsToShip.map((u) => u.id)) }));
     setSummaryModalSerials(unitsToShip);
+    setSummaryModalPoContext(buildShipmentPoContext(unitsToShip, initialPO));
     setSummaryModalPO(initialPO);
   }, [initialPO, initialUnits, shippingUnits]);
 
@@ -565,16 +610,19 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
       {summaryModalPO && (
         <ShipmentSummaryModal
           serials={summaryModalSerials}
+          poContext={summaryModalPoContext ?? undefined}
           onConfirm={(billingAssignments, billingBucketOverrides) => {
             const po = summaryModalPO!;
             const ids = summaryModalSerials.map((s) => s.id);
             setSummaryModalPO(null);
             setSummaryModalSerials([]);
+            setSummaryModalPoContext(null);
             handleCreateShipment(po, ids, billingAssignments, billingBucketOverrides);
           }}
           onCancel={() => {
             setSummaryModalPO(null);
             setSummaryModalSerials([]);
+            setSummaryModalPoContext(null);
           }}
         />
       )}
@@ -683,6 +731,14 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
                             [group.poNumber]: new Set(finalizedUnits.map((u) => u.id)),
                           }));
                           setSummaryModalSerials(finalizedUnits);
+                          setSummaryModalPoContext({
+                            poId: group.shipmentPoId,
+                            poNumber: group.shipmentPoNumber,
+                            poItemId: group.shipmentPoItemId,
+                            projectId: group.projectId,
+                            projectCode: group.projectCode,
+                            projectName: group.projectName,
+                          });
                           setSummaryModalPO(group.poNumber);
                         }}
                       >
@@ -971,6 +1027,14 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
                           onClick={() => {
                             const selected = group.units.filter((u) => shipSelForPO.has(u.id));
                             setSummaryModalSerials(selected);
+                            setSummaryModalPoContext({
+                              poId: group.shipmentPoId,
+                              poNumber: group.shipmentPoNumber,
+                              poItemId: group.shipmentPoItemId,
+                              projectId: group.projectId,
+                              projectCode: group.projectCode,
+                              projectName: group.projectName,
+                            });
                             setSummaryModalPO(group.poNumber);
                           }}
                           className="bg-blue-600 hover:bg-blue-700 text-white"

--- a/client/src/components/p2/ShipmentSummaryModal.tsx
+++ b/client/src/components/p2/ShipmentSummaryModal.tsx
@@ -38,6 +38,8 @@ type SerializedUnit = {
 };
 
 type BillingBucketOverride = {
+  poId?: number;
+  poNumber?: string;
   poItemId: number;
   bucketLabel: string;
   description?: string;
@@ -67,8 +69,18 @@ type PoItem = {
   notes?: string | null;
 };
 
+type ShipmentPoContext = {
+  poId?: number | null;
+  poNumber?: string | null;
+  poItemId?: number | null;
+  projectId?: string | null;
+  projectCode?: string | null;
+  projectName?: string | null;
+};
+
 interface ShipmentSummaryModalProps {
   serials: SerializedUnit[];
+  poContext?: ShipmentPoContext;
   onConfirm: (
     assignments?: { serializedItemId: string; allocationId: string }[],
     bucketOverrides?: BillingBucketOverride[],
@@ -78,12 +90,14 @@ interface ShipmentSummaryModalProps {
 
 export default function ShipmentSummaryModal({
   serials,
+  poContext,
   onConfirm,
   onCancel,
 }: ShipmentSummaryModalProps) {
   const customer = serials[0]?.customerName ?? '-';
-  const poNumber = serials[0]?.poNumber ?? '-';
-  const poId = serials[0]?.poId;
+  const poNumber = poContext?.poNumber || serials[0]?.poNumber || '-';
+  const poId = poContext?.poId ?? serials[0]?.poId;
+  const preferredPoItemId = poContext?.poItemId ?? null;
   const [bucketMode, setBucketMode] = useState<'combined' | 'split'>('combined');
   const [selectedPoItemId, setSelectedPoItemId] = useState<number | null>(null);
   const [combinedBucketOverride, setCombinedBucketOverride] = useState<Omit<BucketOverrideDraft, 'enabled'>>({
@@ -125,6 +139,8 @@ export default function ShipmentSummaryModal({
       const group = groupByPoItemId.get(item.id);
       return {
         poItemId: item.id,
+        poId: item.poId ?? poId,
+        poNumber,
         partNumber: item.partNumber,
         itemName: item.partNumber || `PO Item #${item.id}`,
         partName: item.partName ?? group?.partName ?? '',
@@ -140,6 +156,8 @@ export default function ShipmentSummaryModal({
       .filter((group) => !fetchedIds.has(group.poItemId))
       .map((group) => ({
         poItemId: group.poItemId,
+        poId: group.units[0]?.poId,
+        poNumber: group.units[0]?.poNumber,
         partNumber: group.partNumber,
         itemName: group.itemName || `PO Item #${group.poItemId}`,
         partName: group.partName,
@@ -152,13 +170,22 @@ export default function ShipmentSummaryModal({
     return [...fetchedOptions, ...serialOnlyOptions].sort((a, b) => a.poItemId - b.poItemId);
   }, [poItems, poItemGroups]);
 
-  const effectiveSelectedPoItemId = selectedPoItemId ?? poItemOptions[0]?.poItemId ?? poItemGroups[0]?.poItemId ?? null;
+  const effectiveSelectedPoItemId =
+    selectedPoItemId ??
+    (preferredPoItemId && poItemOptions.some((option) => option.poItemId === preferredPoItemId)
+      ? preferredPoItemId
+      : null) ??
+    poItemOptions[0]?.poItemId ??
+    poItemGroups[0]?.poItemId ??
+    null;
   const selectedPoItemOption =
     poItemOptions.find((option) => option.poItemId === effectiveSelectedPoItemId) ??
     poItemOptions[0] ??
     (poItemGroups[0]
       ? {
           poItemId: poItemGroups[0].poItemId,
+          poId: poItemGroups[0].units[0]?.poId,
+          poNumber: poItemGroups[0].units[0]?.poNumber,
           partNumber: poItemGroups[0].partNumber,
           itemName: poItemGroups[0].itemName || `PO Item #${poItemGroups[0].poItemId}`,
           partName: poItemGroups[0].partName,
@@ -173,6 +200,8 @@ export default function ShipmentSummaryModal({
     const override = bucketOverrides[group.poItemId];
     if (!override?.enabled || !override.bucketLabel.trim()) return [];
     return [{
+      poId: group.units[0]?.poId,
+      poNumber: group.units[0]?.poNumber,
       poItemId: group.poItemId,
       bucketLabel: override.bucketLabel.trim(),
       description: override.description.trim() || undefined,
@@ -198,6 +227,8 @@ export default function ShipmentSummaryModal({
   const shipmentBucketOverrides: BillingBucketOverride[] =
     bucketMode === 'combined' && selectedPoItemOption
       ? [{
+          poId: selectedPoItemOption.poId,
+          poNumber: selectedPoItemOption.poNumber || poNumber,
           poItemId: selectedPoItemOption.poItemId,
           bucketLabel: combinedBucketLabel,
           description: combinedBucketDescription || undefined,

--- a/server/src/routes/p2SerializedItems.ts
+++ b/server/src/routes/p2SerializedItems.ts
@@ -74,8 +74,64 @@ router.get('/shipping-queue', async (req, res) => {
 
     // Exclude any serial already in a lot — prevents re-shipment
     const unshipped = units.filter((u) => !shippedIds.has(u.id));
+    const sourcePoIds = Array.from(
+      new Set(unshipped.map((unit) => unit.poId).filter((poId): poId is number => Number.isInteger(poId))),
+    );
 
-    res.json(unshipped);
+    const projectPoContextBySourcePoId = new Map<number, {
+      projectId: string | null;
+      projectCode: string | null;
+      projectName: string | null;
+      projectPoId: number | null;
+      projectPoNumber: string | null;
+      projectPoItemId: number | null;
+    }>();
+
+    if (sourcePoIds.length > 0) {
+      const contextRows = await pool.query<{
+        source_po_id: number;
+        project_id: string | null;
+        project_code: string | null;
+        project_name: string | null;
+        project_po_id: number | null;
+        project_po_number: string | null;
+        project_po_item_id: number | null;
+      }>(
+        `SELECT DISTINCT ON (source_po.id)
+            source_po.id AS source_po_id,
+            p.id::text AS project_id,
+            p.project_code,
+            p.project_name,
+            COALESCE(p.po_id, source_po.id) AS project_po_id,
+            COALESCE(current_po.po_number, source_po.po_number) AS project_po_number,
+            p.p2_po_item_id AS project_po_item_id
+           FROM p2_purchase_orders source_po
+           LEFT JOIN projects p
+             ON p.id = source_po.project_id
+             OR p.po_id = source_po.id
+           LEFT JOIN p2_purchase_orders current_po
+             ON current_po.id = COALESCE(p.po_id, source_po.id)
+          WHERE source_po.id = ANY($1::int[])
+          ORDER BY source_po.id, (p.po_id IS NOT NULL) DESC, p.updated_at DESC NULLS LAST`,
+        [sourcePoIds],
+      );
+
+      for (const row of contextRows) {
+        projectPoContextBySourcePoId.set(row.source_po_id, {
+          projectId: row.project_id,
+          projectCode: row.project_code,
+          projectName: row.project_name,
+          projectPoId: row.project_po_id,
+          projectPoNumber: row.project_po_number,
+          projectPoItemId: row.project_po_item_id,
+        });
+      }
+    }
+
+    res.json(unshipped.map((unit) => ({
+      ...unit,
+      ...(projectPoContextBySourcePoId.get(unit.poId) ?? {}),
+    })));
   } catch (err: any) {
     res.status(500).json({ error: err?.message || 'Failed to fetch shipping queue' });
   }

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -605,6 +605,8 @@ const createLotSchema = z.object({
     allocationId: z.string().uuid(),
   })).optional(),
   billingBucketOverrides: z.array(z.object({
+    poId: z.coerce.number().int().positive().optional(),
+    poNumber: z.string().trim().optional(),
     poItemId: z.coerce.number().int().positive(),
     bucketLabel: z.string().trim().min(1, 'Bucket label is required'),
     description: z.string().trim().optional(),
@@ -1083,21 +1085,24 @@ async function assignSerialsToPoItemBuckets(
 
   for (const { poItemId, group, override } of bucketGroups) {
     const first = group[0];
+    const targetPoId = override?.poId ?? first.poId;
     const poItemResult = await pool.query<{
       id: number;
       po_id: number;
+      po_number: string;
       part_number: string;
       part_name: string | null;
       quantity: number | null;
       unit_price: string | number | null;
     }>(
-      `SELECT id, po_id, part_number, part_name, quantity, unit_price
-         FROM p2_purchase_order_items
-        WHERE id = $1 AND po_id = $2`,
-      [poItemId, first.poId],
+      `SELECT i.id, i.po_id, po.po_number, i.part_number, i.part_name, i.quantity, i.unit_price
+         FROM p2_purchase_order_items i
+         JOIN p2_purchase_orders po ON po.id = i.po_id
+        WHERE i.id = $1 AND i.po_id = $2`,
+      [poItemId, targetPoId],
     );
     const poItem = poItemResult.rows[0];
-    if (!poItem) throw new Error(`PO item ${poItemId} was not found for PO ${first.poNumber}`);
+    if (!poItem) throw new Error(`PO item ${poItemId} was not found for PO ${override?.poNumber || first.poNumber}`);
 
     const authorizedQuantity = Math.max(
       Number(override?.quantityAuthorized) || 0,
@@ -1108,6 +1113,7 @@ async function assignSerialsToPoItemBuckets(
     const bucketLabel = override?.bucketLabel || `PO Item #${poItem.id}`;
     const description = override?.description || poItem.part_name || first.partName || null;
     const customerPoLine = override?.customerPoLine || String(poItem.id);
+    const allocationPoNumber = override?.poNumber || poItem.po_number || first.poNumber;
 
     const existingAllocationResult = await pool.query<{ id: string }>(
       `SELECT id
@@ -1145,7 +1151,7 @@ async function assignSerialsToPoItemBuckets(
         [
           poItem.po_id,
           poItem.id,
-          first.poNumber,
+          allocationPoNumber,
           poItem.part_number || first.partNumber,
           bucketLabel,
           description,
@@ -1165,7 +1171,7 @@ async function assignSerialsToPoItemBuckets(
       await assignSerialBillingBucket({
         allocationId,
         serializedItemId: serial.id,
-        poId: serial.poId,
+        poId: poItem.po_id,
         poItemId: poItem.id,
         actor,
         assignmentSource: 'po_item_shipment_create',
@@ -1382,6 +1388,8 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
       );
     });
     const lotPoItemId = fullShipmentOverride?.poItemId ?? (poItemIds.length === 1 ? poItemIds[0] : null);
+    const lotPoId = fullShipmentOverride?.poId ?? first.poId;
+    const lotPoNumber = fullShipmentOverride?.poNumber || first.poNumber;
     const lotBucketSerial = lotPoItemId
       ? serials.find((serial) => serial.poItemId === lotPoItemId) ?? first
       : first;
@@ -1406,8 +1414,8 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
         lotBucketSerial.partName,
         first.customerId,
         first.customerName,
-        first.poNumber,
-        first.poId,
+        lotPoNumber,
+        lotPoId,
         lotPoItemId,
         serials.length,
         JSON.stringify(input.serialIds),


### PR DESCRIPTION
## Summary
- Enrich the P2 shipping queue with the project-linked/current PO context for each serialized unit.
- Pass that project PO context into the shipment summary modal so PO line dropdowns load from the project PO, not only the serialized unit's original PO.
- Include the selected PO id/number in shipment bucket overrides and use it when creating billing allocations, serial assignments, and the final lot row.

## Root Cause
Shipment Summary was still deriving `poId` and `poNumber` from the first serialized unit. When the project was linked to a revised/current PO, the modal fetched line items from the old serialized-unit PO and `/api/p2/lots` validated the selected line against that old PO.

## Validation
- `node --experimental-strip-types --check server/src/routes/p2SerializedItems.ts`
- `node --experimental-strip-types --check server/src/routes/p2Shipping.ts`
- `git diff --check -- client/src/components/p2/P2ShippingTab.tsx client/src/components/p2/ShipmentSummaryModal.tsx server/src/routes/p2SerializedItems.ts server/src/routes/p2Shipping.ts`

Note: full frontend type/build validation was not available because this checkout has no local `node_modules`, and the bundled Node syntax checker does not parse `.tsx` directly.