### PR TITLE
[codex] Fix P2 revision family shipping display

### DIFF
--- a/client/src/components/p2/P2ProductionQueue.tsx
+++ b/client/src/components/p2/P2ProductionQueue.tsx
@@ -75,6 +75,7 @@ interface QueueItem {
   partNumber: string;
   partName: string;
   poNumber: string;
+  rawPoNumber?: string;
   customerName: string;
   status: string;
   currentDepartment: string;
@@ -209,24 +210,28 @@ export default function P2ProductionQueue({ selectedPONumbers = [] }: P2Producti
     refetchInterval: 10000,
   });
 
+  const matchesSelectedPO = (item: QueueItem) =>
+    selectedPONumbers.includes(item.poNumber) ||
+    (item.rawPoNumber ? selectedPONumbers.includes(item.rawPoNumber) : false);
+
   const queueData: ProductionQueueData | undefined = queueDataRaw && selectedPONumbers.length > 0
     ? {
         departments: queueDataRaw.departments.map((dept) => ({
           ...dept,
-          items: dept.items.filter((item) => selectedPONumbers.includes(item.poNumber)),
-          totalItems: dept.items.filter((item) => selectedPONumbers.includes(item.poNumber)).length,
-          inProgress: dept.items.filter((item) => selectedPONumbers.includes(item.poNumber) && item.hasActiveTask).length,
-          waiting: dept.items.filter((item) => selectedPONumbers.includes(item.poNumber) && !item.hasActiveTask).length,
+          items: dept.items.filter(matchesSelectedPO),
+          totalItems: dept.items.filter(matchesSelectedPO).length,
+          inProgress: dept.items.filter((item) => matchesSelectedPO(item) && item.hasActiveTask).length,
+          waiting: dept.items.filter((item) => matchesSelectedPO(item) && !item.hasActiveTask).length,
         })).filter((dept) => dept.items.length > 0),
         summary: {
           totalActive: queueDataRaw.departments
             .flatMap((d) => d.items)
-            .filter((item) => selectedPONumbers.includes(item.poNumber)).length,
+            .filter(matchesSelectedPO).length,
           totalInProgress: queueDataRaw.departments
             .flatMap((d) => d.items)
-            .filter((item) => selectedPONumbers.includes(item.poNumber) && item.hasActiveTask).length,
+            .filter((item) => matchesSelectedPO(item) && item.hasActiveTask).length,
           departmentCount: queueDataRaw.departments
-            .filter((d) => d.items.some((item) => selectedPONumbers.includes(item.poNumber))).length,
+            .filter((d) => d.items.some(matchesSelectedPO)).length,
         },
       }
     : queueDataRaw;

--- a/client/src/components/p2/P2ShippingTab.tsx
+++ b/client/src/components/p2/P2ShippingTab.tsx
@@ -50,6 +50,12 @@ type SerializedUnit = {
   partName: string;
   poNumber: string;
   poId: number;
+  rawPoNumber?: string;
+  rawPoId?: number;
+  displayPoNumber?: string;
+  displayPoId?: number;
+  currentRevisionPoNumber?: string;
+  currentRevisionPoId?: number;
   poItemId: number;
   customerName: string;
   customerId: string;
@@ -163,7 +169,13 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   });
 
   const shippingUnits = selectedPOIds.length > 0
