### PR TITLE
[codex] Fix All Orders attachment viewing

### DIFF
--- a/server/replit_integrations/object_storage/objectStorage.ts
+++ b/server/replit_integrations/object_storage/objectStorage.ts
@@ -95,7 +95,12 @@ export class ObjectStorageService {
   }
 
   // Downloads an object to the response.
-  async downloadObject(file: File, res: Response, cacheTtlSec: number = 3600) {
+  async downloadObject(
+    file: File,
+    res: Response,
+    cacheTtlSec: number = 3600,
+    options?: { contentType?: string | null; contentDisposition?: string | null }
+  ) {
     try {
       // Get file metadata
       const [metadata] = await file.getMetadata();
@@ -104,12 +109,15 @@ export class ObjectStorageService {
       const isPublic = aclPolicy?.visibility === "public";
       // Set appropriate headers
       res.set({
-        "Content-Type": metadata.contentType || "application/octet-stream",
+        "Content-Type": options?.contentType || metadata.contentType || "application/octet-stream",
         "Content-Length": metadata.size,
         "Cache-Control": `${
           isPublic ? "public" : "private"
         }, max-age=${cacheTtlSec}`,
       });
+      if (options?.contentDisposition) {
+        res.setHeader("Content-Disposition", options.contentDisposition);
+      }
 
       // Stream the file to the response
       const stream = file.createReadStream();

--- a/server/src/routes/media.ts
+++ b/server/src/routes/media.ts
@@ -15,6 +15,10 @@ import {
 
 const router = Router();
 
+function contentDisposition(disposition: 'inline' | 'attachment', filename: string) {
+  return `${disposition}; filename="${filename.replace(/["\r\n]/g, '_')}"`;
+}
+
 // Configure multer for temporary file uploads (will be moved to cloud storage)
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
@@ -347,13 +351,10 @@ router.get('/file/:filename', async (req, res) => {
       if (record.storage_path.startsWith('/objects/') || record.storage_path.startsWith('objects/')) {
         const objectPath = record.storage_path.startsWith('/') ? record.storage_path : `/${record.storage_path}`;
         try {
-          if (record.mime_type) {
-            res.setHeader('Content-Type', record.mime_type);
-          }
-          if (record.filename) {
-            res.setHeader('Content-Disposition', `inline; filename="${record.filename}"`);
-          }
-          return await getFileStorageProviderForObjectPath(objectPath).downloadObject(objectPath, res);
+          return await getFileStorageProviderForObjectPath(objectPath).downloadObject(objectPath, res, {
+            contentType: record.mime_type,
+            contentDisposition: record.filename ? contentDisposition('inline', record.filename) : null,
+          });
         } catch (objError) {
           console.error('Cloud storage file not found:', objError);
         }
@@ -529,9 +530,10 @@ router.get('/:id/download', async (req, res) => {
     if (storagePath && (storagePath.startsWith('/objects/') || storagePath.startsWith('objects/'))) {
       const objectPath = storagePath.startsWith('/') ? storagePath : `/${storagePath}`;
       try {
-        if (media.mimeType) res.setHeader('Content-Type', media.mimeType);
-        res.setHeader('Content-Disposition', `inline; filename="${media.filename || 'file'}"`);
-        return await getFileStorageProviderForObjectPath(objectPath).downloadObject(objectPath, res);
+        return await getFileStorageProviderForObjectPath(objectPath).downloadObject(objectPath, res, {
+          contentType: media.mimeType,
+          contentDisposition: contentDisposition('inline', media.filename || 'file'),
+        });
       } catch (objError) {
         console.error('Cloud storage download failed:', objError);
       }

--- a/server/src/routes/orderAttachments.ts
+++ b/server/src/routes/orderAttachments.ts
@@ -60,6 +60,10 @@ function normalizeObjectPath(filePath: string | null | undefined) {
   return filePath?.startsWith('objects/') ? `/${filePath}` : filePath;
 }
 
+function contentDisposition(disposition: 'inline' | 'attachment', filename: string) {
+  return `${disposition}; filename="${filename.replace(/["\r\n]/g, '_')}"`;
+}
+
 // GET /api/order-attachments/:orderId - Get all attachments for an order
 router.get('/:orderId', async (req, res) => {
   try {
@@ -284,11 +288,10 @@ router.get('/download/:attachmentId', async (req, res) => {
 
     if (isSupabaseObjectPath(normalizedDownloadPath) || isReplitObjectPath(normalizedDownloadPath)) {
       try {
-        res.setHeader(
-          'Content-Disposition',
-          `${forceDownload ? 'attachment' : 'inline'}; filename="${attachment.originalFileName}"`
-        );
-        await getFileStorageProviderForObjectPath(normalizedDownloadPath!).downloadObject(normalizedDownloadPath!, res);
+        await getFileStorageProviderForObjectPath(normalizedDownloadPath!).downloadObject(normalizedDownloadPath!, res, {
+          contentType: attachment.mimeType,
+          contentDisposition: contentDisposition(forceDownload ? 'attachment' : 'inline', attachment.originalFileName),
+        });
       } catch (cloudError) {
         console.error('[order-attachments/download] Error fetching from cloud storage:', cloudError);
         res.status(404).json({ error: 'File not found in cloud storage' });
@@ -298,7 +301,7 @@ router.get('/download/:attachmentId', async (req, res) => {
         res.download(attachment.filePath, attachment.originalFileName);
       } else {
         res.setHeader('Content-Type', attachment.mimeType);
-        res.setHeader('Content-Disposition', `inline; filename="${attachment.originalFileName}"`);
+        res.setHeader('Content-Disposition', contentDisposition('inline', attachment.originalFileName));
         res.sendFile(path.resolve(attachment.filePath));
       }
     } else {

--- a/server/src/services/fileStorageProvider.ts
+++ b/server/src/services/fileStorageProvider.ts
@@ -18,13 +18,18 @@ export interface UploadTarget {
   provider: FileStorageProviderName;
 }
 
+export interface DownloadObjectOptions {
+  contentType?: string | null;
+  contentDisposition?: string | null;
+}
+
 export interface FileStorageProvider {
   readonly name: FileStorageProviderName;
   createUploadTarget(input: CreateUploadTargetInput): Promise<UploadTarget>;
   uploadBuffer(input: CreateUploadTargetInput & { buffer: Buffer }): Promise<string>;
   setPublicReadPolicy(objectPath: string, owner?: string): Promise<void>;
   deleteObject(objectPath: string): Promise<void>;
-  downloadObject(objectPath: string, res: Response): Promise<void>;
+  downloadObject(objectPath: string, res: Response, options?: DownloadObjectOptions): Promise<void>;
   downloadBuffer(objectPath: string): Promise<Buffer>;
 }
 
@@ -152,9 +157,9 @@ class ReplitFileStorageProvider implements FileStorageProvider {
     await objectFile.delete();
   }
 
-  async downloadObject(objectPath: string, res: Response) {
+  async downloadObject(objectPath: string, res: Response, options?: DownloadObjectOptions) {
     const objectFile = await this.objectStorage.getObjectEntityFile(normalizeLegacyObjectPath(objectPath));
-    await this.objectStorage.downloadObject(objectFile, res);
+    await this.objectStorage.downloadObject(objectFile, res, 3600, options);
   }
 
   async downloadBuffer(objectPath: string) {
@@ -240,7 +245,7 @@ class SupabaseFileStorageProvider implements FileStorageProvider {
     }
   }
 
-  async downloadObject(objectPath: string, res: Response) {
+  async downloadObject(objectPath: string, res: Response, options?: DownloadObjectOptions) {
     const ref = parseSupabaseObjectPath(objectPath);
     const response = await fetch(`${this.url}/storage/v1/object/${encodeURIComponent(ref.bucket)}/${ref.path}`, {
       headers: this.authHeaders(),
@@ -257,9 +262,12 @@ class SupabaseFileStorageProvider implements FileStorageProvider {
 
     response.headers.forEach((value, key) => {
       if (['content-type', 'content-length', 'cache-control'].includes(key.toLowerCase())) {
+        if (key.toLowerCase() === 'content-type' && options?.contentType) return;
         res.setHeader(key, value);
       }
     });
+    if (options?.contentType) res.setHeader('Content-Type', options.contentType);
+    if (options?.contentDisposition) res.setHeader('Content-Disposition', options.contentDisposition);
 
     Readable.fromWeb(response.body as any).pipe(res);
   }


### PR DESCRIPTION
## Summary
- Preserve route-known MIME type and content disposition when serving All Orders order attachments from cloud storage.
- Apply the same header override to Media Library downloads used by linked order attachments.
- Sanitize filenames before emitting `Content-Disposition` headers.

## Root Cause
The app recorded the uploaded file MIME type, but the cloud storage download helper could overwrite or omit browser-friendly response headers from object metadata. That made uploaded files difficult or impossible to view from All Orders even when the attachment record existed.

## Validation
- `node --experimental-strip-types --check` on the four touched TypeScript files using the bundled Codex Node runtime.
- `git diff --cached --check` before commit.