### PR TITLE
[codex] Fix P2 customer serial sequencing

### DIFF
--- a/migrations/0182_repair_rock_west_p2_customer_year_serials.sql
+++ b/migrations/0182_repair_rock_west_p2_customer_year_serials.sql
@@ -1,0 +1,108 @@
+-- Repair Rock West P2 serialized items that were created with a PO/revision
+-- unit barcode as the serial number. P2 serial identity should stay on the
+-- continuous customer/year sequence: PREFIX + YY + NNNNN.
+
+ALTER TABLE p2_customers
+  ADD COLUMN IF NOT EXISTS serial_sequences JSONB DEFAULT '{}'::jsonb;
+
+DROP TABLE IF EXISTS tmp_rock_west_serial_repair;
+
+CREATE TEMP TABLE tmp_rock_west_serial_repair AS
+WITH target AS (
+  SELECT
+    si.id,
+    si.customer_id,
+    si.serial_number AS old_serial_number,
+    si.barcode AS old_barcode,
+    COALESCE(NULLIF(LEFT(regexp_replace(upper(COALESCE(pc.rfq_prefix, pc.customer_name, si.customer_name, 'UNK')), '[^A-Z0-9]', '', 'g'), 3), ''), 'UNK') AS prefix,
+    EXTRACT(YEAR FROM COALESCE(po.po_date::timestamp, si.created_at, now()))::int AS serial_year,
+    RIGHT(EXTRACT(YEAR FROM COALESCE(po.po_date::timestamp, si.created_at, now()))::int::text, 2) AS year_suffix,
+    si.created_at,
+    si.sequence_number
+  FROM p2_serialized_items si
+  JOIN p2_purchase_orders po ON po.id = si.po_id
+  LEFT JOIN p2_customers pc ON pc.customer_id = si.customer_id
+  WHERE (
+      si.customer_name ILIKE 'Rock West%'
+      OR po.customer_name ILIKE 'Rock West%'
+      OR pc.customer_name ILIKE 'Rock West%'
+    )
+    AND (
+      upper(si.serial_number) LIKE '%-UNIT-%'
+      OR upper(si.barcode) LIKE '%-UNIT-%'
+    )
+),
+existing_max AS (
+  SELECT
+    target.customer_id,
+    target.prefix,
+    target.serial_year,
+    target.year_suffix,
+    COALESCE(
+      MAX((substring(upper(si.serial_number) from ('^' || target.prefix || target.year_suffix || '([0-9]{5})$')))::int),
+      0
+    ) AS max_sequence
+  FROM target
+  LEFT JOIN p2_serialized_items si
+    ON si.customer_id = target.customer_id
+   AND si.id NOT IN (SELECT id FROM target)
+   AND upper(si.serial_number) ~ ('^' || target.prefix || target.year_suffix || '[0-9]{5}$')
+  GROUP BY target.customer_id, target.prefix, target.serial_year, target.year_suffix
+),
+ordered AS (
+  SELECT
+    target.*,
+    existing_max.max_sequence,
+    row_number() OVER (
+      PARTITION BY target.customer_id, target.serial_year
+      ORDER BY target.created_at NULLS LAST, target.sequence_number NULLS LAST, target.id
+    ) AS repair_offset
+  FROM target
+  JOIN existing_max
+    ON existing_max.customer_id = target.customer_id
+   AND existing_max.prefix = target.prefix
+   AND existing_max.serial_year = target.serial_year
+)
+SELECT
+  id,
+  customer_id,
+  old_serial_number,
+  old_barcode,
+  prefix || year_suffix || lpad((max_sequence + repair_offset)::text, 5, '0') AS new_serial_number,
+  max_sequence + repair_offset AS new_sequence_number,
+  serial_year::text AS year_key
+FROM ordered
+WHERE old_serial_number IS DISTINCT FROM prefix || year_suffix || lpad((max_sequence + repair_offset)::text, 5, '0');
+
+UPDATE p2_serialized_items si
+SET
+  serial_number = repair.new_serial_number,
+  barcode = repair.new_serial_number,
+  traveler_barcode = repair.new_serial_number,
+  sequence_number = repair.new_sequence_number,
+  updated_at = now()
+FROM tmp_rock_west_serial_repair repair
+WHERE si.id = repair.id;
+
+UPDATE p2_serialized_item_events ev
+SET barcode = repair.new_serial_number
+FROM tmp_rock_west_serial_repair repair
+WHERE ev.serialized_item_id = repair.id;
+
+WITH sequence_updates AS (
+  SELECT
+    customer_id,
+    jsonb_object_agg(year_key, max_sequence) AS serial_sequences
+  FROM (
+    SELECT customer_id, year_key, MAX(new_sequence_number) AS max_sequence
+    FROM tmp_rock_west_serial_repair
+    GROUP BY customer_id, year_key
+  ) yearly
+  GROUP BY customer_id
+)
+UPDATE p2_customers pc
+SET serial_sequences = COALESCE(pc.serial_sequences, '{}'::jsonb) || sequence_updates.serial_sequences
+FROM sequence_updates
+WHERE pc.customer_id = sequence_updates.customer_id;
+
+DROP TABLE IF EXISTS tmp_rock_west_serial_repair;

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -205,6 +205,7 @@ const safeFiles = [
   '0176_part_routings_project_id.sql',
   '0177_inventory_item_primary_image.sql',
   '0179_inventory_item_order_url.sql',
+  '0182_repair_rock_west_p2_customer_year_serials.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16523,6 +16523,95 @@ export class DatabaseStorage implements IStorage {
     return productionOrders;
   }
 
