### PR TITLE
[codex] Clarify Draft Builder source labels

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -480,6 +480,17 @@ function isInventoryManufactured(item?: InventoryItemOption | null) {
   return item.itemType === 'MANUFACTURED' || item.type === 'Manufactured' || item.isPacket === true || !!item.manufacturedCategory;
 }
 
+function lineSourceLabel(line: BomLine) {
+  if (!line.inventoryItemId) return 'User draft';
+  if (line.isManufactured) return 'User / manufactured';
+  return line.supplier || 'Purchased inventory';
+}
+
+function linePartTypeLabel(line: BomLine) {
+  if (!line.inventoryItemId) return 'Draft part';
+  return line.isManufactured ? 'Manufactured inventory' : 'Purchased inventory';
+}
+
 function inventoryPartNumber(item: InventoryItemOption) {
   return item.agPartNumber || item.manufacturerPartNumber || item.supplierPartNumber || `INV-${item.id}`;
 }
@@ -3870,7 +3881,7 @@ function PoDraftWorkspace({
                     ))}
                     <TableCell>
                       <Badge variant={line.inventoryItemId ? 'outline' : 'secondary'}>
-                        {line.inventoryItemId ? 'Inventory' : 'Draft part'}
+                        {linePartTypeLabel(line)}
                       </Badge>
                     </TableCell>
                     <TableCell>
@@ -3913,7 +3924,7 @@ function poColumnValue(line: BomLine, columnId: PoColumnId) {
   if (columnId === 'unitCost') return line.unitCost === '' ? '-' : money(asNumber(line.unitCost));
   if (columnId === 'extCost') return money(asNumber(line.unitCost) * asNumber(line.qtyNeeded));
   if (columnId === 'action') return line.action;
-  if (columnId === 'source') return line.inventoryItemId ? `Inventory #${line.inventoryItemId}` : 'Draft part';
+  if (columnId === 'source') return lineSourceLabel(line);
   return '-';
 }
 


### PR DESCRIPTION
## Summary
- Replace the Draft Builder PO table source value that exposed internal inventory IDs with sourcing labels users can act on.
- Show manufactured inventory, purchased inventory, or draft part in the part type badge.
- Keep AG Part # as the actual part number while leaving inventory IDs out of the visible Source column.

## Root Cause
The PO draft table rendered `Source` from `inventoryItemId`, so rows showed values like `Inventory #2839` next to AG Part # `26247`. That was technically an inventory database row ID, but it read like a mismatched source or part number.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Bundled Node syntax probe attempted on the touched TSX file, but Node rejected `.tsx` with `ERR_UNKNOWN_FILE_EXTENSION` before parsing, which is the known local limitation for this checkout.