### PR TITLE
[codex] Harden P2 traveler part scan resolution

### DIFF
--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -439,6 +439,57 @@ function decodeScanParam(value: string): string | null {
   }
 }
 
+function buildP2PartScanVariants(scanValue: string): string[] {
+  const trimmed = scanValue.trim();
+  const compact = trimmed.replace(/\s+/g, '');
+  const variants = new Set<string>([trimmed, compact]);
+
+  for (const value of Array.from(variants)) {
+    if (/^rec/i.test(value)) variants.add(`ROC${value.slice(3)}`);
+    if (/^roc/i.test(value)) variants.add(`REC${value.slice(3)}`);
+  }
+
+  return Array.from(variants).filter(Boolean);
+}
+
+async function findSerializedItemByPartScan(scanValue: string) {
+  const variants = buildP2PartScanVariants(scanValue);
+  const fields = [
+    p2SerializedItems.barcode,
+    p2SerializedItems.travelerBarcode,
+    p2SerializedItems.serialNumber,
+    p2SerializedItems.customerSerialNumber,
+  ];
+
+  for (const variant of variants) {
+    const item = await db.query.p2SerializedItems.findFirst({
+      where: or(...fields.map(field => ilike(field, variant))),
+    });
+    if (item) return item;
+  }
+
+  for (const variant of variants) {
+    const item = await db.query.p2SerializedItems.findFirst({
+      where: or(...fields.map(field => ilike(field, `%${variant}%`))),
+    });
+    if (item) return item;
+  }
+
+  const numericSuffix = scanValue.match(/(\d{6,})$/)?.[1] ?? null;
+  if (numericSuffix) {
+    return await db.query.p2SerializedItems.findFirst({
+      where: or(
+        ilike(p2SerializedItems.barcode, `%${numericSuffix}`),
+        ilike(p2SerializedItems.travelerBarcode, `%${numericSuffix}`),
+        ilike(p2SerializedItems.serialNumber, `%${numericSuffix}`),
+        ilike(p2SerializedItems.customerSerialNumber, `%${numericSuffix}`)
+      ),
+    });
+  }
+
+  return null;
+}
+
 function getBasePartNumberWithoutRevision(partNumber?: string | null): string | null {
   const match = partNumber?.match(/^(.+?)\s*Rev\s*\w+$/i);
   return match ? match[1].trim() : null;
@@ -1733,24 +1784,7 @@ router.get('/verify-certification/:employeeCode/:barcode', async (req: Request, 
       return res.status(404).json({ error: 'Employee not found' });
     }
 
-    // Get serialized item - check both system barcode and physical traveler barcode (case-insensitive)
-    let serializedItem = await db.query.p2SerializedItems.findFirst({
-      where: or(
-        ilike(p2SerializedItems.barcode, barcode),
-        ilike(p2SerializedItems.travelerBarcode, barcode)
-      ),
-    });
-
-    // If not found, try suffix/contains match (physical labels may omit prefix like "SG0")
-    if (!serializedItem) {
-      serializedItem = await db.query.p2SerializedItems.findFirst({
-        where: or(
-          ilike(p2SerializedItems.barcode, `%${barcode}`),
-          ilike(p2SerializedItems.travelerBarcode, `%${barcode}`),
-          ilike(p2SerializedItems.serialNumber, `%${barcode}`)
-        ),
-      });
-    }
+    const serializedItem = await findSerializedItemByPartScan(barcode);
 
     if (!serializedItem) {
       const looksLikeBadge = /^EMP\d+$/i.test(barcode) || barcode.toUpperCase() === employeeCode.toUpperCase();
@@ -1843,12 +1877,7 @@ router.get('/part-info/:barcode', async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Invalid part barcode. Please rescan the part label.' });
     }
 
-    const serializedItem = await db.query.p2SerializedItems.findFirst({
-      where: or(
-        ilike(p2SerializedItems.barcode, barcode),
-        ilike(p2SerializedItems.travelerBarcode, barcode)
-      ),
-    });
+    const serializedItem = await findSerializedItemByPartScan(barcode);
 
     if (!serializedItem) {
       return res.status(404).json({ error: 'Part not found' });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -6627,11 +6627,36 @@ export class DatabaseStorage implements IStorage {
   // Inventory Items CRUD
   async getAllInventoryItems(): Promise<InventoryItem[]> {
     // Include items where isActive is true OR isActive is null (treat null as active)
-    return await db
-      .select()
-      .from(inventoryItems)
-      .where(or(eq(inventoryItems.isActive, true), isNull(inventoryItems.isActive)))
-      .orderBy(inventoryItems.name);
+    try {
+      return await db
+        .select()
+        .from(inventoryItems)
+        .where(or(eq(inventoryItems.isActive, true), isNull(inventoryItems.isActive)))
+        .orderBy(inventoryItems.name);
+    } catch (error: any) {
+      const message = String(error?.message || error);
+      const code = error?.code || error?.cause?.code;
+      if (code !== '42703' && !/column .* does not exist/i.test(message)) {
+        throw error;
+      }
+
+      console.warn('[Inventory] Falling back to runtime inventory_items columns:', message);
+      const result = await db.execute(sql`
+        SELECT *
+        FROM inventory_items
+        WHERE is_active = TRUE OR is_active IS NULL
+        ORDER BY name
+      `);
+
+      const rows = Array.isArray(result) ? result : ((result as any).rows || []);
+      return rows.map((row: Record<string, unknown>) => {
+        const item: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(row)) {
+          item[key.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase())] = value;
+        }
+        return item as InventoryItem;
+      });
+    }
   }
 
   async getInventoryItem(id: number): Promise<InventoryItem | undefined> {


### PR DESCRIPTION
## Summary

Fixes the live P2 traveler scan path reported from production logs:

- Resolves scanned part values through a shared P2 serialized-item scan helper for both `/verify-certification` and `/part-info`.
- Tries exact, compacted, contains, customer serial, and numeric-suffix matches across system barcode, traveler barcode, serial number, and customer serial number.
- Handles `REC`/`ROC` prefix drift so a scan like `rec2600235` can resolve an item stored as `ROC2600235`.
- Adds a fallback for `/api/enhanced/inventory/items` when production is missing a newer `inventory_items` column: the typed Drizzle read stays primary, but missing-column failures fall back to runtime `SELECT *` and camelCase mapping so inventory-backed pages can still load while migrations catch up.

## Root Cause

The deployed P2 traveler flow reached the correct certification endpoint, but the serialized item lookup only matched a small subset of barcode fields and did not account for REC/ROC label drift or customer-facing serial fields.

The inventory list error is likely a production schema drift issue: Drizzle `select()` asks for every column in the current schema, so one missing inventory column causes the whole `/api/enhanced/inventory/items` request to fail.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/p2Traveler.ts`
- `node --experimental-strip-types --check server/storage.ts`

Vitest/tsc could not be run locally because this worktree and the bundled runtime do not have the repo's JS test/tooling dependencies installed.