+  private normalizeP2SerialPrefix(preferredPrefix?: string | null, fallbackName?: string | null): string {
+    const source = preferredPrefix || fallbackName || 'UNK';
+    const normalized = source.replace(/[^a-zA-Z0-9]/g, '').slice(0, 3).toUpperCase();
+    return normalized || 'UNK';
+  }
+
+  private async allocateP2CustomerYearSerialRange(
+    po: Pick<P2PurchaseOrder, 'customerId' | 'customerName'>,
+    count: number,
+    dbClient: DbOrTx
+  ): Promise<{ prefix: string; yearSuffix: string; startSequence: number; endSequence: number }> {
+    if (count <= 0) {
+      throw new Error('Serial range allocation count must be greater than zero');
+    }
+
+    const currentYear = new Date().getFullYear().toString();
+    const yearSuffix = currentYear.slice(-2);
+
+    const customerResult = await dbClient.execute(sql`
+      SELECT rfq_prefix, customer_name
+      FROM p2_customers
+      WHERE customer_id = ${po.customerId}::text
+      LIMIT 1
+    `);
+    const customer = (customerResult.rows?.[0] || {}) as { rfq_prefix?: string | null; customer_name?: string | null };
+    const prefix = this.normalizeP2SerialPrefix(customer.rfq_prefix, customer.customer_name || po.customerName);
+    const serialPattern = `^${prefix}${yearSuffix}[0-9]{5}$`;
+
+    const seqResult = await dbClient.execute(sql`
+      WITH locked_customer AS (
+        SELECT
+          COALESCE((serial_sequences->>${currentYear}::text)::int, 0) AS stored_sequence
+        FROM p2_customers
+        WHERE customer_id = ${po.customerId}::text
+        FOR UPDATE
+      ),
+      existing_serials AS (
+        SELECT COALESCE(
+          MAX((substring(upper(serial_number) from ${`^${prefix}${yearSuffix}([0-9]{5})$`}))::int),
+          0
+        ) AS max_sequence
+        FROM p2_serialized_items
+        WHERE customer_id = ${po.customerId}::text
+          AND upper(serial_number) ~ ${serialPattern}
+      ),
+      base_sequence AS (
+        SELECT GREATEST(
+          COALESCE((SELECT stored_sequence FROM locked_customer), 0),
+          COALESCE((SELECT max_sequence FROM existing_serials), 0)
+        ) AS value
+      )
+      UPDATE p2_customers
+      SET serial_sequences = COALESCE(serial_sequences, '{}'::jsonb) ||
+        jsonb_build_object(${currentYear}::text, (SELECT value FROM base_sequence) + ${count})
+      WHERE customer_id = ${po.customerId}::text
+      RETURNING ((SELECT value FROM base_sequence) + ${count}) AS end_sequence
+    `);
+
+    const endSequence = Number((seqResult.rows?.[0] as { end_sequence?: unknown } | undefined)?.end_sequence);
+    if (Number.isFinite(endSequence) && endSequence > 0) {
+      return {
+        prefix,
+        yearSuffix,
+        startSequence: endSequence - count + 1,
+        endSequence,
+      };
+    }
+
+    const fallbackResult = await dbClient.execute(sql`
+      SELECT COALESCE(
+        MAX((substring(upper(serial_number) from ${`^${prefix}${yearSuffix}([0-9]{5})$`}))::int),
+        0
+      ) AS max_sequence
+      FROM p2_serialized_items
+      WHERE customer_id = ${po.customerId}::text
+        AND upper(serial_number) ~ ${serialPattern}
+    `);
+    const fallbackMax = Number(
+      (fallbackResult.rows?.[0] as { max_sequence?: unknown } | undefined)?.max_sequence || 0
+    );
+    const fallbackEnd = fallbackMax + count;
+    return {
+      prefix,
+      yearSuffix,
+      startSequence: fallbackMax + 1,
+      endSequence: fallbackEnd,
+    };
+  }
+
   async addP2SerializedItemsForPoItem(
     poItemId: number,
     addCount: number,
@@ -16546,12 +16635,8 @@ export class DatabaseStorage implements IStorage {
       throw new Error(`P2 PO ${poItem.poId} not found`);
     }
 
-    // Continue the per-PO barcode sequence (max+1 across ALL items on this PO)
-    const maxSeqResult = await dbClient
-      .select({ maxSeq: max(p2SerializedItems.sequenceNumber) })
-      .from(p2SerializedItems)
-      .where(eq(p2SerializedItems.poId, po.id));
-    const startSeq = (maxSeqResult[0]?.maxSeq ?? 0) + 1;
+    const { prefix, yearSuffix, startSequence } =
+      await this.allocateP2CustomerYearSerialRange(po, addCount, dbClient);
 
     const [projectForPoItem] = await dbClient
       .select({ id: projects.id })
@@ -16634,13 +16719,12 @@ export class DatabaseStorage implements IStorage {
     };
     const itemsToCreate: SerializedInsertShape[] = [];
     for (let i = 0; i < addCount; i++) {
-      const seq = startSeq + i;
-      const seq4 = seq.toString().padStart(4, '0');
-      const barcode = `${po.poNumber}-UNIT-${seq4}`;
+      const seq = startSequence + i;
+      const serialNumber = `${prefix}${yearSuffix}${String(seq).padStart(5, '0')}`;
       itemsToCreate.push({
-        serialNumber: barcode,
-        barcode,
-        travelerBarcode: barcode,
+        serialNumber,
+        barcode: serialNumber,
+        travelerBarcode: serialNumber,
         poId: po.id,
         poItemId: poItem.id,
         poNumber: po.poNumber,
@@ -17299,40 +17383,8 @@ export class DatabaseStorage implements IStorage {
         throw new Error(`PO ${poItem.poId} not found`);
       }
 
-      // Get the customer's RFQ prefix for serial number generation
-      const currentYear = new Date().getFullYear().toString();
-      const yearSuffix = currentYear.slice(-2);
-      let prefix = '';
-
-      // Look up customer by customerId to get rfqPrefix
-      const customerResult = await tx.execute(sql`
-        SELECT rfq_prefix, customer_name, serial_sequences
-        FROM p2_customers
-        WHERE customer_id = ${po.customerId}::text
-        LIMIT 1
-      `);
-
-      if (customerResult.rows && customerResult.rows.length > 0) {
-        const customer = customerResult.rows[0] as any;
-        prefix = customer.rfq_prefix || customer.customer_name.substring(0, 3).toUpperCase();
-      } else {
-        prefix = (po.customerName || 'UNK').substring(0, 3).toUpperCase();
-      }
-
-      // Atomically increment serial sequence counter for this customer+year
-      const seqResult = await tx.execute(sql`
-        UPDATE p2_customers
-        SET serial_sequences = COALESCE(serial_sequences, '{}'::jsonb) ||
-          jsonb_build_object(
-            ${currentYear}::text,
-            COALESCE((serial_sequences->>${currentYear}::text)::int, 0) + ${poItem.quantity}
-          )
-        WHERE customer_id = ${po.customerId}::text
-        RETURNING (COALESCE((serial_sequences->>${currentYear}::text)::int, 0)) as end_sequence
-      `);
-
-      const endSequence = seqResult.rows?.[0] ? (seqResult.rows[0] as any).end_sequence : poItem.quantity;
-      const startSequence = endSequence - poItem.quantity + 1;
+      const { prefix, yearSuffix, startSequence } =
+        await this.allocateP2CustomerYearSerialRange(po, poItem.quantity, tx);
 
       const serializedItems: P2SerializedItem[] = [];
 


### PR DESCRIPTION
## Summary
- route both P2 serialized item creation paths through a shared customer/year serial allocator
- keep revised/quantity-sync generated serials in `PREFIX + YY + NNNNN` format instead of `PO-UNIT` format
- add a Rock West repair migration for existing bad `*-UNIT-*` serialized items and reseed the customer/year counter

## Root Cause
The main `generateSerializedItems` path used the customer/year sequence, but the quantity-sync path used during later PO item increases generated serials from the PO number (`${poNumber}-UNIT-####`). Revised POs could therefore create serialized items with PO-line identity instead of customer item identity.

## Validation
- `node --experimental-strip-types --check server/storage.ts`
- `git diff --check -- server/storage.ts server/scripts/migrations/runSafeBootMigrations.ts migrations/0182_repair_rock_west_p2_customer_year_serials.sql`
- `git diff --cached --check`