### PR TITLE
[codex] Keep linked spreadsheet imports source-only

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -1424,24 +1424,23 @@ function buildLinesFromRows(rows: string[][], inventoryItems: InventoryItemOptio
 
       const inventoryMatch = linkInventoryMatches ? findInventoryMatch(importedPartNumber, inventoryItems) : null;
       if (inventoryMatch) linkedCount += 1;
-      const fallbackStatus = inventoryMatch ? 'Needs Review' : 'Needs Quote';
       const spreadsheetLabel = `Imported spreadsheet row ${rowIndex + 1}`;
 
       return {
         ...newLine(),
-        action: inventoryMatch ? 'Order / Quote' : 'Review imported line',
-        category: inventoryMatch ? 'Hardware/Misc.' : 'Imported Spreadsheet',
-        description: inventoryMatch ? inventoryDescription(inventoryMatch) : spreadsheetLabel,
-        agPartNumber: inventoryMatch?.agPartNumber || '',
-        supplier: inventoryMatch?.source || inventoryMatch?.supplier || '',
-        supplierItemId: inventoryMatch?.supplierPartNumber || '',
-        manufacturer: inventoryMatch?.manufacturer || '',
-        unit: inventoryMatch?.usageUnit || inventoryMatch?.unit || '',
-        unitCost: Number.isFinite(Number(inventoryMatch?.costPer)) ? Number(inventoryMatch?.costPer) : '',
+        action: 'Review imported line',
+        category: 'Imported Spreadsheet',
+        description: spreadsheetLabel,
+        agPartNumber: '',
+        supplier: '',
+        supplierItemId: '',
+        manufacturer: '',
+        unit: '',
+        unitCost: '',
         actualCost: '',
-        qtyNeeded: inventoryMatch ? 1 : '',
+        qtyNeeded: '',
         service: false,
-        status: fallbackStatus,
+        status: 'Needs Review',
         targetNeedDate: '',
         note: inventoryMatch
           ? `CSV import linked to inventory item #${inventoryMatch.id}`
@@ -2369,7 +2368,7 @@ export default function DraftBOMBuilderPage() {
     }
 
     setCustomColumns((current) => sanitizeCustomColumns([...current, ...result.customColumns]));
-    const sourceColumnMode = !linkInventoryMatches && result.customColumns.length > 0;
+    const sourceColumnMode = result.customColumns.length > 0;
     if (sourceColumnMode) setVisiblePartsRequestColumns([]);
     setDraft((current) => ({
       ...current,


### PR DESCRIPTION
## Summary
- Stop spreadsheet imports from filling native Draft Builder columns when inventory linking is enabled.
- Keep linked inventory matches as hidden metadata only; imported rows keep blank native fields and use the spreadsheet-created columns as the visible source of truth.
- Always switch Parts/request into source-column mode when imported columns are present, so default app columns do not dominate the import view.

## Root Cause
The first source-column import fix still let `Permit inventory linking` copy matched inventory values into native fields like Supplier, Manufacturer, AG Part #, Unit Cost, Quantity, and Status. That made the imported data appear split across app columns and spreadsheet columns, as shown in the screenshot.

## Validation
- `git diff --check`
- `git diff --cached --check`

Full `npm/pnpm run check` is still blocked locally because `npm` is not on PATH and bundled `pnpm` attempts restricted network fetches for missing packages.