### PR TITLE
[codex] Fix imported Draft Builder descriptions in BOM wizard

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -492,8 +492,36 @@ function linePartNumber(line: BomLine) {
   return line.agPartNumber || line.supplierItemId || `DRAFT-${line.id.slice(0, 8).toUpperCase()}`;
 }
 
+const importedPartNumberHeaders = ['agpartnumber', 'agpart', 'partnumber', 'partno', 'partnum', 'part', 'itemnumber', 'sku'];
+const importedDescriptionHeaders = [
+  'description',
+  'desc',
+  'partdescription',
+  'partsdescription',
+  'partdesc',
+  'partsdesc',
+  'itemdescription',
+  'itemdesc',
+  'materialdescription',
+  'productdescription',
+  'name',
+  'item',
+];
+
+function customImportField(line: BomLine, keys: string[]) {
+  const customFields = line.customFields ?? {};
+  for (const [label, value] of Object.entries(customFields)) {
+    if (keys.includes(normalizeCsvHeader(label)) && value.trim()) return value.trim();
+  }
+  return '';
+}
+
 function lineDescription(line: BomLine) {
-  return line.description || line.inventoryItemName || linePartNumber(line);
+  const partNumber = linePartNumber(line);
+  const description = line.description?.trim() ?? '';
+  const customDescription = customImportField(line, importedDescriptionHeaders);
+  if (description && description !== 'Imported spreadsheet line' && description !== partNumber) return description;
+  return customDescription || description || line.inventoryItemName || partNumber;
 }
 
 function normalizeBomLine(line: BomLine): BomLine {
@@ -810,24 +838,33 @@ const knownImportHeaders = new Set([
   'agpartnumber',
   'category',
   'cost',
+  'desc',
   'description',
   'estimatedcost',
   'filter',
   'inventoryitemid',
   'isservice',
   'item',
+  'itemdesc',
   'itemdescription',
   'itemnumber',
   'manufacturer',
+  'materialdescription',
   'mfg',
   'name',
   'note',
   'notes',
   'orderstatus',
   'part',
+  'partdesc',
   'partdescription',
+  'partno',
+  'partnum',
   'partnumber',
+  'partsdesc',
+  'partsdescription',
   'price',
+  'productdescription',
   'qnty',
   'qty',
   'qtyneeded',
@@ -1249,8 +1286,8 @@ function buildLinesFromRows(rows: string[][], inventoryItems: InventoryItemOptio
         if (!column.isKnown && value) acc[column.label] = value;
         return acc;
       }, {});
-      const importedPartNumber = csvField(row, ['agpartnumber', 'agpart', 'partnumber', 'part', 'itemnumber', 'sku']);
-      const description = csvField(row, ['description', 'partdescription', 'name', 'item', 'itemdescription']) || importedPartNumber;
+      const importedPartNumber = csvField(row, importedPartNumberHeaders);
+      const description = csvField(row, importedDescriptionHeaders) || importedPartNumber;
       if (!description && !importedPartNumber && Object.keys(importedCustomFields).length === 0) return null;
 
       const inventoryMatch = linkInventoryMatches ? findInventoryMatch(importedPartNumber, inventoryItems) : null;


### PR DESCRIPTION
## Summary
- Teach Draft Builder spreadsheet imports to recognize additional part description headers such as `Parts Description`, `Part Desc`, `Item Desc`, and material/product description variants.
- Recover real descriptions from preserved custom import fields when older imported rows already saved generic or part-number-only labels.
- Keep BOM wizard draft-part selectors and saved BOM roots showing the part description instead of imported draft fallback text.

## Root Cause
Imported spreadsheet columns with plural or abbreviated description headers were preserved as custom fields but not mapped into the normal Draft Builder `description` field. The BOM wizard uses the Draft Builder line label helper, so those rows could appear as draft/import labels instead of the spreadsheet's part description.

## Validation
- `git diff --check`
- `git diff --cached --check`

Full `npm run check` could not run locally because `npm` is not on PATH in this environment. Bundled `pnpm` attempted to fetch missing packages from the registry and was blocked by restricted network access.