### PR TITLE
[codex] Add QMS parts equipment phase 3

### DIFF
--- a/client/src/pages/QMSPartsEquipmentPage.tsx
+++ b/client/src/pages/QMSPartsEquipmentPage.tsx
@@ -6,6 +6,7 @@ import {
   CalendarClock,
   CheckSquare,
   ClipboardList,
+  Download,
   ExternalLink,
   FileInput,
   History,
@@ -75,11 +76,19 @@ type Summary = {
   events: CalibrationEvent[];
   upcoming: CalibrationAsset[];
   overdue: CalibrationAsset[];
+  cleanup?: {
+    missingEvidence: CalibrationAsset[];
+    needsReview: CalibrationAsset[];
+    multiSourceAssets: CalibrationAsset[];
+  };
   stats: {
     totalAssets: number;
     dueSoon: number;
     overdue: number;
     lockedOut: number;
+    missingEvidence?: number;
+    needsReview?: number;
+    multiSourceRecords?: number;
   };
 };
 
@@ -193,6 +202,7 @@ export default function QMSPartsEquipmentPage() {
     attachedBy: '',
     notes: '',
   });
+  const [evidenceFile, setEvidenceFile] = useState<File | null>(null);
   const [review, setReview] = useState({
     action: 'approve',
     reviewedBy: '',
@@ -220,7 +230,16 @@ export default function QMSPartsEquipmentPage() {
   const createTab = activeTab.key === 'all' ? sourceTabs[0] : activeTab;
   const visibleAssets = useMemo(() => assetsForTab(assets, activeTab), [assets, activeTab]);
   const selectedAsset = assets.find((asset) => asset.id === selectedAssetId) ?? visibleAssets[0];
-  const selectedEvidence = metadataList<{ id?: string; label?: string; evidenceUrl?: string; attachedBy?: string; attachedAt?: string; notes?: string }>(selectedAsset, 'evidenceItems');
+  const selectedEvidence = metadataList<{
+    id?: string;
+    label?: string;
+    evidenceUrl?: string;
+    attachedBy?: string;
+    attachedAt?: string;
+    notes?: string;
+    originalFileName?: string;
+    fileSizeBytes?: number;
+  }>(selectedAsset, 'evidenceItems');
   const selectedReviews = metadataList<{ id?: string; action?: string; reviewedBy?: string; reviewedAt?: string; reason?: string; status?: string }>(selectedAsset, 'reviewActions');
   const auditAssetOptions = useMemo(
     () => assets.filter((asset) => ['measuring_device', 'calibration_gage', 'validation_asset', 'calibration_archive'].includes(asset.assetType)),
@@ -315,6 +334,28 @@ export default function QMSPartsEquipmentPage() {
       toast({ title: 'Evidence attached' });
     },
     onError: (error: any) => toast({ title: 'Evidence failed', description: error.message, variant: 'destructive' }),
+  });
+
+  const evidenceUploadMutation = useMutation({
+    mutationFn: () => {
+      if (!evidenceFile) throw new Error('Select an evidence file first.');
+      const formData = new FormData();
+      formData.append('file', evidenceFile);
+      formData.append('label', evidence.label || evidenceFile.name);
+      formData.append('attachedBy', evidence.attachedBy);
+      formData.append('notes', evidence.notes);
+      return apiRequest(`/api/quality/qms/parts-equipment/assets/${selectedAsset?.id}/evidence/upload`, {
+        method: 'POST',
+        body: formData,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/quality/qms/parts-equipment/summary'] });
+      setEvidence({ label: '', evidenceUrl: '', attachedBy: '', notes: '' });
+      setEvidenceFile(null);
+      toast({ title: 'Evidence file uploaded' });
+    },
+    onError: (error: any) => toast({ title: 'Upload failed', description: error.message, variant: 'destructive' }),
   });
 
   const reviewMutation = useMutation({
@@ -412,7 +453,7 @@ export default function QMSPartsEquipmentPage() {
         </Alert>
       )}
 
-      <div className="qms-screen-only grid gap-3 md:grid-cols-4">
+      <div className="qms-screen-only grid gap-3 md:grid-cols-2 xl:grid-cols-7">
         <Card>
           <CardHeader className="pb-2">
             <CardDescription>Total controlled items</CardDescription>
@@ -437,7 +478,68 @@ export default function QMSPartsEquipmentPage() {
             <CardTitle className="text-2xl text-red-800">{summary?.stats.lockedOut ?? 0}</CardTitle>
           </CardHeader>
         </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Missing evidence</CardDescription>
+            <CardTitle className="text-2xl text-amber-700">{summary?.stats.missingEvidence ?? 0}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Needs review</CardDescription>
+            <CardTitle className="text-2xl text-red-700">{summary?.stats.needsReview ?? 0}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Multi-source</CardDescription>
+            <CardTitle className="text-2xl">{summary?.stats.multiSourceRecords ?? 0}</CardTitle>
+          </CardHeader>
+        </Card>
       </div>
+
+      <Card className="qms-screen-only">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <ShieldCheck className="h-5 w-5" />
+            Register Cleanup Queue
+          </CardTitle>
+          <CardDescription>Focused review lists for evidence gaps, lockouts, expired calibrations, and records that were merged from more than one spreadsheet tab.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 lg:grid-cols-3">
+          {[
+            { title: 'Evidence Gaps', items: summary?.cleanup?.missingEvidence ?? [] },
+            { title: 'Review Required', items: summary?.cleanup?.needsReview ?? [] },
+            { title: 'Merged Sources', items: summary?.cleanup?.multiSourceAssets ?? [] },
+          ].map((group) => (
+            <div key={group.title} className="space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="font-medium">{group.title}</p>
+                <Badge variant="secondary">{group.items.length}</Badge>
+              </div>
+              <div className="space-y-2">
+                {group.items.slice(0, 5).map((asset) => (
+                  <button
+                    key={asset.id}
+                    type="button"
+                    className="w-full rounded-md border px-3 py-2 text-left text-sm hover:bg-muted"
+                    onClick={() => {
+                      setSelectedAssetId(asset.id);
+                      setAudit((prev) => ({ ...prev, assetId: asset.id }));
+                    }}
+                  >
+                    <span className="block font-medium">{asset.assetTag} - {asset.name}</span>
+                    <span className="block text-muted-foreground">
+                      {asset.location || asset.ownerDepartment || 'No location'} - {dateOnly(asset.calibrationDueDate) || 'no due date'}
+                    </span>
+                  </button>
+                ))}
+                {group.items.length === 0 && <p className="text-sm text-muted-foreground">Nothing needs attention here.</p>}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
 
       <Tabs
         className="qms-screen-only"
@@ -643,26 +745,61 @@ export default function QMSPartsEquipmentPage() {
               </div>
             </div>
             <div className="space-y-2">
-              <Label>URL or file reference</Label>
+              <Label>Upload certificate or report</Label>
+              <Label className="flex cursor-pointer items-center justify-between rounded-md border px-3 py-2 text-sm hover:bg-muted">
+                <span className="truncate">{evidenceFile?.name ?? 'Select PDF, image, Excel, Word, or CSV file'}</span>
+                <Upload className="ml-2 h-4 w-4 shrink-0" />
+                <Input
+                  type="file"
+                  accept=".pdf,.png,.jpg,.jpeg,.webp,.csv,.xls,.xlsx,.docx"
+                  className="hidden"
+                  onChange={(event) => setEvidenceFile(event.target.files?.[0] ?? null)}
+                />
+              </Label>
+            </div>
+            <div className="space-y-2">
+              <Label>URL or storage reference</Label>
               <Input value={evidence.evidenceUrl} onChange={(e) => setEvidence((prev) => ({ ...prev, evidenceUrl: e.target.value }))} />
             </div>
             <div className="space-y-2">
               <Label>Evidence notes</Label>
               <Textarea value={evidence.notes} onChange={(e) => setEvidence((prev) => ({ ...prev, notes: e.target.value }))} />
             </div>
-            <Button
-              className="w-full"
-              disabled={!selectedAsset || !evidence.evidenceUrl || evidenceMutation.isPending}
-              onClick={() => evidenceMutation.mutate()}
-            >
-              <ExternalLink className="mr-2 h-4 w-4" />
-              Attach Evidence
-            </Button>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Button
+                variant="outline"
+                disabled={!selectedAsset || !evidenceFile || evidenceUploadMutation.isPending}
+                onClick={() => evidenceUploadMutation.mutate()}
+              >
+                <Upload className="mr-2 h-4 w-4" />
+                Upload File
+              </Button>
+              <Button
+                disabled={!selectedAsset || !evidence.evidenceUrl || evidenceMutation.isPending}
+                onClick={() => evidenceMutation.mutate()}
+              >
+                <ExternalLink className="mr-2 h-4 w-4" />
+                Attach Link
+              </Button>
+            </div>
             <div className="space-y-2">
               {selectedEvidence.slice(-3).map((item, index) => (
                 <div key={item.id ?? index} className="rounded-md border px-3 py-2 text-sm">
-                  <p className="font-medium">{item.label || 'Evidence'}</p>
-                  <p className="break-all text-muted-foreground">{item.evidenceUrl}</p>
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="font-medium">{item.label || item.originalFileName || 'Evidence'}</p>
+                      <p className="break-all text-muted-foreground">{item.originalFileName || item.evidenceUrl}</p>
+                    </div>
+                    {item.evidenceUrl && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => window.open(item.evidenceUrl, '_blank', 'noopener,noreferrer')}
+                      >
+                        <Download className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
                 </div>
               ))}
             </div>

--- a/server/src/routes/quality.ts
+++ b/server/src/routes/quality.ts
@@ -1,5 +1,8 @@
 import { Router, Request, Response } from 'express';
 import crypto from 'crypto';
+import fs from 'fs';
+import multer from 'multer';
+import path from 'path';
 import {
   insertQcDefinitionSchema,
   insertQcSubmissionSchema,
@@ -21,6 +24,48 @@ import { storage } from '../../storage';
 import { requirePermission } from '../../middleware/requirePermission';
 
 const router = Router();
+const qmsEvidenceUploadDir = path.join(process.cwd(), 'uploads', 'qms-calibration-evidence');
+
+type UploadedFile = {
+  originalname: string;
+  filename: string;
+  mimetype: string;
+  size: number;
+  path: string;
+};
+
+if (!fs.existsSync(qmsEvidenceUploadDir)) {
+  fs.mkdirSync(qmsEvidenceUploadDir, { recursive: true });
+}
+
+const qmsEvidenceUpload = multer({
+  storage: multer.diskStorage({
+    destination: (_req, _file, cb) => cb(null, qmsEvidenceUploadDir),
+    filename: (_req, file, cb) => {
+      const ext = path.extname(file.originalname).toLowerCase();
+      const safeBase = path
+        .basename(file.originalname, ext)
+        .replace(/[^a-zA-Z0-9_-]/g, '_')
+        .slice(0, 80);
+      cb(null, `${Date.now()}_${crypto.randomBytes(8).toString('hex')}_${safeBase}${ext}`);
+    },
+  }),
+  limits: { fileSize: 25 * 1024 * 1024, files: 1 },
+  fileFilter: (_req, file, cb) => {
+    const allowedOfficeFiles = [
+      'application/pdf',
+      'text/csv',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ];
+    if (file.mimetype.startsWith('image/') || allowedOfficeFiles.includes(file.mimetype)) {
+      cb(null, true);
+      return;
+    }
+    cb(new Error('Evidence uploads must be PDF, image, CSV, Excel, or Word files.'));
+  },
+});
 
 const qmsPartsEquipmentTabs = [
   {
@@ -174,6 +219,28 @@ function appendMetadataList(metadata: Record<string, unknown>, key: string, item
     ...metadata,
     [key]: [...current, item],
   };
+}
+
+function metadataList(value: unknown, key: string): Record<string, unknown>[] {
+  const metadata = metadataRecord(value);
+  return Array.isArray(metadata[key])
+    ? (metadata[key] as unknown[]).filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    : [];
+}
+
+function sourceTabsForAsset(value: unknown): string[] {
+  const metadata = metadataRecord(value);
+  if (Array.isArray(metadata.qmsSourceTabs)) {
+    return metadata.qmsSourceTabs
+      .map((item) => compactString(item))
+      .filter((item): item is string => Boolean(item));
+  }
+  const source = compactString(metadata.qmsSheetName);
+  return source ? [source] : [];
+}
+
+function assetHasEvidence(asset: { evidenceUrl?: string | null; metadata?: unknown }) {
+  return Boolean(compactString(asset.evidenceUrl) || metadataList(asset.metadata, 'evidenceItems').length > 0);
 }
 
 function reviewStatusFromAction(action: string) {
@@ -473,6 +540,21 @@ router.get('/qms/parts-equipment/summary', async (_req: Request, res: Response) 
       ...tab,
       count: assets.filter((asset) => (asset.metadata as Record<string, unknown> | null)?.qmsSheetName === tab.sheetName || asset.assetType === tab.assetType).length,
     }));
+    const calibrationScopedAssets = assets.filter((asset) => (
+      ['measuring_device', 'calibration_gage', 'validation_asset', 'calibration_archive'].includes(asset.assetType)
+    ));
+    const missingEvidence = calibrationScopedAssets.filter((asset) => !assetHasEvidence(asset));
+    const multiSourceAssets = assets.filter((asset) => sourceTabsForAsset(asset.metadata).length > 1);
+    const needsReview = assets.filter((asset) => (
+      asset.status === 'expired' ||
+      asset.status === 'locked_out' ||
+      missingEvidence.some((missing) => missing.id === asset.id)
+    ));
+    const cleanup = {
+      missingEvidence: missingEvidence.slice(0, 25),
+      needsReview: needsReview.slice(0, 25),
+      multiSourceAssets: multiSourceAssets.slice(0, 25),
+    };
 
     res.json({
       tabs: byTab,
@@ -480,11 +562,15 @@ router.get('/qms/parts-equipment/summary', async (_req: Request, res: Response) 
       events: events.slice(0, 200),
       upcoming,
       overdue,
+      cleanup,
       stats: {
         totalAssets: assets.length,
         dueSoon: upcoming.length,
         overdue: overdue.length,
         lockedOut: assets.filter((asset) => asset.status === 'locked_out').length,
+        missingEvidence: missingEvidence.length,
+        needsReview: needsReview.length,
+        multiSourceRecords: multiSourceAssets.length,
       },
     });
   } catch (error) {
@@ -721,6 +807,97 @@ router.post('/qms/parts-equipment/assets/:id/evidence', requirePermission('quali
     console.error('Attach QMS evidence error:', error);
     if (error instanceof Error) return res.status(400).json({ error: error.message });
     res.status(500).json({ error: 'Failed to attach evidence' });
+  }
+});
+
+router.post('/qms/parts-equipment/assets/:id/evidence/upload', requirePermission('quality.manage_calibration'), qmsEvidenceUpload.single('file'), async (req: Request, res: Response) => {
+  const file = req.file as UploadedFile | undefined;
+  try {
+    if (!file) return res.status(400).json({ error: 'Evidence file is required' });
+
+    const [existing] = await db
+      .select()
+      .from(calibrationAssets)
+      .where(eq(calibrationAssets.id, req.params.id))
+      .limit(1);
+    if (!existing) {
+      fs.unlink(file.path, () => undefined);
+      return res.status(404).json({ error: 'Calibration asset not found' });
+    }
+
+    const evidenceItem = {
+      id: crypto.randomUUID(),
+      label: compactString(req.body?.label) ?? path.basename(file.originalname),
+      evidenceUrl: '',
+      originalFileName: file.originalname,
+      storedFileName: file.filename,
+      mimeType: file.mimetype,
+      fileSizeBytes: file.size,
+      filePath: file.path,
+      notes: compactString(req.body?.notes),
+      attachedBy: compactString(req.body?.attachedBy),
+      attachedAt: new Date().toISOString(),
+    };
+    evidenceItem.evidenceUrl = `/api/quality/qms/parts-equipment/assets/${existing.id}/evidence/${evidenceItem.id}/download`;
+
+    const metadata = appendMetadataList(metadataRecord(existing.metadata), 'evidenceItems', evidenceItem);
+
+    const [asset] = await db
+      .update(calibrationAssets)
+      .set({
+        evidenceUrl: evidenceItem.evidenceUrl,
+        metadata,
+        updatedAt: new Date(),
+      })
+      .where(eq(calibrationAssets.id, existing.id))
+      .returning();
+
+    await db
+      .insert(calibrationEvents)
+      .values({
+        assetId: existing.id,
+        eventType: 'evidence_uploaded',
+        eventDate: new Date().toISOString().slice(0, 10),
+        result: 'pass',
+        performedBy: compactString(req.body?.attachedBy),
+        evidenceUrl: evidenceItem.evidenceUrl,
+        notes: compactString(req.body?.notes) ?? `Evidence uploaded: ${evidenceItem.label}`,
+      });
+
+    res.status(201).json({ asset, evidenceItem });
+  } catch (error) {
+    if (file) fs.unlink(file.path, () => undefined);
+    console.error('Upload QMS evidence error:', error);
+    if (error instanceof Error) return res.status(400).json({ error: error.message });
+    res.status(500).json({ error: 'Failed to upload evidence' });
+  }
+});
+
+router.get('/qms/parts-equipment/assets/:id/evidence/:evidenceId/download', requirePermission('quality.manage_calibration'), async (req: Request, res: Response) => {
+  try {
+    const [existing] = await db
+      .select()
+      .from(calibrationAssets)
+      .where(eq(calibrationAssets.id, req.params.id))
+      .limit(1);
+    if (!existing) return res.status(404).json({ error: 'Calibration asset not found' });
+
+    const evidenceItem = metadataList(existing.metadata, 'evidenceItems')
+      .find((item) => item.id === req.params.evidenceId);
+    const storedPath = compactString(evidenceItem?.filePath);
+    if (!evidenceItem || !storedPath) return res.status(404).json({ error: 'Evidence file not found' });
+
+    const resolvedBase = path.resolve(qmsEvidenceUploadDir);
+    const resolvedPath = path.resolve(storedPath);
+    if (!resolvedPath.startsWith(`${resolvedBase}${path.sep}`) && resolvedPath !== resolvedBase) {
+      return res.status(400).json({ error: 'Invalid evidence file path' });
+    }
+    if (!fs.existsSync(resolvedPath)) return res.status(404).json({ error: 'Evidence file is missing from storage' });
+
+    res.download(resolvedPath, compactString(evidenceItem.originalFileName) ?? path.basename(resolvedPath));
+  } catch (error) {
+    console.error('Download QMS evidence error:', error);
+    res.status(500).json({ error: 'Failed to download evidence' });
   }
 });
 


### PR DESCRIPTION
## Summary
- Add local file upload and guarded download endpoints for QMS calibration evidence.
- Store uploaded evidence metadata on existing calibration asset records and write audit events for uploads.
- Add cleanup metrics and queues for missing evidence, records needing review, and multi-source merged records.
- Add user-friendly upload/download controls to the QMS Parts and Equipment page.

## Validation
- `git diff --cached --check`
- Targeted TypeScript transpile diagnostics for `client/src/pages/QMSPartsEquipmentPage.tsx` and `server/src/routes/quality.ts`

## Notes
- This PR is stacked on Phase 2: `codex/qms-parts-equipment-phase2`.
- Full project `tsc` was not rerun because prior attempts in this worktree were too heavy/long-running.