### PR TITLE
[codex] Add vendor default order method

### DIFF
--- a/client/src/pages/ConsolidatedNeedsListPage.tsx
+++ b/client/src/pages/ConsolidatedNeedsListPage.tsx
@@ -53,6 +53,7 @@ type InventoryItem = {
   source?: string | null;
   vendorName?: string | null;
   vendorId?: number | null;
+  defaultOrderMethod?: 'PO' | 'WEBSITE' | null;
   currentBalance?: number;
   minStock?: number;
   maxStock?: number;
@@ -70,6 +71,7 @@ type Vendor = {
   email?: string;
   phone?: string;
   website?: string;
+  defaultOrderMethod?: 'PO' | 'WEBSITE' | null;
 };
 
 type VendorPO = {
@@ -155,6 +157,12 @@ const isArchivedFromConsolidatedNeeds = (request: PartsRequest) => {
   return request.status === 'RECEIVED' || request.status === 'DELIVERED_TO_DEPT';
 };
 
+const resolveEffectiveOrderMethod = (request: PartsRequest, vendor?: Vendor | null): 'PO' | 'WEBSITE' => {
+  if (request.orderMethod === 'WEBSITE') return 'WEBSITE';
+  if (request.orderMethod === 'PO') return 'PO';
+  return request.inventoryItem?.defaultOrderMethod || vendor?.defaultOrderMethod || 'PO';
+};
+
 export default function ConsolidatedNeedsListPage() {
   const { toast } = useToast();
   const [, setLocation] = useLocation();
@@ -221,9 +229,14 @@ export default function ConsolidatedNeedsListPage() {
   const getRemainingRequestQuantity = (request: PartsRequest) =>
     Math.max(0, Number(request.quantity || 0) - Number(request.qtyOrdered || request.qtyReceived || 0));
 
+  const isOrderMarkableRequest = (request: PartsRequest) =>
+    request.status === 'APPROVED'
+    && getRemainingRequestQuantity(request) > 0;
+
   const isPoDraftableRequest = (request: PartsRequest) =>
     ['APPROVED', 'RECEIVED_PARTIAL'].includes(request.status)
-    && request.orderMethod !== 'WEBSITE'
+    && resolveEffectiveOrderMethod(request, getResolvedVendorForRequest(request)) !== 'WEBSITE'
+    && request.orderMethod !== 'LOCAL_PICKUP'
     && !request.vendorPoId
     && getRemainingRequestQuantity(request) > 0;
 
@@ -824,6 +837,7 @@ export default function ConsolidatedNeedsListPage() {
     for (const request of activeRequests) {
       const vendor = getResolvedVendorForRequest(request);
       const vendorLabel = getRequestVendorLabel(request);
+      const effectiveOrderMethod = resolveEffectiveOrderMethod(request, vendor);
 
       if (vendor) {
         // Has a resolved vendor record — group under that vendor regardless of order method
@@ -833,7 +847,7 @@ export default function ConsolidatedNeedsListPage() {
             key,
             vendorId: vendor.id,
             vendorName: vendor.name,
-            orderMethod: request.orderMethod || null,
+            orderMethod: effectiveOrderMethod,
             websiteUrl: vendor.website || null,
             requests: [],
             totalQuantity: 0,
@@ -851,7 +865,7 @@ export default function ConsolidatedNeedsListPage() {
             key,
             vendorId: null,
             vendorName: vendorLabel,
-            orderMethod: request.orderMethod || null,
+            orderMethod: effectiveOrderMethod,
             websiteUrl: null,
             requests: [],
             totalQuantity: 0,
@@ -861,7 +875,7 @@ export default function ConsolidatedNeedsListPage() {
         groups[key].requests.push(request);
         groups[key].totalQuantity += request.quantity;
         groups[key].totalEstimatedCost += request.estimatedCost || 0;
-      } else if (request.orderMethod === 'WEBSITE') {
+      } else if (effectiveOrderMethod === 'WEBSITE') {
         // WEBSITE order with no resolved vendor — group by vendor text so buyers see per-site buckets.
         // Future improvement: once source_vendor_id FK exists, all WEBSITE items will resolve to a vendor and this fallback will be rarely needed.
         const vendorName = (request.inventoryItem?.vendorName || request.inventoryItem?.source || '').trim();
@@ -1406,7 +1420,6 @@ export default function ConsolidatedNeedsListPage() {
                 variant="default"
                 onClick={() => setIsBulkOrderDialogOpen(true)}
                 data-testid="button-bulk-mark-ordered"
-                className="hidden"
               >
                 <ShoppingCart className="w-4 h-4 mr-1" />
                 Mark Ordered
@@ -1547,11 +1560,11 @@ export default function ConsolidatedNeedsListPage() {
                         <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 w-10">
                           <Checkbox
                             checked={
-                              vendorGroup.requests.filter(isPoDraftableRequest).length > 0
-                              && vendorGroup.requests.filter(isPoDraftableRequest).every(r => selectedVendorRequests.has(r.id))
+                              vendorGroup.requests.filter(isOrderMarkableRequest).length > 0
+                              && vendorGroup.requests.filter(isOrderMarkableRequest).every(r => selectedVendorRequests.has(r.id))
                             }
                             onCheckedChange={(checked) => {
-                              const selectable = vendorGroup.requests.filter(isPoDraftableRequest);
+                              const selectable = vendorGroup.requests.filter(isOrderMarkableRequest);
                               if (checked) {
                                 setSelectedVendorRequests(new Set([
                                   ...Array.from(selectedVendorRequests),
@@ -1582,10 +1595,12 @@ export default function ConsolidatedNeedsListPage() {
                     <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                       {vendorGroup.requests.map((request) => {
                         const selectableForPo = isPoDraftableRequest(request);
+                        const selectableForOrder = isOrderMarkableRequest(request);
+                        const effectiveOrderMethod = resolveEffectiveOrderMethod(request, getResolvedVendorForRequest(request));
                         const canLocalPickup = isLocalPickupRequest(request);
                         const canCreateNewPo = selectableForPo;
                         const canLinkExistingPo = !request.vendorPoId
-                          && request.orderMethod !== 'WEBSITE'
+                          && effectiveOrderMethod !== 'WEBSITE'
                           && ['APPROVED', 'ORDERED', 'ORDERED_PARTIAL', 'RECEIVED', 'RECEIVED_PARTIAL'].includes(request.status)
                           && !['REJECTED', 'CANCELED', 'DELIVERED_TO_DEPT'].includes(request.status);
                         return (
@@ -1594,7 +1609,7 @@ export default function ConsolidatedNeedsListPage() {
                             <Checkbox
                               checked={selectedVendorRequests.has(request.id)}
                               onCheckedChange={() => toggleRequestSelection(request.id)}
-                              disabled={!selectableForPo}
+                              disabled={!selectableForOrder}
                               data-testid={`checkbox-request-${request.id}`}
                             />
                           </td>
@@ -1631,7 +1646,7 @@ export default function ConsolidatedNeedsListPage() {
                           <td className="px-3 py-2">
                             <div className="flex flex-col gap-1">
                               {getStatusBadge(request.status)}
-                              {request.orderMethod === 'WEBSITE' && (
+                              {effectiveOrderMethod === 'WEBSITE' && (
                                 <Badge className="bg-teal-100 text-teal-800 w-fit">Website order</Badge>
                               )}
                               {request.vendorPoId && (
@@ -1684,7 +1699,12 @@ export default function ConsolidatedNeedsListPage() {
                                 Link PO
                               </Button>
                             )}
-                            {selectableForPo && (
+                            {selectableForOrder && (
+                              <Button size="sm" variant="default" onClick={() => handleAction(request, 'order')} data-testid={`button-order-vendor-${request.id}`}>
+                                Mark Ordered
+                              </Button>
+                            )}
+                            {selectableForOrder && (
                               <Button size="sm" variant="default" onClick={() => toggleRequestSelection(request.id)} data-testid={`button-select-request-${request.id}`}>
                                 {selectedVendorRequests.has(request.id) ? 'Selected' : 'Select'}
                               </Button>

--- a/client/src/pages/VendorManagement.tsx
+++ b/client/src/pages/VendorManagement.tsx
@@ -202,6 +202,7 @@ const vendorFormSchema = insertVendorSchema.extend({
   termsAndConditions: z.string().optional(),
   paymentTerms: z.string().optional(),
   shippingInstructions: z.string().optional(),
+  defaultOrderMethod: z.enum(['PO', 'WEBSITE']).optional().nullable(),
 });
 
 const vendorContactFormSchema = insertVendorContactSchema
@@ -296,6 +297,7 @@ export default function VendorManagement() {
       termsAndConditions: '',
       paymentTerms: '',
       shippingInstructions: '',
+      defaultOrderMethod: 'PO',
     },
   });
 
@@ -689,6 +691,7 @@ export default function VendorManagement() {
         termsAndConditions: vendor.termsAndConditions || '',
         paymentTerms: vendor.paymentTerms || '',
         shippingInstructions: vendor.shippingInstructions || '',
+        defaultOrderMethod: (vendor.defaultOrderMethod as 'PO' | 'WEBSITE' | null) || 'PO',
       });
       setVendorAddress({
         street: vendor.street || '',
@@ -1203,6 +1206,7 @@ export default function VendorManagement() {
     approvalPdfUrl: data.approvalPdfUrl || undefined,
     startRenewalDate: data.startRenewalDate || undefined,
     approvalExpiration: data.approvalExpiration || undefined,
+    defaultOrderMethod: data.defaultOrderMethod || 'PO',
     ...extra,
   });
 
@@ -1461,6 +1465,31 @@ export default function VendorManagement() {
 
                       />
                     </div>
+
+                    <FormField
+                      control={form.control}
+                      name="defaultOrderMethod"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Default Order Method</FormLabel>
+                          <Select
+                            value={field.value || 'PO'}
+                            onValueChange={field.onChange}
+                          >
+                            <FormControl>
+                              <SelectTrigger data-testid="select-default-order-method">
+                                <SelectValue placeholder="Select order method" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              <SelectItem value="PO">Purchase Order</SelectItem>
+                              <SelectItem value="WEBSITE">Website</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
 
                     <FormField
                       control={form.control}

--- a/migrations/0129_vendor_default_order_method.sql
+++ b/migrations/0129_vendor_default_order_method.sql
@@ -1,0 +1,4 @@
+-- Vendor-level default order method used by consolidated needs when a part has no override.
+
+ALTER TABLE vendors
+  ADD COLUMN IF NOT EXISTS default_order_method text;

--- a/server/index.ts
+++ b/server/index.ts
@@ -3068,6 +3068,7 @@ async function initializeBackgroundServices() {
         await db.execute(sqlAddr`ALTER TABLE vendors ADD COLUMN IF NOT EXISTS validation_provider TEXT`);
         await db.execute(sqlAddr`ALTER TABLE vendors ADD COLUMN IF NOT EXISTS dpv_match_code TEXT`);
         await db.execute(sqlAddr`ALTER TABLE vendors ADD COLUMN IF NOT EXISTS override_reason TEXT`);
+        await db.execute(sqlAddr`ALTER TABLE vendors ADD COLUMN IF NOT EXISTS default_order_method TEXT`);
         console.log('✅ Ensured address validation columns exist');
       } catch (addrErr: any) {
         console.warn('⚠️ Address validation columns migration:', addrErr.message);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -3661,6 +3661,7 @@ export const vendors = pgTable('vendors', {
   termsAndConditions: text('terms_and_conditions'), // Vendor-specific PO terms and conditions
   paymentTerms: text('payment_terms'), // Vendor-specific payment terms
   shippingInstructions: text('shipping_instructions'), // Vendor-specific shipping instructions
+  defaultOrderMethod: text('default_order_method'), // Default procurement method: 'PO' or 'WEBSITE'
   isActive: boolean('is_active').default(true),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
@@ -4378,6 +4379,7 @@ export const insertVendorSchema = createInsertSchema(vendors)
     state: z.string().optional(),
     zipCode: z.string().optional(),
     country: z.string().optional(),
+    defaultOrderMethod: z.enum(['PO', 'WEBSITE']).optional().nullable(),
     scope: z.string().optional(),
     approvalSource: z.string().optional(),
     approvalPdfUrl: z.string().optional(),

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -1935,6 +1935,7 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
       .select({
         agPartNumber: inventoryItems.agPartNumber,
         vendorId: inventoryItems.vendorId,
+        defaultOrderMethod: inventoryItems.defaultOrderMethod,
         source: inventoryItems.source,
         name: inventoryItems.name,
       })
@@ -1961,6 +1962,7 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
           name: string;
           source: string | null;
           vendorId: number | null;
+          defaultOrderMethod: string | null;
           vendorName: string | null;
         };
       }>;
@@ -1990,8 +1992,10 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
           : sourceVendor;
       const vendorId = request.vendorId ?? resolvedVendor?.id ?? inventoryItem?.vendorId ?? null;
       const vendorName = resolvedVendor?.name ?? request.supplier ?? inventoryItem?.source ?? null;
+      const effectiveOrderMethod = request.orderMethod || inventoryItem?.defaultOrderMethod || resolvedVendor?.defaultOrderMethod || null;
       const enrichedRequest = {
         ...request,
+        orderMethod: effectiveOrderMethod,
         vendorId,
         supplier: vendorName,
         inventoryItem: inventoryItem ? {
@@ -2001,7 +2005,7 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
         } : undefined,
       };
 
-      if (!resolvedVendor && request.orderMethod === 'WEBSITE') {
+      if (!resolvedVendor && effectiveOrderMethod === 'WEBSITE') {
         const key = 'WEBSITE';
         if (!vendorGroups[key]) {
           vendorGroups[key] = {
@@ -2027,7 +2031,7 @@ router.get('/parts-requests/by-vendor', async (req: Request, res: Response) => {
           vendorGroups[key] = {
             vendorId: vendor.id,
             vendorName: vendor.name,
-            orderMethod: request.orderMethod || null,
+            orderMethod: effectiveOrderMethod,
             websiteUrl: null,
             requests: [],
             totalQuantity: 0,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7143,6 +7143,7 @@ export class DatabaseStorage implements IStorage {
         invName: inventoryItems.name,
         invSource: inventoryItems.source,
         invVendorId: inventoryItems.vendorId,
+        invDefaultOrderMethod: inventoryItems.defaultOrderMethod,
         invUsageUnit: inventoryItems.usageUnit,
         projectCode: projects.projectCode,
         projectName: projects.projectName,
@@ -7172,6 +7173,7 @@ export class DatabaseStorage implements IStorage {
         source: r.invSource,
         vendorName: r.invSource,
         vendorId: r.invVendorId,
+        defaultOrderMethod: r.invDefaultOrderMethod,
         usageUnit: r.invUsageUnit,
       } : undefined,
       project: r.projectCode ? {
@@ -7333,6 +7335,7 @@ export class DatabaseStorage implements IStorage {
         id: vendors.id,
         name: vendors.name,
         website: vendors.website,
+        defaultOrderMethod: vendors.defaultOrderMethod,
       })
       .from(vendors)
       .where(eq(vendors.isActive, true));
@@ -7365,15 +7368,18 @@ export class DatabaseStorage implements IStorage {
       const resolvedVendor = requestVendor ?? itemVendor ?? sourceVendor;
       const resolvedVendorId = r.request.vendorId ?? resolvedVendor?.id ?? r.inventoryItem?.vendorId ?? null;
       const resolvedVendorName = resolvedVendor?.name ?? r.request.supplier ?? r.inventoryItem?.source ?? null;
+      const effectiveOrderMethod = r.request.orderMethod || r.inventoryItem?.defaultOrderMethod || resolvedVendor?.defaultOrderMethod || null;
 
       return {
         ...r.request,
+        orderMethod: effectiveOrderMethod,
         vendorId: resolvedVendorId,
         supplier: resolvedVendorName,
         vendor: resolvedVendor ? {
           id: resolvedVendor.id,
           name: resolvedVendor.name,
           website: resolvedVendor.website,
+          defaultOrderMethod: resolvedVendor.defaultOrderMethod,
         } : undefined,
         inventoryItem: r.inventoryItem ? {
           ...r.inventoryItem,


### PR DESCRIPTION
## Summary
- add a vendor-level default order method field and migration/startup guard
- surface the default order method on Vendor Management create/edit
- make Consolidated Needs resolve order method from request override, inventory item default, then vendor default
- expose vendor-card Mark Ordered + ETA flow while keeping PO draft/link actions restricted to PO-effective items

## Impact
Buyers can maintain the default order method at the vendor level, override it per part through the existing inventory item default, and see the effective method on Consolidated Needs vendor cards. Marking items ordered with an ETA updates the parts request `expectedDelivery` field used by existing request cards.

## Validation
- `node --experimental-strip-types --check server/schema.ts`
- `node --experimental-strip-types --check server/src/routes/inventory.ts`
- `node --experimental-strip-types --check server/storage.ts`
- `git diff --check`
- `git diff --cached --check`

Full app/typecheck was not run because this clean worktree does not have its own `node_modules`.