### PR TITLE
[codex] Sync inventory costs from vendor PO pricing

### DIFF
--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -2227,7 +2227,7 @@ router.post(
 
       const payload = linkExistingVendorPoSchema.parse(req.body);
       const actor = String((req as any).user?.username ?? (req as any).user?.id ?? 'unknown');
-      const { partsRequests, partsRequestStatusHistory, vendorPOs, vendorPOItems } = await import('../../schema');
+      const { partsRequests, partsRequestStatusHistory, vendorPOs, vendorPOItems, inventoryItems } = await import('../../schema');
       const { eq: dEq, and: dAnd, or: dOr, sql: dSql } = await import('drizzle-orm');
 
       const result = await db.transaction(async (tx) => {
@@ -2322,6 +2322,16 @@ router.post(
               ].filter(Boolean).join('\n'),
             })
             .returning();
+
+          if (createdLine?.agPartNumber && unitPrice > 0) {
+            await tx
+              .update(inventoryItems)
+              .set({ costPer: unitPrice, updatedAt: new Date() })
+              .where(dAnd(
+                dEq(inventoryItems.agPartNumber, createdLine.agPartNumber),
+                dSql`${inventoryItems.costPer} IS DISTINCT FROM ${unitPrice}`
+              ));
+          }
         }
 
         const nextStatus = statusFromLinkedVendorPo(vendorPO.status, request.status);
@@ -2548,7 +2558,7 @@ router.post(
             })
             .join('\n');
 
-          await tx.insert(vendorPOItems).values({
+          const [createdLine] = await tx.insert(vendorPOItems).values({
             vendorPoId: vendorPO.id,
             lineNumber,
             agPartNumber: first.agPartNumber || null,
@@ -2561,7 +2571,17 @@ router.post(
               extraQty > 0 ? `Includes ${extraQty} extra unit(s) for stock.` : null,
               requests.some((r) => r.vendorPartNumber) ? `Vendor part refs: ${requests.map((r) => r.vendorPartNumber).filter(Boolean).join(', ')}` : null,
             ].filter(Boolean).join('\n'),
-          });
+          }).returning();
+
+          if (createdLine?.agPartNumber && unitPrice > 0) {
+            await tx
+              .update(inventoryItems)
+              .set({ costPer: unitPrice, updatedAt: new Date() })
+              .where(dAnd(
+                dEq(inventoryItems.agPartNumber, createdLine.agPartNumber),
+                dSql`${inventoryItems.costPer} IS DISTINCT FROM ${unitPrice}`
+              ));
+          }
           lineNumber += 1;
         }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -10479,6 +10479,46 @@ export class DatabaseStorage implements IStorage {
     return item;
   }
 
+  private getVendorPOInventoryCost(poLineItem: any): number | null {
+    const purchaseUnitCost = Number(poLineItem?.purchaseUnitPrice);
+    if (Number.isFinite(purchaseUnitCost) && purchaseUnitCost > 0) {
+      return purchaseUnitCost;
+    }
+
+    const vendorUnitCost = Number(poLineItem?.unitPrice);
+    return Number.isFinite(vendorUnitCost) && vendorUnitCost > 0 ? vendorUnitCost : null;
+  }
+
+  private async syncInventoryItemCostFromVendorPOLine(poLineItem: any): Promise<void> {
+    const agPartNumber = poLineItem?.agPartNumber;
+    const nextCost = this.getVendorPOInventoryCost(poLineItem);
+    if (!agPartNumber || nextCost === null) return;
+
+    const [inventoryItem] = await db
+      .select({
+        id: inventoryItems.id,
+        costPer: inventoryItems.costPer,
+      })
+      .from(inventoryItems)
+      .where(eq(inventoryItems.agPartNumber, agPartNumber))
+      .limit(1);
+
+    if (!inventoryItem) return;
+
+    const currentCost = inventoryItem.costPer == null ? null : Number(inventoryItem.costPer);
+    if (currentCost !== null && Number.isFinite(currentCost) && Math.abs(currentCost - nextCost) < 0.0001) {
+      return;
+    }
+
+    await db
+      .update(inventoryItems)
+      .set({
+        costPer: nextCost,
+        updatedAt: new Date(),
+      })
+      .where(eq(inventoryItems.id, inventoryItem.id));
+  }
+
   async createVendorPOItem(data: any): Promise<any> {
     // If purchase unit data is provided, derive vendor unit values server-side
     let processedData = { ...data };
@@ -10531,6 +10571,8 @@ export class DatabaseStorage implements IStorage {
         throw err;
       }
     }
+
+    await this.syncInventoryItemCostFromVendorPOLine(item);
 
     // Reopen a fully-received (closed) PO when a new item is added
     if (data.vendorPoId) {
@@ -10598,6 +10640,10 @@ export class DatabaseStorage implements IStorage {
       .set({ ...processedData, updatedAt: new Date() })
       .where(eq(vendorPOItems.id, id))
       .returning();
+
+    if (item) {
+      await this.syncInventoryItemCostFromVendorPOLine(item);
+    }
     
     // Sync manufacturing queue if quantity changed
     const newQuantity = processedData.quantity !== undefined ? processedData.quantity : data.quantity;


### PR DESCRIPTION
## Summary
- Sync `inventory_items.cost_per` from linked Vendor PO line pricing on PO item create and update.
- Cover direct parts-request Vendor PO link/draft flows that insert PO lines outside the storage helper.
- Skip ad-hoc lines, zero/missing prices, and unchanged costs.

## Validation
- `git diff --check`
- `git diff --cached --check` before commit
- `git diff --check origin/main..HEAD` after rebase

Note: Full `npm run check` was not run because this shell does not have `npm` on PATH and the clean worktree does not have installed `node_modules`.