### PR TITLE
[codex] Add P2 project BOM routing revision flow

### DIFF
--- a/client/src/components/p2/P2ChangesTab.tsx
+++ b/client/src/components/p2/P2ChangesTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -22,12 +22,14 @@ import { useToast } from '@/hooks/use-toast';
 const productionChangeSchema = z.object({
   changeType: z.string().min(1, 'Change type is required'),
   scope: z.string().default('PO'),
+  poId: z.number().optional().nullable(),
   partNumber: z.string().optional(),
   currentRevision: z.string().optional(),
   proposedRevision: z.string().optional(),
   proposedChange: z.string().min(1, 'Proposed change description is required'),
   reason: z.string().min(1, 'Reason is required'),
   riskAssessment: z.string().optional(),
+  notes: z.string().optional(),
   affectedDocuments: z.array(z.string()).default([]),
   requiredActions: z.array(z.string()).default([]),
   approvalAssignments: z.array(z.object({
@@ -118,6 +120,7 @@ export default function P2ChangesTab() {
   const [showAuthorizeDeviationDialog, setShowAuthorizeDeviationDialog] = useState<any | null>(null);
   const [selectedApprover, setSelectedApprover] = useState('');
   const [rejectionReason, setRejectionReason] = useState('');
+  const didPrefillPcfFromUrl = useRef(false);
   const { toast } = useToast();
 
   const { data: productionChanges = [], isLoading: loadingPCFs } = useQuery<any[]>({
@@ -141,12 +144,14 @@ export default function P2ChangesTab() {
     defaultValues: {
       changeType: '',
       scope: 'PO',
+      poId: null,
       partNumber: '',
       currentRevision: '',
       proposedRevision: '',
       proposedChange: '',
       reason: '',
       riskAssessment: '',
+      notes: '',
       affectedDocuments: [],
       requiredActions: [],
       approvalAssignments: PCF_APPROVAL_ROLES.map((role) => ({
@@ -162,6 +167,47 @@ export default function P2ChangesTab() {
   const affectedDocuments = pcfForm.watch('affectedDocuments') || [];
   const requiredActions = pcfForm.watch('requiredActions') || [];
   const approvalAssignments = pcfForm.watch('approvalAssignments') || [];
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (didPrefillPcfFromUrl.current || params.get('newPCF') !== '1') return;
+    didPrefillPcfFromUrl.current = true;
+
+    const documents = (params.get('documents') || '')
+      .split(',')
+      .map((value) => value.trim().toUpperCase())
+      .filter((value) => AFFECTED_DOCUMENT_OPTIONS.some((option) => option.value === value));
+    const actions = (params.get('actions') || '')
+      .split(',')
+      .map((value) => value.trim().toUpperCase())
+      .filter((value) => REQUIRED_ACTION_OPTIONS.some((option) => option.value === value));
+    const projectLabel = params.get('projectLabel') || params.get('projectId') || 'project';
+    const poId = Number(params.get('poId'));
+
+    pcfForm.reset({
+      changeType: params.get('changeType') || 'BOM',
+      scope: params.get('scope') || (Number.isFinite(poId) && poId > 0 ? 'PO' : 'PART'),
+      partNumber: params.get('partNumber') || '',
+      currentRevision: params.get('currentRevision') || '',
+      proposedRevision: params.get('proposedRevision') || '',
+      proposedChange: params.get('proposedChange') || `Revise BOM/routing package for ${projectLabel}.`,
+      reason: params.get('reason') || 'Project BOM/routing revision requires controlled production change review.',
+      riskAssessment: params.get('riskAssessment') || '',
+      notes: params.get('notes') || '',
+      affectedDocuments: documents.length > 0 ? documents : ['BOM', 'ROUTING'],
+      requiredActions: actions.length > 0 ? actions : ['UPDATE_BOM', 'UPDATE_ROUTING'],
+      approvalAssignments: PCF_APPROVAL_ROLES.map((role) => ({
+        ...role,
+        required: role.roleKey === 'PURCHASING_QUALITY_MANAGER' || role.roleKey === 'PRODUCTION_MANAGER',
+        employeeId: '',
+      })),
+      implementationRequired: true,
+      requiresCustomerApproval: params.get('requiresCustomerApproval') === '1',
+      ...(Number.isFinite(poId) && poId > 0 ? { poId } : {}),
+    } as any);
+    setActiveSection('production');
+    setShowNewPCFDialog(true);
+  }, [pcfForm]);
 
   const deviationForm = useForm({
     resolver: zodResolver(travelerChangeSchema),

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -688,6 +688,11 @@ export default function ProjectDetailPage() {
         revisedLineItems: [],
       });
       toast({ title: 'Revision created', description: 'Project revision history was updated.' });
+      const revisionMetadata = (createdRevision as any)?.metadata;
+      if (revisionMetadata?.source === 'project-bom-routing' && revisionMetadata?.pcfRecommended) {
+        setLocation(buildBomRoutingPcfUrl(createdRevision));
+        return;
+      }
       if (createdRevision?.has_po_change && createdRevision.new_po_id) {
         setLocation(`/p2-control-center?tab=setup&projectId=${encodeURIComponent(id || '')}&editPoId=${encodeURIComponent(String(createdRevision.new_po_id))}`);
       }
@@ -792,6 +797,56 @@ export default function ProjectDetailPage() {
         const type = String(revision.revision_type ?? revision.revisionType ?? '').toLowerCase();
         return type === 'drawing' || type === 'contract';
       });
+  const primaryBomRoutingPartNumber = bomRoutingPartNumbers[0] ?? bomRoutingRecords[0]?.parent_part_ag_number ?? bomRoutingRoutings[0]?.part_number ?? '';
+  const latestBomRevisionCode = bomRoutingRecords.find((bom: any) => bom.latest_rev_code)?.latest_rev_code;
+  const latestRoutingRevisionCode = bomRoutingRoutings.find((routing: any) => routing.routing_revision)?.routing_revision;
+  const currentBomRoutingRevision = [latestBomRevisionCode ? `BOM ${latestBomRevisionCode}` : '', latestRoutingRevisionCode ? `Routing ${latestRoutingRevisionCode}` : '']
+    .filter(Boolean)
+    .join(' / ');
+  const buildBomRoutingPcfUrl = (revision?: any) => {
+    const revisionLabel = revision?.revision_label ?? revision?.revisionLabel ?? '';
+    const revisionSummary = revision?.summary ?? '';
+    const params = new URLSearchParams({
+      tab: 'changes',
+      newPCF: '1',
+      changeType: 'BOM',
+      scope: project?.poId ? 'PO' : 'PART',
+      documents: 'BOM,ROUTING',
+      actions: 'UPDATE_BOM,UPDATE_ROUTING',
+      projectId: project?.id ?? '',
+      projectLabel: project?.projectCode || project?.projectName || project?.id || '',
+      proposedChange: revisionLabel
+        ? `${revisionLabel}: ${revisionSummary || 'Revise BOM/routing package'}`
+        : `Revise BOM/routing package for ${project?.projectCode || project?.projectName || 'this project'}.`,
+      reason: revision?.reason || 'Project BOM/routing revision requires controlled production change review.',
+      notes: [
+        project?.id ? `Project ID: ${project.id}` : '',
+        revision?.id ? `Project revision ID: ${revision.id}` : '',
+        revisionLabel ? `Project revision: ${revisionLabel}` : '',
+      ].filter(Boolean).join(' | '),
+    });
+    if (project?.poId) params.set('poId', String(project.poId));
+    if (primaryBomRoutingPartNumber) params.set('partNumber', primaryBomRoutingPartNumber);
+    if (currentBomRoutingRevision) params.set('currentRevision', currentBomRoutingRevision);
+    return `/p2-control-center?${params.toString()}`;
+  };
+  const recordBomRoutingRevision = (revisionType: 'drawing' | 'contract') => {
+    createRevisionMutation.mutate({
+      revisionType,
+      revisionDate: new Date().toISOString().split('T')[0],
+      hasPoChange: false,
+      revisedPoNumber: '',
+      revisedDueDate: '',
+      revisedLineItems: [],
+      summary: `${revisionType === 'drawing' ? 'Drawing' : 'Contract'} revision for BOM/routing`,
+      reason: `BOM/routing revision started from the P2 Project BOM/Routing summary for ${project?.projectCode || project?.projectName || 'this project'}.`,
+      metadata: {
+        source: 'project-bom-routing',
+        pcfRecommended: true,
+        currentBomRoutingRevision,
+      },
+    } as any);
+  };
   const hubPo = hubTabs.po ?? {};
   const currentProjectPo = hubPo.currentPo ?? linkedProjectPO ?? projectP2POs[0] ?? null;
   const currentPoLineItems = Array.isArray(hubPo.lineItems) ? hubPo.lineItems : [];
@@ -2696,7 +2751,70 @@ export default function ProjectDetailPage() {
               <ListChecks className="h-4 w-4 mr-2" />
               Routing
             </Button>
+            <Button
+              variant="outline"
+              onClick={() => setLocation(buildBomRoutingPcfUrl())}
+              data-testid="button-start-project-bom-routing-pcf"
+            >
+              <FileText className="h-4 w-4 mr-2" />
+              Start PCF
+            </Button>
           </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <ClipboardList className="h-4 w-4" />
+                Controlled BOM/Routing Revision
+              </CardTitle>
+              <CardDescription>
+                Record the drawing or contract revision that drives the BOM/routing update, then start the linked production change form.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="rounded-md border bg-muted/30 p-3">
+                  <p className="text-xs text-muted-foreground">Current Package</p>
+                  <p className="font-medium">{currentBomRoutingRevision || 'No revision recorded'}</p>
+                </div>
+                <div className="rounded-md border bg-muted/30 p-3">
+                  <p className="text-xs text-muted-foreground">Primary Part</p>
+                  <p className="font-mono font-medium">{primaryBomRoutingPartNumber || 'Not found'}</p>
+                </div>
+                <div className="rounded-md border bg-muted/30 p-3">
+                  <p className="text-xs text-muted-foreground">Revision Links</p>
+                  <p className="font-medium">{bomRoutingChangeLinks.length}</p>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2 lg:justify-end">
+                <Button
+                  variant="outline"
+                  onClick={() => recordBomRoutingRevision('drawing')}
+                  disabled={createRevisionMutation.isPending}
+                  data-testid="button-record-project-bom-drawing-revision"
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Drawing Revision
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => recordBomRoutingRevision('contract')}
+                  disabled={createRevisionMutation.isPending}
+                  data-testid="button-record-project-bom-contract-revision"
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Contract Revision
+                </Button>
+                <Button
+                  onClick={() => setLocation(buildBomRoutingPcfUrl())}
+                  data-testid="button-start-project-bom-routing-linked-pcf"
+                >
+                  <FileText className="h-4 w-4 mr-2" />
+                  Start Production Change Form
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
 
           {bomRoutingPartNumbers.length > 0 && (
             <Card>
@@ -2830,6 +2948,15 @@ export default function ProjectDetailPage() {
                       </div>
                       <p className="text-sm font-medium">{revision.summary || 'Project change recorded'}</p>
                       {revision.reason && <p className="text-sm text-muted-foreground">{revision.reason}</p>}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setLocation(buildBomRoutingPcfUrl(revision))}
+                        data-testid={`button-start-pcf-for-bom-routing-revision-${revision.id}`}
+                      >
+                        <FileText className="h-4 w-4 mr-1.5" />
+                        Start linked PCF
+                      </Button>
                     </div>
                   );
                 })


### PR DESCRIPTION
## Summary
- Adds a controlled BOM/Routing revision card to the P2 Project BOM/Routing tab.
- Lets users record drawing or contract revision events from the summary view and immediately start a linked Production Change Form.
- Adds PCF deep-link prefill support so project, PO, part, current revision, affected documents, required actions, and revision notes carry into the P2 Changes tab.

## Validation
- `git diff --check`
- `git diff --cached --check`

Note: `npm run check` could not be run because `npm` is not installed/on PATH in this desktop environment and the clean worktree has no `node_modules`.