### PR TITLE
[codex] Backfill P1 PO production statuses

### DIFF
--- a/server/bootstrap/oneTimeRepairs.ts
+++ b/server/bootstrap/oneTimeRepairs.ts
@@ -1,6 +1,7 @@
 import {
   runEarlyBootRepairBackfills,
   runPacketAllocationBackfill,
+  runP1ProductionStatusBackfill,
   runReturnToQcShippedStatusRepair,
 } from '../scripts/maintenance/bootRepairBackfills';
 
@@ -78,6 +79,10 @@ export async function runLaborAllocationBackfill(pool: any) {
 
 export async function runEarlyOneTimeRepairBackfills(context: BootRepairContext) {
   await runEarlyBootRepairBackfills(context);
+}
+
+export async function runP1ProductionStatusBootBackfill(context: BootRepairContext) {
+  return runP1ProductionStatusBackfill(context);
 }
 
 export async function runReturnToQcBootRepair() {

--- a/server/scripts/maintenance/bootRepairBackfills.ts
+++ b/server/scripts/maintenance/bootRepairBackfills.ts
@@ -1,7 +1,62 @@
+export {};
+
 type BootRepairContext = {
   db: any;
   pool: any;
 };
+
+export async function runP1ProductionStatusBackfill({ pool }: BootRepairContext) {
+  try {
+    const result = await pool.query(`
+      WITH candidates AS (
+        SELECT
+          id,
+          production_status AS current_status,
+          CASE
+            WHEN UPPER(COALESCE(NULLIF(TRIM(production_status), ''), '')) = 'CANCELLED'
+              THEN 'CANCELLED'
+            WHEN COALESCE(is_fulfilled, false)
+              THEN 'SHIPPED'
+            WHEN LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) = 'p1 production queue'
+              THEN 'PENDING'
+            WHEN COALESCE(NULLIF(TRIM(current_department), ''), '') = ''
+              THEN 'PENDING'
+            WHEN LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) IN ('fulfilled', 'shipped')
+              THEN 'SHIPPED'
+            ELSE 'IN_PROGRESS'
+          END AS expected_status
+        FROM production_orders
+        WHERE po_id IS NOT NULL
+      ),
+      mismatches AS (
+        SELECT *
+        FROM candidates
+        WHERE UPPER(COALESCE(NULLIF(TRIM(current_status), ''), '')) <> expected_status
+      )
+      UPDATE production_orders prod
+      SET production_status = mismatches.expected_status,
+          updated_at = NOW()
+      FROM mismatches
+      WHERE prod.id = mismatches.id
+      RETURNING
+        prod.id,
+        prod.order_id,
+        mismatches.current_status AS previous_status,
+        prod.production_status AS new_status,
+        prod.current_department
+    `);
+    const updated = result.rowCount ?? result.rows?.length ?? 0;
+    if (updated > 0) {
+      console.log(`✅ P1 production status backfill corrected ${updated} row(s)`);
+    } else {
+      console.log('✅ P1 production status backfill found no mismatches');
+    }
+    return { updated };
+  } catch (err: any) {
+    console.warn('⚠️ P1 production status backfill skipped:', err?.message || err);
+    return { updated: 0, skipped: true, error: err?.message || String(err) };
+  }
+}
 
 export async function runEarlyBootRepairBackfills({ db, pool }: BootRepairContext) {
   // Backfill: ensure all customers have a customer_key derived from their name

--- a/server/scripts/maintenance/runBootRepairs.ts
+++ b/server/scripts/maintenance/runBootRepairs.ts
@@ -3,6 +3,7 @@ import {
   runEarlyOneTimeRepairBackfills,
   runLaborAllocationBackfill,
   runPacketAllocationBootBackfill,
+  runP1ProductionStatusBootBackfill,
   runReturnToQcBootRepair,
 } from '../../bootstrap/oneTimeRepairs';
 
@@ -16,6 +17,8 @@ async function main() {
   }
 
   await runEarlyOneTimeRepairBackfills({ db, pool });
+  const p1StatusBackfill = await runP1ProductionStatusBootBackfill({ db, pool });
+  console.log(`P1 production status backfill updated ${p1StatusBackfill.updated} row(s).`);
   await runReturnToQcBootRepair();
   await runPacketAllocationBootBackfill({ db, pool });
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -33,9 +33,6 @@ const p1ProductionStatusExpectationSql = `
       THEN 'CANCELLED'
     WHEN COALESCE(is_fulfilled, false)
       THEN 'SHIPPED'
-    WHEN UPPER(COALESCE(NULLIF(TRIM(production_status), ''), '')) = 'SHIPPED'
-      AND LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) = 'shipping qc'
-      THEN 'SHIPPED'
     WHEN LOWER(COALESCE(NULLIF(TRIM(current_department), ''), '')) = 'p1 production queue'
       THEN 'PENDING'
     WHEN COALESCE(NULLIF(TRIM(current_department), ''), '') = ''


### PR DESCRIPTION
## Summary
- Add an idempotent P1 production-status backfill to the controlled `maintenance:boot-repairs` path.
- Realign existing `production_orders.production_status` values from `current_department` and `is_fulfilled` so historical moved rows match the new transfer behavior.
- Align the admin P1 PO status repair dry-run/apply SQL so `Shipping QC` is repaired to `IN_PROGRESS` unless the row is actually fulfilled.

## Why
PR #1291 fixes future department moves, but rows moved before that fix can still show stale statuses. For example, a row moved from shipped back into an active department should no longer remain `SHIPPED`; it should be repaired to `IN_PROGRESS`. Rows in `P1 Production Queue` repair to `PENDING`, while fulfilled/shipped rows repair to `SHIPPED`.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/admin.ts`
- `node --experimental-strip-types --check server/bootstrap/oneTimeRepairs.ts`
- `node --experimental-strip-types --check server/scripts/maintenance/runBootRepairs.ts`
- `node --experimental-strip-types --check server/scripts/maintenance/bootRepairBackfills.ts`

Note: Vitest could not be run locally because this environment has no `npx`, and bundled `pnpm` requires blocked npm network access.