### PR TITLE
[codex] Share Draft Builder drafts across users

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -1283,9 +1283,26 @@ function saveDrafts(drafts: BomDraft[]) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(drafts));
 }
 
+async function saveSharedDraft(draft: BomDraft) {
+  return await apiRequest(`/api/draft-bom-drafts/${encodeURIComponent(draft.id)}`, {
+    method: 'PUT',
+    body: draft,
+  }) as BomDraft;
+}
+
+async function deleteSharedDraft(id: string) {
+  try {
+    await apiRequest(`/api/draft-bom-drafts/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+  } catch (error) {
+    if ((error as any)?.status !== 404) throw error;
+  }
+}
+
 function savedDraftListWith(drafts: BomDraft[], draft: BomDraft) {
   const withoutCurrent = drafts.filter((item) => item.id !== draft.id);
-  return [draft, ...withoutCurrent].slice(0, 12);
+  return [draft, ...withoutCurrent];
 }
 
 function projectMatchValue(value?: string | number | null) {
@@ -1373,9 +1390,15 @@ export default function DraftBOMBuilderPage() {
   const [newLaborDepartmentName, setNewLaborDepartmentName] = useState('');
   const [wizardSeedLineId, setWizardSeedLineId] = useState<string | null>(null);
   const [isFinalizingParts, setIsFinalizingParts] = useState(false);
+  const [hasLoadedSharedDrafts, setHasLoadedSharedDrafts] = useState(false);
 
   const { data: projects = [], isLoading: projectsLoading } = useQuery<ProjectOption[]>({
     queryKey: ['/api/projects'],
+  });
+
+  const { data: sharedDrafts = [], isFetched: sharedDraftsFetched } = useQuery<BomDraft[]>({
+    queryKey: ['/api/draft-bom-drafts'],
+    queryFn: () => apiRequest('/api/draft-bom-drafts'),
   });
 
   const { data: inventoryItems = [] } = useQuery<InventoryItemOption[]>({
@@ -1513,6 +1536,19 @@ export default function DraftBOMBuilderPage() {
   }, []);
 
   useEffect(() => {
+    if (!sharedDraftsFetched || hasLoadedSharedDrafts) return;
+    const sourceDrafts = sharedDrafts.length > 0 ? sharedDrafts : loadDrafts();
+    const normalizedDrafts = sourceDrafts.map(normalizeDraft);
+    const nextDrafts = normalizedDrafts.length > 0 ? normalizedDrafts : [createPrivateerDraft()];
+    const selectedDraft = nextDrafts.find((item) => item.id === selectedDraftId) ?? nextDrafts[0];
+
+    setSavedDrafts(nextDrafts);
+    saveDrafts(nextDrafts);
+    applyDraftSelection(selectedDraft);
+    setHasLoadedSharedDrafts(true);
+  }, [hasLoadedSharedDrafts, selectedDraftId, sharedDrafts, sharedDraftsFetched]);
+
+  useEffect(() => {
     if (typeof window === 'undefined') return;
     const nextDraft = normalizeDraft({
       ...draft,
@@ -1532,12 +1568,27 @@ export default function DraftBOMBuilderPage() {
       return nextDrafts;
     });
 
+    if (hasLoadedSharedDrafts) {
+      void saveSharedDraft(nextDraft)
+        .then((savedDraft) => {
+          const normalizedSavedDraft = normalizeDraft(savedDraft);
+          queryClient.setQueryData<BomDraft[]>(['/api/draft-bom-drafts'], (current = []) =>
+            savedDraftListWith(current.map(normalizeDraft), normalizedSavedDraft),
+          );
+        })
+        .catch((error) => {
+          console.error('Failed to save shared Draft Builder draft:', error);
+        });
+    }
+
     if (selectedDraftId !== nextDraft.id) {
       setSelectedDraftId(nextDraft.id);
     }
   }, [
     customColumns,
     draft,
+    hasLoadedSharedDrafts,
+    queryClient,
     selectedDraftId,
     visibleAssemblyColumns,
     visibleDirectLaborColumns,
@@ -1948,7 +1999,7 @@ export default function DraftBOMBuilderPage() {
     });
   }
 
-  function saveDraft() {
+  async function saveDraft() {
     const nextDraft = normalizeDraft({
       ...draft,
       poVisibleColumns: visiblePoColumns,
@@ -1965,6 +2016,20 @@ export default function DraftBOMBuilderPage() {
     setSavedDrafts(nextDrafts);
     setSelectedDraftId(nextDraft.id);
     setDraft(nextDraft);
+    try {
+      const savedDraft = normalizeDraft(await saveSharedDraft(nextDraft));
+      queryClient.setQueryData<BomDraft[]>(['/api/draft-bom-drafts'], (current = []) =>
+        savedDraftListWith(current.map(normalizeDraft), savedDraft),
+      );
+    } catch (error) {
+      console.error('Failed to save shared Draft Builder draft:', error);
+      toast({
+        title: 'Draft saved locally',
+        description: 'The shared draft save failed, so this browser kept the latest local copy.',
+        variant: 'destructive',
+      });
+      return;
+    }
     toast({ title: 'Draft saved', description: `${nextDraft.name} is available in saved BOM drafts.` });
   }
 
@@ -1992,7 +2057,7 @@ export default function DraftBOMBuilderPage() {
     applyDraftSelection(match);
   }
 
-  function deleteCurrentDraft() {
+  async function deleteCurrentDraft() {
     if (!selectedDraftId) {
       toast({
         title: 'Save the draft first',
@@ -2027,14 +2092,23 @@ export default function DraftBOMBuilderPage() {
     const remainingDrafts = savedDrafts.filter((item) => item.id !== draft.id);
     const fallbackDraft = remainingDrafts[0] ?? createPrivateerDraft();
 
-    saveDrafts(remainingDrafts);
-    setSavedDrafts(remainingDrafts);
-    applyDraftSelection(fallbackDraft);
-    setIsDetailsOpen(false);
-    toast({ title: 'Draft deleted', description: `${draft.name} was removed from saved draft BOMs.` });
+    try {
+      await deleteSharedDraft(draft.id);
+      queryClient.setQueryData<BomDraft[]>(['/api/draft-bom-drafts'], (current = []) =>
+        current.filter((item) => item.id !== draft.id),
+      );
+      saveDrafts(remainingDrafts);
+      setSavedDrafts(remainingDrafts);
+      applyDraftSelection(fallbackDraft);
+      setIsDetailsOpen(false);
+      toast({ title: 'Draft deleted', description: `${draft.name} was removed from saved draft BOMs.` });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'The shared draft could not be deleted.';
+      toast({ title: 'Delete failed', description: message, variant: 'destructive' });
+    }
   }
 
-  function clearCurrentDraft() {
+  async function clearCurrentDraft() {
     const confirmed = window.confirm(`Clear "${draft.name} - ${draft.revision}" and start over? This cannot be undone.`);
     if (!confirmed) return;
 
@@ -2060,6 +2134,14 @@ export default function DraftBOMBuilderPage() {
       const nextDrafts = savedDrafts.map((item) => (item.id === draft.id ? clearedDraft : item));
       saveDrafts(nextDrafts);
       setSavedDrafts(nextDrafts);
+      try {
+        const savedDraft = normalizeDraft(await saveSharedDraft(clearedDraft));
+        queryClient.setQueryData<BomDraft[]>(['/api/draft-bom-drafts'], (current = []) =>
+          savedDraftListWith(current.map(normalizeDraft), savedDraft),
+        );
+      } catch (error) {
+        console.error('Failed to save cleared shared Draft Builder draft:', error);
+      }
     }
 
     applyDraftSelection(clearedDraft);

--- a/migrations/0185_draft_bom_drafts.sql
+++ b/migrations/0185_draft_bom_drafts.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS draft_bom_drafts (
+  id text PRIMARY KEY,
+  name text NOT NULL,
+  revision text NOT NULL DEFAULT 'Draft A',
+  project text NOT NULL DEFAULT '',
+  project_id text,
+  project_code text,
+  project_name text,
+  project_type text,
+  data jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_by_user_id integer REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name text NOT NULL DEFAULT 'unknown',
+  updated_by_user_id integer REFERENCES users(id) ON DELETE SET NULL,
+  updated_by_display_name text NOT NULL DEFAULT 'unknown',
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS draft_bom_drafts_project_idx
+  ON draft_bom_drafts(project_type, project_id);
+
+CREATE INDEX IF NOT EXISTS draft_bom_drafts_updated_idx
+  ON draft_bom_drafts(updated_at DESC);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -16339,6 +16339,32 @@ export type InsertImprovementNote = z.infer<typeof insertImprovementNoteSchema>;
 
 // ─── Schema Governance Audit Log ────────────────────────────────────────────
 
+// Draft Builder BOM drafts shared across users with Draft Builder access.
+export const draftBomDrafts = pgTable('draft_bom_drafts', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  revision: text('revision').notNull().default('Draft A'),
+  project: text('project').notNull().default(''),
+  projectId: text('project_id'),
+  projectCode: text('project_code'),
+  projectName: text('project_name'),
+  projectType: text('project_type'),
+  data: jsonb('data').notNull().$type<Record<string, unknown>>().default(sql`'{}'::jsonb`),
+  createdByUserId: integer('created_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  createdByDisplayName: text('created_by_display_name').notNull().default('unknown'),
+  updatedByUserId: integer('updated_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  updatedByDisplayName: text('updated_by_display_name').notNull().default('unknown'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
+export const insertDraftBomDraftSchema = createInsertSchema(draftBomDrafts).omit({
+  createdAt: true,
+  updatedAt: true,
+});
+export type DraftBomDraft = typeof draftBomDrafts.$inferSelect;
+export type InsertDraftBomDraft = z.infer<typeof insertDraftBomDraftSchema>;
+
 export const schemaChangeLog = pgTable('schema_change_log', {
   id: serial('id').primaryKey(),
   timestamp: timestamp('timestamp').defaultNow().notNull(),

--- a/server/src/routes/draftBomDrafts.ts
+++ b/server/src/routes/draftBomDrafts.ts
@@ -1,0 +1,138 @@
+import { Router, type Request, type Response } from 'express';
+import { desc, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../../db';
+import { draftBomDrafts } from '../../schema';
+import { resolveUserSnapshot } from '../../utils/userSnapshot';
+
+const router = Router();
+
+const draftPayloadSchema = z.object({
+  id: z.string().trim().min(1),
+  name: z.string().trim().min(1).default('New Draft BOM'),
+  revision: z.string().trim().min(1).default('Draft A'),
+  project: z.string().default(''),
+  projectId: z.string().nullable().optional(),
+  projectCode: z.string().nullable().optional(),
+  projectName: z.string().nullable().optional(),
+  projectType: z.enum(['P2_PROJECT', 'R_AND_D']).nullable().optional(),
+}).passthrough();
+
+function toClientDraft(row: typeof draftBomDrafts.$inferSelect) {
+  const data = row.data && typeof row.data === 'object' ? row.data : {};
+  return {
+    ...data,
+    id: row.id,
+    name: row.name,
+    revision: row.revision,
+    project: row.project,
+    projectId: row.projectId,
+    projectCode: row.projectCode,
+    projectName: row.projectName,
+    projectType: row.projectType,
+    updatedAt: row.updatedAt?.toISOString?.() ?? (data as any).updatedAt,
+    createdByDisplayName: row.createdByDisplayName,
+    updatedByDisplayName: row.updatedByDisplayName,
+  };
+}
+
+async function userSnapshot(req: Request) {
+  const user = (req as any).user;
+  if (!user) return { userId: null, displayName: 'unknown' };
+  if (!user.id) {
+    return {
+      userId: null,
+      displayName: user.username ?? user.displayName ?? 'unknown',
+    };
+  }
+  return resolveUserSnapshot(user.id).catch(() => ({
+    userId: user.id ?? null,
+    displayName: user.username ?? user.displayName ?? 'unknown',
+  }));
+}
+
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const rows = await db
+      .select()
+      .from(draftBomDrafts)
+      .orderBy(desc(draftBomDrafts.updatedAt));
+    res.json(rows.map(toClientDraft));
+  } catch (error) {
+    console.error('List Draft Builder drafts error:', error);
+    res.status(500).json({ error: 'Failed to fetch Draft Builder drafts' });
+  }
+});
+
+router.put('/:id', async (req: Request, res: Response) => {
+  try {
+    const parsed = draftPayloadSchema.parse({ ...req.body, id: req.params.id });
+    const snapshot = await userSnapshot(req);
+    const now = new Date();
+
+    const [row] = await db
+      .insert(draftBomDrafts)
+      .values({
+        id: parsed.id,
+        name: parsed.name,
+        revision: parsed.revision,
+        project: parsed.project ?? '',
+        projectId: parsed.projectId ?? null,
+        projectCode: parsed.projectCode ?? null,
+        projectName: parsed.projectName ?? null,
+        projectType: parsed.projectType ?? null,
+        data: parsed,
+        createdByUserId: snapshot.userId ?? null,
+        createdByDisplayName: snapshot.displayName ?? 'unknown',
+        updatedByUserId: snapshot.userId ?? null,
+        updatedByDisplayName: snapshot.displayName ?? 'unknown',
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: draftBomDrafts.id,
+        set: {
+          name: parsed.name,
+          revision: parsed.revision,
+          project: parsed.project ?? '',
+          projectId: parsed.projectId ?? null,
+          projectCode: parsed.projectCode ?? null,
+          projectName: parsed.projectName ?? null,
+          projectType: parsed.projectType ?? null,
+          data: parsed,
+          updatedByUserId: snapshot.userId ?? null,
+          updatedByDisplayName: snapshot.displayName ?? 'unknown',
+          updatedAt: now,
+        },
+      })
+      .returning();
+
+    res.json(toClientDraft(row));
+  } catch (error) {
+    console.error('Save Draft Builder draft error:', error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: error.errors[0]?.message || 'Invalid Draft Builder draft payload' });
+    }
+    res.status(500).json({ error: 'Failed to save Draft Builder draft' });
+  }
+});
+
+router.delete('/:id', async (req: Request, res: Response) => {
+  try {
+    const id = req.params.id;
+    const [deleted] = await db
+      .delete(draftBomDrafts)
+      .where(eq(draftBomDrafts.id, id))
+      .returning({ id: draftBomDrafts.id });
+
+    if (!deleted) {
+      return res.status(404).json({ error: 'Draft Builder draft not found' });
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Delete Draft Builder draft error:', error);
+    res.status(500).json({ error: 'Failed to delete Draft Builder draft' });
+  }
+});
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -230,6 +230,7 @@ import {
 import cncDashboardRoutes from './cncDashboard';
 import receivingRoutes from './receiving';
 import estimatingRoutes from './estimating';
+import draftBomDraftsRoutes from './draftBomDrafts';
 import rfqRiskSessionsRoutes from './rfqRiskSessions';
 import auditsRoutes from './audits';
 import commandCenterRoutes from './commandCenter';
@@ -13875,6 +13876,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   // Estimating / RFQ Builder routes
   app.use('/api/estimating', authenticateToken, estimatingRoutes);
+  app.use('/api/draft-bom-drafts', authenticateToken, draftBomDraftsRoutes);
 
   // Conversational RFQ Risk Assessment routes
   app.use('/api/rfq-risk-sessions', authenticateToken, rfqRiskSessionsRoutes);


### PR DESCRIPTION
## Summary
- add a shared `draft_bom_drafts` table and migration for Draft Builder saved drafts
- add authenticated `/api/draft-bom-drafts` list/save/delete routes
- load/save/delete Draft Builder drafts through the shared API so all users with Draft Builder UI access see the same drafts
- keep localStorage as fallback/cache for older browser-local drafts and remove the 12-draft selector cap

## Root Cause
Draft Builder saved drafts were stored only in browser localStorage, so a draft created by one admin/user was invisible to other users who had access to the same UI.

## Validation
- `git diff --check origin/main...HEAD`
- `node --experimental-strip-types --check server/src/routes/draftBomDrafts.ts`
- `node --experimental-strip-types --check server/schema.ts`
- `node --experimental-strip-types --check server/src/routes/index.ts`

Node cannot syntax-check `.tsx` directly in this environment, and full TypeScript validation is blocked because package tooling is unavailable without registry access.