### PR TITLE
[codex] Allow existing cutting packet labels to start scans

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -902,11 +902,15 @@ export default function CuttingOperatorDashboard() {
       clearTimeout(packetScanTimerRef.current);
       packetScanTimerRef.current = null;
     }
-    if (packetScanBarcode && packetScanBarcode.length > 5 && packetScanBarcode.startsWith('MFG-') && /^MFG-\d+-[^-]+/.test(packetScanBarcode)) {
+    const normalizedPacketScan = packetScanBarcode.trim();
+    const isPacketScanBarcode =
+      /^MFG-\d+-.+/.test(normalizedPacketScan) ||
+      /^PKT-.+-\d+-\d+-\d+(?:-\d+)?$/.test(normalizedPacketScan);
+    if (isPacketScanBarcode) {
       packetScanTimerRef.current = setTimeout(() => {
-        if (packetScanBarcode !== lastSubmittedPacketRef.current) {
-          lastSubmittedPacketRef.current = packetScanBarcode;
-          handlePacketScan(packetScanBarcode);
+        if (normalizedPacketScan !== lastSubmittedPacketRef.current) {
+          lastSubmittedPacketRef.current = normalizedPacketScan;
+          handlePacketScan(normalizedPacketScan);
         }
       }, 400);
     }
@@ -1446,7 +1450,7 @@ export default function CuttingOperatorDashboard() {
                   id="packet-scan-barcode"
                   value={packetScanBarcode}
                   onChange={(val) => setPacketScanBarcode(val)}
-                  placeholder="Scan packet barcode (MFG-...)"
+                  placeholder="Scan packet barcode (MFG... or PKT...)"
                   data-testid="input-packet-scan"
                 />
                 <Button

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -42,9 +42,20 @@ function parseBuiltPacketBarcode(barcode: string | null | undefined): { sku: str
   return { sku, queueId, packetNumber };
 }
 
-function parseManufacturingPacketBarcode(barcode: string | null | undefined): { queueId: number; sku: string; sequence: number | null } | null {
+function parseManufacturingPacketBarcode(barcode: string | null | undefined): { queueId: number; sku: string; sequence: number | null; builtPacketBarcode?: string } | null {
   if (!barcode) return null;
-  const parts = barcode.trim().split('-');
+  const trimmed = barcode.trim();
+  const builtPacket = parseBuiltPacketBarcode(trimmed);
+  if (builtPacket) {
+    return {
+      queueId: builtPacket.queueId,
+      sku: builtPacket.sku,
+      sequence: builtPacket.packetNumber,
+      builtPacketBarcode: trimmed,
+    };
+  }
+
+  const parts = trimmed.split('-');
   if (parts.length < 3 || parts[0] !== 'MFG') return null;
 
   const queueId = Number(parts[1]);
@@ -1524,11 +1535,12 @@ router.post('/scan-start', async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Barcode is required' });
     }
     
-    // Parse the barcode format: MFG-{id}-{partNumber} or MFG-{id}-{partNumber}-{seq}.
-    // Part numbers can contain hyphens, so split from the stable prefix/id and optional numeric suffix.
+    // Parse packet barcodes. New labels use MFG-{id}-{partNumber}-{seq};
+    // existing production packet labels may still use PKT-{partNumber}-{id}-{packetNumber}-{timestamp}.
+    // Part numbers can contain hyphens, so split from stable id/sequence positions.
     const parsedBarcode = parseManufacturingPacketBarcode(barcode);
     if (!parsedBarcode) {
-      return res.status(400).json({ error: 'Invalid packet barcode format. Expected: MFG-{id}-{partNumber} or MFG-{id}-{partNumber}-{seq}' });
+      return res.status(400).json({ error: 'Invalid packet barcode format. Expected: MFG-{id}-{partNumber}-{seq} or existing PKT-{partNumber}-{id}-{packetNumber}-{timestamp}' });
     }
     
     const printedQueueId = parsedBarcode.queueId;
@@ -1786,10 +1798,16 @@ router.post('/scan-start', async (req: Request, res: Response) => {
         .orderBy(asc(cuttingBuiltPackets.id));
 
       let targetPacket: { id: number; status: string } | null = null;
-      if (scannedSeq !== null && scannedSeq >= 1 && scannedSeq <= builtPacketsForQueue.length) {
+      if (parsedBarcode.builtPacketBarcode) {
+        targetPacket = await db.query.cuttingBuiltPackets.findFirst({
+          where: eq(cuttingBuiltPackets.barcode, parsedBarcode.builtPacketBarcode),
+        }) ?? null;
+      }
+      if (!targetPacket && scannedSeq !== null && scannedSeq >= 1 && scannedSeq <= builtPacketsForQueue.length) {
         // Use rank-based lookup (1-indexed)
         targetPacket = builtPacketsForQueue[scannedSeq - 1];
-      } else {
+      }
+      if (!targetPacket) {
         // No sequence info — update the first AVAILABLE packet for this queue item
         targetPacket = builtPacketsForQueue.find(p => p.status === 'AVAILABLE') ?? null;
       }


### PR DESCRIPTION
## Summary

Fixes the remaining cutting table scan-start issue for already printed production packet labels:

- Accepts existing `PKT-{partNumber}-{id}-{packetNumber}-{timestamp}` labels in `/api/cutting-table-mfg-queue/scan-start`, not only new `MFG-...` labels.
- Resolves the exact scanned `PKT` built-packet row when available, so the operator starts the physical packet represented by the printed label.
- Keeps support for hyphenated `MFG` part numbers from the prior PR.
- Updates the cutting operator auto-submit gate so scanned `PKT` labels trigger start just like `MFG` labels.

## Root Cause

The prior fix made `MFG` labels more tolerant, but existing printed production labels can be `PKT` barcodes from the built-packet/packet-label path. The operator page only auto-submitted `MFG` values, and the backend scan-start route rejected non-`MFG` barcodes before resolving the queue row.

## Validation

- `git diff --check origin/main..HEAD`
- `node --experimental-strip-types --check server/src/routes/cuttingTableManufacturingQueue.ts`

Vitest/tsc could not be run locally because this worktree and the bundled runtime do not have the repo's JS test/tooling dependencies installed.