### PR TITLE
[codex] allow locked cutting barcode print

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -250,7 +250,8 @@ function isQueueProductionProtected(item: ManufacturingQueueItem): boolean {
 }
 
 function isPacketBarcodePrintable(item: ManufacturingQueueItem): boolean {
-  return (item.status === 'PENDING' || item.status === 'IN_PROGRESS') && !isQueueProductionProtected(item) && getPrintableBarcodeCount(item) > 0;
+  const status = String(item.status || '').toUpperCase();
+  return (status === 'PENDING' || status === 'IN_PROGRESS' || status === 'LOCKED') && getPrintableBarcodeCount(item) > 0;
 }
 
 function useIsAdmin() {
@@ -2278,7 +2279,7 @@ export default function CuttingOperatorDashboard() {
                       data-testid={`row-mfg-item-${item.id}`}
                     >
                       <TableCell>
-                        {isPacketBarcodePrintable(item) && !isProductionProtected ? (
+                        {isPacketBarcodePrintable(item) ? (
                           <input
                             type="checkbox"
                             checked={selectedPrintIds.includes(item.id)}
@@ -2331,7 +2332,7 @@ export default function CuttingOperatorDashboard() {
                         <Badge variant="outline" className="font-mono">{item.estimatedCuts}</Badge>
                       </TableCell>
                       <TableCell className="text-center">
-                        {isPacketBarcodePrintable(item) && !isProductionProtected ? (
+                        {isPacketBarcodePrintable(item) ? (
                           <Input
                             type="number"
                             min={1}

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -228,7 +228,9 @@ router.get('/cutting-table', async (req: Request, res: Response) => {
         routingSignal,
         or(
           eq(manufacturingQueue.status, 'PENDING'),
-          eq(manufacturingQueue.status, 'IN_PROGRESS')
+          eq(manufacturingQueue.status, 'IN_PROGRESS'),
+          eq(manufacturingQueue.status, 'LOCKED'),
+          eq(manufacturingQueue.status, 'locked')
         )
       );
     } else if (status && status !== 'ALL') {


### PR DESCRIPTION
## Summary

- Keeps locked cutting-table work orders visible in the active scheduled packet feed.
- Allows scheduled packet barcode selection and quantity entry for locked/production-protected queue rows.
- Leaves production actions protected; this change only restores read-only barcode printing for scheduled work.

## Root Cause

The cutting dashboard treated production-protected or locked work orders as non-printable, even though scheduled barcode generation is a read-only label operation. Locked rows could also fall out of the active feed, making the print path unavailable.

## Validation

- `git diff --check -- client/src/pages/cutting/CuttingOperatorDashboard.tsx server/src/routes/cuttingTableManufacturingQueue.ts`
- `git diff --cached --check`