### PR TITLE
[codex] Keep P2 packet demand visible after serial allocation fix

### DIFF
--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -2439,11 +2439,16 @@ router.get('/weekly-cutting-queue', async (req, res) => {
               po.quantity as "originalQuantity",
               COALESCE(p2_units.serialized_count, 0) as "serializedQuantity",
               COALESCE(committed_packets.committed_count, 0) as "committedQuantity",
-              GREATEST(
-                COALESCE(NULLIF(p2_units.serialized_count, 0), po.quantity)
-                  - COALESCE(committed_packets.committed_count, 0),
-                0
-              ) as "openQuantity"
+              CASE
+                WHEN COALESCE(committed_packets.committed_count, 0) > 0
+                  AND COALESCE(NULLIF(p2_units.serialized_count, 0), po.quantity) > COALESCE(committed_packets.committed_count, 0)
+                THEN GREATEST(
+                  COALESCE(NULLIF(p2_units.serialized_count, 0), po.quantity)
+                    - COALESCE(committed_packets.committed_count, 0),
+                  0
+                )
+                ELSE po.quantity
+              END as "openQuantity"
             FROM p2_production_orders po
             LEFT JOIN p2_purchase_orders p2 ON po.p2_po_id = p2.id
             LEFT JOIN inventory_items inv ON (
@@ -2509,12 +2514,7 @@ router.get('/weekly-cutting-queue', async (req, res) => {
                 OR LOWER(po.part_name) LIKE '%packet%'
                 OR LOWER(po.sku) LIKE '%packet%'
                 OR po.sku IN ('P706', 'P707')
-              )
-              AND GREATEST(
-                COALESCE(NULLIF(p2_units.serialized_count, 0), po.quantity)
-                  - COALESCE(committed_packets.committed_count, 0),
-                0
-              ) > 0`;
+              )`;
       
       const p2Result = showAll === 'true'
         ? await pool.query(p2Query + `


### PR DESCRIPTION
## Summary
- keep P2 packet-demand rows visible when committed-packet allocation counts are broad
- preserve committed/open quantity diagnostics on the weekly cutting queue response
- only reduce the displayed packet demand when the committed-serial subtraction is a clear partial match

## Root Cause
The prior packet-demand fix added serial allocation subtraction, but it also filtered SQL rows with `openQuantity > 0`. In live data, broad allocation/category matches could make the computed committed count equal or exceed the base P2 demand, causing all P2 packet demands to disappear from the Cutting Weekly Schedule.

## Validation
- `git diff --check origin/main..HEAD`
- `node --experimental-strip-types --check server/src/routes/cuttingTable.ts`