### PR TITLE
[codex] Batch completed P1 packets into inventory

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -110,6 +110,8 @@ type BuiltPacket = {
   sku: string | null;
   queueId: string | null;
   quantityOrdered: number | null;
+  batchQuantity?: number;
+  isBatchEntry?: boolean;
   fabricSources: BuiltPacketFabricSource[];
 };
 
@@ -2669,11 +2671,13 @@ export default function CuttingOperatorDashboard() {
                       <div>
                         {(() => {
                           const mfgParsed = parseMfgBarcode(packet.barcode);
-                          const mfgBarcode = mfgParsed.isMfgFormat
+                          const mfgBarcode = packet.isBatchEntry
+                            ? packet.barcode
+                            : mfgParsed.isMfgFormat
                             ? mfgParsed.raw
                             : buildMfgBarcode(packet.queueId, packet.sku, packet.printedPacketNumber ?? packet.displayPacketNumber ?? packet.packetNumber);
                           const segments = mfgBarcode ? parseMfgBarcode(mfgBarcode) : null;
-                          const isInternalBarcode = !mfgParsed.isMfgFormat;
+                          const isInternalBarcode = !packet.isBatchEntry && !mfgParsed.isMfgFormat;
 
                           const totalPackets = packet.quantityOrdered
                             ?? builtPackets.filter((p) => p.queueId && p.queueId === packet.queueId).length;
@@ -2690,6 +2694,7 @@ export default function CuttingOperatorDashboard() {
                                   variant={
                                     packet.status === 'AVAILABLE' ? 'secondary'
                                     : packet.status === 'CONSUMED' ? 'destructive'
+                                    : packet.status === 'BATCH' ? 'outline'
                                     : 'default'
                                   }
                                   className={cn(
@@ -2717,7 +2722,11 @@ export default function CuttingOperatorDashboard() {
                                 </div>
                               )}
                               <div className="flex items-center gap-3 mt-0.5 flex-wrap">
-                                {totalPackets > 0 && (
+                                {packet.isBatchEntry ? (
+                                  <span className="text-xs font-medium text-foreground">
+                                    Batch {packet.batchQuantity ?? packet.quantityOrdered ?? 0} packets
+                                  </span>
+                                ) : totalPackets > 0 && (
                                   <span className="text-xs font-medium text-foreground">
                                     Packet {packet.displayPacketNumber ?? packet.packetNumber} of {totalPackets}
                                   </span>
@@ -2741,12 +2750,15 @@ export default function CuttingOperatorDashboard() {
                       </div>
                     </div>
                     <div className="text-xs text-muted-foreground shrink-0">
-                      {packet.fabricSources.length} fabric {packet.fabricSources.length === 1 ? 'source' : 'sources'}
+                      {packet.isBatchEntry
+                        ? `${packet.batchQuantity ?? packet.quantityOrdered ?? 0} packet batch`
+                        : `${packet.fabricSources.length} fabric ${packet.fabricSources.length === 1 ? 'source' : 'sources'}`}
                     </div>
                   </button>
 
                   {expandedPacketId === packet.id && (
                     <div className="border-t bg-muted/20 px-4 py-3">
+                      {!packet.isBatchEntry && (
                       <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end">
                         <div className="flex-1 space-y-1">
                           <Label className="text-xs">Scan Material Into Packet</Label>
@@ -2778,8 +2790,13 @@ export default function CuttingOperatorDashboard() {
                           Add Material
                         </Button>
                       </div>
+                      )}
                       {packet.fabricSources.length === 0 ? (
-                        <p className="text-sm text-muted-foreground italic">No fabric source records for this packet.</p>
+                        <p className="text-sm text-muted-foreground italic">
+                          {packet.isBatchEntry
+                            ? 'P1 stock packet batch added to inventory. Individual packet records are not created for this batch.'
+                            : 'No fabric source records for this packet.'}
+                        </p>
                       ) : (
                         <div className="space-y-2">
                           {packet.fabricSources.map((source) => (

--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -83,6 +83,8 @@ type WeeklyCuttingQueueItem = {
   customer: string;
   priority: number;
   packetsNeeded: number;
+  inventoryApplied?: number;
+  packetsToCut?: number;
   usesInventory: boolean;
   requiresNewCut: boolean;
   bomId?: string;
@@ -196,33 +198,38 @@ export default function CuttingWeeklySchedule() {
       
       const stockModel = (item.stockModel || '').toLowerCase();
       const isP1PO = item.source === 'P1_PO';
+      const demandQty = Math.max(0, item.packetsToCut ?? item.packetsNeeded ?? 0);
       const adjustableQty = hasAdjustableStockDemand(item) ? item.packetsNeeded : 0;
       
       // Mesa packets are only for PO orders - regular P1 orders never need mesa packets
-      if (isP1PO && (stockModel.includes('mesa') || item.materialType === 'mesa')) {
-        mesa += item.packetsNeeded;
-        customerMap[customer].mesa += item.packetsNeeded;
-        oemOrders.mesa += item.packetsNeeded;
-        customerMap[customer].poMesa += item.packetsNeeded;
+      if (demandQty > 0 && isP1PO && (stockModel.includes('mesa') || item.materialType === 'mesa')) {
+        mesa += demandQty;
+        customerMap[customer].mesa += demandQty;
+        oemOrders.mesa += demandQty;
+        customerMap[customer].poMesa += demandQty;
       } else if (item.materialType === 'carbon_fiber' || stockModel.includes('cf')) {
-        cf += item.packetsNeeded;
-        customerMap[customer].cf += item.packetsNeeded;
-        if (isP1PO) {
-          oemOrders.cf += item.packetsNeeded;
-          customerMap[customer].poCf += item.packetsNeeded;
-        } else {
-          regularOrders.cf += item.packetsNeeded;
-          customerMap[customer].regCf += item.packetsNeeded;
+        if (demandQty > 0) {
+          cf += demandQty;
+          customerMap[customer].cf += demandQty;
+          if (isP1PO) {
+            oemOrders.cf += demandQty;
+            customerMap[customer].poCf += demandQty;
+          } else {
+            regularOrders.cf += demandQty;
+            customerMap[customer].regCf += demandQty;
+          }
         }
       } else if (item.materialType === 'fiberglass' || stockModel.includes('fg')) {
-        fg += item.packetsNeeded;
-        customerMap[customer].fg += item.packetsNeeded;
-        if (isP1PO) {
-          oemOrders.fg += item.packetsNeeded;
-          customerMap[customer].poFg += item.packetsNeeded;
-        } else {
-          regularOrders.fg += item.packetsNeeded;
-          customerMap[customer].regFg += item.packetsNeeded;
+        if (demandQty > 0) {
+          fg += demandQty;
+          customerMap[customer].fg += demandQty;
+          if (isP1PO) {
+            oemOrders.fg += demandQty;
+            customerMap[customer].poFg += demandQty;
+          } else {
+            regularOrders.fg += demandQty;
+            customerMap[customer].regFg += demandQty;
+          }
         }
       }
 

--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -2287,6 +2287,28 @@ router.get('/weekly-cutting-queue', async (req, res) => {
       console.log('Regular production queue query skipped:', err);
     }
 
+    const applyP1PacketInventory = (materialType: 'carbon_fiber' | 'fiberglass' | 'mesa' | 'cheek_riser', onHand: number) => {
+      let remainingOnHand = Math.max(0, Number(onHand) || 0);
+      for (const item of queueItems) {
+        if (item.materialType !== materialType) continue;
+        if (item.source !== 'P1' && item.source !== 'P1_PO') continue;
+
+        const packetsNeeded = Math.max(0, Number(item.packetsNeeded) || 0);
+        const inventoryApplied = Math.min(remainingOnHand, packetsNeeded);
+        remainingOnHand -= inventoryApplied;
+
+        item.inventoryApplied = inventoryApplied;
+        item.packetsToCut = Math.max(0, packetsNeeded - inventoryApplied);
+        item.usesInventory = inventoryApplied > 0;
+        item.requiresNewCut = item.packetsToCut > 0;
+      }
+    };
+
+    applyP1PacketInventory('carbon_fiber', cfOnHand);
+    applyP1PacketInventory('fiberglass', fgOnHand);
+    applyP1PacketInventory('mesa', stockLevels.mesa);
+    applyP1PacketInventory('cheek_riser', stockLevels.cheek_riser);
+
     // 4. P2 PO Items - Purchase order items with BOMs requiring cutting (packets only)
     try {
       const p2CountResult = await pool.query(`
@@ -2450,28 +2472,32 @@ router.get('/weekly-cutting-queue', async (req, res) => {
     const p2ItemCount = queueItems.filter(i => i.orderType === 'p2_po').length;
 
     // Calculate totals reconciled with inventory
-    const cfTotal = queueItems.filter(i => i.materialType === 'carbon_fiber').reduce((sum, i) => sum + (i.packetsNeeded || 1), 0);
-    const fgTotal = queueItems.filter(i => i.materialType === 'fiberglass').reduce((sum, i) => sum + (i.packetsNeeded || 1), 0);
-    const cfFromInventory = Math.min(cfOnHand, queueItems.filter(i => i.materialType === 'carbon_fiber' && i.usesInventory).length);
-    const fgFromInventory = Math.min(fgOnHand, queueItems.filter(i => i.materialType === 'fiberglass' && i.usesInventory).length);
+    const quantityForDemand = (item: any) => item.source === 'P1' || item.source === 'P1_PO'
+      ? Math.max(0, Number(item.packetsToCut ?? item.packetsNeeded ?? 1))
+      : Math.max(0, Number(item.packetsNeeded ?? 1));
+
+    const cfTotal = queueItems.filter(i => i.materialType === 'carbon_fiber').reduce((sum, i) => sum + quantityForDemand(i), 0);
+    const fgTotal = queueItems.filter(i => i.materialType === 'fiberglass').reduce((sum, i) => sum + quantityForDemand(i), 0);
+    const cfFromInventory = queueItems.filter(i => i.materialType === 'carbon_fiber').reduce((sum, i) => sum + (Number(i.inventoryApplied) || 0), 0);
+    const fgFromInventory = queueItems.filter(i => i.materialType === 'fiberglass').reduce((sum, i) => sum + (Number(i.inventoryApplied) || 0), 0);
 
     const summary = {
       carbon_fiber: {
-        regular: queueItems.filter(i => i.materialType === 'carbon_fiber' && i.orderType === 'regular').length,
-        oem: queueItems.filter(i => i.materialType === 'carbon_fiber' && i.orderType === 'oem').length,
+        regular: queueItems.filter(i => i.materialType === 'carbon_fiber' && i.orderType === 'regular').reduce((sum, i) => sum + quantityForDemand(i), 0),
+        oem: queueItems.filter(i => i.materialType === 'carbon_fiber' && (i.orderType === 'oem' || i.orderType === 'p1_po')).reduce((sum, i) => sum + quantityForDemand(i), 0),
         p2: queueItems.filter(i => i.materialType === 'carbon_fiber' && i.orderType === 'p2_po').reduce((sum, i) => sum + (i.packetsNeeded || 1), 0),
         total: cfTotal,
         fromInventory: cfFromInventory,
-        needsCutting: cfTotal - cfFromInventory,
+        needsCutting: cfTotal,
         onHand: cfOnHand,
       },
       fiberglass: {
-        regular: queueItems.filter(i => i.materialType === 'fiberglass' && i.orderType === 'regular').length,
-        oem: queueItems.filter(i => i.materialType === 'fiberglass' && i.orderType === 'oem').length,
+        regular: queueItems.filter(i => i.materialType === 'fiberglass' && i.orderType === 'regular').reduce((sum, i) => sum + quantityForDemand(i), 0),
+        oem: queueItems.filter(i => i.materialType === 'fiberglass' && (i.orderType === 'oem' || i.orderType === 'p1_po')).reduce((sum, i) => sum + quantityForDemand(i), 0),
         p2: queueItems.filter(i => i.materialType === 'fiberglass' && i.orderType === 'p2_po').reduce((sum, i) => sum + (i.packetsNeeded || 1), 0),
         total: fgTotal,
         fromInventory: fgFromInventory,
-        needsCutting: fgTotal - fgFromInventory,
+        needsCutting: fgTotal,
         onHand: fgOnHand,
       },
       weekStart: startDate.toISOString().split('T')[0],

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -190,6 +190,7 @@ async function ensureBuiltPacketsForCompletedQueueRows(): Promise<void> {
   for (const row of completedRows) {
     const completedQuantity = row.queue.quantityCompleted || 0;
     if (completedQuantity <= 0 || !row.item) continue;
+    if (isP1PacketInventoryQueueItem(parseQueueNotes(row.queue.notes))) continue;
 
     const partNumber = row.item.agPartNumber || 'UNK';
     const barcodePrefix = `PKT-${partNumber}-${row.queue.id}-%`;
@@ -681,26 +682,28 @@ router.post('/:id/complete', async (req: Request, res: Response) => {
         .where(like(cuttingBuiltPackets.barcode, barcodePrefix));
 
       const createdPackets = [];
-      for (let i = 0; i < quantityCompleted; i++) {
-        const packetNumber = existingCount + i + 1;
-        const barcode = `PKT-${inventoryItem.agPartNumber}-${id}-${packetNumber}-${Date.now()}`;
+      if (!shouldAddToP1PacketInventory) {
+        for (let i = 0; i < quantityCompleted; i++) {
+          const packetNumber = existingCount + i + 1;
+          const barcode = `PKT-${inventoryItem.agPartNumber}-${id}-${packetNumber}-${Date.now()}`;
 
-        const [builtPacket] = await tx
-          .insert(cuttingBuiltPackets)
-          .values({
-            productCategoryId,
-            barcode,
-            packetNumber,
-            buildDate: new Date(),
-            status: 'AVAILABLE',
-            isMixedFabric: false,
-            fabricSourceCount: 0,
-            notes: completionNotes || null,
-            createdBy: completedBy || null,
-          })
-          .returning();
+          const [builtPacket] = await tx
+            .insert(cuttingBuiltPackets)
+            .values({
+              productCategoryId,
+              barcode,
+              packetNumber,
+              buildDate: new Date(),
+              status: 'AVAILABLE',
+              isMixedFabric: false,
+              fabricSourceCount: 0,
+              notes: completionNotes || null,
+              createdBy: completedBy || null,
+            })
+            .returning();
 
-        createdPackets.push(builtPacket);
+          createdPackets.push(builtPacket);
+        }
       }
 
       if (shouldAddToP1PacketInventory && currentItem.inventoryItemId) {
@@ -735,6 +738,7 @@ router.post('/:id/complete', async (req: Request, res: Response) => {
     res.json({
       ...updated,
       createdPackets,
+      batchInventoryAdded: shouldAddToP1PacketInventory ? quantityCompleted : 0,
       isPartialCompletion: !isFullyCompleted,
       remainingQuantity: isFullyCompleted ? 0 : currentItem.quantityRequested - newTotalCompleted,
     });
@@ -1025,56 +1029,57 @@ router.post('/:id/complete-with-traceability', async (req: Request, res: Respons
         .from(cuttingBuiltPackets)
         .where(like(cuttingBuiltPackets.barcode, barcodePrefix));
 
-      // Create built packet records with full traceability
       const createdPackets = [];
 
-      for (let i = 0; i < quantityCompleted; i++) {
-        // Offset by existing packet count so each packet receives its true sequential
-        // position across all submissions (not just within this submission).
-        const packetNumber = existingCount + i + 1;
-        const timestamp = Date.now();
-        const barcode = `PKT-${inventoryItem.agPartNumber}-${id}-${packetNumber}-${timestamp}`;
+      if (!shouldAddToP1PacketInventory) {
+        for (let i = 0; i < quantityCompleted; i++) {
+          // Offset by existing packet count so each packet receives its true sequential
+          // position across all submissions (not just within this submission).
+          const packetNumber = existingCount + i + 1;
+          const timestamp = Date.now();
+          const barcode = `PKT-${inventoryItem.agPartNumber}-${id}-${packetNumber}-${timestamp}`;
 
-        // Create the built packet record
-        const [builtPacket] = await tx
-          .insert(cuttingBuiltPackets)
-          .values({
-            productCategoryId: productCategory.id,
-            barcode,
-            packetNumber,
-            buildDate: new Date(),
-            status: 'AVAILABLE',
-            isMixedFabric,
-            fabricSourceCount: fabricSources.length,
-            notes: completionNotes || null,
-            createdBy: completedBy || null,
-          })
-          .returning();
-
-        // Create fabric source records for each fabric used
-        for (let j = 0; j < fabricSources.length; j++) {
-          const source = fabricSources[j];
-          await tx
-            .insert(cuttingBuiltPacketFabricSources)
+          // Create the built packet record
+          const [builtPacket] = await tx
+            .insert(cuttingBuiltPackets)
             .values({
-              builtPacketId: builtPacket.id,
-              fabricInventoryId: source.fabricInventoryId || null,
-              fabricType: source.fabricType || null,
-              lotNumber: source.lotNumber || null,
-              batchNumber: source.batchNumber || null,
-              rollNumber: source.rollNumber || null,
-              supplierPartNumber: source.supplierPartNumber || null,
-              internalControlNumber: source.internalControlNumber || null,
-              expirationDate: source.expirationDate || null,
-              quantityUsed: source.quantityUsed || 1,
-              isPrimary: j === 0, // First source is primary
-            });
-        }
+              productCategoryId: productCategory.id,
+              barcode,
+              packetNumber,
+              buildDate: new Date(),
+              status: 'AVAILABLE',
+              isMixedFabric,
+              fabricSourceCount: fabricSources.length,
+              notes: completionNotes || null,
+              createdBy: completedBy || null,
+            })
+            .returning();
 
-        createdPackets.push({
-          ...builtPacket,
-          fabricSources,
-        });
+          // Create fabric source records for each fabric used
+          for (let j = 0; j < fabricSources.length; j++) {
+            const source = fabricSources[j];
+            await tx
+              .insert(cuttingBuiltPacketFabricSources)
+              .values({
+                builtPacketId: builtPacket.id,
+                fabricInventoryId: source.fabricInventoryId || null,
+                fabricType: source.fabricType || null,
+                lotNumber: source.lotNumber || null,
+                batchNumber: source.batchNumber || null,
+                rollNumber: source.rollNumber || null,
+                supplierPartNumber: source.supplierPartNumber || null,
+                internalControlNumber: source.internalControlNumber || null,
+                expirationDate: source.expirationDate || null,
+                quantityUsed: source.quantityUsed || 1,
+                isPrimary: j === 0, // First source is primary
+              });
+          }
+
+          createdPackets.push({
+            ...builtPacket,
+            fabricSources,
+          });
+        }
       }
 
       const fabricUsageByRoll = new Map<string, { quantityUsed: number; rollNumber: string | null }>();
@@ -1163,6 +1168,7 @@ router.post('/:id/complete-with-traceability', async (req: Request, res: Respons
     res.json({
       queueItem: updated,
       createdPackets,
+      batchInventoryAdded: shouldAddToP1PacketInventory ? quantityCompleted : 0,
       isPartialCompletion: !isFullyCompleted,
       remainingQuantity: isFullyCompleted ? 0 : quantityRequested - newTotalCompleted,
       isMixedFabric,
@@ -2247,6 +2253,8 @@ router.post('/:id/validate-material', async (req: Request, res: Response) => {
 router.get('/built-packets', async (req: Request, res: Response) => {
   try {
     const { limit = '50', offset = '0', status } = req.query;
+    const parsedLimit = parseInt(limit as string);
+    const parsedOffset = parseInt(offset as string);
 
     await ensureBuiltPacketsForCompletedQueueRows();
 
@@ -2268,8 +2276,8 @@ router.get('/built-packets', async (req: Request, res: Response) => {
       .leftJoin(cuttingProductCategories, eq(cuttingProductCategories.id, cuttingBuiltPackets.productCategoryId))
       .where(status ? eq(cuttingBuiltPackets.status, status as string) : undefined)
       .orderBy(desc(cuttingBuiltPackets.buildDate))
-      .limit(parseInt(limit as string))
-      .offset(parseInt(offset as string));
+      .limit(parsedLimit)
+      .offset(parsedOffset);
 
     const packetIds = packets.map(p => p.id);
     let fabricSources: any[] = [];
@@ -2363,7 +2371,56 @@ router.get('/built-packets', async (req: Request, res: Response) => {
       fabricSources: fabricSources.filter(s => s.builtPacketId === packet.id),
     }));
 
-    res.json(result);
+    let batchRows: any[] = [];
+    if (!status) {
+      const cuttingTableDept = supplySourceDashboardToLegacyDept('CUTTING_TABLE')!;
+      const cuttingTableCategories = getDashboardCategories('CUTTING_TABLE');
+      const completedStockRows = await db
+        .select({
+          queue: manufacturingQueue,
+          item: inventoryItems,
+        })
+        .from(manufacturingQueue)
+        .leftJoin(inventoryItems, eq(manufacturingQueue.inventoryItemId, inventoryItems.id))
+        .where(and(
+          or(
+            eq(manufacturingQueue.department, cuttingTableDept),
+            inArray(inventoryItems.manufacturedCategory, cuttingTableCategories)
+          ),
+          eq(manufacturingQueue.status, 'COMPLETED')
+        ))
+        .orderBy(desc(manufacturingQueue.completedAt), desc(manufacturingQueue.updatedAt))
+        .limit(parsedLimit);
+
+      batchRows = completedStockRows
+        .filter((row) => row.item && isP1PacketInventoryQueueItem(parseQueueNotes(row.queue.notes)))
+        .map((row) => ({
+          id: -row.queue.id,
+          barcode: `BATCH-${row.queue.id}`,
+          packetNumber: 1,
+          displayPacketNumber: null,
+          buildDate: row.queue.completedAt || row.queue.updatedAt || row.queue.createdAt,
+          status: 'BATCH',
+          isMixedFabric: false,
+          fabricSourceCount: 0,
+          notes: row.queue.completionNotes || row.queue.notes,
+          createdBy: row.queue.completedBy,
+          allocatedToOrder: null,
+          categoryName: row.item?.name || 'P1 Stock Packet',
+          sku: row.item?.agPartNumber || null,
+          queueId: String(row.queue.id),
+          quantityOrdered: row.queue.quantityCompleted || row.queue.quantityRequested || 0,
+          batchQuantity: row.queue.quantityCompleted || row.queue.quantityRequested || 0,
+          isBatchEntry: true,
+          fabricSources: [],
+        }));
+    }
+
+    const combined = [...result, ...batchRows]
+      .sort((a, b) => new Date(b.buildDate).getTime() - new Date(a.buildDate).getTime())
+      .slice(0, parsedLimit);
+
+    res.json(combined);
   } catch (error) {
     console.error('Error fetching built packets:', error);
     res.status(500).json({ error: 'Failed to fetch built packets' });


### PR DESCRIPTION
## Summary
- Adds completed P1 stock packet work to aggregate packet inventory instead of creating individually viewable made-packet rows.
- Shows completed P1 stock packet work as a single batch entry in Made Packets.
- Nets P1 packet demand against on-hand packet inventory before showing weekly cutting demand.

## Why
Completed P1 packets should increase usable packet inventory and reduce open P1 packet demand. They should not clutter the Made Packets card as individual packet records.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/cuttingTableManufacturingQueue.ts`
- `node --experimental-strip-types --check server/src/routes/cuttingTable.ts`

Full TypeScript validation was not run because this clean worktree does not have local `node_modules`, and package resolution would require network install.