### PR TITLE
[codex] Fix P2 revision family shipping display

### DIFF
--- a/client/src/components/p2/P2ProductionQueue.tsx
+++ b/client/src/components/p2/P2ProductionQueue.tsx
@@ -75,6 +75,7 @@ interface QueueItem {
   partNumber: string;
   partName: string;
   poNumber: string;
+  rawPoNumber?: string;
   customerName: string;
   status: string;
   currentDepartment: string;
@@ -209,24 +210,28 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
     refetchInterval: 10000,
   });
 
+  const matchesSelectedPO = (item: QueueItem) =>
+    selectedPONumbers.includes(item.poNumber) ||
+    (item.rawPoNumber ? selectedPONumbers.includes(item.rawPoNumber) : false);
+
   const queueData: ProductionQueueData | undefined = queueDataRaw && selectedPONumbers.length > 0
     ? {
         departments: queueDataRaw.departments.map((dept) => ({
           ...dept,
-          items: dept.items.filter((item) => selectedPONumbers.includes(item.poNumber)),
-          totalItems: dept.items.filter((item) => selectedPONumbers.includes(item.poNumber)).length,
-          inProgress: dept.items.filter((item) => selectedPONumbers.includes(item.poNumber) && item.hasActiveTask).length,
-          waiting: dept.items.filter((item) => selectedPONumbers.includes(item.poNumber) && !item.hasActiveTask).length,
+          items: dept.items.filter(matchesSelectedPO),
+          totalItems: dept.items.filter(matchesSelectedPO).length,
+          inProgress: dept.items.filter((item) => matchesSelectedPO(item) && item.hasActiveTask).length,
+          waiting: dept.items.filter((item) => matchesSelectedPO(item) && !item.hasActiveTask).length,
         })).filter((dept) => dept.items.length > 0),
         summary: {
           totalActive: queueDataRaw.departments
             .flatMap((d) => d.items)
-            .filter((item) => selectedPONumbers.includes(item.poNumber)).length,
+            .filter(matchesSelectedPO).length,
           totalInProgress: queueDataRaw.departments
             .flatMap((d) => d.items)
-            .filter((item) => selectedPONumbers.includes(item.poNumber) && item.hasActiveTask).length,
+            .filter((item) => matchesSelectedPO(item) && item.hasActiveTask).length,
           departmentCount: queueDataRaw.departments
-            .filter((d) => d.items.some((item) => selectedPONumbers.includes(item.poNumber))).length,
+            .filter((d) => d.items.some(matchesSelectedPO)).length,
         },
       }
     : queueDataRaw;

--- a/client/src/components/p2/P2ShippingTab.tsx
+++ b/client/src/components/p2/P2ShippingTab.tsx
@@ -407,13 +407,22 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
     poNumber: string,
     serialIds: string[],
     billingAssignments: { serializedItemId: string; allocationId: string }[] = [],
