### PR TITLE
[codex] Fix Timer Station kiosk auth loop

### DIFF
--- a/client/src/hooks/useActionAuth.ts
+++ b/client/src/hooks/useActionAuth.ts
@@ -17,6 +17,20 @@ interface ActionAuthState {
 const ACTION_TOKEN_KEY = 'epoch_action_token';
 const ACTION_TOKEN_EXPIRY_KEY = 'epoch_action_token_expiry';
 const ACTION_TOKEN_USER_KEY = 'epoch_action_token_user';
+const ACTION_AUTH_KIOSK_ROUTES = [
+  '/app/production/stations',
+  '/production/timers',
+  '/p2-traveler',
+  '/p2-traveler-viewer',
+  '/traveler',
+  '/travelers',
+];
+
+function isActionAuthKioskRoute() {
+  if (typeof window === 'undefined') return false;
+  const path = window.location.pathname;
+  return ACTION_AUTH_KIOSK_ROUTES.some((route) => path === route || path.startsWith(`${route}/`));
+}
 
 function getStoredAuth(): ActionAuthState {
   try {
@@ -61,10 +75,13 @@ export function useActionAuth() {
   const [actionDescription, setActionDescription] = useState('perform this action');
   const pendingActionRef = useRef<(() => void) | null>(null);
   const authSuccessCloseRef = useRef(false);
+  const skipWebSessionProbe = isActionAuthKioskRoute();
 
   const { data: sessionUser } = useQuery<ActionAuthUser | null>({
     queryKey: ['/api/auth/session'],
+    enabled: !skipWebSessionProbe,
     staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
     retry: false,
   });
 
@@ -99,8 +116,8 @@ export function useActionAuth() {
     }
   }, [authState.isAuthenticated, authState.token]);
 
-  const isAuthenticated = !!sessionUser || authState.isAuthenticated;
-  const currentUser = sessionUser || authState.user;
+  const isAuthenticated = (!skipWebSessionProbe && !!sessionUser) || authState.isAuthenticated;
+  const currentUser = skipWebSessionProbe ? authState.user : sessionUser || authState.user;
 
   const requireAuth = useCallback((action: () => void, actionDescription?: string) => {
     if (isAuthenticated) {

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -95,6 +95,7 @@ let sessionExpiryNotified = false;
 // redirect to /login — that would disrupt workers mid-task.
 const KIOSK_ROUTES = [
   '/kiosk',
+  '/app/production/stations',
   '/p2-traveler',
   '/p2-traveler-viewer',
   '/traveler',


### PR DESCRIPTION
## Summary
- Stop `useActionAuth` from probing `/api/auth/session` on Timer Station and other kiosk/floor routes.
- Keep Timer Station action auth tied to badge/action-token state instead of a missing web session.
- Add `/app/production/stations` to the kiosk route allowlist so expected floor-station 401s do not trigger the global session-expired redirect/toast loop.

## Validation
- `git diff --cached --check`
- Compare range verified as one commit / two files against fresh `origin/main`

Full TypeScript/build validation was not run because `npm` is not available on PATH and this worktree has no local TypeScript binary.