### PR TITLE
[codex] Add unified estimating cost model

### DIFF
--- a/client/src/components/estimating/RFQBuilderStep3Bom.tsx
+++ b/client/src/components/estimating/RFQBuilderStep3Bom.tsx
@@ -16,6 +16,8 @@ export type BomLineRow = {
   vendorNameSnapshot?: string;
   materialSpec?: string;
   notes?: string;
+  sourceType?: "DRAFT" | "MANUAL";
+  sourceLabel?: string;
 };
 
 type PartOption = {
@@ -120,6 +122,7 @@ export default function RFQBuilderStep3Bom({
           <table className="w-full border-collapse min-w-[1550px]">
             <thead>
               <tr className="border-b">
+                <th className="text-left p-2">Source</th>
                 <th className="text-left p-2">Description</th>
                 <th className="text-left p-2">Category</th>
                 <th className="text-left p-2">Qty / Part</th>
@@ -139,13 +142,13 @@ export default function RFQBuilderStep3Bom({
             <tbody>
               {!selectedBomPartId ? (
                 <tr>
-                  <td colSpan={14} className="p-4 text-sm text-muted-foreground">
+                  <td colSpan={15} className="p-4 text-sm text-muted-foreground">
                     Select an RFQ part to begin adding BOM lines.
                   </td>
                 </tr>
               ) : filteredBomLines.length === 0 ? (
                 <tr>
-                  <td colSpan={14} className="p-4 text-sm text-muted-foreground">
+                  <td colSpan={15} className="p-4 text-sm text-muted-foreground">
                     No BOM lines yet for this part.
                   </td>
                 </tr>
@@ -158,6 +161,11 @@ export default function RFQBuilderStep3Bom({
 
                   return (
                     <tr key={`${row.id ?? "new"}-${index}`} className="border-b align-top">
+                      <td className="p-2">
+                        <span className="rounded border px-2 py-1 text-xs">
+                          {row.sourceType === "DRAFT" ? "Draft sourced" : "Manual"}
+                        </span>
+                      </td>
                       <td className="p-2">
                         <input
                           className="w-[180px] border rounded px-2 py-1"

--- a/client/src/lib/estimatingCostModel.ts
+++ b/client/src/lib/estimatingCostModel.ts
@@ -1,0 +1,362 @@
+export type NrcCategory =
+  | "TOOLING"
+  | "NRE_LABOR"
+  | "CAPITAL_ASSET"
+  | "INSTALLATION"
+  | "TRAINING"
+  | "OTHER";
+
+export type ChargeTiming = "ONE_TIME" | "FIRST_PO_ONLY" | "FIRST_ARTICLE_ONLY" | "EVERY_ORDER";
+export type CostSourceType = "DRAFT" | "MANUAL";
+
+export type NrcCostRow = {
+  id?: string;
+  category: NrcCategory;
+  description: string;
+  quantity: number;
+  unitCost: number;
+  totalCost?: number;
+  amortized: boolean;
+  amortizationQty?: number | null;
+  chargeTiming: ChargeTiming;
+  includeInCustomerPrice: boolean;
+  internalOnly: boolean;
+  notes?: string;
+  assetName?: string;
+  usefulLifeMonths?: number | null;
+  amortizationBasis?: string;
+  installationCost?: number;
+  trainingCost?: number;
+  sourceType?: CostSourceType;
+  sourceLabel?: string;
+};
+
+export type PricingSettingMode = "FLAT_PERCENT" | "TIERED_PERCENT" | "MANUAL_AMOUNT" | "DISABLED";
+export type PricingApplyTo = "MATERIAL" | "LABOR" | "NRC" | "DIRECT_COST" | "TOTAL_COST";
+export type PricingSettingKey = "OVERHEAD" | "G_AND_A" | "RISK" | "ESCALATION" | "PROFIT";
+
+export type PricingTierRule = {
+  minAmount: number;
+  percent: number;
+  label?: string;
+};
+
+export type PricingSetting = {
+  key: PricingSettingKey;
+  label: string;
+  enabled: boolean;
+  mode: PricingSettingMode;
+  applyTo: PricingApplyTo;
+  defaultPercent: number;
+  manualAmount?: number;
+  tiers: PricingTierRule[];
+  notes?: string;
+};
+
+export type CostModelBomLine = {
+  rfqPartId?: string;
+  quantityPerPart: number;
+  estimatedUnitCost: number;
+  scrapPercent?: number;
+};
+
+export type CostModelProcessRow = {
+  rfqPartId?: string;
+  setupHours: number;
+  hoursPerPart: number;
+  hourlyRate: number;
+};
+
+export type CostModelToolingRow = {
+  quantity: number;
+  unitCost: number;
+  totalCost?: number;
+  pricingTreatment: string;
+  amortizationQty?: number | null;
+};
+
+export type CostModelAdjustmentRow = {
+  rfqPartId?: string | null;
+  pricingMode: string;
+  amount: number;
+  percentValue?: number | null;
+  appliesToScope: string;
+  includeInCustomerPrice: boolean;
+};
+
+export type CostModelShippingRow = {
+  rfqPartId?: string | null;
+  shippingMode: string;
+  amount: number;
+  includeInCustomerPrice: boolean;
+};
+
+export type CostRollup = {
+  materialCost: number;
+  laborCost: number;
+  nrcCost: number;
+  customerFacingNrcCost: number;
+  tooling: number;
+  nreLabor: number;
+  capitalAssets: number;
+  installationTraining: number;
+  otherNrc: number;
+  adjustments: number;
+  shipping: number;
+  overhead: number;
+  gna: number;
+  riskContingency: number;
+  escalationInflation: number;
+  totalCost: number;
+  profit: number;
+  sellPrice: number;
+  marginPercent: number;
+  warnings: string[];
+};
+
+export type PricingMatrixPartRow = CostRollup & {
+  partId?: string;
+  partNumber: string;
+  materialPerPart: number;
+  laborPerPart: number;
+  nrcPerPart: number;
+  toolingPerPart: number;
+  adjustmentPerPart: number;
+  shippingPerPart: number;
+  totalCostPerPart: number;
+  sellPricePerPart: number;
+  extendedPrice: number;
+};
+
+export type PricingMatrixBreakRow = {
+  id?: string;
+  label: string;
+  quantity: number;
+  rows: PricingMatrixPartRow[];
+  rollup: CostRollup;
+  totalExtended: number;
+  separateTooling: number;
+};
+
+export function roundCurrency(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 10000) / 10000;
+}
+
+export function nrcRowTotal(row: NrcCostRow) {
+  const base = Number(row.quantity || 0) * Number(row.unitCost || 0);
+  const installTraining = row.category === "CAPITAL_ASSET"
+    ? Number(row.installationCost || 0) + Number(row.trainingCost || 0)
+    : 0;
+  return roundCurrency(base + installTraining);
+}
+
+export function nrcCustomerFacingTotal(row: NrcCostRow, breakQty: number) {
+  if (row.internalOnly || !row.includeInCustomerPrice) return 0;
+  const total = nrcRowTotal(row);
+  if (!row.amortized) return total;
+  const amortizationQty = Number(row.amortizationQty || 0);
+  if (amortizationQty > 0) return total * (breakQty / amortizationQty);
+  return 0;
+}
+
+export function calculateNrcSummary(rows: NrcCostRow[], breakQty = 1) {
+  return rows.reduce(
+    (acc, row) => {
+      const total = nrcRowTotal(row);
+      const customerFacing = nrcCustomerFacingTotal(row, breakQty);
+      acc.nrcCost += total;
+      acc.customerFacingNrcCost += customerFacing;
+      if (row.category === "TOOLING") acc.tooling += total;
+      if (row.category === "NRE_LABOR") acc.nreLabor += total;
+      if (row.category === "CAPITAL_ASSET") acc.capitalAssets += total;
+      if (row.category === "INSTALLATION" || row.category === "TRAINING") acc.installationTraining += total;
+      if (row.category === "OTHER") acc.otherNrc += total;
+      return acc;
+    },
+    {
+      nrcCost: 0,
+      customerFacingNrcCost: 0,
+      tooling: 0,
+      nreLabor: 0,
+      capitalAssets: 0,
+      installationTraining: 0,
+      otherNrc: 0,
+    },
+  );
+}
+
+export function defaultPricingSettings(): PricingSetting[] {
+  return [
+    { key: "OVERHEAD", label: "Overhead", enabled: true, mode: "FLAT_PERCENT", applyTo: "LABOR", defaultPercent: 25, tiers: [], notes: "" },
+    { key: "G_AND_A", label: "G&A", enabled: true, mode: "FLAT_PERCENT", applyTo: "DIRECT_COST", defaultPercent: 10, tiers: [], notes: "" },
+    { key: "RISK", label: "Risk / Contingency", enabled: true, mode: "FLAT_PERCENT", applyTo: "DIRECT_COST", defaultPercent: 5, tiers: [], notes: "" },
+    { key: "ESCALATION", label: "Escalation / Inflation", enabled: true, mode: "FLAT_PERCENT", applyTo: "MATERIAL", defaultPercent: 3, tiers: [], notes: "" },
+    { key: "PROFIT", label: "Profit", enabled: true, mode: "FLAT_PERCENT", applyTo: "TOTAL_COST", defaultPercent: 20, tiers: [], notes: "" },
+  ];
+}
+
+function settingBase(setting: PricingSetting, rollup: Pick<CostRollup, "materialCost" | "laborCost" | "customerFacingNrcCost" | "adjustments" | "shipping" | "totalCost">) {
+  if (setting.applyTo === "MATERIAL") return rollup.materialCost;
+  if (setting.applyTo === "LABOR") return rollup.laborCost;
+  if (setting.applyTo === "NRC") return rollup.customerFacingNrcCost;
+  if (setting.applyTo === "TOTAL_COST") return rollup.totalCost;
+  return rollup.materialCost + rollup.laborCost + rollup.customerFacingNrcCost + rollup.adjustments + rollup.shipping;
+}
+
+export function calculateSettingAmount(setting: PricingSetting, rollup: Pick<CostRollup, "materialCost" | "laborCost" | "customerFacingNrcCost" | "adjustments" | "shipping" | "totalCost">) {
+  if (!setting.enabled || setting.mode === "DISABLED") return 0;
+  if (setting.mode === "MANUAL_AMOUNT") return roundCurrency(Number(setting.manualAmount || 0));
+
+  const base = settingBase(setting, rollup);
+  const percent = setting.mode === "TIERED_PERCENT"
+    ? [...setting.tiers]
+        .filter((tier) => base >= Number(tier.minAmount || 0))
+        .sort((a, b) => Number(b.minAmount || 0) - Number(a.minAmount || 0))[0]?.percent ?? setting.defaultPercent
+    : setting.defaultPercent;
+  return roundCurrency(base * (Number(percent || 0) / 100));
+}
+
+export function calculateCostRollup(input: {
+  materialCost: number;
+  laborCost: number;
+  nrcRows: NrcCostRow[];
+  settings: PricingSetting[];
+  breakQty: number;
+  adjustments?: number;
+  shipping?: number;
+}) {
+  const nrc = calculateNrcSummary(input.nrcRows, input.breakQty);
+  const warnings: string[] = [];
+  const rollup: CostRollup = {
+    materialCost: roundCurrency(input.materialCost),
+    laborCost: roundCurrency(input.laborCost),
+    nrcCost: roundCurrency(nrc.nrcCost),
+    customerFacingNrcCost: roundCurrency(nrc.customerFacingNrcCost),
+    tooling: roundCurrency(nrc.tooling),
+    nreLabor: roundCurrency(nrc.nreLabor),
+    capitalAssets: roundCurrency(nrc.capitalAssets),
+    installationTraining: roundCurrency(nrc.installationTraining),
+    otherNrc: roundCurrency(nrc.otherNrc),
+    adjustments: roundCurrency(input.adjustments ?? 0),
+    shipping: roundCurrency(input.shipping ?? 0),
+    overhead: 0,
+    gna: 0,
+    riskContingency: 0,
+    escalationInflation: 0,
+    totalCost: 0,
+    profit: 0,
+    sellPrice: 0,
+    marginPercent: 0,
+    warnings,
+  };
+
+  const disabled = input.settings.filter((setting) => !setting.enabled || setting.mode === "DISABLED");
+  disabled.forEach((setting) => warnings.push(`${setting.label} pricing setting is disabled.`));
+
+  const directCost = rollup.materialCost + rollup.laborCost + rollup.customerFacingNrcCost + rollup.adjustments + rollup.shipping;
+  rollup.totalCost = roundCurrency(directCost);
+  for (const key of ["OVERHEAD", "G_AND_A", "RISK", "ESCALATION"] as const) {
+    const setting = input.settings.find((item) => item.key === key);
+    const amount = setting ? calculateSettingAmount(setting, rollup) : 0;
+    if (key === "OVERHEAD") rollup.overhead = amount;
+    if (key === "G_AND_A") rollup.gna = amount;
+    if (key === "RISK") rollup.riskContingency = amount;
+    if (key === "ESCALATION") rollup.escalationInflation = amount;
+    rollup.totalCost = roundCurrency(rollup.totalCost + amount);
+  }
+
+  const profitSetting = input.settings.find((item) => item.key === "PROFIT");
+  rollup.profit = profitSetting ? calculateSettingAmount(profitSetting, rollup) : 0;
+  rollup.sellPrice = roundCurrency(rollup.totalCost + rollup.profit);
+  rollup.marginPercent = rollup.sellPrice > 0 ? roundCurrency((rollup.profit / rollup.sellPrice) * 100) : 0;
+  return rollup;
+}
+
+export function materialCostPerPart(lines: CostModelBomLine[], partId?: string) {
+  return roundCurrency(lines
+    .filter((line) => !partId || line.rfqPartId === partId)
+    .reduce((sum, line) => {
+      return sum + Number(line.quantityPerPart || 0) * Number(line.estimatedUnitCost || 0) * (1 + Number(line.scrapPercent || 0) / 100);
+    }, 0));
+}
+
+export function laborCostPerPart(rows: CostModelProcessRow[], partId: string | undefined, breakQty: number) {
+  const applicable = rows.filter((row) => row.rfqPartId === partId);
+  const setupCost = applicable.reduce((sum, row) => sum + Number(row.setupHours || 0) * Number(row.hourlyRate || 0), 0);
+  const recurringCost = applicable.reduce((sum, row) => sum + Number(row.hoursPerPart || 0) * Number(row.hourlyRate || 0), 0);
+  return roundCurrency(recurringCost + (breakQty > 0 ? setupCost / breakQty : 0));
+}
+
+export function toolingCostPerPart(rows: CostModelToolingRow[], breakQty: number) {
+  return roundCurrency(rows.reduce((sum, row) => {
+    const total = Number(row.totalCost ?? 0) || Number(row.quantity || 0) * Number(row.unitCost || 0);
+    if (row.pricingTreatment === "BLENDED_UNIT_PRICE") return sum + (breakQty > 0 ? total / breakQty : 0);
+    if (row.pricingTreatment === "AMORTIZED") {
+      const amortizationQty = Number(row.amortizationQty || 0);
+      return sum + (amortizationQty > 0 ? total / amortizationQty : 0);
+    }
+    return sum;
+  }, 0));
+}
+
+export function separateToolingTotal(rows: CostModelToolingRow[]) {
+  return roundCurrency(rows
+    .filter((row) => row.pricingTreatment === "SEPARATE_LINE")
+    .reduce((sum, row) => sum + (Number(row.totalCost ?? 0) || Number(row.quantity || 0) * Number(row.unitCost || 0)), 0));
+}
+
+export function adjustmentCostPerPart(
+  rows: CostModelAdjustmentRow[],
+  partId: string | undefined,
+  breakQty: number,
+  material: number,
+  labor: number,
+) {
+  return roundCurrency(rows
+    .filter((row) => row.includeInCustomerPrice && row.pricingMode !== "INTERNAL_ONLY")
+    .filter((row) => row.appliesToScope === "RFQ" || (row.appliesToScope === "PART" && row.rfqPartId === partId))
+    .reduce((sum, row) => {
+      if (row.pricingMode === "FLAT") return sum + (breakQty > 0 ? Number(row.amount || 0) / breakQty : 0);
+      if (row.pricingMode === "PER_PART") return sum + Number(row.amount || 0);
+      if (row.pricingMode === "PERCENT_OF_MATERIAL") return sum + material * (Number(row.percentValue || 0) / 100);
+      if (row.pricingMode === "PERCENT_OF_LABOR") return sum + labor * (Number(row.percentValue || 0) / 100);
+      return sum;
+    }, 0));
+}
+
+export function shippingCostPerPart(rows: CostModelShippingRow[], partId: string | undefined, breakQty: number) {
+  return roundCurrency(rows
+    .filter((row) => row.includeInCustomerPrice && row.shippingMode !== "INTERNAL_ONLY")
+    .filter((row) => !row.rfqPartId || row.rfqPartId === partId)
+    .reduce((sum, row) => {
+      if (row.shippingMode === "PER_PART") return sum + Number(row.amount || 0);
+      if (row.shippingMode === "PER_PO") return sum + (breakQty > 0 ? Number(row.amount || 0) / breakQty : 0);
+      return sum;
+    }, 0));
+}
+
+export function validationMessages(input: {
+  bomLines: CostModelBomLine[];
+  processRows: CostModelProcessRow[];
+  nrcRows: NrcCostRow[];
+  settings: PricingSetting[];
+}) {
+  const messages: string[] = [];
+  if (input.bomLines.some((line) => Number(line.quantityPerPart || 0) > 0 && Number(line.estimatedUnitCost || 0) <= 0)) {
+    messages.push("One or more BOM rows are missing unit cost.");
+  }
+  if (input.processRows.some((row) => (Number(row.setupHours || 0) > 0 || Number(row.hoursPerPart || 0) > 0) && Number(row.hourlyRate || 0) <= 0)) {
+    messages.push("One or more labor rows are missing labor rate.");
+  }
+  if (input.nrcRows.some((row) => Number(row.quantity || 0) > 0 && Number(row.unitCost || 0) <= 0)) {
+    messages.push("One or more NRC rows are missing unit cost.");
+  }
+  if (input.nrcRows.some((row) => row.amortized && Number(row.amortizationQty || 0) <= 0)) {
+    messages.push("One or more amortized NRC rows are missing amortization quantity.");
+  }
+  input.settings
+    .filter((setting) => !setting.enabled || setting.mode === "DISABLED")
+    .forEach((setting) => messages.push(`${setting.label} pricing setting is disabled.`));
+  return messages;
+}

--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -41,6 +41,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { privateerDraftBomLines, type PrivateerDraftBomLine } from '@/data/privateerDraftBom';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
+import { nrcRowTotal, type ChargeTiming, type NrcCategory, type NrcCostRow } from '@/lib/estimatingCostModel';
 import { cn } from '@/lib/utils';
 import * as XLSX from 'xlsx';
 
@@ -89,7 +90,7 @@ type DraftPartBom = {
   rootPart: DraftBomPart;
   parts: DraftBomPart[];
 };
-type BuiltInWorkspaceTabId = 'po-draft' | 'parts-request' | 'direct-labor' | 'bom-wizard' | 'assembly-tree';
+type BuiltInWorkspaceTabId = 'po-draft' | 'parts-request' | 'direct-labor' | 'nrc' | 'bom-wizard' | 'assembly-tree';
 type CustomWorkspaceTabId = `custom:${string}`;
 type WorkspaceTabId = BuiltInWorkspaceTabId | CustomWorkspaceTabId;
 type DraftLaborEstimateLine = {
@@ -143,6 +144,7 @@ type BomDraft = {
   lines: BomLine[];
   savedDraftBoms?: DraftPartBom[];
   laborEstimateLines?: DraftLaborEstimateLine[];
+  nrcRows?: NrcCostRow[];
   customLaborDepartments?: string[];
   poVisibleColumns?: PoColumnId[];
   partsRequestVisibleColumns?: PartsRequestColumnId[];
@@ -252,11 +254,12 @@ const P2_PROJECT_VALUE_PREFIX = 'p2:';
 const RD_PROJECT_VALUE_PREFIX = 'rd:';
 
 const statuses: BomStatus[] = ['Needs Review', 'Needs Quote', 'RFQ Sent', 'On Order', 'On Hand', 'ETA / Inbound', 'Hold'];
-const defaultWorkspaceTabs: BuiltInWorkspaceTabId[] = ['po-draft', 'parts-request', 'direct-labor', 'bom-wizard', 'assembly-tree'];
+const defaultWorkspaceTabs: BuiltInWorkspaceTabId[] = ['po-draft', 'parts-request', 'direct-labor', 'nrc', 'bom-wizard', 'assembly-tree'];
 const workspaceTabLabels: Record<BuiltInWorkspaceTabId, string> = {
   'po-draft': 'PO draft',
   'parts-request': 'Parts/request',
   'direct-labor': 'Draft Direct Labor Estimate',
+  nrc: 'NRC',
   'bom-wizard': 'BOM wizard',
   'assembly-tree': 'Assembly tree',
 };
@@ -389,6 +392,30 @@ function newLaborEstimateLine(): DraftLaborEstimateLine {
   };
 }
 
+function newNrcRow(): NrcCostRow {
+  return {
+    id: crypto.randomUUID(),
+    category: 'TOOLING',
+    description: '',
+    quantity: 1,
+    unitCost: 0,
+    totalCost: 0,
+    amortized: false,
+    amortizationQty: null,
+    chargeTiming: 'ONE_TIME',
+    includeInCustomerPrice: true,
+    internalOnly: false,
+    notes: '',
+    assetName: '',
+    usefulLifeMonths: null,
+    amortizationBasis: '',
+    installationCost: 0,
+    trainingCost: 0,
+    sourceType: 'MANUAL',
+    sourceLabel: 'Draft Builder',
+  };
+}
+
 function newLine(): BomLine {
   return {
     id: crypto.randomUUID(),
@@ -518,6 +545,7 @@ function createPrivateerDraft(): BomDraft {
     })),
     savedDraftBoms: [],
     laborEstimateLines: [newLaborEstimateLine()],
+    nrcRows: [],
     customLaborDepartments: [],
     poVisibleColumns: defaultPoColumns,
     partsRequestVisibleColumns: defaultPartsRequestColumns,
@@ -573,6 +601,29 @@ function normalizeDraft(draft: BomDraft): BomDraft {
       hoursPerPart: line.hoursPerPart ?? '',
       quantityPerPo: line.quantityPerPo ?? 1,
     })),
+    nrcRows: (draft.nrcRows ?? []).map((row) => {
+      const normalized = {
+        ...newNrcRow(),
+        ...row,
+        id: row.id || crypto.randomUUID(),
+        category: (row.category || 'OTHER') as NrcCategory,
+        quantity: Number(row.quantity || 0),
+        unitCost: Number(row.unitCost || 0),
+        totalCost: Number(row.totalCost ?? Number(row.quantity || 0) * Number(row.unitCost || 0)),
+        amortized: !!row.amortized,
+        amortizationQty: row.amortizationQty != null ? Number(row.amortizationQty) : null,
+        chargeTiming: (row.chargeTiming || 'ONE_TIME') as ChargeTiming,
+        includeInCustomerPrice: row.includeInCustomerPrice !== false,
+        internalOnly: !!row.internalOnly,
+        usefulLifeMonths: row.usefulLifeMonths != null ? Number(row.usefulLifeMonths) : null,
+        installationCost: Number(row.installationCost || 0),
+        trainingCost: Number(row.trainingCost || 0),
+        sourceType: row.sourceType ?? 'MANUAL',
+        sourceLabel: row.sourceLabel ?? 'Draft Builder',
+      };
+      normalized.totalCost = nrcRowTotal(normalized);
+      return normalized;
+    }),
     customLaborDepartments: draft.customLaborDepartments ?? [],
     poVisibleColumns: sanitizePoColumns(draft.poVisibleColumns),
     partsRequestVisibleColumns: draft.partsRequestVisibleColumns ?? defaultPartsRequestColumns,
@@ -1123,11 +1174,15 @@ function laborDepartmentValue(label: string) {
 
 function normalizeWorkspaceTabs(tabs?: WorkspaceTabId[]) {
   const sourceTabs = tabs?.length ? tabs : defaultWorkspaceTabs;
-  if (sourceTabs.includes('direct-labor')) return sourceTabs;
-
   const nextTabs = [...sourceTabs];
-  const partsRequestIndex = nextTabs.indexOf('parts-request');
-  nextTabs.splice(partsRequestIndex >= 0 ? partsRequestIndex + 1 : nextTabs.length, 0, 'direct-labor');
+  if (!nextTabs.includes('direct-labor')) {
+    const partsRequestIndex = nextTabs.indexOf('parts-request');
+    nextTabs.splice(partsRequestIndex >= 0 ? partsRequestIndex + 1 : nextTabs.length, 0, 'direct-labor');
+  }
+  if (!nextTabs.includes('nrc')) {
+    const directLaborIndex = nextTabs.indexOf('direct-labor');
+    nextTabs.splice(directLaborIndex >= 0 ? directLaborIndex + 1 : nextTabs.length, 0, 'nrc');
+  }
   return nextTabs;
 }
 
@@ -1380,18 +1435,24 @@ export default function DraftBOMBuilderPage() {
       (sum, line) => sum + asNumber(line.hoursPerPart) * asNumber(line.quantityPerPo),
       0,
     );
+    const nrcTotal = (draft.nrcRows ?? []).reduce((sum, row) => sum + nrcRowTotal(row), 0);
+    const customerFacingNrcTotal = (draft.nrcRows ?? [])
+      .filter((row) => row.includeInCustomerPrice && !row.internalOnly)
+      .reduce((sum, row) => sum + nrcRowTotal(row), 0);
 
     return {
       materialTotal,
       laborTotal,
       laborHours,
+      nrcTotal,
+      customerFacingNrcTotal,
       selectedTotal,
       onHandTotal,
       needsQuote,
       rfqSent,
       lineCount: draft.lines.length,
     };
-  }, [draft.laborEstimateLines, draft.lines, selectedLines]);
+  }, [draft.laborEstimateLines, draft.lines, draft.nrcRows, selectedLines]);
 
   const filterTotals = useMemo(() => {
     const grouped = new Map<string, { count: number; total: number }>();
@@ -1450,6 +1511,39 @@ export default function DraftBOMBuilderPage() {
         laborEstimateLines: remainingLines.length > 0 ? remainingLines : [newLaborEstimateLine()],
       };
     });
+  }
+
+  function updateNrcRow(id: string, patch: Partial<NrcCostRow>) {
+    setDraft((current) => ({
+      ...current,
+      nrcRows: (current.nrcRows ?? []).map((row) => {
+        if (row.id !== id) return row;
+        const nextRow = { ...row, ...patch };
+        return { ...nextRow, totalCost: nrcRowTotal(nextRow) };
+      }),
+    }));
+  }
+
+  function updateNrcNumberRow(
+    id: string,
+    field: 'quantity' | 'unitCost' | 'amortizationQty' | 'usefulLifeMonths' | 'installationCost' | 'trainingCost',
+    value: string,
+  ) {
+    updateNrcRow(id, { [field]: value === '' ? null : Number(value) } as Partial<NrcCostRow>);
+  }
+
+  function addNrcRow() {
+    setDraft((current) => ({
+      ...current,
+      nrcRows: [...(current.nrcRows ?? []), newNrcRow()],
+    }));
+  }
+
+  function removeNrcRow(id: string) {
+    setDraft((current) => ({
+      ...current,
+      nrcRows: (current.nrcRows ?? []).filter((row) => row.id !== id),
+    }));
   }
 
   function addLaborDepartment() {
@@ -1825,6 +1919,7 @@ export default function DraftBOMBuilderPage() {
       lines: [newLine()],
       savedDraftBoms: [],
       laborEstimateLines: [newLaborEstimateLine()],
+      nrcRows: [],
       customLaborDepartments: [],
       poVisibleColumns: defaultPoColumns,
       partsRequestVisibleColumns: defaultPartsRequestColumns,
@@ -1895,6 +1990,7 @@ export default function DraftBOMBuilderPage() {
       lines: [newLine()],
       savedDraftBoms: [],
       laborEstimateLines: [newLaborEstimateLine()],
+      nrcRows: [],
       customLaborDepartments: [],
       poVisibleColumns: defaultPoColumns,
       partsRequestVisibleColumns: defaultPartsRequestColumns,
@@ -2239,6 +2335,7 @@ export default function DraftBOMBuilderPage() {
                 <SummaryMetric label="Total Material / Tooling" value={money(totals.materialTotal)} />
                 <SummaryMetric label="Direct Labor Estimate" value={money(totals.laborTotal)} />
                 <SummaryMetric label="Direct Labor Hours" value={totals.laborHours.toLocaleString(undefined, { maximumFractionDigits: 2 })} />
+                <SummaryMetric label="NRC Estimate" value={money(totals.nrcTotal)} />
                 <SummaryMetric label="Selected for RFQ / Order" value={money(totals.selectedTotal)} />
                 <SummaryMetric label="On Hand Value" value={money(totals.onHandTotal)} />
                 <SummaryMetric label="Needs Quote Count" value={String(totals.needsQuote)} />
@@ -2515,6 +2612,21 @@ export default function DraftBOMBuilderPage() {
                   onRemoveLine={removeLaborEstimateLine}
                   onUpdateLine={updateLaborEstimateLine}
                   onUpdateNumberLine={updateLaborEstimateNumberLine}
+                  isEditMode={isEditMode}
+                />
+              </TabsContent>
+            ) : null}
+
+            {visibleWorkspaceTabs.includes('nrc') ? (
+              <TabsContent value="nrc" className="mt-4">
+                <NrcEstimateWorkspace
+                  rows={draft.nrcRows ?? []}
+                  totalCost={totals.nrcTotal}
+                  customerFacingTotal={totals.customerFacingNrcTotal}
+                  onAddRow={addNrcRow}
+                  onRemoveRow={removeNrcRow}
+                  onUpdateRow={updateNrcRow}
+                  onUpdateNumberRow={updateNrcNumberRow}
                   isEditMode={isEditMode}
                 />
               </TabsContent>
@@ -3460,6 +3572,192 @@ function DirectLaborEstimateWorkspace({
           </span>
         </div>
       </section>
+    </section>
+  );
+}
+
+const nrcCategoryOptions: { value: NrcCategory; label: string }[] = [
+  { value: 'TOOLING', label: 'Tooling' },
+  { value: 'NRE_LABOR', label: 'NRE Labor' },
+  { value: 'CAPITAL_ASSET', label: 'Capital Asset' },
+  { value: 'INSTALLATION', label: 'Installation' },
+  { value: 'TRAINING', label: 'Training' },
+  { value: 'OTHER', label: 'Other' },
+];
+
+const chargeTimingOptions: { value: ChargeTiming; label: string }[] = [
+  { value: 'ONE_TIME', label: 'One Time' },
+  { value: 'FIRST_PO_ONLY', label: 'First PO Only' },
+  { value: 'FIRST_ARTICLE_ONLY', label: 'First Article Only' },
+  { value: 'EVERY_ORDER', label: 'Every Order' },
+];
+
+function NrcEstimateWorkspace({
+  rows,
+  totalCost,
+  customerFacingTotal,
+  onAddRow,
+  onRemoveRow,
+  onUpdateRow,
+  onUpdateNumberRow,
+  isEditMode,
+}: {
+  rows: NrcCostRow[];
+  totalCost: number;
+  customerFacingTotal: number;
+  onAddRow: () => void;
+  onRemoveRow: (id: string) => void;
+  onUpdateRow: (id: string, patch: Partial<NrcCostRow>) => void;
+  onUpdateNumberRow: (
+    id: string,
+    field: 'quantity' | 'unitCost' | 'amortizationQty' | 'usefulLifeMonths' | 'installationCost' | 'trainingCost',
+    value: string,
+  ) => void;
+  isEditMode: boolean;
+}) {
+  const amortizationWarnings = rows.filter((row) => row.amortized && !Number(row.amortizationQty || 0)).length;
+
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="flex flex-col gap-3 border-b border-slate-200 p-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h2 className="font-semibold text-slate-950">NRC Estimate</h2>
+          <p className="mt-1 text-sm text-slate-600">
+            Capture tooling, NRE labor, capital assets, installation, training, and other non-recurring costs with the draft.
+          </p>
+        </div>
+        <Button type="button" onClick={onAddRow} disabled={!isEditMode}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add NRC
+        </Button>
+      </div>
+
+      <div className="grid gap-3 border-b border-slate-200 p-4 sm:grid-cols-3">
+        <SummaryMetric label="Total NRC" value={money(totalCost)} />
+        <SummaryMetric label="Customer Price NRC" value={money(customerFacingTotal)} />
+        <SummaryMetric label="Amortization Warnings" value={String(amortizationWarnings)} />
+      </div>
+
+      <div className="overflow-x-auto p-4">
+        <Table className="min-w-[1800px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Source</TableHead>
+              <TableHead>Category</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Qty</TableHead>
+              <TableHead>Unit Cost</TableHead>
+              <TableHead>Total</TableHead>
+              <TableHead>Amortized</TableHead>
+              <TableHead>Amort Qty</TableHead>
+              <TableHead>Timing</TableHead>
+              <TableHead>Customer Price</TableHead>
+              <TableHead>Internal Only</TableHead>
+              <TableHead>Capital Asset Details</TableHead>
+              <TableHead>Notes</TableHead>
+              <TableHead className="text-right">Remove</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={14} className="py-8 text-center text-sm text-slate-500">
+                  No NRC rows yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => (
+                <TableRow key={row.id} className="align-top">
+                  <TableCell>
+                    <Badge variant={row.sourceType === 'DRAFT' ? 'default' : 'outline'}>
+                      {row.sourceType === 'DRAFT' ? 'Draft sourced' : 'Manual'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Select value={row.category} onValueChange={(value) => onUpdateRow(row.id ?? '', { category: value as NrcCategory })} disabled={!isEditMode}>
+                      <SelectTrigger className="w-[150px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {nrcCategoryOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    <Input className="w-[220px]" value={row.description} onChange={(event) => onUpdateRow(row.id ?? '', { description: event.target.value })} disabled={!isEditMode} />
+                  </TableCell>
+                  <TableCell>
+                    <Input className="w-[90px]" type="number" min={0} value={row.quantity} onChange={(event) => onUpdateNumberRow(row.id ?? '', 'quantity', event.target.value)} disabled={!isEditMode} />
+                  </TableCell>
+                  <TableCell>
+                    <Input className="w-[120px]" type="number" min={0} step="0.01" value={row.unitCost} onChange={(event) => onUpdateNumberRow(row.id ?? '', 'unitCost', event.target.value)} disabled={!isEditMode} />
+                  </TableCell>
+                  <TableCell className="tabular-nums">{money(nrcRowTotal(row))}</TableCell>
+                  <TableCell>
+                    <Checkbox checked={row.amortized} onCheckedChange={(checked) => onUpdateRow(row.id ?? '', { amortized: checked === true })} disabled={!isEditMode} aria-label="Amortized NRC" />
+                  </TableCell>
+                  <TableCell>
+                    <Input
+                      className={cn('w-[110px]', row.amortized && !Number(row.amortizationQty || 0) ? 'border-amber-400' : '')}
+                      type="number"
+                      min={0}
+                      value={row.amortizationQty ?? ''}
+                      onChange={(event) => onUpdateNumberRow(row.id ?? '', 'amortizationQty', event.target.value)}
+                      disabled={!isEditMode || !row.amortized}
+                    />
+                    {row.amortized && !Number(row.amortizationQty || 0) ? <p className="mt-1 text-xs text-amber-700">Required</p> : null}
+                  </TableCell>
+                  <TableCell>
+                    <Select value={row.chargeTiming} onValueChange={(value) => onUpdateRow(row.id ?? '', { chargeTiming: value as ChargeTiming })} disabled={!isEditMode}>
+                      <SelectTrigger className="w-[150px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {chargeTimingOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    <Checkbox checked={row.includeInCustomerPrice} onCheckedChange={(checked) => onUpdateRow(row.id ?? '', { includeInCustomerPrice: checked === true })} disabled={!isEditMode} aria-label="Include NRC in customer price" />
+                  </TableCell>
+                  <TableCell>
+                    <Checkbox checked={row.internalOnly} onCheckedChange={(checked) => onUpdateRow(row.id ?? '', { internalOnly: checked === true })} disabled={!isEditMode} aria-label="Internal-only NRC" />
+                  </TableCell>
+                  <TableCell>
+                    {row.category === 'CAPITAL_ASSET' ? (
+                      <div className="grid w-[420px] grid-cols-2 gap-2">
+                        <Input value={row.assetName ?? ''} onChange={(event) => onUpdateRow(row.id ?? '', { assetName: event.target.value })} placeholder="Asset name" disabled={!isEditMode} />
+                        <Input type="number" min={0} value={row.usefulLifeMonths ?? ''} onChange={(event) => onUpdateNumberRow(row.id ?? '', 'usefulLifeMonths', event.target.value)} placeholder="Useful life months" disabled={!isEditMode} />
+                        <Input value={row.amortizationBasis ?? ''} onChange={(event) => onUpdateRow(row.id ?? '', { amortizationBasis: event.target.value })} placeholder="Amortization basis" disabled={!isEditMode} />
+                        <Input type="number" min={0} step="0.01" value={row.installationCost ?? 0} onChange={(event) => onUpdateNumberRow(row.id ?? '', 'installationCost', event.target.value)} placeholder="Installation cost" disabled={!isEditMode} />
+                        <Input type="number" min={0} step="0.01" value={row.trainingCost ?? 0} onChange={(event) => onUpdateNumberRow(row.id ?? '', 'trainingCost', event.target.value)} placeholder="Training cost" disabled={!isEditMode} />
+                      </div>
+                    ) : (
+                      <span className="text-sm text-slate-500">Only shown for capital assets</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Input className="w-[220px]" value={row.notes ?? ''} onChange={(event) => onUpdateRow(row.id ?? '', { notes: event.target.value })} disabled={!isEditMode} />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button type="button" variant="ghost" size="icon" onClick={() => onRemoveRow(row.id ?? '')} disabled={!isEditMode}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
     </section>
   );
 }

--- a/client/src/pages/RFQBuilderPage.tsx
+++ b/client/src/pages/RFQBuilderPage.tsx
@@ -9,6 +9,26 @@ import RFQBuilderStep3Bom, {
   type BomLineRow,
 } from "@/components/estimating/RFQBuilderStep3Bom";
 import { privateerDraftBomLines, type PrivateerDraftBomLine } from "@/data/privateerDraftBom";
+import {
+  adjustmentCostPerPart,
+  calculateCostRollup,
+  calculateNrcSummary,
+  defaultPricingSettings,
+  laborCostPerPart,
+  materialCostPerPart,
+  nrcRowTotal,
+  separateToolingTotal,
+  shippingCostPerPart,
+  toolingCostPerPart,
+  validationMessages,
+  type ChargeTiming,
+  type CostSourceType,
+  type NrcCategory,
+  type NrcCostRow,
+  type PricingApplyTo,
+  type PricingSetting,
+  type PricingSettingMode,
+} from "@/lib/estimatingCostModel";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -25,6 +45,15 @@ type RfqPartRow = {
   makeBuyType: string;
   partType: string;
   notes: string;
+};
+
+type DraftLaborEstimateLine = {
+  id: string;
+  department: string;
+  employeeRole: string;
+  hourlyRate: number | "";
+  hoursPerPart: number | "";
+  quantityPerPo: number | "";
 };
 
 type RfqHeader = {
@@ -158,10 +187,13 @@ type DraftBomRecord = {
   revision: string;
   project: string;
   lines: PrivateerDraftBomLine[];
+  laborEstimateLines?: DraftLaborEstimateLine[];
+  nrcRows?: NrcCostRow[];
 };
 
 type BomSourceType = "draft-bom" | "draft-po" | "parts-list" | "existing";
 type ToolingFilter = "exclude" | "include" | "only";
+type RomSourceMode = "USE_DRAFT" | "MANUAL" | "IMPORT_EDIT";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -181,6 +213,10 @@ const pricingModeOptions = [
 const shippingModeOptions = ["PER_PART", "PER_PO", "INTERNAL_ONLY"];
 const shippingAllocationOptions = ["EVEN", "BY_QUANTITY", "BY_VALUE", "MANUAL"];
 const draftBomStorageKey = "epoch:draft-boms";
+const nrcCategoryOptions: NrcCategory[] = ["TOOLING", "NRE_LABOR", "CAPITAL_ASSET", "INSTALLATION", "TRAINING", "OTHER"];
+const chargeTimingOptions: ChargeTiming[] = ["ONE_TIME", "FIRST_PO_ONLY", "FIRST_ARTICLE_ONLY", "EVERY_ORDER"];
+const settingModeOptions: PricingSettingMode[] = ["FLAT_PERCENT", "TIERED_PERCENT", "MANUAL_AMOUNT", "DISABLED"];
+const settingApplyToOptions: PricingApplyTo[] = ["MATERIAL", "LABOR", "NRC", "DIRECT_COST", "TOTAL_COST"];
 
 // ── Factories ─────────────────────────────────────────────────────────────────
 
@@ -199,7 +235,7 @@ const emptyBomLine = (rfqPartId: string): BomLineRow => ({
   rfqPartId, inventoryItemId: null, childPartAgNumber: "", description: "",
   category: "PREPREG", quantityPerPart: 0, uom: "EA", estimatedUnitCost: 0,
   scrapPercent: 0, isEstimated: true, isDraftInventoryItem: false,
-  vendorNameSnapshot: "", materialSpec: "", notes: "",
+  vendorNameSnapshot: "", materialSpec: "", notes: "", sourceType: "MANUAL", sourceLabel: "ROM Builder",
 });
 
 const privateerDraftBomRecord = (): DraftBomRecord => ({
@@ -208,13 +244,19 @@ const privateerDraftBomRecord = (): DraftBomRecord => ({
   revision: "Draft A",
   project: "Privateer",
   lines: privateerDraftBomLines,
+  laborEstimateLines: [],
+  nrcRows: [],
 });
 
 function loadDraftBomRecords(): DraftBomRecord[] {
   try {
     const raw = window.localStorage.getItem(draftBomStorageKey);
     if (!raw) return [privateerDraftBomRecord()];
-    const saved = JSON.parse(raw) as DraftBomRecord[];
+    const saved = (JSON.parse(raw) as DraftBomRecord[]).map((draft) => ({
+      ...draft,
+      laborEstimateLines: draft.laborEstimateLines ?? [],
+      nrcRows: (draft.nrcRows ?? []).map((row) => normalizeNrcRow(row, "DRAFT", `${draft.name} - ${draft.revision}`)),
+    }));
     const hasPrivateer = saved.some((draft) => draft.id === "privateer");
     return hasPrivateer ? saved : [privateerDraftBomRecord(), ...saved];
   } catch {
@@ -256,6 +298,52 @@ const emptyQuantityBreak = (sortOrder: number): QuantityBreakRow => ({
   label: "", quantity: 1, sortOrder,
 });
 
+const emptyNrcRow = (sourceType: CostSourceType = "MANUAL", sourceLabel = "ROM Builder"): NrcCostRow => ({
+  id: crypto.randomUUID(),
+  category: "TOOLING",
+  description: "",
+  quantity: 1,
+  unitCost: 0,
+  totalCost: 0,
+  amortized: false,
+  amortizationQty: null,
+  chargeTiming: "ONE_TIME",
+  includeInCustomerPrice: true,
+  internalOnly: false,
+  notes: "",
+  assetName: "",
+  usefulLifeMonths: null,
+  amortizationBasis: "",
+  installationCost: 0,
+  trainingCost: 0,
+  sourceType,
+  sourceLabel,
+});
+
+function normalizeNrcRow(row: Partial<NrcCostRow>, sourceType: CostSourceType = "MANUAL", sourceLabel = "ROM Builder"): NrcCostRow {
+  const normalized: NrcCostRow = {
+    ...emptyNrcRow(sourceType, sourceLabel),
+    ...row,
+    id: row.id || crypto.randomUUID(),
+    category: (row.category || "OTHER") as NrcCategory,
+    quantity: Number(row.quantity || 0),
+    unitCost: Number(row.unitCost || 0),
+    totalCost: Number(row.totalCost ?? Number(row.quantity || 0) * Number(row.unitCost || 0)),
+    amortized: !!row.amortized,
+    amortizationQty: row.amortizationQty != null ? Number(row.amortizationQty) : null,
+    chargeTiming: (row.chargeTiming || "ONE_TIME") as ChargeTiming,
+    includeInCustomerPrice: row.includeInCustomerPrice !== false,
+    internalOnly: !!row.internalOnly,
+    usefulLifeMonths: row.usefulLifeMonths != null ? Number(row.usefulLifeMonths) : null,
+    installationCost: Number(row.installationCost || 0),
+    trainingCost: Number(row.trainingCost || 0),
+    sourceType: row.sourceType ?? sourceType,
+    sourceLabel: row.sourceLabel ?? sourceLabel,
+  };
+  normalized.totalCost = nrcRowTotal(normalized);
+  return normalized;
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export default function RFQBuilderPage() {
@@ -282,10 +370,14 @@ export default function RFQBuilderPage() {
   const [selectedExistingBomId, setSelectedExistingBomId] = useState("");
   const [toolingFilter, setToolingFilter] = useState<ToolingFilter>("exclude");
   const [bomSourceMessage, setBomSourceMessage] = useState("");
+  const [romSourceMode, setRomSourceMode] = useState<RomSourceMode>("IMPORT_EDIT");
 
   const [selectedProcessPartId, setSelectedProcessPartId] = useState("");
   const [processRows, setProcessRows] = useState<ProcessRow[]>([]);
   const [processMessage, setProcessMessage] = useState("");
+  const [nrcRows, setNrcRows] = useState<NrcCostRow[]>([]);
+  const [nrcMessage, setNrcMessage] = useState("");
+  const [pricingSettings, setPricingSettings] = useState<PricingSetting[]>(() => defaultPricingSettings());
 
   const [selectedAdjustmentPartId, setSelectedAdjustmentPartId] = useState("");
   const [adjustmentScopeFilter, setAdjustmentScopeFilter] = useState<"RFQ" | "PART">("RFQ");
@@ -304,7 +396,6 @@ export default function RFQBuilderPage() {
   const [createdQuoteId, setCreatedQuoteId] = useState<string | null>(null);
   const [createdQuoteNumber, setCreatedQuoteNumber] = useState<string | null>(null);
   const [isHandingOff, setIsHandingOff] = useState(false);
-  const [marginPercent, setMarginPercent] = useState(20);
   const [controlMessage, setControlMessage] = useState("");
   const [versionSummary, setVersionSummary] = useState("");
   const [assumptionDraft, setAssumptionDraft] = useState({
@@ -406,7 +497,7 @@ export default function RFQBuilderPage() {
   });
 
   const releaseReadinessQuery = useQuery<ReleaseReadiness>({
-    queryKey: ["estimating-rfq-release-readiness", rfqId, marginPercent], enabled: !!rfqId,
+    queryKey: ["estimating-rfq-release-readiness", rfqId], enabled: !!rfqId,
     queryFn: async () => apiRequest(`/api/estimating/rfqs/${rfqId}/approval-readiness`, { method: "POST", body: {} }),
   });
 
@@ -460,7 +551,7 @@ export default function RFQBuilderPage() {
         uom: l.uom ?? "EA", estimatedUnitCost: Number(l.estimatedUnitCost ?? 0),
         scrapPercent: Number(l.scrapPercent ?? 0), isEstimated: !!l.isEstimated,
         isDraftInventoryItem: !!l.isDraftInventoryItem, vendorNameSnapshot: l.vendorNameSnapshot ?? "",
-        materialSpec: l.materialSpec ?? "", notes: l.notes ?? "",
+        materialSpec: l.materialSpec ?? "", notes: l.notes ?? "", sourceType: "MANUAL", sourceLabel: "Saved ROM",
       })));
     }
   }, [bomLinesQuery.data]);
@@ -686,10 +777,27 @@ export default function RFQBuilderPage() {
     vendorNameSnapshot: line.supplier || "",
     materialSpec: line.manufacturer || "",
     notes: [
+      "Draft sourced",
       `${bomSourceType.replace("-", " ")} source`,
       line.category,
       line.supplierItemId,
       line.note,
+    ].filter(Boolean).join(" | "),
+    sourceType: "DRAFT",
+    sourceLabel: draftBomRecords.find((item) => item.id === selectedDraftBomId)?.name ?? "Draft Builder",
+  });
+
+  const mapDraftLaborLineToProcessRow = (line: DraftLaborEstimateLine): ProcessRow => ({
+    rfqPartId: selectedProcessPartId || selectedBomPartId,
+    departmentName: (line.department || "OTHER").toUpperCase(),
+    sourceType: "DRAFT_BUILDER",
+    setupHours: 0,
+    hoursPerPart: Number(line.hoursPerPart || 0),
+    hourlyRate: Number(line.hourlyRate || 0),
+    notes: [
+      "Draft sourced",
+      line.employeeRole,
+      `Draft quantity ${line.quantityPerPo || 1}`,
     ].filter(Boolean).join(" | "),
   });
 
@@ -706,12 +814,29 @@ export default function RFQBuilderPage() {
     }
 
     const mappedLines = filterDraftSourceLines(draft).map(mapDraftLineToBomLine);
+    const mappedProcessRows = (draft.laborEstimateLines ?? [])
+      .filter((line) => Number(line.hoursPerPart || 0) > 0 || Number(line.hourlyRate || 0) > 0)
+      .map(mapDraftLaborLineToProcessRow);
+    const mappedNrcRows = (draft.nrcRows ?? []).map((row) => normalizeNrcRow({
+      ...row,
+      id: crypto.randomUUID(),
+      sourceType: "DRAFT",
+      sourceLabel: `${draft.name} - ${draft.revision}`,
+    }, "DRAFT", `${draft.name} - ${draft.revision}`));
 
     setBomLines((prev) => [
       ...prev.filter((line) => line.rfqPartId !== selectedBomPartId || line.id),
       ...mappedLines,
     ]);
-    setBomSourceMessage(`${mappedLines.length} line(s) loaded from ${draft.name}. Save individual lines to persist them to this ROM.`);
+    setProcessRows((prev) => [
+      ...prev.filter((row) => row.rfqPartId !== (selectedProcessPartId || selectedBomPartId) || row.id),
+      ...mappedProcessRows,
+    ]);
+    setNrcRows((prev) => [
+      ...prev.filter((row) => row.sourceLabel !== `${draft.name} - ${draft.revision}`),
+      ...mappedNrcRows,
+    ]);
+    setBomSourceMessage(`${mappedLines.length} material, ${mappedProcessRows.length} labor, and ${mappedNrcRows.length} NRC row(s) loaded from ${draft.name}. Save individual server-backed rows to persist BOM and labor.`);
   };
 
   const loadExistingBomIntoRfq = async () => {
@@ -743,6 +868,8 @@ export default function RFQBuilderPage() {
       vendorNameSnapshot: line.childInventoryItem?.source || "",
       materialSpec: line.referenceDesignator || "",
       notes: `Loaded from existing BOM ${selectedBom.code ?? selectedBom.id}`,
+      sourceType: "MANUAL",
+      sourceLabel: "Existing BOM",
     }));
 
     setBomLines((prev) => [
@@ -880,6 +1007,31 @@ export default function RFQBuilderPage() {
   const selectedProcessPart = useMemo(() => parts.find((p) => p.id === selectedProcessPartId), [parts, selectedProcessPartId]);
   const selectedProcessQty = Number(selectedProcessPart?.quantity ?? 0);
   const processExtendedTotal = processSummary.setupCost + processSummary.recurringCostPerPart * selectedProcessQty;
+
+  const nrcSummary = useMemo(() => calculateNrcSummary(nrcRows, Number(quantityBreakRows[0]?.quantity || 1)), [nrcRows, quantityBreakRows]);
+
+  const addNrcRow = () => {
+    setNrcRows((prev) => [...prev, emptyNrcRow("MANUAL", "ROM Builder")]);
+  };
+
+  const updateNrcRow = (index: number, field: keyof NrcCostRow, value: string | number | boolean | null) => {
+    setNrcRows((prev) => {
+      const next = [...prev];
+      const current = next[index];
+      if (!current) return prev;
+      next[index] = normalizeNrcRow({ ...current, [field]: value }, current.sourceType ?? "MANUAL", current.sourceLabel ?? "ROM Builder");
+      return next;
+    });
+  };
+
+  const deleteNrcRow = (index: number) => {
+    setNrcRows((prev) => prev.filter((_, rowIndex) => rowIndex !== index));
+    setNrcMessage("NRC row removed from this ROM.");
+  };
+
+  const updatePricingSetting = (key: PricingSetting["key"], patch: Partial<PricingSetting>) => {
+    setPricingSettings((prev) => prev.map((setting) => (setting.key === key ? { ...setting, ...patch } : setting)));
+  };
 
   // ── Adjustment helpers ───────────────────────────────────────────────────────
 
@@ -1068,99 +1220,90 @@ export default function RFQBuilderPage() {
 
   // ── Pricing calculator functions ──────────────────────────────────────────────
 
-  const getToolingCostPerPartForBreak = (breakQty: number) => {
-    return toolingRows.reduce((sum, row) => {
-      const total = Number(row.totalCost ?? 0);
-      if (row.pricingTreatment === "BLENDED_UNIT_PRICE") return sum + (breakQty > 0 ? total / breakQty : 0);
-      if (row.pricingTreatment === "AMORTIZED") {
-        const amortQty = Number(row.amortizationQty || 0);
-        return sum + (amortQty > 0 ? total / amortQty : 0);
-      }
-      return sum;
-    }, 0);
-  };
-
-  const getMaterialCostPerPartForPart = (partId: string | undefined) => {
-    return bomLines
-      .filter((l) => l.rfqPartId === partId)
-      .reduce((sum, r) => {
-        return sum + Number(r.quantityPerPart || 0) * Number(r.estimatedUnitCost || 0) * (1 + Number(r.scrapPercent || 0) / 100);
-      }, 0);
-  };
-
-  const getLaborCostPerPartForPartAndBreak = (partId: string | undefined, breakQty: number) => {
-    const rows = processRows.filter((r) => r.rfqPartId === partId);
-    const setupCost = rows.reduce((s, r) => s + Number(r.setupHours || 0) * Number(r.hourlyRate || 0), 0);
-    const recurringPerPart = rows.reduce((s, r) => s + Number(r.hoursPerPart || 0) * Number(r.hourlyRate || 0), 0);
-    return recurringPerPart + (breakQty > 0 ? setupCost / breakQty : 0);
-  };
-
-  const getAdjustmentCostForPartAndBreak = (
-    partId: string | undefined,
-    breakQty: number,
-    materialCostPerPart: number,
-    laborCostPerPart: number
-  ) => {
-    const applicable = adjustmentRows.filter((r) => {
-      if (!r.includeInCustomerPrice) return false;
-      if (r.pricingMode === "INTERNAL_ONLY") return false;
-      if (r.appliesToScope === "RFQ") return true;
-      return r.appliesToScope === "PART" && r.rfqPartId === partId;
-    });
-    return applicable.reduce((sum, r) => {
-      if (r.pricingMode === "FLAT") return sum + (breakQty > 0 ? Number(r.amount || 0) / breakQty : 0);
-      if (r.pricingMode === "PER_PART") return sum + Number(r.amount || 0);
-      if (r.pricingMode === "PERCENT_OF_MATERIAL") return sum + materialCostPerPart * (Number(r.percentValue || 0) / 100);
-      if (r.pricingMode === "PERCENT_OF_LABOR") return sum + laborCostPerPart * (Number(r.percentValue || 0) / 100);
-      return sum;
-    }, 0);
-  };
-
-  const getShippingCostPerPartForBreak = (partId: string | undefined, breakQty: number) => {
-    const applicable = shippingRows.filter((r) => {
-      if (!r.includeInCustomerPrice) return false;
-      if (r.shippingMode === "INTERNAL_ONLY") return false;
-      if (!r.rfqPartId) return true;
-      return r.rfqPartId === partId;
-    });
-    return applicable.reduce((sum, r) => {
-      if (r.shippingMode === "PER_PART") return sum + Number(r.amount || 0);
-      if (r.shippingMode === "PER_PO") return sum + (breakQty > 0 ? Number(r.amount || 0) / breakQty : 0);
-      return sum;
-    }, 0);
-  };
-
   const pricingMatrix = useMemo(() => {
     return quantityBreakRows
       .slice()
       .sort((a, b) => a.sortOrder - b.sortOrder)
       .map((qb) => {
         const breakQty = Number(qb.quantity || 0);
-        const toolingPerPart = getToolingCostPerPartForBreak(breakQty);
+        const toolingPerPart = toolingCostPerPart(toolingRows, breakQty);
+        const nrcPerPartRows = nrcRows.map((row) => {
+          const customerFacingTotal = calculateNrcSummary([row], breakQty).customerFacingNrcCost;
+          const unitCost = breakQty > 0 ? customerFacingTotal / breakQty : 0;
+          return {
+            ...row,
+            quantity: 1,
+            unitCost,
+            totalCost: unitCost,
+            amortized: false,
+            installationCost: 0,
+            trainingCost: 0,
+          };
+        });
         const partRows = parts.filter((p) => p.id).map((part) => {
-          const materialPerPart = getMaterialCostPerPartForPart(part.id);
-          const laborPerPart = getLaborCostPerPartForPartAndBreak(part.id, breakQty);
-          const adjustmentPerPart = getAdjustmentCostForPartAndBreak(part.id, breakQty, materialPerPart, laborPerPart);
-          const shippingPerPart = getShippingCostPerPartForBreak(part.id, breakQty);
-          const totalCostPerPart = materialPerPart + laborPerPart + toolingPerPart + adjustmentPerPart + shippingPerPart;
-          const marginDecimal = Number(marginPercent || 0) / 100;
-          const sellPricePerPart = marginDecimal >= 1 ? totalCostPerPart : totalCostPerPart / (1 - marginDecimal);
+          const materialPerPart = materialCostPerPart(bomLines, part.id);
+          const laborPerPart = laborCostPerPart(processRows, part.id, breakQty);
+          const adjustmentPerPart = adjustmentCostPerPart(adjustmentRows, part.id, breakQty, materialPerPart, laborPerPart);
+          const shippingPerPart = shippingCostPerPart(shippingRows, part.id, breakQty);
+          const rollup = calculateCostRollup({
+            materialCost: materialPerPart,
+            laborCost: laborPerPart,
+            nrcRows: nrcPerPartRows,
+            settings: pricingSettings,
+            breakQty: 1,
+            adjustments: toolingPerPart + adjustmentPerPart,
+            shipping: shippingPerPart,
+          });
+          const nrcPerPart = rollup.customerFacingNrcCost;
+          const totalCostPerPart = rollup.totalCost;
+          const sellPricePerPart = rollup.sellPrice;
           return {
             partId: part.id, partNumber: part.partNumber,
-            materialPerPart, laborPerPart, toolingPerPart, adjustmentPerPart, shippingPerPart,
+            ...rollup,
+            materialPerPart, laborPerPart, nrcPerPart, toolingPerPart, adjustmentPerPart, shippingPerPart,
             totalCostPerPart, sellPricePerPart,
             extendedPrice: sellPricePerPart * breakQty,
           };
         });
         const totalExtended = partRows.reduce((s, r) => s + r.extendedPrice, 0);
-        const separateTooling = toolingRows
-          .filter((t) => t.pricingTreatment === "SEPARATE_LINE")
-          .reduce((s, t) => s + Number(t.totalCost ?? 0), 0);
+        const separateTooling = separateToolingTotal(toolingRows);
+        const rollup = partRows.reduce(
+          (acc, row) => {
+            acc.materialCost += row.materialCost * breakQty;
+            acc.laborCost += row.laborCost * breakQty;
+            acc.nrcCost += row.nrcCost * breakQty;
+            acc.customerFacingNrcCost += row.customerFacingNrcCost * breakQty;
+            acc.tooling += row.tooling * breakQty;
+            acc.nreLabor += row.nreLabor * breakQty;
+            acc.capitalAssets += row.capitalAssets * breakQty;
+            acc.installationTraining += row.installationTraining * breakQty;
+            acc.otherNrc += row.otherNrc * breakQty;
+            acc.adjustments += row.adjustments * breakQty;
+            acc.shipping += row.shipping * breakQty;
+            acc.overhead += row.overhead * breakQty;
+            acc.gna += row.gna * breakQty;
+            acc.riskContingency += row.riskContingency * breakQty;
+            acc.escalationInflation += row.escalationInflation * breakQty;
+            acc.totalCost += row.totalCost * breakQty;
+            acc.profit += row.profit * breakQty;
+            acc.sellPrice += row.sellPrice * breakQty;
+            acc.warnings = [...new Set([...acc.warnings, ...row.warnings])];
+            return acc;
+          },
+          {
+            materialCost: 0, laborCost: 0, nrcCost: 0, customerFacingNrcCost: 0,
+            tooling: 0, nreLabor: 0, capitalAssets: 0, installationTraining: 0, otherNrc: 0,
+            adjustments: 0, shipping: 0, overhead: 0, gna: 0, riskContingency: 0,
+            escalationInflation: 0, totalCost: 0, profit: 0, sellPrice: 0, marginPercent: 0,
+            warnings: [] as string[],
+          }
+        );
+        rollup.marginPercent = rollup.sellPrice > 0 ? (rollup.profit / rollup.sellPrice) * 100 : 0;
 
-        return { id: qb.id, label: qb.label, quantity: breakQty, rows: partRows, totalExtended, separateTooling };
+        return { id: qb.id, label: qb.label, quantity: breakQty, rows: partRows, rollup, totalExtended, separateTooling };
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [quantityBreakRows, parts, bomLines, processRows, toolingRows, adjustmentRows, shippingRows, marginPercent]);
+  }, [quantityBreakRows, parts, bomLines, processRows, toolingRows, adjustmentRows, shippingRows, nrcRows, pricingSettings]);
 
   // ── Step 8: Pricing Snapshot rows ────────────────────────────────────────────
 
@@ -1172,16 +1315,23 @@ export default function RFQBuilderPage() {
         quantityBreakId: breakRow.id,
         materialCostPerPart: String(row.materialPerPart),
         laborCostPerPart: String(row.laborPerPart),
-        overheadCostPerPart: String(row.adjustmentPerPart),
+        overheadCostPerPart: String(row.overhead + row.gna + row.riskContingency + row.escalationInflation + row.adjustmentPerPart + row.nrcPerPart),
         shippingCostPerPart: String(row.shippingPerPart),
         toolingCostPerPart: String(row.toolingPerPart),
         totalCostPerPart: String(row.totalCostPerPart),
-        marginPercent: String(marginPercent),
+        marginPercent: String(row.marginPercent),
         sellPricePerPart: String(row.sellPricePerPart),
         extendedPrice: String(row.extendedPrice),
       })),
     );
-  }, [pricingMatrix, rfqId, marginPercent]);
+  }, [pricingMatrix, rfqId]);
+
+  const costModelValidationMessages = useMemo(() => validationMessages({
+    bomLines,
+    processRows,
+    nrcRows,
+    settings: pricingSettings,
+  }), [bomLines, processRows, nrcRows, pricingSettings]);
 
   const latestVersion = versionsQuery.data?.[0];
   const latestRiskAssessment = riskAssessmentsQuery.data?.[0];
@@ -1451,6 +1601,29 @@ export default function RFQBuilderPage() {
             onSaveToolingRow={saveToolingRow} onDeleteToolingRow={deleteToolingRow}
           />
 
+          <div className="border rounded-lg p-5 space-y-4">
+            <div>
+              <h2 className="text-lg font-semibold">ROM Source Mode</h2>
+              <p className="text-sm text-muted-foreground">Choose whether this ROM is driven from Draft Builder data, manually authored, or imported and edited.</p>
+            </div>
+            <div className="grid gap-3 md:grid-cols-3">
+              {([
+                ["USE_DRAFT", "Use Draft Builder data"],
+                ["MANUAL", "Create manually in ROM Builder"],
+                ["IMPORT_EDIT", "Import and edit"],
+              ] as [RomSourceMode, string][]).map(([mode, label]) => (
+                <button
+                  key={mode}
+                  type="button"
+                  className={`rounded border px-4 py-3 text-left ${romSourceMode === mode ? "border-primary bg-primary/5" : ""}`}
+                  onClick={() => setRomSourceMode(mode)}
+                >
+                  <span className="font-medium">{label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
           {/* ── Step 3: BOM Builder (extracted component) ────────────────────── */}
           <div className="border rounded-lg p-5 space-y-4">
             <div>
@@ -1589,6 +1762,7 @@ export default function RFQBuilderPage() {
                             <td className="p-2">
                               <select className="w-[160px] border rounded px-2 py-1" value={row.sourceType} onChange={(e) => updateProcessRow(index, "sourceType", e.target.value)}>
                                 <option value="MANUAL">Manual</option>
+                                <option value="DRAFT_BUILDER">Draft Builder</option>
                                 <option value="ROUTING_TEMPLATE">Routing Template</option>
                                 <option value="HISTORICAL">Historical</option>
                               </select>
@@ -1619,6 +1793,81 @@ export default function RFQBuilderPage() {
                   <div className="flex justify-between"><span>Recurring / Part</span><span>${processSummary.recurringCostPerPart.toFixed(4)}</span></div>
                   <div className="border-t pt-2 flex justify-between font-semibold"><span>Labor / Part</span><span>${processSummary.totalPerPart.toFixed(4)}</span></div>
                   <div className="flex justify-between font-semibold"><span>Total @ Qty</span><span>${processExtendedTotal.toFixed(2)}</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="border rounded-lg p-5 space-y-4">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold">Step 4B - NRC</h2>
+                <p className="text-sm text-muted-foreground">Estimate non-recurring tooling, NRE labor, capital assets, installation, training, and other one-time costs.</p>
+              </div>
+              <button className="border rounded px-4 py-2" onClick={addNrcRow} type="button">+ Add NRC</button>
+            </div>
+            {nrcMessage && <div className="rounded border px-3 py-2 text-sm">{nrcMessage}</div>}
+            <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
+              <div className="lg:col-span-3 overflow-x-auto">
+                <table className="w-full border-collapse min-w-[1750px]">
+                  <thead>
+                    <tr className="border-b">
+                      {["Source","Category","Description","Qty","Unit Cost","Total","Amortized","Amort Qty","Timing","Customer Price","Internal","Capital Asset","Notes","Actions"].map((h) => (
+                        <th key={h} className="text-left p-2">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {nrcRows.length === 0 ? (
+                      <tr><td colSpan={14} className="p-4 text-sm text-muted-foreground">No NRC rows yet.</td></tr>
+                    ) : (
+                      nrcRows.map((row, index) => (
+                        <tr key={`${row.id ?? "new"}-${index}`} className="border-b align-top">
+                          <td className="p-2"><span className="rounded border px-2 py-1 text-xs">{row.sourceType === "DRAFT" ? "Draft sourced" : "Manual"}</span></td>
+                          <td className="p-2"><select className="w-[150px] border rounded px-2 py-1" value={row.category} onChange={(e) => updateNrcRow(index, "category", e.target.value)}>{nrcCategoryOptions.map((o) => <option key={o} value={o}>{o}</option>)}</select></td>
+                          <td className="p-2"><input className="w-[200px] border rounded px-2 py-1" value={row.description} onChange={(e) => updateNrcRow(index, "description", e.target.value)} /></td>
+                          <td className="p-2"><input type="number" min={0} className="w-[90px] border rounded px-2 py-1" value={row.quantity} onChange={(e) => updateNrcRow(index, "quantity", Number(e.target.value))} /></td>
+                          <td className="p-2">
+                            <input type="number" min={0} step="0.01" className={`w-[120px] border rounded px-2 py-1 ${Number(row.quantity || 0) > 0 && Number(row.unitCost || 0) <= 0 ? "border-amber-400" : ""}`} value={row.unitCost} onChange={(e) => updateNrcRow(index, "unitCost", Number(e.target.value))} />
+                            {Number(row.quantity || 0) > 0 && Number(row.unitCost || 0) <= 0 ? <p className="mt-1 text-xs text-amber-700">Missing unit cost</p> : null}
+                          </td>
+                          <td className="p-2">${nrcRowTotal(row).toFixed(2)}</td>
+                          <td className="p-2 text-center"><input type="checkbox" checked={row.amortized} onChange={(e) => updateNrcRow(index, "amortized", e.target.checked)} /></td>
+                          <td className="p-2">
+                            <input type="number" min={0} className={`w-[110px] border rounded px-2 py-1 ${row.amortized && !Number(row.amortizationQty || 0) ? "border-amber-400" : ""}`} value={row.amortizationQty ?? ""} disabled={!row.amortized} onChange={(e) => updateNrcRow(index, "amortizationQty", e.target.value ? Number(e.target.value) : null)} />
+                            {row.amortized && !Number(row.amortizationQty || 0) ? <p className="mt-1 text-xs text-amber-700">Required</p> : null}
+                          </td>
+                          <td className="p-2"><select className="w-[150px] border rounded px-2 py-1" value={row.chargeTiming} onChange={(e) => updateNrcRow(index, "chargeTiming", e.target.value)}>{chargeTimingOptions.map((o) => <option key={o} value={o}>{o}</option>)}</select></td>
+                          <td className="p-2 text-center"><input type="checkbox" checked={row.includeInCustomerPrice} onChange={(e) => updateNrcRow(index, "includeInCustomerPrice", e.target.checked)} /></td>
+                          <td className="p-2 text-center"><input type="checkbox" checked={row.internalOnly} onChange={(e) => updateNrcRow(index, "internalOnly", e.target.checked)} /></td>
+                          <td className="p-2">
+                            {row.category === "CAPITAL_ASSET" ? (
+                              <div className="grid w-[390px] grid-cols-2 gap-2">
+                                <input className="border rounded px-2 py-1" placeholder="Asset name" value={row.assetName ?? ""} onChange={(e) => updateNrcRow(index, "assetName", e.target.value)} />
+                                <input className="border rounded px-2 py-1" type="number" min={0} placeholder="Life months" value={row.usefulLifeMonths ?? ""} onChange={(e) => updateNrcRow(index, "usefulLifeMonths", e.target.value ? Number(e.target.value) : null)} />
+                                <input className="border rounded px-2 py-1" placeholder="Basis" value={row.amortizationBasis ?? ""} onChange={(e) => updateNrcRow(index, "amortizationBasis", e.target.value)} />
+                                <input className="border rounded px-2 py-1" type="number" min={0} step="0.01" placeholder="Install" value={row.installationCost ?? 0} onChange={(e) => updateNrcRow(index, "installationCost", Number(e.target.value))} />
+                                <input className="border rounded px-2 py-1" type="number" min={0} step="0.01" placeholder="Training" value={row.trainingCost ?? 0} onChange={(e) => updateNrcRow(index, "trainingCost", Number(e.target.value))} />
+                              </div>
+                            ) : <span className="text-sm text-muted-foreground">Capital asset only</span>}
+                          </td>
+                          <td className="p-2"><input className="w-[180px] border rounded px-2 py-1" value={row.notes ?? ""} onChange={(e) => updateNrcRow(index, "notes", e.target.value)} /></td>
+                          <td className="p-2"><button className="border rounded px-3 py-1" onClick={() => deleteNrcRow(index)} type="button">Delete</button></td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+              <div className="border rounded-lg p-4 h-fit">
+                <h3 className="font-semibold mb-3">NRC Summary</h3>
+                <div className="space-y-2 text-sm">
+                  <div className="flex justify-between"><span>Tooling</span><span>${nrcSummary.tooling.toFixed(2)}</span></div>
+                  <div className="flex justify-between"><span>NRE Labor</span><span>${nrcSummary.nreLabor.toFixed(2)}</span></div>
+                  <div className="flex justify-between"><span>Capital Assets</span><span>${nrcSummary.capitalAssets.toFixed(2)}</span></div>
+                  <div className="flex justify-between"><span>Install / Training</span><span>${nrcSummary.installationTraining.toFixed(2)}</span></div>
+                  <div className="border-t pt-2 flex justify-between font-semibold"><span>Total NRC</span><span>${nrcSummary.nrcCost.toFixed(2)}</span></div>
+                  <div className="flex justify-between"><span>Customer Facing</span><span>${nrcSummary.customerFacingNrcCost.toFixed(2)}</span></div>
                 </div>
               </div>
             </div>
@@ -1792,6 +2041,71 @@ export default function RFQBuilderPage() {
             </div>
           </div>
 
+          <div className="border rounded-lg p-5 space-y-4">
+            <div>
+              <h2 className="text-lg font-semibold">Step 6B - ROM Settings</h2>
+              <p className="text-sm text-muted-foreground">Apply overhead, G&A, risk, escalation, and profit rules to the pricing snapshot.</p>
+            </div>
+            {costModelValidationMessages.length > 0 && (
+              <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+                {costModelValidationMessages.map((message) => <div key={message}>{message}</div>)}
+              </div>
+            )}
+            <div className="grid gap-4 xl:grid-cols-5">
+              {pricingSettings.map((setting) => (
+                <div key={setting.key} className={`rounded border p-4 space-y-3 ${!setting.enabled || setting.mode === "DISABLED" ? "border-amber-300 bg-amber-50/50" : ""}`}>
+                  <div className="flex items-start justify-between gap-3">
+                    <h3 className="font-semibold">{setting.label}</h3>
+                    <label className="text-sm flex items-center gap-2">
+                      <input type="checkbox" checked={setting.enabled} onChange={(e) => updatePricingSetting(setting.key, { enabled: e.target.checked })} />
+                      Enabled
+                    </label>
+                  </div>
+                  <div>
+                    <label className="block text-xs mb-1 text-muted-foreground">Mode</label>
+                    <select className="w-full border rounded px-2 py-1" value={setting.mode} onChange={(e) => updatePricingSetting(setting.key, { mode: e.target.value as PricingSettingMode })}>
+                      {settingModeOptions.map((mode) => <option key={mode} value={mode}>{mode}</option>)}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs mb-1 text-muted-foreground">Apply To</label>
+                    <select className="w-full border rounded px-2 py-1" value={setting.applyTo} onChange={(e) => updatePricingSetting(setting.key, { applyTo: e.target.value as PricingApplyTo })}>
+                      {settingApplyToOptions.map((applyTo) => <option key={applyTo} value={applyTo}>{applyTo}</option>)}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-xs mb-1 text-muted-foreground">Default %</label>
+                    <input type="number" min={0} step="0.01" className="w-full border rounded px-2 py-1" value={setting.defaultPercent} onChange={(e) => updatePricingSetting(setting.key, { defaultPercent: Number(e.target.value) })} />
+                  </div>
+                  <div>
+                    <label className="block text-xs mb-1 text-muted-foreground">Manual Amount</label>
+                    <input type="number" min={0} step="0.01" className="w-full border rounded px-2 py-1" value={setting.manualAmount ?? 0} onChange={(e) => updatePricingSetting(setting.key, { manualAmount: Number(e.target.value) })} disabled={setting.mode !== "MANUAL_AMOUNT"} />
+                  </div>
+                  <div>
+                    <label className="block text-xs mb-1 text-muted-foreground">Tiers JSON</label>
+                    <textarea
+                      className="w-full border rounded px-2 py-1 min-h-[70px] text-xs"
+                      value={JSON.stringify(setting.tiers)}
+                      onChange={(e) => {
+                        try {
+                          const tiers = JSON.parse(e.target.value);
+                          if (Array.isArray(tiers)) updatePricingSetting(setting.key, { tiers });
+                        } catch {
+                          updatePricingSetting(setting.key, { notes: "Invalid tiers JSON" });
+                        }
+                      }}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs mb-1 text-muted-foreground">Notes</label>
+                    <textarea className="w-full border rounded px-2 py-1 min-h-[60px] text-sm" value={setting.notes ?? ""} onChange={(e) => updatePricingSetting(setting.key, { notes: e.target.value })} />
+                  </div>
+                  {!setting.enabled || setting.mode === "DISABLED" ? <p className="text-xs text-amber-700">Visible disabled pricing setting</p> : null}
+                </div>
+              ))}
+            </div>
+          </div>
+
           {/* ── Step 7: Quantity Break Pricing ──────────────────────────────── */}
           <div className="border rounded-lg p-5 space-y-4">
             <div className="flex items-center justify-between gap-4">
@@ -1806,9 +2120,10 @@ export default function RFQBuilderPage() {
 
             <div className="flex flex-wrap items-end gap-4">
               <div>
-                <label className="block text-sm mb-1">Margin %</label>
+                <label className="block text-sm mb-1">Profit %</label>
                 <input type="number" min={0} step="0.01" className="border rounded px-3 py-2 w-[140px]"
-                  value={marginPercent} onChange={(e) => setMarginPercent(Number(e.target.value))} />
+                  value={pricingSettings.find((setting) => setting.key === "PROFIT")?.defaultPercent ?? 0}
+                  onChange={(e) => updatePricingSetting("PROFIT", { defaultPercent: Number(e.target.value), mode: "FLAT_PERCENT", enabled: true })} />
               </div>
             </div>
 
@@ -1861,25 +2176,27 @@ export default function RFQBuilderPage() {
                       <table className="w-full border-collapse min-w-[1100px]">
                         <thead>
                           <tr className="border-b">
-                            {["Part","Material / Part","Labor / Part","Tooling / Part","Adjustments / Part","Shipping / Part","Cost / Part","Sell / Part","Extended"].map((h) => (
+                            {["Part","Material / Part","Labor / Part","NRC / Part","Tooling / Part","OH/G&A/Risk/Esc","Profit / Part","Cost / Part","Sell / Part","Margin %","Extended"].map((h) => (
                               <th key={h} className="text-left p-2">{h}</th>
                             ))}
                           </tr>
                         </thead>
                         <tbody>
                           {breakRow.rows.length === 0 ? (
-                            <tr><td colSpan={9} className="p-4 text-sm text-muted-foreground">No parts with saved IDs yet.</td></tr>
+                            <tr><td colSpan={11} className="p-4 text-sm text-muted-foreground">No parts with saved IDs yet.</td></tr>
                           ) : (
                             breakRow.rows.map((row) => (
                               <tr key={row.partId} className="border-b">
                                 <td className="p-2">{row.partNumber}</td>
                                 <td className="p-2">${row.materialPerPart.toFixed(4)}</td>
                                 <td className="p-2">${row.laborPerPart.toFixed(4)}</td>
+                                <td className="p-2">${row.nrcPerPart.toFixed(4)}</td>
                                 <td className="p-2">${row.toolingPerPart.toFixed(4)}</td>
-                                <td className="p-2">${row.adjustmentPerPart.toFixed(4)}</td>
-                                <td className="p-2">${row.shippingPerPart.toFixed(4)}</td>
+                                <td className="p-2">${(row.overhead + row.gna + row.riskContingency + row.escalationInflation).toFixed(4)}</td>
+                                <td className="p-2">${row.profit.toFixed(4)}</td>
                                 <td className="p-2 font-medium">${row.totalCostPerPart.toFixed(4)}</td>
                                 <td className="p-2 font-medium">${row.sellPricePerPart.toFixed(4)}</td>
+                                <td className="p-2">{row.marginPercent.toFixed(2)}%</td>
                                 <td className="p-2 font-semibold">${row.extendedPrice.toFixed(2)}</td>
                               </tr>
                             ))
@@ -2125,6 +2442,62 @@ export default function RFQBuilderPage() {
                           )}
                         </tbody>
                         <tfoot className="border-t bg-muted/30">
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Material Cost</td>
+                            <td className="p-2">${breakRow.rollup.materialCost.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Labor Cost</td>
+                            <td className="p-2">${breakRow.rollup.laborCost.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">NRC Cost</td>
+                            <td className="p-2">${breakRow.rollup.nrcCost.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Tooling</td>
+                            <td className="p-2">${breakRow.rollup.tooling.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">NRE Labor</td>
+                            <td className="p-2">${breakRow.rollup.nreLabor.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Capital Assets</td>
+                            <td className="p-2">${breakRow.rollup.capitalAssets.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Installation / Training</td>
+                            <td className="p-2">${breakRow.rollup.installationTraining.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Overhead</td>
+                            <td className="p-2">${breakRow.rollup.overhead.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">G&A</td>
+                            <td className="p-2">${breakRow.rollup.gna.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Risk / Contingency</td>
+                            <td className="p-2">${breakRow.rollup.riskContingency.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Escalation / Inflation</td>
+                            <td className="p-2">${breakRow.rollup.escalationInflation.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Total Cost</td>
+                            <td className="p-2 font-semibold">${breakRow.rollup.totalCost.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Profit</td>
+                            <td className="p-2 font-semibold">${breakRow.rollup.profit.toFixed(2)}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={3} className="p-2 text-right text-muted-foreground">Margin %</td>
+                            <td className="p-2 font-semibold">{breakRow.rollup.marginPercent.toFixed(2)}%</td>
+                          </tr>
                           <tr>
                             <td colSpan={3} className="p-2 text-right text-muted-foreground">Parts subtotal</td>
                             <td className="p-2 font-semibold">${breakRow.totalExtended.toFixed(2)}</td>


### PR DESCRIPTION
## Summary
- adds a shared estimating cost model utility with NRC rows, pricing settings, tier rules, validation messages, and rollup calculations
- adds a Draft Builder NRC workspace tab stored with local draft BOM records
- expands the ROM Builder to import Draft Builder material, labor, and NRC data, edit NRC rows manually, tune ROM settings, and show detailed pricing rollups

## Impact
- Draft Builder users can capture tooling, NRE labor, capital assets, installation, training, and other NRC costs before a server table exists
- ROM Builder users can choose Draft Builder data, manual creation, or import-and-edit workflows while preserving existing save, BOM, tooling, process, adjustments, shipping, quantity break, risk, approval, and quote handoff paths
- pricing snapshots remain compatible with the existing backend schema while the UI exposes the richer rollup

## Validation
- `git diff --cached --check`
- `node --experimental-strip-types --check client/src/lib/estimatingCostModel.ts`

Full `npm run check` was not run because `npm` is not available in this Windows session and the fresh worktree has no app `node_modules`.