### PR TITLE
[codex] Add preproduction checklist wizard

### DIFF
--- a/client/src/pages/PreproductionChecklistPage.tsx
+++ b/client/src/pages/PreproductionChecklistPage.tsx
@@ -97,6 +97,7 @@ interface TemplateTask {
 
 interface Checklist {
   id: string;
+  projectId: string;
   projectName: string;
   poNumber: string | null;
   dueDate: string | null;
@@ -155,6 +156,22 @@ interface Employee {
   id: number;
   name: string;
   email: string;
+}
+
+interface ProjectOption {
+  id: string;
+  projectCode?: string | null;
+  projectName: string;
+  poNumber?: string | null;
+  poId?: number | null;
+  currentStage?: string | null;
+  status?: string | null;
+}
+
+interface WizardDepartment {
+  id: string;
+  name: string;
+  tasks: { id: string; description: string }[];
 }
 
 export default function PreproductionChecklistPage() {
@@ -222,6 +239,7 @@ export default function PreproductionChecklistPage() {
               isCreateOpen={isCreateChecklistOpen}
               setIsCreateOpen={setIsCreateChecklistOpen}
               selectedChecklistId={contextChecklistId}
+              initialProjectId={contextProjectId}
               initialProjectName={contextProjectName}
               initialPoNumber={contextPoNumber}
             />
@@ -251,6 +269,346 @@ export default function PreproductionChecklistPage() {
 // CHECKLISTS TAB
 // ===============================
 
+function PreproductionChecklistWizard({
+  open,
+  onOpenChange,
+  projects,
+  departmentOptions,
+  initialProjectId,
+  initialProjectName,
+  initialPoNumber,
+  isSubmitting,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projects: ProjectOption[];
+  departmentOptions: string[];
+  initialProjectId: string;
+  initialProjectName: string;
+  initialPoNumber: string;
+  isSubmitting: boolean;
+  onSubmit: (data: {
+    templateName: string;
+    templateDescription: string;
+    projectId: string;
+    projectName: string;
+    poNumber: string;
+    departments: WizardDepartment[];
+  }) => void;
+}) {
+  const [templateName, setTemplateName] = useState('');
+  const [templateDescription, setTemplateDescription] = useState('');
+  const [projectId, setProjectId] = useState(initialProjectId || '');
+  const [projectName, setProjectName] = useState(initialProjectName || '');
+  const [poNumber, setPoNumber] = useState(initialPoNumber || '');
+  const [departmentName, setDepartmentName] = useState('');
+  const [customDepartmentName, setCustomDepartmentName] = useState('');
+  const [departments, setDepartments] = useState<WizardDepartment[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    setProjectId(initialProjectId || '');
+    setProjectName(initialProjectName || '');
+    setPoNumber(initialPoNumber || '');
+  }, [open, initialProjectId, initialProjectName, initialPoNumber]);
+
+  const selectedProject = projects.find((project) => project.id === projectId);
+
+  useEffect(() => {
+    if (!selectedProject) return;
+    setProjectName(selectedProject.projectName || '');
+    setPoNumber(selectedProject.poNumber || '');
+  }, [selectedProject?.id]);
+
+  const addDepartment = () => {
+    const name = (departmentName === '__new__' ? customDepartmentName : departmentName).trim();
+    if (!name || departments.some((department) => department.name.toLowerCase() === name.toLowerCase())) {
+      return;
+    }
+
+    setDepartments((current) => [
+      ...current,
+      {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        name,
+        tasks: [{ id: `${Date.now()}-task`, description: '' }],
+      },
+    ]);
+    setDepartmentName('');
+    setCustomDepartmentName('');
+  };
+
+  const updateTask = (departmentId: string, taskId: string, description: string) => {
+    setDepartments((current) =>
+      current.map((department) =>
+        department.id === departmentId
+          ? {
+              ...department,
+              tasks: department.tasks.map((task) =>
+                task.id === taskId ? { ...task, description } : task
+              ),
+            }
+          : department
+      )
+    );
+  };
+
+  const addTask = (departmentId: string) => {
+    setDepartments((current) =>
+      current.map((department) =>
+        department.id === departmentId
+          ? {
+              ...department,
+              tasks: [
+                ...department.tasks,
+                { id: `${Date.now()}-${Math.random().toString(36).slice(2)}`, description: '' },
+              ],
+            }
+          : department
+      )
+    );
+  };
+
+  const removeTask = (departmentId: string, taskId: string) => {
+    setDepartments((current) =>
+      current.map((department) =>
+        department.id === departmentId
+          ? { ...department, tasks: department.tasks.filter((task) => task.id !== taskId) }
+          : department
+      )
+    );
+  };
+
+  const removeDepartment = (departmentId: string) => {
+    setDepartments((current) => current.filter((department) => department.id !== departmentId));
+  };
+
+  const cleanedDepartments = departments
+    .map((department) => ({
+      ...department,
+      name: department.name.trim(),
+      tasks: department.tasks
+        .map((task) => ({ ...task, description: task.description.trim() }))
+        .filter((task) => task.description),
+    }))
+    .filter((department) => department.name && department.tasks.length > 0);
+
+  const canSubmit =
+    templateName.trim() &&
+    projectName.trim() &&
+    cleanedDepartments.length > 0 &&
+    cleanedDepartments.every((department) => department.tasks.length > 0);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Pre-production Checklist Wizard</DialogTitle>
+          <DialogDescription>
+            Build a reusable department checklist template and assign it to a project.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Template Name *</Label>
+              <Input
+                value={templateName}
+                onChange={(event) => setTemplateName(event.target.value)}
+                placeholder="Privateer pre-production readiness"
+                data-testid="input-wizard-template-name"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Assign to Project *</Label>
+              <Select
+                value={projectId || 'manual'}
+                onValueChange={(value) => {
+                  setProjectId(value === 'manual' ? '' : value);
+                  if (value === 'manual') {
+                    setProjectName('');
+                    setPoNumber('');
+                  }
+                }}
+              >
+                <SelectTrigger data-testid="select-wizard-project">
+                  <SelectValue placeholder="Select project" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="manual">Manual project name</SelectItem>
+                  {projects.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {[project.projectCode, project.projectName].filter(Boolean).join(' - ')}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Project Name *</Label>
+              <Input
+                value={projectName}
+                onChange={(event) => setProjectName(event.target.value)}
+                placeholder="Project name"
+                data-testid="input-wizard-project-name"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>PO Number</Label>
+              <Input
+                value={poNumber}
+                onChange={(event) => setPoNumber(event.target.value)}
+                placeholder="PO number"
+                data-testid="input-wizard-po-number"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Description</Label>
+            <Textarea
+              value={templateDescription}
+              onChange={(event) => setTemplateDescription(event.target.value)}
+              placeholder="Optional template notes"
+              data-testid="input-wizard-template-description"
+            />
+          </div>
+
+          <Separator />
+
+          <div className="space-y-3">
+            <div>
+              <h3 className="text-base font-semibold">Departments and Tasks</h3>
+              <p className="text-sm text-muted-foreground">
+                New departments are saved with this template and will be available in future wizard runs.
+              </p>
+            </div>
+            <div className="grid gap-2 md:grid-cols-[1fr_1fr_auto]">
+              <Select value={departmentName} onValueChange={setDepartmentName}>
+                <SelectTrigger data-testid="select-wizard-department">
+                  <SelectValue placeholder="Select department" />
+                </SelectTrigger>
+                <SelectContent>
+                  {departmentOptions.map((department) => (
+                    <SelectItem key={department} value={department}>
+                      {department}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="__new__">Add new department</SelectItem>
+                </SelectContent>
+              </Select>
+              <Input
+                value={customDepartmentName}
+                onChange={(event) => setCustomDepartmentName(event.target.value)}
+                placeholder="New department name"
+                disabled={departmentName !== '__new__'}
+                data-testid="input-wizard-new-department"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={addDepartment}
+                disabled={!departmentName || (departmentName === '__new__' && !customDepartmentName.trim())}
+                data-testid="button-wizard-add-department"
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                Add
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {departments.length === 0 ? (
+              <Card>
+                <CardContent className="py-8 text-center text-sm text-muted-foreground">
+                  Add a department to start building the template.
+                </CardContent>
+              </Card>
+            ) : (
+              departments.map((department) => (
+                <Card key={department.id}>
+                  <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <CardTitle className="text-base">{department.name}</CardTitle>
+                        <CardDescription>{department.tasks.length} task{department.tasks.length === 1 ? '' : 's'}</CardDescription>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeDepartment(department.id)}
+                        data-testid={`button-wizard-remove-department-${department.id}`}
+                      >
+                        <Trash2 className="h-4 w-4 text-red-500" />
+                      </Button>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    {department.tasks.map((task, index) => (
+                      <div key={task.id} className="flex gap-2">
+                        <Input
+                          value={task.description}
+                          onChange={(event) => updateTask(department.id, task.id, event.target.value)}
+                          placeholder={`Task ${index + 1}`}
+                          data-testid={`input-wizard-task-${department.id}-${index}`}
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeTask(department.id, task.id)}
+                          disabled={department.tasks.length === 1}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => addTask(department.id)}
+                      data-testid={`button-wizard-add-task-${department.id}`}
+                    >
+                      <Plus className="h-4 w-4 mr-2" />
+                      Add Task
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() =>
+              onSubmit({
+                templateName: templateName.trim(),
+                templateDescription: templateDescription.trim(),
+                projectId,
+                projectName: projectName.trim(),
+                poNumber: poNumber.trim(),
+                departments: cleanedDepartments,
+              })
+            }
+            disabled={!canSubmit || isSubmitting}
+            data-testid="button-submit-checklist-wizard"
+          >
+            {isSubmitting ? 'Creating...' : 'Create Template and Assign'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function ChecklistsTab({
   searchTerm,
   setSearchTerm,
@@ -260,6 +618,7 @@ function ChecklistsTab({
   isCreateOpen,
   setIsCreateOpen,
   selectedChecklistId = '',
+  initialProjectId = '',
   initialProjectName = '',
   initialPoNumber = '',
 }: {
@@ -271,11 +630,13 @@ function ChecklistsTab({
   isCreateOpen: boolean;
   setIsCreateOpen: (b: boolean) => void;
   selectedChecklistId?: string;
+  initialProjectId?: string;
   initialProjectName?: string;
   initialPoNumber?: string;
 }) {
   const { toast } = useToast();
   const qc = useQueryClient();
+  const [isWizardOpen, setIsWizardOpen] = useState(false);
 
   const { data: checklists = [], isLoading } = useQuery<Checklist[]>({
     queryKey: ['/api/preproduction-checklists', statusFilter],
@@ -293,6 +654,14 @@ function ChecklistsTab({
 
   const { data: templates = [] } = useQuery<Template[]>({
     queryKey: ['/api/preproduction-checklists/templates'],
+  });
+
+  const { data: projects = [] } = useQuery<ProjectOption[]>({
+    queryKey: ['/api/projects'],
+  });
+
+  const { data: departmentOptions = [] } = useQuery<string[]>({
+    queryKey: ['/api/preproduction-checklists/templates/departments'],
   });
 
   const [newChecklist, setNewChecklist] = useState({
@@ -337,6 +706,57 @@ function ChecklistsTab({
     },
     onError: () => {
       toast({ title: 'Error', description: 'Failed to create checklist', variant: 'destructive' });
+    },
+  });
+
+  const wizardMutation = useMutation({
+    mutationFn: async (data: {
+      templateName: string;
+      templateDescription: string;
+      projectId: string;
+      projectName: string;
+      poNumber: string;
+      departments: WizardDepartment[];
+    }) => {
+      const template = await apiRequest('/api/preproduction-checklists/templates/wizard', {
+        method: 'POST',
+        body: {
+          name: data.templateName,
+          description: data.templateDescription || null,
+          sections: data.departments.map((department, index) => ({
+            name: department.name,
+            sortOrder: index + 1,
+            tasks: department.tasks.map((task, taskIndex) => ({
+              description: task.description,
+              sortOrder: taskIndex + 1,
+            })),
+          })),
+        },
+      });
+
+      return apiRequest('/api/preproduction-checklists', {
+        method: 'POST',
+        body: {
+          projectName: data.projectName,
+          poNumber: data.poNumber || undefined,
+          templateId: template.id,
+          assignedProjectId: data.projectId || undefined,
+        },
+      });
+    },
+    onSuccess: (checklist: Checklist) => {
+      qc.invalidateQueries({ queryKey: ['/api/preproduction-checklists'] });
+      qc.invalidateQueries({ queryKey: ['/api/preproduction-checklists/templates'] });
+      qc.invalidateQueries({ queryKey: ['/api/preproduction-checklists/templates/departments'] });
+      qc.invalidateQueries({ queryKey: ['/api/projects'] });
+      if (checklist?.projectId) {
+        qc.invalidateQueries({ queryKey: ['/api/projects', checklist.projectId] });
+      }
+      toast({ title: 'Success', description: 'Template created and checklist assigned' });
+      setIsWizardOpen(false);
+    },
+    onError: () => {
+      toast({ title: 'Error', description: 'Failed to create checklist from wizard', variant: 'destructive' });
     },
   });
 
@@ -390,11 +810,29 @@ function ChecklistsTab({
             </SelectContent>
           </Select>
         </div>
-        <Button onClick={() => setIsCreateOpen(true)} data-testid="button-create-checklist">
-          <Plus className="h-4 w-4 mr-2" />
-          New Checklist
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setIsWizardOpen(true)} data-testid="button-open-checklist-wizard">
+            <ClipboardList className="h-4 w-4 mr-2" />
+            Checklist Wizard
+          </Button>
+          <Button onClick={() => setIsCreateOpen(true)} data-testid="button-create-checklist">
+            <Plus className="h-4 w-4 mr-2" />
+            New Checklist
+          </Button>
+        </div>
       </div>
+
+      <PreproductionChecklistWizard
+        open={isWizardOpen}
+        onOpenChange={setIsWizardOpen}
+        projects={projects}
+        departmentOptions={departmentOptions}
+        initialProjectId={initialProjectId}
+        initialProjectName={initialProjectName}
+        initialPoNumber={initialPoNumber}
+        isSubmitting={wizardMutation.isPending}
+        onSubmit={(data) => wizardMutation.mutate(data)}
+      />
 
       {/* Checklists Grid */}
       {isLoading ? (

--- a/server/src/routes/preproductionChecklists.ts
+++ b/server/src/routes/preproductionChecklists.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { db } from '../../db';
+import { storage } from '../../storage';
 import { requirePermission } from '../../middleware/requirePermission';
 import { 
   preproductionTemplates, 
@@ -18,6 +19,9 @@ import { eq, desc, asc, and, sql } from 'drizzle-orm';
 
 const router = Router();
 
+const normalizeDepartmentName = (name: unknown) =>
+  typeof name === 'string' ? name.trim().replace(/\s+/g, ' ') : '';
+
 // =========================
 // TEMPLATES
 // =========================
@@ -34,6 +38,100 @@ router.get('/templates', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Error fetching templates:', error);
     res.status(500).json({ error: 'Failed to fetch templates' });
+  }
+});
+
+// Get reusable department names from existing active templates.
+router.get('/templates/departments', async (req: Request, res: Response) => {
+  try {
+    const rows = await db
+      .select({ name: preproductionTemplateSections.name })
+      .from(preproductionTemplateSections)
+      .innerJoin(
+        preproductionTemplates,
+        eq(preproductionTemplateSections.templateId, preproductionTemplates.id)
+      )
+      .where(eq(preproductionTemplates.isActive, true))
+      .orderBy(asc(preproductionTemplateSections.name));
+
+    const departments = Array.from(
+      new Set(rows.map((row) => normalizeDepartmentName(row.name)).filter(Boolean))
+    );
+
+    res.json(departments);
+  } catch (error) {
+    console.error('Error fetching preproduction departments:', error);
+    res.status(500).json({ error: 'Failed to fetch departments' });
+  }
+});
+
+// Create a complete template with department sections and task rows.
+router.post('/templates/wizard', async (req: Request, res: Response) => {
+  try {
+    const { sections = [], ...templateData } = req.body;
+    const parsed = insertPreproductionTemplateSchema.safeParse(templateData);
+
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid template data', details: parsed.error });
+    }
+
+    const cleanSections = Array.isArray(sections)
+      ? sections
+          .map((section: any, index: number) => ({
+            name: normalizeDepartmentName(section?.name),
+            sortOrder: Number.isFinite(Number(section?.sortOrder))
+              ? Number(section.sortOrder)
+              : index + 1,
+            tasks: Array.isArray(section?.tasks)
+              ? section.tasks
+                  .map((task: any, taskIndex: number) => ({
+                    description: typeof task === 'string'
+                      ? task.trim()
+                      : typeof task?.description === 'string'
+                        ? task.description.trim()
+                        : '',
+                    sortOrder: Number.isFinite(Number(task?.sortOrder))
+                      ? Number(task.sortOrder)
+                      : taskIndex + 1,
+                  }))
+                  .filter((task: any) => task.description)
+              : [],
+          }))
+          .filter((section: any) => section.name && section.tasks.length > 0)
+      : [];
+
+    if (cleanSections.length === 0) {
+      return res.status(400).json({ error: 'Add at least one department with one task' });
+    }
+
+    const [template] = await db
+      .insert(preproductionTemplates)
+      .values(parsed.data)
+      .returning();
+
+    for (const section of cleanSections) {
+      const [createdSection] = await db
+        .insert(preproductionTemplateSections)
+        .values({
+          templateId: template.id,
+          name: section.name,
+          sortOrder: section.sortOrder,
+        })
+        .returning();
+
+      for (const task of section.tasks) {
+        await db.insert(preproductionTemplateTasks).values({
+          sectionId: createdSection.id,
+          description: task.description,
+          sortOrder: task.sortOrder,
+        });
+      }
+    }
+
+    res.status(201).json(template);
+  } catch (error) {
+    console.error('Error creating template from wizard:', error);
+    res.status(500).json({ error: 'Failed to create template from wizard' });
   }
 });
 
@@ -324,7 +422,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // Create checklist from template
 router.post('/', async (req: Request, res: Response) => {
   try {
-    const { templateId, ...checklistData } = req.body;
+    const { templateId, assignedProjectId, ...checklistData } = req.body;
     
     // Convert date strings to Date objects for timestamp fields
     const dateFields = [
@@ -342,7 +440,9 @@ router.post('/', async (req: Request, res: Response) => {
     }
     
     // Auto-generate projectId if not provided (format: PRE + timestamp)
-    if (!checklistData.projectId) {
+    if (!checklistData.projectId && assignedProjectId) {
+      checklistData.projectId = assignedProjectId;
+    } else if (!checklistData.projectId) {
       const timestamp = Date.now().toString(36).toUpperCase();
       checklistData.projectId = `PRE${timestamp}`;
     }
@@ -384,6 +484,19 @@ router.post('/', async (req: Request, res: Response) => {
             sortOrder: templateTask.sortOrder,
           });
         }
+      }
+    }
+
+    if (assignedProjectId) {
+      const steps = await storage.getProjectSteps(assignedProjectId);
+      const preproductionStep = steps.find((step) => step.stepType === 'preproduction_checklist');
+
+      if (preproductionStep) {
+        await storage.updateProjectStep(preproductionStep.id, {
+          linkedPreproductionChecklistId: checklist.id,
+          status: preproductionStep.status === 'pending' ? 'in_progress' : preproductionStep.status,
+          startedAt: preproductionStep.startedAt || new Date(),
+        } as any);
       }
     }
     


### PR DESCRIPTION
## Summary

- Adds a guided Pre-production Checklist Wizard on the existing preproduction checklist page.
- Lets users select an existing project, select reusable department sections, add new departments, and add tasks under each department.
- Creates a reusable preproduction template from the wizard and then creates a project checklist from that template.
- Links the created checklist back to the project workflow step through `linked_preproduction_checklist_id`.

## Why

The previous flow separated template creation, checklist creation, and project assignment. This makes the intended workflow one guided path while preserving the existing manual checklist and template screens.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/preproductionChecklists.ts`

Full TypeScript check was not available in this environment because `npm` is not on PATH, the clean worktree has no local `tsc`, and bundled `pnpm` attempted restricted network package fetches.