### PR TITLE
Fix ProjectDetailPage BOM fallback initialization

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -772,7 +772,6 @@ export default function ProjectDetailPage() {
   const projectSerializedItems = Array.isArray(hubProduction.serializedItems) ? hubProduction.serializedItems : traceabilitySerials;
   const productionAssemblyTree = hubProduction.assemblyTree ?? {};
   const assemblyPoItems = Array.isArray(productionAssemblyTree.poItems) ? productionAssemblyTree.poItems : [];
-  const assemblyBomRecords = Array.isArray(productionAssemblyTree.bomRecords) ? productionAssemblyTree.bomRecords : bomRoutingRecords;
   const productionStatusCounts = projectProductionOrders.reduce((counts: Record<string, number>, order: any) => {
     const status = String(order.status || 'Unknown');
     counts[status] = (counts[status] ?? 0) + 1;
@@ -784,6 +783,7 @@ export default function ProjectDetailPage() {
   const hubBomRouting = hubTabs.bomRouting ?? {};
   const bomRoutingSummary = hubBomRouting.summary ?? {};
   const bomRoutingRecords = Array.isArray(hubBomRouting.bomRecords) ? hubBomRouting.bomRecords : [];
+  const assemblyBomRecords = Array.isArray(productionAssemblyTree.bomRecords) ? productionAssemblyTree.bomRecords : bomRoutingRecords;
   const bomRoutingRoutings = Array.isArray(hubBomRouting.routings) ? hubBomRouting.routings : [];
   const bomRoutingPartNumbers = Array.isArray(hubBomRouting.sourcePartNumbers) ? hubBomRouting.sourcePartNumbers : [];
   const bomRoutingChangeLinks = Array.isArray(hubBomRouting.changeLinks)


### PR DESCRIPTION
## Summary
- Move `assemblyBomRecords` initialization below `bomRoutingRecords` so the production assembly fallback does not reference a `const` before initialization.
- Move the `quoteFeedback` query above `romCategories` so ROM category labels do not reference quote feedback before its `const` is initialized.
- Fixes the Project Detail runtime crashes seen as `Cannot access '$s' before initialization` and `Cannot access 'x' before initialization`.

## Validation
- `git diff --check -- client/src/pages/ProjectDetailPage.tsx`
- `git diff --cached --check`
- Static source-order check confirmed:
  - `bomRoutingRecords` is declared before `assemblyBomRecords`
  - `quoteFeedback` is declared before `romCategories`

Full Vite build was not run locally because this clean worktree does not have `node_modules` and `npm` is not available on PATH in this PowerShell session.