### PR TITLE
[codex] Fix P2 scheduled serial generation

### DIFF
--- a/migrations/0187_repair_p2_po_unit_serials.sql
+++ b/migrations/0187_repair_p2_po_unit_serials.sql
@@ -1,0 +1,126 @@
+-- Repair legacy P2 serialized items generated in PO-UNIT format.
+--
+-- The canonical P2 serial is PREFIX + YY + NNNNN, where PREFIX comes from the
+-- customer RFQ prefix (or customer name fallback), YY is the created year, and
+-- NNNNN is the customer/year sequence. This migration only rewrites rows whose
+-- serial/barcode/traveler barcode are still in the old PO-UNIT shape.
+
+ALTER TABLE p2_customers
+  ADD COLUMN IF NOT EXISTS serial_sequences JSONB DEFAULT '{}'::jsonb;
+
+WITH candidates AS (
+  SELECT
+    si.id,
+    si.customer_id,
+    COALESCE(si.created_at, NOW()) AS created_at,
+    EXTRACT(YEAR FROM COALESCE(si.created_at, NOW()))::int AS serial_year,
+    RIGHT(EXTRACT(YEAR FROM COALESCE(si.created_at, NOW()))::int::text, 2) AS year_suffix,
+    COALESCE(
+      NULLIF(
+        UPPER(LEFT(REGEXP_REPLACE(COALESCE(c.rfq_prefix, c.customer_name, si.customer_name, 'UNK'), '[^a-zA-Z0-9]', '', 'g'), 3)),
+        ''
+      ),
+      'UNK'
+    ) AS serial_prefix
+  FROM p2_serialized_items si
+  LEFT JOIN p2_customers c ON c.customer_id = si.customer_id::text
+  WHERE COALESCE(si.serial_number, '') ~ '^[^-]+-UNIT-[0-9]+$'
+     OR COALESCE(si.barcode, '') ~ '^[^-]+-UNIT-[0-9]+$'
+     OR COALESCE(si.traveler_barcode, '') ~ '^[^-]+-UNIT-[0-9]+$'
+),
+candidate_groups AS (
+  SELECT DISTINCT customer_id, serial_year, year_suffix, serial_prefix
+  FROM candidates
+),
+existing_valid AS (
+  SELECT
+    g.customer_id,
+    g.serial_year,
+    COALESCE(
+      MAX(
+        (SUBSTRING(
+          UPPER(si.serial_number)
+          FROM ('^' || g.serial_prefix || g.year_suffix || '([0-9]{5})$')
+        ))::int
+      ),
+      0
+    ) AS max_sequence
+  FROM candidate_groups g
+  LEFT JOIN p2_serialized_items si
+    ON si.customer_id = g.customer_id
+   AND NOT EXISTS (SELECT 1 FROM candidates c WHERE c.id = si.id)
+   AND UPPER(COALESCE(si.serial_number, '')) ~ ('^' || g.serial_prefix || g.year_suffix || '[0-9]{5}$')
+  GROUP BY g.customer_id, g.serial_year
+),
+group_base AS (
+  SELECT
+    g.customer_id,
+    g.serial_year,
+    g.year_suffix,
+    g.serial_prefix,
+    GREATEST(
+      COALESCE((pc.serial_sequences->>g.serial_year::text)::int, 0),
+      COALESCE(ev.max_sequence, 0)
+    ) AS base_sequence
+  FROM candidate_groups g
+  LEFT JOIN p2_customers pc ON pc.customer_id = g.customer_id::text
+  LEFT JOIN existing_valid ev
+    ON ev.customer_id = g.customer_id
+   AND ev.serial_year = g.serial_year
+),
+numbered AS (
+  SELECT
+    c.id,
+    c.customer_id,
+    c.serial_year,
+    gb.base_sequence
+      + ROW_NUMBER() OVER (
+          PARTITION BY c.customer_id, c.serial_year
+          ORDER BY c.created_at, c.id
+        ) AS new_sequence,
+    c.serial_prefix || c.year_suffix ||
+      LPAD(
+        (
+          gb.base_sequence
+            + ROW_NUMBER() OVER (
+                PARTITION BY c.customer_id, c.serial_year
+                ORDER BY c.created_at, c.id
+              )
+        )::text,
+        5,
+        '0'
+      ) AS new_serial
+  FROM candidates c
+  JOIN group_base gb
+    ON gb.customer_id = c.customer_id
+   AND gb.serial_year = c.serial_year
+),
+updated_items AS (
+  UPDATE p2_serialized_items si
+  SET
+    serial_number = n.new_serial,
+    barcode = n.new_serial,
+    traveler_barcode = n.new_serial,
+    sequence_number = n.new_sequence,
+    updated_at = NOW()
+  FROM numbered n
+  WHERE si.id = n.id
+  RETURNING si.customer_id, n.serial_year, n.new_sequence
+),
+sequence_updates AS (
+  SELECT customer_id, serial_year, MAX(new_sequence) AS max_sequence
+  FROM updated_items
+  GROUP BY customer_id, serial_year
+),
+customer_sequences AS (
+  SELECT
+    customer_id,
+    jsonb_object_agg(serial_year::text, max_sequence) AS sequence_patch
+  FROM sequence_updates
+  GROUP BY customer_id
+)
+UPDATE p2_customers pc
+SET serial_sequences = COALESCE(pc.serial_sequences, '{}'::jsonb) ||
+  cs.sequence_patch
+FROM customer_sequences cs
+WHERE pc.customer_id = cs.customer_id::text;

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -210,6 +210,7 @@ const safeFiles = [
   '0184_cnc_operation_batches.sql',
   '0185_draft_bom_drafts.sql',
   '0186_inventory_items_machined_part_fields.sql',
+  '0187_repair_p2_po_unit_serials.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -6695,9 +6695,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
               .where(eq(p2PurchaseOrders.id, poItem.poId));
             
             // Create serialized items for scheduling when BOM is complete
-            const { p2SerializedItems, partRoutings: partRoutingsTable, projects: projectsTable } = await import('../../schema');
-            const { v4: uuidv4 } = await import('uuid');
-            const { and: andOp, eq: eqOp, ilike: ilikeOp, isNull: isNullOp } = await import('drizzle-orm');
+            const { p2SerializedItems } = await import('../../schema');
+            const { eq: eqOp } = await import('drizzle-orm');
             
             // Get the PO for additional info
             const [po] = await db
@@ -6717,88 +6716,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
               console.log(`Creating serialized items for PO ${po?.poNumber} with ${allItems.length} line items`);
               
               for (const lineItem of allItems) {
-                const [projectForPoItem] = await db
-                  .select({ id: projectsTable.id })
-                  .from(projectsTable)
-                  .where(andOp(eqOp(projectsTable.poId, poItem.poId), eqOp(projectsTable.p2PoItemId, lineItem.id)))
-                  .limit(1);
-                const [projectForPo] = projectForPoItem
-                  ? [projectForPoItem]
-                  : await db
-                      .select({ id: projectsTable.id })
-                      .from(projectsTable)
-                      .where(eqOp(projectsTable.poId, poItem.poId))
-                      .limit(1);
-                const projectId = projectForPo?.id ?? null;
-
-                let itemRouting = projectId
-                  ? await db.query.partRoutings.findFirst({
-                      where: andOp(
-                        eqOp(partRoutingsTable.projectId, projectId),
-                        eqOp(partRoutingsTable.partNumber, lineItem.partNumber),
-                        eqOp(partRoutingsTable.isActive, true)
-                      ),
-                    })
-                  : null;
-                if (!itemRouting && projectId) {
-                  itemRouting = await db.query.partRoutings.findFirst({
-                    where: andOp(
-                      eqOp(partRoutingsTable.projectId, projectId),
-                      ilikeOp(partRoutingsTable.partNumber, lineItem.partNumber),
-                      eqOp(partRoutingsTable.isActive, true)
-                    ),
-                  });
-                }
-                if (!itemRouting) {
-                  itemRouting = await db.query.partRoutings.findFirst({
-                    where: andOp(
-                      isNullOp(partRoutingsTable.projectId),
-                      eqOp(partRoutingsTable.partNumber, lineItem.partNumber),
-                      eqOp(partRoutingsTable.isActive, true)
-                    ),
-                  });
-                }
-                if (!itemRouting) {
-                  itemRouting = await db.query.partRoutings.findFirst({
-                    where: andOp(
-                      isNullOp(partRoutingsTable.projectId),
-                      ilikeOp(partRoutingsTable.partNumber, lineItem.partNumber),
-                      eqOp(partRoutingsTable.isActive, true)
-                    ),
-                  });
-                }
-                const baseMatch = lineItem.partNumber.match(/^(.+?)\s*Rev\s*\w+$/i);
-                const familyKey = baseMatch ? baseMatch[1].trim() : lineItem.partNumber;
-
-                for (let i = 0; i < (lineItem.quantity || 1); i++) {
-                  const sequenceNum = i + 1;
-                  const seq4 = String(sequenceNum).padStart(4, '0');
-                  const barcode = `${po?.poNumber || 'P2'}-UNIT-${seq4}`;
-                  const serialNumber = barcode;
-                  
-                  await db.insert(p2SerializedItems).values({
-                    id: uuidv4(),
-                    poId: poItem.poId,
-                    poItemId: lineItem.id,
-                    poNumber: po?.poNumber || 'Unknown',
-                    partNumber: lineItem.partNumber,
-                    partName: lineItem.partName || lineItem.partNumber,
-                    customerId: po?.customerId || 'Unknown',
-                    customerName: po?.customerName || 'Unknown',
-                    sequenceNumber: sequenceNum,
-                    serialNumber,
-                    barcode,
-                    travelerBarcode: barcode,
-                    buildFamilyKey: familyKey,
-                    partRoutingId: itemRouting?.id || null,
-                    partRoutingRevision: itemRouting ? ((itemRouting as any).routingRevision || 1) : null,
-                    status: 'ACTIVE',
-                    currentDepartment: 'Pending Layup',
-                    currentStageIndex: 0,
-                    createdAt: new Date(),
-                    updatedAt: new Date()
-                  });
-                }
+                await storage.addP2SerializedItemsForPoItem(lineItem.id, lineItem.quantity || 1);
               }
               
               console.log(`Created serialized items for PO ${po?.poNumber}`);

--- a/server/src/routes/p2LayupSchedules.ts
+++ b/server/src/routes/p2LayupSchedules.ts
@@ -1,16 +1,15 @@
 import { Router, type Request, Response } from 'express';
 import { db } from '../../db';
+import { storage } from '../../storage';
 import { 
   p2LayupSchedules, 
   p2SerializedItems,
   p2PurchaseOrders,
   p2PurchaseOrderItems,
   p2ProductionOrders,
-  partRoutings,
-  projects,
   insertP2LayupScheduleSchema 
 } from '../../schema';
-import { eq, and, gte, lte, desc, inArray, ilike, max, isNull } from 'drizzle-orm';
+import { eq, and, gte, lte, desc, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
 import JsBarcode from 'jsbarcode';
@@ -656,102 +655,7 @@ router.post('/layup-schedules/generate-serialized-items/:poItemId', async (req: 
       });
     }
 
-    // Find the highest sequence number already used across ALL items on this PO
-    // so that a second (or third) line continues the sequence instead of restarting at 1.
-    const maxSeqResult = await db
-      .select({ maxSeq: max(p2SerializedItems.sequenceNumber) })
-      .from(p2SerializedItems)
-      .where(eq(p2SerializedItems.poId, po.id));
-    const startSeq = (maxSeqResult[0]?.maxSeq ?? 0) + 1;
-
-    const [projectForPoItem] = await db
-      .select({ id: projects.id })
-      .from(projects)
-      .where(and(eq(projects.poId, po.id), eq(projects.p2PoItemId, poItem.id)))
-      .limit(1);
-    const [projectForPo] = projectForPoItem
-      ? [projectForPoItem]
-      : await db
-          .select({ id: projects.id })
-          .from(projects)
-          .where(eq(projects.poId, po.id))
-          .limit(1);
-    const projectId = projectForPo?.id ?? null;
-
-    let itemRouting = projectId
-      ? await db.query.partRoutings.findFirst({
-          where: and(
-            eq(partRoutings.projectId, projectId),
-            eq(partRoutings.partNumber, poItem.partNumber),
-            eq(partRoutings.isActive, true)
-          ),
-        })
-      : null;
-    if (!itemRouting && projectId) {
-      itemRouting = await db.query.partRoutings.findFirst({
-        where: and(
-          eq(partRoutings.projectId, projectId),
-          ilike(partRoutings.partNumber, poItem.partNumber),
-          eq(partRoutings.isActive, true)
-        ),
-      });
-    }
-    if (!itemRouting) {
-      itemRouting = await db.query.partRoutings.findFirst({
-        where: and(
-          isNull(partRoutings.projectId),
-          eq(partRoutings.partNumber, poItem.partNumber),
-          eq(partRoutings.isActive, true)
-        ),
-      });
-    }
-    if (!itemRouting) {
-      itemRouting = await db.query.partRoutings.findFirst({
-        where: and(
-          isNull(partRoutings.projectId),
-          ilike(partRoutings.partNumber, poItem.partNumber),
-          eq(partRoutings.isActive, true)
-        ),
-      });
-    }
-    const baseMatch = poItem.partNumber.match(/^(.+?)\s*Rev\s*\w+$/i);
-    const familyKey = baseMatch ? baseMatch[1].trim() : poItem.partNumber;
-
-    const itemsToCreate = [];
-    for (let i = 0; i < poItem.quantity; i++) {
-      const seq = startSeq + i;
-      const seq4 = seq.toString().padStart(4, '0');
-      const barcode = `${po.poNumber}-UNIT-${seq4}`;
-      const serialNumber = barcode;
-
-      itemsToCreate.push({
-        serialNumber,
-        barcode,
-        travelerBarcode: barcode,
-        poId: po.id,
-        poItemId: poItem.id,
-        poNumber: po.poNumber,
-        partNumber: poItem.partNumber,
-        partName: poItem.partName,
-        customerId: po.customerId,
-        customerName: po.customerName,
-        sequenceNumber: seq,
-        currentDepartment: 'Pending Layup',
-        currentStageIndex: 0,
-        status: 'ACTIVE',
-        departmentHistory: [],
-        metadata: poItem.specifications ? { specifications: poItem.specifications } : null,
-        buildFamilyKey: familyKey,
-        partRoutingId: itemRouting?.id || null,
-        partRoutingRevision: itemRouting ? ((itemRouting as any).routingRevision || 1) : null,
-      });
-    }
-
-    // Insert all serialized items in batch
-    const createdItems = await db
-      .insert(p2SerializedItems)
-      .values(itemsToCreate)
-      .returning();
+    const createdItems = await storage.addP2SerializedItemsForPoItem(poItem.id, poItem.quantity);
 
     let productionOrderCount = 0;
     let cuttingOrderCount = 0;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -17415,6 +17415,7 @@ export class DatabaseStorage implements IStorage {
         const itemData: InsertP2SerializedItem = {
           serialNumber,
           barcode,
+          travelerBarcode: barcode,
           poId: po.id,
           poItemId: poItem.id,
           poNumber: po.poNumber,


### PR DESCRIPTION
## Summary
- Replace P2 scheduled serialized-item `PO-UNIT` barcode generation with the shared customer/year serial allocator.
- Route layup scheduling and BOM-complete auto-generation through `addP2SerializedItemsForPoItem` so new scheduled pitot tube units use `PREFIX + YY + NNNNN` consistently.
- Add a safe boot migration to repair existing P2 `*-UNIT-*` serial/barcode/traveler barcode rows and advance customer serial counters.

## Root Cause
Layup scheduling still had route-local serialized-item creation logic that generated values like `20P005356-UNIT-0087`, bypassing the customer/year serial-number policy already used elsewhere.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Bundled Node syntax checks:
  - `node --experimental-strip-types --check server/storage.ts`
  - `node --experimental-strip-types --check server/src/routes/p2LayupSchedules.ts`
  - `node --experimental-strip-types --check server/src/routes/index.ts`
  - `node --experimental-strip-types --check server/scripts/migrations/runSafeBootMigrations.ts`