### PR TITLE
[codex] Fix P2 traveler certification matching

### DIFF
--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -5,7 +5,6 @@ import {
   p2SerializedItemEvents, 
   p2WorkTasks,
   partRoutings,
-  p2EmployeePartCertifications,
   p2SerializedItemTraceability,
   p2SerializedItemCustomData,
   employees,
@@ -1808,29 +1807,21 @@ router.get('/verify-certification/:employeeCode/:barcode', async (req: Request, 
 
     const nextDepartment = departmentSequence[currentIndex];
 
-    const deptVariants = getDepartmentVariants(nextDepartment);
     const certificationPartNumber =
       inventoryIdentity.internalPartNumber ||
       routing?.partNumber ||
       serializedItem.partNumber;
-    const certification = await db.query.p2EmployeePartCertifications.findFirst({
-      where: and(
-        eq(p2EmployeePartCertifications.employeeId, employee.id),
-        or(
-          eq(p2EmployeePartCertifications.partNumber, certificationPartNumber),
-          eq(p2EmployeePartCertifications.partNumber, serializedItem.partNumber)
-        ),
-        or(
-          inArray(p2EmployeePartCertifications.department, deptVariants),
-          sql`lower(trim(${p2EmployeePartCertifications.department})) = lower(trim(${nextDepartment}))`
-        ),
-        eq(p2EmployeePartCertifications.drawingKnowledge, true),
-        eq(p2EmployeePartCertifications.specSheetUnderstanding, true),
-        eq(p2EmployeePartCertifications.procedureCompletion, true)
-      ),
-    });
-
-    const isCertified = !!certification;
+    const certificationCandidateInputs = [certificationPartNumber, serializedItem.partNumber];
+    const certificationPartCandidates = Array.from(
+      new Set(certificationCandidateInputs.filter((value): value is string => Boolean(value)))
+    );
+    let isCertified = false;
+    for (const candidate of certificationPartCandidates) {
+      if (await storage.checkEmployeeP2PartCertification(employee.id, candidate, nextDepartment)) {
+        isCertified = true;
+        break;
+      }
+    }
 
     const departmentConfig = routing ? (routing.departmentConfig as any) : {};
     const config = departmentConfig?.[nextDepartment] || {};
@@ -2158,31 +2149,26 @@ router.post('/start-task', async (req: Request, res: Response) => {
     const config = departmentConfig?.[department] || {};
 
     // BACKEND CERTIFICATION ENFORCEMENT - Critical for AS9100 compliance
-    const startDeptVariants = getDepartmentVariants(department);
     const certificationPartNumber =
       inventoryIdentity.internalPartNumber ||
       routing?.partNumber ||
       serializedItem.partNumber;
-    const certification = await db.query.p2EmployeePartCertifications.findFirst({
-      where: and(
-        eq(p2EmployeePartCertifications.employeeId, parseInt(employeeId)),
-        or(
-          eq(p2EmployeePartCertifications.partNumber, certificationPartNumber),
-          eq(p2EmployeePartCertifications.partNumber, serializedItem.partNumber)
-        ),
-        or(
-          inArray(p2EmployeePartCertifications.department, startDeptVariants),
-          sql`lower(trim(${p2EmployeePartCertifications.department})) = lower(trim(${department}))`
-        ),
-        eq(p2EmployeePartCertifications.drawingKnowledge, true),
-        eq(p2EmployeePartCertifications.specSheetUnderstanding, true),
-        eq(p2EmployeePartCertifications.procedureCompletion, true)
-      ),
-    });
+    const employeeIdNumber = parseInt(employeeId);
+    const certificationCandidateInputs = [certificationPartNumber, serializedItem.partNumber];
+    const certificationPartCandidates = Array.from(
+      new Set(certificationCandidateInputs.filter((value): value is string => Boolean(value)))
+    );
+    let isCertified = false;
+    for (const candidate of certificationPartCandidates) {
+      if (await storage.checkEmployeeP2PartCertification(employeeIdNumber, candidate, department)) {
+        isCertified = true;
+        break;
+      }
+    }
 
-    if (!certification) {
+    if (!isCertified) {
       return res.status(403).json({ 
-        error: `Employee ${employeeName} is not certified for ${department} on part ${partNumber}`,
+        error: `Employee ${employeeName} is not certified for ${department} on part ${certificationPartNumber || partNumber}`,
         code: 'NOT_CERTIFIED'
       });
     }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19528,10 +19528,44 @@ export class DatabaseStorage implements IStorage {
 
   // Training enforcement helpers
 
+  private getP2PartNumberVariants(partNumber: string): string[] {
+    const variants = new Set<string>();
+    const add = (value?: string | null) => {
+      const trimmed = value?.trim();
+      if (trimmed) variants.add(trimmed);
+    };
+
+    add(partNumber);
+    add(partNumber.replace(/\s+/g, ' '));
+
+    for (const value of Array.from(variants)) {
+      const base = value.match(/^(.+?)(?:\s+|\s*-\s*)(?:rev|revision)\.?\s*[a-z0-9]+$/i)?.[1]?.trim();
+      add(base);
+    }
+
+    return Array.from(variants);
+  }
+
+  private getP2DepartmentKeys(department: string): string[] {
+    const normalize = (value: string) => value.toLowerCase().trim().replace(/[^a-z0-9]/g, '');
+    const keys = new Set<string>([normalize(department)]);
+    const [compact] = Array.from(keys);
+
+    if (compact === 'assembledisassembly') {
+      keys.add('assemblydisassembly');
+    }
+    if (compact === 'assemblydisassembly') {
+      keys.add('assembledisassembly');
+    }
+
+    return Array.from(keys);
+  }
+
   async getP2PartCertificationForStep(
     partNumber: string,
     department: string
   ): Promise<{ id: number; partNumber: string; departments: string[] } | undefined> {
+    const partVariants = this.getP2PartNumberVariants(partNumber);
     const rows = await db
       .select({
         id: p2PartCertifications.id,
@@ -19539,12 +19573,18 @@ export class DatabaseStorage implements IStorage {
         departments: p2PartCertifications.departments,
       })
       .from(p2PartCertifications)
-      .where(eq(p2PartCertifications.partNumber, partNumber));
+      .where(
+        or(
+          ...partVariants.map((variant) =>
+            sql`lower(trim(${p2PartCertifications.partNumber})) = lower(trim(${variant}))`
+          )
+        )
+      );
 
-    const deptLower = department.toLowerCase().trim().replace(/[^a-z0-9]/g, '');
+    const deptKeys = this.getP2DepartmentKeys(department);
     return rows.find((r) => {
       const depts = (r.departments as string[]) || [];
-      return depts.some((d) => d.toLowerCase().trim().replace(/[^a-z0-9]/g, '') === deptLower);
+      return depts.some((d) => deptKeys.includes(d.toLowerCase().trim().replace(/[^a-z0-9]/g, '')));
     });
   }
 
@@ -19553,6 +19593,7 @@ export class DatabaseStorage implements IStorage {
     partNumber: string,
     department: string
   ): Promise<boolean> {
+    const partVariants = this.getP2PartNumberVariants(partNumber);
     const rows = await db
       .select({
         id: p2EmployeePartCertifications.id,
@@ -19566,13 +19607,17 @@ export class DatabaseStorage implements IStorage {
       .where(
         and(
           eq(p2EmployeePartCertifications.employeeId, employeeId),
-          eq(p2EmployeePartCertifications.partNumber, partNumber)
+          or(
+            ...partVariants.map((variant) =>
+              sql`lower(trim(${p2EmployeePartCertifications.partNumber})) = lower(trim(${variant}))`
+            )
+          )
         )
       );
 
-    const deptLower = department.toLowerCase().trim().replace(/[^a-z0-9]/g, '');
+    const deptKeys = this.getP2DepartmentKeys(department);
     const match = rows.find(
-      (r) => r.department.toLowerCase().trim().replace(/[^a-z0-9]/g, '') === deptLower
+      (r) => deptKeys.includes(r.department.toLowerCase().trim().replace(/[^a-z0-9]/g, ''))
     );
 
     if (!match) return false;
@@ -19589,6 +19634,7 @@ export class DatabaseStorage implements IStorage {
     partNumber: string
   ): Promise<{ id: number; expiresAt: Date | null } | undefined> {
     const now = new Date();
+    const partVariants = this.getP2PartNumberVariants(partNumber);
     const rows = await db
       .select({
         id: travelerAuthorizations.id,
@@ -19598,7 +19644,11 @@ export class DatabaseStorage implements IStorage {
       .where(
         and(
           eq(travelerAuthorizations.employeeId, employeeId),
-          eq(travelerAuthorizations.partNumber, partNumber),
+          or(
+            ...partVariants.map((variant) =>
+              sql`lower(trim(${travelerAuthorizations.partNumber})) = lower(trim(${variant}))`
+            )
+          ),
           eq(travelerAuthorizations.isActive, true)
         )
       );
@@ -19612,12 +19662,17 @@ export class DatabaseStorage implements IStorage {
    * bypass the check) from "auth records exist but this employee doesn't have one" (block).
    */
   async anyAuthorizationsExistForPart(partNumber: string): Promise<boolean> {
+    const partVariants = this.getP2PartNumberVariants(partNumber);
     const rows = await db
       .select({ id: travelerAuthorizations.id })
       .from(travelerAuthorizations)
       .where(
         and(
-          eq(travelerAuthorizations.partNumber, partNumber),
+          or(
+            ...partVariants.map((variant) =>
+              sql`lower(trim(${travelerAuthorizations.partNumber})) = lower(trim(${variant}))`
+            )
+          ),
           eq(travelerAuthorizations.isActive, true)
         )
       )


### PR DESCRIPTION
## Summary
- Centralize tolerant P2 part certification matching in storage for traveler gates.
- Match certifications and traveler authorizations across trimmed/case-insensitive part numbers and common `Rev` / `Revision` base-part forms.
- Reuse the same storage check in the P2 traveler certification preview and task-start enforcement so the UI and backend agree.
- Treat `Assemble/Disassembly` and `Assembly/Disassembly` as equivalent in the actual start gate.

## Root Cause
The live `roc2600538` scan could resolve to the serialized item, but the certification gate compared employee certifications, part-cert requirements, and traveler authorizations against exact `part_number` values. When the traveler/routing/internal inventory identity differed from the part number used on the certification record, the operator was rejected as not certified even when the certification existed.

## Validation
- `git diff --cached --check`
- `node --experimental-strip-types --check server/storage.ts`
- `node --experimental-strip-types --check server/src/routes/p2Traveler.ts`

Note: validation used the bundled Codex Node runtime because `node`/`gh` are not installed on this shell PATH.