### PR TITLE
[codex] Fix P2 project attachment and quote loading

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -1520,12 +1520,9 @@ export default function ProjectDetailPage() {
 
   const deleteAttachmentMutation = useMutation({
     mutationFn: async (attachmentId: number) => {
-      const response = await fetch(`/api/project-step-attachments/${attachmentId}`, {
+      return apiRequest(`/api/project-step-attachments/${attachmentId}`, {
         method: 'DELETE',
-        credentials: 'include',
       });
-      if (!response.ok) throw new Error('Failed to delete attachment');
-      return response.json();
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/project-step-attachments', selectedStep?.id] });
@@ -1544,24 +1541,16 @@ export default function ProjectDetailPage() {
     
     setIsUploading(true);
     try {
-      const urlResponse = await fetch('/api/project-step-attachments/request-upload-url', {
+      const { uploadURL, objectPath } = await apiRequest('/api/project-step-attachments/request-upload-url', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
+        body: {
           name: file.name,
           size: file.size,
           contentType: file.type || 'application/octet-stream',
           projectId: project.id,
           stepId: selectedStep.id,
-        }),
-      });
-
-      if (!urlResponse.ok) {
-        throw new Error('Failed to get upload URL');
-      }
-
-      const { uploadURL, objectPath } = await urlResponse.json();
+        },
+      }) as { uploadURL: string; objectPath: string };
 
       const uploadResponse = await fetch(uploadURL, {
         method: 'PUT',
@@ -1573,11 +1562,9 @@ export default function ProjectDetailPage() {
         throw new Error('Failed to upload file');
       }
 
-      const completeResponse = await fetch('/api/project-step-attachments/complete-upload', {
+      await apiRequest('/api/project-step-attachments/complete-upload', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
+        body: {
           objectPath,
           projectId: project.id,
           stepId: selectedStep.id,
@@ -1585,12 +1572,8 @@ export default function ProjectDetailPage() {
           fileSize: file.size,
           mimeType: file.type || 'application/octet-stream',
           notes: uploadNotes || null,
-        }),
+        },
       });
-
-      if (!completeResponse.ok) {
-        throw new Error('Failed to complete upload');
-      }
 
       queryClient.invalidateQueries({ queryKey: ['/api/project-step-attachments', selectedStep.id] });
       queryClient.invalidateQueries({ queryKey: ['/api/project-step-attachments/by-project', id] });


### PR DESCRIPTION
## Summary
- Route P2 project step attachment API calls through the shared `apiRequest` client.
- Preserve the direct signed storage `PUT` while adding app auth headers/retry handling to request-upload, complete-upload, and delete calls.
- Fix the P2 Project page's Open Quote action to pass the linked quote id when available.
- Allow `P2QuoteForm` to resolve legacy `/p2-quote-form?projectId=...` links by loading the project's linked quote step, with quote-feedback as a fallback source.

## Root Cause
The P2 project attachment flow used raw `fetch` for app API calls, so those requests skipped the bearer token that the rest of the app sends through `apiRequest`, causing request-upload-url to return 401 in token-backed sessions.

The quote action on the P2 Project page opened `/p2-quote-form?projectId=...`, but the quote form only loaded existing quotes from an `id` query parameter. That left the form unable to load the actual linked quote from the project workflow.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Verified final diff is scoped to `client/src/pages/ProjectDetailPage.tsx` and `client/src/pages/P2QuoteForm.tsx`

Note: A full TypeScript compile was not run because this clean worktree does not have local `node_modules`/`tsc`; bundled Node also cannot directly `--check` `.tsx` files.