### PR TITLE
[codex] Improve timer station traveler scan flow

### DIFF
--- a/client/src/components/StartProductionTimerModal.tsx
+++ b/client/src/components/StartProductionTimerModal.tsx
@@ -12,7 +12,6 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -85,6 +84,8 @@ interface StartProductionTimerModalProps {
   travelerTaskId?: string;
   departmentName?: string;
   enableTravelerScan?: boolean;
+  requireAuth?: (action: () => void, description?: string) => void;
+  getAuthHeaders?: () => Record<string, string>;
 }
 
 export default function StartProductionTimerModal({
@@ -100,6 +101,8 @@ export default function StartProductionTimerModal({
   travelerTaskId,
   departmentName,
   enableTravelerScan = false,
+  requireAuth,
+  getAuthHeaders,
 }: StartProductionTimerModalProps) {
   const [, setLocation] = useLocation();
   const { toast } = useToast();
@@ -107,17 +110,15 @@ export default function StartProductionTimerModal({
   const streamRef = useRef<MediaStream | null>(null);
   const travelerInputRef = useRef<HTMLInputElement>(null);
   const serialInputRef = useRef<HTMLInputElement>(null);
+  const scanningActiveRef = useRef(false);
 
   const [travelerBarcode, setTravelerBarcode] = useState('');
   const [resolvedTraveler, setResolvedTraveler] = useState<TravelerScanResolution | null>(null);
   const [programId, setProgramId] = useState('');
   const [serialNumber, setSerialNumber] = useState('');
-  const [description, setDescription] = useState('');
   const [mandrelNumber, setMandrelNumber] = useState('');
   const [ovenNumber, setOvenNumber] = useState('');
   const [ovenSlot, setOvenSlot] = useState('');
-  const [notes, setNotes] = useState('');
-  const [scannedBy, setScannedBy] = useState('');
   const [isScanning, setIsScanning] = useState(false);
   const [barcodeSupported, setBarcodeSupported] = useState(false);
   const [isResolvingTraveler, setIsResolvingTraveler] = useState(false);
@@ -154,14 +155,18 @@ export default function StartProductionTimerModal({
       setTravelerBarcode('');
       setResolvedTraveler(null);
       setSerialNumber('');
-      setDescription('');
       setMandrelNumber('');
       setOvenNumber('');
       setOvenSlot('');
-      setNotes('');
-      setScannedBy('');
     }
   }, [open, defaultSerialNumber, defaultProgramId, enableTravelerScan]);
+
+  useEffect(() => {
+    if (!open || defaultProgramId || programId || !programs?.length) return;
+    if (programs.length === 1) {
+      setProgramId(programs[0].id);
+    }
+  }, [open, defaultProgramId, programId, programs]);
 
   const applyTravelerResolution = (resolution: TravelerScanResolution) => {
     setResolvedTraveler(resolution);
@@ -203,17 +208,17 @@ export default function StartProductionTimerModal({
     mutationFn: async () => {
       return apiRequest('/api/production/timers/runs/start', {
         method: 'POST',
+        headers: getAuthHeaders?.(),
         body: JSON.stringify({
           programId,
           serialNumber: serialNumber.trim(),
-          description: description.trim() || undefined,
           mandrelNumber: parseInt(mandrelNumber, 10),
           ovenNumber: parseInt(ovenNumber, 10),
           ovenSlot,
           ...(resolvedTraveler?.scannedTravelerBarcode || travelerBarcode.trim()
             ? { scannedTravelerBarcode: resolvedTraveler?.scannedTravelerBarcode || travelerBarcode.trim() }
             : {}),
-          ...(scannedBy.trim() ? { badgeId: scannedBy.trim() } : badgeId ? { badgeId } : {}),
+          ...(badgeId ? { badgeId } : {}),
           ...(travelerId || resolvedTraveler?.traveler?.id ? { travelerId: travelerId || resolvedTraveler?.traveler?.id } : {}),
           ...(travelerStepId ? { travelerStepId } : {}),
           ...(travelerTaskId ? { travelerTaskId } : {}),
@@ -253,6 +258,7 @@ export default function StartProductionTimerModal({
         await videoRef.current.play();
       }
 
+      scanningActiveRef.current = true;
       setIsScanning(true);
 
       if ('BarcodeDetector' in window) {
@@ -261,7 +267,7 @@ export default function StartProductionTimerModal({
         });
 
         const scanFrame = async () => {
-          if (!videoRef.current || !isScanning) return;
+          if (!videoRef.current || !scanningActiveRef.current) return;
 
           try {
             const barcodes = await detector.detect(videoRef.current);
@@ -280,7 +286,7 @@ export default function StartProductionTimerModal({
             console.error('Barcode detection error:', err);
           }
 
-          if (isScanning) {
+          if (scanningActiveRef.current) {
             requestAnimationFrame(scanFrame);
           }
         };
@@ -294,11 +300,13 @@ export default function StartProductionTimerModal({
         description: 'Please allow camera access to scan barcodes',
         variant: 'destructive',
       });
+      scanningActiveRef.current = false;
       setIsScanning(false);
     }
   };
 
   const stopScanning = () => {
+    scanningActiveRef.current = false;
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((track) => track.stop());
       streamRef.current = null;
@@ -319,29 +327,35 @@ export default function StartProductionTimerModal({
       });
       return;
     }
-    startMutation.mutate();
+    const startTimer = () => startMutation.mutate();
+    if (requireAuth && !badgeId) {
+      requireAuth(startTimer, 'start this timer');
+      return;
+    }
+    startTimer();
   };
 
   const isValid = programId && serialNumber.trim() && mandrelNumber && ovenNumber && ovenSlot;
+  const showProgramSelector = !enableTravelerScan || (!programId && (programs?.length || 0) > 1);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-xl">
-            <Play className="w-5 h-5" />
-            Start Timer
+            <ScanBarcode className="w-5 h-5" />
+            Scan Traveler to Start Timer
           </DialogTitle>
           <DialogDescription>
-            Configure production run parameters
+            Scan the traveler, then enter mandrel, oven, and side.
           </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {enableTravelerScan && (
             <div className="space-y-2">
-              <Label htmlFor="travelerBarcode">Traveler Scan</Label>
-              <div className="flex gap-2">
+              <Label htmlFor="travelerBarcode" className="text-base font-semibold">Traveler Barcode *</Label>
+              <div className="flex gap-2 rounded-lg border-2 border-emerald-300 bg-emerald-50/70 p-3 dark:border-emerald-700 dark:bg-emerald-950/30">
                 <Input
                   id="travelerBarcode"
                   ref={travelerInputRef}
@@ -354,7 +368,7 @@ export default function StartProductionTimerModal({
                     }
                   }}
                   placeholder="Scan traveler barcode"
-                  className="flex-1 font-mono"
+                  className="h-14 flex-1 bg-white font-mono text-lg dark:bg-slate-950"
                   autoComplete="off"
                 />
                 <Button
@@ -362,6 +376,7 @@ export default function StartProductionTimerModal({
                   variant="outline"
                   onClick={() => resolveTravelerScan(travelerBarcode)}
                   disabled={!travelerBarcode.trim() || isResolvingTraveler}
+                  className="h-14 border-emerald-300 bg-white dark:bg-slate-950"
                 >
                   {isResolvingTraveler ? (
                     <Loader2 className="w-4 h-4 animate-spin" />
@@ -391,32 +406,35 @@ export default function StartProductionTimerModal({
             </div>
           )}
 
-          <div className="space-y-2">
-            <Label htmlFor="program">Program *</Label>
-            <Select value={programId} onValueChange={setProgramId}>
-              <SelectTrigger id="program">
-                <SelectValue placeholder="Select a program..." />
-              </SelectTrigger>
-              <SelectContent>
-                {programsLoading ? (
-                  <div className="p-2 text-center text-muted-foreground">
-                    Loading programs...
-                  </div>
-                ) : programs?.length === 0 ? (
-                  <div className="p-2 text-center text-muted-foreground">
-                    No active programs available
-                  </div>
-                ) : (
-                  programs?.map((program) => (
-                    <SelectItem key={program.id} value={program.id}>
-                      {program.name}
-                    </SelectItem>
-                  ))
-                )}
-              </SelectContent>
-            </Select>
-          </div>
+          {showProgramSelector && (
+            <div className="space-y-2">
+              <Label htmlFor="program">Program *</Label>
+              <Select value={programId} onValueChange={setProgramId}>
+                <SelectTrigger id="program">
+                  <SelectValue placeholder="Select a program..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {programsLoading ? (
+                    <div className="p-2 text-center text-muted-foreground">
+                      Loading programs...
+                    </div>
+                  ) : programs?.length === 0 ? (
+                    <div className="p-2 text-center text-muted-foreground">
+                      No active programs available
+                    </div>
+                  ) : (
+                    programs?.map((program) => (
+                      <SelectItem key={program.id} value={program.id}>
+                        {program.name}
+                      </SelectItem>
+                    ))
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
+          {!enableTravelerScan && (
           <div className="space-y-2">
             <Label htmlFor="serialNumber">Serial # *</Label>
             <div className="flex gap-2">
@@ -452,6 +470,7 @@ export default function StartProductionTimerModal({
               )}
             </div>
           </div>
+          )}
 
           {isScanning && (
             <div className="relative rounded-lg overflow-hidden bg-black">
@@ -470,17 +489,7 @@ export default function StartProductionTimerModal({
             </div>
           )}
 
-          <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
-            <Input
-              id="description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Enter description (optional)"
-            />
-          </div>
-
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             <div className="space-y-2">
               <Label htmlFor="mandrel">Mandrel # *</Label>
               <Select value={mandrelNumber} onValueChange={setMandrelNumber}>
@@ -509,7 +518,7 @@ export default function StartProductionTimerModal({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="ovenSlot">Oven Slot *</Label>
+              <Label htmlFor="ovenSlot">Side *</Label>
               <Select value={ovenSlot} onValueChange={setOvenSlot}>
                 <SelectTrigger id="ovenSlot">
                   <SelectValue placeholder="Select" />
@@ -520,28 +529,6 @@ export default function StartProductionTimerModal({
                 </SelectContent>
               </Select>
             </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="notes">Notes (optional)</Label>
-            <Textarea
-              id="notes"
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              placeholder="Any additional notes..."
-              rows={2}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="scannedBy">Employee Code</Label>
-            <Input
-              id="scannedBy"
-              value={scannedBy}
-              onChange={(e) => setScannedBy(e.target.value)}
-              placeholder="Scan or enter your badge/employee code"
-              autoComplete="off"
-            />
           </div>
 
           <DialogFooter className="gap-2 sm:gap-0">

--- a/client/src/hooks/useActionAuth.ts
+++ b/client/src/hooks/useActionAuth.ts
@@ -58,6 +58,7 @@ function clearStoredAuth() {
 export function useActionAuth() {
   const [authState, setAuthState] = useState<ActionAuthState>(getStoredAuth);
   const [showAuthModal, setShowAuthModal] = useState(false);
+  const [actionDescription, setActionDescription] = useState('perform this action');
   const pendingActionRef = useRef<(() => void) | null>(null);
 
   const { data: sessionUser } = useQuery<ActionAuthUser | null>({
@@ -107,8 +108,17 @@ export function useActionAuth() {
     }
 
     pendingActionRef.current = action;
+    setActionDescription(actionDescription || 'perform this action');
     setShowAuthModal(true);
   }, [isAuthenticated]);
+
+  const requireFreshAuth = useCallback((action: () => void, actionDescription?: string) => {
+    clearStoredAuth();
+    setAuthState({ isAuthenticated: false, user: null, token: null, expiresAt: null });
+    pendingActionRef.current = action;
+    setActionDescription(actionDescription || 'perform this action');
+    setShowAuthModal(true);
+  }, []);
 
   const handleAuthSuccess = useCallback((token: string, user: ActionAuthUser, expiresAt?: string) => {
     const expiry = expiresAt || new Date(Date.now() + 15 * 60 * 1000).toISOString();
@@ -144,7 +154,9 @@ export function useActionAuth() {
     user: currentUser,
     actionToken: authState.token,
     showAuthModal,
+    actionDescription,
     requireAuth,
+    requireFreshAuth,
     handleAuthSuccess,
     handleAuthModalClose,
     getAuthHeaders,

--- a/client/src/pages/ProductionStationDashboard.tsx
+++ b/client/src/pages/ProductionStationDashboard.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
-import { Loader2, Pause, Play, SkipForward, Square, Clock, Timer, AlertCircle, Plus, Home, History, Settings, Volume2, VolumeX, Lock, Smartphone, Volume1, CalendarDays, Fingerprint } from 'lucide-react';
+import { Loader2, Pause, Play, SkipForward, Square, Timer, AlertCircle, Home, History, Settings, Volume2, VolumeX, Smartphone, Volume1, CalendarDays, Fingerprint, ScanBarcode } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { queryClient, apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
@@ -132,7 +132,7 @@ function getStatusLabel(status: string): string {
   }
 }
 
-function TimerCard({ run, onTimerEvent, toast, requireAuth, getAuthHeaders }: { run: RunWithDetails; onTimerEvent: (event: Omit<TimerEvent, 'timestamp'>) => void; toast: ReturnType<typeof useToast>['toast']; requireAuth: (action: () => void, description?: string) => void; getAuthHeaders: () => Record<string, string> }) {
+function TimerCard({ run, onTimerEvent, toast, requireFreshAuth, getAuthHeaders }: { run: RunWithDetails; onTimerEvent: (event: Omit<TimerEvent, 'timestamp'>) => void; toast: ReturnType<typeof useToast>['toast']; requireFreshAuth: (action: () => void, description?: string) => void; getAuthHeaders: () => Record<string, string> }) {
   const [elapsedTime, setElapsedTime] = useState(0);
   const [currentPauseSeconds, setCurrentPauseSeconds] = useState(0);
   const [hasTriggeredTimeout, setHasTriggeredTimeout] = useState(false);
@@ -412,7 +412,7 @@ function TimerCard({ run, onTimerEvent, toast, requireAuth, getAuthHeaders }: { 
               size="sm"
               variant="outline"
               className="flex-1 h-9 text-sm font-medium"
-              onClick={() => requireAuth(() => pauseMutation.mutate(), 'pause this timer')}
+              onClick={() => requireFreshAuth(() => pauseMutation.mutate(), 'pause this timer')}
               disabled={pauseMutation.isPending}
             >
               {pauseMutation.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Pause className="w-3.5 h-3.5 mr-1.5" />}
@@ -424,7 +424,7 @@ function TimerCard({ run, onTimerEvent, toast, requireAuth, getAuthHeaders }: { 
             <Button
               size="sm"
               className="flex-1 h-9 text-sm font-medium bg-emerald-600 hover:bg-emerald-700"
-              onClick={() => requireAuth(() => resumeMutation.mutate(), 'resume this timer')}
+              onClick={() => requireFreshAuth(() => resumeMutation.mutate(), 'resume this timer')}
               disabled={resumeMutation.isPending}
             >
               {resumeMutation.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Play className="w-3.5 h-3.5 mr-1.5" />}
@@ -436,7 +436,7 @@ function TimerCard({ run, onTimerEvent, toast, requireAuth, getAuthHeaders }: { 
             <Button
               size="sm"
               className="flex-1 h-9 text-sm font-medium bg-sky-600 hover:bg-sky-700"
-              onClick={() => requireAuth(() => advanceMutation.mutate(), 'advance to next step')}
+              onClick={() => requireFreshAuth(() => advanceMutation.mutate(), 'advance to next step')}
               disabled={advanceMutation.isPending}
             >
               {advanceMutation.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <SkipForward className="w-3.5 h-3.5 mr-1.5" />}
@@ -448,7 +448,7 @@ function TimerCard({ run, onTimerEvent, toast, requireAuth, getAuthHeaders }: { 
             size="sm"
             variant="outline"
             className="h-9 px-3 text-rose-600 border-rose-200 hover:bg-rose-50 hover:text-rose-700"
-            onClick={() => requireAuth(() => stopMutation.mutate(), 'stop this timer')}
+            onClick={() => requireFreshAuth(() => stopMutation.mutate(), 'stop this timer')}
             disabled={stopMutation.isPending}
           >
             {stopMutation.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Square className="w-3.5 h-3.5" />}
@@ -490,10 +490,10 @@ export default function ProductionStationDashboard() {
   const { toast } = useToast();
   
   const {
-    isAuthenticated,
-    user: authUser,
     showAuthModal,
+    actionDescription,
     requireAuth,
+    requireFreshAuth,
     handleAuthSuccess,
     handleAuthModalClose,
     getAuthHeaders,
@@ -635,8 +635,8 @@ export default function ProductionStationDashboard() {
               className="hidden md:inline-flex h-9 bg-emerald-600 hover:bg-emerald-700"
               onClick={() => setStartModalOpen(true)}
             >
-              <Plus className="w-4 h-4 mr-1.5" />
-              Start Timer
+              <ScanBarcode className="w-4 h-4 mr-1.5" />
+              Scan Traveler
             </Button>
             <div className="relative">
               <Button
@@ -751,7 +751,35 @@ export default function ProductionStationDashboard() {
           open={startModalOpen}
           onOpenChange={setStartModalOpen}
           enableTravelerScan
+          requireAuth={requireAuth}
+          getAuthHeaders={getAuthHeaders}
         />
+
+        <section className="mb-6 rounded-lg border border-emerald-200 bg-white p-4 shadow-sm dark:border-emerald-900 dark:bg-slate-900 md:p-5">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-center gap-4">
+              <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+                <ScanBarcode className="h-8 w-8" />
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+                  Scan Traveler to Start Timer
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  After the traveler scan, enter mandrel #, oven, and side.
+                </p>
+              </div>
+            </div>
+            <Button
+              size="lg"
+              className="h-14 w-full bg-emerald-600 text-base font-semibold hover:bg-emerald-700 md:w-auto md:px-8"
+              onClick={() => setStartModalOpen(true)}
+            >
+              <ScanBarcode className="mr-2 h-5 w-5" />
+              Scan Traveler
+            </Button>
+          </div>
+        </section>
 
         {detailedRuns.length === 0 ? (
           <Card className="border-dashed border-2 bg-white dark:bg-slate-900">
@@ -768,7 +796,7 @@ export default function ProductionStationDashboard() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
             {detailedRuns.map((run) => (
-              <TimerCard key={run.id} run={run} onTimerEvent={handleTimerEvent} toast={toast} requireAuth={requireAuth} getAuthHeaders={getAuthHeaders} />
+              <TimerCard key={run.id} run={run} onTimerEvent={handleTimerEvent} toast={toast} requireFreshAuth={requireFreshAuth} getAuthHeaders={getAuthHeaders} />
             ))}
           </div>
         )}
@@ -780,8 +808,8 @@ export default function ProductionStationDashboard() {
           className="w-full h-14 text-base font-semibold bg-emerald-600 hover:bg-emerald-700 shadow-lg rounded-xl"
           onClick={() => setStartModalOpen(true)}
         >
-          <Plus className="w-5 h-5 mr-2" />
-          Start Timer
+          <ScanBarcode className="w-5 h-5 mr-2" />
+          Scan Traveler
         </Button>
       </div>
       
@@ -789,7 +817,7 @@ export default function ProductionStationDashboard() {
         isOpen={showAuthModal}
         onClose={handleAuthModalClose}
         onSuccess={handleAuthSuccess}
-        actionDescription="control timers on the production floor"
+        actionDescription={actionDescription}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Make the timer station start action a prominent "Scan Traveler" workflow on the station screen.
- Keep the start modal focused on traveler scan plus mandrel #, oven #, and side L/R while preserving current traveler lookup/defaulting.
- Require a fresh badge prompt for timer progress actions so pause/resume/next/stop timestamps are tied to the operator taking the action.

## Validation
- `git diff --check`
- Full TypeScript validation was not run locally because this environment does not have `npm` on PATH or local `node_modules` installed.