### PR TITLE
[codex] Link and edit P2 BOMs

### DIFF
--- a/client/src/components/p2/P2BOMWizard.tsx
+++ b/client/src/components/p2/P2BOMWizard.tsx
@@ -65,7 +65,9 @@ interface DepartmentOption {
 
 interface PartNeedingBOM {
   id: string;
+  inventoryItemId?: string | null;
   partNumber: string;
+  displayPartNumber?: string;
   description: string;
   quantity: number;
   hasBOM: boolean;
@@ -108,6 +110,11 @@ function getDepartmentLabel(value: string | undefined, options: DepartmentOption
 function departmentOptionsWithCurrent(options: DepartmentOption[], value: string | undefined) {
   if (!value || options.some((department) => department.value === value)) return options;
   return [...options, { value, label: getDepartmentLabel(value, options) }];
+}
+
+function parsePositiveQuantity(value: string, fallback = 0) {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardProps) {
@@ -200,7 +207,9 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
     if (poData?.lineItems) {
       const parts: PartNeedingBOM[] = poData.lineItems.map((item: any) => ({
         id: item.id.toString(),
-        partNumber: item.partNumber,
+        inventoryItemId: item.inventoryItemId != null ? String(item.inventoryItemId) : null,
+        partNumber: item.internalPartNumber || item.agPartNumber || item.partNumber,
+        displayPartNumber: item.partNumber,
         description: item.partName || item.description || '',
         quantity: item.quantity,
         hasBOM: item.hasBOM || false,
@@ -554,7 +563,9 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
               <Input
                 type="number"
                 value={newItem.quantity || ''}
-                onChange={(e) => setNewItem({ ...newItem, quantity: parseInt(e.target.value) || 0 })}
+                onChange={(e) => setNewItem({ ...newItem, quantity: parsePositiveQuantity(e.target.value) })}
+                min="0.0001"
+                step="any"
                 placeholder="Qty"
                 data-testid="input-bom-quantity"
               />
@@ -685,7 +696,9 @@ export default function P2BOMWizard({ poId, onComplete, onCancel }: P2BOMWizardP
                     <Input
                       type="number"
                       value={editingItem.quantity}
-                      onChange={(e) => setEditingItem({ ...editingItem, quantity: parseInt(e.target.value) || 1 })}
+                      onChange={(e) => setEditingItem({ ...editingItem, quantity: parsePositiveQuantity(e.target.value, 1) })}
+                      min="0.0001"
+                      step="any"
                       data-testid="input-edit-quantity"
                     />
                   </div>

--- a/client/src/pages/RobustBOMAdministration.tsx
+++ b/client/src/pages/RobustBOMAdministration.tsx
@@ -1702,6 +1702,15 @@ function P2POBOMsSection() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedBom, setSelectedBom] = useState<any>(null);
   const [isViewOpen, setIsViewOpen] = useState(false);
+  const [metadataDraft, setMetadataDraft] = useState<any>({});
+  const [itemDrafts, setItemDrafts] = useState<any[]>([]);
+  const [newItemDraft, setNewItemDraft] = useState({
+    partName: '',
+    quantity: '1',
+    itemType: 'material',
+    firstDept: 'Layup',
+    notes: '',
+  });
 
   const { data: p2PoBoms, isLoading } = useQuery({
     queryKey: ['/api/robust-boms/p2-po-boms', { search: searchTerm }],
@@ -1713,6 +1722,102 @@ function P2POBOMsSection() {
     queryFn: () => apiRequest(`/api/robust-boms/p2-po-boms/${selectedBom?.id}`),
     enabled: !!selectedBom?.id && isViewOpen,
   });
+
+  useEffect(() => {
+    if (!bomDetail) return;
+    setMetadataDraft({
+      sku: bomDetail.sku || '',
+      modelName: bomDetail.modelName || '',
+      revision: bomDetail.revision || 'A',
+      description: bomDetail.description || '',
+    });
+    setItemDrafts((bomDetail.items || []).map((item: any) => ({
+      ...item,
+      quantity: String(item.quantity ?? 1),
+      firstDept: item.firstDept || 'Layup',
+      itemType: item.itemType || 'material',
+      notes: item.notes || '',
+    })));
+  }, [bomDetail]);
+
+  const invalidateP2BomQueries = () => {
+    queryClient.invalidateQueries({ queryKey: ['/api/robust-boms/p2-po-boms'] });
+    if (selectedBom?.id) {
+      queryClient.invalidateQueries({ queryKey: ['/api/robust-boms/p2-po-boms', selectedBom.id] });
+    }
+  };
+
+  const updateMetadataMutation = useMutation({
+    mutationFn: () => apiRequest(`/api/robust-boms/p2-po-boms/${selectedBom?.id}`, {
+      method: 'PUT',
+      body: metadataDraft,
+    }),
+    onSuccess: (updatedBom) => {
+      setSelectedBom(updatedBom);
+      invalidateP2BomQueries();
+      toast({ title: 'P2 BOM updated' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to update P2 BOM', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const updateItemMutation = useMutation({
+    mutationFn: (item: any) => apiRequest(`/api/robust-boms/p2-po-boms/${selectedBom?.id}/items/${item.id}`, {
+      method: 'PUT',
+      body: {
+        partName: item.partName,
+        quantity: Number.parseFloat(String(item.quantity)),
+        itemType: item.itemType,
+        firstDept: item.firstDept,
+        notes: item.notes,
+      },
+    }),
+    onSuccess: () => {
+      invalidateP2BomQueries();
+      toast({ title: 'BOM item updated' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to update BOM item', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const addItemMutation = useMutation({
+    mutationFn: () => apiRequest(`/api/robust-boms/p2-po-boms/${selectedBom?.id}/items`, {
+      method: 'POST',
+      body: {
+        ...newItemDraft,
+        quantity: Number.parseFloat(String(newItemDraft.quantity)),
+      },
+    }),
+    onSuccess: () => {
+      setNewItemDraft({ partName: '', quantity: '1', itemType: 'material', firstDept: 'Layup', notes: '' });
+      invalidateP2BomQueries();
+      toast({ title: 'BOM item added' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to add BOM item', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const deleteItemMutation = useMutation({
+    mutationFn: (itemId: string) => apiRequest(`/api/robust-boms/p2-po-boms/${selectedBom?.id}/items/${itemId}`, {
+      method: 'DELETE',
+    }),
+    onSuccess: () => {
+      invalidateP2BomQueries();
+      toast({ title: 'BOM item removed' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to remove BOM item', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const updateItemDraft = (index: number, updates: Record<string, unknown>) => {
+    setItemDrafts((current) => current.map((item, itemIndex) => (
+      itemIndex === index ? { ...item, ...updates } : item
+    )));
+  };
 
   return (
     <Card>
@@ -1745,6 +1850,7 @@ function P2POBOMsSection() {
             <TableHeader>
               <TableRow>
                 <TableHead>Part Number / SKU</TableHead>
+                <TableHead>Internal Part #</TableHead>
                 <TableHead>Model Name</TableHead>
                 <TableHead>Revision</TableHead>
                 <TableHead>Description</TableHead>
@@ -1756,6 +1862,19 @@ function P2POBOMsSection() {
               {p2PoBoms.map((bom: any) => (
                 <TableRow key={bom.id}>
                   <TableCell className="font-medium">{bom.sku || '-'}</TableCell>
+                  <TableCell>
+                    {bom.internalPartNumber ? (
+                      <Button
+                        variant="link"
+                        className="h-auto p-0 font-mono"
+                        onClick={() => window.open(`/inventory/manager?part=${encodeURIComponent(bom.internalPartNumber)}`, '_self')}
+                      >
+                        {bom.internalPartNumber}
+                      </Button>
+                    ) : (
+                      <span className="text-muted-foreground">Unlinked</span>
+                    )}
+                  </TableCell>
                   <TableCell>{bom.modelName}</TableCell>
                   <TableCell>
                     <Badge variant="outline">{bom.revision}</Badge>
@@ -1774,7 +1893,7 @@ function P2POBOMsSection() {
                       }}
                       title="View BOM details"
                     >
-                      <FileText className="h-4 w-4" />
+                      <FileEdit className="h-4 w-4" />
                     </Button>
                   </TableCell>
                 </TableRow>
@@ -1787,9 +1906,9 @@ function P2POBOMsSection() {
           setIsViewOpen(open);
           if (!open) setSelectedBom(null);
         }}>
-          <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+          <SheetContent side="right" className="w-full sm:max-w-4xl overflow-y-auto">
             <SheetHeader>
-              <SheetTitle>P2 PO BOM Details</SheetTitle>
+              <SheetTitle>Edit P2 PO BOM</SheetTitle>
               <SheetDescription>
                 {selectedBom?.sku} - {selectedBom?.modelName}
               </SheetDescription>
@@ -1800,21 +1919,56 @@ function P2POBOMsSection() {
               <div className="mt-6 space-y-6">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <label className="text-sm font-medium text-muted-foreground">Part Number</label>
-                    <p className="font-medium">{bomDetail.sku || '-'}</p>
+                    <Label>Part Number / SKU</Label>
+                    <Input
+                      value={metadataDraft.sku || ''}
+                      onChange={(e) => setMetadataDraft({ ...metadataDraft, sku: e.target.value })}
+                    />
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-muted-foreground">Model Name</label>
-                    <p className="font-medium">{bomDetail.modelName}</p>
+                    <Label>Model Name</Label>
+                    <Input
+                      value={metadataDraft.modelName || ''}
+                      onChange={(e) => setMetadataDraft({ ...metadataDraft, modelName: e.target.value })}
+                    />
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-muted-foreground">Revision</label>
-                    <p>{bomDetail.revision}</p>
+                    <Label>Revision</Label>
+                    <Input
+                      value={metadataDraft.revision || ''}
+                      onChange={(e) => setMetadataDraft({ ...metadataDraft, revision: e.target.value })}
+                    />
                   </div>
                   <div>
-                    <label className="text-sm font-medium text-muted-foreground">Description</label>
-                    <p>{bomDetail.description || '-'}</p>
+                    <Label>Internal Part #</Label>
+                    {bomDetail.internalPartNumber ? (
+                      <Button
+                        variant="link"
+                        className="h-10 px-0 font-mono"
+                        onClick={() => window.open(`/inventory/manager?part=${encodeURIComponent(bomDetail.internalPartNumber)}`, '_self')}
+                      >
+                        {bomDetail.internalPartNumber} - {bomDetail.internalPartName || 'Inventory item'}
+                      </Button>
+                    ) : (
+                      <div className="flex h-10 items-center text-sm text-muted-foreground">No internal inventory part linked</div>
+                    )}
                   </div>
+                  <div className="col-span-2">
+                    <Label>Description</Label>
+                    <Textarea
+                      value={metadataDraft.description || ''}
+                      onChange={(e) => setMetadataDraft({ ...metadataDraft, description: e.target.value })}
+                    />
+                  </div>
+                </div>
+                <div className="flex justify-end">
+                  <Button
+                    onClick={() => updateMetadataMutation.mutate()}
+                    disabled={updateMetadataMutation.isPending}
+                  >
+                    <Save className="mr-2 h-4 w-4" />
+                    Save BOM
+                  </Button>
                 </div>
 
                 {bomDetail.linkedPurchaseOrders && bomDetail.linkedPurchaseOrders.length > 0 && (
@@ -1832,7 +1986,7 @@ function P2POBOMsSection() {
 
                 <div>
                   <h4 className="font-semibold mb-2">BOM Items ({bomDetail.items?.length || 0})</h4>
-                  {bomDetail.items && bomDetail.items.length > 0 ? (
+                  {itemDrafts.length > 0 ? (
                     <Table>
                       <TableHeader>
                         <TableRow>
@@ -1841,21 +1995,77 @@ function P2POBOMsSection() {
                           <TableHead>Qty</TableHead>
                           <TableHead>First Dept</TableHead>
                           <TableHead>Notes</TableHead>
+                          <TableHead className="text-right">Actions</TableHead>
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {bomDetail.items.map((item: any) => (
+                        {itemDrafts.map((item: any, index: number) => (
                           <TableRow key={item.id}>
-                            <TableCell className="font-medium">{item.partName}</TableCell>
                             <TableCell>
-                              <Badge variant={item.itemType === 'manufactured' ? 'default' : 'outline'}>
-                                {item.itemType}
-                              </Badge>
+                              <Input
+                                value={item.partName || ''}
+                                onChange={(e) => updateItemDraft(index, { partName: e.target.value })}
+                              />
                             </TableCell>
-                            <TableCell>{item.quantity}</TableCell>
-                            <TableCell>{item.firstDept}</TableCell>
-                            <TableCell className="text-muted-foreground text-sm max-w-[200px] truncate">
-                              {item.notes || '-'}
+                            <TableCell>
+                              <Select
+                                value={item.itemType || 'material'}
+                                onValueChange={(value) => updateItemDraft(index, { itemType: value })}
+                              >
+                                <SelectTrigger>
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="material">Material</SelectItem>
+                                  <SelectItem value="manufactured">Manufactured</SelectItem>
+                                  <SelectItem value="sub_assembly">Sub-assembly</SelectItem>
+                                  <SelectItem value="labor">Labor</SelectItem>
+                                </SelectContent>
+                              </Select>
+                            </TableCell>
+                            <TableCell>
+                              <Input
+                                type="number"
+                                min="0.0001"
+                                step="any"
+                                value={item.quantity}
+                                onChange={(e) => updateItemDraft(index, { quantity: e.target.value })}
+                                className="w-24"
+                              />
+                            </TableCell>
+                            <TableCell>
+                              <Input
+                                value={item.firstDept || ''}
+                                onChange={(e) => updateItemDraft(index, { firstDept: e.target.value })}
+                              />
+                            </TableCell>
+                            <TableCell>
+                              <Input
+                                value={item.notes || ''}
+                                onChange={(e) => updateItemDraft(index, { notes: e.target.value })}
+                              />
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <div className="flex justify-end gap-1">
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => updateItemMutation.mutate(item)}
+                                  disabled={updateItemMutation.isPending}
+                                  title="Save item"
+                                >
+                                  <Save className="h-4 w-4" />
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => deleteItemMutation.mutate(item.id)}
+                                  disabled={deleteItemMutation.isPending}
+                                  title="Remove item"
+                                >
+                                  <Trash2 className="h-4 w-4 text-destructive" />
+                                </Button>
+                              </div>
                             </TableCell>
                           </TableRow>
                         ))}
@@ -1864,6 +2074,69 @@ function P2POBOMsSection() {
                   ) : (
                     <p className="text-sm text-muted-foreground">No items configured yet</p>
                   )}
+                </div>
+
+                <Separator />
+
+                <div className="space-y-3">
+                  <h4 className="font-semibold">Add BOM Item</h4>
+                  <div className="grid grid-cols-[1.4fr_0.8fr_0.6fr_0.9fr_1.2fr_auto] gap-2 items-end">
+                    <div>
+                      <Label>Part Name / Internal #</Label>
+                      <Input
+                        value={newItemDraft.partName}
+                        onChange={(e) => setNewItemDraft({ ...newItemDraft, partName: e.target.value })}
+                      />
+                    </div>
+                    <div>
+                      <Label>Type</Label>
+                      <Select
+                        value={newItemDraft.itemType}
+                        onValueChange={(value) => setNewItemDraft({ ...newItemDraft, itemType: value })}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="material">Material</SelectItem>
+                          <SelectItem value="manufactured">Manufactured</SelectItem>
+                          <SelectItem value="sub_assembly">Sub-assembly</SelectItem>
+                          <SelectItem value="labor">Labor</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label>Qty</Label>
+                      <Input
+                        type="number"
+                        min="0.0001"
+                        step="any"
+                        value={newItemDraft.quantity}
+                        onChange={(e) => setNewItemDraft({ ...newItemDraft, quantity: e.target.value })}
+                      />
+                    </div>
+                    <div>
+                      <Label>First Dept</Label>
+                      <Input
+                        value={newItemDraft.firstDept}
+                        onChange={(e) => setNewItemDraft({ ...newItemDraft, firstDept: e.target.value })}
+                      />
+                    </div>
+                    <div>
+                      <Label>Notes</Label>
+                      <Input
+                        value={newItemDraft.notes}
+                        onChange={(e) => setNewItemDraft({ ...newItemDraft, notes: e.target.value })}
+                      />
+                    </div>
+                    <Button
+                      onClick={() => addItemMutation.mutate()}
+                      disabled={addItemMutation.isPending || !newItemDraft.partName.trim()}
+                    >
+                      <Plus className="mr-2 h-4 w-4" />
+                      Add
+                    </Button>
+                  </div>
                 </div>
               </div>
             ) : null}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -6367,8 +6367,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { id } = req.params;
       const { storage } = await import('../../storage');
       const { db } = await import('../../db');
-      const { bomDefinitions, bomItems: bomItemsTable } = await import('../../schema');
-      const { eq, and } = await import('drizzle-orm');
+      const { bomDefinitions, bomItems: bomItemsTable, inventoryItems } = await import('../../schema');
+      const { eq, and, inArray } = await import('drizzle-orm');
       
       const po = await storage.getP2PurchaseOrder(parseInt(id), { includeItems: true });
       
@@ -6378,12 +6378,28 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       
       // Get line items with BOM status
       const lineItems = await Promise.all((po.items || []).map(async (item: any) => {
+        const [linkedInventoryItem] = item.inventoryItemId
+          ? await db
+            .select({
+              id: inventoryItems.id,
+              agPartNumber: inventoryItems.agPartNumber,
+              name: inventoryItems.name,
+            })
+            .from(inventoryItems)
+            .where(eq(inventoryItems.id, item.inventoryItemId))
+            .limit(1)
+          : [];
+        const internalPartNumber = linkedInventoryItem?.agPartNumber || null;
+        const bomLookupKeys = [internalPartNumber, item.partNumber].filter(Boolean);
+
         // Check if a BOM exists for this part number
         const existingBOM = await db
           .select()
           .from(bomDefinitions)
           .where(and(
-            eq(bomDefinitions.sku, item.partNumber),
+            bomLookupKeys.length > 1
+              ? inArray(bomDefinitions.sku, bomLookupKeys)
+              : eq(bomDefinitions.sku, bomLookupKeys[0] || item.partNumber),
             eq(bomDefinitions.isActive, true)
           ))
           .limit(1);
@@ -6401,6 +6417,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         
         return {
           ...item,
+          internalPartNumber,
+          inventoryPartName: linkedInventoryItem?.name || null,
           hasBOM: existingBOM.length > 0,
           bomDefinitionId: existingBOM[0]?.id || null,
           bomItems: bomItemsList.map(bi => ({
@@ -6524,13 +6542,67 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { bomItems: bomItemsInput, poItemId, partNumber } = req.body;
       
       const { db } = await import('../../db');
-      const { bomDefinitions, bomItems: bomItemsTable, p2PurchaseOrders, p2PurchaseOrderItems } = await import('../../schema');
+      const { bomDefinitions, bomItems: bomItemsTable, inventoryItems, p2PurchaseOrders, p2PurchaseOrderItems } = await import('../../schema');
       const { eq, and, sql, inArray } = await import('drizzle-orm');
       
       console.log(`Saving BOM for part ${partId}, partNumber: ${partNumber}:`, bomItemsInput);
+
+      const poItemIdNum = parseInt(poItemId);
+      const [linkedPoItem] = poItemId && !isNaN(poItemIdNum) && !String(poItemId).startsWith('mfg-')
+        ? await db
+          .select()
+          .from(p2PurchaseOrderItems)
+          .where(eq(p2PurchaseOrderItems.id, poItemIdNum))
+          .limit(1)
+        : [];
+      const [linkedPoInventoryItem] = linkedPoItem?.inventoryItemId
+        ? await db
+          .select({
+            id: inventoryItems.id,
+            agPartNumber: inventoryItems.agPartNumber,
+            name: inventoryItems.name,
+          })
+          .from(inventoryItems)
+          .where(eq(inventoryItems.id, linkedPoItem.inventoryItemId))
+          .limit(1)
+        : [];
+
+      const canonicalPartNumber = String(linkedPoInventoryItem?.agPartNumber || partNumber || linkedPoItem?.partNumber || `P2-PART-${partId}`).trim();
+      const normalizedBomItems = await Promise.all((bomItemsInput || []).map(async (item: any) => {
+        const quantity = Number.parseFloat(String(item.quantity ?? ''));
+        if (!Number.isFinite(quantity) || quantity <= 0) {
+          throw new Error(`Invalid BOM quantity for ${item.partNumber || 'component'}`);
+        }
+
+        const inventoryItemId = item.inventoryItemId ? Number.parseInt(String(item.inventoryItemId), 10) : null;
+        const [linkedInventoryItem] = inventoryItemId
+          ? await db
+            .select({
+              id: inventoryItems.id,
+              agPartNumber: inventoryItems.agPartNumber,
+              name: inventoryItems.name,
+            })
+            .from(inventoryItems)
+            .where(eq(inventoryItems.id, inventoryItemId))
+            .limit(1)
+          : [];
+
+        const componentPartNumber = String(linkedInventoryItem?.agPartNumber || item.partNumber || '').trim();
+        if (!componentPartNumber) {
+          throw new Error('BOM component part number is required');
+        }
+
+        return {
+          ...item,
+          quantity,
+          partNumber: componentPartNumber,
+          description: item.description || linkedInventoryItem?.name || '',
+          inventoryItemId: linkedInventoryItem?.id ?? inventoryItemId ?? null,
+        };
+      }));
       
       // Gather all manufactured child part numbers upfront for batch lookup
-      const manufacturedPartNumbers = (bomItemsInput || [])
+      const manufacturedPartNumbers = normalizedBomItems
         .filter((item: any) => item.isManufactured && item.partNumber)
         .map((item: any) => item.partNumber);
       
@@ -6550,11 +6622,11 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       
       // First check if a BOM definition already exists for this part number
       let bomDef: any = null;
-      if (partNumber) {
+      if (canonicalPartNumber) {
         const existing = await db
           .select()
           .from(bomDefinitions)
-          .where(eq(bomDefinitions.sku, partNumber))
+          .where(eq(bomDefinitions.sku, canonicalPartNumber))
           .limit(1);
         
         if (existing.length > 0) {
@@ -6565,10 +6637,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       // Create new BOM definition if it doesn't exist
       if (!bomDef) {
         const [newBom] = await db.insert(bomDefinitions).values({
-          sku: partNumber || `P2-PART-${partId}`,
-          modelName: partNumber || `Part ${partId}`,
+          sku: canonicalPartNumber,
+          modelName: linkedPoInventoryItem?.name || canonicalPartNumber,
           revision: 'A',
-          description: `BOM for P2 part ${partNumber || partId}`,
+          description: `BOM for P2 part ${canonicalPartNumber}`,
           isActive: true
         }).returning();
         bomDef = newBom;
@@ -6584,7 +6656,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const insertedItems = [];
       const createdChildBomDefinitions = [];
       
-      for (const item of bomItemsInput || []) {
+      for (const item of normalizedBomItems) {
         let childBomDef = null;
         
         // If the item is manufactured, ensure it has a BOM definition
@@ -6645,7 +6717,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const [inserted] = await db.insert(bomItemsTable).values({
           bomId: bomDef.id,
           partName: item.partNumber,
-          quantity: item.quantity || 1,
+          quantity: item.quantity,
           firstDept: effectiveFirstDept,
           itemType: item.isManufactured ? 'manufactured' : 'material',
           notes: item.description || '',
@@ -6657,13 +6729,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       
       // Update the PO's bomConfigured flag if we have a valid numeric poItemId
       // Skip this for manufactured child parts (IDs starting with 'mfg-')
-      const poItemIdNum = parseInt(poItemId);
-      if (poItemId && !isNaN(poItemIdNum) && !String(poItemId).startsWith('mfg-')) {
-        const [poItem] = await db
-          .select()
-          .from(p2PurchaseOrderItems)
-          .where(eq(p2PurchaseOrderItems.id, poItemIdNum))
-          .limit(1);
+      if (linkedPoItem) {
+        const poItem = linkedPoItem;
         
         if (poItem) {
           // Check if all items for this PO have BOMs
@@ -6674,11 +6741,21 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           
           let allHaveBOMs = true;
           for (const pi of allItems) {
+            const [piInventoryItem] = pi.inventoryItemId
+              ? await db
+                .select({
+                  agPartNumber: inventoryItems.agPartNumber,
+                })
+                .from(inventoryItems)
+                .where(eq(inventoryItems.id, pi.inventoryItemId))
+                .limit(1)
+              : [];
+            const piBomKey = piInventoryItem?.agPartNumber || pi.partNumber;
             const hasBOM = await db
               .select()
               .from(bomDefinitions)
               .where(and(
-                eq(bomDefinitions.sku, pi.partNumber),
+                eq(bomDefinitions.sku, piBomKey),
                 eq(bomDefinitions.isActive, true)
               ))
               .limit(1);
@@ -6731,7 +6808,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                 .where(eq(p2ProdTable.p2PoId, poItem.poId));
 
               const hasCuttingDemands = existingProdOrders.some(o => o.department === 'Cutting Table');
-              const bomHasPacketItems = (bomItemsInput || []).some((item: any) => item.isManufactured);
+              const bomHasPacketItems = normalizedBomItems.some((item: any) => item.isManufactured);
 
               if (existingProdOrders.length === 0) {
                 console.log(`🔄 Auto-generating production orders for PO ${po?.poNumber} (including cutting table packet demands)...`);

--- a/server/src/routes/robustBoms.ts
+++ b/server/src/routes/robustBoms.ts
@@ -500,13 +500,57 @@ router.get('/p2-po-boms', async (req, res) => {
       .where(eq(bomDefinitions.isActive, true))
       .orderBy(desc(bomDefinitions.createdAt));
 
-    const poItemPartNumbers = await db.select({ partNumber: p2PurchaseOrderItems.partNumber })
+    const poItemPartNumbers = await db.select({
+      partNumber: p2PurchaseOrderItems.partNumber,
+      inventoryItemId: p2PurchaseOrderItems.inventoryItemId,
+    })
       .from(p2PurchaseOrderItems);
-    const poPartSet = new Set(poItemPartNumbers.map(p => p.partNumber).filter(Boolean));
+    const inventoryIds = Array.from(new Set(poItemPartNumbers.map(p => p.inventoryItemId).filter(Boolean))) as number[];
+    const linkedInventoryById = inventoryIds.length > 0
+      ? await db.select({
+          id: inventoryItems.id,
+          agPartNumber: inventoryItems.agPartNumber,
+          name: inventoryItems.name,
+        })
+        .from(inventoryItems)
+        .where(inArray(inventoryItems.id, inventoryIds))
+      : [];
+    const candidatePartNumbers = Array.from(new Set(allBomDefs.flatMap(bom => {
+      const sku = String(bom.sku || '').trim();
+      const baseSku = sku.replace(/\s+Rev\s+.+$/i, '');
+      return [sku, baseSku].filter(Boolean);
+    })));
+    const linkedInventoryBySku = candidatePartNumbers.length > 0
+      ? await db.select({
+          id: inventoryItems.id,
+          agPartNumber: inventoryItems.agPartNumber,
+          name: inventoryItems.name,
+        })
+        .from(inventoryItems)
+        .where(inArray(inventoryItems.agPartNumber, candidatePartNumbers))
+      : [];
+    const linkedInventory = [...linkedInventoryById, ...linkedInventoryBySku];
+    const inventoryById = new Map(linkedInventory.map(item => [item.id, item]));
+    const inventoryByPartNumber = new Map(linkedInventory.map(item => [item.agPartNumber, item]));
+    const poPartSet = new Set<string>();
+    poItemPartNumbers.forEach(p => {
+      if (p.partNumber) poPartSet.add(p.partNumber);
+      const internalPart = p.inventoryItemId ? inventoryById.get(p.inventoryItemId)?.agPartNumber : null;
+      if (internalPart) poPartSet.add(internalPart);
+    });
 
     const p2Boms = allBomDefs.filter(bom => 
       bom.sku && poPartSet.has(bom.sku)
-    );
+    ).map(bom => {
+      const baseSku = String(bom.sku || '').replace(/\s+Rev\s+.+$/i, '');
+      const internalPart = inventoryByPartNumber.get(String(bom.sku || '')) || inventoryByPartNumber.get(baseSku);
+      return {
+        ...bom,
+        internalPartNumber: internalPart?.agPartNumber || null,
+        internalPartName: internalPart?.name || null,
+        inventoryItemId: internalPart?.id || null,
+      };
+    });
 
     const filtered = search
       ? p2Boms.filter(bom => {
@@ -514,6 +558,8 @@ router.get('/p2-po-boms', async (req, res) => {
           return (
             bom.modelName?.toLowerCase().includes(s) ||
             bom.sku?.toLowerCase().includes(s) ||
+            bom.internalPartNumber?.toLowerCase().includes(s) ||
+            bom.internalPartName?.toLowerCase().includes(s) ||
             bom.description?.toLowerCase().includes(s)
           );
         })
@@ -543,6 +589,18 @@ router.get('/p2-po-boms/:id', async (req, res) => {
       .where(and(eq(bomItems.bomId, id), eq(bomItems.isActive, true)))
       .orderBy(bomItems.assemblyLevel, bomItems.partName);
 
+    const baseSku = String(bom.sku || '').replace(/\s+Rev\s+.+$/i, '');
+    const [internalPart] = bom.sku
+      ? await db.select({
+          id: inventoryItems.id,
+          agPartNumber: inventoryItems.agPartNumber,
+          name: inventoryItems.name,
+        })
+        .from(inventoryItems)
+        .where(inArray(inventoryItems.agPartNumber, [bom.sku, baseSku]))
+        .limit(1)
+      : [];
+
     const poItems = bom.sku
       ? await db.select({
           poId: p2PurchaseOrderItems.poId,
@@ -551,13 +609,123 @@ router.get('/p2-po-boms/:id', async (req, res) => {
         })
         .from(p2PurchaseOrderItems)
         .innerJoin(p2PurchaseOrders, eq(p2PurchaseOrderItems.poId, p2PurchaseOrders.id))
-        .where(eq(p2PurchaseOrderItems.partNumber, bom.sku))
+        .where(internalPart
+          ? inArray(p2PurchaseOrderItems.inventoryItemId, [internalPart.id])
+          : eq(p2PurchaseOrderItems.partNumber, bom.sku))
       : [];
 
-    res.json({ ...bom, items, linkedPurchaseOrders: poItems });
+    res.json({
+      ...bom,
+      internalPartNumber: internalPart?.agPartNumber || null,
+      internalPartName: internalPart?.name || null,
+      inventoryItemId: internalPart?.id || null,
+      items,
+      linkedPurchaseOrders: poItems,
+    });
   } catch (error) {
     console.error('Get P2 PO BOM error:', error);
     res.status(500).json({ error: 'Failed to fetch P2 PO BOM' });
+  }
+});
+
+router.put('/p2-po-boms/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const updateData = {
+      sku: req.body.sku,
+      modelName: req.body.modelName,
+      revision: req.body.revision,
+      description: req.body.description,
+      updatedAt: new Date(),
+    };
+
+    const [updated] = await db.update(bomDefinitions)
+      .set(updateData)
+      .where(eq(bomDefinitions.id, id))
+      .returning();
+
+    if (!updated) {
+      return res.status(404).json({ error: 'P2 PO BOM not found' });
+    }
+
+    res.json(updated);
+  } catch (error) {
+    console.error('Update P2 PO BOM error:', error);
+    res.status(500).json({ error: 'Failed to update P2 PO BOM' });
+  }
+});
+
+router.post('/p2-po-boms/:id/items', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const quantity = Number.parseFloat(String(req.body.quantity ?? ''));
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      return res.status(400).json({ error: 'Quantity must be greater than 0' });
+    }
+
+    const [newItem] = await db.insert(bomItems)
+      .values({
+        bomId: id,
+        partName: String(req.body.partName || '').trim(),
+        quantity,
+        firstDept: String(req.body.firstDept || 'Layup').trim(),
+        itemType: String(req.body.itemType || 'material').trim(),
+        notes: req.body.notes || '',
+        isActive: true,
+        updatedAt: new Date(),
+      })
+      .returning();
+
+    res.json(newItem);
+  } catch (error) {
+    console.error('Add P2 PO BOM item error:', error);
+    res.status(500).json({ error: 'Failed to add P2 PO BOM item' });
+  }
+});
+
+router.put('/p2-po-boms/:bomId/items/:itemId', async (req, res) => {
+  try {
+    const { bomId, itemId } = req.params;
+    const quantity = Number.parseFloat(String(req.body.quantity ?? ''));
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      return res.status(400).json({ error: 'Quantity must be greater than 0' });
+    }
+
+    const [updatedItem] = await db.update(bomItems)
+      .set({
+        partName: String(req.body.partName || '').trim(),
+        quantity,
+        firstDept: String(req.body.firstDept || 'Layup').trim(),
+        itemType: String(req.body.itemType || 'material').trim(),
+        notes: req.body.notes || '',
+        updatedAt: new Date(),
+      })
+      .where(and(eq(bomItems.id, itemId), eq(bomItems.bomId, bomId)))
+      .returning();
+
+    if (!updatedItem) {
+      return res.status(404).json({ error: 'P2 PO BOM item not found' });
+    }
+
+    res.json(updatedItem);
+  } catch (error) {
+    console.error('Update P2 PO BOM item error:', error);
+    res.status(500).json({ error: 'Failed to update P2 PO BOM item' });
+  }
+});
+
+router.delete('/p2-po-boms/:bomId/items/:itemId', async (req, res) => {
+  try {
+    const { bomId, itemId } = req.params;
+
+    await db.update(bomItems)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(and(eq(bomItems.id, itemId), eq(bomItems.bomId, bomId)));
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Delete P2 PO BOM item error:', error);
+    res.status(500).json({ error: 'Failed to delete P2 PO BOM item' });
   }
 });
 


### PR DESCRIPTION
## Summary
- Allow decimal quantities in the P2 BOM wizard instead of truncating with integer parsing.
- Key P2 BOM definitions to the internal inventory AG part number when a PO line is linked to inventory, so future POs for the same manufactured part can reuse the BOM package.
- Show internal part links in the Robust BOM P2 Purchase Order BOMs table and convert the detail drawer into an editor for metadata and BOM rows.
- Add P2 PO BOM item add/update/delete endpoints that preserve decimal quantities.

## Root Cause
P2 BOM configuration was storing mostly revisioned PO display text and integer-parsed quantities. The Robust BOM P2 section also only exposed a read-only detail drawer, so users could see a BOM but could not link or maintain it from that UI.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Bundled Node syntax checks for `server/src/routes/index.ts` and `server/src/routes/robustBoms.ts`

Full `tsc` could not complete in the clean worktree because `pnpm` attempted to fetch dependencies from npm and network access was blocked in the sandbox.