### PR TITLE
[codex] Tighten P2 production traveler scan identity matching

### DIFF
--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -696,6 +696,24 @@ async function findSerializedItemByPrintedTravelerScan(scanValue: string) {
   const printedTraveler = await findTravelerByPrintedScan(scanValue);
   if (!printedTraveler) return null;
 
+  const scanVariants = new Set(buildP2PartScanVariants(scanValue).map((value) => value.toLowerCase()));
+  const printedTravelerSerialVariants = new Set(
+    buildP2PartScanVariants(printedTraveler.serialNumber || '').map((value) => value.toLowerCase()),
+  );
+
+  const candidateMatchesScannedIdentity = (candidate: typeof p2SerializedItems.$inferSelect): boolean => {
+    const candidateValues = [
+      candidate.barcode,
+      candidate.travelerBarcode,
+      candidate.serialNumber,
+      candidate.customerSerialNumber,
+    ]
+      .map((value) => value?.trim().toLowerCase())
+      .filter((value): value is string => Boolean(value));
+
+    return candidateValues.some((value) => scanVariants.has(value) || printedTravelerSerialVariants.has(value));
+  };
+
   const projectIds = new Set<string>();
   if (printedTraveler.projectId) projectIds.add(printedTraveler.projectId);
   if (printedTraveler.productionWorkOrderId) {
@@ -724,6 +742,8 @@ async function findSerializedItemByPrintedTravelerScan(scanValue: string) {
     .limit(250);
 
   for (const candidate of candidateRows) {
+    if (!candidateMatchesScannedIdentity(candidate)) continue;
+
     const identity = await getSerializedItemInventoryIdentity(candidate);
     const routing = await findActiveRoutingForSerializedItem(candidate);
     const partMatches = buildTravelerPartIdentityMatches({
@@ -991,22 +1011,6 @@ async function findTravelerForSerializedItemIdentity(params: {
       or(...partMatches),
     )!,
   ];
-
-  const projectId = workOrder?.projectId ?? routing?.projectId ?? null;
-  if (projectId) {
-    const projectOrWorkOrderMatches = [
-      projectId ? eq(travelers.projectId, projectId) : null,
-    ].filter((condition): condition is SQL<unknown> => Boolean(condition));
-
-    if (projectOrWorkOrderMatches.length > 0) {
-      identityMatches.push(
-        and(
-          or(...projectOrWorkOrderMatches),
-          or(...partMatches),
-        )!,
-      );
-    }
-  }
 
   const rows = await db
     .select()

--- a/server/src/routes/p2TravelerViewer.ts
+++ b/server/src/routes/p2TravelerViewer.ts
@@ -62,6 +62,37 @@ function generateDocumentNumber(prefix: string): string {
   return `${prefix}-${dateStr}-${randomNum}`;
 }
 
+function buildP2ViewerScanVariants(scanValue: string): string[] {
+  const trimmed = scanValue.trim();
+  const compact = trimmed.replace(/\s+/g, '');
+  const variants = new Set<string>([trimmed, compact]);
+
+  for (const value of Array.from(variants)) {
+    if (/^rec/i.test(value)) variants.add(`ROC${value.slice(3)}`);
+    if (/^roc/i.test(value)) variants.add(`REC${value.slice(3)}`);
+  }
+
+  return Array.from(variants).filter(Boolean);
+}
+
+async function findSerializedItemForViewerScan(scanValue: string) {
+  const fields = [
+    p2SerializedItems.barcode,
+    p2SerializedItems.travelerBarcode,
+    p2SerializedItems.serialNumber,
+    p2SerializedItems.customerSerialNumber,
+  ];
+
+  for (const variant of buildP2ViewerScanVariants(scanValue)) {
+    const item = await db.query.p2SerializedItems.findFirst({
+      where: or(...fields.map((field) => ilike(field, variant))),
+    });
+    if (item) return item;
+  }
+
+  return null;
+}
+
 async function findProductionWorkOrderForTravelerViewer(params: {
   serializedItem: typeof p2SerializedItems.$inferSelect;
   routing: typeof partRoutings.$inferSelect | null;
@@ -191,13 +222,7 @@ router.get('/item/:barcode', async (req: Request, res: Response) => {
   try {
     const barcode = decodeURIComponent(req.params.barcode).trim();
 
-    // Get serialized item - check both system barcode and physical traveler barcode (case-insensitive)
-    const serializedItem = await db.query.p2SerializedItems.findFirst({
-      where: or(
-        ilike(p2SerializedItems.barcode, barcode),
-        ilike(p2SerializedItems.travelerBarcode, barcode)
-      ),
-    });
+    const serializedItem = await findSerializedItemForViewerScan(barcode);
 
     if (!serializedItem) {
       return res.status(404).json({ error: 'Serialized item not found' });


### PR DESCRIPTION
## Summary
- remove the project/part fallback that could reuse a traveler for a different P2 serial in the production traveler UI
- require printed-traveler fallback candidates to match the scanned barcode/serial identity before returning a serialized item
- make the read-only traveler viewer resolve exact barcode/traveler/serial/customer-serial variants before loading traveler history

## Root cause
After PR #1338, the production traveler route still had a project-level traveler identity fallback. That could let a scan like `roc2600539` resolve to another traveler, such as `roc2600123`, when the project/part matched but the scanned serial did not.

## AS9100 traceability behavior
A P2 barcode/serialized unit now reuses a traveler only when the traveler is linked to the same resolved production identity and matching serial. If no such traveler exists, the production traveler flow generates a new traveler so that each unit has its own traveler audit trail.

## Validation
- `git diff --check`
- `git diff --cached --check`
- bundled Node `--experimental-strip-types --check server/src/routes/p2Traveler.ts`
- bundled Node `--experimental-strip-types --check server/src/routes/p2TravelerViewer.ts`