### PR TITLE
[codex] Add WAD document coverage transition

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -785,6 +785,9 @@ export default function ProjectDetailPage() {
   const hubMaterial = hubTabs.material ?? {};
   const hubLabor = hubTabs.labor ?? {};
   const hubShippingInvoicing = hubTabs.shippingInvoicing ?? {};
+  const hubDocumentCoverage = hubTabs.documentCoverage ?? {};
+  const documentCoverageSummary = hubDocumentCoverage.summary ?? {};
+  const documentCoverageItems = Array.isArray(hubDocumentCoverage.items) ? hubDocumentCoverage.items : [];
   const hubBomRouting = hubTabs.bomRouting ?? {};
   const bomRoutingSummary = hubBomRouting.summary ?? {};
   const bomRoutingRecords = Array.isArray(hubBomRouting.bomRecords) ? hubBomRouting.bomRecords : [];
@@ -878,6 +881,35 @@ export default function ProjectDetailPage() {
     if (value === null || value === undefined || value === '') return fallback;
     const hours = Number(value);
     return Number.isFinite(hours) ? `${hours.toLocaleString()} hrs` : fallback;
+  };
+  const coverageStatusLabels: Record<string, string> = {
+    attached: 'Attached',
+    covered_by_project_data: 'Covered by project data',
+    needs_upload: 'Needs upload',
+    needs_setup: 'Needs setup',
+    needs_clarification: 'Needs clarification',
+    not_applicable: 'Not applicable',
+  };
+  const coverageStatusClass = (status: string) => {
+    switch (status) {
+      case 'attached':
+      case 'covered_by_project_data':
+        return 'bg-green-100 text-green-800 border-green-200';
+      case 'needs_upload':
+      case 'needs_setup':
+        return 'bg-amber-100 text-amber-800 border-amber-200';
+      case 'needs_clarification':
+        return 'bg-blue-100 text-blue-800 border-blue-200';
+      case 'not_applicable':
+        return 'bg-gray-100 text-gray-700 border-gray-200';
+      default:
+        return 'bg-gray-100 text-gray-700 border-gray-200';
+    }
+  };
+  const coverageStatusIcon = (status: string) => {
+    if (status === 'attached') return <Paperclip className="h-4 w-4" />;
+    if (status === 'covered_by_project_data' || status === 'not_applicable') return <CheckCircle2 className="h-4 w-4" />;
+    return <AlertCircle className="h-4 w-4" />;
   };
   const { data: quoteFeedback, isLoading: isLoadingFeedback } = useQuery<QuoteExecutionFeedback | null>({
     queryKey: ['/api/projects', id, 'quote-feedback'],
@@ -1979,6 +2011,7 @@ export default function ProjectDetailPage() {
       <Tabs defaultValue={initialTab} className="space-y-4">
         <TabsList className="flex h-auto flex-wrap justify-start">
           <TabsTrigger value="workflow" data-testid="tab-workflow">Workflow</TabsTrigger>
+          <TabsTrigger value="document-coverage" data-testid="tab-document-coverage">Document Coverage</TabsTrigger>
           <TabsTrigger value="po" data-testid="tab-po">
             <Receipt className="h-4 w-4 mr-1.5" />
             PO
@@ -2694,6 +2727,113 @@ export default function ProjectDetailPage() {
                 })()}
 
               </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="document-coverage" className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-4">
+            <div className="rounded-md border bg-muted/30 p-3">
+              <p className="text-xs text-muted-foreground">Covered</p>
+              <p className="font-medium">
+                {documentCoverageSummary.coveredItems ?? documentCoverageItems.filter((item: any) => ['attached', 'covered_by_project_data', 'not_applicable'].includes(item.status)).length}
+                {' / '}
+                {documentCoverageSummary.totalItems ?? documentCoverageItems.length}
+              </p>
+            </div>
+            <div className="rounded-md border bg-muted/30 p-3">
+              <p className="text-xs text-muted-foreground">Needs Attention</p>
+              <p className="font-medium">{documentCoverageSummary.needsAttention ?? documentCoverageItems.filter((item: any) => !['attached', 'covered_by_project_data', 'not_applicable'].includes(item.status)).length}</p>
+            </div>
+            <div className="rounded-md border bg-muted/30 p-3">
+              <p className="text-xs text-muted-foreground">Attached Files</p>
+              <p className="font-medium">{documentCoverageSummary.attachedItems ?? documentCoverageItems.filter((item: any) => item.status === 'attached').length}</p>
+            </div>
+            <div className="rounded-md border bg-muted/30 p-3">
+              <p className="text-xs text-muted-foreground">Project Data Coverage</p>
+              <p className="font-medium">{documentCoverageSummary.coveredByProjectData ?? documentCoverageItems.filter((item: any) => item.status === 'covered_by_project_data').length}</p>
+            </div>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <CardTitle className="flex items-center gap-2">
+                    <ShieldCheck className="h-5 w-5 text-green-600" />
+                    Required Document Coverage
+                  </CardTitle>
+                  <CardDescription>
+                    Shows whether each WAD/customer requirement is attached, covered by Epoch project data, or still needs setup.
+                  </CardDescription>
+                </div>
+                <Button
+                  variant="outline"
+                  onClick={() => setLocation(latestWad?.id ? `/work-orders/${latestWad.id}/wad-summary` : `/wad-wizard?search=${encodeURIComponent(project.projectCode || project.projectName || project.id)}`)}
+                  data-testid="button-open-wad-from-coverage"
+                >
+                  <ExternalLink className="h-4 w-4 mr-2" />
+                  Open WAD
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {documentCoverageItems.length === 0 ? (
+                <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                  Coverage data is still loading or unavailable for this project.
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {documentCoverageItems.map((item: any) => {
+                    const missingParts = Array.isArray(item.missingParts) ? item.missingParts : [];
+                    return (
+                      <div key={item.key} className="rounded-md border p-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0 space-y-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <p className="font-medium">{item.label}</p>
+                              <Badge variant="outline" className={coverageStatusClass(item.status)}>
+                                <span className="mr-1">{coverageStatusIcon(item.status)}</span>
+                                {coverageStatusLabels[item.status] ?? item.status}
+                              </Badge>
+                            </div>
+                            <p className="text-sm text-muted-foreground">{item.detail}</p>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {typeof item.relatedCount === 'number' && (
+                              <Badge variant="secondary">{item.relatedCount} source{item.relatedCount === 1 ? '' : 's'}</Badge>
+                            )}
+                            {item.route && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setLocation(item.route)}
+                                data-testid={`button-open-coverage-${item.key}`}
+                              >
+                                <ExternalLink className="h-4 w-4 mr-1.5" />
+                                Open
+                              </Button>
+                            )}
+                          </div>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                          <span className="rounded bg-muted px-2 py-1">Source: {item.source || 'Project record'}</span>
+                          {missingParts.slice(0, 8).map((part: string) => (
+                            <span key={part} className="rounded bg-amber-50 px-2 py-1 text-amber-800">
+                              Missing: {part}
+                            </span>
+                          ))}
+                          {missingParts.length > 8 && (
+                            <span className="rounded bg-amber-50 px-2 py-1 text-amber-800">
+                              +{missingParts.length - 8} more
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
               )}
             </CardContent>
           </Card>

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1927,6 +1927,7 @@ router.get('/:id/p2-hub', async (req, res) => {
       projectRoutings,
       bomRecords,
       quoteFeedback,
+      projectFarFlowdowns,
     ] = await Promise.all([
       poIds.length > 0
         ? optionalHubQuery<any>(
@@ -2030,13 +2031,15 @@ router.get('/:id/p2-hub', async (req, res) => {
         'part routings',
         partNumbers.length > 0
           ? `SELECT id, project_id, part_number, part_name, routing_name,
-                    routing_revision, routing_type, is_active, created_by,
+                    routing_revision, routing_type, is_active, department_config,
+                    qc_standards, created_by,
                     created_at, updated_at
              FROM part_routings
              WHERE project_id = $1 OR part_number = ANY($2::text[])
              ORDER BY is_active DESC, updated_at DESC`
           : `SELECT id, project_id, part_number, part_name, routing_name,
-                    routing_revision, routing_type, is_active, created_by,
+                    routing_revision, routing_type, is_active, department_config,
+                    qc_standards, created_by,
                     created_at, updated_at
              FROM part_routings
              WHERE project_id = $1
@@ -2076,7 +2079,42 @@ router.get('/:id/p2-hub', async (req, res) => {
          LIMIT 1`,
         [id],
       ),
+      optionalHubQuery<any>(
+        'project FAR flowdowns',
+        `SELECT pff.id, pff.project_id, pff.purchase_review_checklist_id,
+                pff.applicable, pff.reasoning, pff.source, pff.status,
+                ffc.clause_number, ffc.title
+         FROM project_far_flowdowns pff
+         JOIN far_flowdown_clauses ffc ON ffc.id = pff.clause_id
+         WHERE pff.project_id = $1
+         ORDER BY pff.created_at DESC`,
+        [id],
+      ),
     ]);
+
+    const routingIds = projectRoutings.map((routing: any) => routing.id).filter(Boolean);
+    const routingOperationSummaries = routingIds.length > 0
+      ? await optionalHubQuery<any>(
+          'routing operation summaries',
+          `SELECT part_routing_id,
+                  COUNT(*)::int AS operation_count,
+                  COUNT(*) FILTER (
+                    WHERE instruction_pack IS NOT NULL
+                      AND instruction_pack::text NOT IN ('{}', '[]', 'null', '""')
+                  )::int AS instruction_pack_count,
+                  COUNT(*) FILTER (
+                    WHERE operation_type IN ('QC', 'INSPECT')
+                  )::int AS inspection_operation_count,
+                  COUNT(*) FILTER (
+                    WHERE certificate_required = true
+                       OR receiving_inspection_required = true
+                  )::int AS material_cert_requirement_count
+           FROM routing_operations
+           WHERE part_routing_id = ANY($1::uuid[])
+           GROUP BY part_routing_id`,
+          [routingIds],
+        )
+      : [];
 
     const completedSteps = steps.filter((step: any) => step.status === 'completed');
     const latestWad = [...workOrders].sort((a: any, b: any) => {
@@ -2101,6 +2139,180 @@ router.get('/:id/p2-hub', async (req, res) => {
       return Number.isFinite(amount) ? sum + amount : sum;
     }, 0);
     const latestQuoteFeedback = quoteFeedback[0] ?? null;
+    const routeByPartNumber = new Map(
+      projectRoutings
+        .filter((routing: any) => routing.part_number)
+        .map((routing: any) => [String(routing.part_number).trim().toLowerCase(), routing]),
+    );
+    const routingOperationSummaryById = new Map(
+      routingOperationSummaries.map((summary: any) => [String(summary.part_routing_id), summary]),
+    );
+    const hasManualDocument = (...needles: string[]) => manualDocuments.some((document: any) => {
+      const haystack = [
+        document.label,
+        document.original_file_name,
+        document.mime_type,
+      ].filter(Boolean).join(' ').toLowerCase();
+      return needles.some(needle => haystack.includes(needle.toLowerCase()));
+    });
+    const stepByType = new Map(steps.map((step: any) => [step.stepType, step]));
+    const isStepCovered = (stepType: string) => {
+      const step = stepByType.get(stepType) as any;
+      return !!step && ['completed', 'not_applicable'].includes(step.status);
+    };
+    const activePoPartNumbers = Array.from(new Set(activePoItems.map((item: any) => item.part_number).filter(Boolean)));
+    const partsMissingRoutings = activePoPartNumbers.filter((partNumber: string) => (
+      !routeByPartNumber.has(String(partNumber).trim().toLowerCase())
+    ));
+    const partsMissingInstructions = activePoPartNumbers.filter((partNumber: string) => {
+      const routing = routeByPartNumber.get(String(partNumber).trim().toLowerCase()) as any;
+      if (!routing) return true;
+      const operationSummary = routingOperationSummaryById.get(String(routing.id)) as any;
+      const departmentConfigText = JSON.stringify(routing.department_config ?? {});
+      const hasInstructionConfig = /workInstructionRefs|aiSnippets|specialNotes|instructionPack|media/i.test(departmentConfigText);
+      return !hasInstructionConfig && Number(operationSummary?.instruction_pack_count ?? 0) === 0;
+    });
+    const routingInspectionCount = routingOperationSummaries.reduce((sum: number, summary: any) => (
+      sum + Number(summary.inspection_operation_count ?? 0)
+    ), 0);
+    const routingMaterialCertRequirementCount = routingOperationSummaries.reduce((sum: number, summary: any) => (
+      sum + Number(summary.material_cert_requirement_count ?? 0)
+    ), 0);
+    const routingQcStandardCount = projectRoutings.reduce((sum: number, routing: any) => {
+      const standards = routing.qc_standards;
+      return sum + (Array.isArray(standards) ? standards.length : standards ? 1 : 0);
+    }, 0);
+    const poSpecsCount = activePoItems.filter((item: any) => item.specifications || item.notes).length;
+    const revisionsForSpecs = projectRevisions.filter((revision: any) => {
+      const type = String(revision.revisionType ?? revision.revision_type ?? '').toLowerCase();
+      return ['drawing', 'contract', 'spec', 'po'].includes(type);
+    });
+    const coverageItems = [
+      {
+        key: 'customer_po',
+        label: 'Customer PO',
+        status: currentPo ? 'covered_by_project_data' : 'needs_upload',
+        source: currentPo ? 'P2 PO record' : 'Project document upload',
+        detail: currentPo ? `PO ${currentPo.po_number ?? currentPo.poNumber ?? activePoId} is linked to the project.` : 'Attach or link the customer PO before release.',
+        route: project.poId ? `/p2/purchase-orders/${project.poId}/preview` : '/p2-control-center',
+        relatedCount: currentPo ? 1 : 0,
+      },
+      {
+        key: 'drawing',
+        label: 'Drawing',
+        status: hasManualDocument('drawing', 'print') ? 'attached' : 'covered_by_project_data',
+        source: hasManualDocument('drawing', 'print') ? 'Project document attachment' : 'Received / pending vaulted storage',
+        detail: hasManualDocument('drawing', 'print')
+          ? 'Drawing file is attached to the project.'
+          : 'Vaulted drawing storage is not available yet, so received drawing status is tracked as acceptable project coverage.',
+        route: `/projects/${id}?tab=workflow`,
+        relatedCount: manualDocuments.filter((document: any) => String(document.label ?? document.original_file_name ?? '').toLowerCase().includes('drawing')).length,
+      },
+      {
+        key: 'rev_spec',
+        label: 'Revision / Specification',
+        status: revisionsForSpecs.length > 0 || poSpecsCount > 0 ? 'covered_by_project_data' : 'needs_clarification',
+        source: revisionsForSpecs.length > 0 ? 'Project revision ledger' : poSpecsCount > 0 ? 'PO line specifications' : 'Clarification required',
+        detail: revisionsForSpecs.length > 0 || poSpecsCount > 0
+          ? 'Revision/spec coverage is present through project revisions or PO line specifications.'
+          : 'Define whether Rev/Spec means drawing revision, customer spec, PO revision, or part specification for this project.',
+        route: `/projects/${id}?tab=po`,
+        relatedCount: revisionsForSpecs.length + poSpecsCount,
+      },
+      {
+        key: 'work_instructions',
+        label: 'Work Instructions',
+        status: activePoPartNumbers.length > 0 && partsMissingInstructions.length === 0 ? 'covered_by_project_data' : 'needs_setup',
+        source: 'Part routing instruction packs',
+        detail: activePoPartNumbers.length === 0
+          ? 'No PO parts are linked yet.'
+          : partsMissingInstructions.length === 0
+            ? 'Every PO part has routing instruction evidence.'
+            : `${partsMissingInstructions.length} PO part(s) need work instruction setup.`,
+        route: `/p2-control-center?tab=routing&projectId=${encodeURIComponent(id)}`,
+        relatedCount: Math.max(activePoPartNumbers.length - partsMissingInstructions.length, 0),
+        missingParts: partsMissingInstructions,
+      },
+      {
+        key: 'bom',
+        label: 'BOM',
+        status: bomRecords.length > 0 ? 'covered_by_project_data' : 'needs_setup',
+        source: 'Project BOM/Routing tab',
+        detail: bomRecords.length > 0 ? `${bomRecords.length} BOM record(s) match PO parts.` : 'Create or link BOM records for the PO parts.',
+        route: `/projects/${id}?tab=bom-routing`,
+        relatedCount: bomRecords.length,
+      },
+      {
+        key: 'routing',
+        label: 'Routing',
+        status: projectRoutings.length > 0 && partsMissingRoutings.length === 0 ? 'covered_by_project_data' : 'needs_setup',
+        source: 'Part routings',
+        detail: partsMissingRoutings.length === 0 && projectRoutings.length > 0
+          ? `${projectRoutings.length} routing record(s) cover the PO parts.`
+          : `${partsMissingRoutings.length || activePoPartNumbers.length} PO part(s) need routing coverage.`,
+        route: `/projects/${id}?tab=bom-routing`,
+        relatedCount: projectRoutings.length,
+        missingParts: partsMissingRoutings,
+      },
+      {
+        key: 'quote',
+        label: 'Quote',
+        status: isStepCovered('quote') || !!latestQuoteFeedback ? 'covered_by_project_data' : 'needs_setup',
+        source: latestQuoteFeedback ? 'ROM / quote feedback' : 'Project workflow',
+        detail: isStepCovered('quote') || !!latestQuoteFeedback ? 'Quote or quote execution feedback is linked to the project.' : 'Link or complete the quote workflow step.',
+        route: `/p2-quote-form?projectId=${encodeURIComponent(id)}`,
+        relatedCount: isStepCovered('quote') || !!latestQuoteFeedback ? 1 : 0,
+      },
+      {
+        key: 'risk_assessment',
+        label: 'Risk Assessment',
+        status: isStepCovered('rfq_risk_assessment') ? 'covered_by_project_data' : 'needs_setup',
+        source: 'RFQ risk assessment step',
+        detail: isStepCovered('rfq_risk_assessment') ? 'Risk assessment workflow step is complete.' : 'Complete or link the RFQ risk assessment.',
+        route: '/rfq-risk-assessment',
+        relatedCount: isStepCovered('rfq_risk_assessment') ? 1 : 0,
+      },
+      {
+        key: 'purchase_review_checklist',
+        label: 'Purchase Review Checklist',
+        status: isStepCovered('purchase_review_checklist') || projectFarFlowdowns.length > 0 ? 'covered_by_project_data' : 'needs_setup',
+        source: 'Purchase review workflow',
+        detail: isStepCovered('purchase_review_checklist') || projectFarFlowdowns.length > 0 ? 'Purchase review evidence is linked to the project.' : 'Complete the purchase review checklist.',
+        route: `/purchase-review-checklist?projectId=${encodeURIComponent(id)}`,
+        relatedCount: projectFarFlowdowns.length || (isStepCovered('purchase_review_checklist') ? 1 : 0),
+      },
+      {
+        key: 'material_cert_requirements',
+        label: 'Material Cert Requirements',
+        status: routingMaterialCertRequirementCount > 0 || certificates.length > 0 ? 'covered_by_project_data' : 'needs_setup',
+        source: routingMaterialCertRequirementCount > 0 ? 'Routing operation requirements' : certificates.length > 0 ? 'COC / cert records' : 'Structured requirement setup needed',
+        detail: routingMaterialCertRequirementCount > 0 || certificates.length > 0
+          ? 'Certificate requirements or resulting cert records are visible in the project read model.'
+          : 'Add a structured requirement model for material cert type, supplier responsibility, receiving hold, and closeout evidence.',
+        route: `/projects/${id}?tab=material`,
+        relatedCount: routingMaterialCertRequirementCount + certificates.length,
+      },
+      {
+        key: 'inspection_plan',
+        label: 'Inspection Plan',
+        status: routingInspectionCount > 0 || routingQcStandardCount > 0 ? 'covered_by_project_data' : 'needs_setup',
+        source: 'QC routing requirements',
+        detail: routingInspectionCount > 0 || routingQcStandardCount > 0 ? 'QC/inspection operations or standards exist on the routing.' : 'Add QC standards or inspection operations to the part routing.',
+        route: `/projects/${id}?tab=bom-routing`,
+        relatedCount: routingInspectionCount + routingQcStandardCount,
+      },
+      {
+        key: 'flowdowns',
+        label: 'Flow Downs',
+        status: projectFarFlowdowns.length > 0 ? 'covered_by_project_data' : 'needs_setup',
+        source: 'WAD / purchase review flowdowns',
+        detail: projectFarFlowdowns.length > 0 ? `${projectFarFlowdowns.length} project flowdown clause(s) are recorded.` : 'Capture flowdowns through the purchase review checklist so WAD can display them.',
+        route: `/projects/${id}?tab=workflow`,
+        relatedCount: projectFarFlowdowns.length,
+      },
+    ];
+    const coveredStatuses = new Set(['attached', 'covered_by_project_data', 'not_applicable']);
+    const coverageCoveredCount = coverageItems.filter(item => coveredStatuses.has(item.status)).length;
 
     return res.json({
       project,
@@ -2123,6 +2335,18 @@ router.get('/:id/p2-hub', async (req, res) => {
           completedForms: completedSteps,
           activityLog,
           documents: manualDocuments,
+        },
+        documentCoverage: {
+          summary: {
+            totalItems: coverageItems.length,
+            coveredItems: coverageCoveredCount,
+            needsAttention: coverageItems.length - coverageCoveredCount,
+            attachedItems: coverageItems.filter(item => item.status === 'attached').length,
+            coveredByProjectData: coverageItems.filter(item => item.status === 'covered_by_project_data').length,
+          },
+          items: coverageItems,
+          flowdowns: projectFarFlowdowns,
+          routingOperationSummaries,
         },
         po: {
           summary: {


### PR DESCRIPTION
## What changed
- Added a derived `documentCoverage` block to the P2 project hub read model.
- Added a new Project `Document Coverage` tab that separates attached files from items covered by structured Epoch project data.
- Tracks Customer PO, Drawing, Rev/Spec, Work Instructions, BOM, Routing, Quote, Risk Assessment, Purchase Review Checklist, Material Cert Requirements, Inspection Plan, and Flow Downs.
- Calls out missing PO parts for routing and work-instruction coverage.

## Why
WAD/customer requirements say the required documents need to be attached, but several of those items already live as structured project records in Epoch. This transition gives the project a visible coverage matrix without forcing duplicate PDF uploads for BOM, routing, quote, risk, purchase review, QC, or flowdown records.

## Notes
- Drawing coverage is treated as received / pending vaulted storage until a drawing vault exists.
- Material Cert Requirements are surfaced as a setup gap when no routing cert requirement or resulting cert record exists.
- Work Instructions are sourced from part routing instruction packs and routing operation instruction packs.

## Validation
- `git diff --check`
- `git diff --cached --check`

TypeScript check was not run because `npm` and a local TypeScript compiler were unavailable in this shell.