### PR TITLE
[codex] Share Draft Builder drafts and finalize parts

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useLocation } from 'wouter';
 import {
   ArrowUpDown,
@@ -201,6 +201,11 @@ type InventoryItemOption = {
   type?: string | null;
   isPacket?: boolean | null;
   manufacturedCategory?: string | null;
+};
+type DraftFinalizedInventoryItem = InventoryItemOption & {
+  id: number;
+  agPartNumber: string;
+  name: string;
 };
 
 type InventoryDepartmentOption = {
@@ -479,6 +484,34 @@ function draftLineToPart(line: BomLine): DraftBomPart {
     bomItems: [],
     hasBOM: false,
   };
+}
+
+function draftLineNeedsInventoryItem(line: BomLine) {
+  return line.isDraftPart !== false && !line.inventoryItemId;
+}
+
+async function createInventoryItemFromDraftLine(
+  line: BomLine,
+  draft: BomDraft,
+): Promise<DraftFinalizedInventoryItem> {
+  return await apiRequest('/api/inventory/items/from-draft-builder', {
+    method: 'POST',
+    body: {
+      name: lineDescription(line),
+      description: lineDescription(line),
+      supplier: line.supplier || null,
+      supplierPartNumber: line.supplierItemId || null,
+      manufacturer: line.manufacturer || null,
+      costPer: asNumber(line.actualCost) || asNumber(line.unitCost) || null,
+      usageUnit: line.unit || 'EA',
+      department: line.firstDepartment || line.department || defaultDepartment,
+      isManufactured: line.isManufactured === true,
+      manufacturedCategory: line.isManufactured === true ? 'COMPONENT' : null,
+      project: draft.projectName || draft.project || null,
+      draftName: `${draft.name} ${draft.revision}`.trim(),
+      draftLineId: line.id,
+    },
+  }) as DraftFinalizedInventoryItem;
 }
 
 function inventoryItemToPart(item: InventoryItemOption): DraftBomPart {
@@ -1312,6 +1345,7 @@ function createBlankDraftForProject(selectedProject: ProjectSelectOption): BomDr
 
 export default function DraftBOMBuilderPage() {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [, setLocation] = useLocation();
   const [savedDrafts, setSavedDrafts] = useState<BomDraft[]>(() => loadDrafts());
   const [selectedDraftId, setSelectedDraftId] = useState<string>(PRIVATEER_DRAFT_ID);
@@ -1338,6 +1372,7 @@ export default function DraftBOMBuilderPage() {
   const [newWorkspaceTabName, setNewWorkspaceTabName] = useState('');
   const [newLaborDepartmentName, setNewLaborDepartmentName] = useState('');
   const [wizardSeedLineId, setWizardSeedLineId] = useState<string | null>(null);
+  const [isFinalizingParts, setIsFinalizingParts] = useState(false);
 
   const { data: projects = [], isLoading: projectsLoading } = useQuery<ProjectOption[]>({
     queryKey: ['/api/projects'],
@@ -2086,7 +2121,7 @@ export default function DraftBOMBuilderPage() {
     setActiveWorkspaceTab('po-draft');
   }
 
-  function markSelectedFinalized() {
+  async function markSelectedFinalized() {
     if (!draft.project) {
       toast({
         title: 'Select a project first',
@@ -2096,16 +2131,59 @@ export default function DraftBOMBuilderPage() {
       return;
     }
 
-    setDraft((current) => ({
-      ...current,
-      lines: current.lines.map((line) =>
-        line.include ? { ...line, finalized: true, include: false, action: 'Do Not Order' } : line,
-      ),
-    }));
-    toast({
-      title: 'Inventory finalization staged',
-      description: 'Selected lines are marked final and ready for inventory-item creation when backend submission is wired.',
-    });
+    const selectedDraftLines = draft.lines.filter((line) => line.include);
+    const linesToCreate = selectedDraftLines.filter(draftLineNeedsInventoryItem);
+    const createdByLineId = new Map<string, DraftFinalizedInventoryItem>();
+
+    setIsFinalizingParts(true);
+    try {
+      for (const line of linesToCreate) {
+        const createdItem = await createInventoryItemFromDraftLine(line, draft);
+        createdByLineId.set(line.id, createdItem);
+      }
+
+      setDraft((current) => ({
+        ...current,
+        lines: current.lines.map((line) => {
+          if (!line.include) return line;
+          const createdItem = createdByLineId.get(line.id);
+          if (draftLineNeedsInventoryItem(line) && !createdItem) return line;
+          return {
+            ...line,
+            finalized: true,
+            include: false,
+            action: 'Do Not Order',
+            agPartNumber: createdItem?.agPartNumber ?? line.agPartNumber,
+            inventoryItemId: createdItem?.id ?? line.inventoryItemId ?? null,
+            inventoryItemName: createdItem?.name ?? line.inventoryItemName ?? lineDescription(line),
+            isDraftPart: false,
+            note: createdItem
+              ? `Finalized to inventory item #${createdItem.id} (${createdItem.agPartNumber})`
+              : line.note,
+          };
+        }),
+      }));
+
+      if (createdByLineId.size > 0) {
+        await queryClient.invalidateQueries({ queryKey: ['/api/inventory'] });
+      }
+
+      toast({
+        title: 'Inventory finalization complete',
+        description: createdByLineId.size > 0
+          ? `${selectedDraftLines.length} line(s) finalized, ${createdByLineId.size} new inventory item(s) created with AG part numbers.`
+          : `${selectedDraftLines.length} line(s) finalized.`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to create inventory items from the selected draft lines.';
+      toast({
+        title: 'Inventory finalization failed',
+        description: message,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsFinalizingParts(false);
+    }
   }
 
   function createVendorPoHandoff() {
@@ -2289,9 +2367,9 @@ export default function DraftBOMBuilderPage() {
                 <Save className="mr-2 h-4 w-4" />
                 Save draft
               </Button>
-              <Button onClick={markSelectedFinalized} disabled={!isEditMode || selectedLines.length === 0}>
+              <Button onClick={markSelectedFinalized} disabled={!isEditMode || selectedLines.length === 0 || isFinalizingParts}>
                 <Check className="mr-2 h-4 w-4" />
-                Finalize to inventory
+                {isFinalizingParts ? 'Finalizing...' : 'Finalize to inventory'}
               </Button>
             </div>
           </div>
@@ -2668,6 +2746,7 @@ export default function DraftBOMBuilderPage() {
                   onFinalizeSelected={markSelectedFinalized}
                   onDeleteLine={deleteLine}
                   isEditMode={isEditMode}
+                  isFinalizingParts={isFinalizingParts}
                 />
               </TabsContent>
             ) : null}
@@ -3062,6 +3141,7 @@ function PartsRequestWorkspace({
   onFinalizeSelected,
   onDeleteLine,
   isEditMode,
+  isFinalizingParts,
 }: {
   lines: BomLine[];
   visibleColumns: PartsRequestColumnId[];
@@ -3075,9 +3155,10 @@ function PartsRequestWorkspace({
   onUpdateNumberLine: (id: string, field: 'unitCost' | 'actualCost' | 'qtyNeeded', value: string) => void;
   onImportCsv: (file: File, linkInventoryMatches: boolean) => Promise<void>;
   onCreateVendorPoDraft: () => void;
-  onFinalizeSelected: () => void;
+  onFinalizeSelected: () => Promise<void>;
   onDeleteLine: (lineId: string) => void;
   isEditMode: boolean;
+  isFinalizingParts: boolean;
 }) {
   const typedDescription = description.trim();
   const selectedCount = lines.filter((line) => line.include).length;
@@ -3282,9 +3363,9 @@ function PartsRequestWorkspace({
               <PackagePlus className="mr-2 h-4 w-4" />
               Create Vendor PO draft
             </Button>
-            <Button type="button" onClick={onFinalizeSelected} disabled={!isEditMode || selectedCount === 0}>
+            <Button type="button" onClick={onFinalizeSelected} disabled={!isEditMode || selectedCount === 0 || isFinalizingParts}>
               <Check className="mr-2 h-4 w-4" />
-              Finalize checked
+              {isFinalizingParts ? 'Finalizing...' : 'Finalize checked'}
             </Button>
           </div>
         </div>

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -68,6 +68,41 @@ const INVENTORY_UPLOAD_ROOT = process.env.INVENTORY_UPLOAD_DIR
     ? path.join(os.tmpdir(), 'epoch-inventory-documents')
     : path.join(process.cwd(), 'uploads', 'inventory-documents');
 
+const draftBuilderInventoryItemSchema = z.object({
+  name: z.string().min(1, 'Part name is required'),
+  description: z.string().optional().nullable(),
+  supplier: z.string().optional().nullable(),
+  supplierPartNumber: z.string().optional().nullable(),
+  manufacturer: z.string().optional().nullable(),
+  costPer: z.number().min(0).optional().nullable(),
+  usageUnit: z.string().optional().nullable(),
+  department: z.string().optional().nullable(),
+  isManufactured: z.boolean().default(false),
+  manufacturedCategory: z
+    .enum(['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT'])
+    .optional()
+    .nullable(),
+  project: z.string().optional().nullable(),
+  draftName: z.string().optional().nullable(),
+  draftLineId: z.string().optional().nullable(),
+});
+
+async function nextNumericInventoryPartNumber() {
+  const result = await db.execute(
+    sql`SELECT ag_part_number FROM inventory_items WHERE ag_part_number ~ '^[0-9]+$' ORDER BY CAST(ag_part_number AS INTEGER) DESC LIMIT 1`
+  );
+  const maxNum = result.rows?.[0]?.ag_part_number ? parseInt(result.rows[0].ag_part_number as string, 10) : 0;
+  return String(maxNum + 1);
+}
+
+function duplicateInventoryPartNumberError(error: unknown) {
+  return typeof error === 'object' && error !== null && (
+    (error as any).code === '23505' ||
+    (error as any).cause?.code === '23505' ||
+    String((error as any).message || '').includes('inventory_items_ag_part_number')
+  );
+}
+
 // Keep legacy locations readable so existing DB file paths still work.
 const LEGACY_SDS_UPLOAD_DIR = path.join(process.cwd(), 'server/src/assets/sds');
 const LEGACY_TDS_UPLOAD_DIR = path.join(process.cwd(), 'server/src/assets/tds');
@@ -255,14 +290,73 @@ router.get('/items', async (req: Request, res: Response) => {
 // Get next available AG Part Number
 router.get('/items/next-part-number', async (req: Request, res: Response) => {
   try {
-    const result = await db.execute(
-      sql`SELECT ag_part_number FROM inventory_items WHERE ag_part_number ~ '^[0-9]+$' ORDER BY CAST(ag_part_number AS INTEGER) DESC LIMIT 1`
-    );
-    const maxNum = result.rows?.[0]?.ag_part_number ? parseInt(result.rows[0].ag_part_number as string, 10) : 0;
-    res.json({ nextPartNumber: String(maxNum + 1) });
+    res.json({ nextPartNumber: await nextNumericInventoryPartNumber() });
   } catch (error) {
     console.error('Get next part number error:', error);
     res.status(500).json({ error: 'Failed to get next part number' });
+  }
+});
+
+router.post('/items/from-draft-builder', requirePermission('inventory.adjust'), async (req: Request, res: Response) => {
+  try {
+    const draftPart = draftBuilderInventoryItemSchema.parse(req.body);
+    const manufacturedCategory = draftPart.isManufactured
+      ? draftPart.manufacturedCategory ?? 'COMPONENT'
+      : null;
+    const itemType = draftPart.isManufactured ? 'MANUFACTURED' : 'PURCHASED';
+    const notes = [
+      'Created from Draft Builder finalization.',
+      draftPart.project ? `Project: ${draftPart.project}` : null,
+      draftPart.draftName ? `Draft: ${draftPart.draftName}` : null,
+      draftPart.draftLineId ? `Draft line: ${draftPart.draftLineId}` : null,
+      draftPart.manufacturer ? `Manufacturer: ${draftPart.manufacturer}` : null,
+      draftPart.description && draftPart.description !== draftPart.name ? `Description: ${draftPart.description}` : null,
+    ].filter(Boolean).join('\n');
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const agPartNumber = await nextNumericInventoryPartNumber();
+      const itemData = insertInventoryItemSchema.parse({
+        agPartNumber,
+        name: draftPart.name,
+        description: draftPart.description || draftPart.name,
+        source: draftPart.supplier || null,
+        supplier: draftPart.supplier || null,
+        supplierPartNumber: draftPart.supplierPartNumber || null,
+        costPer: draftPart.costPer ?? null,
+        unitCost: draftPart.costPer ?? null,
+        usageUnit: draftPart.usageUnit || 'EA',
+        purchaseUnit: draftPart.usageUnit || 'EA',
+        department: draftPart.department || null,
+        assignedDepartments: draftPart.department ? [draftPart.department] : [],
+        notes,
+        itemType,
+        type: draftPart.isManufactured ? 'Manufactured' : 'Purchased',
+        manufacturedCategory,
+        manufacturingLevel: draftPart.isManufactured ? 'COMPONENT' : null,
+        isActive: true,
+      });
+
+      try {
+        const newItem = await storage.createInventoryItem(itemData);
+        return res.status(201).json(withSupplySourceDashboard(newItem));
+      } catch (error) {
+        if (duplicateInventoryPartNumberError(error) && attempt < 4) {
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    return res.status(409).json({ error: 'Unable to allocate a unique AG part number. Please retry finalization.' });
+  } catch (error) {
+    console.error('Create Draft Builder inventory item error:', error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: error.errors[0]?.message || 'Invalid draft inventory item payload' });
+    }
+    if (error instanceof Error) {
+      return res.status(400).json({ error: error.message });
+    }
+    res.status(500).json({ error: 'Failed to create inventory item from Draft Builder' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add a shared Draft Builder drafts table and authenticated `/api/draft-bom-drafts` API
- load/save/delete Draft Builder drafts through the shared API so all users with UI access see the same saved drafts
- keep browser localStorage as a fallback/cache for older local-only drafts
- add a Draft Builder inventory creation endpoint that assigns the next numeric AG part number server-side
- make Finalize to inventory create real inventory items for checked draft-only lines and write the generated AG part number back to the row

## Root Cause
Draft Builder drafts were stored only in browser localStorage, so a saved draft was invisible to other admins or users on the same UI. Finalization also only set local row flags, so drafted new parts never appeared in inventory and never received official AG part numbers.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/draftBomDrafts.ts`
- `node --experimental-strip-types --check server/src/routes/inventory.ts`
- `node --experimental-strip-types --check server/schema.ts`
- `node --experimental-strip-types --check server/src/routes/index.ts`

Node cannot syntax-check `.tsx` directly in this environment, and full TypeScript validation is still blocked because package tooling is unavailable without registry access.