### PR TITLE
[codex] Add editable ROM draft workflow

### DIFF
--- a/client/src/components/wad/WADWizard.tsx
+++ b/client/src/components/wad/WADWizard.tsx
@@ -759,6 +759,7 @@ export default function WADWizard({ wadId, onClose, initialStep = null }: WADWiz
     const totalBudget: number = wad.totalBudgetHours
       ? Number(wad.totalBudgetHours) || 0
       : budgetEntries.reduce((sum, [, h]) => sum + (Number(h) || 0), 0);
+    const materialBudget = Number((wad as any).materialBudgetAmount ?? 0);
     const defaultChargeCode = wad.defaultChargeCodeId ? String(wad.defaultChargeCodeId) : '';
     setData((prev) => {
       const next: WizardData = { ...prev };
@@ -837,6 +838,23 @@ export default function WADWizard({ wadId, onClose, initialStep = null }: WADWiz
         if (pruned.length !== next.step4.chargeCodes.length) {
           next.step4 = { chargeCodes: pruned };
         }
+      }
+      if ((!next.step5 || !next.step5.materialSpendCap) && Number.isFinite(materialBudget) && materialBudget > 0) {
+        next.step5 = {
+          bomLinked: next.step5?.bomLinked ?? false,
+          materialLotsRequired: next.step5?.materialLotsRequired ?? false,
+          serializedMaterial: next.step5?.serializedMaterial ?? false,
+          icnScanRequired: next.step5?.icnScanRequired ?? false,
+          expirationBlocking: next.step5?.expirationBlocking ?? false,
+          outTimeTracking: next.step5?.outTimeTracking ?? false,
+          customerSuppliedMaterial: next.step5?.customerSuppliedMaterial ?? false,
+          certsRequired: next.step5?.certsRequired ?? false,
+          materialSpendCap: materialBudget,
+          outsideProcessingCap: next.step5?.outsideProcessingCap ?? 0,
+          materialOverrunRule: next.step5?.materialOverrunRule ?? 'REQUIRE_APPROVAL',
+          outsideProcessingRule: next.step5?.outsideProcessingRule ?? 'REQUIRE_APPROVAL',
+          notes: next.step5?.notes ?? 'Seeded from project ROM material budget.',
+        };
       }
       if (scopeOperation && next.step4?.chargeCodes?.length) {
         const currentRows = next.step4.chargeCodes;

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -70,6 +70,26 @@ import {
 } from 'lucide-react';
 import { format, formatDistanceToNow } from 'date-fns';
 
+const ROM_CATEGORY_CONFIG = [
+  { key: 'labor', label: 'Labor', field: 'quotedHours', kind: 'hours', detail: 'Direct labor estimate from ROM/quote feedback' },
+  { key: 'material', label: 'Material', field: 'budgetAmount', kind: 'currency', detail: 'Material budget that will seed the WAD' },
+  { key: 'outsideProcessing', label: 'Outside Processing', field: 'budgetAmount', kind: 'currency', detail: 'Vendor services and outside operations' },
+  { key: 'nrc', label: 'NRC', field: 'budgetAmount', kind: 'currency', detail: 'Non-recurring cost' },
+  { key: 'tooling', label: 'Tooling', field: 'budgetAmount', kind: 'currency', detail: 'Tooling budget' },
+  { key: 'design', label: 'Design', field: 'budgetAmount', kind: 'currency', detail: 'Design labor and engineering budget' },
+  { key: 'capital', label: 'Capital', field: 'budgetAmount', kind: 'currency', detail: 'Assets, startup services, and startup labor' },
+  { key: 'generalAndAdmin', label: 'G&A', field: 'budgetAmount', kind: 'currency', detail: 'General and administrative burden' },
+  { key: 'overhead', label: 'Overhead', field: 'budgetAmount', kind: 'currency', detail: 'Indirect cost burden' },
+  { key: 'qualityAndCompliance', label: 'Quality and Compliance', field: 'budgetAmount', kind: 'currency', detail: 'Inspection, compliance, and quality planning' },
+  { key: 'shippingAndPackaging', label: 'Shipping and Packaging', field: 'budgetAmount', kind: 'currency', detail: 'Pack, ship, freight, and documentation' },
+  { key: 'contingency', label: 'Contingency', field: 'budgetAmount', kind: 'currency', detail: 'Risk reserve' },
+  { key: 'escalationAndInflation', label: 'Escalation and Inflation', field: 'budgetAmount', kind: 'currency', detail: 'Schedule and pricing escalation' },
+  { key: 'profitFee', label: 'Profit / Fee', field: 'budgetAmount', kind: 'currency', detail: 'Quote profit or fee target' },
+] as const;
+
+type RomCategoryKey = typeof ROM_CATEGORY_CONFIG[number]['key'];
+type RomCategoryField = typeof ROM_CATEGORY_CONFIG[number]['field'];
+
 interface ProjectStep {
   id: string;
   stepType: string;
@@ -485,6 +505,13 @@ export default function ProjectDetailPage() {
     revisedLineItems: [] as P2PurchaseOrderItem[],
   });
   const [showProjectPOWizard, setShowProjectPOWizard] = useState(false);
+  const [romForm, setRomForm] = useState({
+    summary: '',
+    assumptions: '',
+    riskNotes: '',
+    categories: {} as Record<string, Record<string, string>>,
+  });
+  const [romFormHydratedKey, setRomFormHydratedKey] = useState('');
 
   const linkedProjectPO = useMemo(() => {
     if (!project?.poId) return null;
@@ -879,6 +906,26 @@ export default function ProjectDetailPage() {
     const hours = Number(value);
     return Number.isFinite(hours) ? `${hours.toLocaleString()} hrs` : fallback;
   };
+  const romSummary = hubRom.summary ?? {};
+  const romDraft = hubRom.draft ?? null;
+  const romLockState = hubRom.lockState ?? { locked: Boolean(romSummary.locked), reason: romSummary.lockedReason ?? null };
+  const isRomLocked = Boolean(romLockState.locked || romSummary.locked);
+  const getRomCategoryValue = (categoryKey: RomCategoryKey, field: RomCategoryField) => {
+    const value = hubRom.categories?.[categoryKey]?.[field];
+    return value === null || value === undefined ? '' : String(value);
+  };
+  const buildRomFormFromHub = () => {
+    const categories = ROM_CATEGORY_CONFIG.reduce((acc, category) => {
+      acc[category.key] = { [category.field]: getRomCategoryValue(category.key, category.field) };
+      return acc;
+    }, {} as Record<string, Record<string, string>>);
+    return {
+      summary: romSummary.draftSummary ?? romDraft?.summary ?? '',
+      assumptions: romSummary.assumptions ?? romDraft?.assumptions ?? '',
+      riskNotes: romSummary.riskNotes ?? romDraft?.risk_notes ?? romDraft?.riskNotes ?? '',
+      categories,
+    };
+  };
   const { data: quoteFeedback, isLoading: isLoadingFeedback } = useQuery<QuoteExecutionFeedback | null>({
     queryKey: ['/api/projects', id, 'quote-feedback'],
     queryFn: () =>
@@ -888,6 +935,35 @@ export default function ProjectDetailPage() {
         return r.json();
       }),
     enabled: !!id,
+  });
+
+  useEffect(() => {
+    const hydrateKey = `${id ?? ''}:${romDraft?.id ?? 'default'}:${romSummary.updatedAt ?? ''}:${JSON.stringify(hubRom.categories ?? {})}`;
+    if (!id || hydrateKey === romFormHydratedKey) return;
+    setRomForm(buildRomFormFromHub());
+    setRomFormHydratedKey(hydrateKey);
+  }, [id, romDraft?.id, romSummary.updatedAt, hubRom.categories, romFormHydratedKey]);
+
+  const saveRomMutation = useMutation({
+    mutationFn: () =>
+      apiRequest(`/api/projects/${id}/rom-draft`, {
+        method: 'PATCH',
+        body: {
+          summary: romForm.summary,
+          assumptions: romForm.assumptions,
+          riskNotes: romForm.riskNotes,
+          categories: romForm.categories,
+        },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'p2-hub'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/work-orders/project', id] });
+      toast({ title: 'ROM draft saved', description: 'WAD creation will use the updated ROM values.' });
+    },
+    onError: (err: any) => {
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'p2-hub'] });
+      toast({ title: 'ROM save failed', description: err?.message || 'The ROM may be locked after award.', variant: 'destructive' });
+    },
   });
 
   const romCategories = [
@@ -901,16 +977,16 @@ export default function ProjectDetailPage() {
       value: formatCurrencyLabel(hubRom.categories?.material?.budgetAmount, 'Not set'),
       detail: 'Material budget from WAD/project work orders',
     },
-    { label: 'Outside Processing', value: formatCurrencyLabel(hubRom.categories?.outsideProcessing), detail: 'Vendor services and outside operations' },
-    { label: 'NRC / Tooling / Design', value: formatCurrencyLabel(hubRom.categories?.nrc), detail: 'Non-recurring cost, tooling, and design labor' },
-    { label: 'Capital', value: formatCurrencyLabel(hubRom.categories?.capital), detail: 'Assets, startup services, and startup labor' },
-    { label: 'G&A', value: formatCurrencyLabel(hubRom.categories?.generalAndAdmin), detail: 'General and administrative burden' },
-    { label: 'Overhead', value: formatCurrencyLabel(hubRom.categories?.overhead), detail: 'Indirect cost burden' },
-    { label: 'Quality and Compliance', value: formatCurrencyLabel(hubRom.categories?.qualityAndCompliance), detail: 'Inspection, compliance, and quality planning' },
-    { label: 'Shipping and Packaging', value: formatCurrencyLabel(hubRom.categories?.shippingAndPackaging), detail: 'Pack, ship, freight, and documentation' },
-    { label: 'Contingency', value: formatCurrencyLabel(hubRom.categories?.contingency), detail: 'Risk reserve' },
-    { label: 'Escalation and Inflation', value: formatCurrencyLabel(hubRom.categories?.escalationAndInflation), detail: 'Schedule and pricing escalation' },
-    { label: 'Profit / Fee', value: formatCurrencyLabel(hubRom.categories?.profitFee), detail: 'Quote profit or fee target' },
+    { label: 'Outside Processing', value: formatCurrencyLabel(hubRom.categories?.outsideProcessing?.budgetAmount), detail: 'Vendor services and outside operations' },
+    { label: 'NRC / Tooling / Design', value: formatCurrencyLabel(hubRom.categories?.nrc?.budgetAmount), detail: 'Non-recurring cost, tooling, and design labor' },
+    { label: 'Capital', value: formatCurrencyLabel(hubRom.categories?.capital?.budgetAmount), detail: 'Assets, startup services, and startup labor' },
+    { label: 'G&A', value: formatCurrencyLabel(hubRom.categories?.generalAndAdmin?.budgetAmount), detail: 'General and administrative burden' },
+    { label: 'Overhead', value: formatCurrencyLabel(hubRom.categories?.overhead?.budgetAmount), detail: 'Indirect cost burden' },
+    { label: 'Quality and Compliance', value: formatCurrencyLabel(hubRom.categories?.qualityAndCompliance?.budgetAmount), detail: 'Inspection, compliance, and quality planning' },
+    { label: 'Shipping and Packaging', value: formatCurrencyLabel(hubRom.categories?.shippingAndPackaging?.budgetAmount), detail: 'Pack, ship, freight, and documentation' },
+    { label: 'Contingency', value: formatCurrencyLabel(hubRom.categories?.contingency?.budgetAmount), detail: 'Risk reserve' },
+    { label: 'Escalation and Inflation', value: formatCurrencyLabel(hubRom.categories?.escalationAndInflation?.budgetAmount), detail: 'Schedule and pricing escalation' },
+    { label: 'Profit / Fee', value: formatCurrencyLabel(hubRom.categories?.profitFee?.budgetAmount), detail: 'Quote profit or fee target' },
   ];
 
   const { data: projectFarFlowdowns = [] } = useQuery<ProjectFarFlowdown[]>({
@@ -3124,6 +3200,90 @@ export default function ProjectDetailPage() {
                   <p className="text-sm text-muted-foreground">{quoteFeedback.summary}</p>
                 </div>
               )}
+
+              <div className="rounded-md border p-4 space-y-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">ROM Draft</p>
+                    <p className="text-sm text-muted-foreground">
+                      Editable until PO/contract award. Saved ROM values auto-fill the WAD when it is created.
+                    </p>
+                  </div>
+                  <Badge variant={isRomLocked ? 'secondary' : 'outline'} className="gap-1">
+                    {isRomLocked ? <Lock className="h-3 w-3" /> : <Edit className="h-3 w-3" />}
+                    {isRomLocked ? 'Locked after award' : 'Draft editable'}
+                  </Badge>
+                </div>
+                {isRomLocked && (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+                    {romLockState.reason || romSummary.lockedReason || 'PO/contract award has locked this ROM.'}
+                  </div>
+                )}
+                <div className="grid gap-3 md:grid-cols-3">
+                  <div className="space-y-2 md:col-span-3">
+                    <Label>ROM summary</Label>
+                    <Textarea
+                      value={romForm.summary}
+                      onChange={(event) => setRomForm((current) => ({ ...current, summary: event.target.value }))}
+                      disabled={isRomLocked}
+                      placeholder="Scope, pricing basis, and award assumptions"
+                    />
+                  </div>
+                  <div className="space-y-2 md:col-span-3">
+                    <Label>Assumptions</Label>
+                    <Textarea
+                      value={romForm.assumptions}
+                      onChange={(event) => setRomForm((current) => ({ ...current, assumptions: event.target.value }))}
+                      disabled={isRomLocked}
+                      placeholder="Customer, schedule, material, and routing assumptions"
+                    />
+                  </div>
+                  <div className="space-y-2 md:col-span-3">
+                    <Label>Risk notes</Label>
+                    <Textarea
+                      value={romForm.riskNotes}
+                      onChange={(event) => setRomForm((current) => ({ ...current, riskNotes: event.target.value }))}
+                      disabled={isRomLocked}
+                      placeholder="Risks that WAD planning should inherit"
+                    />
+                  </div>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                  {ROM_CATEGORY_CONFIG.map((category) => (
+                    <div key={category.key} className="space-y-2">
+                      <Label>{category.label}</Label>
+                      <Input
+                        type="number"
+                        min="0"
+                        step={category.kind === 'hours' ? '0.1' : '0.01'}
+                        value={romForm.categories[category.key]?.[category.field] ?? ''}
+                        onChange={(event) => setRomForm((current) => ({
+                          ...current,
+                          categories: {
+                            ...current.categories,
+                            [category.key]: {
+                              ...(current.categories[category.key] ?? {}),
+                              [category.field]: event.target.value,
+                            },
+                          },
+                        }))}
+                        disabled={isRomLocked}
+                        placeholder={category.kind === 'hours' ? 'Hours' : 'USD'}
+                      />
+                      <p className="text-xs text-muted-foreground">{category.detail}</p>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex justify-end">
+                  <Button
+                    onClick={() => saveRomMutation.mutate()}
+                    disabled={isRomLocked || saveRomMutation.isPending}
+                  >
+                    {saveRomMutation.isPending ? <RefreshCw className="h-4 w-4 mr-2 animate-spin" /> : <Save className="h-4 w-4 mr-2" />}
+                    Save ROM Draft
+                  </Button>
+                </div>
+              </div>
 
               <div className="grid gap-3 md:grid-cols-3">
                 <div className="rounded-md border bg-muted/30 p-3">

--- a/migrations/0181_project_rom_drafts.sql
+++ b/migrations/0181_project_rom_drafts.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS project_rom_drafts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  status text NOT NULL DEFAULT 'draft',
+  summary text,
+  assumptions text,
+  risk_notes text,
+  categories jsonb NOT NULL DEFAULT '{}'::jsonb,
+  locked_at timestamp,
+  locked_reason text,
+  created_by integer REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name text,
+  updated_by integer REFERENCES users(id) ON DELETE SET NULL,
+  updated_by_display_name text,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now(),
+  CONSTRAINT project_rom_drafts_project_unique UNIQUE (project_id),
+  CONSTRAINT project_rom_drafts_status_check CHECK (status IN ('draft', 'locked'))
+);
+
+CREATE INDEX IF NOT EXISTS project_rom_drafts_project_idx ON project_rom_drafts(project_id);
+CREATE INDEX IF NOT EXISTS project_rom_drafts_status_idx ON project_rom_drafts(status);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -5308,6 +5308,37 @@ export const p2PurchaseOrderItems = pgTable('p2_purchase_order_items', {
   updatedAt: timestamp('updated_at').defaultNow(),
 });
 
+export const projectRomDrafts = pgTable('project_rom_drafts', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  projectId: uuid('project_id').notNull().references((): AnyPgColumn => projects.id, { onDelete: 'cascade' }).unique(),
+  status: text('status').notNull().default('draft'),
+  summary: text('summary'),
+  assumptions: text('assumptions'),
+  riskNotes: text('risk_notes'),
+  categories: jsonb('categories').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  lockedAt: timestamp('locked_at'),
+  lockedReason: text('locked_reason'),
+  createdBy: integer('created_by').references((): AnyPgColumn => users.id, { onDelete: 'set null' }),
+  createdByDisplayName: text('created_by_display_name'),
+  updatedBy: integer('updated_by').references((): AnyPgColumn => users.id, { onDelete: 'set null' }),
+  updatedByDisplayName: text('updated_by_display_name'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+}, (table) => ({
+  projectIdx: index('project_rom_drafts_project_idx').on(table.projectId),
+  statusIdx: index('project_rom_drafts_status_idx').on(table.status),
+}));
+
+export const insertProjectRomDraftSchema = createInsertSchema(projectRomDrafts).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  lockedAt: true,
+});
+
+export type ProjectRomDraft = typeof projectRomDrafts.$inferSelect;
+export type InsertProjectRomDraft = z.infer<typeof insertProjectRomDraftSchema>;
+
 // RFQ Risk Assessments - stores RFQ risk assessment records
 export const rfqRiskAssessments = pgTable('rfq_risk_assessments', {
   id: serial('id').primaryKey(),

--- a/server/src/lib/wadHelper.ts
+++ b/server/src/lib/wadHelper.ts
@@ -7,6 +7,7 @@ import {
   quoteLineItems,
   p2PurchaseOrders,
   p2PurchaseOrderItems,
+  projectRomDrafts,
   bomDefinitions,
   bomItems,
   partRoutings,
@@ -19,6 +20,7 @@ import { cancelWadWorkOrdersSupersededByP2 } from '../services/wadSupersedeServi
 export interface WadSeedData {
   partNumber: string | null;
   totalBudgetHours: string | null;
+  materialBudgetAmount: string | null;
   departmentBudgets: Record<string, number> | null;
   description: string | null;
   quantity: number | null;
@@ -28,6 +30,7 @@ export interface WadSeedData {
     poId: number | null;
     bomDefinitionId: string | null;
     routingId: string | null;
+    romDraftId: string | null;
     quoteLineItemCount: number;
     poLineItemCount: number;
     bomItemCount: number;
@@ -97,6 +100,7 @@ const productionWorkOrderReadColumns = {
   status: productionWorkOrders.status,
   departmentBudgets: productionWorkOrders.departmentBudgets,
   totalBudgetHours: productionWorkOrders.totalBudgetHours,
+  materialBudgetAmount: productionWorkOrders.materialBudgetAmount,
   startDate: productionWorkOrders.startDate,
   dueDate: productionWorkOrders.dueDate,
   warningThreshold: productionWorkOrders.warningThreshold,
@@ -115,6 +119,17 @@ const productionWorkOrderReadColumns = {
 
 function withDefaultMaterialBudgetAmount(row: Record<string, unknown>): ProductionWorkOrder {
   return { ...row, materialBudgetAmount: '0' } as ProductionWorkOrder;
+}
+
+function getRomCategoryNumber(categories: Record<string, any> | null | undefined, category: string, key = 'budgetAmount'): number | null {
+  const value = categories?.[category]?.[key];
+  if (value === null || value === undefined || value === '') return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function formatRomCurrency(value: number | null): string | null {
+  return value == null ? null : value.toFixed(2);
 }
 
 /**
@@ -240,6 +255,17 @@ export async function ensureProjectHasWADFromCanonicalSources(
       throw new Error(`Project ${projectId} not found`);
     }
 
+    const [romDraft] = await tx
+      .select()
+      .from(projectRomDrafts)
+      .where(eq(projectRomDrafts.projectId, projectId))
+      .limit(1);
+    const romCategories = (romDraft?.categories && typeof romDraft.categories === 'object'
+      ? romDraft.categories
+      : {}) as Record<string, any>;
+    const romLaborHours = getRomCategoryNumber(romCategories, 'labor', 'quotedHours');
+    const romMaterialBudget = getRomCategoryNumber(romCategories, 'material');
+
     // Source 1: originating quote line items (preferred — has laborHours + department).
     let quoteId: string | null = null;
     let quoteLines: QuoteLineItem[] = [];
@@ -332,10 +358,10 @@ export async function ensureProjectHasWADFromCanonicalSources(
         : null);
     const dueDate = poExpectedDelivery ?? project.targetShipDate ?? null;
 
-    // Precedence for hour budgets: quote line items → BOM labor items.
+    // Precedence for hour budgets: ROM draft → quote line items → BOM labor items.
     // Routing (zero-hour department list) is only used when neither has data,
     // so the wizard still gets pre-populated department rows from the routing.
-    const totalBudgetHours = quoteSeed.totalBudgetHours ?? bomSeed.totalBudgetHours;
+    const totalBudgetHours = romLaborHours != null ? String(romLaborHours) : (quoteSeed.totalBudgetHours ?? bomSeed.totalBudgetHours);
     let departmentBudgets = quoteSeed.departmentBudgets ?? bomSeed.departmentBudgets;
     if (!departmentBudgets && routingSeed.departments.length > 0) {
       departmentBudgets = Object.fromEntries(routingSeed.departments.map((d) => [d, 0]));
@@ -344,6 +370,7 @@ export async function ensureProjectHasWADFromCanonicalSources(
     const seedData: WadSeedData = {
       partNumber,
       totalBudgetHours,
+      materialBudgetAmount: formatRomCurrency(romMaterialBudget),
       departmentBudgets,
       description,
       quantity,
@@ -353,6 +380,7 @@ export async function ensureProjectHasWADFromCanonicalSources(
         poId,
         bomDefinitionId,
         routingId: routingSeed.routingId,
+        romDraftId: romDraft?.id ?? null,
         quoteLineItemCount: quoteLines.length,
         poLineItemCount: poLines.length,
         bomItemCount: bomItemRows.length,
@@ -372,6 +400,16 @@ export async function ensureProjectHasWADFromCanonicalSources(
       description,
       dueDate,
       totalBudgetHours: seedData.totalBudgetHours,
+      materialBudgetAmount: seedData.materialBudgetAmount ?? undefined,
+      wizardData: romDraft ? {
+        __romSeed: {
+          romDraftId: romDraft.id,
+          summary: romDraft.summary ?? null,
+          assumptions: romDraft.assumptions ?? null,
+          riskNotes: romDraft.riskNotes ?? null,
+          categories: romDraft.categories ?? {},
+        },
+      } : undefined,
       ...(seedData.departmentBudgets ? { departmentBudgets: seedData.departmentBudgets } : {}),
     });
 

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -42,6 +42,87 @@ const router = Router();
 let projectRevisionSchemaReady = false;
 let projectClinSchemaReady = false;
 
+const ROM_LOCK_STAGES = new Set(['po_received', 'p2_release', 'production', 'completed']);
+const ROM_EDITABLE_PO_STATUSES = new Set(['OPEN', 'DRAFT', 'CREATED']);
+
+function currentUserSnapshot(req: any): { id: number | null; displayName: string | null } {
+  const user = req.user ?? null;
+  const rawId = user?.id;
+  const parsedId = rawId == null ? null : Number.parseInt(String(rawId), 10);
+  return {
+    id: Number.isFinite(parsedId) ? parsedId : null,
+    displayName: user?.displayName || user?.username || null,
+  };
+}
+
+function normalizeRomNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function normalizeRomCategories(raw: unknown): Record<string, any> {
+  const source = raw && typeof raw === 'object' ? raw as Record<string, any> : {};
+  const normalizeCategory = (key: string, numericKeys: string[]) => {
+    const category = source[key] && typeof source[key] === 'object' ? source[key] : {};
+    return numericKeys.reduce((acc: Record<string, number | null>, numericKey) => {
+      acc[numericKey] = normalizeRomNumber(category[numericKey]);
+      return acc;
+    }, {});
+  };
+
+  return {
+    labor: normalizeCategory('labor', ['quotedHours']),
+    material: normalizeCategory('material', ['budgetAmount']),
+    outsideProcessing: normalizeCategory('outsideProcessing', ['budgetAmount']),
+    nrc: normalizeCategory('nrc', ['budgetAmount']),
+    tooling: normalizeCategory('tooling', ['budgetAmount']),
+    design: normalizeCategory('design', ['budgetAmount']),
+    capital: normalizeCategory('capital', ['budgetAmount']),
+    generalAndAdmin: normalizeCategory('generalAndAdmin', ['budgetAmount']),
+    overhead: normalizeCategory('overhead', ['budgetAmount']),
+    qualityAndCompliance: normalizeCategory('qualityAndCompliance', ['budgetAmount']),
+    shippingAndPackaging: normalizeCategory('shippingAndPackaging', ['budgetAmount']),
+    contingency: normalizeCategory('contingency', ['budgetAmount']),
+    escalationAndInflation: normalizeCategory('escalationAndInflation', ['budgetAmount']),
+    profitFee: normalizeCategory('profitFee', ['budgetAmount']),
+  };
+}
+
+async function getRomLockState(projectId: string) {
+  const projectRows = await pool.query(
+    `SELECT id, current_stage, po_id FROM projects WHERE id = $1 LIMIT 1`,
+    [projectId],
+  );
+  const project = projectRows.rows[0];
+  if (!project) return { project: null, locked: false, reason: null as string | null, po: null as any };
+
+  const poRows = await pool.query(
+    `SELECT id, status, locked_at
+     FROM p2_purchase_orders
+     WHERE id = $1 OR project_id = $2
+     ORDER BY locked_at DESC NULLS LAST, updated_at DESC NULLS LAST, id DESC
+     LIMIT 1`,
+    [project.po_id ?? null, projectId],
+  );
+  const po = poRows.rows[0] ?? null;
+  const stage = String(project.current_stage ?? '');
+  const poStatus = String(po?.status ?? '').toUpperCase();
+  const locked =
+    ROM_LOCK_STAGES.has(stage) ||
+    Boolean(po?.locked_at) ||
+    Boolean(po && poStatus && !ROM_EDITABLE_PO_STATUSES.has(poStatus));
+  const reason = ROM_LOCK_STAGES.has(stage)
+    ? 'Project has reached PO received/award stage.'
+    : po?.locked_at
+      ? 'Linked PO is locked.'
+      : locked
+        ? `Linked PO status is ${poStatus}.`
+        : null;
+
+  return { project, locked, reason, po };
+}
+
 async function ensureProjectRevisionSchema() {
   if (projectRevisionSchemaReady) return;
 
@@ -1842,6 +1923,79 @@ router.get('/:id/p2-gate-status', async (req, res) => {
   }
 });
 
+const romDraftBodySchema = z.object({
+  summary: z.string().trim().optional().nullable(),
+  assumptions: z.string().trim().optional().nullable(),
+  riskNotes: z.string().trim().optional().nullable(),
+  categories: z.record(z.any()).optional().default({}),
+});
+
+// PATCH /api/projects/:id/rom-draft - edit ROM draft until PO/contract award locks it.
+router.patch('/:id/rom-draft', async (req, res) => {
+  try {
+    const parsed = romDraftBodySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ message: 'Invalid ROM draft payload', details: parsed.error.flatten() });
+    }
+
+    const lockState = await getRomLockState(req.params.id);
+    if (!lockState.project) return res.status(404).json({ message: 'Project not found' });
+    if (lockState.locked) {
+      await pool.query(
+        `UPDATE project_rom_drafts
+         SET status = 'locked',
+             locked_at = COALESCE(locked_at, NOW()),
+             locked_reason = COALESCE(locked_reason, $2),
+             updated_at = NOW()
+         WHERE project_id = $1`,
+        [req.params.id, lockState.reason],
+      );
+      return res.status(409).json({ message: 'ROM is locked after PO/contract award.', lockedReason: lockState.reason });
+    }
+
+    const actor = currentUserSnapshot(req as any);
+    const categories = normalizeRomCategories(parsed.data.categories);
+    const result = await pool.query(
+      `INSERT INTO project_rom_drafts (
+         project_id, status, summary, assumptions, risk_notes, categories,
+         created_by, created_by_display_name, updated_by, updated_by_display_name
+       )
+       VALUES ($1, 'draft', $2, $3, $4, $5::jsonb, $6, $7, $6, $7)
+       ON CONFLICT (project_id) DO UPDATE
+       SET summary = EXCLUDED.summary,
+           assumptions = EXCLUDED.assumptions,
+           risk_notes = EXCLUDED.risk_notes,
+           categories = EXCLUDED.categories,
+           updated_by = EXCLUDED.updated_by,
+           updated_by_display_name = EXCLUDED.updated_by_display_name,
+           updated_at = NOW()
+       WHERE project_rom_drafts.status = 'draft'
+       RETURNING *`,
+      [
+        req.params.id,
+        parsed.data.summary || null,
+        parsed.data.assumptions || null,
+        parsed.data.riskNotes || null,
+        JSON.stringify(categories),
+        actor.id,
+        actor.displayName,
+      ],
+    );
+
+    if (!result.rows[0]) {
+      return res.status(409).json({ message: 'ROM is locked and cannot be edited.' });
+    }
+
+    res.json({
+      ...result.rows[0],
+      lockState: { locked: false, reason: null },
+    });
+  } catch (error: any) {
+    console.error('Error saving ROM draft:', error);
+    res.status(500).json({ message: 'Failed to save ROM draft', error: error.message });
+  }
+});
+
 // GET /api/projects/:id/p2-hub - read-only P2 Project Hub tab model.
 router.get('/:id/p2-hub', async (req, res) => {
   try {
@@ -1927,6 +2081,7 @@ router.get('/:id/p2-hub', async (req, res) => {
       projectRoutings,
       bomRecords,
       quoteFeedback,
+      romDraftRows,
     ] = await Promise.all([
       poIds.length > 0
         ? optionalHubQuery<any>(
@@ -2076,6 +2231,16 @@ router.get('/:id/p2-hub', async (req, res) => {
          LIMIT 1`,
         [id],
       ),
+      optionalHubQuery<any>(
+        'project ROM draft',
+        `SELECT id, project_id, status, summary, assumptions, risk_notes,
+                categories, locked_at, locked_reason, updated_at,
+                updated_by_display_name
+         FROM project_rom_drafts
+         WHERE project_id = $1
+         LIMIT 1`,
+        [id],
+      ),
     ]);
 
     const completedSteps = steps.filter((step: any) => step.status === 'completed');
@@ -2101,6 +2266,18 @@ router.get('/:id/p2-hub', async (req, res) => {
       return Number.isFinite(amount) ? sum + amount : sum;
     }, 0);
     const latestQuoteFeedback = quoteFeedback[0] ?? null;
+    const latestRomDraft = romDraftRows[0] ?? null;
+    const romLockState = await getRomLockState(id);
+    const savedRomCategories = latestRomDraft?.categories && typeof latestRomDraft.categories === 'object'
+      ? latestRomDraft.categories
+      : {};
+    const getSavedRomNumber = (category: string, key = 'budgetAmount') => {
+      const value = savedRomCategories?.[category]?.[key];
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+    const romLaborHours = getSavedRomNumber('labor', 'quotedHours') ?? latestQuoteFeedback?.quoted_labor_hours ?? null;
+    const romMaterialBudget = getSavedRomNumber('material') ?? materialBudget;
 
     return res.json({
       project,
@@ -2157,22 +2334,39 @@ router.get('/:id/p2-hub', async (req, res) => {
           revisions: projectRevisions.filter((revision: any) => revision.revisionType === 'wad'),
         },
         rom: {
-          summary: latestQuoteFeedback,
+          summary: {
+            ...(latestQuoteFeedback ?? {}),
+            draftId: latestRomDraft?.id ?? null,
+            status: romLockState.locked ? 'locked' : (latestRomDraft?.status ?? 'draft'),
+            locked: romLockState.locked,
+            lockedAt: latestRomDraft?.locked_at ?? null,
+            lockedReason: romLockState.reason ?? latestRomDraft?.locked_reason ?? null,
+            draftSummary: latestRomDraft?.summary ?? latestQuoteFeedback?.summary ?? null,
+            assumptions: latestRomDraft?.assumptions ?? null,
+            riskNotes: latestRomDraft?.risk_notes ?? null,
+            updatedAt: latestRomDraft?.updated_at ?? latestQuoteFeedback?.updated_at ?? null,
+            updatedByDisplayName: latestRomDraft?.updated_by_display_name ?? null,
+          },
+          draft: latestRomDraft,
+          lockState: {
+            locked: romLockState.locked,
+            reason: romLockState.reason,
+          },
           categories: {
-            labor: { quotedHours: latestQuoteFeedback?.quoted_labor_hours ?? null },
-            material: { budgetAmount: materialBudget },
-            outsideProcessing: null,
-            nrc: null,
-            tooling: null,
-            design: null,
-            capital: null,
-            generalAndAdmin: null,
-            overhead: null,
-            qualityAndCompliance: null,
-            shippingAndPackaging: null,
-            contingency: null,
-            escalationAndInflation: null,
-            profitFee: null,
+            labor: { quotedHours: romLaborHours },
+            material: { budgetAmount: romMaterialBudget },
+            outsideProcessing: { budgetAmount: getSavedRomNumber('outsideProcessing') },
+            nrc: { budgetAmount: getSavedRomNumber('nrc') },
+            tooling: { budgetAmount: getSavedRomNumber('tooling') },
+            design: { budgetAmount: getSavedRomNumber('design') },
+            capital: { budgetAmount: getSavedRomNumber('capital') },
+            generalAndAdmin: { budgetAmount: getSavedRomNumber('generalAndAdmin') },
+            overhead: { budgetAmount: getSavedRomNumber('overhead') },
+            qualityAndCompliance: { budgetAmount: getSavedRomNumber('qualityAndCompliance') },
+            shippingAndPackaging: { budgetAmount: getSavedRomNumber('shippingAndPackaging') },
+            contingency: { budgetAmount: getSavedRomNumber('contingency') },
+            escalationAndInflation: { budgetAmount: getSavedRomNumber('escalationAndInflation') },
+            profitFee: { budgetAmount: getSavedRomNumber('profitFee') },
           },
         },
         production: {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -885,6 +885,7 @@ const productionWorkOrderReadColumns = {
   status: productionWorkOrders.status,
   departmentBudgets: productionWorkOrders.departmentBudgets,
   totalBudgetHours: productionWorkOrders.totalBudgetHours,
+  materialBudgetAmount: productionWorkOrders.materialBudgetAmount,
   startDate: productionWorkOrders.startDate,
   dueDate: productionWorkOrders.dueDate,
   warningThreshold: productionWorkOrders.warningThreshold,
@@ -902,7 +903,7 @@ const productionWorkOrderReadColumns = {
 };
 
 function withDefaultMaterialBudgetAmount<T extends Record<string, unknown>>(row: T | undefined): (T & { materialBudgetAmount: string }) | undefined {
-  return row ? ({ ...row, materialBudgetAmount: '0' } as T & { materialBudgetAmount: string }) : undefined;
+  return row ? ({ ...row, materialBudgetAmount: row.materialBudgetAmount ?? '0' } as T & { materialBudgetAmount: string }) : undefined;
 }
 
 type P1OrderNoteParts = {


### PR DESCRIPTION
## Summary
- Add persisted project ROM drafts with a lock state after PO/contract award.
- Make the P2 Project ROM tab a summary-first editable draft surface until it locks.
- Save ROM category values, assumptions, and risk notes through a project ROM draft API.
- Feed saved ROM labor/material values into WAD creation and WAD Step 5 material planning defaults.

## Validation
- `git diff --check origin/main..HEAD` passed.
- `git diff --cached --check` passed before commit.
- `npm run check` could not be run locally because `npm` is not available on PATH and this clean worktree has no `node_modules`.