### PR TITLE
[codex] Fix packing slip PO display for existing slips

### DIFF
--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -1804,7 +1804,18 @@ router.get('/packing-slips/:id', async (req: Request, res: Response) => {
       lineItems = Array.isArray(slip.lineItems) ? slip.lineItems : [];
     }
 
-    return res.json({ ...slip, lineItems, originalPackingSlip, replacementSlips });
+    return res.json({
+      ...slip,
+      poNumber: formatP2DocumentPoNumber(slip.poNumber),
+      lineItems,
+      originalPackingSlip: originalPackingSlip
+        ? { ...originalPackingSlip, poNumber: formatP2DocumentPoNumber(originalPackingSlip.poNumber) }
+        : null,
+      replacementSlips: replacementSlips.map((replacement) => ({
+        ...replacement,
+        poNumber: formatP2DocumentPoNumber(replacement.poNumber),
+      })),
+    });
   } catch (err: any) {
     console.error('Get packing slip error:', err);
     return res.status(500).json({ error: 'Failed to fetch packing slip' });


### PR DESCRIPTION
## Summary
- Normalize the PO number returned by `GET /api/p2/packing-slips/:id` so existing packing slips display the base customer PO number.
- Apply the same display cleanup to original/replacement packing slip links returned with the packing slip payload.

## Root Cause
PR #1251 normalized newly-created packing slip records and PDF/CoC/invoice paths, but the browser packing slip page renders the JSON response for existing slips. That response still returned stored revision PO numbers like `PO014332-RA`.

## Validation
- `git diff --check`

Full TypeScript validation was not available in this shell because `npm` is not on PATH and the local PowerShell host is currently resource-constrained.