### PR TITLE
[codex] Route master document links through app

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -318,11 +318,6 @@ export default function MasterDocumentRegister() {
     Boolean(doc.filePath && /^https?:\/\//i.test(doc.filePath));
 
   const openDocumentFile = (doc: ControlledDocument, mode: 'view' | 'download') => {
-    if (isExternalDocument(doc)) {
-      window.open(doc.filePath!, '_blank', 'noopener,noreferrer');
-      return;
-    }
-
     const path = `/api/controlled-documents/${doc.id}/${mode}`;
     window.open(path, '_blank', 'noopener,noreferrer');
   };

--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -314,7 +314,15 @@ export default function MasterDocumentRegister() {
   const isPdfDocument = (doc: ControlledDocument) =>
     Boolean(doc.filePath?.toLowerCase().endsWith('.pdf'));
 
+  const isExternalDocument = (doc: ControlledDocument) =>
+    Boolean(doc.filePath && /^https?:\/\//i.test(doc.filePath));
+
   const openDocumentFile = (doc: ControlledDocument, mode: 'view' | 'download') => {
+    if (isExternalDocument(doc)) {
+      window.open(doc.filePath!, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
     const path = `/api/controlled-documents/${doc.id}/${mode}`;
     window.open(path, '_blank', 'noopener,noreferrer');
   };
@@ -689,13 +697,13 @@ export default function MasterDocumentRegister() {
                           <div className="flex items-center gap-2">
                             {doc.filePath && (
                               <>
-                                {isPdfDocument(doc) && (
+                                {(isPdfDocument(doc) || isExternalDocument(doc)) && (
                                   <Badge
                                     variant="outline"
                                     role="button"
                                     tabIndex={0}
                                     className="h-8 cursor-pointer gap-1 border-blue-300 px-2 text-blue-700 hover:bg-blue-50"
-                                    title="View PDF"
+                                    title={isExternalDocument(doc) ? 'Open linked document' : 'View PDF'}
                                     data-testid={`badge-view-pdf-${doc.id}`}
                                     onClick={() => openDocumentFile(doc, 'view')}
                                     onKeyDown={(event) => {
@@ -1372,7 +1380,8 @@ export default function MasterDocumentRegister() {
                 required
               />
               <p className="text-xs text-gray-500">
-                CSV should have columns: TITLE, CODE, Department, Version, Date, Record Retention Length, Summary of Changes
+                CSV should have columns: TITLE, CODE, Department, Version, Date, Record Retention Length, Summary of Changes.
+                Include Document Link, File URL, URL, Link, or File Path to attach document links.
               </p>
             </div>
 

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -158,6 +158,44 @@ const nextRevisionVersion = (version: string | null | undefined): string => {
   return `${major}.${minor + 1}`;
 };
 
+const getCsvValue = (row: Record<string, unknown>, names: string[]) => {
+  for (const name of names) {
+    const value = row[name];
+    if (value !== undefined && value !== null && String(value).trim()) {
+      return String(value).trim();
+    }
+  }
+  return '';
+};
+
+const normalizeImportedFilePath = async (row: Record<string, unknown>, documentName: string) => {
+  const explicitLink = getCsvValue(row, [
+    'Document Link',
+    'Document URL',
+    'File Link',
+    'File URL',
+    'URL',
+    'Link',
+    'File Path',
+    'filePath',
+  ]);
+
+  if (/^https?:\/\//i.test(explicitLink)) return explicitLink;
+  if (explicitLink.startsWith('/assets/documents/')) return explicitLink;
+
+  const candidateName = explicitLink || documentName;
+  if (!/\.[a-z0-9]{2,5}$/i.test(candidateName)) return null;
+
+  const safeName = path.basename(candidateName);
+  const localPath = path.join(process.cwd(), 'server/src/assets/documents', safeName);
+  try {
+    await fs.access(localPath);
+    return `/assets/documents/${safeName}`;
+  } catch {
+    return null;
+  }
+};
+
 // Get all controlled documents (authenticated users only)
 router.get('/', requireAuth, async (req: Request, res: Response) => {
   try {
@@ -747,6 +785,7 @@ router.post('/import/csv', requireDocumentEditor, csvUpload.single('file'), asyn
         const retentionLength = String(row['Record Retention Length'] || 'N/A').trim();
         const description = String(row['Summary of Changes (if needed)'] || '').trim();
         const dateStr = String(row.Date || '').trim();
+        const filePath = await normalizeImportedFilePath(row, documentName);
         
         // Parse effective date
         let effectiveDate = null;
@@ -776,6 +815,7 @@ router.post('/import/csv', requireDocumentEditor, csvUpload.single('file'), asyn
           currentVersion,
           retentionLength,
           description,
+          filePath,
           effectiveDate,
           expirationDate: expirationDate.toISOString().split('T')[0],
           rowNumber: i + 2,
@@ -824,6 +864,7 @@ router.post('/import/csv', requireDocumentEditor, csvUpload.single('file'), asyn
             currentVersion: doc.currentVersion,
             retentionLength: doc.retentionLength,
             description: doc.description || existing.description,
+            filePath: doc.filePath || existing.filePath,
             effectiveDate: doc.effectiveDate || existing.effectiveDate,
             expirationDate: doc.expirationDate,
             updatedAt: new Date(),
@@ -839,6 +880,7 @@ router.post('/import/csv', requireDocumentEditor, csvUpload.single('file'), asyn
           status: doc.effectiveDate ? 'approved' : 'draft',
           retentionLength: doc.retentionLength,
           description: doc.description,
+          filePath: doc.filePath,
           effectiveDate: doc.effectiveDate,
           expirationDate: doc.expirationDate,
           createdBy: user.username,
@@ -858,6 +900,7 @@ router.post('/import/csv', requireDocumentEditor, csvUpload.single('file'), asyn
         changeType: 'major',
         status: newDoc.status,
         createdBy: user.username,
+        filePath: newDoc.filePath,
         effectiveDate: newDoc.effectiveDate,
         expirationDate: newDoc.expirationDate,
       }));

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -196,6 +196,9 @@ const normalizeImportedFilePath = async (row: Record<string, unknown>, documentN
   }
 };
 
+const isExternalDocumentPath = (filePath: string | null | undefined) =>
+  Boolean(filePath && /^https?:\/\//i.test(filePath));
+
 // Get all controlled documents (authenticated users only)
 router.get('/', requireAuth, async (req: Request, res: Response) => {
   try {
@@ -581,6 +584,11 @@ router.get('/:id/view', requireAuth, requireStepUp(), async (req: Request, res: 
       return res.status(404).json({ error: 'No file attached to this document' });
     }
 
+    if (isExternalDocumentPath(doc.filePath)) {
+      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'view', ipAddress });
+      return res.redirect(doc.filePath);
+    }
+
     // Strip leading slash from filePath before joining
     const relativePath = doc.filePath.replace(/^\//, '');
     const filePath = path.join(process.cwd(), 'server/src', relativePath);
@@ -651,6 +659,11 @@ router.get('/:id/download', requireAuth, requireStepUp(), async (req: Request, r
 
     if (!doc.filePath) {
       return res.status(404).json({ error: 'No file attached to this document' });
+    }
+
+    if (isExternalDocumentPath(doc.filePath)) {
+      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
+      return res.redirect(doc.filePath);
     }
 
     // Strip leading slash from filePath before joining


### PR DESCRIPTION
## Summary
- Import document links into `controlled_documents.file_path` from explicit CSV columns such as `Document Link`, `File URL`, `URL`, `Link`, or `File Path`.
- Preserve existing document links unless a CSV import supplies a new one.
- Route imported external document links through Epoch's controlled-document view/download endpoints after auth, ACL checks, step-up, and access logging.
- Keep UI document actions pointed at `/api/controlled-documents/:id/view` and `/download` instead of opening external URLs directly.
- Add an `Expired` status filter that uses the same computed expiration logic as the register badge and row highlighting.

## Why
The previous import created register rows but did not attach any `filePath`, so imported documents had no View/Download actions. Since Epoch is moving away from Replit, users should enter document access through the app route rather than depending on direct external/Replit links from the UI.

The register already visually marks expired approved documents, but the status filter only matched stored status values. The new filter option exposes that computed expired state in the normal search/filter workflow.

## Important import note
CSV exports from Google Sheets do not preserve hidden cell hyperlinks. The sheet/export needs an explicit URL/path column such as `Document Link`, `File URL`, `URL`, `Link`, or `File Path` for the importer to attach the document link.

## Validation
- `git diff --check origin/main..HEAD`
- `git diff --check -- client/src/pages/MasterDocumentRegister.tsx`
- Bundled Node syntax check: `node --experimental-strip-types --check server/src/routes/controlledDocuments.ts`

## Notes
- Full frontend TypeScript validation was not available locally because this worktree has no `node_modules`, bundled TSX parser, or PATH `npm`.