### PR TITLE
[codex] Add WAD charge code request flow

### DIFF
--- a/client/src/components/wad/WADWizard.tsx
+++ b/client/src/components/wad/WADWizard.tsx
@@ -24,7 +24,7 @@ import {
 import {
   Check, ChevronRight, ChevronLeft, AlertTriangle, FileText, Users, ClipboardList,
   DollarSign, Package, Route, ShieldCheck, Calendar, AlertCircle, FolderOpen,
-  Star, Loader2, CheckCircle, XCircle, Plus, Trash2
+  Star, Loader2, CheckCircle, XCircle, Plus, Trash2, Send
 } from 'lucide-react';
 import { apiRequest, queryClient } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
@@ -94,6 +94,22 @@ interface ChargeCodeRow {
   overrunRule: 'WARN' | 'REQUIRE_APPROVAL' | 'HARD_STOP';
   seeded?: boolean;
   seededFrom?: string;
+}
+
+interface ChargeCodeRequest {
+  id: string;
+  wadId: string;
+  workOrderNumber?: string | null;
+  department: string;
+  operation: string;
+  laborCategory?: string | null;
+  classification: string;
+  budgetedHours?: string | null;
+  requestedByDisplayName: string;
+  requestedAt: string;
+  status: 'PENDING' | 'ASSIGNED' | string;
+  assignedChargeCodeId?: number | null;
+  assignedChargeCode?: string | null;
 }
 
 interface RiskEntry {
@@ -1053,6 +1069,7 @@ export default function WADWizard({ wadId, onClose, initialStep = null }: WADWiz
           {/* ── Step 4: Charge Codes ─────────────────────────────────── */}
           {step === 4 && (
             <Step4ChargeCodes
+              wadId={wadId}
               rows={data.step3?.rows ?? []}
               data={data.step4}
               onChange={(v) => patch('step4', v)}
@@ -1761,12 +1778,45 @@ function Step3WorkBreakdown({ departments, scopeDescription, data, onChange, onR
 }
 
 // ─── Step 4: Charge Codes ─────────────────────────────────────────────────────
-function Step4ChargeCodes({ rows: wbRows, data, onChange }: {
+function Step4ChargeCodes({ wadId, rows: wbRows, data, onChange }: {
+  wadId: string;
   rows: WorkBreakdownRow[];
   data?: WizardData['step4'];
   onChange: (v: WizardData['step4']) => void;
 }) {
+  const { toast } = useToast();
   const deptLabels = Object.fromEntries(WAD_DEPARTMENTS.map(d => [d.key, d.label]));
+  const { data: chargeCodeRequests = [] } = useQuery<ChargeCodeRequest[]>({
+    queryKey: ['/api/charge-codes/requests', wadId],
+    queryFn: () => apiRequest(`/api/charge-codes/requests?wadId=${encodeURIComponent(wadId)}&status=all`),
+  });
+  const requestMutation = useMutation({
+    mutationFn: (row: ChargeCodeRow) => apiRequest('/api/charge-codes/requests', {
+      method: 'POST',
+      body: {
+        wadId,
+        department: row.department,
+        operation: row.operation || deptLabels[row.department] || row.department,
+        laborCategory: row.laborCategory,
+        classification: row.classification,
+        budgetedHours: row.budgetedHours,
+        notes: row.chargeCode ? `Requested while current WAD code field held ${row.chargeCode}` : '',
+      },
+    }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/charge-codes/requests', wadId] });
+      queryClient.invalidateQueries({ queryKey: ['/api/charge-codes/requests'] });
+      toast({ title: 'Charge code request sent' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Request failed', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const requestKey = (department: string, operation: string) => `${department}::${operation || deptLabels[department] || department}`;
+  const requestByOperation = new Map(
+    chargeCodeRequests.map(request => [requestKey(request.department, request.operation), request])
+  );
 
   const buildDefault = (): ChargeCodeRow[] =>
     wbRows.map(r => ({
@@ -1829,7 +1879,17 @@ function Step4ChargeCodes({ rows: wbRows, data, onChange }: {
                   </Badge>
                 )}
               </div>
-              <Badge variant="outline" className="text-xs">{row.classification}</Badge>
+              <div className="flex items-center gap-2">
+                {requestByOperation.get(requestKey(row.department, row.operation))?.status === 'PENDING' && (
+                  <Badge variant="secondary" className="text-xs">Request pending</Badge>
+                )}
+                {requestByOperation.get(requestKey(row.department, row.operation))?.status === 'ASSIGNED' && (
+                  <Badge className="bg-green-100 text-green-800 hover:bg-green-100 text-xs">
+                    Assigned {requestByOperation.get(requestKey(row.department, row.operation))?.assignedChargeCode}
+                  </Badge>
+                )}
+                <Badge variant="outline" className="text-xs">{row.classification}</Badge>
+              </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1">
@@ -1887,6 +1947,24 @@ function Step4ChargeCodes({ rows: wbRows, data, onChange }: {
                 <BoolField label="Overtime Allowed" value={row.overtimeAllowed} onChange={v => setRow(idx, { overtimeAllowed: v })} />
                 <BoolField label="Operator Override" value={row.operatorOverrideAllowed} onChange={v => setRow(idx, { operatorOverrideAllowed: v })} />
               </div>
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-3 border-t pt-3">
+              <p className="text-xs text-muted-foreground">
+                Need finance to create or select the cost objective for this direct labor row?
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => requestMutation.mutate(row)}
+                disabled={
+                  requestMutation.isPending ||
+                  requestByOperation.get(requestKey(row.department, row.operation))?.status === 'PENDING'
+                }
+              >
+                {requestMutation.isPending ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Send className="h-4 w-4 mr-2" />}
+                Request Charge Code
+              </Button>
             </div>
           </Card>
         ))}

--- a/client/src/pages/finance/ChargeCodeManagerPage.tsx
+++ b/client/src/pages/finance/ChargeCodeManagerPage.tsx
@@ -14,6 +14,7 @@ import {
   ChevronsUpDown,
   Search,
   Users,
+  CheckCircle,
 } from 'lucide-react';
 import { insertChargeCodeSchema, type ChargeCode } from '@shared/schema';
 
@@ -116,6 +117,22 @@ type ChargeCodeAssignments = {
   employeeIds: number[];
   defaultEmployeeIds: number[];
   assignedEmployees: EmployeeOption[];
+};
+
+type ChargeCodeRequest = {
+  id: string;
+  wadId: string | null;
+  workOrderNumber?: string | null;
+  department: string;
+  operation: string;
+  laborCategory?: string | null;
+  classification: string;
+  budgetedHours?: string | null;
+  requestedByDisplayName: string;
+  requestedAt: string;
+  status: 'PENDING' | 'ASSIGNED' | string;
+  assignedChargeCodeId?: number | null;
+  assignedChargeCode?: string | null;
 };
 
 const PRODUCTION_LINE_OPTIONS = [
@@ -947,6 +964,7 @@ function resolvePoolContext(
 }
 
 export default function ChargeCodeManagerPage() {
+  const { toast } = useToast();
   const [showInactive, setShowInactive] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ChargeCode | null>(null);
@@ -954,9 +972,14 @@ export default function ChargeCodeManagerPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+  const [requestAssignments, setRequestAssignments] = useState<Record<string, string>>({});
 
   const { data: chargeCodes, isLoading } = useQuery<ChargeCode[]>({
     queryKey: ['/api/charge-codes'],
+  });
+  const { data: chargeCodeRequests = [] } = useQuery<ChargeCodeRequest[]>({
+    queryKey: ['/api/charge-codes/requests'],
+    queryFn: () => apiRequest('/api/charge-codes/requests?status=PENDING'),
   });
   const { data: pools = [] } = useQuery<IndirectCostPool[]>({
     queryKey: ['/api/burden-rates/pools'],
@@ -1060,6 +1083,40 @@ export default function ChargeCodeManagerPage() {
     setCopySource(null);
   }
 
+  const assignRequestMutation = useMutation({
+    mutationFn: ({ requestId, chargeCodeId }: { requestId: string; chargeCodeId: number }) =>
+      apiRequest(`/api/charge-codes/requests/${requestId}/assign`, {
+        method: 'PATCH',
+        body: { chargeCodeId },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/charge-codes/requests'] });
+      toast({ title: 'Charge code request assigned' });
+    },
+    onError: (err: Error) => {
+      toast({
+        title: 'Failed to assign request',
+        description: err.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const activeChargeCodes = (chargeCodes ?? []).filter((code) => code.active);
+
+  function assignRequest(request: ChargeCodeRequest) {
+    const selected = Number(requestAssignments[request.id]);
+    if (!Number.isInteger(selected) || selected <= 0) {
+      toast({
+        title: 'Select a charge code',
+        description: 'Choose the charge code that should satisfy this WAD request.',
+        variant: 'destructive',
+      });
+      return;
+    }
+    assignRequestMutation.mutate({ requestId: request.id, chargeCodeId: selected });
+  }
+
   const typeLabel: Record<string, string> = {
     DIRECT: 'Direct',
     OVERHEAD: 'Overhead',
@@ -1119,6 +1176,70 @@ export default function ChargeCodeManagerPage() {
           </Label>
         </div>
       </div>
+
+      {chargeCodeRequests.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <h2 className="text-lg font-semibold">Charge Code Requests</h2>
+            <Badge variant="secondary">{chargeCodeRequests.length}</Badge>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {chargeCodeRequests.map((request) => (
+              <div key={request.id} className="rounded-md border p-4 space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold">
+                      {request.workOrderNumber ?? 'WAD'} - {request.operation}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {request.department} - {request.classification}
+                      {request.budgetedHours ? ` - ${request.budgetedHours} hrs` : ''}
+                    </p>
+                  </div>
+                  <Badge variant="outline">Pending</Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Requested by {request.requestedByDisplayName}
+                </p>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Select
+                    value={requestAssignments[request.id] ?? ''}
+                    onValueChange={(value) =>
+                      setRequestAssignments((prev) => ({ ...prev, [request.id]: value }))
+                    }
+                  >
+                    <SelectTrigger className="h-9">
+                      <SelectValue placeholder="Assign charge code" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {activeChargeCodes.map((code) => (
+                        <SelectItem key={code.id} value={String(code.id)}>
+                          {code.code} - {code.description ?? code.department ?? 'No description'}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => assignRequest(request)}
+                    disabled={assignRequestMutation.isPending}
+                    className="sm:w-auto"
+                  >
+                    {assignRequestMutation.isPending ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <CheckCircle className="mr-2 h-4 w-4" />
+                    )}
+                    Assign
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="rounded-md border">
         <Table>

--- a/migrations/0183_wad_charge_code_requests.sql
+++ b/migrations/0183_wad_charge_code_requests.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS wad_charge_code_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  wad_id UUID REFERENCES production_work_orders(id) ON DELETE CASCADE,
+  department TEXT NOT NULL,
+  operation TEXT NOT NULL,
+  labor_category TEXT,
+  classification TEXT NOT NULL DEFAULT 'DIRECT',
+  budgeted_hours NUMERIC,
+  requested_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  requested_by_display_name TEXT NOT NULL DEFAULT 'Unknown',
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  assigned_charge_code_id INTEGER REFERENCES charge_codes(id) ON DELETE SET NULL,
+  assigned_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  assigned_at TIMESTAMPTZ,
+  notes TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS wad_charge_code_requests_status_idx
+  ON wad_charge_code_requests(status, requested_at DESC);
+
+CREATE INDEX IF NOT EXISTS wad_charge_code_requests_wad_idx
+  ON wad_charge_code_requests(wad_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS wad_charge_code_requests_open_operation_idx
+  ON wad_charge_code_requests(wad_id, department, operation)
+  WHERE status = 'PENDING';

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -6086,6 +6086,33 @@ export const chargeCodeEmployeeAssignments = pgTable('charge_code_employee_assig
 
 export type ChargeCodeEmployeeAssignment = typeof chargeCodeEmployeeAssignments.$inferSelect;
 
+export const wadChargeCodeRequests = pgTable('wad_charge_code_requests', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  wadId: uuid('wad_id').references((): AnyPgColumn => productionWorkOrders.id, { onDelete: 'cascade' }),
+  department: text('department').notNull(),
+  operation: text('operation').notNull(),
+  laborCategory: text('labor_category'),
+  classification: text('classification').notNull().default('DIRECT'),
+  budgetedHours: numeric('budgeted_hours'),
+  requestedByUserId: integer('requested_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  requestedByDisplayName: text('requested_by_display_name').notNull().default('Unknown'),
+  requestedAt: timestamp('requested_at', { withTimezone: true }).defaultNow().notNull(),
+  status: text('status').notNull().default('PENDING'),
+  assignedChargeCodeId: integer('assigned_charge_code_id').references(() => chargeCodes.id, { onDelete: 'set null' }),
+  assignedByUserId: integer('assigned_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  assignedAt: timestamp('assigned_at', { withTimezone: true }),
+  notes: text('notes'),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  statusIdx: index('wad_charge_code_requests_status_idx').on(table.status, table.requestedAt),
+  wadIdx: index('wad_charge_code_requests_wad_idx').on(table.wadId),
+  openOperationIdx: uniqueIndex('wad_charge_code_requests_open_operation_idx')
+    .on(table.wadId, table.department, table.operation)
+    .where(sql`status = 'PENDING'`),
+}));
+
+export type WadChargeCodeRequest = typeof wadChargeCodeRequests.$inferSelect;
+
 // ============================================================================
 // TRAVELER SYSTEM - AS9100 Digital Travelers (Execution Records)
 // ============================================================================

--- a/server/src/routes/chargeCodes.ts
+++ b/server/src/routes/chargeCodes.ts
@@ -8,6 +8,7 @@ import { pgPool, pool } from '../../db';
 const router: IRouter = Router();
 
 let chargeCodeAssignmentTableReady: Promise<void> | null = null;
+let chargeCodeRequestTableReady: Promise<void> | null = null;
 
 function ensureChargeCodeAssignmentTable(): Promise<void> {
   if (!chargeCodeAssignmentTableReady) {
@@ -33,6 +34,44 @@ function ensureChargeCodeAssignmentTable(): Promise<void> {
     });
   }
   return chargeCodeAssignmentTableReady;
+}
+
+function ensureChargeCodeRequestTable(): Promise<void> {
+  if (!chargeCodeRequestTableReady) {
+    chargeCodeRequestTableReady = (async () => {
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS wad_charge_code_requests (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          wad_id UUID REFERENCES production_work_orders(id) ON DELETE CASCADE,
+          department TEXT NOT NULL,
+          operation TEXT NOT NULL,
+          labor_category TEXT,
+          classification TEXT NOT NULL DEFAULT 'DIRECT',
+          budgeted_hours NUMERIC,
+          requested_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+          requested_by_display_name TEXT NOT NULL DEFAULT 'Unknown',
+          requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          status TEXT NOT NULL DEFAULT 'PENDING',
+          assigned_charge_code_id INTEGER REFERENCES charge_codes(id) ON DELETE SET NULL,
+          assigned_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+          assigned_at TIMESTAMPTZ,
+          notes TEXT,
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+      `);
+      await pool.query(`CREATE INDEX IF NOT EXISTS wad_charge_code_requests_status_idx ON wad_charge_code_requests(status, requested_at DESC)`);
+      await pool.query(`CREATE INDEX IF NOT EXISTS wad_charge_code_requests_wad_idx ON wad_charge_code_requests(wad_id)`);
+      await pool.query(`
+        CREATE UNIQUE INDEX IF NOT EXISTS wad_charge_code_requests_open_operation_idx
+        ON wad_charge_code_requests(wad_id, department, operation)
+        WHERE status = 'PENDING'
+      `);
+    })().catch((error) => {
+      chargeCodeRequestTableReady = null;
+      throw error;
+    });
+  }
+  return chargeCodeRequestTableReady;
 }
 
 function h(fn: (req: Request, res: Response, next: NextFunction) => Promise<void>): RequestHandler {
@@ -115,6 +154,61 @@ async function getChargeCodeAssignments(chargeCodeId: number) {
   );
 }
 
+function normalizeRequestStatus(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim().toUpperCase() : 'PENDING';
+}
+
+function normalizeRequestText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+async function listChargeCodeRequests(filters: { status?: string; wadId?: string }) {
+  await ensureChargeCodeRequestTable();
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (filters.status) {
+    params.push(filters.status);
+    conditions.push(`wccr.status = $${params.length}`);
+  }
+  if (filters.wadId) {
+    params.push(filters.wadId);
+    conditions.push(`wccr.wad_id = $${params.length}::uuid`);
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  return pool.query(
+    `SELECT
+       wccr.id,
+       wccr.wad_id AS "wadId",
+       pwo.work_order_number AS "workOrderNumber",
+       pwo.project_id AS "projectId",
+       wccr.department,
+       wccr.operation,
+       wccr.labor_category AS "laborCategory",
+       wccr.classification,
+       wccr.budgeted_hours::text AS "budgetedHours",
+       wccr.requested_by_user_id AS "requestedByUserId",
+       wccr.requested_by_display_name AS "requestedByDisplayName",
+       wccr.requested_at AS "requestedAt",
+       wccr.status,
+       wccr.assigned_charge_code_id AS "assignedChargeCodeId",
+       cc.code AS "assignedChargeCode",
+       wccr.assigned_by_user_id AS "assignedByUserId",
+       wccr.assigned_at AS "assignedAt",
+       wccr.notes,
+       wccr.updated_at AS "updatedAt"
+     FROM wad_charge_code_requests wccr
+     LEFT JOIN production_work_orders pwo ON pwo.id = wccr.wad_id
+     LEFT JOIN charge_codes cc ON cc.id = wccr.assigned_charge_code_id
+     ${where}
+     ORDER BY
+       CASE wccr.status WHEN 'PENDING' THEN 0 ELSE 1 END,
+       wccr.requested_at DESC`,
+    params
+  );
+}
+
 // GET /api/charge-codes — list all charge codes; supports ?active=true filter
 router.get('/', authenticateToken, h(async (req, res) => {
   const activeOnly = req.query.active === 'true';
@@ -123,6 +217,163 @@ router.get('/', authenticateToken, h(async (req, res) => {
 }));
 
 // POST /api/charge-codes — admin create
+router.get('/requests', authenticateToken, h(async (req, res) => {
+  const status = req.query.status === 'all' ? undefined : normalizeRequestStatus(req.query.status);
+  const wadId = normalizeRequestText(req.query.wadId);
+  const requests = await listChargeCodeRequests({ status, wadId: wadId || undefined });
+  res.json(requests);
+}));
+
+router.post('/requests', authenticateToken, h(async (req, res) => {
+  await ensureChargeCodeRequestTable();
+  const wadId = normalizeRequestText(req.body?.wadId);
+  const department = normalizeRequestText(req.body?.department);
+  const operation = normalizeRequestText(req.body?.operation);
+  const laborCategory = normalizeRequestText(req.body?.laborCategory);
+  const classification = normalizeRequestText(req.body?.classification) || 'DIRECT';
+  const notes = normalizeRequestText(req.body?.notes);
+  const budgetedHoursRaw = req.body?.budgetedHours;
+  const budgetedHours = budgetedHoursRaw === null || budgetedHoursRaw === undefined || budgetedHoursRaw === ''
+    ? null
+    : Number(budgetedHoursRaw);
+
+  if (!wadId || !department || !operation) {
+    res.status(400).json({ error: 'wadId, department, and operation are required' });
+    return;
+  }
+  if (budgetedHours !== null && (!Number.isFinite(budgetedHours) || budgetedHours < 0)) {
+    res.status(400).json({ error: 'budgetedHours must be a positive number' });
+    return;
+  }
+
+  const wadRows = await pool.query(`SELECT id FROM production_work_orders WHERE id = $1::uuid LIMIT 1`, [wadId]);
+  if (wadRows.length === 0) {
+    res.status(404).json({ error: 'WAD not found' });
+    return;
+  }
+
+  const { actorId, actorName, actorRole } = extractActor(req);
+  const rows = await pool.query(
+    `INSERT INTO wad_charge_code_requests (
+       wad_id, department, operation, labor_category, classification, budgeted_hours,
+       requested_by_user_id, requested_by_display_name, notes
+     )
+     VALUES ($1::uuid, $2, $3, NULLIF($4, ''), $5, $6, $7, $8, NULLIF($9, ''))
+     ON CONFLICT (wad_id, department, operation) WHERE status = 'PENDING'
+     DO UPDATE SET
+       labor_category = EXCLUDED.labor_category,
+       classification = EXCLUDED.classification,
+       budgeted_hours = EXCLUDED.budgeted_hours,
+       notes = EXCLUDED.notes,
+       updated_at = NOW()
+     RETURNING id`,
+    [wadId, department, operation, laborCategory, classification, budgetedHours, actorId, actorName, notes]
+  );
+
+  await recordAuditEvent({
+    eventType: 'WAD_CHARGE_CODE_REQUESTED',
+    subjectType: 'wad_charge_code_request',
+    subjectId: String(rows[0].id),
+    sourceService: 'chargeCodes.routes',
+    actor: { id: actorId, username: actorName, role: actorRole },
+    meta: { wadId, department, classification },
+    ipAddress: req.ip ?? null,
+    userAgent: req.headers['user-agent'] ?? null,
+    payload: { wadId, department, operation, laborCategory, classification, budgetedHours },
+  });
+
+  const requests = await listChargeCodeRequests({ wadId, status: 'PENDING' });
+  res.status(201).json(requests.find((request: any) => request.id === rows[0].id) ?? rows[0]);
+}));
+
+router.patch('/requests/:requestId/assign', authenticateToken, requireRole('ADMIN'), h(async (req, res) => {
+  await ensureChargeCodeRequestTable();
+  const requestId = normalizeRequestText(req.params.requestId);
+  const chargeCodeId = Number(req.body?.chargeCodeId);
+  if (!requestId || !Number.isInteger(chargeCodeId) || chargeCodeId <= 0) {
+    res.status(400).json({ error: 'Valid requestId and chargeCodeId are required' });
+    return;
+  }
+
+  const chargeCode = await storage.getChargeCodeById(chargeCodeId);
+  if (!chargeCode || !chargeCode.active) {
+    res.status(400).json({ error: 'Selected charge code is not active' });
+    return;
+  }
+
+  const existing = await pool.query(
+    `SELECT id, status, wad_id AS "wadId", department, operation
+       FROM wad_charge_code_requests
+      WHERE id = $1::uuid
+      LIMIT 1`,
+    [requestId]
+  );
+  if (existing.length === 0) {
+    res.status(404).json({ error: 'Charge code request not found' });
+    return;
+  }
+  if (existing[0].status !== 'PENDING') {
+    res.status(400).json({ error: 'Only pending requests can be assigned' });
+    return;
+  }
+
+  const { actorId, actorName, actorRole } = extractActor(req);
+  await pool.query(
+    `UPDATE wad_charge_code_requests
+        SET status = 'ASSIGNED',
+            assigned_charge_code_id = $2,
+            assigned_by_user_id = $3,
+            assigned_at = NOW(),
+            updated_at = NOW()
+      WHERE id = $1::uuid`,
+    [requestId, chargeCodeId, actorId]
+  );
+  await pool.query(
+    `UPDATE production_work_orders pwo
+        SET wizard_data = jsonb_set(
+              COALESCE(pwo.wizard_data, '{}'::jsonb),
+              '{step4,chargeCodes}',
+              COALESCE((
+                SELECT jsonb_agg(
+                  CASE
+                    WHEN charge_row->>'department' = $2
+                     AND charge_row->>'operation' = $3
+                      THEN jsonb_set(charge_row, '{chargeCode}', to_jsonb($4::text), true)
+                    ELSE charge_row
+                  END
+                  ORDER BY ordinality
+                )
+                FROM jsonb_array_elements(
+                  CASE
+                    WHEN jsonb_typeof(pwo.wizard_data->'step4'->'chargeCodes') = 'array'
+                      THEN pwo.wizard_data->'step4'->'chargeCodes'
+                    ELSE '[]'::jsonb
+                  END
+                ) WITH ORDINALITY AS rows(charge_row, ordinality)
+              ), '[]'::jsonb),
+              true
+            ),
+            updated_at = NOW()
+      WHERE pwo.id = $1::uuid`,
+    [existing[0].wadId, existing[0].department, existing[0].operation, chargeCode.code]
+  );
+
+  await recordAuditEvent({
+    eventType: 'WAD_CHARGE_CODE_REQUEST_ASSIGNED',
+    subjectType: 'wad_charge_code_request',
+    subjectId: requestId,
+    sourceService: 'chargeCodes.routes',
+    actor: { id: actorId, username: actorName, role: actorRole },
+    meta: { chargeCodeId, chargeCode: chargeCode.code },
+    ipAddress: req.ip ?? null,
+    userAgent: req.headers['user-agent'] ?? null,
+    payload: { requestId, chargeCodeId, chargeCode: chargeCode.code },
+  });
+
+  const rows = await listChargeCodeRequests({});
+  res.json(rows.find((request: any) => request.id === requestId));
+}));
+
 router.get('/:id/assignments', authenticateToken, h(async (req, res) => {
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) {


### PR DESCRIPTION
## Summary
- Add WAD Step 4 request action for direct-labor charge code needs
- Add charge-code manager request cards so finance/admin can assign an existing charge code
- Persist request state in `wad_charge_code_requests` and write assigned codes back into the matching WAD Step 4 row

## Validation
- `git diff --cached --check`
- `git diff --check`
- `node --experimental-strip-types --check server/src/routes/chargeCodes.ts`
- `node --experimental-strip-types --check server/schema.ts`

Full `npm/pnpm run check` could not run locally because `npm` is unavailable in this shell and bundled `pnpm` attempted a blocked registry install.