-    ? shippingUnitsRaw.filter((u) => selectedPOIds.includes(u.projectPoId ?? u.poId) || selectedPOIds.includes(u.poId))
+    ? shippingUnitsRaw.filter((u) =>
+      selectedPOIds.includes(u.poId) ||
+      (u.projectPoId !== undefined && u.projectPoId !== null && selectedPOIds.includes(u.projectPoId)) ||
+      (u.rawPoId !== undefined && selectedPOIds.includes(u.rawPoId)) ||
+      (u.displayPoId !== undefined && selectedPOIds.includes(u.displayPoId)) ||
+      (u.currentRevisionPoId !== undefined && selectedPOIds.includes(u.currentRevisionPoId))
+    )
     : shippingUnitsRaw;
 
   const buildShipmentPoContext = (
@@ -208,13 +220,12 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   const shipmentPoIdToGroupKeys = useMemo(() => {
     const map: Record<number, Set<string>> = {};
     for (const u of shippingUnits) {
-      if (u.poId && u.poNumber) {
-        map[u.poId] = map[u.poId] ?? new Set<string>();
-        map[u.poId].add(u.poNumber);
-      }
-      if (u.projectPoId && u.poNumber) {
-        map[u.projectPoId] = map[u.projectPoId] ?? new Set<string>();
-        map[u.projectPoId].add(u.poNumber);
+      const displayNumber = u.displayPoNumber || u.poNumber;
+      for (const poId of [u.poId, u.projectPoId, u.rawPoId, u.displayPoId, u.currentRevisionPoId]) {
+        if (poId && displayNumber) {
+          map[poId] = map[poId] ?? new Set<string>();
+          map[poId].add(displayNumber);
+        }
       }
     }
     return map;
@@ -273,11 +284,11 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   const poGroups = useMemo(() => {
     const groups: Record<string, POGroup> = {};
     for (const unit of shippingUnits) {
-      const key = unit.poNumber;
+      const key = unit.displayPoNumber || unit.poNumber;
       if (!groups[key]) {
         groups[key] = {
-          poNumber: unit.poNumber,
-          poId: unit.poId,
+          poNumber: key,
+          poId: unit.displayPoId || unit.currentRevisionPoId || unit.projectPoId || unit.poId,
           shipmentPoId: unit.projectPoId ?? unit.poId,
           shipmentPoNumber: unit.projectPoNumber ?? unit.poNumber,
           shipmentPoItemId: unit.projectPoItemId ?? null,
@@ -322,7 +333,9 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
           (u) =>
             u.barcode.toLowerCase().includes(term) ||
             u.serialNumber.toLowerCase().includes(term) ||
-            u.partNumber.toLowerCase().includes(term)
+            u.partNumber.toLowerCase().includes(term) ||
+            (u.rawPoNumber ?? '').toLowerCase().includes(term) ||
+            (u.currentRevisionPoNumber ?? '').toLowerCase().includes(term)
         )
     );
   }, [poGroups, searchTerm]);
@@ -348,14 +361,17 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   // Auto-select and open modal when navigated here from the dashboard with a ?po= param
   useEffect(() => {
     if (!initialPO || autoTriggered.current || shippingUnits.length === 0) return;
+    const matchesInitialPO = (u: SerializedUnit) =>
+      [u.poNumber, u.projectPoNumber, u.rawPoNumber, u.displayPoNumber, u.currentRevisionPoNumber].some((po) => po === initialPO);
     const readyForPO = shippingUnits.filter(
-      (u) => (u.poNumber === initialPO || u.projectPoNumber === initialPO) &&
+      (u) => matchesInitialPO(u) &&
              u.status === 'COMPLETED' &&
              !!(u.finalizedAt && u.sku && u.drawingName)
     );
     if (readyForPO.length === 0) return;
+    const displayPO = readyForPO[0]?.displayPoNumber || readyForPO[0]?.poNumber || initialPO;
     autoTriggered.current = true;
-    setExpandedPO(initialPO);
+    setExpandedPO(displayPO);
 
     // If specific unit IDs were passed via ?units=, pre-select only those; otherwise select all ready units
     const preselectedIds = initialUnits ? new Set(initialUnits.split(',').map((s) => s.trim()).filter(Boolean)) : null;
@@ -368,10 +384,10 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
       return;
     }
 
-    setSelectedSerials((prev) => ({ ...prev, [initialPO]: new Set(unitsToShip.map((u) => u.id)) }));
+    setSelectedSerials((prev) => ({ ...prev, [displayPO]: new Set(unitsToShip.map((u) => u.id)) }));
     setSummaryModalSerials(unitsToShip);
-    setSummaryModalPoContext(buildShipmentPoContext(unitsToShip, initialPO));
-    setSummaryModalPO(initialPO);
+    setSummaryModalPoContext(buildShipmentPoContext(unitsToShip, displayPO));
+    setSummaryModalPO(displayPO);
   }, [initialPO, initialUnits, shippingUnits]);
 
   const finalizeMutation = useMutation({

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -5437,6 +5437,37 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         ...legacyProductionRows.map((row: any) => row.poId).filter(Boolean),
         ...legacyProjectProductionRows.map((row: any) => row.poId).filter(Boolean),
       ])];
+      const poFamilyRows = poIds.length > 0
+        ? await optionalP2Rows(
+          'PO revision family display',
+          dbPool.query(
+            `SELECT
+               po.id AS "poId",
+               COALESCE(root.id, po.id) AS "displayPoId",
+               COALESCE(root.po_number, po.po_number) AS "displayPoNumber",
+               COALESCE(current_po.id, po.id) AS "currentRevisionPoId",
+               COALESCE(current_po.po_number, po.po_number) AS "currentRevisionPoNumber"
+             FROM p2_purchase_orders po
+             LEFT JOIN p2_purchase_orders root ON root.id = po.parent_po_id
+             LEFT JOIN LATERAL (
+               SELECT family.id, family.po_number
+               FROM p2_purchase_orders family
+               WHERE COALESCE(family.parent_po_id, family.id) = COALESCE(po.parent_po_id, po.id)
+               ORDER BY family.is_current_revision DESC, family.revision_number DESC, family.id DESC
+               LIMIT 1
+             ) current_po ON true
+             WHERE po.id = ANY($1::int[])`,
+            [poIds]
+          )
+        )
+        : [];
+      const poFamilyByPoId = new Map<number, any>(
+        poFamilyRows.map((row: any) => [Number(row.poId), row])
+      );
+      const getProductionDisplayPoNumber = (poId: number | null, rawPoNumber: string | null | undefined) => {
+        if (!poId) return rawPoNumber;
+        return poFamilyByPoId.get(Number(poId))?.displayPoNumber || rawPoNumber;
+      };
       const projectRows = poIds.length > 0
         ? await optionalP2Rows(
             'project link',
@@ -5671,7 +5702,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           serialNumber: item.serialNumber,
           partNumber: item.partNumber,
           partName: item.partName,
-          poNumber: item.poNumber,
+          poNumber: getProductionDisplayPoNumber(Number(poId), item.poNumber),
+          rawPoNumber: item.poNumber,
           customerName: item.customerName,
           status: item.status,
           currentDepartment: dept,
@@ -5737,7 +5769,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           serialNumber: row.orderId,
           partNumber: row.partNumber || row.orderId,
           partName: row.partName || row.department || '',
-          poNumber: row.poNumber,
+          poNumber: getProductionDisplayPoNumber(Number(poId), row.poNumber),
+          rawPoNumber: row.poNumber,
           customerName: row.customerName || 'Unknown',
           status: displayStatus,
           currentDepartment: dept,
@@ -5797,7 +5830,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           serialNumber: row.activeTravelerNumber || row.workOrderNumber,
           partNumber: row.partNumber || row.workOrderNumber,
           partName: row.description || 'Legacy project work order',
-          poNumber: row.poNumber,
+          poNumber: getProductionDisplayPoNumber(Number(poId), row.poNumber),
+          rawPoNumber: row.poNumber,
           customerName: row.customerName || 'Unknown',
           status: isComplete ? 'COMPLETED' : 'ACTIVE',
           currentDepartment: dept,

--- a/server/src/routes/p2SerializedItems.ts
+++ b/server/src/routes/p2SerializedItems.ts
@@ -8,6 +8,14 @@ const router = Router();
 
 const FINALIZATION_DEPARTMENTS = ['Final QC', 'Shipping QC', 'Shipping', 'COMPLETED'];
 
+type P2PoFamilyDisplay = {
+  po_id: number;
+  display_po_id: number;
+  display_po_number: string;
+  current_po_id: number;
+  current_po_number: string;
+};
+
 router.get('/', async (req, res) => {
   try {
     const poItemIdRaw = req.query.poItemId;
@@ -128,10 +136,44 @@ router.get('/shipping-queue', async (req, res) => {
       }
     }
 
-    res.json(unshipped.map((unit) => ({
-      ...unit,
-      ...(projectPoContextBySourcePoId.get(unit.poId) ?? {}),
-    })));
+    const familyRows = sourcePoIds.length > 0
+      ? await pool.query<P2PoFamilyDisplay>(
+        `SELECT
+           po.id AS po_id,
+           COALESCE(root.id, po.id) AS display_po_id,
+           COALESCE(root.po_number, po.po_number) AS display_po_number,
+           COALESCE(current_po.id, po.id) AS current_po_id,
+           COALESCE(current_po.po_number, po.po_number) AS current_po_number
+         FROM p2_purchase_orders po
+         LEFT JOIN p2_purchase_orders root ON root.id = po.parent_po_id
+         LEFT JOIN LATERAL (
+           SELECT family.id, family.po_number
+             FROM p2_purchase_orders family
+            WHERE COALESCE(family.parent_po_id, family.id) = COALESCE(po.parent_po_id, po.id)
+            ORDER BY family.is_current_revision DESC, family.revision_number DESC, family.id DESC
+            LIMIT 1
+         ) current_po ON true
+         WHERE po.id = ANY($1::int[])`,
+        [sourcePoIds],
+      )
+      : [];
+    const familyByPoId = new Map(familyRows.map((row) => [Number(row.po_id), row]));
+
+    res.json(unshipped.map((unit) => {
+      const family = familyByPoId.get(Number(unit.poId));
+      const projectContext = projectPoContextBySourcePoId.get(unit.poId) ?? {};
+      return {
+        ...unit,
+        ...projectContext,
+        rawPoNumber: unit.poNumber,
+        rawPoId: unit.poId,
+        displayPoNumber: family?.display_po_number ?? unit.poNumber,
+        displayPoId: family?.display_po_id ?? unit.poId,
+        currentRevisionPoNumber: family?.current_po_number ?? unit.poNumber,
+        currentRevisionPoId: family?.current_po_id ?? unit.poId,
+        poNumber: family?.display_po_number ?? unit.poNumber,
+      };
+    }));
   } catch (err: any) {
     res.status(500).json({ error: err?.message || 'Failed to fetch shipping queue' });
   }

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -1114,6 +1114,30 @@ async function assignSerialBillingBucket(params: {
   );
 }
 
+type P2PoFamilyRow = {
+  id: number;
+  po_number: string;
+  family_po_id: number;
+};
+
+async function assertSerialsSharePoFamily(serials: any[]): Promise<void> {
+  const poIds = Array.from(new Set(serials.map((serial) => Number(serial.poId)).filter(Number.isFinite)));
+  if (poIds.length <= 1) return;
+
+  const rows = await pool.query<P2PoFamilyRow>(
+    `SELECT id, po_number, COALESCE(parent_po_id, id) AS family_po_id
+       FROM p2_purchase_orders
+      WHERE id = ANY($1::int[])`,
+    [poIds],
+  );
+  const familyIds = Array.from(new Set(rows.map((row) => Number(row.family_po_id))));
+  if (familyIds.length > 1 || rows.length !== poIds.length) {
+    throw new Error(`All serials must belong to the same PO project. Found: ${
+      Array.from(new Set(serials.map((serial) => serial.poNumber))).join(', ')
+    }`);
+  }
+}
+
 async function assignSerialsToPoItemBuckets(
   serials: any[],
   actor: string,
@@ -1271,11 +1295,12 @@ router.post('/lots', authenticateToken, requirePermission('shipping.release_ship
       });
     }
 
-    const poNumbers = Array.from(new Set(serials.map((s) => s.poNumber)));
-    if (poNumbers.length > 1) {
+    try {
+      await assertSerialsSharePoFamily(serials);
+    } catch (familyErr: any) {
       return res.status(400).json({
-        error: 'All serials must belong to the same PO',
-        found: poNumbers,
+        error: familyErr?.message || 'All serials must belong to the same PO project',
+        found: Array.from(new Set(serials.map((s) => s.poNumber))),
       });
     }
 


### PR DESCRIPTION
## Summary
- group P2 shipping queue rows by the PO revision family display number so revised POs do not appear as separate shipping projects
- allow shipment creation across original/revised serial rows when they share the same PO revision root
- keep production queue display aligned to the project/root PO while preserving raw PO numbers for filters and operational records

## Root Cause
The shipping tab grouped serialized units directly by each unit's raw `poNumber`, so `PO014332` and `PO014332-RA` rendered as separate shipping cards even though they belong to the same project/revision family. Lot creation also compared raw PO numbers, which could reject same-project serial selections after a PO revision.

## Validation
- `git diff --check origin/main..HEAD`
- `git diff --cached --check`
- bundled Node `--experimental-strip-types --check` on `server/src/routes/p2SerializedItems.ts`
- bundled Node `--experimental-strip-types --check` on `server/src/routes/p2Shipping.ts`
- bundled Node `--experimental-strip-types --check` on `server/src/routes/index.ts`