### PR TITLE
[codex] Fix Draft Builder status column sanitizer crash

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -1552,6 +1552,10 @@ function uniqueColumnNames(columns: unknown[]) {
   }, []);
 }
 
+function isStatusDuplicateColumn(column: string) {
+  return normalizeCsvHeader(column) === 'status';
+}
+
 function sanitizeCustomColumns(columns: unknown[]) {
   return uniqueColumnNames(columns).filter((column) => !isStatusDuplicateColumn(column));
 }


### PR DESCRIPTION
## Summary
- Restore the missing `isStatusDuplicateColumn` helper used by Draft Builder custom-column sanitization.
- Keep imported/custom `Status` columns filtered out without throwing during page load.

## Root Cause
The merged Draft Builder conflict repair left `sanitizeCustomColumns(...)` calling `isStatusDuplicateColumn(...)`, but that helper was no longer defined in the resolved file. The browser crashed with `isStatusDuplicateColumn is not defined` before Draft Builder could render.

## User Impact
Draft Builder should load instead of showing the application error screen. Imported duplicate Status columns continue to be suppressed so the editable Parts/request status remains the source of truth.

## Validation
- `git diff --check -- client/src/pages/DraftBOMBuilderPage.tsx`