### PR TITLE
[codex] Add P1 cutting packet run planner

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -170,6 +170,10 @@ type ManufacturingQueueItem = {
   printableBarcodeCount?: number;
   productionProtected?: boolean;
   productionProtectionReason?: string | null;
+  materialType?: string | null;
+  source?: string | null;
+  orderId?: string | null;
+  packetName?: string | null;
 };
 
 type PacketBOM = {
@@ -238,6 +242,112 @@ function buildMfgBarcode(queueId: string | null, sku: string | null, packetNumbe
   return `MFG-${queueId}-${sku}-${packetNumber}`;
 }
 
+type P1PacketRecipeComponent = {
+  label: string;
+  partsPerPacket: number;
+  programName: string;
+  yieldPerRun: number;
+};
+
+type P1PacketRecipe = {
+  name: string;
+  matchers: string[];
+  materialTypes: string[];
+  components: P1PacketRecipeComponent[];
+};
+
+type P1PacketRunPlan = {
+  packetName: string;
+  packetsNeeded: number;
+  totalRuns: number;
+  requirements: Array<P1PacketRecipeComponent & {
+    totalParts: number;
+    runsNeeded: number;
+  }>;
+};
+
+const P1_PACKET_RECIPES: P1PacketRecipe[] = [
+  {
+    name: 'Carbon Fiber Stock Packet',
+    matchers: ['carbon fiber packet', 'carbon fiber stock packet', 'carbon fiber stock', 'carbon_fiber'],
+    materialTypes: ['carbon_fiber'],
+    components: [
+      { label: 'Shells', partsPerPacket: 2, programName: 'Shells', yieldPerRun: 26 },
+      { label: 'Wrist Reinforcements', partsPerPacket: 10, programName: 'Wrists reinforcement', yieldPerRun: 500 },
+      { label: 'BSRs', partsPerPacket: 6, programName: 'BSRs', yieldPerRun: 946 },
+      { label: 'Buttstock Reinforcements', partsPerPacket: 2, programName: 'Buttstock reinforcements', yieldPerRun: 70 },
+      { label: 'Forends', partsPerPacket: 2, programName: 'Forends', yieldPerRun: 68 },
+      { label: 'Half Gridle', partsPerPacket: 1, programName: 'Half Gridle', yieldPerRun: 440 },
+      { label: 'Seam', partsPerPacket: 1, programName: 'Seams', yieldPerRun: 39 },
+      { label: 'Pillar Seam', partsPerPacket: 1, programName: 'Pillar Seams', yieldPerRun: 156 },
+    ],
+  },
+];
+
+function normalizePacketText(value: string | null | undefined): string {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isP2QueueItem(item: ManufacturingQueueItem): boolean {
+  const source = normalizePacketText(item.source);
+  const materialType = normalizePacketText(item.materialType);
+  return source === 'p2 sync'
+    || source === 'p2_sync'
+    || materialType.startsWith('p2 ')
+    || (item.poNumbers || []).some(po => Boolean(po.p2PoId || po.p2PoItemId));
+}
+
+function findP1PacketRecipe(item: ManufacturingQueueItem): P1PacketRecipe | null {
+  if (isP2QueueItem(item)) return null;
+
+  const haystack = [
+    item.displayName,
+    item.packetName,
+    item.partName,
+    item.partNumber,
+    item.materialType,
+  ].map(normalizePacketText);
+
+  return P1_PACKET_RECIPES.find(recipe => {
+    const materialMatch = recipe.materialTypes.some(materialType =>
+      haystack.includes(normalizePacketText(materialType))
+    );
+    const nameMatch = recipe.matchers.some(matcher => {
+      const normalizedMatcher = normalizePacketText(matcher);
+      return haystack.some(value => value && (value === normalizedMatcher || value.includes(normalizedMatcher) || normalizedMatcher.includes(value)));
+    });
+    return materialMatch || nameMatch;
+  }) || null;
+}
+
+function getP1PacketRunPlan(item: ManufacturingQueueItem): P1PacketRunPlan | null {
+  const recipe = findP1PacketRecipe(item);
+  if (!recipe) return null;
+
+  const packetsNeeded = Math.max(0, (item.quantityOrdered || 0) - (item.quantityCompleted || 0));
+  if (packetsNeeded <= 0) return null;
+
+  const requirements = recipe.components.map(component => {
+    const totalParts = component.partsPerPacket * packetsNeeded;
+    return {
+      ...component,
+      totalParts,
+      runsNeeded: Math.ceil(totalParts / component.yieldPerRun),
+    };
+  });
+
+  return {
+    packetName: recipe.name,
+    packetsNeeded,
+    totalRuns: requirements.reduce((sum, requirement) => sum + requirement.runsNeeded, 0),
+    requirements,
+  };
+}
+
 function getPrintableBarcodeCount(item: ManufacturingQueueItem): number {
   if (typeof item.printableBarcodeCount === 'number') {
     return Math.max(0, item.printableBarcodeCount);
@@ -251,7 +361,7 @@ function isQueueProductionProtected(item: ManufacturingQueueItem): boolean {
 
 function isPacketBarcodePrintable(item: ManufacturingQueueItem): boolean {
   const status = String(item.status || '').toUpperCase();
-  return (status === 'PENDING' || status === 'IN_PROGRESS' || status === 'LOCKED') && getPrintableBarcodeCount(item) > 0;
+  return isP2QueueItem(item) && (status === 'PENDING' || status === 'IN_PROGRESS' || status === 'LOCKED') && getPrintableBarcodeCount(item) > 0;
 }
 
 function useIsAdmin() {
@@ -480,6 +590,7 @@ export default function CuttingOperatorDashboard() {
       let userNotes: string | null = null;
       let orderId: string | null = null;
       let materialType: string | null = item.materialType || null;
+      let source: string | null = item.source || null;
       let poNumbers: GroupedPO[] = Array.isArray(item.poNumbers) ? item.poNumbers : [];
       if (item.notes) {
         try {
@@ -489,6 +600,7 @@ export default function CuttingOperatorDashboard() {
           userNotes = parsedNotes.userNotes || null;
           orderId = parsedNotes.orderId || null;
           if (!materialType) materialType = parsedNotes.materialType || null;
+          if (!source) source = parsedNotes.source || null;
           if (poNumbers.length === 0 && Array.isArray(parsedNotes.poNumbers)) {
             poNumbers = parsedNotes.poNumbers as GroupedPO[];
           }
@@ -543,6 +655,10 @@ export default function CuttingOperatorDashboard() {
         bomMatchReason: item.bomMatchReason || (bomId || matchingBOM?.id ? 'client_fallback' : null),
         bomMatchConfidence: item.bomMatchConfidence || (bomId ? 'strong' : matchingBOM?.id ? 'fallback' : 'none'),
         poNumbers,
+        materialType,
+        source,
+        orderId,
+        packetName,
       };
     });
   }, [mfgQueueItemsRaw, packetBOMs]);
@@ -2271,6 +2387,8 @@ export default function CuttingOperatorDashboard() {
                   <TableBody>
                     {filteredMfgQueueItems.map((item) => {
                     const isProductionProtected = isQueueProductionProtected(item);
+                    const p1RunPlan = getP1PacketRunPlan(item);
+                    const isP2Packet = isP2QueueItem(item);
 
                     return (
                     <TableRow 
@@ -2292,7 +2410,9 @@ export default function CuttingOperatorDashboard() {
                             data-testid={`checkbox-print-${item.id}`}
                           />
                         ) : (
-                          <span className="text-xs text-muted-foreground">-</span>
+                          <Badge variant="outline" className="text-[10px]">
+                            {p1RunPlan ? 'P1' : '-'}
+                          </Badge>
                         )}
                       </TableCell>
                       <TableCell className="max-w-[420px]">
@@ -2301,6 +2421,9 @@ export default function CuttingOperatorDashboard() {
                             <span className="truncate font-medium" title={item.displayName || item.partName || ""}>
                               {item.displayName || item.partName || '-'}
                             </span>
+                            <Badge variant={isP2Packet ? "default" : "secondary"} className="h-5 shrink-0 text-[10px]">
+                              {isP2Packet ? 'P2 trace' : 'P1 cut/make'}
+                            </Badge>
                             <GroupedPOsBadge
                               poNumbers={item.poNumbers}
                               className="h-6 shrink-0 bg-muted px-1.5 text-[11px] text-muted-foreground hover:bg-muted"
@@ -2318,6 +2441,21 @@ export default function CuttingOperatorDashboard() {
                             </span>
                           </div>
                           <CuttingQueueProductionLockNotice item={item} compact />
+                          {p1RunPlan && (
+                            <div className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <span className="font-medium">{p1RunPlan.packetsNeeded} packets</span>
+                                <span>{p1RunPlan.totalRuns} total program runs</span>
+                              </div>
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {p1RunPlan.requirements.map(requirement => (
+                                  <Badge key={requirement.programName} variant="outline" className="bg-background text-[10px]">
+                                    {requirement.programName}: {requirement.runsNeeded}
+                                  </Badge>
+                                ))}
+                              </div>
+                            </div>
+                          )}
                         </div>
                       </TableCell>
                       <TableCell className="text-center">
@@ -2333,7 +2471,14 @@ export default function CuttingOperatorDashboard() {
                         </div>
                       </TableCell>
                       <TableCell className="text-center">
-                        <Badge variant="outline" className="font-mono">{item.estimatedCuts}</Badge>
+                        {p1RunPlan ? (
+                          <div className="space-y-1">
+                            <Badge variant="outline" className="font-mono">{p1RunPlan.totalRuns} runs</Badge>
+                            <div className="text-[11px] text-muted-foreground">{p1RunPlan.requirements.length} programs</div>
+                          </div>
+                        ) : (
+                          <Badge variant="outline" className="font-mono">{item.estimatedCuts}</Badge>
+                        )}
                       </TableCell>
                       <TableCell className="text-center">
                         {isPacketBarcodePrintable(item) ? (
@@ -2354,7 +2499,9 @@ export default function CuttingOperatorDashboard() {
                             data-testid={`input-print-qty-${item.id}`}
                           />
                         ) : (
-                          <span className="text-xs text-muted-foreground">None</span>
+                          <span className="text-xs text-muted-foreground">
+                            {p1RunPlan ? 'No barcode' : 'None'}
+                          </span>
                         )}
                       </TableCell>
                       <TableCell>{getStatusBadge(item.status)}</TableCell>
@@ -2801,10 +2948,19 @@ export default function CuttingOperatorDashboard() {
 
       <Dialog open={isCuttingWorkflowOpen} onOpenChange={setIsCuttingWorkflowOpen}>
         <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+          {(() => {
+            const selectedP1RunPlan = selectedMfgItem ? getP1PacketRunPlan(selectedMfgItem) : null;
+            return (
+              <>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Scissors className="h-5 w-5" />
               Cutting Workflow: {selectedMfgItem?.displayName || selectedMfgItem?.partNumber || selectedMfgItem?.partName}
+              {selectedMfgItem && (
+                <Badge variant={isP2QueueItem(selectedMfgItem) ? "default" : "secondary"} className="ml-1">
+                  {isP2QueueItem(selectedMfgItem) ? 'P2 trace packet' : 'P1 cut/make packet'}
+                </Badge>
+              )}
             </DialogTitle>
             <DialogDescription>
               Step {workflowStep === 'fabric' ? '1 of 4: Retrieve Fabric' : workflowStep === 'cutting' ? '2 of 4: Cutting Programs' : workflowStep === 'complete' ? '3 of 4: Complete & Print Labels' : '4 of 4: Fabric Disposition'}
@@ -2841,11 +2997,13 @@ export default function CuttingOperatorDashboard() {
                     <p className="font-bold text-lg">{(selectedMfgItem?.quantityOrdered || 0) - (selectedMfgItem?.quantityCompleted || 0)}</p>
                   </div>
                   <div>
-                    <Label className="text-muted-foreground text-xs">Cuts Needed</Label>
+                    <Label className="text-muted-foreground text-xs">{selectedP1RunPlan ? 'Program Runs' : 'Cuts Needed'}</Label>
                     <p className="font-bold text-lg">{
-                      matchingBOM
-                        ? Math.ceil(((selectedMfgItem?.quantityOrdered || 0) - (selectedMfgItem?.quantityCompleted || 0)) / (matchingBOM.yieldPerCut || 4))
-                        : (selectedMfgItem?.estimatedCuts || Math.ceil(((selectedMfgItem?.quantityOrdered || 0) - (selectedMfgItem?.quantityCompleted || 0)) / 4))
+                      selectedP1RunPlan
+                        ? selectedP1RunPlan.totalRuns
+                        : matchingBOM
+                          ? Math.ceil(((selectedMfgItem?.quantityOrdered || 0) - (selectedMfgItem?.quantityCompleted || 0)) / (matchingBOM.yieldPerCut || 4))
+                          : (selectedMfgItem?.estimatedCuts || Math.ceil(((selectedMfgItem?.quantityOrdered || 0) - (selectedMfgItem?.quantityCompleted || 0)) / 4))
                     }</p>
                   </div>
                   <div>
@@ -2853,6 +3011,34 @@ export default function CuttingOperatorDashboard() {
                     <p className="font-bold text-lg">{matchingBOM?.squareMetersPerCut || 0.5} m²</p>
                   </div>
                 </div>
+                {selectedP1RunPlan && (
+                  <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/40">
+                    <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-medium text-amber-950 dark:text-amber-100">{selectedP1RunPlan.packetName}</p>
+                        <p className="text-xs text-amber-800 dark:text-amber-200">
+                          {selectedP1RunPlan.packetsNeeded} packets to make; no P1 packet barcodes required.
+                        </p>
+                      </div>
+                      <Badge variant="outline" className="bg-background font-mono">
+                        {selectedP1RunPlan.totalRuns} total runs
+                      </Badge>
+                    </div>
+                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      {selectedP1RunPlan.requirements.map(requirement => (
+                        <div key={requirement.programName} className="rounded-md border bg-background px-3 py-2 text-sm">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="font-medium">{requirement.programName}</span>
+                            <Badge>{requirement.runsNeeded} run{requirement.runsNeeded === 1 ? '' : 's'}</Badge>
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {requirement.totalParts} {requirement.label.toLowerCase()} needed at {requirement.yieldPerRun}/run
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
 
               <div className="bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-lg p-4">
@@ -3038,15 +3224,33 @@ export default function CuttingOperatorDashboard() {
                   <Scissors className="h-4 w-4" />
                   Cutting Programs
                 </h4>
-                <p className="text-sm text-muted-foreground">
-                  Execute the following cutting program for {(selectedMfgItem?.quantityOrdered || 0) - (selectedMfgItem?.quantityCompleted || 0)} packets
-                </p>
-                <div className="mt-3 p-3 bg-background rounded border">
-                  <p className="font-mono text-sm">Program: {selectedMfgItem?.partNumber || 'STANDARD'}</p>
-                  <p className="text-sm text-muted-foreground mt-1">
+                {selectedP1RunPlan ? (
+                  <div className="mt-3 space-y-2">
+                    {selectedP1RunPlan.requirements.map(requirement => (
+                      <div key={requirement.programName} className="rounded border bg-background p-3">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-mono text-sm">{requirement.programName}</p>
+                          <Badge>{requirement.runsNeeded} run{requirement.runsNeeded === 1 ? '' : 's'}</Badge>
+                        </div>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          Make {requirement.totalParts} {requirement.label.toLowerCase()} for {selectedP1RunPlan.packetsNeeded} packets ({requirement.partsPerPacket}/packet; yield {requirement.yieldPerRun}/run).
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <>
+                    <p className="text-sm text-muted-foreground">
+                      Execute the following cutting program for {(selectedMfgItem?.quantityOrdered || 0) - (selectedMfgItem?.quantityCompleted || 0)} packets
+                    </p>
+                    <div className="mt-3 p-3 bg-background rounded border">
+                      <p className="font-mono text-sm">Program: {selectedMfgItem?.partNumber || 'STANDARD'}</p>
+                      <p className="text-sm text-muted-foreground mt-1">
                     Cuts Required: {selectedMfgItem?.estimatedCuts || Math.ceil(((selectedMfgItem?.quantityOrdered || 0) - (selectedMfgItem?.quantityCompleted || 0)) / (matchingBOM?.yieldPerCut || 4))}
                   </p>
-                </div>
+                    </div>
+                  </>
+                )}
               </div>
 
               {matchingBOM && matchingBOM.cuts && matchingBOM.cuts.length > 0 ? (
@@ -3308,6 +3512,9 @@ export default function CuttingOperatorDashboard() {
               )}
             </div>
           </DialogFooter>
+              </>
+            );
+          })()}
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
## Summary
- Add P1/P2 packet category indicators to the cutting table scheduled packet queue.
- Keep P2 trace packets on the existing barcode/traceability print path while suppressing packet barcode printing for P1 cut/make packets.
- Add a Carbon Fiber Stock Packet run planner using the provided packet recipe and cut-program yields, visible in the queue and cutting workflow modal.

## Impact
Operators can see how many times each cutting program must run to make a P1 packet workorder quantity. For 100 Carbon Fiber Stock Packets, the planner shows Shells 8, Wrists reinforcement 2, BSRs 1, Buttstock reinforcements 3, Forends 3, Half Gridle 1, Seams 3, and Pillar Seams 1.

P2 traveler/traceability production routes are not changed; the update is limited to the cutting operator dashboard UI.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Manual calculation check for 100 Carbon Fiber Stock Packets

Full TypeScript/build validation was not run because this clean worktree did not have installed project dependencies and no local TypeScript parser was available.