### PR TITLE
[codex] Fix P2 traveler scan identity reuse

### DIFF
--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -909,7 +909,7 @@ async function findProductionWorkOrderForSerializedItem(params: {
 
   const whereParts: SQL<unknown>[] = [
     inArray(productionWorkOrders.projectId, projectRows.map((project) => project.id)),
-    sql`${productionWorkOrders.status} NOT IN ('CANCELLED', 'CANCELED', 'CLOSED', 'COMPLETE')`,
+    sql`${productionWorkOrders.status} NOT IN ('CANCELLED', 'CANCELED')`,
   ];
   if (partFilters.length > 0) {
     whereParts.push(or(...partFilters)!);
@@ -968,6 +968,23 @@ async function findTravelerForSerializedItemIdentity(params: {
   const partMatches = buildTravelerPartIdentityMatches({ serializedItem, routing, inventoryIdentity });
   if (partMatches.length === 0) return null;
 
+  if (workOrder?.id) {
+    const rows = await db
+      .select()
+      .from(travelers)
+      .where(
+        and(
+          eq(travelers.productionWorkOrderId, workOrder.id),
+          sql`lower(trim(${travelers.serialNumber})) = lower(trim(${serializedItem.serialNumber}))`,
+          or(...partMatches),
+        ),
+      )
+      .orderBy(desc(travelers.updatedAt))
+      .limit(1);
+
+    return rows[0] ?? null;
+  }
+
   const identityMatches: SQL<unknown>[] = [
     and(
       sql`lower(trim(${travelers.serialNumber})) = lower(trim(${serializedItem.serialNumber}))`,
@@ -976,9 +993,8 @@ async function findTravelerForSerializedItemIdentity(params: {
   ];
 
   const projectId = workOrder?.projectId ?? routing?.projectId ?? null;
-  if (workOrder?.id || projectId) {
+  if (projectId) {
     const projectOrWorkOrderMatches = [
-      workOrder?.id ? eq(travelers.productionWorkOrderId, workOrder.id) : null,
       projectId ? eq(travelers.projectId, projectId) : null,
     ].filter((condition): condition is SQL<unknown> => Boolean(condition));
 
@@ -2309,114 +2325,22 @@ router.post('/generate-traveler', async (req: Request, res: Response) => {
       }
     }
 
-    const workOrder = await findProductionWorkOrderForSerializedItem({
+    const travelerResult = await ensureTravelerForSerializedItem({
       serializedItem,
       routing,
       inventoryIdentity,
+      actor: resolvedDisplayName,
     });
-    const existingTraveler = await findTravelerForSerializedItemIdentity({
-      serializedItem,
-      routing,
-      inventoryIdentity,
-      workOrder,
-    });
-
-    if (existingTraveler) {
-      const repaired = await ensureExistingTravelerHasRoutingDetails({
-        traveler: existingTraveler,
-        routing,
-        actor: resolvedDisplayName,
-      });
-      if (workOrder && existingTraveler.productionWorkOrderId !== workOrder.id) {
-        await storage.linkTravelerToProductionWorkOrder(existingTraveler.id, workOrder.id);
-      }
-
-      return res.json({
-        travelerId: existingTraveler.id,
-        travelerNumber: existingTraveler.travelerNumber,
-        created: false,
-        repaired,
-      });
-    }
-
-    const traveler = await storage.generateTravelerFromRouting(routing.id, {
-      serialNumber: serializedItem.serialNumber,
-      lotNumber: serializedItem.poNumber || undefined,
-      createdBy: resolvedDisplayName,
-    });
-
-    await storage.updateTraveler(traveler.id, { status: 'IN_PROGRESS' });
-    if (workOrder) {
-      await storage.linkTravelerToProductionWorkOrder(traveler.id, workOrder.id);
-    }
-
-    const currentStageIndex = serializedItem.currentStageIndex || 0;
-    if (currentStageIndex > 0) {
-      const steps = await db
-        .select()
-        .from(travelerSteps)
-        .where(eq(travelerSteps.travelerId, traveler.id))
-        .orderBy(asc(travelerSteps.stepNumber));
-
-      const now = new Date();
-
-      for (let i = 0; i < steps.length && i < currentStageIndex; i++) {
-        await db
-          .update(travelerSteps)
-          .set({
-            status: 'COMPLETED',
-            completedAt: now,
-            completedBy: resolvedDisplayName,
-          })
-          .where(eq(travelerSteps.id, steps[i].id));
-
-        await db
-          .update(travelerTasks)
-          .set({
-            status: 'COMPLETED',
-            completedAt: now,
-            completedBy: resolvedDisplayName,
-          })
-          .where(eq(travelerTasks.travelerStepId, steps[i].id));
-      }
-
-      if (steps[currentStageIndex]) {
-        await db
-          .update(travelerSteps)
-          .set({
-            status: 'IN_PROGRESS',
-            startedAt: new Date(),
-            startedBy: resolvedDisplayName,
-          })
-          .where(eq(travelerSteps.id, steps[currentStageIndex].id));
-      }
-
-      console.log(`[P2Traveler] Advanced traveler to step ${currentStageIndex + 1} of ${steps.length} (matching P2 item stage)`);
-    } else {
-      const steps = await db
-        .select()
-        .from(travelerSteps)
-        .where(eq(travelerSteps.travelerId, traveler.id))
-        .orderBy(asc(travelerSteps.stepNumber));
-
-      if (steps.length > 0) {
-        await db
-          .update(travelerSteps)
-          .set({
-            status: 'IN_PROGRESS',
-            startedAt: new Date(),
-            startedBy: resolvedDisplayName,
-          })
-          .where(eq(travelerSteps.id, steps[0].id));
-      }
-    }
-
-    console.log(`[P2Traveler] Generated traveler ${traveler.travelerNumber} for serialized item ${serializedItem.serialNumber}`);
+    console.log(
+      `[P2Traveler] ${travelerResult.created ? 'Generated' : 'Resolved'} traveler ${travelerResult.traveler.travelerNumber} for serialized item ${serializedItem.serialNumber}`,
+    );
 
     return res.json({
-      travelerId: traveler.id,
-      travelerNumber: traveler.travelerNumber,
-      created: true,
+      travelerId: travelerResult.traveler.id,
+      travelerNumber: travelerResult.traveler.travelerNumber,
+      created: travelerResult.created,
+      repaired: travelerResult.repaired,
+      linkedWorkOrderId: travelerResult.linkedWorkOrderId,
     });
   } catch (error: any) {
     console.error('[P2Traveler] Error generating traveler:', error);

--- a/server/src/routes/p2TravelerViewer.ts
+++ b/server/src/routes/p2TravelerViewer.ts
@@ -21,6 +21,8 @@ import {
   travelers,
   routingDocuments,
   inventoryItems,
+  projects,
+  productionWorkOrders,
   cuttingFabricInventory,
   cuttingBuiltPackets,
   cuttingBuiltPacketFabricSources,
@@ -39,7 +41,7 @@ import {
   insertP2FinalInspectionResultSchema,
   insertP2DepartmentTransferSignatureSchema,
 } from '../../schema';
-import { eq, and, desc, sql, inArray, or, ilike, asc } from 'drizzle-orm';
+import { eq, and, desc, sql, inArray, or, ilike, asc, type SQL } from 'drizzle-orm';
 import { formatP2DocumentPoNumber } from '../utils/p2DocumentPoNumber';
 
 const router = Router();
@@ -58,6 +60,59 @@ function generateDocumentNumber(prefix: string): string {
   const dateStr = date.toISOString().slice(0, 10).replace(/-/g, '');
   const randomNum = Math.floor(1000 + Math.random() * 9000);
   return `${prefix}-${dateStr}-${randomNum}`;
+}
+
+async function findProductionWorkOrderForTravelerViewer(params: {
+  serializedItem: typeof p2SerializedItems.$inferSelect;
+  routing: typeof partRoutings.$inferSelect | null;
+  poItem: typeof p2PurchaseOrderItems.$inferSelect | null;
+}) {
+  const { serializedItem, routing, poItem } = params;
+  const projectRows = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(eq(projects.poId, serializedItem.poId));
+
+  if (projectRows.length === 0) return null;
+
+  let inventoryItem: typeof inventoryItems.$inferSelect | null = null;
+  if (poItem?.inventoryItemId) {
+    inventoryItem = await db.query.inventoryItems.findFirst({
+      where: eq(inventoryItems.id, poItem.inventoryItemId),
+    }) ?? null;
+  }
+
+  const partCandidates = new Set<string>();
+  const addPart = (value?: string | null) => {
+    const trimmed = value?.trim();
+    if (trimmed) partCandidates.add(trimmed);
+  };
+  addPart(inventoryItem?.agPartNumber ?? null);
+  addPart(poItem?.partNumber ?? null);
+  addPart(routing?.partNumber ?? null);
+  addPart(serializedItem.partNumber);
+
+  const whereParts: SQL<unknown>[] = [
+    inArray(productionWorkOrders.projectId, projectRows.map((project) => project.id)),
+    sql`${productionWorkOrders.status} NOT IN ('CANCELLED', 'CANCELED')`,
+  ];
+
+  const partFilters = Array.from(partCandidates).flatMap((part) => [
+    eq(productionWorkOrders.partNumber, part),
+    sql`lower(trim(${productionWorkOrders.partNumber})) = lower(trim(${part}))`,
+  ]);
+  if (partFilters.length > 0) {
+    whereParts.push(or(...partFilters)!);
+  }
+
+  const [workOrder] = await db
+    .select({ id: productionWorkOrders.id })
+    .from(productionWorkOrders)
+    .where(and(...whereParts))
+    .orderBy(desc(productionWorkOrders.createdAt))
+    .limit(1);
+
+  return workOrder ?? null;
 }
 
 const DEFAULT_COC_CERTIFICATION_TEXT =
@@ -294,12 +349,25 @@ router.get('/item/:barcode', async (req: Request, res: Response) => {
       orderBy: [desc(p2DepartmentTransferSignatures.signedAt)],
     });
 
-    // Get traveler steps linked to this serialized item via serial number
+    const linkedWorkOrder = await findProductionWorkOrderForTravelerViewer({
+      serializedItem,
+      routing,
+      poItem,
+    });
+
+    // Get traveler steps linked to this serialized item. When a production
+    // work order exists, use it as the unit identity so repeated customer
+    // serials do not hydrate a prior completed traveler.
     let travelerStepData: any[] = [];
     let activeTravelerId: string | null = null;
     let activeTravelerRow: any = null;
     const linkedTravelers = await db.query.travelers.findMany({
-      where: eq(travelers.serialNumber, serializedItem.serialNumber),
+      where: linkedWorkOrder
+        ? and(
+            eq(travelers.serialNumber, serializedItem.serialNumber),
+            eq(travelers.productionWorkOrderId, linkedWorkOrder.id),
+          )
+        : eq(travelers.serialNumber, serializedItem.serialNumber),
       orderBy: [asc(travelers.createdAt)],
     });
     if (linkedTravelers.length > 0) {


### PR DESCRIPTION
## Summary
- scope P2 traveler reuse to the serialized item's resolved production work order when available
- route `/api/p2-traveler/generate-traveler` through the shared traveler identity helper
- make the P2 traveler viewer hydrate traveler steps by work-order identity instead of serial-only fallback

## Root cause
Scans such as `roc2600123` can represent a repeated customer serial. The traveler generation and viewer paths were still willing to match any traveler with the same serial/part, so a new unit could surface an already completed traveler.

## Validation
- `git diff --check`
- `git diff --cached --check`
- bundled Node `--experimental-strip-types --check server/src/routes/p2Traveler.ts`
- bundled Node `--experimental-strip-types --check server/src/routes/p2TravelerViewer.ts`