### PR TITLE
[codex] Show revised-PO shipments under source PO

### DIFF
--- a/client/src/components/p2/P2ShippingTab.tsx
+++ b/client/src/components/p2/P2ShippingTab.tsx
@@ -178,6 +178,8 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
 
   type ExistingShipmentRow = {
     po_id: number;
+    source_po_ids?: number[] | null;
+    source_po_numbers?: string[] | null;
     lot_id: string;
     lot_number: string;
     slip_id: string;
@@ -198,11 +200,17 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   });
 
   // Build poId → poNumber lookup from the live shipping queue
-  const poIdToNumber = useMemo(() => {
-    const map: Record<number, string> = {};
+  const shipmentPoIdToGroupKeys = useMemo(() => {
+    const map: Record<number, Set<string>> = {};
     for (const u of shippingUnits) {
-      if (u.poId && u.poNumber) map[u.poId] = u.poNumber;
-      if (u.projectPoId && u.projectPoNumber) map[u.projectPoId] = u.projectPoNumber;
+      if (u.poId && u.poNumber) {
+        map[u.poId] = map[u.poId] ?? new Set<string>();
+        map[u.poId].add(u.poNumber);
+      }
+      if (u.projectPoId && u.poNumber) {
+        map[u.projectPoId] = map[u.projectPoId] ?? new Set<string>();
+        map[u.projectPoId].add(u.poNumber);
+      }
     }
     return map;
   }, [shippingUnits]);
@@ -211,14 +219,16 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   // Merges server rows into existing local state: adds missing lots but preserves locally-enriched
   // fields (e.g. certId/certNumber set by handleGenerateCoC before the next server refetch).
   useEffect(() => {
-    if (!existingShipmentRows.length || !Object.keys(poIdToNumber).length) return;
+    if (!existingShipmentRows.length || !Object.keys(shipmentPoIdToGroupKeys).length) return;
     setCreatedShipments((prev) => {
       const next: Record<string, CreatedShipment[]> = { ...prev };
       for (const row of existingShipmentRows) {
-        const poNumber = poIdToNumber[row.po_id];
-        if (!poNumber) continue;
-        if (!next[poNumber]) next[poNumber] = [];
-        const existingIdx = next[poNumber].findIndex((s) => s.lotId === row.lot_id);
+        const poNumbers = Array.from(new Set<string>([
+          ...(row.source_po_numbers ?? []),
+          ...Array.from(shipmentPoIdToGroupKeys[row.po_id] ?? []),
+          ...(row.source_po_ids ?? []).flatMap((poId) => Array.from(shipmentPoIdToGroupKeys[poId] ?? [])),
+        ].filter((poNumber): poNumber is string => !!poNumber)));
+        if (poNumbers.length === 0) continue;
         const serverEntry: CreatedShipment = {
           lotId: row.lot_id,
           lotNumber: row.lot_number,
@@ -234,22 +244,26 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
           journalEntryStatus: row.journal_entry_status ?? undefined,
           journalLineCount: row.journal_line_count ?? undefined,
         };
-        if (existingIdx === -1) {
-          next[poNumber] = [...next[poNumber], serverEntry];
-        } else {
-          const local = next[poNumber][existingIdx];
-          // Prefer local cert fields if server hasn't caught up yet
-          const merged: CreatedShipment = {
-            ...serverEntry,
-            certId: local.certId ?? serverEntry.certId,
-            certNumber: local.certNumber ?? serverEntry.certNumber,
-          };
-          next[poNumber] = next[poNumber].map((s, i) => (i === existingIdx ? merged : s));
+        for (const poNumber of poNumbers) {
+          if (!next[poNumber]) next[poNumber] = [];
+          const existingIdx = next[poNumber].findIndex((s) => s.lotId === row.lot_id);
+          if (existingIdx === -1) {
+            next[poNumber] = [...next[poNumber], serverEntry];
+          } else {
+            const local = next[poNumber][existingIdx];
+            // Prefer local cert fields if server hasn't caught up yet
+            const merged: CreatedShipment = {
+              ...serverEntry,
+              certId: local.certId ?? serverEntry.certId,
+              certNumber: local.certNumber ?? serverEntry.certNumber,
+            };
+            next[poNumber] = next[poNumber].map((s, i) => (i === existingIdx ? merged : s));
+          }
         }
       }
       return next;
     });
-  }, [existingShipmentRows, poIdToNumber]);
+  }, [existingShipmentRows, shipmentPoIdToGroupKeys]);
 
   const poGroups = useMemo(() => {
     const groups: Record<string, POGroup> = {};
@@ -453,6 +467,8 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
     serialIds: string[],
     billingAssignments: { serializedItemId: string; allocationId: string }[] = [],
     billingBucketOverrides: {
+      poId?: number;
+      poNumber?: string;
       poItemId: number;
       bucketLabel: string;
       description?: string;

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -1463,6 +1463,8 @@ router.get('/lots/existing-shipments', async (req: Request, res: Response) => {
   try {
     const rows = await pool.query<{
       po_id: number;
+      source_po_ids: number[] | null;
+      source_po_numbers: string[] | null;
       lot_id: string;
       lot_number: string;
       slip_id: string;
@@ -1479,6 +1481,8 @@ router.get('/lots/existing-shipments', async (req: Request, res: Response) => {
     }>(`
       SELECT
         l.po_id,
+        COALESCE(source.source_po_ids, ARRAY[]::int[]) AS source_po_ids,
+        COALESCE(source.source_po_numbers, ARRAY[]::text[]) AS source_po_numbers,
         l.id           AS lot_id,
         l.lot_number,
         ps.id          AS slip_id,
@@ -1494,6 +1498,19 @@ router.get('/lots/existing-shipments', async (req: Request, res: Response) => {
         0::int AS journal_line_count
       FROM p2_lot_numbers l
       JOIN p2_packing_slips ps ON ps.id = l.packing_slip_id
+      LEFT JOIN LATERAL (
+        SELECT
+          ARRAY_AGG(DISTINCT si.po_id) FILTER (WHERE si.po_id IS NOT NULL) AS source_po_ids,
+          ARRAY_AGG(DISTINCT si.po_number) FILTER (WHERE si.po_number IS NOT NULL) AS source_po_numbers
+        FROM jsonb_array_elements_text(
+          CASE
+            WHEN jsonb_typeof(COALESCE(l.serialized_item_ids, '[]'::jsonb)) = 'array'
+              THEN COALESCE(l.serialized_item_ids, '[]'::jsonb)
+            ELSE '[]'::jsonb
+          END
+        ) serial(serial_id)
+        JOIN p2_serialized_items si ON si.id = serial.serial_id::uuid
+      ) source ON true
       WHERE l.po_id IS NOT NULL
         AND l.packing_slip_id IS NOT NULL
         AND COALESCE(l.status, '') <> 'VOID'


### PR DESCRIPTION
## Summary
- Adds source PO ids/numbers to `/api/p2/lots/existing-shipments` by resolving each lot's serialized item ids.
- Hydrates P2 Shipping tab shipment cards under the visible source PO accordion even when the lot itself is stored on the revised/project PO.
- Keeps the project/current PO shipment creation behavior from #1234 while restoring visibility under the original production PO group.

## Root Cause
PR #1234 correctly stores revised/project PO context on new shipment lots. The Shipping tab accordion still groups units by the original/source production PO, so the existing-shipment hydration could miss lots whose stored `po_id` is now the revised/project PO.

## Conflict Resolution
Rebased this follow-up onto current `origin/main` after #1234 and #1235 were merged. The conflict in `P2ShippingTab.tsx` was resolved by preserving the one-to-many shipment PO id -> visible source PO group map.

## Validation
- `node --experimental-strip-types --check server/src/routes/p2Shipping.ts`
- `git diff --check -- client/src/components/p2/P2ShippingTab.tsx server/src/routes/p2Shipping.ts`

Note: full frontend type/build validation is still unavailable in this checkout because local `node_modules` is not installed.