### PR TITLE
Fix ProjectDetailPage quote feedback initialization

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -824,6 +824,17 @@ export default function ProjectDetailPage() {
     const hours = Number(value);
     return Number.isFinite(hours) ? `${hours.toLocaleString()} hrs` : fallback;
   };
+  const { data: quoteFeedback, isLoading: isLoadingFeedback } = useQuery<QuoteExecutionFeedback | null>({
+    queryKey: ['/api/projects', id, 'quote-feedback'],
+    queryFn: () =>
+      fetch(`/api/projects/${id}/quote-feedback`, { credentials: 'include' }).then(async r => {
+        if (r.status === 404) return null;
+        if (!r.ok) throw new Error('Failed to fetch quote feedback');
+        return r.json();
+      }),
+    enabled: !!id,
+  });
+
   const romCategories = [
     {
       label: 'Labor',
@@ -1048,17 +1059,6 @@ export default function ProjectDetailPage() {
       toast({ title: 'Closing record updated', description: 'Lessons learned have been saved.' });
     },
     onError: (err: any) => toast({ title: 'Update failed', description: err?.message || 'Could not update closing record.', variant: 'destructive' }),
-  });
-
-  const { data: quoteFeedback, isLoading: isLoadingFeedback } = useQuery<QuoteExecutionFeedback | null>({
-    queryKey: ['/api/projects', id, 'quote-feedback'],
-    queryFn: () =>
-      fetch(`/api/projects/${id}/quote-feedback`, { credentials: 'include' }).then(async r => {
-        if (r.status === 404) return null;
-        if (!r.ok) throw new Error('Failed to fetch quote feedback');
-        return r.json();
-      }),
-    enabled: !!id,
   });
 
   const regenerateFeedbackMutation = useMutation({


### PR DESCRIPTION
## Summary
- Move the `quoteFeedback` query above `romCategories` so ROM category labels do not reference quote feedback before its `const` is initialized.
- Fixes the remaining Project Detail runtime crash shown as `Cannot access 'x' before initialization` in the deployed bundle.

## Validation
- `git diff --check -- client/src/pages/ProjectDetailPage.tsx`
- `git diff --cached --check`
- Static source-order check confirmed:
  - `bomRoutingRecords` is declared before `assemblyBomRecords`
  - `quoteFeedback` is declared before `romCategories`

Full Vite build was not run locally because this clean worktree does not have `node_modules` and `npm` is not available on PATH in this PowerShell session.