### PR TITLE
[codex] Add WAD revision and ROM draft workflows

### DIFF
--- a/client/src/components/wad/WADWizard.tsx
+++ b/client/src/components/wad/WADWizard.tsx
@@ -903,7 +903,7 @@ export default function WADWizard({ wadId, onClose, initialStep = null }: WADWiz
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
-          <h1 className="text-xl font-bold">WAD Wizard — {wad?.workOrderNumber}</h1>
+          <h1 className="text-xl font-bold">WAD (Working Authorization Document) — {wad?.workOrderNumber}</h1>
           <p className="text-sm text-muted-foreground">
             {project?.projectName ?? ''}
             {project?.projectCode && <span className="ml-1">· {project.projectCode}</span>}

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -1863,7 +1863,7 @@ export default function ProjectDetailPage() {
                 ))
               ) : (
                 <div className="space-y-2">
-                  {['PO Review', 'WAD (Work Authorization Document)', 'Preproduction'].map(label => (
+                  {['PO Review', 'WAD (Working Authorization Document)', 'Preproduction'].map(label => (
                     <div key={label} className="flex items-center gap-3 py-1">
                       <Clock className="h-5 w-5 text-gray-400 flex-shrink-0" />
                       <span className="text-sm text-muted-foreground">{label}</span>
@@ -3008,7 +3008,9 @@ export default function ProjectDetailPage() {
                 </div>
               </div>
               <div className="flex flex-wrap gap-2">
-                <Button onClick={() => setLocation(`/wad-wizard?search=${encodeURIComponent(project.projectCode || project.projectName || project.id)}`)}>
+                <Button
+                  onClick={() => setLocation(latestWad?.id ? `/work-orders/${latestWad.id}/wad-summary` : `/wad-wizard?search=${encodeURIComponent(project.projectCode || project.projectName || project.id)}`)}
+                >
                   <ExternalLink className="h-4 w-4 mr-2" />
                   Open WAD
                 </Button>
@@ -3018,7 +3020,8 @@ export default function ProjectDetailPage() {
                 </Button>
                 <Button
                   variant="outline"
-                  onClick={() => setLocation(`/wad-wizard?search=${encodeURIComponent(project.projectCode || project.projectName || project.id)}&revision=1`)}
+                  onClick={() => setLocation(latestWad?.id ? `/work-orders/${latestWad.id}/wad-summary?tab=revisions&createRevision=1` : `/wad-wizard?search=${encodeURIComponent(project.projectCode || project.projectName || project.id)}`)}
+                  disabled={!latestWad?.id}
                   data-testid="button-add-project-wad-revision"
                 >
                   <History className="h-4 w-4 mr-2" />

--- a/client/src/pages/TravelerExecution.tsx
+++ b/client/src/pages/TravelerExecution.tsx
@@ -183,6 +183,7 @@ interface Traveler {
   quantity: number;
   status: string;
   partRoutingId: string | null;
+  wadRevisionId: string | null;
   createdBy: string;
   createdAt: string;
 }
@@ -191,6 +192,12 @@ interface TravelerWithDetails {
   traveler: Traveler;
   steps: TravelerStep[];
   events: TravelerEvent[];
+}
+
+interface WadRevisionBanner {
+  id: string;
+  revisionCode: string;
+  status: string;
 }
 
 const firstTraceValue = (...values: Array<string | undefined | null>) =>
@@ -517,6 +524,15 @@ export default function TravelerExecution() {
   });
 
   const { traveler, steps = [], events = [] } = travelerData || {};
+  const { data: wadRevisionBanner } = useQuery<WadRevisionBanner | null>({
+    queryKey: ['/api/wad-revisions', traveler?.wadRevisionId],
+    queryFn: async () => {
+      if (!traveler?.wadRevisionId) return null;
+      return apiRequest(`/api/wad-revisions/${traveler.wadRevisionId}`);
+    },
+    enabled: !!traveler?.wadRevisionId,
+  });
+
   const legacyRocBackfillEditScope = useMemo(() => {
     const stepIds = new Set<string>();
     const taskIds = new Set<string>();
@@ -1503,6 +1519,15 @@ export default function TravelerExecution() {
           )}
         </div>
       </div>
+
+      {traveler.wadRevisionId && (
+        <div className="flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+          <ShieldCheck className="h-4 w-4 shrink-0" />
+          <span>
+            This traveler was created under WAD {wadRevisionBanner?.revisionCode ?? 'revision on record'}.
+          </span>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
         <div className="lg:col-span-1 space-y-4">

--- a/client/src/pages/WADSummaryPage.tsx
+++ b/client/src/pages/WADSummaryPage.tsx
@@ -24,10 +24,13 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Textarea } from '@/components/ui/textarea';
 import { apiRequest, queryClient } from '@/lib/queryClient';
@@ -41,7 +44,81 @@ const REQUIRED_APPROVAL_ROLES = [
   { key: 'executive', label: 'Executive' },
 ];
 
+const WAD_REVISION_REASONS = [
+  'PO quantity change',
+  'Delivery date change',
+  'Drawing revision change',
+  'Routing change',
+  'Traveler change',
+  'Work instruction change',
+  'BOM/material change',
+  'Quality requirement change',
+  'Budget/labor change',
+  'Customer requirement change',
+  'NCR/CAR related change',
+  'Schedule/priority change',
+  'Other',
+] as const;
+
+const REVISION_APPROVAL_ROLES = [
+  { key: 'project_manager', label: 'Project Manager' },
+  { key: 'production_manager', label: 'Production Manager' },
+  { key: 'quality', label: 'Quality' },
+  { key: 'engineering', label: 'Engineering' },
+  { key: 'finance_admin', label: 'Finance/Admin' },
+];
+
+const IMPACT_FIELDS = [
+  { key: 'impactReleasedTravelers', label: 'Affects released travelers?' },
+  { key: 'impactCompletedWork', label: 'Affects work already completed?' },
+  { key: 'impactMaterialIssued', label: 'Affects material issued?' },
+  { key: 'impactInspection', label: 'Affects inspection requirements?' },
+  { key: 'impactLaborBudget', label: 'Affects labor budget?' },
+  { key: 'impactDeliveryDate', label: 'Affects delivery date?' },
+  { key: 'impactCustomerApproval', label: 'Affects customer approval?' },
+  { key: 'requiresProductionHold', label: 'Requires production hold?' },
+] as const;
+
+type ImpactFieldKey = typeof IMPACT_FIELDS[number]['key'];
+
 type Decision = 'APPROVED' | 'REJECTED';
+
+type WadRevisionStatus = 'draft' | 'pending_approval' | 'approved' | 'superseded' | 'rejected';
+
+type WadRevisionApproval = {
+  id: string;
+  approverRole: string;
+  approverUserId: number | null;
+  status: 'pending' | 'approved' | 'rejected';
+  comments: string | null;
+  signedAt: string | null;
+};
+
+type WadRevision = Record<ImpactFieldKey, boolean> & {
+  id: string;
+  wadId: string;
+  revisionCode: string;
+  status: WadRevisionStatus;
+  revisionReason: string;
+  reasonNotes: string | null;
+  impactProduction: boolean;
+  effectiveDate: string | null;
+  createdBy: number | null;
+  createdByDisplayName: string | null;
+  approvedBy: number | null;
+  approvedByDisplayName: string | null;
+  approvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  approvals?: WadRevisionApproval[];
+};
+
+type TravelerSummary = {
+  id: string;
+  travelerNumber?: string | null;
+  status?: string | null;
+  wadRevisionId?: string | null;
+};
 
 type ApprovalRecord = {
   role: string;
@@ -110,6 +187,10 @@ function roleLabel(role: string): string {
   return REQUIRED_APPROVAL_ROLES.find((r) => r.key === role)?.label ?? role.replace(/_/g, ' ');
 }
 
+function statusText(status: string): string {
+  return status.replace(/_/g, ' ').replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
 function FieldGrid({ rows }: { rows: Array<[string, unknown]> }) {
   return (
     <div className="grid grid-cols-1 gap-2 text-sm sm:grid-cols-2 lg:grid-cols-3">
@@ -153,10 +234,37 @@ export default function WADSummaryPage({ params }: WADSummaryPageProps) {
   const [decision, setDecision] = useState<Decision>('APPROVED');
   const [comments, setComments] = useState('');
   const [signature, setSignature] = useState('');
+  const [activeTab, setActiveTab] = useState(query.get('tab') === 'revisions' ? 'revisions' : 'summary');
+  const [revisionDialogOpen, setRevisionDialogOpen] = useState(query.get('createRevision') === '1');
+  const [revisionReason, setRevisionReason] = useState<(typeof WAD_REVISION_REASONS)[number]>('PO quantity change');
+  const [revisionNotes, setRevisionNotes] = useState('');
+  const [revisionEffectiveDate, setRevisionEffectiveDate] = useState('');
+  const [revisionImpacts, setRevisionImpacts] = useState<Record<ImpactFieldKey, boolean>>({
+    impactReleasedTravelers: false,
+    impactCompletedWork: false,
+    impactMaterialIssued: false,
+    impactInspection: false,
+    impactLaborBudget: false,
+    impactDeliveryDate: false,
+    impactCustomerApproval: false,
+    requiresProductionHold: false,
+  });
+  const [revisionApprovalRole, setRevisionApprovalRole] = useState(REVISION_APPROVAL_ROLES[0].key);
+  const [revisionApprovalComments, setRevisionApprovalComments] = useState('');
 
   const { data, isLoading, isError, error } = useQuery<WizardContext>({
     queryKey: ['/api/work-orders/production', wadId, 'wizard'],
     queryFn: () => apiRequest(`/api/work-orders/production/${wadId}/wizard`),
+  });
+
+  const { data: revisions = [] } = useQuery<WadRevision[]>({
+    queryKey: ['/api/wads', wadId, 'revisions'],
+    queryFn: () => apiRequest(`/api/wads/${wadId}/revisions`),
+  });
+
+  const { data: travelers = [] } = useQuery<TravelerSummary[]>({
+    queryKey: ['/api/work-orders', wadId, 'travelers'],
+    queryFn: () => apiRequest(`/api/work-orders/${wadId}/travelers`),
   });
 
   const wizardData = (data?.wad?.wizardData ?? {}) as WizardData;
@@ -201,6 +309,88 @@ export default function WADSummaryPage({ params }: WADSummaryPageProps) {
     },
     onError: (err: Error) => {
       toast({ title: 'Could not record decision', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const latestRevision = revisions[0];
+  const currentApprovedRevision = revisions.find((revision) => revision.status === 'approved');
+  const openRevision = revisions.find((revision) => revision.status === 'draft' || revision.status === 'pending_approval');
+  const blockingRevision = revisions.find((revision) =>
+    (revision.status === 'draft' || revision.status === 'pending_approval') &&
+    (revision.impactProduction || revision.impactReleasedTravelers || revision.impactInspection || revision.impactMaterialIssued || revision.requiresProductionHold)
+  );
+  const firstTraveler = travelers[0];
+  const anyImpactSelected = Object.values(revisionImpacts).some(Boolean);
+  const revisionNotesRequired = revisionReason === 'Other' || anyImpactSelected;
+  const canCreateRevision = revisionReason && (!revisionNotesRequired || revisionNotes.trim().length > 0);
+
+  const resetRevisionForm = () => {
+    setRevisionReason('PO quantity change');
+    setRevisionNotes('');
+    setRevisionEffectiveDate('');
+    setRevisionImpacts({
+      impactReleasedTravelers: false,
+      impactCompletedWork: false,
+      impactMaterialIssued: false,
+      impactInspection: false,
+      impactLaborBudget: false,
+      impactDeliveryDate: false,
+      impactCustomerApproval: false,
+      requiresProductionHold: false,
+    });
+  };
+
+  const createRevisionMutation = useMutation({
+    mutationFn: () =>
+      apiRequest(`/api/wads/${wadId}/revisions`, {
+        method: 'POST',
+        body: JSON.stringify({
+          revisionReason,
+          reasonNotes: revisionNotes.trim() || null,
+          effectiveDate: revisionEffectiveDate || null,
+          ...revisionImpacts,
+        }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/wads', wadId, 'revisions'] });
+      setRevisionDialogOpen(false);
+      setActiveTab('revisions');
+      resetRevisionForm();
+      toast({ title: 'WAD revision created', description: 'Draft revision is ready for review.' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Could not create WAD revision', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const submitRevisionMutation = useMutation({
+    mutationFn: (revisionId: string) =>
+      apiRequest(`/api/wad-revisions/${revisionId}/submit`, { method: 'POST' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/wads', wadId, 'revisions'] });
+      toast({ title: 'WAD revision submitted', description: 'Approval routing has been started.' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Could not submit WAD revision', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const approveRevisionMutation = useMutation({
+    mutationFn: ({ revisionId, action }: { revisionId: string; action: 'approve' | 'reject' }) =>
+      apiRequest(`/api/wad-revisions/${revisionId}/${action}`, {
+        method: 'POST',
+        body: JSON.stringify({
+          approverRole: revisionApprovalRole,
+          comments: revisionApprovalComments.trim() || null,
+        }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/wads', wadId, 'revisions'] });
+      setRevisionApprovalComments('');
+      toast({ title: 'WAD revision updated', description: 'Revision approval history was recorded.' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Could not update WAD revision', description: err.message, variant: 'destructive' });
     },
   });
 
@@ -272,7 +462,7 @@ export default function WADSummaryPage({ params }: WADSummaryPageProps) {
           <CardHeader className="border-b">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <CardTitle className="text-2xl">Work Authorization Document Summary</CardTitle>
+                <CardTitle className="text-2xl">WAD (Working Authorization Document)</CardTitle>
                 <CardDescription className="mt-1">
                   {data.wad.workOrderNumber} - {data.project?.projectName ?? data.project?.projectCode ?? 'Project not linked'}
                 </CardDescription>
@@ -286,7 +476,24 @@ export default function WADSummaryPage({ params }: WADSummaryPageProps) {
               </div>
             </div>
           </CardHeader>
-          <CardContent className="space-y-8 p-6">
+          <CardContent className="p-6">
+            <div className="space-y-4">
+              {blockingRevision && (
+                <Alert variant={blockingRevision.requiresProductionHold ? 'destructive' : 'default'} className="no-print">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertDescription>
+                    {blockingRevision.requiresProductionHold
+                      ? 'Production Hold Required — Revision approval required before continuing.'
+                      : 'Pending WAD Revision — Production changes cannot be released until approved.'}
+                  </AlertDescription>
+                </Alert>
+              )}
+              <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+                <TabsList className="no-print">
+                  <TabsTrigger value="summary">WAD Summary</TabsTrigger>
+                  <TabsTrigger value="revisions">WAD Revisions</TabsTrigger>
+                </TabsList>
+                <TabsContent value="summary" className="space-y-8">
             <Section title="Contract Context" icon={<FileText className="h-4 w-4 text-blue-600" />}>
               <FieldGrid
                 rows={[
@@ -543,9 +750,229 @@ export default function WADSummaryPage({ params }: WADSummaryPageProps) {
                 </div>
               </div>
             </section>
+                </TabsContent>
+
+                <TabsContent value="revisions" className="space-y-6">
+                  <Section title="Current WAD Revision Summary" icon={<ShieldCheck className="h-4 w-4 text-blue-600" />}>
+                    <FieldGrid
+                      rows={[
+                        ['WAD Number', data.wad.workOrderNumber],
+                        ['Current Revision', currentApprovedRevision?.revisionCode ?? `Rev ${wizardData.currentRevision ?? '-'}`],
+                        ['Status', currentApprovedRevision ? statusText(currentApprovedRevision.status) : data.wad.wadStatus],
+                        ['Linked PO', step1.poNumber ?? data.po?.poNumber],
+                        ['Linked routing', step6.routingRequired ? step6.routingDescription ?? data.wad.partNumber : 'No routing linked'],
+                        ['Linked traveler', firstTraveler?.travelerNumber ?? '-'],
+                        ['Effective date', currentApprovedRevision?.effectiveDate ?? data.wad.updatedAt],
+                      ]}
+                    />
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        onClick={() => setRevisionDialogOpen(true)}
+                        disabled={!isApproved || Boolean(openRevision)}
+                        data-testid="button-create-wad-revision"
+                      >
+                        <PenLine className="mr-2 h-4 w-4" />
+                        Create WAD Revision
+                      </Button>
+                      {openRevision && (
+                        <Badge variant="outline">
+                          {openRevision.revisionCode} {statusText(openRevision.status)}
+                        </Badge>
+                      )}
+                    </div>
+                    {!isApproved && (
+                      <Alert>
+                        <AlertTriangle className="h-4 w-4" />
+                        <AlertDescription>Only approved WADs can start a new revision.</AlertDescription>
+                      </Alert>
+                    )}
+                  </Section>
+
+                  <Section title="Approval Panel" icon={<Users className="h-4 w-4 text-blue-600" />}>
+                    {latestRevision ? (
+                      <div className="space-y-4">
+                        <div className="grid gap-3 md:grid-cols-5">
+                          {REVISION_APPROVAL_ROLES.map((approvalRole) => {
+                            const approval = latestRevision.approvals?.find((item) => item.approverRole === approvalRole.key);
+                            return (
+                              <div key={approvalRole.key} className="rounded border bg-white p-3 text-sm">
+                                <div className="font-medium">{approvalRole.label}</div>
+                                <div className="mt-2 text-xs text-muted-foreground">
+                                  {approval ? (
+                                    <>
+                                      <div className={approval.status === 'approved' ? 'font-semibold text-green-700' : approval.status === 'rejected' ? 'font-semibold text-red-700' : 'font-semibold text-yellow-700'}>
+                                        {statusText(approval.status)}
+                                      </div>
+                                      <div>{dateText(approval.signedAt)}</div>
+                                      {approval.comments && <div className="mt-1 italic">"{approval.comments}"</div>}
+                                    </>
+                                  ) : (
+                                    latestRevision.status === 'draft' ? 'Added on submit' : 'Not required'
+                                  )}
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                        {latestRevision.status === 'draft' && (
+                          <Button
+                            onClick={() => submitRevisionMutation.mutate(latestRevision.id)}
+                            disabled={submitRevisionMutation.isPending}
+                          >
+                            {submitRevisionMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            Submit Revision For Approval
+                          </Button>
+                        )}
+                        {latestRevision.status === 'pending_approval' && (
+                          <div className="grid gap-3 rounded-md border bg-white p-4 md:grid-cols-2">
+                            <div className="space-y-2">
+                              <Label>Approval role</Label>
+                              <Select value={revisionApprovalRole} onValueChange={setRevisionApprovalRole}>
+                                <SelectTrigger>
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {REVISION_APPROVAL_ROLES.map((approvalRole) => (
+                                    <SelectItem key={approvalRole.key} value={approvalRole.key}>
+                                      {approvalRole.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                            <div className="space-y-2 md:col-span-2">
+                              <Label>Comments</Label>
+                              <Textarea
+                                value={revisionApprovalComments}
+                                onChange={(event) => setRevisionApprovalComments(event.target.value)}
+                                placeholder="Required when rejecting"
+                              />
+                            </div>
+                            <div className="flex justify-end gap-2 md:col-span-2">
+                              <Button
+                                variant="outline"
+                                onClick={() => approveRevisionMutation.mutate({ revisionId: latestRevision.id, action: 'reject' })}
+                                disabled={approveRevisionMutation.isPending}
+                              >
+                                Reject
+                              </Button>
+                              <Button
+                                onClick={() => approveRevisionMutation.mutate({ revisionId: latestRevision.id, action: 'approve' })}
+                                disabled={approveRevisionMutation.isPending}
+                              >
+                                Approve
+                              </Button>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="rounded border border-dashed bg-white p-4 text-sm text-muted-foreground">
+                        No WAD revisions have been created.
+                      </div>
+                    )}
+                  </Section>
+
+                  <Section title="Revision History" icon={<ClipboardList className="h-4 w-4 text-blue-600" />}>
+                    <DataTable
+                      emptyText="No WAD revisions created."
+                      headers={['Revision', 'Status', 'Reason', 'Created By', 'Created Date', 'Approved By', 'Approved Date', 'Effective Date', 'Actions']}
+                      rows={revisions.map((revision) => [
+                        revision.revisionCode,
+                        statusText(revision.status),
+                        revision.revisionReason,
+                        revision.createdByDisplayName ?? revision.createdBy,
+                        dateText(revision.createdAt),
+                        revision.approvedByDisplayName ?? revision.approvedBy,
+                        dateText(revision.approvedAt),
+                        dateText(revision.effectiveDate),
+                        revision.status === 'draft' ? 'Submit available' : revision.status === 'pending_approval' ? 'Approval pending' : '-',
+                      ])}
+                    />
+                  </Section>
+                </TabsContent>
+              </Tabs>
+            </div>
           </CardContent>
         </Card>
       </main>
+
+      <Dialog open={revisionDialogOpen} onOpenChange={setRevisionDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Create WAD Revision</DialogTitle>
+            <DialogDescription>
+              Start a draft revision from the currently approved WAD authorization.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-5">
+            <div className="space-y-2">
+              <Label>Revision reason</Label>
+              <Select value={revisionReason} onValueChange={(value) => setRevisionReason(value as (typeof WAD_REVISION_REASONS)[number])}>
+                <SelectTrigger data-testid="select-wad-revision-reason">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {WAD_REVISION_REASONS.map((reason) => (
+                    <SelectItem key={reason} value={reason}>
+                      {reason}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Impact Review</Label>
+              <div className="grid gap-2 rounded-md border bg-white p-3 sm:grid-cols-2">
+                {IMPACT_FIELDS.map((field) => (
+                  <label key={field.key} className="flex items-center gap-2 rounded border px-3 py-2 text-sm">
+                    <Checkbox
+                      checked={revisionImpacts[field.key]}
+                      onCheckedChange={(checked) =>
+                        setRevisionImpacts((current) => ({ ...current, [field.key]: checked === true }))
+                      }
+                    />
+                    <span>{field.label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Effective date</Label>
+              <Input
+                type="date"
+                value={revisionEffectiveDate}
+                onChange={(event) => setRevisionEffectiveDate(event.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>{revisionNotesRequired ? 'Notes / explanation' : 'Notes'}</Label>
+              <Textarea
+                value={revisionNotes}
+                onChange={(event) => setRevisionNotes(event.target.value)}
+                placeholder={revisionNotesRequired ? 'Required for Other or any Yes impact answer' : 'Optional revision notes'}
+                data-testid="textarea-wad-revision-notes"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRevisionDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => createRevisionMutation.mutate()}
+              disabled={!canCreateRevision || createRevisionMutation.isPending}
+              data-testid="button-submit-wad-revision"
+            >
+              {createRevisionMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Create Draft Revision
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/pages/WADWizardLauncherPage.tsx
+++ b/client/src/pages/WADWizardLauncherPage.tsx
@@ -203,7 +203,7 @@ export default function WADWizardLauncherPage() {
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <Wand2 className="h-6 w-6 text-blue-600" />
-            WAD Wizard
+            WAD (Working Authorization Document)
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
             Pick a Production Work Order to author, edit, or review its Work Authorization Document.

--- a/migrations/0180_wad_revisions.sql
+++ b/migrations/0180_wad_revisions.sql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS wad_revisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wad_id uuid NOT NULL REFERENCES production_work_orders(id) ON DELETE CASCADE,
+  revision_code text NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  revision_reason text NOT NULL,
+  reason_notes text,
+  impact_production boolean NOT NULL DEFAULT false,
+  impact_released_travelers boolean NOT NULL DEFAULT false,
+  impact_completed_work boolean NOT NULL DEFAULT false,
+  impact_material_issued boolean NOT NULL DEFAULT false,
+  impact_inspection boolean NOT NULL DEFAULT false,
+  impact_labor_budget boolean NOT NULL DEFAULT false,
+  impact_delivery_date boolean NOT NULL DEFAULT false,
+  impact_customer_approval boolean NOT NULL DEFAULT false,
+  requires_production_hold boolean NOT NULL DEFAULT false,
+  effective_date date,
+  wad_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_by integer REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name text,
+  approved_by integer REFERENCES users(id) ON DELETE SET NULL,
+  approved_by_display_name text,
+  approved_at timestamp,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now(),
+  CONSTRAINT wad_revisions_status_check CHECK (status IN ('draft', 'pending_approval', 'approved', 'superseded', 'rejected')),
+  CONSTRAINT wad_revisions_wad_revision_unique UNIQUE (wad_id, revision_code)
+);
+
+CREATE INDEX IF NOT EXISTS wad_revisions_wad_id_idx ON wad_revisions(wad_id);
+CREATE INDEX IF NOT EXISTS wad_revisions_status_idx ON wad_revisions(status);
+
+CREATE TABLE IF NOT EXISTS wad_revision_approval_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wad_revision_id uuid NOT NULL REFERENCES wad_revisions(id) ON DELETE CASCADE,
+  approver_role text NOT NULL,
+  approver_user_id integer REFERENCES users(id) ON DELETE SET NULL,
+  status text NOT NULL DEFAULT 'pending',
+  comments text,
+  signed_at timestamp,
+  CONSTRAINT wad_revision_approval_status_check CHECK (status IN ('pending', 'approved', 'rejected'))
+);
+
+CREATE INDEX IF NOT EXISTS wad_revision_approval_history_revision_idx
+  ON wad_revision_approval_history(wad_revision_id);
+CREATE INDEX IF NOT EXISTS wad_revision_approval_history_approver_idx
+  ON wad_revision_approval_history(approver_role, approver_user_id);
+
+ALTER TABLE travelers
+  ADD COLUMN IF NOT EXISTS wad_revision_id uuid REFERENCES wad_revisions(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS travelers_wad_revision_idx ON travelers(wad_revision_id);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -6065,6 +6065,7 @@ export const travelers = pgTable('travelers', {
   salesOrderId: varchar('sales_order_id', { length: 255 }),
   workOrderId: varchar('work_order_id', { length: 255 }),
   productionWorkOrderId: uuid('production_work_order_id').references((): AnyPgColumn => productionWorkOrders.id),
+  wadRevisionId: uuid('wad_revision_id'),
   projectId: uuid('project_id').references((): AnyPgColumn => projects.id),
   defaultChargeCodeId: integer('default_charge_code_id').references(() => chargeCodes.id, { onDelete: 'set null' }),
 
@@ -6097,6 +6098,7 @@ export const travelers = pgTable('travelers', {
   statusIdx: index('travelers_status_idx').on(table.status),
   partNumberIdx: index('travelers_part_number_idx').on(table.partNumber),
   workOrderIdx: index('travelers_work_order_idx').on(table.workOrderId),
+  wadRevisionIdx: index('travelers_wad_revision_idx').on(table.wadRevisionId),
 }));
 
 // Traveler Steps - Departments in sequence
@@ -17094,6 +17096,65 @@ export const insertProductionWorkOrderSchema = createInsertSchema(productionWork
 
 export type ProductionWorkOrder = typeof productionWorkOrders.$inferSelect;
 export type InsertProductionWorkOrder = z.infer<typeof insertProductionWorkOrderSchema>;
+
+export const wadRevisions = pgTable('wad_revisions', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  wadId: uuid('wad_id').notNull().references(() => productionWorkOrders.id, { onDelete: 'cascade' }),
+  revisionCode: text('revision_code').notNull(),
+  status: text('status').notNull().default('draft'),
+  revisionReason: text('revision_reason').notNull(),
+  reasonNotes: text('reason_notes'),
+  impactProduction: boolean('impact_production').notNull().default(false),
+  impactReleasedTravelers: boolean('impact_released_travelers').notNull().default(false),
+  impactCompletedWork: boolean('impact_completed_work').notNull().default(false),
+  impactMaterialIssued: boolean('impact_material_issued').notNull().default(false),
+  impactInspection: boolean('impact_inspection').notNull().default(false),
+  impactLaborBudget: boolean('impact_labor_budget').notNull().default(false),
+  impactDeliveryDate: boolean('impact_delivery_date').notNull().default(false),
+  impactCustomerApproval: boolean('impact_customer_approval').notNull().default(false),
+  requiresProductionHold: boolean('requires_production_hold').notNull().default(false),
+  effectiveDate: date('effective_date'),
+  wadSnapshot: jsonb('wad_snapshot').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  createdBy: integer('created_by').references(() => users.id, { onDelete: 'set null' }),
+  createdByDisplayName: text('created_by_display_name'),
+  approvedBy: integer('approved_by').references(() => users.id, { onDelete: 'set null' }),
+  approvedByDisplayName: text('approved_by_display_name'),
+  approvedAt: timestamp('approved_at'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+}, (table) => ({
+  wadIdIdx: index('wad_revisions_wad_id_idx').on(table.wadId),
+  statusIdx: index('wad_revisions_status_idx').on(table.status),
+  wadRevisionUnique: uniqueIndex('wad_revisions_wad_revision_unique').on(table.wadId, table.revisionCode),
+}));
+
+export const wadRevisionApprovalHistory = pgTable('wad_revision_approval_history', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  wadRevisionId: uuid('wad_revision_id').notNull().references(() => wadRevisions.id, { onDelete: 'cascade' }),
+  approverRole: text('approver_role').notNull(),
+  approverUserId: integer('approver_user_id').references(() => users.id, { onDelete: 'set null' }),
+  status: text('status').notNull().default('pending'),
+  comments: text('comments'),
+  signedAt: timestamp('signed_at'),
+}, (table) => ({
+  revisionIdx: index('wad_revision_approval_history_revision_idx').on(table.wadRevisionId),
+  approverIdx: index('wad_revision_approval_history_approver_idx').on(table.approverRole, table.approverUserId),
+}));
+
+export const insertWadRevisionSchema = createInsertSchema(wadRevisions).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  approvedAt: true,
+}).extend({
+  revisionReason: z.string().min(1, 'revisionReason is required'),
+  reasonNotes: z.string().optional().nullable(),
+  effectiveDate: z.string().optional().nullable(),
+});
+
+export type WadRevision = typeof wadRevisions.$inferSelect;
+export type InsertWadRevision = z.infer<typeof insertWadRevisionSchema>;
+export type WadRevisionApprovalHistory = typeof wadRevisionApprovalHistory.$inferSelect;
 
 // Program Manufacturing Orchestration - additive layer above P2 queues/WADs.
 export const programBuilds = pgTable('program_builds', {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -201,6 +201,7 @@ import { qrResolverRouter, qrAdminRouter } from './qrCodes';
 import onboardingRoutes from './onboarding';
 import assetManagementRoutes from './assetManagement';
 import workOrdersRoutes from './workOrders';
+import wadRevisionsRoutes from './wadRevisions';
 import productionControlTemplatesRoutes from './productionControlTemplates';
 import productLabelsRoutes from './productLabels';
 import executiveRundownRoutes from './executiveRundown';
@@ -1251,6 +1252,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   // Work Orders — Consolidated: maintenance events + production WADs (EPOCH v9 spine)
   app.use('/api/work-orders', workOrdersRoutes);
+  app.use('/api', wadRevisionsRoutes);
 
   // Production Control Templates — WAD Step 6 Template Library
   app.use('/api/production-control-templates', productionControlTemplatesRoutes);

--- a/server/src/routes/wadRevisions.ts
+++ b/server/src/routes/wadRevisions.ts
@@ -1,0 +1,539 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { pool } from '../../db';
+import { authenticateToken } from '../../middleware/auth';
+import { recordAuditEvent } from '../services/auditLedgerService';
+
+const router = Router();
+
+const WAD_REVISION_REASONS = [
+  'PO quantity change',
+  'Delivery date change',
+  'Drawing revision change',
+  'Routing change',
+  'Traveler change',
+  'Work instruction change',
+  'BOM/material change',
+  'Quality requirement change',
+  'Budget/labor change',
+  'Customer requirement change',
+  'NCR/CAR related change',
+  'Schedule/priority change',
+  'Other',
+] as const;
+
+const WAD_REVISION_APPROVAL_ROLES = ['project_manager', 'production_manager', 'quality', 'engineering', 'finance_admin'] as const;
+
+const WAD_REVISION_ALLOWED_SYSTEM_ROLES = new Set([
+  'ADMIN',
+  'OWNER',
+  'PROJECT_MANAGER',
+  'QUALITY_MANAGER',
+  'QUALITY',
+  'QC',
+  'PRODUCTION_MANAGER',
+  'MANAGER',
+]);
+
+const APPROVER_SYSTEM_ROLES: Record<string, string[]> = {
+  project_manager: ['PROJECT_MANAGER', 'ADMIN', 'OWNER'],
+  production_manager: ['PRODUCTION_MANAGER', 'MANAGER', 'ADMIN', 'OWNER'],
+  quality: ['QUALITY_MANAGER', 'QUALITY', 'QC', 'ADMIN', 'OWNER'],
+  engineering: ['ENGINEERING', 'ENGINEER', 'ADMIN', 'OWNER'],
+  finance_admin: ['FINANCE', 'ADMIN', 'OWNER'],
+};
+
+function getUser(req: Request): { id?: number | string | null; username?: string | null; displayName?: string | null; role?: string | null } | null {
+  return (req as Request & { user?: any }).user ?? null;
+}
+
+function userDisplayName(req: Request): string {
+  const user = getUser(req);
+  return user?.displayName || user?.username || `user:${user?.id ?? 'unknown'}`;
+}
+
+function userIdNumber(req: Request): number | null {
+  const id = getUser(req)?.id;
+  if (typeof id === 'number') return id;
+  if (id == null) return null;
+  const parsed = Number.parseInt(String(id), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function requireWadRevisionRole(req: Request, res: Response, next: NextFunction) {
+  const role = String(getUser(req)?.role ?? '').toUpperCase();
+  if (!WAD_REVISION_ALLOWED_SYSTEM_ROLES.has(role)) {
+    return res.status(403).json({
+      error: 'Only Admin, Owner, Project Manager, Quality Manager, or Production Manager can create or approve WAD revisions.',
+    });
+  }
+  next();
+}
+
+function requireApprovalRole(req: Request, res: Response, approvalRole: string): boolean {
+  const systemRole = String(getUser(req)?.role ?? '').toUpperCase();
+  const allowed = APPROVER_SYSTEM_ROLES[approvalRole] ?? [];
+  if (!allowed.includes(systemRole)) {
+    res.status(403).json({ error: `Your role cannot approve the ${approvalRole.replace(/_/g, ' ')} WAD revision slot.` });
+    return false;
+  }
+  return true;
+}
+
+function revisionCodeFromIndex(index: number): string {
+  let n = Math.max(1, index);
+  let code = '';
+  while (n > 0) {
+    n -= 1;
+    code = String.fromCharCode(65 + (n % 26)) + code;
+    n = Math.floor(n / 26);
+  }
+  return `Rev ${code}`;
+}
+
+function requiredRolesForRevision(revision: any): string[] {
+  const roles = new Set<string>(['project_manager', 'production_manager', 'quality']);
+  const reason = String(revision.revision_reason ?? revision.revisionReason ?? '').toLowerCase();
+  if (
+    reason.includes('drawing') ||
+    reason.includes('routing') ||
+    reason.includes('traveler') ||
+    reason.includes('work instruction') ||
+    revision.impact_inspection ||
+    revision.impactInspection
+  ) {
+    roles.add('engineering');
+  }
+  if (reason.includes('budget') || revision.impact_labor_budget || revision.impactLaborBudget) {
+    roles.add('finance_admin');
+  }
+  return [...roles];
+}
+
+function mapRevision(row: any) {
+  if (!row) return row;
+  return {
+    id: row.id,
+    wadId: row.wad_id,
+    revisionCode: row.revision_code,
+    status: row.status,
+    revisionReason: row.revision_reason,
+    reasonNotes: row.reason_notes,
+    impactProduction: row.impact_production,
+    impactReleasedTravelers: row.impact_released_travelers,
+    impactCompletedWork: row.impact_completed_work,
+    impactMaterialIssued: row.impact_material_issued,
+    impactInspection: row.impact_inspection,
+    impactLaborBudget: row.impact_labor_budget,
+    impactDeliveryDate: row.impact_delivery_date,
+    impactCustomerApproval: row.impact_customer_approval,
+    requiresProductionHold: row.requires_production_hold,
+    effectiveDate: row.effective_date,
+    wadSnapshot: row.wad_snapshot,
+    createdBy: row.created_by,
+    createdByDisplayName: row.created_by_display_name,
+    approvedBy: row.approved_by,
+    approvedByDisplayName: row.approved_by_display_name,
+    approvedAt: row.approved_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    approvals: row.approvals ?? [],
+  };
+}
+
+async function revisionWithApprovals(revisionId: string) {
+  const rows = await pool.query(
+    `SELECT wr.*,
+            COALESCE(
+              json_agg(
+                json_build_object(
+                  'id', ah.id,
+                  'wadRevisionId', ah.wad_revision_id,
+                  'approverRole', ah.approver_role,
+                  'approverUserId', ah.approver_user_id,
+                  'status', ah.status,
+                  'comments', ah.comments,
+                  'signedAt', ah.signed_at
+                )
+                ORDER BY ah.approver_role
+              ) FILTER (WHERE ah.id IS NOT NULL),
+              '[]'::json
+            ) AS approvals
+     FROM wad_revisions wr
+     LEFT JOIN wad_revision_approval_history ah ON ah.wad_revision_id = wr.id
+     WHERE wr.id = $1
+     GROUP BY wr.id`,
+    [revisionId],
+  );
+  return mapRevision(rows.rows[0] ?? null);
+}
+
+async function logWadRevisionAction(req: Request, revisionId: string, action: string, reason?: string | null, payload?: Record<string, unknown>) {
+  const revision = await pool.query('SELECT wad_id, revision_code FROM wad_revisions WHERE id = $1', [revisionId]);
+  const row = revision.rows[0];
+  await recordAuditEvent({
+    eventType: action,
+    subjectType: 'wad_revision',
+    subjectId: revisionId,
+    sourceService: 'wadRevisions.router',
+    actor: { id: userIdNumber(req), username: userDisplayName(req), role: getUser(req)?.role ?? null },
+    reason: reason ?? null,
+    payload: {
+      wadId: row?.wad_id ?? null,
+      revisionCode: row?.revision_code ?? null,
+      ...payload,
+    },
+  }).catch((error: Error) => console.warn(`[AuditLedger] ${action} failed:`, error?.message));
+}
+
+const revisionBodySchema = z.object({
+  revisionReason: z.enum(WAD_REVISION_REASONS),
+  reasonNotes: z.string().trim().optional().nullable(),
+  impactProduction: z.boolean().optional().default(false),
+  impactReleasedTravelers: z.boolean().optional().default(false),
+  impactCompletedWork: z.boolean().optional().default(false),
+  impactMaterialIssued: z.boolean().optional().default(false),
+  impactInspection: z.boolean().optional().default(false),
+  impactLaborBudget: z.boolean().optional().default(false),
+  impactDeliveryDate: z.boolean().optional().default(false),
+  impactCustomerApproval: z.boolean().optional().default(false),
+  requiresProductionHold: z.boolean().optional().default(false),
+  effectiveDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().nullable(),
+}).superRefine((data, ctx) => {
+  const impactValues = [
+    data.impactProduction,
+    data.impactReleasedTravelers,
+    data.impactCompletedWork,
+    data.impactMaterialIssued,
+    data.impactInspection,
+    data.impactLaborBudget,
+    data.impactDeliveryDate,
+    data.impactCustomerApproval,
+    data.requiresProductionHold,
+  ];
+  if (data.revisionReason === 'Other' && !data.reasonNotes?.trim()) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Reason notes are required when Other is selected.', path: ['reasonNotes'] });
+  }
+  if (impactValues.some(Boolean) && !data.reasonNotes?.trim()) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Impact notes are required when any impact answer is Yes.', path: ['reasonNotes'] });
+  }
+});
+
+router.get('/wads/:wadId/revisions', async (req, res) => {
+  try {
+    const { wadId } = req.params;
+    const rows = await pool.query(
+      `SELECT wr.*,
+              COALESCE(
+                json_agg(
+                  json_build_object(
+                    'id', ah.id,
+                    'wadRevisionId', ah.wad_revision_id,
+                    'approverRole', ah.approver_role,
+                    'approverUserId', ah.approver_user_id,
+                    'status', ah.status,
+                    'comments', ah.comments,
+                    'signedAt', ah.signed_at
+                  )
+                  ORDER BY ah.approver_role
+                ) FILTER (WHERE ah.id IS NOT NULL),
+                '[]'::json
+              ) AS approvals
+       FROM wad_revisions wr
+       LEFT JOIN wad_revision_approval_history ah ON ah.wad_revision_id = wr.id
+       WHERE wr.wad_id = $1
+       GROUP BY wr.id
+       ORDER BY wr.created_at DESC`,
+      [wadId],
+    );
+    res.json(rows.rows.map(mapRevision));
+  } catch (error: any) {
+    console.error('[WAD Revisions] list failed:', error);
+    res.status(500).json({ error: 'Failed to fetch WAD revisions', message: error.message });
+  }
+});
+
+router.post('/wads/:wadId/revisions', authenticateToken, requireWadRevisionRole, async (req, res) => {
+  const parsed = revisionBodySchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten() });
+
+  const client = await pool.connect();
+  try {
+    const { wadId } = req.params;
+    await client.query('BEGIN');
+    const wadRows = await client.query('SELECT * FROM production_work_orders WHERE id = $1 FOR UPDATE', [wadId]);
+    const wad = wadRows.rows[0];
+    if (!wad) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'WAD not found' });
+    }
+    if (wad.wad_status !== 'APPROVED') {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: 'Only approved WADs can create a new revision.' });
+    }
+
+    const openRows = await client.query(
+      `SELECT id FROM wad_revisions
+       WHERE wad_id = $1 AND status IN ('draft', 'pending_approval')
+       LIMIT 1`,
+      [wadId],
+    );
+    if (openRows.rows.length > 0) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: 'A draft or pending WAD revision already exists for this WAD.' });
+    }
+
+    const countRows = await client.query('SELECT COUNT(*)::int AS count FROM wad_revisions WHERE wad_id = $1', [wadId]);
+    const revisionCode = revisionCodeFromIndex(Number(countRows.rows[0]?.count ?? 0) + 1);
+    const data = parsed.data;
+    const inserted = await client.query(
+      `INSERT INTO wad_revisions (
+         wad_id, revision_code, status, revision_reason, reason_notes,
+         impact_production, impact_released_travelers, impact_completed_work,
+         impact_material_issued, impact_inspection, impact_labor_budget,
+         impact_delivery_date, impact_customer_approval, requires_production_hold,
+         effective_date, wad_snapshot, created_by, created_by_display_name
+       )
+       VALUES ($1, $2, 'draft', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14::date, $15::jsonb, $16, $17)
+       RETURNING *`,
+      [
+        wadId,
+        revisionCode,
+        data.revisionReason,
+        data.reasonNotes ?? null,
+        data.impactProduction,
+        data.impactReleasedTravelers,
+        data.impactCompletedWork,
+        data.impactMaterialIssued,
+        data.impactInspection,
+        data.impactLaborBudget,
+        data.impactDeliveryDate,
+        data.impactCustomerApproval,
+        data.requiresProductionHold,
+        data.effectiveDate ?? null,
+        JSON.stringify(wad),
+        userIdNumber(req),
+        userDisplayName(req),
+      ],
+    );
+    await client.query('COMMIT');
+    await logWadRevisionAction(req, inserted.rows[0].id, 'wad_revision_created', data.revisionReason, { productionHold: data.requiresProductionHold });
+    if (data.requiresProductionHold) {
+      await logWadRevisionAction(req, inserted.rows[0].id, 'wad_revision_production_hold_applied', data.reasonNotes ?? data.revisionReason);
+    }
+    res.status(201).json(mapRevision(inserted.rows[0]));
+  } catch (error: any) {
+    await client.query('ROLLBACK').catch(() => undefined);
+    console.error('[WAD Revisions] create failed:', error);
+    res.status(500).json({ error: 'Failed to create WAD revision', message: error.message });
+  } finally {
+    client.release();
+  }
+});
+
+router.get('/wad-revisions/:revisionId', async (req, res) => {
+  try {
+    const revision = await revisionWithApprovals(req.params.revisionId);
+    if (!revision) return res.status(404).json({ error: 'WAD revision not found' });
+    res.json(revision);
+  } catch (error: any) {
+    console.error('[WAD Revisions] get failed:', error);
+    res.status(500).json({ error: 'Failed to fetch WAD revision', message: error.message });
+  }
+});
+
+router.patch('/wad-revisions/:revisionId', authenticateToken, requireWadRevisionRole, async (req, res) => {
+  const parsed = revisionBodySchema.partial().safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten() });
+  try {
+    const existing = await pool.query('SELECT * FROM wad_revisions WHERE id = $1', [req.params.revisionId]);
+    if (!existing.rows[0]) return res.status(404).json({ error: 'WAD revision not found' });
+    if (existing.rows[0].status !== 'draft') return res.status(409).json({ error: 'Only draft WAD revisions can be edited.' });
+    const current = existing.rows[0];
+    const data = { ...current, ...parsed.data };
+    const updated = await pool.query(
+      `UPDATE wad_revisions
+       SET revision_reason = $2,
+           reason_notes = $3,
+           impact_production = $4,
+           impact_released_travelers = $5,
+           impact_completed_work = $6,
+           impact_material_issued = $7,
+           impact_inspection = $8,
+           impact_labor_budget = $9,
+           impact_delivery_date = $10,
+           impact_customer_approval = $11,
+           requires_production_hold = $12,
+           effective_date = $13::date,
+           updated_at = NOW()
+       WHERE id = $1
+       RETURNING *`,
+      [
+        req.params.revisionId,
+        data.revisionReason ?? data.revision_reason,
+        data.reasonNotes ?? data.reason_notes,
+        data.impactProduction ?? data.impact_production,
+        data.impactReleasedTravelers ?? data.impact_released_travelers,
+        data.impactCompletedWork ?? data.impact_completed_work,
+        data.impactMaterialIssued ?? data.impact_material_issued,
+        data.impactInspection ?? data.impact_inspection,
+        data.impactLaborBudget ?? data.impact_labor_budget,
+        data.impactDeliveryDate ?? data.impact_delivery_date,
+        data.impactCustomerApproval ?? data.impact_customer_approval,
+        data.requiresProductionHold ?? data.requires_production_hold,
+        data.effectiveDate ?? data.effective_date,
+      ],
+    );
+    await logWadRevisionAction(req, req.params.revisionId, 'wad_revision_updated', parsed.data.reasonNotes ?? null);
+    res.json(mapRevision(updated.rows[0]));
+  } catch (error: any) {
+    console.error('[WAD Revisions] patch failed:', error);
+    res.status(500).json({ error: 'Failed to update WAD revision', message: error.message });
+  }
+});
+
+router.post('/wad-revisions/:revisionId/submit', authenticateToken, requireWadRevisionRole, async (req, res) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const revisionRows = await client.query('SELECT * FROM wad_revisions WHERE id = $1 FOR UPDATE', [req.params.revisionId]);
+    const revision = revisionRows.rows[0];
+    if (!revision) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'WAD revision not found' });
+    }
+    if (revision.status !== 'draft') {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: 'Only draft WAD revisions can be submitted.' });
+    }
+    const roles = requiredRolesForRevision(revision);
+    await client.query(`UPDATE wad_revisions SET status = 'pending_approval', updated_at = NOW() WHERE id = $1`, [revision.id]);
+    for (const role of roles) {
+      await client.query(
+        `INSERT INTO wad_revision_approval_history (wad_revision_id, approver_role, status)
+         VALUES ($1, $2, 'pending')`,
+        [revision.id, role],
+      );
+    }
+    await client.query('COMMIT');
+    await logWadRevisionAction(req, revision.id, 'wad_revision_submitted', revision.revision_reason, { requiredRoles: roles });
+    res.json(await revisionWithApprovals(revision.id));
+  } catch (error: any) {
+    await client.query('ROLLBACK').catch(() => undefined);
+    console.error('[WAD Revisions] submit failed:', error);
+    res.status(500).json({ error: 'Failed to submit WAD revision', message: error.message });
+  } finally {
+    client.release();
+  }
+});
+
+const decisionBodySchema = z.object({
+  approverRole: z.enum(WAD_REVISION_APPROVAL_ROLES),
+  comments: z.string().trim().optional().nullable(),
+});
+
+router.post('/wad-revisions/:revisionId/approve', authenticateToken, requireWadRevisionRole, async (req, res) => {
+  const parsed = decisionBodySchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten() });
+  if (!requireApprovalRole(req, res, parsed.data.approverRole)) return;
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const revisionRows = await client.query('SELECT * FROM wad_revisions WHERE id = $1 FOR UPDATE', [req.params.revisionId]);
+    const revision = revisionRows.rows[0];
+    if (!revision) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'WAD revision not found' });
+    }
+    if (revision.status !== 'pending_approval') {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: 'Only pending WAD revisions can be approved.' });
+    }
+    const approval = await client.query(
+      `UPDATE wad_revision_approval_history
+       SET status = 'approved', approver_user_id = $3, comments = $4, signed_at = NOW()
+       WHERE wad_revision_id = $1 AND approver_role = $2
+       RETURNING *`,
+      [revision.id, parsed.data.approverRole, userIdNumber(req), parsed.data.comments ?? null],
+    );
+    if (approval.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'Approval slot was not found for this WAD revision.' });
+    }
+
+    const pendingRows = await client.query(
+      `SELECT COUNT(*)::int AS count
+       FROM wad_revision_approval_history
+       WHERE wad_revision_id = $1 AND status <> 'approved'`,
+      [revision.id],
+    );
+    const allApproved = Number(pendingRows.rows[0]?.count ?? 0) === 0;
+    let supersededRevisionIds: string[] = [];
+    if (allApproved) {
+      const supersededRows = await client.query(
+        `UPDATE wad_revisions
+         SET status = 'superseded', updated_at = NOW()
+         WHERE wad_id = $1 AND status = 'approved' AND id <> $2
+         RETURNING id`,
+        [revision.wad_id, revision.id],
+      );
+      supersededRevisionIds = supersededRows.rows.map((row) => row.id);
+      await client.query(
+        `UPDATE wad_revisions
+         SET status = 'approved', approved_by = $2, approved_by_display_name = $3, approved_at = NOW(),
+             effective_date = COALESCE(effective_date, CURRENT_DATE), updated_at = NOW()
+         WHERE id = $1`,
+        [revision.id, userIdNumber(req), userDisplayName(req)],
+      );
+    }
+    await client.query('COMMIT');
+    await logWadRevisionAction(req, revision.id, allApproved ? 'wad_revision_approved' : 'wad_revision_approval_signed', parsed.data.comments ?? null, { approverRole: parsed.data.approverRole });
+    for (const supersededRevisionId of supersededRevisionIds) {
+      await logWadRevisionAction(req, supersededRevisionId, 'wad_revision_superseded', `Superseded by ${revision.revision_code}`);
+    }
+    if (allApproved && revision.requires_production_hold) {
+      await logWadRevisionAction(req, revision.id, 'wad_revision_production_hold_removed', 'WAD revision approved');
+    }
+    res.json(await revisionWithApprovals(revision.id));
+  } catch (error: any) {
+    await client.query('ROLLBACK').catch(() => undefined);
+    console.error('[WAD Revisions] approve failed:', error);
+    res.status(500).json({ error: 'Failed to approve WAD revision', message: error.message });
+  } finally {
+    client.release();
+  }
+});
+
+router.post('/wad-revisions/:revisionId/reject', authenticateToken, requireWadRevisionRole, async (req, res) => {
+  const parsed = decisionBodySchema.extend({ comments: z.string().trim().min(1, 'comments are required') }).safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten() });
+  if (!requireApprovalRole(req, res, parsed.data.approverRole)) return;
+
+  try {
+    const updated = await pool.query(
+      `UPDATE wad_revisions
+       SET status = 'rejected', updated_at = NOW()
+       WHERE id = $1 AND status = 'pending_approval'
+       RETURNING *`,
+      [req.params.revisionId],
+    );
+    if (!updated.rows[0]) return res.status(404).json({ error: 'Pending WAD revision not found' });
+    await pool.query(
+      `UPDATE wad_revision_approval_history
+       SET status = CASE WHEN approver_role = $2 THEN 'rejected' ELSE status END,
+           approver_user_id = CASE WHEN approver_role = $2 THEN $3 ELSE approver_user_id END,
+           comments = CASE WHEN approver_role = $2 THEN $4 ELSE comments END,
+           signed_at = CASE WHEN approver_role = $2 THEN NOW() ELSE signed_at END
+       WHERE wad_revision_id = $1`,
+      [req.params.revisionId, parsed.data.approverRole, userIdNumber(req), parsed.data.comments],
+    );
+    await logWadRevisionAction(req, req.params.revisionId, 'wad_revision_rejected', parsed.data.comments, { approverRole: parsed.data.approverRole });
+    res.json(await revisionWithApprovals(req.params.revisionId));
+  } catch (error: any) {
+    console.error('[WAD Revisions] reject failed:', error);
+    res.status(500).json({ error: 'Failed to reject WAD revision', message: error.message });
+  }
+});
+
+export default router;

--- a/server/src/routes/workOrders.ts
+++ b/server/src/routes/workOrders.ts
@@ -1271,6 +1271,46 @@ function validateUuid(value: string): boolean {
   return UUID_REGEX.test(value);
 }
 
+type BlockingWadRevision = {
+  id: string;
+  revision_code: string;
+  requires_production_hold: boolean;
+};
+
+async function getBlockingWadRevision(wadId: string): Promise<BlockingWadRevision | null> {
+  const result = await pool.query<BlockingWadRevision>(
+    `
+      SELECT id, revision_code, requires_production_hold
+      FROM wad_revisions
+      WHERE wad_id = $1
+        AND status IN ('draft', 'pending_approval')
+        AND (
+          impact_production = true
+          OR impact_released_travelers = true
+          OR impact_inspection = true
+          OR impact_material_issued = true
+          OR requires_production_hold = true
+        )
+      ORDER BY created_at DESC
+      LIMIT 1
+    `,
+    [wadId]
+  );
+
+  return result.rows[0] ?? null;
+}
+
+function sendBlockedWadRevisionResponse(res: Response, revision: BlockingWadRevision) {
+  const productionHoldMessage = 'Production Hold Required — Revision approval required before continuing.';
+  const pendingRevisionMessage = 'Pending WAD Revision — Production changes cannot be released until approved.';
+  return res.status(409).json({
+    error: revision.requires_production_hold ? productionHoldMessage : pendingRevisionMessage,
+    revisionId: revision.id,
+    revisionCode: revision.revision_code,
+    productionHoldRequired: revision.requires_production_hold,
+  });
+}
+
 // POST /api/work-orders/:id/travelers/create — create a traveler from a WAD using its part routing
 router.post('/:id/travelers/create', requirePermission('work_orders.release'), async (req: Request, res: Response) => {
   try {
@@ -1282,6 +1322,11 @@ router.post('/:id/travelers/create', requirePermission('work_orders.release'), a
 
     const user = (req as any).user;
     const createdBy = req.body?.createdBy ?? user?.username ?? user?.id ?? 'system';
+
+    const blockingRevision = await getBlockingWadRevision(id);
+    if (blockingRevision) {
+      return sendBlockedWadRevisionResponse(res, blockingRevision);
+    }
 
     let traveler: Awaited<ReturnType<typeof storage.createTravelerFromProductionWorkOrder>>;
     try {
@@ -1309,6 +1354,7 @@ router.post('/:id/travelers/create', requirePermission('work_orders.release'), a
       partNumber: traveler.partNumber,
       status: traveler.status,
       partRoutingId: traveler.partRoutingId,
+      wadRevisionId: traveler.wadRevisionId,
     });
   } catch (error: any) {
     console.error('[WorkOrders] Error creating traveler from WAD:', error);
@@ -1745,6 +1791,11 @@ router.post('/:id/release', authenticateToken, requirePermission('work_orders.re
 
     if (wad.status === 'IN_PROGRESS' || wad.status === 'COMPLETE' || wad.status === 'CLOSED') {
       return res.status(400).json({ error: `Cannot release a work order with status: ${wad.status}` });
+    }
+
+    const blockingRevision = await getBlockingWadRevision(id);
+    if (blockingRevision) {
+      return sendBlockedWadRevisionResponse(res, blockingRevision);
     }
 
     const readiness = await evaluateWorkOrderReadiness(id);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -632,6 +632,7 @@ import {
   type InsertTravelerComponentAssociation,
   p2LotNumbers,
   productionWorkOrders,
+  wadRevisions,
   type ProductionWorkOrder,
   type InsertProductionWorkOrder,
   // Labor → GL Posting Engine
@@ -20711,6 +20712,7 @@ export class DatabaseStorage implements IStorage {
         id: productionWorkOrders.id,
         workOrderNumber: productionWorkOrders.workOrderNumber,
         partNumber: productionWorkOrders.partNumber,
+        description: productionWorkOrders.description,
         quantity: productionWorkOrders.quantity,
       })
       .from(productionWorkOrders)
@@ -20741,6 +20743,16 @@ export class DatabaseStorage implements IStorage {
 
     traveler = await this.linkTravelerToProductionWorkOrder(traveler.id, wadId);
 
+    const [activeWadRevision] = await db
+      .select({
+        id: wadRevisions.id,
+        revisionCode: wadRevisions.revisionCode,
+      })
+      .from(wadRevisions)
+      .where(and(eq(wadRevisions.wadId, wadId), eq(wadRevisions.status, 'approved')))
+      .orderBy(desc(wadRevisions.approvedAt), desc(wadRevisions.createdAt))
+      .limit(1);
+
     // Patch traveler to inherit part number, description, and quantity from the WAD
     const [patched] = await db
       .update(travelers)
@@ -20748,6 +20760,7 @@ export class DatabaseStorage implements IStorage {
         partNumber: wad.partNumber,
         partName: wad.description ?? traveler.partName,
         quantity: wad.quantity,
+        wadRevisionId: activeWadRevision?.id ?? null,
         updatedAt: new Date(),
       })
       .where(eq(travelers.id, traveler.id))


### PR DESCRIPTION
## Summary
- Add WAD revision and approval-history persistence with migration and schema types.
- Add WAD revision API routes for create, submit, approve, reject, list, and detail reads.
- Add WAD summary revision UI with create modal, impact review, approval panel, history table, and production-hold warnings.
- Gate production release/traveler creation while impactful WAD revisions are draft or pending, and stamp travelers with the active approved WAD revision.
- Route the P2 project WAD tab to the WAD summary/revision workflow and standardize WAD page headers.
- Add an editable project ROM draft tab workflow that locks after PO/contract award and remains available as a summary view.
- Use saved ROM labor/material values to auto-fill WAD creation and WAD material planning defaults.

## Validation
- `git diff --cached --check` passed for both commits.
- `git diff --check` passed before staging.
- `npm run check` could not be run locally because `npm` is not available on PATH and this clean worktree has no `node_modules`.