### PR TITLE
[codex] Backfill WAD charge code request tasks

### DIFF
--- a/server/src/routes/chargeCodes.ts
+++ b/server/src/routes/chargeCodes.ts
@@ -4,6 +4,11 @@ import { storage } from '../../storage';
 import { insertChargeCodeSchema } from '../../schema';
 import { recordAuditEvent } from '../services/auditLedgerService';
 import { pgPool, pool } from '../../db';
+import {
+  completeGlennChargeCodeTask,
+  upsertGlennChargeCodeTask,
+  upsertGlennChargeCodeTasksForPendingRequests,
+} from '../services/wadChargeCodeTaskService';
 
 const router: IRouter = Router();
 
@@ -162,88 +167,6 @@ function normalizeRequestText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
-function requestTaskMarker(requestId: string): string {
-  return `WAD_CHARGE_CODE_REQUEST:${requestId}`;
-}
-
-function chargeCodeRequestLink(requestId: string, wadId: string): string {
-  const params = new URLSearchParams({
-    wadChargeCodeRequestId: requestId,
-    wadId,
-    autofill: '1',
-  });
-  return `/finance/charge-codes?${params.toString()}`;
-}
-
-async function upsertGlennChargeCodeTask(requestId: string): Promise<void> {
-  const requests = await listChargeCodeRequests({ status: 'PENDING' });
-  const request = requests.find((row: any) => row.id === requestId);
-  if (!request) return;
-  if (!request.wadId) return;
-
-  const marker = requestTaskMarker(requestId);
-  const link = chargeCodeRequestLink(requestId, request.wadId);
-  const title = `Assign WAD charge code - ${request.workOrderNumber ?? 'WAD'} / ${request.operation}`;
-  const description = [
-    `A WAD charge code was requested for ${request.workOrderNumber ?? 'this WAD'}.`,
-    `Department: ${request.department}`,
-    `Operation: ${request.operation}`,
-    request.budgetedHours ? `Budgeted hours: ${request.budgetedHours}` : null,
-    `Open charge code engine: ${link}`,
-  ].filter(Boolean).join('\n');
-  const notes = `${marker}\n${link}`;
-  const existing = await pool.query(
-    `SELECT id
-       FROM task_items
-      WHERE notes LIKE $1
-      ORDER BY id DESC
-      LIMIT 1`,
-    [`%${marker}%`]
-  );
-
-  if (existing.length > 0) {
-    await pool.query(
-      `UPDATE task_items
-          SET title = $2,
-              description = $3,
-              category = 'WAD Charge Codes',
-              priority = 'High',
-              assigned_to = 'Glenn Jones',
-              gj_status = FALSE,
-              tm_status = FALSE,
-              finished_status = FALSE,
-              is_active = TRUE,
-              updated_at = NOW()
-        WHERE id = $1`,
-      [existing[0].id, title, description]
-    );
-    return;
-  }
-
-  await pool.query(
-    `INSERT INTO task_items (
-       title, description, category, priority, assigned_to, created_by, notes
-     )
-     VALUES ($1, $2, 'WAD Charge Codes', 'High', 'Glenn Jones', 'WAD Charge Code Engine', $3)`,
-    [title, description, notes]
-  );
-}
-
-async function completeGlennChargeCodeTask(requestId: string, chargeCode: string, actorName: string): Promise<void> {
-  const marker = requestTaskMarker(requestId);
-  await pool.query(
-    `UPDATE task_items
-        SET finished_status = TRUE,
-            finished_completed_by = $2,
-            finished_completed_at = NOW(),
-            notes = CONCAT(COALESCE(notes, ''), E'\nAssigned charge code: ', $3),
-            updated_at = NOW()
-      WHERE notes LIKE $1
-        AND is_active = TRUE`,
-    [`%${marker}%`, actorName, chargeCode]
-  );
-}
-
 async function listChargeCodeRequests(filters: { status?: string; wadId?: string }) {
   await ensureChargeCodeRequestTable();
   const conditions: string[] = [];
@@ -303,6 +226,12 @@ router.get('/requests', authenticateToken, h(async (req, res) => {
   const status = req.query.status === 'all' ? undefined : normalizeRequestStatus(req.query.status);
   const wadId = normalizeRequestText(req.query.wadId);
   const requests = await listChargeCodeRequests({ status, wadId: wadId || undefined });
+  const pendingRequestIds = requests
+    .filter((request: any) => request.status === 'PENDING')
+    .map((request: any) => String(request.id));
+  if (pendingRequestIds.length > 0) {
+    await upsertGlennChargeCodeTasksForPendingRequests(pendingRequestIds);
+  }
   res.json(requests);
 }));
 

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -2,12 +2,14 @@ import { Router, Request, Response } from 'express';
 import { insertTaskItemSchema } from '@shared/schema';
 
 import { storage } from '../../storage';
+import { upsertGlennChargeCodeTasksForPendingRequests } from '../services/wadChargeCodeTaskService';
 
 const router = Router();
 
 // Task Tracker Management
 router.get('/', async (req: Request, res: Response) => {
   try {
+    await upsertGlennChargeCodeTasksForPendingRequests();
     const tasks = await storage.getAllTaskItems();
     res.json(tasks);
   } catch (error) {

--- a/server/src/services/wadChargeCodeTaskService.ts
+++ b/server/src/services/wadChargeCodeTaskService.ts
@@ -1,0 +1,169 @@
+import { pool } from '../../db';
+
+type PendingWadChargeCodeRequest = {
+  id: string;
+  wadId: string | null;
+  workOrderNumber: string | null;
+  department: string;
+  operation: string;
+  budgetedHours: string | null;
+};
+
+let taskBackfillReady: Promise<void> | null = null;
+
+function requestTaskMarker(requestId: string): string {
+  return `WAD_CHARGE_CODE_REQUEST:${requestId}`;
+}
+
+function chargeCodeRequestLink(requestId: string, wadId: string): string {
+  const params = new URLSearchParams({
+    wadChargeCodeRequestId: requestId,
+    wadId,
+    autofill: '1',
+  });
+  return `/finance/charge-codes?${params.toString()}`;
+}
+
+function ensureTaskBackfillTables(): Promise<void> {
+  if (!taskBackfillReady) {
+    taskBackfillReady = (async () => {
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS wad_charge_code_requests (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          wad_id UUID REFERENCES production_work_orders(id) ON DELETE CASCADE,
+          department TEXT NOT NULL,
+          operation TEXT NOT NULL,
+          labor_category TEXT,
+          classification TEXT NOT NULL DEFAULT 'DIRECT',
+          budgeted_hours NUMERIC,
+          requested_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+          requested_by_display_name TEXT NOT NULL DEFAULT 'Unknown',
+          requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          status TEXT NOT NULL DEFAULT 'PENDING',
+          assigned_charge_code_id INTEGER REFERENCES charge_codes(id) ON DELETE SET NULL,
+          assigned_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+          assigned_at TIMESTAMPTZ,
+          notes TEXT,
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+      `);
+      await pool.query(`CREATE INDEX IF NOT EXISTS wad_charge_code_requests_status_idx ON wad_charge_code_requests(status, requested_at DESC)`);
+      await pool.query(`CREATE INDEX IF NOT EXISTS wad_charge_code_requests_wad_idx ON wad_charge_code_requests(wad_id)`);
+      await pool.query(`
+        CREATE UNIQUE INDEX IF NOT EXISTS wad_charge_code_requests_open_operation_idx
+        ON wad_charge_code_requests(wad_id, department, operation)
+        WHERE status = 'PENDING'
+      `);
+    })().catch((error) => {
+      taskBackfillReady = null;
+      throw error;
+    });
+  }
+  return taskBackfillReady;
+}
+
+async function getPendingRequests(requestIds?: string[]): Promise<PendingWadChargeCodeRequest[]> {
+  await ensureTaskBackfillTables();
+  const params: unknown[] = [];
+  let idFilter = '';
+  if (requestIds && requestIds.length > 0) {
+    params.push(requestIds);
+    idFilter = `AND wccr.id = ANY($${params.length}::uuid[])`;
+  }
+
+  return pool.query(
+    `SELECT
+       wccr.id::text AS id,
+       wccr.wad_id::text AS "wadId",
+       pwo.work_order_number AS "workOrderNumber",
+       wccr.department,
+       wccr.operation,
+       wccr.budgeted_hours::text AS "budgetedHours"
+     FROM wad_charge_code_requests wccr
+     LEFT JOIN production_work_orders pwo ON pwo.id = wccr.wad_id
+     WHERE wccr.status = 'PENDING'
+       ${idFilter}
+     ORDER BY wccr.requested_at DESC`,
+    params
+  );
+}
+
+async function upsertGlennChargeCodeTaskForRequest(request: PendingWadChargeCodeRequest): Promise<void> {
+  if (!request.wadId) return;
+
+  const marker = requestTaskMarker(request.id);
+  const link = chargeCodeRequestLink(request.id, request.wadId);
+  const title = `Assign WAD charge code - ${request.workOrderNumber ?? 'WAD'} / ${request.operation}`;
+  const description = [
+    `A WAD charge code was requested for ${request.workOrderNumber ?? 'this WAD'}.`,
+    `Department: ${request.department}`,
+    `Operation: ${request.operation}`,
+    request.budgetedHours ? `Budgeted hours: ${request.budgetedHours}` : null,
+    `Open charge code engine: ${link}`,
+  ].filter(Boolean).join('\n');
+  const notes = `${marker}\n${link}`;
+  const existing = await pool.query(
+    `SELECT id
+       FROM task_items
+      WHERE notes LIKE $1
+      ORDER BY id DESC
+      LIMIT 1`,
+    [`%${marker}%`]
+  );
+
+  if (existing.length > 0) {
+    await pool.query(
+      `UPDATE task_items
+          SET title = $2,
+              description = $3,
+              category = 'WAD Charge Codes',
+              priority = 'High',
+              assigned_to = 'Glenn Jones',
+              gj_status = FALSE,
+              tm_status = FALSE,
+              finished_status = FALSE,
+              is_active = TRUE,
+              updated_at = NOW()
+        WHERE id = $1`,
+      [existing[0].id, title, description]
+    );
+    return;
+  }
+
+  await pool.query(
+    `INSERT INTO task_items (
+       title, description, category, priority, assigned_to, created_by, notes
+     )
+     VALUES ($1, $2, 'WAD Charge Codes', 'High', 'Glenn Jones', 'WAD Charge Code Engine', $3)`,
+    [title, description, notes]
+  );
+}
+
+export async function upsertGlennChargeCodeTask(requestId: string): Promise<void> {
+  const [request] = await getPendingRequests([requestId]);
+  if (request) {
+    await upsertGlennChargeCodeTaskForRequest(request);
+  }
+}
+
+export async function upsertGlennChargeCodeTasksForPendingRequests(requestIds?: string[]): Promise<void> {
+  const requests = await getPendingRequests(requestIds);
+  for (const request of requests) {
+    await upsertGlennChargeCodeTaskForRequest(request);
+  }
+}
+
+export async function completeGlennChargeCodeTask(requestId: string, chargeCode: string, actorName: string): Promise<void> {
+  const marker = requestTaskMarker(requestId);
+  await pool.query(
+    `UPDATE task_items
+        SET finished_status = TRUE,
+            finished_completed_by = $2,
+            finished_completed_at = NOW(),
+            notes = CONCAT(COALESCE(notes, ''), E'\nAssigned charge code: ', $3),
+            updated_at = NOW()
+      WHERE notes LIKE $1
+        AND is_active = TRUE`,
+    [`%${marker}%`, actorName, chargeCode]
+  );
+}


### PR DESCRIPTION
## Summary
- move WAD charge-code task creation into a shared service
- keep new WAD charge-code requests notifying Glenn Jones through Task Tracker
- backfill missing Task Tracker rows for already-pending WAD charge-code requests when Tasks or the request queue loads

## Root Cause
Pending WAD charge-code requests that were created before the Task Tracker notification hook existed could remain only in the charge-code request queue. Glenn Jones would not see an actionable task unless the request was submitted again.

## Validation
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/chargeCodes.ts`
- `node --experimental-strip-types --check server/src/routes/tasks.ts`
- `node --experimental-strip-types --check server/src/services/wadChargeCodeTaskService.ts`