### PR TITLE
[codex] Fix Draft Builder blank render after project helper

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -2686,6 +2686,8 @@ export default function DraftBOMBuilderPage() {
       projectType: selectedProject.projectType,
       updatedAt: new Date().toISOString(),
     };
+  }
+
   async function clearPartsRequestTab() {
     if (!canEditActiveDraft) {
       toast({


### PR DESCRIPTION
## Summary
- Close the `applyProjectToDraft(...)` helper before `clearPartsRequestTab(...)` starts.
- Restores the Draft Builder component function boundary after the recent conflict repair.

## Root Cause
The resolved Draft Builder source left `clearPartsRequestTab(...)` immediately after the object return from `applyProjectToDraft(...)` without closing the helper function. That malformed boundary can break the Draft Builder module/render path after the API calls succeed, leaving the page blank.

## User Impact
Draft Builder should render again after `/api/draft-bom-drafts`, `/api/inventory`, and `/api/draft-bom-drafts/privateer` complete successfully.

## Validation
- `git diff --check -- client/src/pages/DraftBOMBuilderPage.tsx`
- `git diff --cached --check`