### PR TITLE
[codex] Prefer supplier part number in consolidated needs

### DIFF
--- a/client/src/pages/ConsolidatedNeedsListPage.tsx
+++ b/client/src/pages/ConsolidatedNeedsListPage.tsx
@@ -53,6 +53,7 @@ type InventoryItem = {
   source?: string | null;
   vendorName?: string | null;
   vendorId?: number | null;
+  supplierPartNumber?: string | null;
   currentBalance?: number;
   minStock?: number;
   maxStock?: number;
@@ -782,15 +783,23 @@ export default function ConsolidatedNeedsListPage() {
     if (partNumber) setLocation(getInventoryProfilePath(partNumber));
   }, [getInventoryPartNumber, getInventoryProfilePath, setLocation]);
 
+  const getVendorSkuDisplay = useCallback((request: PartsRequest) => {
+    const supplierPartNumber = request.inventoryItem?.supplierPartNumber?.trim();
+    if (supplierPartNumber) return supplierPartNumber;
+
+    const vendorPartNumber = request.vendorPartNumber?.trim();
+    return vendorPartNumber || '';
+  }, []);
+
   const getVendorPartNumbersForRequests = useCallback((requests: PartsRequest[]) => {
     return Array.from(
       new Set(
         requests
-          .map((request) => request.vendorPartNumber?.trim())
+          .map((request) => getVendorSkuDisplay(request))
           .filter((value): value is string => !!value)
       )
     );
-  }, []);
+  }, [getVendorSkuDisplay]);
 
   const openLinkPoDialog = (request: PartsRequest) => {
     setLinkPoRequest(request);
@@ -1084,7 +1093,7 @@ export default function ConsolidatedNeedsListPage() {
     const rows = vendorGroup.requests.map(r => [
       r.partNumber,
       r.partName,
-      r.vendorPartNumber || '',
+      getVendorSkuDisplay(r),
       r.quantity.toString(),
       r.estimatedCost?.toFixed(2) || '',
       r.department,
@@ -1111,7 +1120,7 @@ export default function ConsolidatedNeedsListPage() {
 
   const copyOrderList = (vendorGroup: VendorGroup) => {
     const lines = vendorGroup.requests.map(r => 
-      `${r.vendorPartNumber || r.partNumber}\t${r.partName}\t${r.quantity}`
+      `${getVendorSkuDisplay(r) || r.partNumber}\t${r.partName}\t${r.quantity}`
     );
     const text = lines.join('\n');
     navigator.clipboard.writeText(text);
@@ -1617,7 +1626,7 @@ export default function ConsolidatedNeedsListPage() {
                             )}
                           </td>
                           <td className="px-3 py-2 text-sm text-gray-600 dark:text-gray-400">
-                            {request.vendorPartNumber || '-'}
+                            {getVendorSkuDisplay(request) || '-'}
                           </td>
                           <td className="px-3 py-2 text-sm font-medium text-gray-900 dark:text-gray-100">{request.quantity}</td>
                           <td className="px-3 py-2 text-sm text-gray-600 dark:text-gray-400">

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7143,6 +7143,7 @@ export class DatabaseStorage implements IStorage {
         invName: inventoryItems.name,
         invSource: inventoryItems.source,
         invVendorId: inventoryItems.vendorId,
+        invSupplierPartNumber: inventoryItems.supplierPartNumber,
         invUsageUnit: inventoryItems.usageUnit,
         projectCode: projects.projectCode,
         projectName: projects.projectName,
@@ -7172,6 +7173,7 @@ export class DatabaseStorage implements IStorage {
         source: r.invSource,
         vendorName: r.invSource,
         vendorId: r.invVendorId,
+        supplierPartNumber: r.invSupplierPartNumber,
         usageUnit: r.invUsageUnit,
       } : undefined,
       project: r.projectCode ? {


### PR DESCRIPTION
## Summary
- Include `supplierPartNumber` in the inventory item data returned by `/api/inventory/parts-requests`.
- Prefer supplier part number over request vendor SKU in Consolidated Needs vendor SKU displays.
- Apply the same preferred value to the consolidated part summary, vendor CSV export, and copied order list.

## Root Cause
Consolidated Needs was rendering `vendorPartNumber` directly, while the joined inventory item payload did not expose `supplierPartNumber`. Rows with a supplier part number could therefore still show the request vendor SKU instead of the supplier part number.

## Validation
- `git diff --check -- client/src/pages/ConsolidatedNeedsListPage.tsx server/storage.ts`
- `node --experimental-strip-types --check server/storage.ts`

Note: direct TSX parsing is not available through this Node strip-types check, so the React change was validated by focused diff review.