### PR TITLE
[codex] Fix P2 document PO number display

### DIFF
--- a/client/src/pages/InvoiceDetailPage.tsx
+++ b/client/src/pages/InvoiceDetailPage.tsx
@@ -569,7 +569,7 @@ export default function InvoiceDetailPage() {
   const lines = invoice.lines || [];
   const payments = invoice.payments || [];
   const isP1Invoice = invoice.invoiceSource === 'P1';
-  const sourcePoLabel = invoice.poOverride || invoice.poNumber || invoice.poId;
+  const sourcePoLabel = invoice.poOverride || invoice.poNumber || packingSlipInfo?.poNumber || invoice.poId;
 
   return (
     <div className="p-6 max-w-4xl mx-auto space-y-6">
@@ -726,15 +726,15 @@ export default function InvoiceDetailPage() {
                   <p className="text-sm text-muted-foreground">Terms</p>
                   <p className="font-medium">{invoice.terms || '—'}</p>
                 </div>
-                {(invoice.poId || invoice.poOverride) && (
+                {sourcePoLabel && (
                   <div>
                     <p className="text-sm text-muted-foreground">PO</p>
-                    <p className="font-medium">{invoice.poOverride || invoice.poNumber || invoice.poId || '—'}</p>
+                    <p className="font-medium">{sourcePoLabel}</p>
                   </div>
                 )}
               </div>
 
-              {(invoice.packingSlipId || invoice.lotId || invoice.poOverride || invoice.poId) && (
+              {(invoice.packingSlipId || invoice.lotId || sourcePoLabel) && (
                 <>
                   <Separator className="my-4" />
                   <div>
@@ -767,14 +767,14 @@ export default function InvoiceDetailPage() {
                           </Link>
                         </Button>
                       )}
-                      {(invoice.poOverride || invoice.poId) && (
+                      {sourcePoLabel && (invoice.poOverride || invoice.poNumber || invoice.poId) && (
                         <Button variant="outline" size="sm" asChild>
                           <Link href={isP1Invoice
                             ? `/oem-shipments?search=${encodeURIComponent(sourcePoLabel || '')}`
                             : `/p2-control-center?tab=pos&search=${encodeURIComponent(sourcePoLabel || '')}`}
                           >
                             <FileText className="h-3.5 w-3.5 mr-1.5" />
-                            {isP1Invoice ? 'P1 PO' : 'P2 PO'}: {sourcePoLabel || invoice.poId}
+                            {isP1Invoice ? 'P1 PO' : 'P2 PO'}: {sourcePoLabel}
                             <ExternalLink className="h-3 w-3 ml-1.5 opacity-60" />
                           </Link>
                         </Button>

--- a/server/src/routes/arInvoices.ts
+++ b/server/src/routes/arInvoices.ts
@@ -33,6 +33,7 @@ import {
   buildRevenueDimensionTags,
   resolveRevenueAccountForProductionLine,
 } from '../services/productionLineAccounting';
+import { formatP2DocumentPoNumber } from '../utils/p2DocumentPoNumber';
 
 const LOCKED_STATUSES = ['POSTED', 'SENT', 'VOID', 'PAID'];
 
@@ -156,6 +157,17 @@ const invoicePoNumberSql = () => sql<string | null>`
     ${p2PurchaseOrders.poNumber}
   )
 `;
+
+function normalizeInvoiceDocumentPo<T extends { invoiceSource?: string | null; poNumber?: string | null; poOverride?: string | null }>(
+  invoice: T,
+): T {
+  if (invoice.invoiceSource === 'P1') return invoice;
+  return {
+    ...invoice,
+    poNumber: formatP2DocumentPoNumber(invoice.poNumber),
+    poOverride: formatP2DocumentPoNumber(invoice.poOverride) ?? invoice.poOverride,
+  };
+}
 
 async function isP1PackingSlipInvoice(invoiceId: string): Promise<boolean> {
   const [row] = await db
@@ -455,7 +467,7 @@ router.get('/', async (req: Request, res: Response) => {
       )
       .orderBy(desc(arInvoices.createdAt));
 
-    res.json(results);
+    res.json(results.map(normalizeInvoiceDocumentPo));
   } catch (error) {
     console.error('Failed to fetch invoices:', error);
     res.status(500).json({ error: 'Failed to fetch invoices' });
@@ -545,7 +557,7 @@ router.get('/needs-review', async (_req: Request, res: Response) => {
         )
       )
       .orderBy(desc(arInvoices.createdAt));
-    res.json(results);
+    res.json(results.map(normalizeInvoiceDocumentPo));
   } catch (error) {
     console.error('Failed to fetch needs-review invoices:', error);
     res.status(500).json({ error: 'Failed to fetch needs-review invoices' });
@@ -568,7 +580,7 @@ router.get('/unsent', async (_req: Request, res: Response) => {
         )
       )
       .orderBy(desc(arInvoices.createdAt));
-    res.json(results);
+    res.json(results.map(normalizeInvoiceDocumentPo));
   } catch (error) {
     console.error('Failed to fetch unsent invoices:', error);
     res.status(500).json({ error: 'Failed to fetch unsent invoices' });
@@ -591,7 +603,7 @@ router.get('/disputed', async (_req: Request, res: Response) => {
         )
       )
       .orderBy(desc(arInvoices.createdAt));
-    res.json(results);
+    res.json(results.map(normalizeInvoiceDocumentPo));
   } catch (error) {
     console.error('Failed to fetch disputed invoices:', error);
     res.status(500).json({ error: 'Failed to fetch disputed invoices' });
@@ -806,7 +818,7 @@ router.get('/:id', async (req: Request, res: Response) => {
       .from(arPaymentAllocations)
       .where(eq(arPaymentAllocations.invoiceId, id));
 
-    res.json({ ...invoice, lines, payments });
+    res.json({ ...normalizeInvoiceDocumentPo(invoice), lines, payments });
   } catch (error) {
     console.error('Failed to fetch invoice:', error);
     res.status(500).json({ error: 'Failed to fetch invoice' });

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -22,6 +22,7 @@ import {
   evaluateShippingCertPackageGate,
 } from '../services/certPackageService';
 import { recordAuditEvent } from '../services/auditLedgerService';
+import { formatP2DocumentPoNumber } from '../utils/p2DocumentPoNumber';
 import multer from 'multer';
 import {
   getFileStorageProvider,
@@ -1680,7 +1681,7 @@ router.post('/packing-slips', authenticateToken, requirePermission('shipping.rel
         customerId: lot.customerId || '',
         customerName: lot.customerName || '',
         customerAddress,
-        poNumber: lot.poNumber,
+        poNumber: formatP2DocumentPoNumber(lot.poNumber),
         lineItems,
         totalQuantity: serials.length,
         status: 'DRAFT',
@@ -2461,7 +2462,7 @@ router.post('/certificates', authenticateToken, requirePermission('shipping.rele
         customerId: lot.customerId || '',
         customerName: lot.customerName || '',
         customerAddress,
-        poNumber: lot.poNumber,
+        poNumber: formatP2DocumentPoNumber(lot.poNumber),
         partNumber: assignedSku || lot.partNumber,
         partName: lot.partName,
         quantity: serials.length,
@@ -2487,7 +2488,7 @@ router.post('/certificates', authenticateToken, requirePermission('shipping.rele
       .set({ certificateId: cert.id })
       .where(eq(p2LotNumbers.id, lot.id));
 
-    return res.status(201).json(cert);
+    return res.status(201).json({ ...cert, poNumber: formatP2DocumentPoNumber(cert.poNumber) });
   } catch (err: any) {
     if (err instanceof z.ZodError)
       return res.status(400).json({ error: err.errors[0].message });
@@ -2521,6 +2522,7 @@ router.get('/certificates/:id', async (req: Request, res: Response) => {
     const assignedSku = await getAssignedSkuForLot(cert.lotNumberId);
     return res.json({
       ...cert,
+      poNumber: formatP2DocumentPoNumber(cert.poNumber),
       partNumber: assignedSku || cert.partNumber,
       specialProcesses: getSpecialProcesses(cert.processRecords),
       qaMgrTitle: getQaMgrTitle(cert.traceabilityData),
@@ -2619,7 +2621,7 @@ router.get('/certificates/:id/pdf', async (req: Request, res: Response) => {
 
     const infoRows: [string, string][] = [
       ['Customer:', cert.customerName],
-      ['Purchase Order #:', cert.poNumber || '—'],
+      ['Purchase Order #:', formatP2DocumentPoNumber(cert.poNumber) || '—'],
       [assignedSku ? 'SKU:' : 'Part Number:', displayPartNumber],
       ['Part Description:', cert.partName || '—'],
       ['Special Processes:', specialProcesses],

--- a/server/src/routes/p2TravelerViewer.ts
+++ b/server/src/routes/p2TravelerViewer.ts
@@ -40,6 +40,7 @@ import {
   insertP2DepartmentTransferSignatureSchema,
 } from '../../schema';
 import { eq, and, desc, sql, inArray, or, ilike, asc } from 'drizzle-orm';
+import { formatP2DocumentPoNumber } from '../utils/p2DocumentPoNumber';
 
 const router = Router();
 
@@ -1413,7 +1414,13 @@ router.post('/packing-slip', async (req: Request, res: Response) => {
       packingSlipNumber,
     });
     
-    const [packingSlip] = await db.insert(p2PackingSlips).values(validatedData).returning();
+    const [packingSlip] = await db
+      .insert(p2PackingSlips)
+      .values({
+        ...validatedData,
+        poNumber: formatP2DocumentPoNumber(validatedData.poNumber),
+      })
+      .returning();
 
     // If associated with a lot, update the lot
     if (req.body.lotNumberId) {
@@ -1423,7 +1430,10 @@ router.post('/packing-slip', async (req: Request, res: Response) => {
         .where(eq(p2LotNumbers.id, req.body.lotNumberId));
     }
 
-    return res.json({ success: true, packingSlip });
+    return res.json({
+      success: true,
+      packingSlip: { ...packingSlip, poNumber: formatP2DocumentPoNumber(packingSlip.poNumber) },
+    });
   } catch (error: any) {
     console.error('Error creating packing slip:', error);
     return res.status(500).json({ error: error.message || 'Failed to create packing slip' });
@@ -1455,7 +1465,7 @@ router.get('/packing-slip/:id', async (req: Request, res: Response) => {
     if (!packingSlip) {
       return res.status(404).json({ error: 'Packing slip not found' });
     }
-    return res.json(packingSlip);
+    return res.json({ ...packingSlip, poNumber: formatP2DocumentPoNumber(packingSlip.poNumber) });
   } catch (error: any) {
     console.error('Error getting packing slip:', error);
     return res.status(500).json({ error: 'Failed to get packing slip' });
@@ -1516,7 +1526,13 @@ router.post('/certificate-of-conformance', async (req: Request, res: Response) =
       traceabilityData,
     });
     
-    const [certificate] = await db.insert(p2CertificatesOfConformance).values(validatedData).returning();
+    const [certificate] = await db
+      .insert(p2CertificatesOfConformance)
+      .values({
+        ...validatedData,
+        poNumber: formatP2DocumentPoNumber(validatedData.poNumber),
+      })
+      .returning();
 
     // If associated with a lot, update the lot
     if (req.body.lotNumberId) {
@@ -1526,7 +1542,10 @@ router.post('/certificate-of-conformance', async (req: Request, res: Response) =
         .where(eq(p2LotNumbers.id, req.body.lotNumberId));
     }
 
-    return res.json({ success: true, certificate });
+    return res.json({
+      success: true,
+      certificate: { ...certificate, poNumber: formatP2DocumentPoNumber(certificate.poNumber) },
+    });
   } catch (error: any) {
     console.error('Error creating certificate of conformance:', error);
     return res.status(500).json({ error: error.message || 'Failed to create certificate of conformance' });
@@ -1561,6 +1580,7 @@ router.get('/certificate-of-conformance/:id', async (req: Request, res: Response
     const assignedSku = await getAssignedSkuForLot(certificate.lotNumberId);
     return res.json({
       ...certificate,
+      poNumber: formatP2DocumentPoNumber(certificate.poNumber),
       partNumber: assignedSku || certificate.partNumber,
       specialProcesses: getSpecialProcesses(certificate.processRecords),
       qaMgrTitle: getQaMgrTitle(certificate.traceabilityData),
@@ -1759,7 +1779,7 @@ router.post('/generate-from-lot/:lotId', async (req: Request, res: Response) => 
         lotNumber: lot.lotNumber,
         customerId: lot.customerId || '',
         customerName: lot.customerName || '',
-        poNumber: lot.poNumber,
+        poNumber: formatP2DocumentPoNumber(lot.poNumber),
         lineItems,
         totalQuantity: serializedItems.length,
         status: 'DRAFT',
@@ -1791,7 +1811,7 @@ router.post('/generate-from-lot/:lotId', async (req: Request, res: Response) => 
         lotNumber: lot.lotNumber,
         customerId: lot.customerId || '',
         customerName: lot.customerName || '',
-        poNumber: lot.poNumber,
+        poNumber: formatP2DocumentPoNumber(lot.poNumber),
         partNumber: lot.partNumber,
         partName: lot.partName,
         quantity: serializedItems.length,
@@ -1870,7 +1890,7 @@ router.post('/generate-from-lot/:lotId', async (req: Request, res: Response) => 
         lotNumber: lot.lotNumber,
         customerId: lot.customerId || '',
         customerName: lot.customerName || '',
-        poNumber: lot.poNumber,
+        poNumber: formatP2DocumentPoNumber(lot.poNumber),
         partNumber: lot.partNumber,
         partName: lot.partName,
         quantity: serializedItems.length,

--- a/server/src/utils/p2DocumentPoNumber.ts
+++ b/server/src/utils/p2DocumentPoNumber.ts
@@ -1,0 +1,6 @@
+export function formatP2DocumentPoNumber(poNumber: string | null | undefined): string | null {
+  if (!poNumber) return null;
+  const trimmed = poNumber.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/(?:[-\s]+R[A-Z]+)$/i, '');
+}


### PR DESCRIPTION
## Summary
- Strip P2 revision suffixes like `-RA` / `-RB` from customer-facing document PO numbers.
- Apply the display cleanup to P2 packing slips, CoCs, traveler-viewer document routes, and AR invoice responses.
- Let invoice detail use the linked packing slip PO label when an invoice is sourced through a P2 packing slip.

## Root Cause
P2 PO revisions are stored as distinct internal PO numbers with suffixes such as `-RA`, and those internal values were flowing directly into customer-facing COCs, packing slips, and invoice views.

## Validation
- `git diff --check`
- `git diff --cached --check`

Full TypeScript validation was not available in this shell because `npm` is not on PATH and this worktree does not have a local `typescript` binary.