### PR TITLE
[codex] Notify Glenn for WAD charge code requests

### DIFF
--- a/client/src/pages/TaskTracker.tsx
+++ b/client/src/pages/TaskTracker.tsx
@@ -64,6 +64,24 @@ interface TaskItem {
   updatedAt: string;
 }
 
+function renderLinkedText(text: string) {
+  const parts = text.split(/(\/finance\/charge-codes\?[^\s]+)/g);
+  return parts.map((part, index) => {
+    if (part.startsWith('/finance/charge-codes?')) {
+      return (
+        <a
+          key={`${part}-${index}`}
+          href={part}
+          className="font-medium text-blue-700 underline underline-offset-2"
+        >
+          Open charge code engine
+        </a>
+      );
+    }
+    return <span key={`${index}-${part.slice(0, 8)}`}>{part}</span>;
+  });
+}
+
 export default function TaskTracker() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -576,8 +594,8 @@ export default function TaskTracker() {
                               {task.title}
                             </div>
                             {task.description && (
-                              <div className="text-sm text-gray-600 mt-1">
-                                {task.description}
+                              <div className="text-sm text-gray-600 mt-1 whitespace-pre-line">
+                                {renderLinkedText(task.description)}
                               </div>
                             )}
                             <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">

--- a/client/src/pages/finance/ChargeCodeManagerPage.tsx
+++ b/client/src/pages/finance/ChargeCodeManagerPage.tsx
@@ -144,27 +144,58 @@ const PRODUCTION_LINE_OPTIONS = [
   { value: 'R_AND_D', label: 'R&D' },
 ];
 
+function chargeCodeRequestSlug(value?: string | null): string {
+  const slug = (value ?? '')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'WAD';
+}
+
 function defaultValues(
   code?: ChargeCode,
-  mode: 'create' | 'edit' | 'copy' = 'create'
+  mode: 'create' | 'edit' | 'copy' = 'create',
+  request?: ChargeCodeRequest | null
 ): ChargeCodeFormValues {
   const isCopy = mode === 'copy';
+  const requestType =
+    request?.classification === 'INDIRECT'
+      ? 'OVERHEAD'
+      : request?.classification === 'UNALLOWABLE'
+        ? 'G_AND_A'
+        : 'DIRECT';
+  const requestHandling =
+    request?.classification === 'INDIRECT'
+      ? 'OVERHEAD'
+      : request?.classification === 'UNALLOWABLE'
+        ? 'UNALLOWABLE'
+        : 'DIRECT_CONTRACT';
+  const suggestedRequestCode = request
+    ? [
+        'P2',
+        chargeCodeRequestSlug(request.department),
+        chargeCodeRequestSlug(request.operation),
+      ].join('-').slice(0, 64)
+    : '';
   return {
-    code: code?.code ?? '',
+    code: code?.code ?? suggestedRequestCode,
     description: isCopy
       ? `${code?.description?.trim() || code?.code || 'Charge code'} - Copy`
-      : (code?.description ?? ''),
-    type: (code?.type as ChargeCodeType) ?? 'DIRECT',
+      : (code?.description
+        ?? (request
+          ? `${request.workOrderNumber ?? 'WAD'} ${request.department} ${request.operation} labor charge code`
+          : '')),
+    type: (code?.type as ChargeCodeType) ?? requestType,
     costHandling:
       (code?.costHandling as ChargeCodeFormValues['costHandling']) ??
-      'DIRECT_CONTRACT',
-    department: code?.department ?? '',
-    productionLine: (code as any)?.productionLine ?? 'P1',
-    activityCategory: (code as any)?.activityCategory ?? '',
-    costObjectivePolicy: (code as any)?.costObjectivePolicy ?? 'NONE',
+      requestHandling,
+    department: code?.department ?? request?.department ?? '',
+    productionLine: (code as any)?.productionLine ?? (request ? 'P2' : 'P1'),
+    activityCategory: (code as any)?.activityCategory ?? request?.laborCategory ?? request?.operation ?? '',
+    costObjectivePolicy: (code as any)?.costObjectivePolicy ?? (request ? 'PROJECT_REQUIRED' : 'NONE'),
     inventoryWipPolicy: (code as any)?.inventoryWipPolicy ?? '',
-    allowProject: (code as any)?.allowProject ?? false,
-    requireProject: (code as any)?.requireProject ?? false,
+    allowProject: (code as any)?.allowProject ?? !!request,
+    requireProject: (code as any)?.requireProject ?? !!request,
     allowClin: (code as any)?.allowClin ?? false,
     requireClin: (code as any)?.requireClin ?? false,
     contractReference: code?.contractReference ?? '',
@@ -179,11 +210,13 @@ function defaultValues(
 function ChargeCodeForm({
   editTarget,
   copySource,
+  requestToAssign,
   existingChargeCodes,
   onClose,
 }: {
   editTarget: ChargeCode | null;
   copySource: ChargeCode | null;
+  requestToAssign?: ChargeCodeRequest | null;
   existingChargeCodes: ChargeCode[];
   onClose: () => void;
 }) {
@@ -226,7 +259,8 @@ function ChargeCodeForm({
     resolver: zodResolver(chargeCodeFormSchema),
     defaultValues: defaultValues(
       editTarget ?? copySource ?? undefined,
-      isEdit ? 'edit' : isCopy ? 'copy' : 'create'
+      isEdit ? 'edit' : isCopy ? 'copy' : 'create',
+      requestToAssign
     ),
   });
 
@@ -252,17 +286,29 @@ function ChargeCodeForm({
       if (assignmentScope === 'SELECTED_EMPLOYEES') {
         await saveAssignments(created.id);
       }
+      if (requestToAssign?.id) {
+        await apiRequest(`/api/charge-codes/requests/${requestToAssign.id}/assign`, {
+          method: 'PATCH',
+          body: { chargeCodeId: created.id },
+        });
+      }
       return created;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/charge-codes'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/charge-codes/requests'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/task-items'] });
       queryClient.invalidateQueries({
         queryKey: ['/api/timekeeping/charge-codes'],
       });
       queryClient.invalidateQueries({
         queryKey: ['/api/timekeeping/kiosk/charge-codes'],
       });
-      toast({ title: 'Charge code created successfully' });
+      toast({
+        title: requestToAssign?.id
+          ? 'Charge code created and assigned to WAD'
+          : 'Charge code created successfully',
+      });
       onClose();
     },
     onError: (err: Error) => {
@@ -409,6 +455,11 @@ function ChargeCodeForm({
         className="flex max-h-[calc(90vh-5rem)] flex-col"
       >
         <div className="space-y-4 overflow-y-auto px-1 pb-4">
+          {requestToAssign && (
+            <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+              Creating for {requestToAssign.workOrderNumber ?? 'WAD'} - {requestToAssign.operation}. Saving will assign the new code to this WAD request.
+            </div>
+          )}
           <div className="grid grid-cols-2 gap-4">
             <FormField
               control={form.control}
@@ -969,6 +1020,8 @@ export default function ChargeCodeManagerPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ChargeCode | null>(null);
   const [copySource, setCopySource] = useState<ChargeCode | null>(null);
+  const [requestToAssign, setRequestToAssign] = useState<ChargeCodeRequest | null>(null);
+  const [handledRequestId, setHandledRequestId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
@@ -987,6 +1040,36 @@ export default function ChargeCodeManagerPage() {
   const { data: bases = [] } = useQuery<AllocationBase[]>({
     queryKey: ['/api/burden-rates/bases'],
   });
+
+  const chargeCodeRequestIdFromLink = useMemo(() => {
+    if (typeof window === 'undefined') return null;
+    return new URLSearchParams(window.location.search).get('wadChargeCodeRequestId');
+  }, []);
+
+  const shouldAutofillFromLink = useMemo(() => {
+    if (typeof window === 'undefined') return false;
+    return new URLSearchParams(window.location.search).get('autofill') === '1';
+  }, []);
+
+  useEffect(() => {
+    if (!chargeCodeRequestIdFromLink || handledRequestId === chargeCodeRequestIdFromLink) return;
+    const linkedRequest = chargeCodeRequests.find((request) => request.id === chargeCodeRequestIdFromLink);
+    if (!linkedRequest) return;
+
+    setHandledRequestId(chargeCodeRequestIdFromLink);
+    window.setTimeout(() => {
+      document
+        .getElementById(`charge-code-request-${chargeCodeRequestIdFromLink}`)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 100);
+
+    if (shouldAutofillFromLink) {
+      setEditTarget(null);
+      setCopySource(null);
+      setRequestToAssign(linkedRequest);
+      setDialogOpen(true);
+    }
+  }, [chargeCodeRequests, chargeCodeRequestIdFromLink, handledRequestId, shouldAutofillFromLink]);
 
   function handleSort(column: SortColumn) {
     if (sortColumn === column) {
@@ -1062,18 +1145,28 @@ export default function ChargeCodeManagerPage() {
   function openCreate() {
     setEditTarget(null);
     setCopySource(null);
+    setRequestToAssign(null);
     setDialogOpen(true);
   }
 
   function openEdit(code: ChargeCode) {
     setEditTarget(code);
     setCopySource(null);
+    setRequestToAssign(null);
     setDialogOpen(true);
   }
 
   function openCopy(code: ChargeCode) {
     setEditTarget(null);
     setCopySource(code);
+    setRequestToAssign(null);
+    setDialogOpen(true);
+  }
+
+  function openCreateForRequest(request: ChargeCodeRequest) {
+    setEditTarget(null);
+    setCopySource(null);
+    setRequestToAssign(request);
     setDialogOpen(true);
   }
 
@@ -1081,6 +1174,7 @@ export default function ChargeCodeManagerPage() {
     setDialogOpen(false);
     setEditTarget(null);
     setCopySource(null);
+    setRequestToAssign(null);
   }
 
   const assignRequestMutation = useMutation({
@@ -1090,7 +1184,9 @@ export default function ChargeCodeManagerPage() {
         body: { chargeCodeId },
       }),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/charge-codes'] });
       queryClient.invalidateQueries({ queryKey: ['/api/charge-codes/requests'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/task-items'] });
       toast({ title: 'Charge code request assigned' });
     },
     onError: (err: Error) => {
@@ -1186,7 +1282,15 @@ export default function ChargeCodeManagerPage() {
           </div>
           <div className="grid gap-3 md:grid-cols-2">
             {chargeCodeRequests.map((request) => (
-              <div key={request.id} className="rounded-md border p-4 space-y-3">
+              <div
+                key={request.id}
+                id={`charge-code-request-${request.id}`}
+                className={`rounded-md border p-4 space-y-3 ${
+                  request.id === chargeCodeRequestIdFromLink
+                    ? 'border-blue-500 bg-blue-50'
+                    : ''
+                }`}
+              >
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <p className="text-sm font-semibold">
@@ -1233,6 +1337,15 @@ export default function ChargeCodeManagerPage() {
                       <CheckCircle className="mr-2 h-4 w-4" />
                     )}
                     Assign
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => openCreateForRequest(request)}
+                  >
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create & Assign
                   </Button>
                 </div>
               </div>
@@ -1422,13 +1535,16 @@ export default function ChargeCodeManagerPage() {
                 ? `Edit: ${editTarget.code}`
                 : copySource
                   ? `Copy: ${copySource.code}`
-                  : 'Add Charge Code'}
+                  : requestToAssign
+                    ? 'Create WAD Charge Code'
+                    : 'Add Charge Code'}
             </DialogTitle>
           </DialogHeader>
           {dialogOpen && (
             <ChargeCodeForm
               editTarget={editTarget}
               copySource={copySource}
+              requestToAssign={requestToAssign}
               existingChargeCodes={chargeCodes ?? []}
               onClose={closeDialog}
             />

--- a/server/src/routes/chargeCodes.ts
+++ b/server/src/routes/chargeCodes.ts
@@ -162,6 +162,88 @@ function normalizeRequestText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function requestTaskMarker(requestId: string): string {
+  return `WAD_CHARGE_CODE_REQUEST:${requestId}`;
+}
+
+function chargeCodeRequestLink(requestId: string, wadId: string): string {
+  const params = new URLSearchParams({
+    wadChargeCodeRequestId: requestId,
+    wadId,
+    autofill: '1',
+  });
+  return `/finance/charge-codes?${params.toString()}`;
+}
+
+async function upsertGlennChargeCodeTask(requestId: string): Promise<void> {
+  const requests = await listChargeCodeRequests({ status: 'PENDING' });
+  const request = requests.find((row: any) => row.id === requestId);
+  if (!request) return;
+  if (!request.wadId) return;
+
+  const marker = requestTaskMarker(requestId);
+  const link = chargeCodeRequestLink(requestId, request.wadId);
+  const title = `Assign WAD charge code - ${request.workOrderNumber ?? 'WAD'} / ${request.operation}`;
+  const description = [
+    `A WAD charge code was requested for ${request.workOrderNumber ?? 'this WAD'}.`,
+    `Department: ${request.department}`,
+    `Operation: ${request.operation}`,
+    request.budgetedHours ? `Budgeted hours: ${request.budgetedHours}` : null,
+    `Open charge code engine: ${link}`,
+  ].filter(Boolean).join('\n');
+  const notes = `${marker}\n${link}`;
+  const existing = await pool.query(
+    `SELECT id
+       FROM task_items
+      WHERE notes LIKE $1
+      ORDER BY id DESC
+      LIMIT 1`,
+    [`%${marker}%`]
+  );
+
+  if (existing.length > 0) {
+    await pool.query(
+      `UPDATE task_items
+          SET title = $2,
+              description = $3,
+              category = 'WAD Charge Codes',
+              priority = 'High',
+              assigned_to = 'Glenn Jones',
+              gj_status = FALSE,
+              tm_status = FALSE,
+              finished_status = FALSE,
+              is_active = TRUE,
+              updated_at = NOW()
+        WHERE id = $1`,
+      [existing[0].id, title, description]
+    );
+    return;
+  }
+
+  await pool.query(
+    `INSERT INTO task_items (
+       title, description, category, priority, assigned_to, created_by, notes
+     )
+     VALUES ($1, $2, 'WAD Charge Codes', 'High', 'Glenn Jones', 'WAD Charge Code Engine', $3)`,
+    [title, description, notes]
+  );
+}
+
+async function completeGlennChargeCodeTask(requestId: string, chargeCode: string, actorName: string): Promise<void> {
+  const marker = requestTaskMarker(requestId);
+  await pool.query(
+    `UPDATE task_items
+        SET finished_status = TRUE,
+            finished_completed_by = $2,
+            finished_completed_at = NOW(),
+            notes = CONCAT(COALESCE(notes, ''), E'\nAssigned charge code: ', $3),
+            updated_at = NOW()
+      WHERE notes LIKE $1
+        AND is_active = TRUE`,
+    [`%${marker}%`, actorName, chargeCode]
+  );
+}
+
 async function listChargeCodeRequests(filters: { status?: string; wadId?: string }) {
   await ensureChargeCodeRequestTable();
   const conditions: string[] = [];
@@ -283,6 +365,7 @@ router.post('/requests', authenticateToken, h(async (req, res) => {
   });
 
   const requests = await listChargeCodeRequests({ wadId, status: 'PENDING' });
+  await upsertGlennChargeCodeTask(String(rows[0].id));
   res.status(201).json(requests.find((request: any) => request.id === rows[0].id) ?? rows[0]);
 }));
 
@@ -369,6 +452,7 @@ router.patch('/requests/:requestId/assign', authenticateToken, requireRole('ADMI
     userAgent: req.headers['user-agent'] ?? null,
     payload: { requestId, chargeCodeId, chargeCode: chargeCode.code },
   });
+  await completeGlennChargeCodeTask(requestId, chargeCode.code, actorName);
 
   const rows = await listChargeCodeRequests({});
   res.json(rows.find((request: any) => request.id === requestId));


### PR DESCRIPTION
## Summary
- Creates or updates a Task Tracker item assigned to Glenn Jones whenever a WAD charge code request is submitted.
- Adds a task link into the charge code engine that highlights the pending WAD request and opens a prefilled create-and-assign flow.
- Marks the generated task finished when an existing or newly created charge code is assigned back to the WAD request.

## Why
WAD charge code requests needed to land in Glenn Jones' task list and provide a direct path to the charge code engine so the requested cost objective can be created or assigned without manually hunting for the WAD row.

## Validation
- `git diff --cached --check`
- `git diff --check`
- `node --experimental-strip-types --check server/src/routes/chargeCodes.ts`

Full `tsc` was attempted with bundled pnpm, but pnpm tried to fetch missing packages from npm and network access is restricted in this environment.