### PR TITLE
[codex] Show actual project production placement

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -800,13 +800,15 @@ export default function ProjectDetailPage() {
   const hubRom = hubTabs.rom ?? {};
   const hubProduction = hubTabs.production ?? {};
   const productionSummary = hubProduction.summary ?? {};
-  const projectProductionOrders = Array.isArray(hubProduction.productionOrders) ? hubProduction.productionOrders : [];
   const projectSerializedItems = Array.isArray(hubProduction.serializedItems) ? hubProduction.serializedItems : traceabilitySerials;
+  const productionLinePlacements = Array.isArray(hubProduction.poLinePlacements) ? hubProduction.poLinePlacements : [];
   const productionAssemblyTree = hubProduction.assemblyTree ?? {};
   const assemblyPoItems = Array.isArray(productionAssemblyTree.poItems) ? productionAssemblyTree.poItems : [];
-  const productionStatusCounts = projectProductionOrders.reduce((counts: Record<string, number>, order: any) => {
-    const status = String(order.status || 'Unknown');
-    counts[status] = (counts[status] ?? 0) + 1;
+  const productionPlacementCounts = productionLinePlacements.reduce((counts: Record<string, number>, line: any) => {
+    Object.entries(line.placementCounts ?? {}).forEach(([placement, count]) => {
+      const numericCount = Number(count);
+      counts[placement] = (counts[placement] ?? 0) + (Number.isFinite(numericCount) ? numericCount : 0);
+    });
     return counts;
   }, {});
   const hubMaterial = hubTabs.material ?? {};
@@ -905,6 +907,10 @@ export default function ProjectDetailPage() {
     if (value === null || value === undefined || value === '') return fallback;
     const hours = Number(value);
     return Number.isFinite(hours) ? `${hours.toLocaleString()} hrs` : fallback;
+  };
+  const formatQuantityLabel = (value: unknown) => {
+    const quantity = Number(value ?? 0);
+    return Number.isFinite(quantity) ? quantity.toLocaleString() : '0';
   };
   const romSummary = hubRom.summary ?? {};
   const romDraft = hubRom.draft ?? null;
@@ -3326,20 +3332,20 @@ export default function ProjectDetailPage() {
             <CardContent className="space-y-4">
               <div className="grid gap-3 md:grid-cols-4">
                 <div className="rounded-md border bg-muted/30 p-3">
-                  <p className="text-xs text-muted-foreground">Production Orders</p>
-                  <p className="font-medium">{productionSummary.productionOrderCount ?? projectProductionOrders.length}</p>
+                  <p className="text-xs text-muted-foreground">PO Quantity</p>
+                  <p className="font-medium">{formatQuantityLabel(productionSummary.orderedQuantity)}</p>
                 </div>
                 <div className="rounded-md border bg-muted/30 p-3">
-                  <p className="text-xs text-muted-foreground">Serialized Parts</p>
-                  <p className="font-medium">{productionSummary.serializedCount ?? projectSerializedItems.length}</p>
+                  <p className="text-xs text-muted-foreground">In Production</p>
+                  <p className="font-medium">{formatQuantityLabel(Number(productionSummary.serializedQuantity ?? projectSerializedItems.length) - Number(productionSummary.completedQuantity ?? productionSummary.completedSerializedCount ?? 0))}</p>
                 </div>
                 <div className="rounded-md border bg-muted/30 p-3">
-                  <p className="text-xs text-muted-foreground">Completed Serialized</p>
-                  <p className="font-medium">{productionSummary.completedSerializedCount ?? 0}</p>
+                  <p className="text-xs text-muted-foreground">Completed</p>
+                  <p className="font-medium">{formatQuantityLabel(productionSummary.completedQuantity ?? productionSummary.completedSerializedCount)}</p>
                 </div>
                 <div className="rounded-md border bg-muted/30 p-3">
-                  <p className="text-xs text-muted-foreground">Assembly Lines</p>
-                  <p className="font-medium">{assemblyPoItems.length}</p>
+                  <p className="text-xs text-muted-foreground">Remaining on PO</p>
+                  <p className="font-medium">{formatQuantityLabel(productionSummary.remainingQuantity)}</p>
                 </div>
               </div>
               <div className="flex flex-wrap gap-2">
@@ -3364,16 +3370,161 @@ export default function ProjectDetailPage() {
                   BOM/Routing
                 </Button>
               </div>
-              {Object.keys(productionStatusCounts).length > 0 && (
+              {Object.keys(productionPlacementCounts).length > 0 && (
                 <div className="flex flex-wrap gap-2">
-                  {Object.entries(productionStatusCounts).map(([status, count]) => (
-                    <Badge key={status} variant="outline">
-                      {status}: {count}
+                  {Object.entries(productionPlacementCounts).map(([placement, count]) => (
+                    <Badge key={placement} variant="outline">
+                      {placement}: {formatQuantityLabel(count)}
                     </Badge>
                   ))}
                 </div>
               )}
-              {Array.isArray(hubProduction.productionOrders) && hubProduction.productionOrders.length > 0 ? (
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h3 className="text-base font-semibold">PO Line Production Placement</h3>
+                    <p className="text-sm text-muted-foreground">Current production placement, remaining PO quantity, and work orders by part.</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="secondary">{formatQuantityLabel(productionLinePlacements.length)} PO lines</Badge>
+                    <Badge variant="outline">{formatQuantityLabel(productionSummary.workOrderCount ?? wadWorkOrders.length)} work orders</Badge>
+                  </div>
+                </div>
+                {productionLinePlacements.length === 0 ? (
+                  <p className="rounded-md border p-3 text-sm text-muted-foreground">No current PO line production placement is available yet.</p>
+                ) : (
+                  productionLinePlacements.map((line: any) => {
+                    const lineWorkOrders = Array.isArray(line.workOrders) ? line.workOrders : [];
+                    const lineProductionOrders = Array.isArray(line.productionOrders) ? line.productionOrders : [];
+                    const lineSerializedItems = Array.isArray(line.serializedItems) ? line.serializedItems : [];
+                    const inProductionQuantity = Math.max(0, Number(line.serializedQuantity ?? 0) - Number(line.completedQuantity ?? 0));
+
+                    return (
+                      <div key={line.poItemId ?? line.partNumber} className="rounded-md border p-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="font-mono text-sm font-semibold">{line.partNumber ?? 'Unassigned part'}</p>
+                            <p className="text-sm text-muted-foreground">{line.partName ?? 'No description'}</p>
+                          </div>
+                          <div className="grid grid-cols-2 gap-2 text-right sm:grid-cols-4">
+                            <div>
+                              <p className="text-xs text-muted-foreground">PO Qty</p>
+                              <p className="font-medium">{formatQuantityLabel(line.orderedQuantity)}</p>
+                            </div>
+                            <div>
+                              <p className="text-xs text-muted-foreground">In Prod</p>
+                              <p className="font-medium">{formatQuantityLabel(inProductionQuantity)}</p>
+                            </div>
+                            <div>
+                              <p className="text-xs text-muted-foreground">Complete</p>
+                              <p className="font-medium">{formatQuantityLabel(line.completedQuantity)}</p>
+                            </div>
+                            <div>
+                              <p className="text-xs text-muted-foreground">Remain</p>
+                              <p className="font-medium">{formatQuantityLabel(line.remainingQuantity)}</p>
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {Object.entries(line.placementCounts ?? {}).map(([placement, count]) => (
+                            <Badge key={placement} variant={placement === 'Completed' ? 'default' : 'outline'}>
+                              {placement}: {formatQuantityLabel(count)}
+                            </Badge>
+                          ))}
+                          {Object.keys(line.placementCounts ?? {}).length === 0 && (
+                            <Badge variant="outline">No production placement</Badge>
+                          )}
+                        </div>
+
+                        <div className="mt-4 grid gap-3 xl:grid-cols-3">
+                          <div className="rounded-md border bg-muted/20 p-3">
+                            <div className="mb-2 flex items-center justify-between gap-2">
+                              <p className="text-sm font-medium">Serialized / Traveler Status</p>
+                              <Badge variant="secondary">{formatQuantityLabel(lineSerializedItems.length)}</Badge>
+                            </div>
+                            {lineSerializedItems.length === 0 ? (
+                              <p className="text-sm text-muted-foreground">No serialized items have been released for this line.</p>
+                            ) : (
+                              <div className="space-y-2">
+                                {lineSerializedItems.slice(0, 5).map((item: any) => (
+                                  <div key={item.id} className="flex items-center justify-between gap-2 rounded-md border bg-background p-2">
+                                    <div className="min-w-0">
+                                      <p className="truncate font-mono text-sm">{item.serial_number ?? item.serialNumber ?? item.barcode}</p>
+                                      <p className="truncate text-xs text-muted-foreground">
+                                        Traveler {item.activeTravelerNumber ?? item.traveler_barcode ?? item.travelerBarcode ?? 'not linked'}
+                                      </p>
+                                    </div>
+                                    <Badge variant="outline">{item.productionPlacement ?? item.current_department ?? item.status ?? 'Unknown'}</Badge>
+                                  </div>
+                                ))}
+                                {lineSerializedItems.length > 5 && (
+                                  <p className="text-xs text-muted-foreground">+{formatQuantityLabel(lineSerializedItems.length - 5)} more serialized items</p>
+                                )}
+                              </div>
+                            )}
+                          </div>
+
+                          <div className="rounded-md border bg-muted/20 p-3">
+                            <div className="mb-2 flex items-center justify-between gap-2">
+                              <p className="text-sm font-medium">Associated Work Orders</p>
+                              <Badge variant="secondary">{formatQuantityLabel(lineWorkOrders.length)}</Badge>
+                            </div>
+                            {lineWorkOrders.length === 0 ? (
+                              <p className="text-sm text-muted-foreground">No WAD/work orders are linked to this part yet.</p>
+                            ) : (
+                              <div className="space-y-2">
+                                {lineWorkOrders.slice(0, 5).map((wo: any) => (
+                                  <div key={wo.id ?? wo.workOrderNumber} className="rounded-md border bg-background p-2">
+                                    <div className="flex items-center justify-between gap-2">
+                                      <p className="truncate font-medium">{wo.workOrderNumber ?? wo.work_order_number}</p>
+                                      <Badge variant="outline">{wo.status ?? 'Unknown'}</Badge>
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                      Qty {formatQuantityLabel(wo.quantity)} - Due {formatDateLabel(wo.dueDate ?? wo.due_date)}
+                                    </p>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+
+                          <div className="rounded-md border bg-muted/20 p-3">
+                            <div className="mb-2 flex items-center justify-between gap-2">
+                              <p className="text-sm font-medium">Production Orders</p>
+                              <Badge variant="secondary">{formatQuantityLabel(lineProductionOrders.length)}</Badge>
+                            </div>
+                            {lineProductionOrders.length === 0 ? (
+                              <p className="text-sm text-muted-foreground">No generated production-order rows are linked to this PO line.</p>
+                            ) : (
+                              <div className="space-y-2">
+                                {lineProductionOrders.slice(0, 5).map((order: any) => (
+                                  <div key={order.id} className="rounded-md border bg-background p-2">
+                                    <div className="flex items-center justify-between gap-2">
+                                      <p className="truncate font-medium">{order.order_id}</p>
+                                      <Badge variant="outline">{order.status ?? 'Unknown'}</Badge>
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                      Qty {formatQuantityLabel(order.quantity)} - Made {formatQuantityLabel(order.quantity_manufactured)}
+                                    </p>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+                {assemblyBomRecords.length > 0 && (
+                  <div className="rounded-md border bg-muted/30 p-3">
+                    <p className="text-xs text-muted-foreground">BOM Records Available</p>
+                    <p className="font-medium">{formatQuantityLabel(assemblyBomRecords.length)}</p>
+                  </div>
+                )}
+              </div>
+              {productionLinePlacements.length < 0 && (Array.isArray(hubProduction.productionOrders) && hubProduction.productionOrders.length > 0 ? (
                 <div className="space-y-2">
                   {hubProduction.productionOrders.slice(0, 8).map((order: any) => (
                     <div key={order.id} className="flex items-center justify-between rounded-md border p-3">
@@ -3387,7 +3538,8 @@ export default function ProjectDetailPage() {
                 </div>
               ) : (
                 <p className="text-sm text-muted-foreground">No P2 production orders are linked yet.</p>
-              )}
+              ))}
+              {productionLinePlacements.length < 0 && (
               <div className="grid gap-4 xl:grid-cols-2">
                 <Card>
                   <CardHeader className="pb-3">
@@ -3449,6 +3601,7 @@ export default function ProjectDetailPage() {
                   </CardContent>
                 </Card>
               </div>
+              ))}
             </CardContent>
           </Card>
         </TabsContent>

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -2102,8 +2102,35 @@ router.get('/:id/p2-hub', async (req, res) => {
             `SELECT id, serial_number, barcode, po_id, po_item_id, po_number,
                     part_number, part_name, current_department, status, completed_at,
                     finalized_at, part_routing_id, traveler_barcode, sku,
-                    sequence_number, created_at, updated_at
+                    sequence_number, created_at, updated_at,
+                    active_traveler.traveler_number AS active_traveler_number,
+                    active_traveler.status AS active_traveler_status,
+                    active_traveler.department_name AS active_traveler_department,
+                    active_traveler.started_at AS active_traveler_started_at
              FROM p2_serialized_items
+             LEFT JOIN LATERAL (
+               SELECT t.traveler_number, t.status, active_step.department_name, active_step.started_at
+               FROM travelers t
+               LEFT JOIN LATERAL (
+                 SELECT ts.department_name, ts.started_at
+                 FROM traveler_steps ts
+                 WHERE ts.traveler_id = t.id
+                   AND UPPER(ts.status) IN ('IN_PROGRESS', 'ACTIVE', 'STARTED')
+                 ORDER BY ts.step_number ASC
+                 LIMIT 1
+               ) active_step ON true
+               WHERE (
+                   LOWER(TRIM(t.serial_number)) = LOWER(TRIM(p2_serialized_items.serial_number))
+                   OR LOWER(TRIM(t.serial_number)) = LOWER(TRIM(p2_serialized_items.barcode))
+                   OR LOWER(TRIM(t.lot_number)) = LOWER(TRIM(p2_serialized_items.serial_number))
+                   OR LOWER(TRIM(t.lot_number)) = LOWER(TRIM(p2_serialized_items.barcode))
+                 )
+                 AND UPPER(t.status) IN ('IN_PROGRESS', 'ACTIVE', 'STARTED', 'COMPLETED')
+               ORDER BY
+                 CASE WHEN UPPER(t.status) IN ('IN_PROGRESS', 'ACTIVE', 'STARTED') THEN 0 ELSE 1 END,
+                 t.updated_at DESC NULLS LAST
+               LIMIT 1
+             ) active_traveler ON true
              WHERE po_id = ANY($1::int[])
              ORDER BY po_number, part_number, sequence_number`,
             [poIds],
@@ -2250,9 +2277,143 @@ router.get('/:id/p2-hub', async (req, res) => {
       return bTime - aTime;
     })[0] ?? null;
     const activePoItems = activePoId ? poItems.filter((item: any) => item.po_id === activePoId) : poItems;
-    const completedSerials = serializedItems.filter((item: any) => (
-      item.status === 'COMPLETED' || item.completed_at || item.finalized_at
-    ));
+    const normalizeProductionKey = (value: unknown) => String(value ?? '').trim().toLowerCase();
+    const normalizePlacementLabel = (value: unknown) => {
+      const raw = String(value ?? '').trim();
+      if (!raw) return '';
+      const key = raw.toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ');
+      const canonical: Record<string, string> = {
+        active: 'In Production',
+        in_progress: 'In Production',
+        'in progress': 'In Production',
+        started: 'In Production',
+        scheduled: 'Scheduled',
+        pending: 'Pending',
+        completed: 'Completed',
+        complete: 'Completed',
+        finalized: 'Completed',
+        shipped: 'Shipped',
+        closed: 'Closed',
+        'pending layup': 'Pending Layup',
+        layup: 'Layup',
+        'cutting table': 'Cutting Table',
+        cnc: 'CNC',
+        finish: 'Finish',
+        paint: 'Paint',
+        'final qc': 'Final QC',
+        qc: 'Final QC',
+        shipping: 'Shipping',
+      };
+      return canonical[key] || raw;
+    };
+    const isCompletedSerializedItem = (item: any) => {
+      const status = String(item.status ?? item.active_traveler_status ?? '').toUpperCase();
+      return ['COMPLETE', 'COMPLETED', 'FINALIZED', 'SHIPPED', 'CLOSED'].includes(status)
+        || Boolean(item.completed_at || item.finalized_at);
+    };
+    const getSerializedPlacement = (item: any) => {
+      if (isCompletedSerializedItem(item)) return 'Completed';
+      return normalizePlacementLabel(
+        item.active_traveler_department
+          || item.current_department
+          || item.active_traveler_status
+          || item.status
+          || 'Not placed'
+      );
+    };
+    const completedSerials = serializedItems.filter(isCompletedSerializedItem);
+    const activePoItemIds = new Set(activePoItems.map((item: any) => Number(item.id)).filter(Number.isFinite));
+    const lineIdByPart = new Map<string, number>();
+    activePoItems.forEach((item: any) => {
+      const partKey = normalizeProductionKey(item.part_number);
+      const itemId = Number(item.id);
+      if (partKey && Number.isFinite(itemId) && !lineIdByPart.has(partKey)) {
+        lineIdByPart.set(partKey, itemId);
+      }
+    });
+    const resolveLineId = (row: any, partValue?: unknown) => {
+      const exactId = Number(row.po_item_id ?? row.p2_po_item_id);
+      if (Number.isFinite(exactId) && activePoItemIds.has(exactId)) return exactId;
+      const partKey = normalizeProductionKey(partValue ?? row.part_number ?? row.sku);
+      return partKey ? lineIdByPart.get(partKey) ?? null : null;
+    };
+    const serializedByLineId = new Map<number, any[]>();
+    serializedItems.forEach((item: any) => {
+      const lineId = resolveLineId(item);
+      if (!lineId) return;
+      const rows = serializedByLineId.get(lineId) ?? [];
+      rows.push(item);
+      serializedByLineId.set(lineId, rows);
+    });
+    const productionOrdersByLineId = new Map<number, any[]>();
+    productionOrders.forEach((order: any) => {
+      const lineId = resolveLineId(order, order.sku ?? order.part_number);
+      if (!lineId) return;
+      const rows = productionOrdersByLineId.get(lineId) ?? [];
+      rows.push(order);
+      productionOrdersByLineId.set(lineId, rows);
+    });
+    const workOrdersByPart = new Map<string, any[]>();
+    workOrders.forEach((workOrder: any) => {
+      const partKey = normalizeProductionKey(workOrder.partNumber ?? workOrder.part_number);
+      if (!partKey) return;
+      const rows = workOrdersByPart.get(partKey) ?? [];
+      rows.push(workOrder);
+      workOrdersByPart.set(partKey, rows);
+    });
+    const poLinePlacements = activePoItems.map((item: any) => {
+      const lineId = Number(item.id);
+      const lineSerializedItems = serializedByLineId.get(lineId) ?? [];
+      const lineProductionOrders = productionOrdersByLineId.get(lineId) ?? [];
+      const lineWorkOrders = workOrdersByPart.get(normalizeProductionKey(item.part_number)) ?? [];
+      const orderedQuantity = Math.max(0, Number(item.quantity ?? 0) || 0);
+      const completedQuantity = lineSerializedItems.filter(isCompletedSerializedItem).length;
+      const serializedQuantity = lineSerializedItems.length;
+      const unreleasedQuantity = Math.max(orderedQuantity - serializedQuantity, 0);
+      const remainingQuantity = Math.max(orderedQuantity - completedQuantity, 0);
+      const placementCounts = lineSerializedItems.reduce((counts: Record<string, number>, serializedItem: any) => {
+        const placement = getSerializedPlacement(serializedItem) || 'Not placed';
+        counts[placement] = (counts[placement] ?? 0) + 1;
+        return counts;
+      }, {});
+      if (unreleasedQuantity > 0) {
+        placementCounts['Not serialized / not released'] = unreleasedQuantity;
+      }
+
+      return {
+        poItemId: item.id,
+        poId: item.po_id,
+        partNumber: item.part_number,
+        partName: item.part_name,
+        orderedQuantity,
+        serializedQuantity,
+        completedQuantity,
+        remainingQuantity,
+        unreleasedQuantity,
+        placementCounts,
+        productionOrders: lineProductionOrders,
+        workOrders: lineWorkOrders,
+        serializedItems: lineSerializedItems.map((serializedItem: any) => ({
+          ...serializedItem,
+          productionPlacement: getSerializedPlacement(serializedItem),
+          activeTravelerNumber: serializedItem.active_traveler_number ?? null,
+        })),
+      };
+    });
+    const productionTotals = poLinePlacements.reduce((totals: Record<string, number>, line: any) => {
+      totals.orderedQuantity += line.orderedQuantity;
+      totals.serializedQuantity += line.serializedQuantity;
+      totals.completedQuantity += line.completedQuantity;
+      totals.remainingQuantity += line.remainingQuantity;
+      totals.unreleasedQuantity += line.unreleasedQuantity;
+      return totals;
+    }, {
+      orderedQuantity: 0,
+      serializedQuantity: 0,
+      completedQuantity: 0,
+      remainingQuantity: 0,
+      unreleasedQuantity: 0,
+    });
     const laborBudgetHours = workOrders.reduce((sum: number, workOrder: any) => {
       const hours = Number(workOrder.totalBudgetHours ?? 0);
       return Number.isFinite(hours) ? sum + hours : sum;
@@ -2374,11 +2535,14 @@ router.get('/:id/p2-hub', async (req, res) => {
             productionOrderCount: productionOrders.length,
             serializedCount: serializedItems.length,
             completedSerializedCount: completedSerials.length,
+            workOrderCount: workOrders.length,
+            ...productionTotals,
           },
+          poLinePlacements,
           productionOrders,
           serializedItems,
           assemblyTree: {
-            poItems,
+            poItems: activePoItems,
             bomRecords,
             productionOrders,
           },


### PR DESCRIPTION
## Summary
- Add a project production read model grouped by active PO line item with ordered, serialized, completed, remaining, and unreleased quantities.
- Enrich serialized production records with active traveler placement and group current placement counts by PO line.
- Show associated WAD/work orders and generated P2 production orders for each part in the Project Production tab.

## Validation
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `git diff --check origin/main..HEAD` passed.
- `npm run check` could not be run because `npm` is not available on PATH in this shell and this clean worktree has no `node_modules`.