+    billingBucketOverrides: {
+      poItemId: number;
+      bucketLabel: string;
+      description?: string;
+      customerPoLine?: string;
+      quantityAuthorized?: number;
+      unitPrice?: number;
+      serialIds?: string[];
+    }[] = [],
   ) => {
     if (serialIds.length === 0) return;
     setCreatingShipmentFor(poNumber);
     try {
       const lot = await apiRequest('/api/p2/lots', {
         method: 'POST',
-        body: JSON.stringify({ serialIds, createdBy: 'shipping', billingAssignments }),
+        body: JSON.stringify({ serialIds, createdBy: 'shipping', billingAssignments, billingBucketOverrides }),
       });
       const slip = await apiRequest('/api/p2/packing-slips', {
         method: 'POST',
@@ -556,12 +565,12 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
       {summaryModalPO && (
         <ShipmentSummaryModal
           serials={summaryModalSerials}
-          onConfirm={(billingAssignments) => {
+          onConfirm={(billingAssignments, billingBucketOverrides) => {
             const po = summaryModalPO!;
             const ids = summaryModalSerials.map((s) => s.id);
             setSummaryModalPO(null);
             setSummaryModalSerials([]);
-            handleCreateShipment(po, ids, billingAssignments);
+            handleCreateShipment(po, ids, billingAssignments, billingBucketOverrides);
           }}
           onCancel={() => {
             setSummaryModalPO(null);

--- a/client/src/components/p2/P2ShippingTab.tsx
+++ b/client/src/components/p2/P2ShippingTab.tsx
@@ -50,6 +50,12 @@ type SerializedUnit = {
   partName: string;
   poNumber: string;
   poId: number;
+  rawPoNumber?: string;
+  rawPoId?: number;
+  displayPoNumber?: string;
+  displayPoId?: number;
+  currentRevisionPoNumber?: string;
+  currentRevisionPoId?: number;
   poItemId: number;
   customerName: string;
   customerId: string;
@@ -136,7 +142,12 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   });
 
   const shippingUnits = selectedPOIds.length > 0
-    ? shippingUnitsRaw.filter((u) => selectedPOIds.includes(u.poId))
+    ? shippingUnitsRaw.filter((u) =>
+      selectedPOIds.includes(u.poId) ||
+      (u.rawPoId !== undefined && selectedPOIds.includes(u.rawPoId)) ||
+      (u.displayPoId !== undefined && selectedPOIds.includes(u.displayPoId)) ||
+      (u.currentRevisionPoId !== undefined && selectedPOIds.includes(u.currentRevisionPoId))
+    )
     : shippingUnitsRaw;
 
   type ExistingShipmentRow = {
@@ -164,7 +175,10 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   const poIdToNumber = useMemo(() => {
     const map: Record<number, string> = {};
     for (const u of shippingUnits) {
-      if (u.poId && u.poNumber) map[u.poId] = u.poNumber;
+      const displayNumber = u.displayPoNumber || u.poNumber;
+      for (const poId of [u.poId, u.rawPoId, u.displayPoId, u.currentRevisionPoId]) {
+        if (poId && displayNumber) map[poId] = displayNumber;
+      }
     }
     return map;
   }, [shippingUnits]);
@@ -216,11 +230,11 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   const poGroups = useMemo(() => {
     const groups: Record<string, POGroup> = {};
     for (const unit of shippingUnits) {
-      const key = unit.poNumber;
+      const key = unit.displayPoNumber || unit.poNumber;
       if (!groups[key]) {
         groups[key] = {
-          poNumber: unit.poNumber,
-          poId: unit.poId,
+          poNumber: key,
+          poId: unit.displayPoId || unit.currentRevisionPoId || unit.poId,
           customerName: unit.customerName,
           units: [],
           totalUnits: 0,
@@ -259,7 +273,9 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
           (u) =>
             u.barcode.toLowerCase().includes(term) ||
             u.serialNumber.toLowerCase().includes(term) ||
-            u.partNumber.toLowerCase().includes(term)
+            u.partNumber.toLowerCase().includes(term) ||
+            (u.rawPoNumber ?? '').toLowerCase().includes(term) ||
+            (u.currentRevisionPoNumber ?? '').toLowerCase().includes(term)
         )
     );
   }, [poGroups, searchTerm]);
@@ -285,14 +301,17 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   // Auto-select and open modal when navigated here from the dashboard with a ?po= param
   useEffect(() => {
     if (!initialPO || autoTriggered.current || shippingUnits.length === 0) return;
+    const matchesInitialPO = (u: SerializedUnit) =>
+      [u.poNumber, u.rawPoNumber, u.displayPoNumber, u.currentRevisionPoNumber].some((po) => po === initialPO);
     const readyForPO = shippingUnits.filter(
-      (u) => u.poNumber === initialPO &&
+      (u) => matchesInitialPO(u) &&
              u.status === 'COMPLETED' &&
              !!(u.finalizedAt && u.sku && u.drawingName)
     );
     if (readyForPO.length === 0) return;
+    const displayPO = readyForPO[0]?.displayPoNumber || readyForPO[0]?.poNumber || initialPO;
     autoTriggered.current = true;
-    setExpandedPO(initialPO);
+    setExpandedPO(displayPO);
 
     // If specific unit IDs were passed via ?units=, pre-select only those; otherwise select all ready units
     const preselectedIds = initialUnits ? new Set(initialUnits.split(',').map((s) => s.trim()).filter(Boolean)) : null;
@@ -305,9 +324,9 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
       return;
     }
 
-    setSelectedSerials((prev) => ({ ...prev, [initialPO]: new Set(unitsToShip.map((u) => u.id)) }));
+    setSelectedSerials((prev) => ({ ...prev, [displayPO]: new Set(unitsToShip.map((u) => u.id)) }));
     setSummaryModalSerials(unitsToShip);
-    setSummaryModalPO(initialPO);
+    setSummaryModalPO(displayPO);
   }, [initialPO, initialUnits, shippingUnits]);
 
   const finalizeMutation = useMutation({

--- a/client/src/components/p2/ShipmentSummaryModal.tsx
+++ b/client/src/components/p2/ShipmentSummaryModal.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   Dialog,
   DialogContent,
@@ -12,8 +10,8 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { queryClient, apiRequest } from '@/lib/queryClient';
-import { Truck, Package, CalendarClock, Plus, DollarSign } from 'lucide-react';
+import { Truck, Package, CalendarClock, Receipt, Plus, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 type SerializedUnit = {
   id: string;
@@ -27,29 +25,20 @@ type SerializedUnit = {
   customerName: string;
 };
 
-type BillingAllocation = {
-  id: string;
-  po_item_id: number;
-  part_number: string;
-  bucket_label: string;
-  description: string | null;
-  customer_po_line: string | null;
-  quantity_authorized: number;
-  unit_price: string;
-  assigned_quantity: number;
-};
-
-type PoItem = {
-  id: number;
-  part_number: string;
-  part_name: string;
-  quantity: number;
-  unit_price: number | null;
-};
-
 interface ShipmentSummaryModalProps {
   serials: SerializedUnit[];
-  onConfirm: (assignments: { serializedItemId: string; allocationId: string }[]) => void;
+  onConfirm: (
+    assignments?: { serializedItemId: string; allocationId: string }[],
+    bucketOverrides?: {
+      poItemId: number;
+      bucketLabel: string;
+      description?: string;
+      customerPoLine?: string;
+      quantityAuthorized?: number;
+      unitPrice?: number;
+      serialIds?: string[];
+    }[],
+  ) => void;
   onCancel: () => void;
 }
 
@@ -60,96 +49,92 @@ export default function ShipmentSummaryModal({
 }: ShipmentSummaryModalProps) {
   const customer = serials[0]?.customerName ?? '-';
   const poNumber = serials[0]?.poNumber ?? '-';
-  const poId = serials[0]?.poId;
-  const [assignments, setAssignments] = useState<Record<string, string>>({});
-  const [newBucket, setNewBucket] = useState({
-    poItemId: serials[0]?.poItemId ? String(serials[0].poItemId) : '',
-    bucketLabel: '',
-    description: '',
-    customerPoLine: '',
-    quantityAuthorized: String(serials.length || 1),
-    unitPrice: '',
-    notes: '',
+  const [bucketOverrides, setBucketOverrides] = useState<Record<number, {
+    enabled: boolean;
+    bucketLabel: string;
+    description: string;
+    customerPoLine: string;
+    quantityAuthorized: string;
+    unitPrice: string;
+  }>>({});
+
+  const poItemGroups = useMemo(() => {
+    const groups = new Map<number, SerializedUnit[]>();
+    for (const serial of serials) {
+      const existing = groups.get(serial.poItemId) ?? [];
+      groups.set(serial.poItemId, [...existing, serial]);
+    }
+
+    return Array.from(groups.entries())
+      .map(([poItemId, units]) => ({
+        poItemId,
+        units: units.sort((a, b) => a.sequenceNumber - b.sequenceNumber),
+        partNumber: units[0]?.partNumber ?? '',
+        partName: units[0]?.partName ?? '',
+      }))
+      .sort((a, b) => a.poItemId - b.poItemId);
+  }, [serials]);
+  const enabledBucketOverrides = poItemGroups.flatMap((group) => {
+    const override = bucketOverrides[group.poItemId];
+    if (!override?.enabled || !override.bucketLabel.trim()) return [];
+    return [{
+      poItemId: group.poItemId,
+      bucketLabel: override.bucketLabel.trim(),
+      description: override.description.trim() || undefined,
+      customerPoLine: override.customerPoLine.trim() || undefined,
+      quantityAuthorized: Number(override.quantityAuthorized) || group.units.length,
+      unitPrice: Number(override.unitPrice) || 0,
+      serialIds: group.units.map((serial) => serial.id),
+    }];
   });
 
-  const { data: allocationData, isLoading: loadingAllocations } = useQuery<{ poItems: PoItem[]; allocations: BillingAllocation[] }>({
-    queryKey: ['/api/p2/billing-allocations', poId],
-    queryFn: async () => apiRequest(`/api/p2/billing-allocations?poId=${encodeURIComponent(String(poId))}`),
-    enabled: !!poId,
-  });
-
-  const poItems = allocationData?.poItems ?? [];
-  const allocations = allocationData?.allocations ?? [];
-
-  useEffect(() => {
-    if (!allocations.length || !serials.length) return;
-    setAssignments((current) => {
-      const next = { ...current };
-      const remainingByAllocation = new Map(
-        allocations.map((allocation) => [
-          allocation.id,
-          Math.max(0, Number(allocation.quantity_authorized) - Number(allocation.assigned_quantity || 0)),
-        ]),
-      );
-
-      for (const serial of [...serials].sort((a, b) => a.sequenceNumber - b.sequenceNumber)) {
-        if (next[serial.id]) continue;
-        const allocation = allocations.find((candidate) =>
-          candidate.po_item_id === serial.poItemId &&
-          (remainingByAllocation.get(candidate.id) ?? 0) > 0
-        );
-        if (!allocation) continue;
-        next[serial.id] = allocation.id;
-        remainingByAllocation.set(allocation.id, (remainingByAllocation.get(allocation.id) ?? 0) - 1);
+  const toggleBucketOverride = (group: (typeof poItemGroups)[number]) => {
+    setBucketOverrides((prev) => {
+      const current = prev[group.poItemId];
+      if (current?.enabled) {
+        return {
+          ...prev,
+          [group.poItemId]: { ...current, enabled: false },
+        };
       }
 
-      return next;
-    });
-  }, [allocations, serials]);
-
-  const createAllocationMutation = useMutation({
-    mutationFn: () => apiRequest('/api/p2/billing-allocations', {
-      method: 'POST',
-      body: {
-        poId,
-        poItemId: Number(newBucket.poItemId),
-        bucketLabel: newBucket.bucketLabel,
-        description: newBucket.description,
-        customerPoLine: newBucket.customerPoLine,
-        quantityAuthorized: Number(newBucket.quantityAuthorized),
-        unitPrice: Number(newBucket.unitPrice),
-        notes: newBucket.notes,
-      },
-    }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/p2/billing-allocations', poId] });
-      setNewBucket((prev) => ({
+      return {
         ...prev,
+        [group.poItemId]: {
+          enabled: true,
+          bucketLabel: current?.bucketLabel || `Pending revised PO item #${group.poItemId}`,
+          description: current?.description || group.partName,
+          customerPoLine: current?.customerPoLine || '',
+          quantityAuthorized: current?.quantityAuthorized || String(group.units.length),
+          unitPrice: current?.unitPrice || '',
+        },
+      };
+    });
+  };
+
+  const updateBucketOverride = (
+    poItemId: number,
+    field: keyof Omit<NonNullable<(typeof bucketOverrides)[number]>, 'enabled'>,
+    value: string,
+  ) => {
+    setBucketOverrides((prev) => ({
+      ...prev,
+      [poItemId]: {
+        enabled: true,
         bucketLabel: '',
         description: '',
         customerPoLine: '',
-        quantityAuthorized: '1',
+        quantityAuthorized: '',
         unitPrice: '',
-        notes: '',
-      }));
-    },
-  });
-
-  const grouped: Record<string, SerializedUnit[]> = {};
-  for (const serial of serials) {
-    if (!grouped[serial.partNumber]) grouped[serial.partNumber] = [];
-    grouped[serial.partNumber].push(serial);
-  }
-
-  const missingAssignments = serials.filter((serial) => !assignments[serial.id]);
-  const confirmAssignments = serials.map((serial) => ({
-    serializedItemId: serial.id,
-    allocationId: assignments[serial.id],
-  }));
+        ...prev[poItemId],
+        [field]: value,
+      },
+    }));
+  };
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onCancel(); }}>
-      <DialogContent className="max-w-4xl max-h-[86vh] flex flex-col">
+      <DialogContent className="max-w-3xl max-h-[84vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Truck className="h-5 w-5 text-blue-600" />
@@ -174,156 +159,96 @@ export default function ShipmentSummaryModal({
 
         <Separator />
 
-        <div className="overflow-y-auto flex-1 space-y-4 pr-1">
-          <div className="space-y-3">
-            <div className="flex items-center gap-2">
-              <DollarSign className="h-4 w-4 text-emerald-600" />
-              <div className="font-medium text-sm">Billing Bucket / CLIN Assignment</div>
-              {missingAssignments.length > 0 && (
-                <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-200">
-                  {missingAssignments.length} unassigned
-                </Badge>
-              )}
-            </div>
-
-            <div className="border rounded-md p-3 space-y-3">
-              <div className="grid grid-cols-6 gap-2">
-                <div className="space-y-1 col-span-2">
-                  <Label className="text-xs">PO Item</Label>
-                  <select
-                    className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-                    value={newBucket.poItemId}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, poItemId: e.target.value }))}
-                  >
-                    {poItems.map((item) => (
-                      <option key={item.id} value={String(item.id)}>
-                        {item.part_number} - {item.part_name}
-                      </option>
-                    ))}
-                  </select>
+        <div className="overflow-y-auto flex-1 space-y-3 pr-1">
+          {poItemGroups.map((group) => (
+            <div key={group.poItemId} className="border rounded-md p-3 space-y-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Receipt className="h-4 w-4 text-emerald-600 shrink-0" />
+                    <span className="text-xs text-muted-foreground">Bucket</span>
+                    <span className="font-mono text-sm font-semibold">PO Item #{group.poItemId}</span>
+                    <Badge variant="secondary" className="text-xs">
+                      {group.units.length} unit{group.units.length !== 1 ? 's' : ''}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                    <Package className="h-3.5 w-3.5 shrink-0" />
+                    <span className="font-mono text-foreground">{group.partNumber}</span>
+                    <span className="truncate">{group.partName}</span>
+                  </div>
                 </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">CLIN/Bucket</Label>
-                  <Input
-                    className="h-9"
-                    value={newBucket.bucketLabel}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, bucketLabel: e.target.value }))}
-                    placeholder="CLIN 0001"
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">Qty</Label>
-                  <Input
-                    className="h-9"
-                    type="number"
-                    min="1"
-                    value={newBucket.quantityAuthorized}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, quantityAuthorized: e.target.value }))}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">Unit Price</Label>
-                  <Input
-                    className="h-9"
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    value={newBucket.unitPrice}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, unitPrice: e.target.value }))}
-                    placeholder="0.00"
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs">PO Line Ref</Label>
-                  <Input
-                    className="h-9"
-                    value={newBucket.customerPoLine}
-                    onChange={(e) => setNewBucket((prev) => ({ ...prev, customerPoLine: e.target.value }))}
-                    placeholder="optional"
-                  />
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <Input
-                  className="h-9"
-                  value={newBucket.description}
-                  onChange={(e) => setNewBucket((prev) => ({ ...prev, description: e.target.value }))}
-                  placeholder="Bucket description or pricing note"
-                />
                 <Button
                   type="button"
                   variant="outline"
-                  disabled={!newBucket.poItemId || !newBucket.bucketLabel.trim() || !newBucket.unitPrice || createAllocationMutation.isPending}
-                  onClick={() => createAllocationMutation.mutate()}
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => toggleBucketOverride(group)}
                 >
-                  <Plus className="h-4 w-4 mr-2" />
-                  Add Bucket
+                  {bucketOverrides[group.poItemId]?.enabled ? (
+                    <><X className="h-3.5 w-3.5 mr-1" />Use PO Line</>
+                  ) : (
+                    <><Plus className="h-3.5 w-3.5 mr-1" />Add Bucket</>
+                  )}
                 </Button>
               </div>
-              {createAllocationMutation.isError && (
-                <p className="text-xs text-red-600">{(createAllocationMutation.error as any)?.message || 'Failed to add bucket'}</p>
-              )}
-            </div>
 
-            <div className="border rounded-md overflow-hidden">
-              <table className="w-full text-sm">
-                <thead className="bg-muted/50">
-                  <tr>
-                    <th className="text-left px-3 py-2 font-medium text-xs">Serial</th>
-                    <th className="text-left px-3 py-2 font-medium text-xs">Part</th>
-                    <th className="text-left px-3 py-2 font-medium text-xs">Billing Bucket</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {serials.map((serial) => {
-                    const matchingAllocations = allocations.filter((allocation) => allocation.po_item_id === serial.poItemId);
-                    return (
-                      <tr key={serial.id}>
-                        <td className="px-3 py-2 font-mono text-xs">{serial.serialNumber}</td>
-                        <td className="px-3 py-2 text-xs">
-                          <div className="font-mono">{serial.partNumber}</div>
-                          <div className="text-muted-foreground">{serial.partName}</div>
-                        </td>
-                        <td className="px-3 py-2">
-                          <select
-                            className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-                            value={assignments[serial.id] || ''}
-                            onChange={(e) => setAssignments((prev) => ({ ...prev, [serial.id]: e.target.value }))}
-                            disabled={loadingAllocations}
-                          >
-                            <option value="">Select bucket...</option>
-                            {matchingAllocations.map((allocation) => (
-                              <option key={allocation.id} value={allocation.id}>
-                                {allocation.bucket_label} - ${Number(allocation.unit_price).toFixed(2)}
-                                {' '}({allocation.assigned_quantity}/{allocation.quantity_authorized} assigned)
-                              </option>
-                            ))}
-                          </select>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          <Separator />
-
-          {Object.entries(grouped).map(([partNumber, group]) => (
-            <div key={partNumber} className="border rounded-md p-3 space-y-2">
-              <div className="flex items-start justify-between gap-2">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <Package className="h-4 w-4 text-muted-foreground shrink-0" />
-                    <span className="font-mono text-sm font-semibold">{partNumber}</span>
-                    <Badge variant="secondary" className="text-xs">{group.length} unit{group.length !== 1 ? 's' : ''}</Badge>
+              {bucketOverrides[group.poItemId]?.enabled && (
+                <div className="grid grid-cols-6 gap-2 rounded-md border bg-muted/20 p-3">
+                  <div className="space-y-1 col-span-2">
+                    <Label className="text-xs">Bucket</Label>
+                    <Input
+                      className="h-9"
+                      value={bucketOverrides[group.poItemId]?.bucketLabel || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'bucketLabel', e.target.value)}
+                      placeholder="Pending revised PO item"
+                    />
                   </div>
-                  <div className="text-xs text-muted-foreground mt-0.5 ml-6">{group[0].partName}</div>
+                  <div className="space-y-1 col-span-2">
+                    <Label className="text-xs">Description</Label>
+                    <Input
+                      className="h-9"
+                      value={bucketOverrides[group.poItemId]?.description || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'description', e.target.value)}
+                      placeholder={group.partName}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Qty</Label>
+                    <Input
+                      className="h-9"
+                      type="number"
+                      min="1"
+                      value={bucketOverrides[group.poItemId]?.quantityAuthorized || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'quantityAuthorized', e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Unit Price</Label>
+                    <Input
+                      className="h-9"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={bucketOverrides[group.poItemId]?.unitPrice || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'unitPrice', e.target.value)}
+                      placeholder="0.00"
+                    />
+                  </div>
+                  <div className="space-y-1 col-span-6">
+                    <Label className="text-xs">Revised PO Line Reference</Label>
+                    <Input
+                      className="h-9"
+                      value={bucketOverrides[group.poItemId]?.customerPoLine || ''}
+                      onChange={(e) => updateBucketOverride(group.poItemId, 'customerPoLine', e.target.value)}
+                      placeholder="optional"
+                    />
+                  </div>
                 </div>
-              </div>
-              <div className="ml-6 flex flex-wrap gap-1.5">
-                {group.map((serial) => (
+              )}
+
+              <div className="flex flex-wrap gap-1.5">
+                {group.units.map((serial) => (
                   <span
                     key={serial.id}
                     className="font-mono text-[11px] bg-muted px-1.5 py-0.5 rounded border"
@@ -340,7 +265,7 @@ export default function ShipmentSummaryModal({
 
         <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/30 rounded-md px-3 py-2">
           <CalendarClock className="h-3.5 w-3.5 shrink-0" />
-          Lot number will be generated upon confirmation (format: YYMMDD-XX)
+          Each unit will be assigned to its PO item line unless a pending revised-PO bucket is added.
         </div>
 
         <DialogFooter className="gap-2">
@@ -349,8 +274,8 @@ export default function ShipmentSummaryModal({
           </Button>
           <Button
             className="bg-blue-600 hover:bg-blue-700 text-white"
-            disabled={missingAssignments.length > 0}
-            onClick={() => onConfirm(confirmAssignments)}
+            disabled={serials.length === 0}
+            onClick={() => onConfirm([], enabledBucketOverrides)}
           >
             <Truck className="h-4 w-4 mr-2" />
             Confirm Shipment ({serials.length} unit{serials.length !== 1 ? 's' : ''})

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -179,7 +179,14 @@ export default function P2ControlCenter() {
     refetchInterval: 30000,
   });
 
-  const openPOs = allPOStatuses.filter((po) => po.status !== 'completed');
+  const openPOs = useMemo(
+    () => allPOStatuses.filter((po) => po.status !== 'completed'),
+    [allPOStatuses]
+  );
+  const poFilterOptions = useMemo(
+    () => activeTab === 'shipping' ? allPOStatuses : openPOs,
+    [activeTab, allPOStatuses, openPOs]
+  );
 
   useEffect(() => {
     if (selectedPOIds.length === 0) return;
@@ -617,7 +624,7 @@ export default function P2ControlCenter() {
       )}
 
       {/* PO Filter Bar */}
-      {openPOs.length > 1 && (
+      {poFilterOptions.length > 1 && (
         <div className="space-y-2">
           <div className="flex items-center gap-3 flex-wrap">
             <div className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
@@ -658,7 +665,7 @@ export default function P2ControlCenter() {
                   <div className="h-px bg-border my-1" />
 
                   {/* Individual PO options */}
-                  {openPOs.map((po) => {
+                  {poFilterOptions.map((po) => {
                     const isChecked = selectedPOIds.includes(po.id);
                     return (
                       <div
@@ -697,7 +704,7 @@ export default function P2ControlCenter() {
           {selectedPOIds.length > 0 && (
             <div className="flex items-center gap-2 flex-wrap">
               <span className="text-xs text-muted-foreground">Showing:</span>
-              {openPOs.filter((po) => selectedPOIds.includes(po.id)).map((po) => (
+              {poFilterOptions.filter((po) => selectedPOIds.includes(po.id)).map((po) => (
                 <Badge
                   key={po.id}
                   variant="secondary"

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -5119,6 +5119,37 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         ...legacyProductionRows.map((row: any) => row.poId).filter(Boolean),
         ...legacyProjectProductionRows.map((row: any) => row.poId).filter(Boolean),
       ])];
+      const poFamilyRows = poIds.length > 0
+        ? await optionalP2Rows(
+          'PO revision family display',
+          dbPool.query(
+            `SELECT
+               po.id AS "poId",
+               COALESCE(root.id, po.id) AS "displayPoId",
+               COALESCE(root.po_number, po.po_number) AS "displayPoNumber",
+               COALESCE(current_po.id, po.id) AS "currentRevisionPoId",
+               COALESCE(current_po.po_number, po.po_number) AS "currentRevisionPoNumber"
+             FROM p2_purchase_orders po
+             LEFT JOIN p2_purchase_orders root ON root.id = po.parent_po_id
+             LEFT JOIN LATERAL (
+               SELECT family.id, family.po_number
+               FROM p2_purchase_orders family
+               WHERE COALESCE(family.parent_po_id, family.id) = COALESCE(po.parent_po_id, po.id)
+               ORDER BY family.is_current_revision DESC, family.revision_number DESC, family.id DESC
+               LIMIT 1
+             ) current_po ON true
+             WHERE po.id = ANY($1::int[])`,
+            [poIds]
+          )
+        )
+        : [];
+      const poFamilyByPoId = new Map<number, any>(
+        poFamilyRows.map((row: any) => [Number(row.poId), row])
+      );
+      const getProductionDisplayPoNumber = (poId: number | null, rawPoNumber: string | null | undefined) => {
+        if (!poId) return rawPoNumber;
+        return poFamilyByPoId.get(Number(poId))?.displayPoNumber || rawPoNumber;
+      };
       const projectRows = poIds.length > 0
         ? await optionalP2Rows(
             'project link',
@@ -5353,7 +5384,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           serialNumber: item.serialNumber,
           partNumber: item.partNumber,
           partName: item.partName,
-          poNumber: item.poNumber,
+          poNumber: getProductionDisplayPoNumber(Number(poId), item.poNumber),
+          rawPoNumber: item.poNumber,
           customerName: item.customerName,
           status: item.status,
           currentDepartment: dept,
@@ -5419,7 +5451,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           serialNumber: row.orderId,
           partNumber: row.partNumber || row.orderId,
           partName: row.partName || row.department || '',
-          poNumber: row.poNumber,
+          poNumber: getProductionDisplayPoNumber(Number(poId), row.poNumber),
+          rawPoNumber: row.poNumber,
           customerName: row.customerName || 'Unknown',
           status: displayStatus,
           currentDepartment: dept,
@@ -5479,7 +5512,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           serialNumber: row.activeTravelerNumber || row.workOrderNumber,
           partNumber: row.partNumber || row.workOrderNumber,
           partName: row.description || 'Legacy project work order',
-          poNumber: row.poNumber,
+          poNumber: getProductionDisplayPoNumber(Number(poId), row.poNumber),
+          rawPoNumber: row.poNumber,
           customerName: row.customerName || 'Unknown',
           status: isComplete ? 'COMPLETED' : 'ACTIVE',
           currentDepartment: dept,

--- a/server/src/routes/p2SerializedItems.ts
+++ b/server/src/routes/p2SerializedItems.ts
@@ -8,6 +8,14 @@ const router = Router();
 
 const FINALIZATION_DEPARTMENTS = ['Final QC', 'Shipping QC', 'Shipping', 'COMPLETED'];
 
+type P2PoFamilyDisplay = {
+  po_id: number;
+  display_po_id: number;
+  display_po_number: string;
+  current_po_id: number;
+  current_po_number: string;
+};
+
 router.get('/', async (req, res) => {
   try {
     const poItemIdRaw = req.query.poItemId;
@@ -75,7 +83,43 @@ router.get('/shipping-queue', async (req, res) => {
     // Exclude any serial already in a lot — prevents re-shipment
     const unshipped = units.filter((u) => !shippedIds.has(u.id));
 
-    res.json(unshipped);
+    const poIds = Array.from(new Set(unshipped.map((u) => u.poId).filter(Boolean)));
+    const familyRows = poIds.length > 0
+      ? await pool.query<P2PoFamilyDisplay>(
+        `SELECT
+           po.id AS po_id,
+           COALESCE(root.id, po.id) AS display_po_id,
+           COALESCE(root.po_number, po.po_number) AS display_po_number,
+           COALESCE(current_po.id, po.id) AS current_po_id,
+           COALESCE(current_po.po_number, po.po_number) AS current_po_number
+         FROM p2_purchase_orders po
+         LEFT JOIN p2_purchase_orders root ON root.id = po.parent_po_id
+         LEFT JOIN LATERAL (
+           SELECT family.id, family.po_number
+             FROM p2_purchase_orders family
+            WHERE COALESCE(family.parent_po_id, family.id) = COALESCE(po.parent_po_id, po.id)
+            ORDER BY family.is_current_revision DESC, family.revision_number DESC, family.id DESC
+            LIMIT 1
+         ) current_po ON true
+         WHERE po.id = ANY($1::int[])`,
+        [poIds],
+      )
+      : [];
+    const familyByPoId = new Map(familyRows.map((row) => [Number(row.po_id), row]));
+
+    res.json(unshipped.map((unit) => {
+      const family = familyByPoId.get(Number(unit.poId));
+      return {
+        ...unit,
+        rawPoNumber: unit.poNumber,
+        rawPoId: unit.poId,
+        displayPoNumber: family?.display_po_number ?? unit.poNumber,
+        displayPoId: family?.display_po_id ?? unit.poId,
+        currentRevisionPoNumber: family?.current_po_number ?? unit.poNumber,
+        currentRevisionPoId: family?.current_po_id ?? unit.poId,
+        poNumber: family?.display_po_number ?? unit.poNumber,
+      };
+    }));
   } catch (err: any) {
     res.status(500).json({ error: err?.message || 'Failed to fetch shipping queue' });
   }

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -899,6 +899,30 @@ router.post('/billing-allocations', authenticateToken, requirePermission('shippi
 
 type BillingBucketOverride = NonNullable<z.infer<typeof createLotSchema>['billingBucketOverrides']>[number];
 
+type P2PoFamilyRow = {
+  id: number;
+  po_number: string;
+  family_po_id: number;
+};
+
+async function assertSerialsSharePoFamily(serials: any[]): Promise<void> {
+  const poIds = Array.from(new Set(serials.map((serial) => Number(serial.poId)).filter(Number.isFinite)));
+  if (poIds.length <= 1) return;
+
+  const rows = await pool.query<P2PoFamilyRow>(
+    `SELECT id, po_number, COALESCE(parent_po_id, id) AS family_po_id
+       FROM p2_purchase_orders
+      WHERE id = ANY($1::int[])`,
+    [poIds],
+  );
+  const familyIds = Array.from(new Set(rows.map((row) => Number(row.family_po_id))));
+  if (familyIds.length > 1 || rows.length !== poIds.length) {
+    throw new Error(`All serials must belong to the same PO project. Found: ${
+      Array.from(new Set(serials.map((serial) => serial.poNumber))).join(', ')
+    }`);
+  }
+}
+
 async function assignSerialsToPoItemBuckets(
   serials: any[],
   actor: string,
@@ -1041,11 +1065,12 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
       });
     }
 
-    const poNumbers = Array.from(new Set(serials.map((s) => s.poNumber)));
-    if (poNumbers.length > 1) {
+    try {
+      await assertSerialsSharePoFamily(serials);
+    } catch (familyErr: any) {
       return res.status(400).json({
-        error: 'All serials must belong to the same PO',
-        found: poNumbers,
+        error: familyErr?.message || 'All serials must belong to the same PO project',
+        found: Array.from(new Set(serials.map((s) => s.poNumber))),
       });
     }
 

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -604,6 +604,15 @@ const createLotSchema = z.object({
     serializedItemId: z.string().uuid(),
     allocationId: z.string().uuid(),
   })).optional(),
+  billingBucketOverrides: z.array(z.object({
+    poItemId: z.coerce.number().int().positive(),
+    bucketLabel: z.string().trim().min(1, 'Bucket label is required'),
+    description: z.string().trim().optional(),
+    customerPoLine: z.string().trim().optional(),
+    quantityAuthorized: z.coerce.number().int().positive().optional(),
+    unitPrice: z.coerce.number().min(0).optional(),
+    serialIds: z.array(z.string().uuid()).optional(),
+  })).optional(),
 });
 
 const voidShipmentSchema = z.object({
@@ -888,6 +897,126 @@ router.post('/billing-allocations', authenticateToken, requirePermission('shippi
   }
 });
 
+type BillingBucketOverride = NonNullable<z.infer<typeof createLotSchema>['billingBucketOverrides']>[number];
+
+async function assignSerialsToPoItemBuckets(
+  serials: any[],
+  actor: string,
+  bucketOverrides: BillingBucketOverride[] = [],
+): Promise<void> {
+  const serialsByPoItemId = new Map<number, any[]>();
+  for (const serial of serials) {
+    const poItemId = Number(serial.poItemId);
+    if (!Number.isFinite(poItemId)) {
+      throw new Error(`Serial ${serial.serialNumber} is missing a PO item line`);
+    }
+    const existing = serialsByPoItemId.get(poItemId) ?? [];
+    serialsByPoItemId.set(poItemId, [...existing, serial]);
+  }
+
+  const overrideByPoItemId = new Map(bucketOverrides.map((override) => [override.poItemId, override]));
+
+  for (const [poItemId, group] of serialsByPoItemId.entries()) {
+    const first = group[0];
+    const override = overrideByPoItemId.get(poItemId);
+    const poItemResult = await pool.query<{
+      id: number;
+      po_id: number;
+      part_number: string;
+      part_name: string | null;
+      quantity: number | null;
+      unit_price: string | number | null;
+    }>(
+      `SELECT id, po_id, part_number, part_name, quantity, unit_price
+         FROM p2_purchase_order_items
+        WHERE id = $1 AND po_id = $2`,
+      [poItemId, first.poId],
+    );
+    const poItem = poItemResult.rows[0];
+    if (!poItem) {
+      throw new Error(`PO item ${poItemId} was not found for PO ${first.poNumber}`);
+    }
+
+    const authorizedQuantity = Math.max(Number(override?.quantityAuthorized) || 0, Number(poItem.quantity) || 0, group.length);
+    const unitPrice = Number(override?.unitPrice ?? poItem.unit_price) || 0;
+    const bucketLabel = override?.bucketLabel || `PO Item #${poItem.id}`;
+    const description = override?.description || poItem.part_name || first.partName || null;
+    const customerPoLine = override?.customerPoLine || String(poItem.id);
+
+    const existingAllocationResult = await pool.query<{ id: string }>(
+      `SELECT id
+         FROM p2_billing_allocations
+        WHERE po_id = $1
+          AND po_item_id = $2
+          AND bucket_label = $3
+          AND active = true
+        ORDER BY created_at
+        LIMIT 1`,
+      [poItem.po_id, poItem.id, bucketLabel],
+    );
+
+    let allocationId = existingAllocationResult.rows[0]?.id;
+    if (allocationId) {
+      await pool.query(
+        `UPDATE p2_billing_allocations
+            SET bucket_label = $1,
+                description = COALESCE(description, $2),
+                customer_po_line = COALESCE(customer_po_line, $6),
+                quantity_authorized = GREATEST(quantity_authorized, $3),
+                unit_price = $4,
+                updated_at = now()
+          WHERE id = $5`,
+        [bucketLabel, description, authorizedQuantity, unitPrice.toFixed(2), allocationId, customerPoLine],
+      );
+    } else {
+      const createdAllocationResult = await pool.query<{ id: string }>(
+        `INSERT INTO p2_billing_allocations (
+           po_id, po_item_id, po_number, part_number, bucket_label, description,
+           customer_po_line, quantity_authorized, unit_price, notes, created_by
+         )
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+         RETURNING id`,
+        [
+          poItem.po_id,
+          poItem.id,
+          first.poNumber,
+          poItem.part_number || first.partNumber,
+          bucketLabel,
+          description,
+          customerPoLine,
+          authorizedQuantity,
+          unitPrice.toFixed(2),
+          override
+            ? 'Pending revised PO bucket created during shipment creation'
+            : 'Auto-created from PO item line during shipment creation',
+          actor,
+        ],
+      );
+      allocationId = createdAllocationResult.rows[0].id;
+    }
+
+    for (const serial of group) {
+      await pool.query(
+        `INSERT INTO p2_serial_billing_assignments (
+           allocation_id, serialized_item_id, po_id, po_item_id, assigned_by, assignment_source
+         )
+         VALUES ($1,$2,$3,$4,$5,'po_item_shipment_create')
+         ON CONFLICT (serialized_item_id)
+         DO UPDATE SET
+           allocation_id = EXCLUDED.allocation_id,
+           po_id = EXCLUDED.po_id,
+           po_item_id = EXCLUDED.po_item_id,
+           assigned_at = now(),
+           assigned_by = EXCLUDED.assigned_by,
+           assignment_source = EXCLUDED.assignment_source,
+           updated_at = now()
+         WHERE p2_serial_billing_assignments.locked_at IS NULL`,
+        [allocationId, serial.id, serial.poId, serial.poItemId, actor],
+      );
+    }
+  }
+}
+
 router.post('/lots', authenticateToken, requirePermission('shipping.release_shipment'), async (req: Request, res: Response) => {
   try {
     await ensureP2BillingAllocationSchema();
@@ -925,6 +1054,9 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
     const incomingAssignmentBySerialId = new Map(
       incomingAssignments.map((assignment) => [assignment.serializedItemId, assignment.allocationId]),
     );
+    if (incomingAssignments.length === 0) {
+      await assignSerialsToPoItemBuckets(serials, actor, input.billingBucketOverrides ?? []);
+    }
     if (incomingAssignments.length > 0) {
       const missingIncoming = input.serialIds.filter((serialId) => !incomingAssignmentBySerialId.has(serialId));
       const outsideShipment = incomingAssignments.filter((assignment) => !selectedSerialIdSet.has(assignment.serializedItemId));


### PR DESCRIPTION
## Summary
- group P2 shipping queue rows by the PO revision family display number so revised POs do not appear as separate shipping projects
- allow shipment creation across original/revised serial rows when they share the same PO revision root
- keep production queue display aligned to the project/root PO while preserving raw PO numbers for filters and operational records

## Root Cause
The shipping tab grouped serialized units directly by each unit's raw `poNumber`, so `PO014332` and `PO014332-RA` rendered as separate shipping cards even though they belong to the same project/revision family. Lot creation also compared raw PO numbers, which could reject same-project serial selections after a PO revision.

## Validation
- `git diff --check`
- `git diff --cached --check`
- bundled Node `--experimental-strip-types --check` on `server/src/routes/p2SerializedItems.ts`
- bundled Node `--experimental-strip-types --check` on `server/src/routes/p2Shipping.ts`
- bundled Node `--experimental-strip-types --check` on `server/src/routes/index.ts`