### PR TITLE
[codex] Fix P2 project quote loading

### DIFF
--- a/client/src/pages/P2QuoteForm.tsx
+++ b/client/src/pages/P2QuoteForm.tsx
@@ -168,50 +168,78 @@ export default function P2QuoteForm() {
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const quoteId = urlParams.get('id');
+    const projectId = urlParams.get('projectId');
     
-    if (quoteId) {
-      // Fetch the quote data
-      fetch(`/api/quotes/${quoteId}`)
-        .then(res => res.json())
-        .then(data => {
-          // Populate form with quote data
-          setSavedQuoteId(data.id);
-          setQuoteNumber(data.quoteNumber);
-          setQuoteStatus(data.status);
-          setLinkedProjectId(data.projectId ?? null);
-          setCustomerName(data.description?.split('(')[0]?.replace('From: ', '').trim() || '');
-          setCustomerCompany(data.customerName);
-          setNotes(data.notes || '');
-          setValidityDays(String(Math.round((new Date(data.validUntil).getTime() - new Date(data.createdAt).getTime()) / (1000 * 60 * 60 * 24))));
-          setAttachments(data.attachments || []);
-          
-          // Load line items if present
-          if (data.lineItems && data.lineItems.length > 0) {
-            const loadedItems = data.lineItems.map((item: any) => ({
-              id: `${Date.now()}-${item.lineNumber}`,
-              lineNumber: item.lineNumber,
-              quantity: item.quantity,
-              description: item.description,
-              unitPrice: item.unitPrice,
-              totalPrice: item.totalPrice,
-            }));
-            setLineItems(loadedItems);
+    if (!quoteId && !projectId) return;
+
+    const populateQuote = (data: any) => {
+      setSavedQuoteId(data.id);
+      setQuoteNumber(data.quoteNumber);
+      setQuoteStatus(data.status);
+      setLinkedProjectId(data.projectId ?? null);
+      setCustomerName(data.description?.split('(')[0]?.replace('From: ', '').trim() || '');
+      setCustomerCompany(data.customerName);
+      setNotes(data.notes || '');
+      setValidityDays(String(Math.round((new Date(data.validUntil).getTime() - new Date(data.createdAt).getTime()) / (1000 * 60 * 60 * 24))));
+      setAttachments(data.attachments || []);
+
+      if (data.lineItems && data.lineItems.length > 0) {
+        const loadedItems = data.lineItems.map((item: any) => ({
+          id: `${Date.now()}-${item.lineNumber}`,
+          lineNumber: item.lineNumber,
+          quantity: item.quantity,
+          description: item.description,
+          unitPrice: item.unitPrice,
+          totalPrice: item.totalPrice,
+        }));
+        setLineItems(loadedItems);
+      }
+
+      toast({
+        title: 'Quote Loaded',
+        description: `Viewing quote ${data.quoteNumber}`,
+      });
+    };
+
+    const loadQuote = async () => {
+      try {
+        let resolvedQuoteId = quoteId;
+
+        if (!resolvedQuoteId && projectId) {
+          const projectData = await apiRequest(`/api/projects/${projectId}`);
+          const projectSteps = Array.isArray(projectData?.steps) ? projectData.steps : [];
+          resolvedQuoteId =
+            projectSteps.find((step: any) => step.stepType === 'quote')?.linkedQuoteId ??
+            null;
+
+          if (!resolvedQuoteId) {
+            const feedback = await apiRequest(`/api/projects/${projectId}/quote-feedback`);
+            resolvedQuoteId = feedback?.quoteId ?? null;
           }
-          
+        }
+
+        if (!resolvedQuoteId) {
           toast({
-            title: 'Quote Loaded',
-            description: `Viewing quote ${data.quoteNumber}`,
-          });
-        })
-        .catch(error => {
-          console.error('Error loading quote:', error);
-          toast({
-            title: 'Error',
-            description: 'Failed to load quote data',
+            title: 'Quote not linked',
+            description: 'This project does not have a linked quote record yet.',
             variant: 'destructive',
           });
+          return;
+        }
+
+        const data = await apiRequest(`/api/quotes/${resolvedQuoteId}`);
+        populateQuote(data);
+      } catch (error) {
+        console.error('Error loading quote:', error);
+        toast({
+          title: 'Error',
+          description: 'Failed to load quote data',
+          variant: 'destructive',
         });
-    }
+      }
+    };
+
+    void loadQuote();
   }, []);
 
   // Auto-select by rfqNumber URL param (takes priority over customerId)

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -974,6 +974,12 @@ export default function ProjectDetailPage() {
       }),
     enabled: !!id,
   });
+  const linkedProjectQuoteId =
+    projectSteps.find((step) => step.stepType === 'quote')?.linkedQuoteId ??
+    quoteFeedback?.quoteId ??
+    hubLabor.quoteFeedback?.quoteId ??
+    hubLabor.quoteFeedback?.quote_id ??
+    null;
 
   useEffect(() => {
     const hydrateKey = `${id ?? ''}:${romDraft?.id ?? 'default'}:${romSummary.updatedAt ?? ''}:${JSON.stringify(hubRom.categories ?? {})}`;
@@ -3430,7 +3436,13 @@ export default function ProjectDetailPage() {
               </div>
 
               <div className="flex flex-wrap gap-2">
-                <Button onClick={() => setLocation(`/p2-quote-form?projectId=${encodeURIComponent(project.id)}`)}>
+                <Button
+                  onClick={() => setLocation(
+                    linkedProjectQuoteId
+                      ? `/p2-quote-form?id=${encodeURIComponent(linkedProjectQuoteId)}`
+                      : `/p2-quote-form?projectId=${encodeURIComponent(project.id)}`
+                  )}
+                >
                   <ExternalLink className="h-4 w-4 mr-2" />
                   Open Quote
                 </Button>


### PR DESCRIPTION
## Summary
- Fix the P2 Project page's Open Quote action to pass the linked quote id when available.
- Allow `P2QuoteForm` to resolve legacy `/p2-quote-form?projectId=...` links by loading the project's linked quote step.
- Fall back to quote-feedback's `quoteId` when a project step link is missing but a feedback snapshot has the quote relationship.

## Root Cause
The P2 Project page opened `/p2-quote-form?projectId=...`, but `P2QuoteForm` only loaded existing quotes from an `id` query parameter. That left the quote form unable to load the actual quote from the project workflow.

## Validation
- `git diff --check origin/main..HEAD`
- Verified final diff is scoped to `client/src/pages/ProjectDetailPage.tsx` and `client/src/pages/P2QuoteForm.tsx`

Note: A full TypeScript compile was not run because this clean worktree does not have local `node_modules`/`tsc`; bundled Node also cannot directly `--check` `.tsx` files.