### PR TITLE
[codex] Fix PCF saves and document step-up viewing

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -179,6 +179,15 @@ export default function MasterDocumentRegister() {
   const [createNewVersion, setCreateNewVersion] = useState(false);
   const [newDocumentDepartment, setNewDocumentDepartment] = useState('');
   const [newDocumentType, setNewDocumentType] = useState('');
+  const [pendingDocumentAccess, setPendingDocumentAccess] = useState<{
+    doc: ControlledDocument;
+    mode: 'view' | 'download';
+  } | null>(null);
+  const [stepUpPassword, setStepUpPassword] = useState('');
+  const [stepUpError, setStepUpError] = useState<string | null>(null);
+  const [isStepUpOpen, setIsStepUpOpen] = useState(false);
+  const [isStepUpSubmitting, setIsStepUpSubmitting] = useState(false);
+  const [openingDocumentId, setOpeningDocumentId] = useState<string | null>(null);
   const { toast } = useToast();
 
   // Fetch controlled documents
@@ -319,9 +328,153 @@ export default function MasterDocumentRegister() {
   const isExternalDocument = (doc: ControlledDocument) =>
     Boolean(doc.filePath && /^https?:\/\//i.test(doc.filePath));
 
-  const openDocumentFile = (doc: ControlledDocument, mode: 'view' | 'download') => {
+  const getAuthHeaders = (): Record<string, string> => {
+    const storedToken = localStorage.getItem('sessionToken') || localStorage.getItem('jwtToken');
+    return storedToken ? { Authorization: `Bearer ${storedToken}` } : {};
+  };
+
+  const getFilenameFromDisposition = (disposition: string | null, fallback: string) => {
+    if (!disposition) return fallback;
+    const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+    if (utf8Match?.[1]) return decodeURIComponent(utf8Match[1].replace(/"/g, ''));
+    const filenameMatch = disposition.match(/filename="?([^"]+)"?/i);
+    return filenameMatch?.[1] || fallback;
+  };
+
+  const openDocumentBlob = (blob: Blob, filename: string, mode: 'view' | 'download', targetWindow?: Window | null) => {
+    const blobUrl = URL.createObjectURL(blob);
+    if (mode === 'view') {
+      if (targetWindow) {
+        targetWindow.location.href = blobUrl;
+      } else {
+        window.open(blobUrl, '_blank', 'noopener,noreferrer');
+      }
+      window.setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
+      return;
+    }
+
+    const link = document.createElement('a');
+    link.href = blobUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(blobUrl);
+  };
+
+  const openDocumentFile = async (doc: ControlledDocument, mode: 'view' | 'download', targetWindowOverride?: Window | null) => {
+    if (isExternalDocument(doc)) {
+      window.open(doc.filePath!, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
     const path = `/api/controlled-documents/${doc.id}/${mode}`;
-    window.open(path, '_blank', 'noopener,noreferrer');
+    const targetWindow =
+      targetWindowOverride ?? (mode === 'view'
+        ? window.open('', '_blank')
+        : null);
+
+    if (targetWindow) {
+      targetWindow.opener = null;
+      targetWindow.document.write('<p style="font-family: sans-serif; padding: 1rem;">Loading document...</p>');
+    }
+
+    try {
+      setOpeningDocumentId(doc.id);
+      const response = await fetch(path, {
+        credentials: 'include',
+        headers: getAuthHeaders(),
+      });
+      if (!response.ok) {
+        let errorData: any = null;
+        try {
+          errorData = await response.json();
+        } catch {
+          // Keep default message below.
+        }
+
+        if (response.status === 401 && errorData?.requireStepUp) {
+          targetWindow?.close();
+          setPendingDocumentAccess({ doc, mode });
+          setStepUpPassword('');
+          setStepUpError(null);
+          setIsStepUpOpen(true);
+          return;
+        }
+
+        targetWindow?.close();
+        throw new Error(errorData?.error || `Failed to ${mode} document`);
+      }
+
+      const blob = await response.blob();
+      const filename = getFilenameFromDisposition(
+        response.headers.get('content-disposition'),
+        `${doc.documentNumber || 'document'}.pdf`
+      );
+      openDocumentBlob(blob, filename, mode, targetWindow);
+    } catch (error: any) {
+      targetWindow?.close();
+      toast({
+        title: 'Unable to open document',
+        description: error.message || 'Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setOpeningDocumentId(null);
+    }
+  };
+
+  const handleStepUpSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!pendingDocumentAccess) return;
+    if (!stepUpPassword.trim()) {
+      setStepUpError('Enter your password to verify your credentials.');
+      return;
+    }
+
+    try {
+      setIsStepUpSubmitting(true);
+      setStepUpError(null);
+      const targetWindow =
+        pendingDocumentAccess.mode === 'view'
+          ? window.open('', '_blank')
+          : null;
+      if (targetWindow) {
+        targetWindow.opener = null;
+        targetWindow.document.write('<p style="font-family: sans-serif; padding: 1rem;">Verifying credentials...</p>');
+      }
+
+      const response = await fetch('/api/auth/step-up', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getAuthHeaders(),
+        },
+        credentials: 'include',
+        body: JSON.stringify({ password: stepUpPassword }),
+      });
+
+      if (!response.ok) {
+        targetWindow?.close();
+        let errorData: any = null;
+        try {
+          errorData = await response.json();
+        } catch {
+          // Keep default message below.
+        }
+        throw new Error(errorData?.error || 'Credential verification failed');
+      }
+
+      const access = pendingDocumentAccess;
+      setIsStepUpOpen(false);
+      setPendingDocumentAccess(null);
+      setStepUpPassword('');
+      await openDocumentFile(access.doc, access.mode, targetWindow);
+    } catch (error: any) {
+      setStepUpError(error.message || 'Credential verification failed');
+    } finally {
+      setIsStepUpSubmitting(false);
+    }
   };
 
   // Create document mutation
@@ -712,14 +865,15 @@ export default function MasterDocumentRegister() {
                                     }}
                                   >
                                     <Eye className="h-3.5 w-3.5" />
-                                    View
+                                    {openingDocumentId === doc.id ? 'Opening' : isExternalDocument(doc) ? 'Open' : 'View'}
                                   </Badge>
                                 )}
                                 <Button
                                   size="sm"
                                   variant="ghost"
                                   className="h-8 w-8 p-0"
-                                  title="Download"
+                                  title={isExternalDocument(doc) ? 'Open linked document' : 'Download'}
+                                  disabled={openingDocumentId === doc.id}
                                   onClick={() => openDocumentFile(doc, 'download')}
                                   data-testid={`button-download-${doc.id}`}
                                 >
@@ -1353,6 +1507,74 @@ export default function MasterDocumentRegister() {
               </Table>
             </div>
           )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Credential Verification Dialog */}
+      <Dialog open={isStepUpOpen} onOpenChange={(open) => {
+        setIsStepUpOpen(open);
+        if (!open) {
+          setPendingDocumentAccess(null);
+          setStepUpPassword('');
+          setStepUpError(null);
+        }
+      }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Verify Credentials</DialogTitle>
+            <DialogDescription>
+              Controlled document access requires recent credential verification.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleStepUpSubmit} className="space-y-4">
+            {pendingDocumentAccess && (
+              <div className="rounded-md border bg-gray-50 p-3 text-sm">
+                <div className="font-medium">{pendingDocumentAccess.doc.documentName}</div>
+                <div className="text-xs text-gray-500">
+                  {pendingDocumentAccess.mode === 'view' ? 'View PDF' : 'Download file'}
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="stepUpPassword">Password</Label>
+              <Input
+                id="stepUpPassword"
+                type="password"
+                value={stepUpPassword}
+                onChange={(event) => setStepUpPassword(event.target.value)}
+                autoComplete="current-password"
+                autoFocus
+                disabled={isStepUpSubmitting}
+                data-testid="input-step-up-password"
+              />
+              {stepUpError && (
+                <p className="text-sm text-red-600" data-testid="text-step-up-error">
+                  {stepUpError}
+                </p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isStepUpSubmitting}
+                onClick={() => {
+                  setIsStepUpOpen(false);
+                  setPendingDocumentAccess(null);
+                  setStepUpPassword('');
+                  setStepUpError(null);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isStepUpSubmitting}>
+                {isStepUpSubmitting ? 'Verifying...' : 'Verify and Continue'}
+              </Button>
+            </DialogFooter>
+          </form>
         </DialogContent>
       </Dialog>
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -5365,6 +5365,37 @@ async function initializeBackgroundServices() {
             updated_at                 TIMESTAMPTZ DEFAULT NOW()
           )
         `);
+        await pool.query(`
+          ALTER TABLE p2_production_changes
+            ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid(),
+            ADD COLUMN IF NOT EXISTS change_number TEXT,
+            ADD COLUMN IF NOT EXISTS change_type TEXT,
+            ADD COLUMN IF NOT EXISTS scope TEXT DEFAULT 'PO',
+            ADD COLUMN IF NOT EXISTS part_number TEXT,
+            ADD COLUMN IF NOT EXISTS po_id INTEGER REFERENCES p2_purchase_orders(id),
+            ADD COLUMN IF NOT EXISTS routing_id UUID,
+            ADD COLUMN IF NOT EXISTS current_revision TEXT,
+            ADD COLUMN IF NOT EXISTS proposed_change TEXT,
+            ADD COLUMN IF NOT EXISTS reason TEXT,
+            ADD COLUMN IF NOT EXISTS risk_assessment TEXT,
+            ADD COLUMN IF NOT EXISTS requires_customer_approval BOOLEAN DEFAULT false,
+            ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'DRAFT',
+            ADD COLUMN IF NOT EXISTS submitted_by_id INTEGER REFERENCES employees(id),
+            ADD COLUMN IF NOT EXISTS submitted_by_name TEXT,
+            ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS approved_by_id INTEGER REFERENCES employees(id),
+            ADD COLUMN IF NOT EXISTS approved_by_name TEXT,
+            ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS rejected_by_id INTEGER REFERENCES employees(id),
+            ADD COLUMN IF NOT EXISTS rejected_by_name TEXT,
+            ADD COLUMN IF NOT EXISTS rejected_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS rejection_reason TEXT,
+            ADD COLUMN IF NOT EXISTS implemented_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS effective_date DATE,
+            ADD COLUMN IF NOT EXISTS notes TEXT,
+            ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW(),
+            ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW()
+        `);
         await pool.query(`CREATE INDEX IF NOT EXISTS p2_prod_changes_po_id_idx ON p2_production_changes(po_id)`);
         await pool.query(`CREATE INDEX IF NOT EXISTS p2_prod_changes_status_idx ON p2_production_changes(status)`);
         await pool.query(`CREATE INDEX IF NOT EXISTS p2_prod_changes_type_idx ON p2_production_changes(change_type)`);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -17217,17 +17217,29 @@ export class DatabaseStorage implements IStorage {
       .where(like(p2ProductionChanges.changeNumber, `PCF-${year}-%`));
     const nextNum = (lastNumber ?? 0) + 1;
     const changeNumber = `PCF-${year}-${String(nextNum).padStart(3, '0')}`;
+    const changeData = this.normalizeP2ProductionChangeDates(data);
     
-    const [change] = await db.insert(p2ProductionChanges).values({ ...data, changeNumber }).returning();
+    const [change] = await db.insert(p2ProductionChanges).values({ ...changeData, changeNumber }).returning();
     return change;
   }
 
   async updateP2ProductionChange(id: string, data: Partial<InsertP2ProductionChange>): Promise<P2ProductionChange> {
+    const changeData = this.normalizeP2ProductionChangeDates(data);
     const [change] = await db.update(p2ProductionChanges)
-      .set({ ...data, updatedAt: new Date() })
+      .set({ ...changeData, updatedAt: new Date() })
       .where(eq(p2ProductionChanges.id, id))
       .returning();
     return change;
+  }
+
+  private normalizeP2ProductionChangeDates<T extends Partial<InsertP2ProductionChange>>(data: T): T {
+    const normalized: any = { ...data };
+    for (const field of ['submittedAt', 'approvedAt', 'rejectedAt', 'implementedAt'] as const) {
+      if (typeof normalized[field] === 'string' && normalized[field].trim()) {
+        normalized[field] = new Date(normalized[field]);
+      }
+    }
+    return normalized;
   }
 
   // P2 Traveler Changes (Deviations) CRUD


### PR DESCRIPTION
## Summary
- Normalize production change timestamp fields before Drizzle inserts/updates so JSON-submitted PCFs save reliably.
- Add additive startup repair for existing `p2_production_changes` tables that may be missing base columns.
- Update the Master Document Register to handle expired credential verification in-app, run `/api/auth/step-up`, and retry protected document view/download requests.

## Root Cause
- PCF creation could send timestamp fields as JSON strings, while the Drizzle timestamp columns expect `Date` values.
- Existing PCF tables were only created if missing; partial/drifted tables did not get the base columns repaired.
- Controlled document view/download opened protected API URLs directly, so `requireStepUp()` failures appeared as raw expired-credential errors instead of prompting the user to re-verify.

## Validation
- `git diff --check` passed before commit.
- `git diff --check origin/main..HEAD` passed after rebase.
- Bundled Node syntax check passed for `server/storage.ts` and `server/index.ts`.
- `npm run check` could not run because `npm` and local `node_modules` are unavailable in this worktree; bundled Node cannot syntax-check `.tsx` files (`ERR_UNKNOWN_FILE_EXTENSION`).