### PR TITLE
[codex] Fix RFQ draft link loading

### DIFF
--- a/client/src/pages/RFQBuilderPage.tsx
+++ b/client/src/pages/RFQBuilderPage.tsx
@@ -347,9 +347,13 @@ function normalizeNrcRow(row: Partial<NrcCostRow>, sourceType: CostSourceType = 
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export default function RFQBuilderPage() {
-  const [, setLocation] = useLocation();
+  const [location, setLocation] = useLocation();
   const [, params] = useRoute("/rfq-builder/:id");
-  const rfqId = params?.id;
+  const queryRfqId = useMemo(() => {
+    const query = location.split("?")[1];
+    return query ? new URLSearchParams(query).get("rfqId") ?? undefined : undefined;
+  }, [location]);
+  const rfqId = params?.id ?? queryRfqId;
   const queryClient = useQueryClient();
 
   const [header, setHeader] = useState<RfqHeader>({


### PR DESCRIPTION
## What changed
- Updated the RFQ builder to load an RFQ id from either the canonical `/rfq-builder/:id` route or legacy `/rfq-builder?rfqId=...` links.

## Why
Some navigation paths can still provide the RFQ id as a query parameter. The builder only read the route parameter, so those links opened as a new blank builder instead of loading the existing draft.

## Impact
Existing draft links now load the intended RFQ while preserving the canonical route behavior already used by the list page.

## Validation
- Confirmed current `main` already opens list rows with `/rfq-builder/:id`.
- Verified the PR branch diff is limited to `client/src/pages/RFQBuilderPage.tsx`.
- Ran `git diff --check` successfully.

Full TypeScript check was not run because this clean worktree has no `node_modules` installed in the local environment.