### PR TITLE
[codex] Fix P1 PO department status moves

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -11550,7 +11550,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           }
 
           // Departments that are initial queue placements — orders there can keep FINALIZED
-          const INITIAL_QUEUE_DEPARTMENTS = ['P1 Production Queue', 'Shipping QC'];
+          const INITIAL_QUEUE_DEPARTMENTS = ['P1 Production Queue'];
 
           // If the destination is a real production department (not an initial queue),
           // always force status to IN_PROGRESS regardless of what the caller sent.
@@ -11574,13 +11574,22 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           // Update the appropriate table based on order type
           let updatedOrder;
           if (isProductionOrder) {
+            const productionStatus = deriveP1ProductionStatus({
+              currentDepartment: department,
+              isFulfilled: (currentOrder as any).isFulfilled,
+              currentStatus: (currentOrder as any).productionStatus,
+            });
+            const productionUpdateData = {
+              ...updateData,
+              productionStatus,
+              updatedAt: now,
+            };
+            delete (productionUpdateData as any).status;
+
             // Update production order table
             updatedOrder = await storage.updateProductionOrder(
               (currentOrder as any).id,
-              {
-                ...updateData,
-                updatedAt: now,
-              }
+              productionUpdateData
             );
             console.log(`[PROGRESSION SUCCESS] ${orderId} → ${department}`);
           } else if (isFinalized) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -14050,21 +14050,14 @@ export class DatabaseStorage implements IStorage {
     try {
       // Departments that are initial queue placements — orders there may keep FINALIZED.
       // Any other department is a real production department and must be IN_PROGRESS.
-      const INITIAL_QUEUE_DEPARTMENTS = ['P1 Production Queue', 'Shipping QC'];
+      const INITIAL_QUEUE_DEPARTMENTS = ['P1 Production Queue'];
       const resolvedStatus = INITIAL_QUEUE_DEPARTMENTS.includes(department)
         ? status
         : 'IN_PROGRESS';
-      const normalizedDepartment = department.trim().toLowerCase();
-      const normalizedStatus = status.trim().toUpperCase();
-      const resolvedProductionStatus =
-        normalizedDepartment === 'p1 production queue'
-          ? 'PENDING'
-          : normalizedDepartment === 'fulfilled' ||
-            normalizedDepartment === 'shipped' ||
-            normalizedStatus === 'FULFILLED' ||
-            normalizedStatus === 'SHIPPED'
-            ? 'SHIPPED'
-            : 'LAID_UP';
+      const resolvedProductionStatus = deriveP1ProductionStatus({
+        currentDepartment: department,
+        currentStatus: status,
+      });
 
       console.log(
         ` প্রক্র PRODUCTION FLOW: Updating order ${orderId} to department ${department} with status ${resolvedStatus}`


### PR DESCRIPTION
## Summary
- Update manual department transfers so P1 production orders write the derived `productionStatus` when their department changes.
- Treat only `P1 Production Queue` as the pending queue; moves into work departments now resolve as `IN_PROGRESS`.
- Reuse the shared P1 production status helper in the storage transfer path instead of the old hard-coded `LAID_UP` fallback.
- Add a controlled historical backfill to `maintenance:boot-repairs` that realigns existing P1 production rows whose stored `production_status` no longer matches their current department/fulfilled state.
- Align the admin P1 PO status repair dry-run/apply SQL with the same rule so `Shipping QC` is repaired to `IN_PROGRESS` unless the row is actually fulfilled.

## Why
P1 purchase order items could be moved between departments while keeping a stale or inappropriate status. For example, an item moved from shipped back into a work department should become in progress, while an item moved to the P1 Production Queue should be pending. Existing rows that were moved before the route fix also need to be repaired.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/index.ts`
- `node --experimental-strip-types --check server/storage.ts`
- `node --experimental-strip-types --check server/src/routes/admin.ts`
- `node --experimental-strip-types --check server/bootstrap/oneTimeRepairs.ts`
- `node --experimental-strip-types --check server/scripts/maintenance/runBootRepairs.ts`
- `node --experimental-strip-types --check server/scripts/maintenance/bootRepairBackfills.ts`

Note: a focused Vitest run could not be completed locally because `npx` is not installed and bundled `pnpm` attempted to fetch packages from npm, which is blocked in this environment.