### PR TITLE
[codex] Add Forms & Reports document builder

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1170,6 +1170,7 @@ function App() {
 
                   {/* Forms and Reports Routes */}
                   <Route path="/forms" component={AdminFormsPage} />
+                  <Route path="/forms/document-builder" component={RoutingDocumentManagement} />
                   <Route path="/form/:id" component={FormPage} />
                   <Route path="/reports" component={ReportPage} />
                   <Route path="/reports/po-production-orders" component={POProductionOrdersReport} />

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -733,6 +733,13 @@ export default function Navigation() {
         'Unified document repository with advanced tagging and organization',
     },
     {
+      path: '/forms/document-builder',
+      label: 'Form & Document Builder',
+      icon: ClipboardList,
+      description:
+        'Create work instructions, assembly instructions, operator instructions, maintenance schedules, and reusable form templates',
+    },
+    {
       path: '/signature-workflow',
       label: 'Signature Routing',
       icon: FileSignature,

--- a/client/src/config/userPermissions.ts
+++ b/client/src/config/userPermissions.ts
@@ -39,7 +39,7 @@ export function getRequiredCapability(route: string): string | string[] | undefi
 export const DEFAULT_USER_ROUTES: string[] = ['/employee-portal'];
 
 // Universal routes that ALL authenticated users can access regardless of permissions
-export const UNIVERSAL_ACCESS_ROUTES: string[] = ['/communications/inbox', '/employee-portal', '/badge-scanner', '/help', '/pdf-signature-tool', '/routing-document-management', '/tickets', '/tickets-command-center', '/quick-notes', '/training', '/training/my-training', '/policies', '/approvals', '/pto-command-center'];
+export const UNIVERSAL_ACCESS_ROUTES: string[] = ['/communications/inbox', '/employee-portal', '/badge-scanner', '/help', '/pdf-signature-tool', '/routing-document-management', '/forms/document-builder', '/tickets', '/tickets-command-center', '/quick-notes', '/training', '/training/my-training', '/policies', '/approvals', '/pto-command-center'];
 
 // All valid navbar routes for reference (from Navigation.tsx)
 // This helps ensure permissions use correct paths
@@ -96,6 +96,7 @@ export const VALID_NAVBAR_ROUTES = [
   '/department-queue/shipping',
   '/discounts',
   '/document-management',
+  '/forms/document-builder',
   '/employee',
   '/employee-portal',
   '/onboarding',

--- a/client/src/pages/RoutingDocumentManagement.tsx
+++ b/client/src/pages/RoutingDocumentManagement.tsx
@@ -74,6 +74,47 @@ interface SpecSheet {
   createdAt: string;
 }
 
+const FORM_DOCUMENT_TYPES = [
+  { value: 'work_instruction', label: 'Work Instruction' },
+  { value: 'assembly_instruction', label: 'Assembly Instruction' },
+  { value: 'operator_instruction', label: 'Operator Instruction' },
+  { value: 'maintenance_schedule', label: 'Maintenance Schedule' },
+  { value: 'maintenance_instruction', label: 'Maintenance Instruction' },
+  { value: 'inspection_form', label: 'Inspection Form' },
+  { value: 'quality_checklist', label: 'Quality Checklist' },
+  { value: 'training_form', label: 'Training Form' },
+  { value: 'procedure', label: 'Procedure' },
+  { value: 'quality_procedure', label: 'Quality Procedure' },
+  { value: 'spec_sheet', label: 'Spec Sheet' },
+  { value: 'specification', label: 'Specification' },
+  { value: 'traveler_template', label: 'Traveler Template' },
+  { value: 'reference', label: 'Reference' },
+  { value: 'other', label: 'Other' },
+];
+
+const TEMPLATE_TYPES = [
+  { value: 'work_instruction', label: 'Work Instruction' },
+  { value: 'assembly_instruction', label: 'Assembly Instruction' },
+  { value: 'operator_instruction', label: 'Operator Instruction' },
+  { value: 'maintenance_schedule', label: 'Maintenance Schedule' },
+  { value: 'maintenance_instruction', label: 'Maintenance Instruction' },
+  { value: 'inspection_form', label: 'Inspection Form' },
+  { value: 'quality_checklist', label: 'Quality Checklist' },
+  { value: 'training_form', label: 'Training Form' },
+  { value: 'procedure', label: 'Procedure' },
+  { value: 'quality_procedure', label: 'Quality Procedure' },
+  { value: 'spec_sheet', label: 'Spec Sheet' },
+  { value: 'traveler_template', label: 'Traveler Template' },
+  { value: 'mixed', label: 'Mixed' },
+  { value: 'other', label: 'Other' },
+];
+
+function typeLabel(value: string | null | undefined) {
+  if (!value) return 'Document';
+  return [...FORM_DOCUMENT_TYPES, ...TEMPLATE_TYPES].find((t) => t.value === value)?.label
+    ?? value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 export default function RoutingDocumentManagement() {
   const [activeTab, setActiveTab] = useState('documents');
   const [showUploadDialog, setShowUploadDialog] = useState(false);
@@ -99,6 +140,7 @@ export default function RoutingDocumentManagement() {
   const [generateForm, setGenerateForm] = useState({
     partNumber: '',
     partName: '',
+    documentType: 'work_instruction',
     templateId: '',
   });
   const [learnForm, setLearnForm] = useState({
@@ -260,7 +302,7 @@ export default function RoutingDocumentManagement() {
       });
     },
     onSuccess: () => {
-      toast({ title: 'AI Analysis Complete', description: 'Document has been analyzed and fields extracted' });
+      toast({ title: 'AI Analysis Complete', description: 'Form fields, instructions, and requirements have been extracted' });
       queryClient.invalidateQueries({ queryKey: ['/api/routing-documents'] });
       setShowParseDialog(false);
       setParseContent('');
@@ -271,7 +313,7 @@ export default function RoutingDocumentManagement() {
   });
 
   const generateMutation = useMutation({
-    mutationFn: async (data: { partNumber: string; partName: string; templateId?: string; referenceDocumentIds?: string[] }) => {
+    mutationFn: async (data: { partNumber: string; partName: string; documentType: string; templateId?: string; referenceDocumentIds?: string[] }) => {
       return apiRequest('/api/routing-documents/ai-generate', {
         method: 'POST',
         body: data,
@@ -279,10 +321,10 @@ export default function RoutingDocumentManagement() {
       });
     },
     onSuccess: () => {
-      toast({ title: 'Document Generated', description: 'New document has been created from AI analysis' });
+      toast({ title: 'Form Generated', description: 'New form or instruction document has been created from AI analysis' });
       queryClient.invalidateQueries({ queryKey: ['/api/routing-documents'] });
       setShowGenerateDialog(false);
-      setGenerateForm({ partNumber: '', partName: '', templateId: '' });
+      setGenerateForm({ partNumber: '', partName: '', documentType: 'work_instruction', templateId: '' });
     },
     onError: (error: any) => {
       toast({ title: 'Error', description: error.message || 'Failed to generate document', variant: 'destructive' });
@@ -303,7 +345,7 @@ export default function RoutingDocumentManagement() {
       });
     },
     onSuccess: () => {
-      toast({ title: 'Reference Document Imported', description: 'Document has been linked from the media library' });
+      toast({ title: 'Reference Imported', description: 'Reference has been linked from the media library' });
       queryClient.invalidateQueries({ queryKey: ['/api/routing-documents'] });
       setShowMediaLibraryPicker(false);
     },
@@ -601,12 +643,13 @@ export default function RoutingDocumentManagement() {
 
   const handleGenerate = () => {
     if (!generateForm.partNumber) {
-      toast({ title: 'Error', description: 'Please enter a part number', variant: 'destructive' });
+      toast({ title: 'Error', description: 'Please enter a reference, part, or equipment ID', variant: 'destructive' });
       return;
     }
     generateMutation.mutate({
       partNumber: generateForm.partNumber,
       partName: generateForm.partName,
+      documentType: generateForm.documentType,
       templateId: generateForm.templateId || undefined,
       referenceDocumentIds: selectedDocuments.length > 0 ? selectedDocuments : undefined,
     });
@@ -632,6 +675,13 @@ export default function RoutingDocumentManagement() {
   const getDocTypeIcon = (type: string) => {
     switch (type) {
       case 'work_instruction': return <ClipboardList className="h-4 w-4" />;
+      case 'assembly_instruction': return <ClipboardList className="h-4 w-4" />;
+      case 'operator_instruction': return <ClipboardList className="h-4 w-4" />;
+      case 'maintenance_schedule': return <ClipboardList className="h-4 w-4" />;
+      case 'maintenance_instruction': return <ClipboardList className="h-4 w-4" />;
+      case 'inspection_form': return <CheckCircle className="h-4 w-4" />;
+      case 'quality_checklist': return <CheckCircle className="h-4 w-4" />;
+      case 'training_form': return <BookOpen className="h-4 w-4" />;
       case 'spec_sheet': return <FileSpreadsheet className="h-4 w-4" />;
       case 'traveler_template': return <BookOpen className="h-4 w-4" />;
       default: return <FileText className="h-4 w-4" />;
@@ -642,9 +692,9 @@ export default function RoutingDocumentManagement() {
     <div className="container mx-auto p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Routing Document Management</h1>
+          <h1 className="text-3xl font-bold tracking-tight">Form & Document Builder</h1>
           <p className="text-muted-foreground">
-            Work instructions, spec sheets, and AI-powered document generation for part routing
+            Create work instructions, assembly instructions, operator instructions, maintenance schedules, and reusable controlled form templates
           </p>
         </div>
         <div className="flex gap-2">
@@ -658,11 +708,11 @@ export default function RoutingDocumentManagement() {
           </Button>
           <Button variant="outline" onClick={() => setShowGenerateDialog(true)}>
             <Sparkles className="h-4 w-4 mr-2" />
-            AI Generate
+            Generate Form
           </Button>
           <Button onClick={() => setShowUploadDialog(true)}>
             <Upload className="h-4 w-4 mr-2" />
-            Upload Document
+            Add Document
           </Button>
         </div>
       </div>
@@ -724,8 +774,8 @@ export default function RoutingDocumentManagement() {
         <TabsContent value="documents" className="space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle>Routing Documents</CardTitle>
-              <CardDescription>Work instructions, procedures, and traveler templates</CardDescription>
+              <CardTitle>Forms & Documents</CardTitle>
+              <CardDescription>Work instructions, assembly instructions, operator instructions, maintenance schedules, procedures, and reusable form templates</CardDescription>
             </CardHeader>
             <CardContent>
               {loadingDocs ? (
@@ -762,7 +812,7 @@ export default function RoutingDocumentManagement() {
                           </div>
                         </TableCell>
                         <TableCell>
-                          <Badge variant="outline">{doc.documentType.replace('_', ' ')}</Badge>
+                          <Badge variant="outline">{typeLabel(doc.documentType)}</Badge>
                         </TableCell>
                         <TableCell>{doc.partNumber || '-'}</TableCell>
                         <TableCell>{doc.departmentName || '-'}</TableCell>
@@ -908,7 +958,7 @@ export default function RoutingDocumentManagement() {
                       <CardContent>
                         <div className="space-y-2">
                           <div className="flex items-center gap-2">
-                            <Badge variant="outline">{template.templateType.replace('_', ' ')}</Badge>
+                            <Badge variant="outline">{typeLabel(template.templateType)}</Badge>
                             <Badge variant="secondary">Learned from {template.learnedFromCount} docs</Badge>
                           </div>
                           <div className="text-sm text-muted-foreground">
@@ -1024,8 +1074,8 @@ export default function RoutingDocumentManagement() {
       <Dialog open={showUploadDialog} onOpenChange={setShowUploadDialog}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Upload Document</DialogTitle>
-            <DialogDescription>Upload a work instruction, spec sheet, or traveler template</DialogDescription>
+            <DialogTitle>Add Form or Document</DialogTitle>
+            <DialogDescription>Upload or register a work instruction, assembly instruction, operator instruction, maintenance schedule, or reusable form template</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>
@@ -1054,11 +1104,9 @@ export default function RoutingDocumentManagement() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="work_instruction">Work Instruction</SelectItem>
-                  <SelectItem value="procedure">Procedure</SelectItem>
-                  <SelectItem value="specification">Specification</SelectItem>
-                  <SelectItem value="traveler_template">Traveler Template</SelectItem>
-                  <SelectItem value="reference">Reference</SelectItem>
+                  {FORM_DOCUMENT_TYPES.map((type) => (
+                    <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
@@ -1086,7 +1134,7 @@ export default function RoutingDocumentManagement() {
                 checked={uploadForm.isTemplate}
                 onCheckedChange={(checked) => setUploadForm({ ...uploadForm, isTemplate: !!checked })}
               />
-              <Label htmlFor="isTemplate">Save as template for future use</Label>
+              <Label htmlFor="isTemplate">Save as template for future forms</Label>
             </div>
           </div>
           <DialogFooter>
@@ -1108,16 +1156,16 @@ export default function RoutingDocumentManagement() {
       }}>
         <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col">
           <DialogHeader>
-            <DialogTitle>AI Document Analysis</DialogTitle>
+            <DialogTitle>AI Form Analysis</DialogTitle>
             <DialogDescription>
-              Upload a PDF or paste document content for AI to extract routing steps, data fields, and requirements
+              Upload a PDF or paste content for AI to extract sections, data fields, instructions, checks, schedules, and requirements
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 overflow-y-auto flex-1 pr-2">
             {selectedDocument && (
               <div className="p-3 bg-muted rounded-lg">
                 <div className="font-medium">{selectedDocument.title}</div>
-                <div className="text-sm text-muted-foreground">{selectedDocument.documentType.replace('_', ' ')}</div>
+                <div className="text-sm text-muted-foreground">{typeLabel(selectedDocument.documentType)}</div>
               </div>
             )}
             <div className="p-4 border-2 border-dashed rounded-lg text-center">
@@ -1192,27 +1240,43 @@ export default function RoutingDocumentManagement() {
       <Dialog open={showGenerateDialog} onOpenChange={setShowGenerateDialog}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>AI Generate Document</DialogTitle>
+            <DialogTitle>Generate Form or Document</DialogTitle>
             <DialogDescription>
-              Generate a new document using AI based on templates and reference documents
+              Generate a new form or instruction document using a template and selected reference documents
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>
-              <Label>Part Number *</Label>
+              <Label>Reference / Part / Equipment ID *</Label>
               <Input
                 value={generateForm.partNumber}
                 onChange={(e) => setGenerateForm({ ...generateForm, partNumber: e.target.value })}
-                placeholder="e.g., AG-001"
+                placeholder="e.g., AG-001, CNC-03, Paint Booth PM"
               />
             </div>
             <div>
-              <Label>Part Name</Label>
+              <Label>Subject / Part Name</Label>
               <Input
                 value={generateForm.partName}
                 onChange={(e) => setGenerateForm({ ...generateForm, partName: e.target.value })}
-                placeholder="e.g., Carbon Fiber Stock"
+                placeholder="e.g., Carbon Fiber Stock, Weekly CNC Maintenance"
               />
+            </div>
+            <div>
+              <Label>Form / Document Type</Label>
+              <Select
+                value={generateForm.documentType}
+                onValueChange={(value) => setGenerateForm({ ...generateForm, documentType: value })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {FORM_DOCUMENT_TYPES.filter((type) => type.value !== 'reference').map((type) => (
+                    <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div>
               <Label>Use Template (Optional)</Label>
@@ -1250,9 +1314,9 @@ export default function RoutingDocumentManagement() {
       <Dialog open={showLearnDialog} onOpenChange={setShowLearnDialog}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Learn Template from Documents</DialogTitle>
+            <DialogTitle>Learn Template from Forms</DialogTitle>
             <DialogDescription>
-              AI will analyze the selected documents and create a reusable template
+              AI will analyze the selected documents and create a reusable form template
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
@@ -1282,10 +1346,9 @@ export default function RoutingDocumentManagement() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="work_instruction">Work Instruction</SelectItem>
-                  <SelectItem value="spec_sheet">Spec Sheet</SelectItem>
-                  <SelectItem value="traveler">Traveler</SelectItem>
-                  <SelectItem value="mixed">Mixed</SelectItem>
+                  {TEMPLATE_TYPES.map((type) => (
+                    <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
@@ -1328,7 +1391,7 @@ export default function RoutingDocumentManagement() {
                 </div>
                 <div className="space-y-2">
                   <Label className="text-muted-foreground">Document Type</Label>
-                  <Badge variant="outline">{selectedDocument.documentType.replace('_', ' ')}</Badge>
+                  <Badge variant="outline">{typeLabel(selectedDocument.documentType)}</Badge>
                 </div>
                 <div className="space-y-2">
                   <Label className="text-muted-foreground">Part Number</Label>
@@ -1643,11 +1706,9 @@ export default function RoutingDocumentManagement() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="work_instruction">Work Instruction</SelectItem>
-                  <SelectItem value="spec_sheet">Spec Sheet</SelectItem>
-                  <SelectItem value="traveler_template">Traveler Template</SelectItem>
-                  <SelectItem value="quality_procedure">Quality Procedure</SelectItem>
-                  <SelectItem value="other">Other</SelectItem>
+                  {FORM_DOCUMENT_TYPES.map((type) => (
+                    <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
@@ -1723,12 +1784,9 @@ export default function RoutingDocumentManagement() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="work_instruction">Work Instruction</SelectItem>
-                  <SelectItem value="spec_sheet">Spec Sheet</SelectItem>
-                  <SelectItem value="traveler_template">Traveler Template</SelectItem>
-                  <SelectItem value="quality_procedure">Quality Procedure</SelectItem>
-                  <SelectItem value="mixed">Mixed</SelectItem>
-                  <SelectItem value="other">Other</SelectItem>
+                  {TEMPLATE_TYPES.map((type) => (
+                    <SelectItem key={type.value} value={type.value}>{type.label}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
@@ -1770,7 +1828,7 @@ export default function RoutingDocumentManagement() {
           </DialogHeader>
           <div className="space-y-4">
             <div className="flex items-center gap-2">
-              <Badge variant="outline">{selectedTemplate?.templateType?.replace('_', ' ')}</Badge>
+              <Badge variant="outline">{typeLabel(selectedTemplate?.templateType)}</Badge>
               <Badge variant="secondary">Learned from {selectedTemplate?.learnedFromCount || 0} docs</Badge>
             </div>
             {selectedTemplate?.sections && selectedTemplate.sections.length > 0 && (

--- a/server/__tests__/universalRouteAccess.test.ts
+++ b/server/__tests__/universalRouteAccess.test.ts
@@ -19,6 +19,7 @@ describe('hasRouteAccess — universal routes bypass explicit permission entries
       '/help',
       '/pdf-signature-tool',
       '/routing-document-management',
+      '/forms/document-builder',
       '/tickets',
       '/quick-notes',
       '/training',

--- a/server/middleware/routeAuthorization.ts
+++ b/server/middleware/routeAuthorization.ts
@@ -18,6 +18,7 @@ const UNIVERSAL_ACCESS_ROUTES: string[] = [
   '/help',
   '/pdf-signature-tool',
   '/routing-document-management',
+  '/forms/document-builder',
   '/tickets',
   '/tickets-command-center',
   '/quick-notes',

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -13945,7 +13945,23 @@ export const insertRoutingDocumentSchema = createInsertSchema(routingDocuments)
   .omit({ id: true, createdAt: true, updatedAt: true })
   .extend({
     title: z.string().min(1, 'Title is required'),
-    documentType: z.enum(['work_instruction', 'procedure', 'specification', 'reference', 'traveler_template']).default('work_instruction'),
+    documentType: z.enum([
+      'work_instruction',
+      'assembly_instruction',
+      'operator_instruction',
+      'maintenance_schedule',
+      'maintenance_instruction',
+      'inspection_form',
+      'quality_checklist',
+      'training_form',
+      'procedure',
+      'quality_procedure',
+      'spec_sheet',
+      'specification',
+      'reference',
+      'traveler_template',
+      'other',
+    ]).default('work_instruction'),
     sourceType: z.enum(['uploaded', 'generated', 'imported']).default('uploaded'),
   });
 
@@ -13960,7 +13976,23 @@ export const insertDocumentTemplateSchema = createInsertSchema(documentTemplates
   .omit({ id: true, createdAt: true, updatedAt: true })
   .extend({
     templateName: z.string().min(1, 'Template name is required'),
-    templateType: z.enum(['work_instruction', 'spec_sheet', 'traveler', 'mixed']),
+    templateType: z.enum([
+      'work_instruction',
+      'assembly_instruction',
+      'operator_instruction',
+      'maintenance_schedule',
+      'maintenance_instruction',
+      'inspection_form',
+      'quality_checklist',
+      'training_form',
+      'procedure',
+      'quality_procedure',
+      'spec_sheet',
+      'traveler_template',
+      'traveler',
+      'mixed',
+      'other',
+    ]),
   });
 
 export const insertTemplateFieldSchema = createInsertSchema(templateFields)
@@ -13976,7 +14008,21 @@ export const insertRoutingDocumentLinkSchema = createInsertSchema(routingDocumen
   .omit({ id: true, createdAt: true })
   .extend({
     partRoutingId: z.string().uuid('Invalid routing ID'),
-    documentType: z.enum(['work_instruction', 'spec_sheet', 'traveler_template']),
+    documentType: z.enum([
+      'work_instruction',
+      'assembly_instruction',
+      'operator_instruction',
+      'maintenance_schedule',
+      'maintenance_instruction',
+      'inspection_form',
+      'quality_checklist',
+      'training_form',
+      'procedure',
+      'quality_procedure',
+      'spec_sheet',
+      'traveler_template',
+      'other',
+    ]),
     documentId: z.string().uuid('Invalid document ID'),
   });
 
@@ -13989,7 +14035,22 @@ export const insertCertificationTaskLinkSchema = createInsertSchema(certificatio
 export const insertDocumentDistributionLogSchema = createInsertSchema(documentDistributionLogs)
   .omit({ id: true, printedAt: true })
   .extend({
-    documentType: z.enum(['work_instruction', 'spec_sheet', 'traveler']),
+    documentType: z.enum([
+      'work_instruction',
+      'assembly_instruction',
+      'operator_instruction',
+      'maintenance_schedule',
+      'maintenance_instruction',
+      'inspection_form',
+      'quality_checklist',
+      'training_form',
+      'procedure',
+      'quality_procedure',
+      'spec_sheet',
+      'traveler_template',
+      'traveler',
+      'other',
+    ]),
     documentId: z.string().uuid('Invalid document ID'),
     distributionMethod: z.enum(['print', 'email', 'digital']).default('print'),
   });

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -320,7 +320,7 @@ router.get('/routing-links/:partRoutingId', async (req: Request, res: Response) 
     const enrichedLinks = await Promise.all(links.map(async (link: any) => {
       let document = null;
       try {
-        if (link.document_type === 'work_instruction' || link.document_type === 'procedure' || link.document_type === 'traveler_template') {
+        if (link.document_type !== 'spec_sheet') {
           const docResult = await db.execute(sql`SELECT * FROM routing_documents WHERE id = ${link.document_id} LIMIT 1`);
           const docRows = (docResult as any)?.rows || docResult || [];
           document = docRows[0] || null;
@@ -1078,10 +1078,13 @@ router.post('/:id/ai-parse', async (req: Request, res: Response) => {
 // AI Generate new document from templates
 router.post('/ai-generate', async (req: Request, res: Response) => {
   try {
-    const { templateId, partNumber, partName, customFields, referenceDocumentIds } = req.body;
+    const { templateId, partNumber, partName, documentType, customFields, referenceDocumentIds } = req.body;
+    const finalDocumentType = typeof documentType === 'string' && documentType.trim()
+      ? documentType.trim()
+      : 'work_instruction';
     
     if (!partNumber) {
-      return res.status(400).json({ error: 'Part number is required' });
+      return res.status(400).json({ error: 'Reference, part, or equipment ID is required' });
     }
     
     // Validate and get reference documents
@@ -1128,13 +1131,14 @@ router.post('/ai-generate', async (req: Request, res: Response) => {
       templateContent = `Template: ${template.template_name}\nStructure: ${JSON.stringify(template.structure)}\nSections: ${JSON.stringify(template.sections)}\nFields: ${JSON.stringify(fields)}`;
     }
     
-    const systemPrompt = `You are an expert at creating composite manufacturing work instructions, spec sheets, and travelers for composite layup, mold creation, curing, bonding, and fabrication processes. Based on the provided reference documents and template, generate a new document structure with all necessary fields.
+    const systemPrompt = `You are an expert at creating controlled manufacturing forms and instruction documents, including work instructions, assembly instructions, operator instructions, maintenance schedules, maintenance instructions, inspection forms, quality checklists, training forms, procedures, spec sheets, and travelers. Based on the requested document type, the provided reference documents, and the selected template, generate a practical document structure with all necessary sections and fields.
 
-You deeply understand composite manufacturing terminology: ply layup, fiber orientation, prepreg handling/out-time, vacuum bagging, autoclave/oven cure cycles, mold prep, surface prep, bonding, trimming, and NDI/NDT inspection. Use standard departments: Layup, Assemble/Disassembly, Trim, Paint, Quality Control, CNC, Finish, Bonding, Prep, Mold Prep, Oven/Cure.
+When the source material is composite manufacturing related, preserve exact composite terminology such as ply layup, fiber orientation, prepreg handling/out-time, vacuum bagging, autoclave/oven cure cycles, mold prep, surface prep, bonding, trimming, and NDI/NDT inspection. Use exact reference values where provided. For maintenance and operator forms, include frequencies, ownership, safety checks, acceptance criteria, signoffs, and escalation notes when supported by the source material.
 
 Return a JSON object with:
 {
   "title": "Generated document title",
+  "documentType": "requested document type",
   "sections": [{"name": "string", "content": "string", "fields": [...]}],
   "fields": [{"fieldName": "string", "fieldLabel": "string", "fieldType": "string", "isRequired": boolean, "isUniquePerSerial": boolean, "defaultValue": "string", "unit": "string or null"}],
   "routingSteps": [...],
@@ -1144,8 +1148,9 @@ Return a JSON object with:
 }`;
 
     const userPrompt = `Generate a document for:
-Part Number: ${partNumber || 'Not specified'}
-Part Name: ${partName || 'Not specified'}
+Document Type: ${finalDocumentType}
+Reference / Part / Equipment ID: ${partNumber || 'Not specified'}
+Subject / Part Name: ${partName || 'Not specified'}
 Custom Requirements: ${JSON.stringify(customFields || {})}
 
 ${referenceContent ? `Reference Documents:\n${referenceContent}` : ''}
@@ -1167,7 +1172,7 @@ ${templateContent ? `\nTemplate:\n${templateContent}` : ''}`;
     const [newDocument] = await db.insert(routingDocuments).values({
       title: generatedContent.title || `Generated Document for ${partNumber}`,
       partNumber,
-      documentType: 'work_instruction',
+      documentType: finalDocumentType,
       sourceType: 'generated',
       aiExtractedContent: generatedContent,
       aiExtractedFields: generatedContent.fields || [],


### PR DESCRIPTION
## Summary

- Adds a visible Forms & Reports entry and route for the existing form/document builder at `/forms/document-builder` while keeping `/routing-document-management` available.
- Broadens the builder from routing-only document language to work instructions, assembly instructions, operator instructions, maintenance schedules, inspection/checklist/training forms, procedures, and reusable templates.
- Carries the selected form/document type through AI generation and expands server-side schema validation plus route authorization for the new URL.

## Validation

- `git diff --check origin/main..HEAD`
- `node --experimental-strip-types --check server/src/routes/routingDocuments.ts`
- `node --experimental-strip-types --check server/schema.ts`
- `node --experimental-strip-types --check server/middleware/routeAuthorization.ts`
- `node --experimental-strip-types --check server/__tests__/universalRouteAccess.test.ts`

Note: full TSX typecheck was not run because this local shell/worktree does not have a local TypeScript binary available.