### PR TITLE
[codex] Fix CNC batch barcode labels

### DIFF
--- a/client/src/components/BarcodeDisplay.tsx
+++ b/client/src/components/BarcodeDisplay.tsx
@@ -30,6 +30,8 @@ interface BarcodeDisplayProps {
   modelId?: string; // Stock model ID
   isHighPriority?: boolean; // High priority flag
   isLate?: boolean; // Late order flag
+  titleLabel?: string;
+  printHeaderLabel?: string;
 }
 
 export function BarcodeDisplay({
@@ -49,9 +51,12 @@ export function BarcodeDisplay({
   modelId,
   isHighPriority,
   isLate,
+  titleLabel = 'Order Barcode',
+  printHeaderLabel = 'P1 ORDER',
 }: BarcodeDisplayProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [showAveryDialog, setShowAveryDialog] = useState(false);
+  const barcodeFormat = getBarcodeFormat(barcode);
 
   // Color coding logic
   const getBarcodeColor = () => {
@@ -88,12 +93,10 @@ export function BarcodeDisplay({
   useEffect(() => {
     if (canvasRef.current && barcode) {
       const config = getSizeConfig();
-      const format = getBarcodeFormat(barcode);
-
       try {
         JsBarcode(canvasRef.current, barcode, {
-          format: format,
-          width: format === 'CODE128' ? config.width * 0.8 : config.width,
+          format: barcodeFormat,
+          width: barcodeFormat === 'CODE128' ? config.width * 0.8 : config.width,
           height: config.height,
           displayValue: true,
           fontSize: config.fontSize,
@@ -114,7 +117,7 @@ export function BarcodeDisplay({
         console.error('Error generating barcode:', error);
       }
     }
-  }, [barcode, size]);
+  }, [barcode, size, barcodeFormat]);
 
   const handleDownload = () => {
     if (canvasRef.current) {
@@ -218,7 +221,7 @@ export function BarcodeDisplay({
                     (_, i) => `
                   <div class="avery-label">
                     <div class="label-content">
-                      <div class="order-header">P1 ORDER</div>
+                      <div class="order-header">${printHeaderLabel}</div>
                       <img src="${img}" alt="Barcode ${orderId}" class="barcode-img" />
                       <div class="order-details">
                         <div class="date-info">Printed: ${currentDate}</div>
@@ -263,7 +266,7 @@ export function BarcodeDisplay({
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Package className="h-5 w-5" />
-            Order Barcode - {orderId}
+            {titleLabel} - {orderId}
           </CardTitle>
         </CardHeader>
       )}
@@ -275,7 +278,7 @@ export function BarcodeDisplay({
 
           <div className="text-center text-sm text-gray-600">
             <p className="font-mono">{barcode}</p>
-            <p className="mt-1">CODE39 Format</p>
+            <p className="mt-1">{barcodeFormat} Format</p>
           </div>
 
           <div className="flex gap-2">

--- a/client/src/pages/cnc/index.tsx
+++ b/client/src/pages/cnc/index.tsx
@@ -2217,6 +2217,8 @@ export default function CNCDashboardPage() {
               dueDate={barcodeBatch.dueDate ?? undefined}
               status={BATCH_STATUS_LABELS[barcodeBatch.status] ?? barcodeBatch.status}
               isHighPriority={barcodeBatch.priority === 'critical' || barcodeBatch.priority === 'high'}
+              titleLabel="Operation Batch Barcode"
+              printHeaderLabel="CNC OP BATCH"
             />
           )}
         </DialogContent>


### PR DESCRIPTION
## Summary
- Make the shared barcode display show the actual resolved barcode format instead of a hard-coded CODE39 label.
- Add optional barcode title/quick-print header props while preserving existing order barcode defaults.
- Use CNC-specific labels for operation batch barcode print/reprint from the CNC Dashboard.

## Why
The CNC operation batch workflow reused the existing order barcode component, so OPB labels could still print with P1-specific wording. This keeps the shared component compatible while making CNC batch labels clear for shop-floor use.

## Validation
- `git diff --check`
- `git diff --cached --check`

Note: React/Vitest checks were not run because this checkout does not have `node_modules` installed.