### PR TITLE
[codex] Share R&D design projects

### DIFF
--- a/client/src/pages/RDProjectsPage.tsx
+++ b/client/src/pages/RDProjectsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useLocation } from 'wouter';
 import {
   AlertTriangle,
@@ -286,6 +286,27 @@ function mergeDraftRecords(localRecords: DraftBomRecord[], sharedRecords: DraftB
   return [...byId.values()].sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
 }
 
+function mergeProjects(sharedProjects: RDProject[], localProjects: RDProject[]) {
+  const byId = new Map<string, RDProject>();
+  for (const project of [...sharedProjects, ...localProjects]) {
+    if (project?.id) byId.set(project.id, project);
+  }
+  return [...byId.values()];
+}
+
+async function saveSharedProject(project: RDProject) {
+  const response = await fetch(`/api/rd-projects/${encodeURIComponent(project.id)}`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(project),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to save R&D project');
+  }
+  return response.json() as Promise<RDProject>;
+}
+
 function findDraftLineForComponent(component: DraftBomComponent | DraftBomPart, lines: DraftBomLine[]) {
   if (component.sourceLineId) {
     const match = lines.find((line) => line.id === component.sourceLineId);
@@ -454,8 +475,19 @@ function AssemblyTreeNode({ node, depth = 0 }: { node: AssemblyNode; depth?: num
 
 export default function RDProjectsPage() {
   const [, setLocation] = useLocation();
+  const queryClient = useQueryClient();
   const { data: employees = [] } = useQuery<EmployeeOption[]>({
     queryKey: ['/api/employees'],
+  });
+  const { data: sharedProjects = [] } = useQuery<RDProject[]>({
+    queryKey: ['/api/rd-projects'],
+    retry: false,
+    queryFn: async () => {
+      const response = await fetch('/api/rd-projects', { credentials: 'include' });
+      if (!response.ok) return [];
+      const payload = await response.json();
+      return Array.isArray(payload) ? payload : [];
+    },
   });
   const { data: sharedDraftRecords = [] } = useQuery<DraftBomRecord[]>({
     queryKey: ['/api/draft-bom-drafts'],
@@ -470,9 +502,13 @@ export default function RDProjectsPage() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [form, setForm] = useState(emptyProject);
   const [localDraftRecords, setLocalDraftRecords] = useState<DraftBomRecord[]>(() => readJsonStorage(DRAFT_BOM_STORAGE_KEY, []));
-  const [projects, setProjects] = useState<RDProject[]>(() => readJsonStorage(R_AND_D_PROJECT_STORAGE_KEY, []));
+  const [localProjects, setLocalProjects] = useState<RDProject[]>(() => readJsonStorage(R_AND_D_PROJECT_STORAGE_KEY, []));
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
 
+  const projects = useMemo(
+    () => mergeProjects(sharedProjects, localProjects),
+    [sharedProjects, localProjects],
+  );
   const draftRecords = useMemo(
     () => mergeDraftRecords(localDraftRecords, sharedDraftRecords),
     [localDraftRecords, sharedDraftRecords],
@@ -496,8 +532,8 @@ export default function RDProjectsPage() {
   );
 
   useEffect(() => {
-    writeJsonStorage(R_AND_D_PROJECT_STORAGE_KEY, projects);
-  }, [projects]);
+    writeJsonStorage(R_AND_D_PROJECT_STORAGE_KEY, localProjects);
+  }, [localProjects]);
 
   useEffect(() => {
     const refreshDraftRecords = () => setLocalDraftRecords(readJsonStorage(DRAFT_BOM_STORAGE_KEY, []));
@@ -511,6 +547,18 @@ export default function RDProjectsPage() {
 
   const resetForm = () => setForm(emptyProject);
 
+  const persistProject = (project: RDProject) => {
+    setLocalProjects((current) => [project, ...current.filter((item) => item.id !== project.id)]);
+    saveSharedProject(project)
+      .then((saved) => {
+        setLocalProjects((current) => current.map((item) => (item.id === saved.id ? saved : item)));
+        queryClient.invalidateQueries({ queryKey: ['/api/rd-projects'] });
+      })
+      .catch((error) => {
+        console.error('Failed to persist shared R&D project:', error);
+      });
+  };
+
   const createProject = () => {
     const ownerEmployee = activeEmployees.find((employee) => String(employee.id) === form.owner);
     const project: RDProject = {
@@ -523,20 +571,16 @@ export default function RDProjectsPage() {
       draftTabIds: form.draftTabIds,
       status: 'draft',
     };
-    setProjects((current) => [project, ...current]);
+    persistProject(project);
     setSelectedProjectId(project.id);
     resetForm();
     setIsDialogOpen(false);
   };
 
   const toggleProjectStatus = (projectId: string, active: boolean) => {
-    setProjects((current) =>
-      current.map((project) =>
-        project.id === projectId
-          ? { ...project, status: active ? 'active' : 'draft' }
-          : project
-      )
-    );
+    const project = projects.find((item) => item.id === projectId);
+    if (!project) return;
+    persistProject({ ...project, status: active ? 'active' : 'draft' });
   };
 
   const toggleDraftTab = (tabId: string, checked: boolean) => {

--- a/migrations/0188_rd_projects.sql
+++ b/migrations/0188_rd_projects.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS rd_projects (
+  id text PRIMARY KEY,
+  project_name text NOT NULL,
+  owner text NOT NULL DEFAULT '',
+  status text NOT NULL DEFAULT 'draft',
+  signoff_required boolean NOT NULL DEFAULT false,
+  signoff_user_id text NOT NULL DEFAULT '',
+  draft_tab_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+  description text NOT NULL DEFAULT '',
+  created_by_user_id integer REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name text NOT NULL DEFAULT 'unknown',
+  updated_by_user_id integer REFERENCES users(id) ON DELETE SET NULL,
+  updated_by_display_name text NOT NULL DEFAULT 'unknown',
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rd_projects_updated_at ON rd_projects (updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_rd_projects_status ON rd_projects (status);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -16373,6 +16373,32 @@ export const insertDraftBomDraftSchema = createInsertSchema(draftBomDrafts).omit
 export type DraftBomDraft = typeof draftBomDrafts.$inferSelect;
 export type InsertDraftBomDraft = z.infer<typeof insertDraftBomDraftSchema>;
 
+// R&D projects created from the Design tab. These are shared for every user
+// with access to the Design / R&D Projects page.
+export const rdProjects = pgTable('rd_projects', {
+  id: text('id').primaryKey(),
+  projectName: text('project_name').notNull(),
+  owner: text('owner').notNull().default(''),
+  status: text('status').notNull().default('draft'),
+  signoffRequired: boolean('signoff_required').notNull().default(false),
+  signoffUserId: text('signoff_user_id').notNull().default(''),
+  draftTabIds: jsonb('draft_tab_ids').notNull().$type<string[]>().default(sql`'[]'::jsonb`),
+  description: text('description').notNull().default(''),
+  createdByUserId: integer('created_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  createdByDisplayName: text('created_by_display_name').notNull().default('unknown'),
+  updatedByUserId: integer('updated_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  updatedByDisplayName: text('updated_by_display_name').notNull().default('unknown'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
+export const insertRdProjectSchema = createInsertSchema(rdProjects).omit({
+  createdAt: true,
+  updatedAt: true,
+});
+export type RdProject = typeof rdProjects.$inferSelect;
+export type InsertRdProject = z.infer<typeof insertRdProjectSchema>;
+
 export const schemaChangeLog = pgTable('schema_change_log', {
   id: serial('id').primaryKey(),
   timestamp: timestamp('timestamp').defaultNow().notNull(),

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -231,6 +231,7 @@ import cncDashboardRoutes from './cncDashboard';
 import receivingRoutes from './receiving';
 import estimatingRoutes from './estimating';
 import draftBomDraftsRoutes from './draftBomDrafts';
+import rdProjectsRoutes from './rdProjects';
 import rfqRiskSessionsRoutes from './rfqRiskSessions';
 import auditsRoutes from './audits';
 import commandCenterRoutes from './commandCenter';
@@ -13916,6 +13917,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   // Estimating / RFQ Builder routes
   app.use('/api/estimating', authenticateToken, estimatingRoutes);
   app.use('/api/draft-bom-drafts', authenticateToken, draftBomDraftsRoutes);
+  app.use('/api/rd-projects', authenticateToken, rdProjectsRoutes);
 
   // Conversational RFQ Risk Assessment routes
   app.use('/api/rfq-risk-sessions', authenticateToken, rfqRiskSessionsRoutes);

--- a/server/src/routes/rdProjects.ts
+++ b/server/src/routes/rdProjects.ts
@@ -1,0 +1,116 @@
+import { Router, type Request, type Response } from 'express';
+import { desc, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../../db';
+import { rdProjects } from '../../schema';
+import { resolveUserSnapshot } from '../../utils/userSnapshot';
+
+const router = Router();
+
+const rdProjectPayloadSchema = z.object({
+  id: z.string().trim().min(1),
+  projectName: z.string().trim().min(1),
+  owner: z.string().default(''),
+  status: z.enum(['draft', 'active']).default('draft'),
+  signoffRequired: z.boolean().default(false),
+  signoffUserId: z.string().default(''),
+  draftTabIds: z.array(z.string()).default([]),
+  description: z.string().default(''),
+});
+
+async function userSnapshot(req: Request) {
+  const user = (req as any).user;
+  if (!user) return { userId: null, displayName: 'unknown' };
+  if (!user.id) {
+    return {
+      userId: null,
+      displayName: user.username ?? user.displayName ?? 'unknown',
+    };
+  }
+  return resolveUserSnapshot(user.id).catch(() => ({
+    userId: user.id ?? null,
+    displayName: user.username ?? user.displayName ?? 'unknown',
+  }));
+}
+
+function toClientProject(row: typeof rdProjects.$inferSelect) {
+  return {
+    id: row.id,
+    projectName: row.projectName,
+    owner: row.owner,
+    status: row.status,
+    signoffRequired: row.signoffRequired,
+    signoffUserId: row.signoffUserId,
+    draftTabIds: Array.isArray(row.draftTabIds) ? row.draftTabIds : [],
+    description: row.description,
+    createdAt: row.createdAt?.toISOString?.(),
+    updatedAt: row.updatedAt?.toISOString?.(),
+    createdByUserId: row.createdByUserId,
+    createdByDisplayName: row.createdByDisplayName,
+    updatedByDisplayName: row.updatedByDisplayName,
+  };
+}
+
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const rows = await db.select().from(rdProjects).orderBy(desc(rdProjects.updatedAt));
+    res.json(rows.map(toClientProject));
+  } catch (error) {
+    console.error('List R&D projects error:', error);
+    res.status(500).json({ error: 'Failed to fetch R&D projects' });
+  }
+});
+
+router.put('/:id', async (req: Request, res: Response) => {
+  try {
+    const parsed = rdProjectPayloadSchema.parse({ ...req.body, id: req.params.id });
+    const snapshot = await userSnapshot(req);
+    const now = new Date();
+
+    const [existing] = await db.select().from(rdProjects).where(eq(rdProjects.id, parsed.id)).limit(1);
+
+    const [row] = await db
+      .insert(rdProjects)
+      .values({
+        id: parsed.id,
+        projectName: parsed.projectName,
+        owner: parsed.owner,
+        status: parsed.status,
+        signoffRequired: parsed.signoffRequired,
+        signoffUserId: parsed.signoffRequired ? parsed.signoffUserId : '',
+        draftTabIds: parsed.draftTabIds,
+        description: parsed.description,
+        createdByUserId: existing?.createdByUserId ?? snapshot.userId ?? null,
+        createdByDisplayName: existing?.createdByDisplayName ?? snapshot.displayName ?? 'unknown',
+        updatedByUserId: snapshot.userId ?? null,
+        updatedByDisplayName: snapshot.displayName ?? 'unknown',
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: rdProjects.id,
+        set: {
+          projectName: parsed.projectName,
+          owner: parsed.owner,
+          status: parsed.status,
+          signoffRequired: parsed.signoffRequired,
+          signoffUserId: parsed.signoffRequired ? parsed.signoffUserId : '',
+          draftTabIds: parsed.draftTabIds,
+          description: parsed.description,
+          updatedByUserId: snapshot.userId ?? null,
+          updatedByDisplayName: snapshot.displayName ?? 'unknown',
+          updatedAt: now,
+        },
+      })
+      .returning();
+
+    res.json(toClientProject(row));
+  } catch (error) {
+    console.error('Save R&D project error:', error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: error.errors[0]?.message || 'Invalid R&D project payload' });
+    }
+    res.status(500).json({ error: 'Failed to save R&D project' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## What changed
- Added shared server persistence for Design / R&D projects via `/api/rd-projects`.
- Added the `rd_projects` database table and migration.
- Updated the R&D Projects page to merge existing local drafts with shared projects and save new/status-updated projects to the shared endpoint.

## Why
R&D projects started from the Design tab were stored only in browser localStorage, so they were not visible from another authorized user's session.

## Impact
Users who can access the Design / R&D Projects tab now see the same shared project list.

## Validation
- `git diff --check origin/main...HEAD`

Full TypeScript checks were not run in this clean worktree because dependencies are not installed locally.