### PR TITLE
[codex] Fix timer action after badge auth

### DIFF
--- a/client/src/hooks/useActionAuth.ts
+++ b/client/src/hooks/useActionAuth.ts
@@ -60,6 +60,7 @@ export function useActionAuth() {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [actionDescription, setActionDescription] = useState('perform this action');
   const pendingActionRef = useRef<(() => void) | null>(null);
+  const authSuccessCloseRef = useRef(false);
 
   const { data: sessionUser } = useQuery<ActionAuthUser | null>({
     queryKey: ['/api/auth/session'],
@@ -123,16 +124,22 @@ export function useActionAuth() {
   const handleAuthSuccess = useCallback((token: string, user: ActionAuthUser, expiresAt?: string) => {
     const expiry = expiresAt || new Date(Date.now() + 15 * 60 * 1000).toISOString();
     storeAuth(token, expiry, user);
+    authSuccessCloseRef.current = true;
     setAuthState({
       isAuthenticated: true,
       user,
       token,
       expiresAt: new Date(expiry),
     });
+    setShowAuthModal(false);
   }, []);
 
   const handleAuthModalClose = useCallback(() => {
     setShowAuthModal(false);
+    if (authSuccessCloseRef.current) {
+      authSuccessCloseRef.current = false;
+      return;
+    }
     pendingActionRef.current = null;
   }, []);
 


### PR DESCRIPTION
## Summary
- Preserve the queued timer action when the badge authentication modal closes after a successful scan.
- Keep cancel/normal close behavior clearing pending actions, so abandoned auth prompts still do not run anything.

## Root Cause
The inline credential modal calls `onSuccess()` and then `onClose()`. The timer-station hook treated every close as a cancellation and cleared `pendingActionRef`, so the authenticated pause/resume/next/stop action was dropped before it could run.

## Validation
- `git diff --check`
- Verified the PR branch contains the success-close guard in `client/src/hooks/useActionAuth.ts`.
- Full TypeScript validation was not run locally because this environment does not have `npm` on PATH or local `node_modules` installed.