### PR TITLE
Fix Draft Builder imported descriptions

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -544,12 +544,16 @@ function customImportField(line: BomLine, keys: string[]) {
   return '';
 }
 
+function isImportedSpreadsheetDescription(value: string) {
+  return /^Imported spreadsheet (?:line|row \d+)$/i.test(value.trim());
+}
+
 function lineDescription(line: BomLine) {
   const partNumber = linePartNumber(line);
   const description = line.description?.trim() ?? '';
   const customDescription = customImportField(line, importedDescriptionHeaders);
   if (line.importedSource === 'spreadsheet' && customDescription) return customDescription;
-  if (description && description !== 'Imported spreadsheet line' && description !== partNumber) return description;
+  if (description && !isImportedSpreadsheetDescription(description) && description !== partNumber) return description;
   return customDescription || description || line.inventoryItemName || partNumber;
 }
 
@@ -559,7 +563,7 @@ function normalizeBomLine(line: Partial<BomLine> | null | undefined): BomLine {
   const id = typeof safeLine.id === 'string' && safeLine.id.trim() ? safeLine.id : baseLine.id;
   const status = statuses.includes(safeLine.status as BomStatus) ? safeLine.status as BomStatus : baseLine.status;
 
-  return {
+  const normalizedLine = {
     ...baseLine,
     ...safeLine,
     id,
@@ -576,6 +580,10 @@ function normalizeBomLine(line: Partial<BomLine> | null | undefined): BomLine {
     actualCost: safeLine.actualCost ?? '',
     service: safeLine.service ?? false,
   };
+  if (normalizedLine.importedSource === 'spreadsheet' && isImportedSpreadsheetDescription(normalizedLine.description ?? '')) {
+    return { ...normalizedLine, description: lineDescription(normalizedLine) };
+  }
+  return normalizedLine;
 }
 
 function draftLineToPart(line: BomLine): DraftBomPart {
@@ -1460,12 +1468,13 @@ function buildLinesFromRows(rows: string[][], inventoryItems: InventoryItemOptio
       const inventoryMatch = linkInventoryMatches ? findInventoryMatch(importedPartNumber, inventoryItems) : null;
       if (inventoryMatch) linkedCount += 1;
       const spreadsheetLabel = `Imported spreadsheet row ${rowIndex + 1}`;
+      const description = inventoryMatch ? inventoryDescription(inventoryMatch) : sourceDescription || spreadsheetLabel;
 
       return {
         ...newLine(),
         action: 'Review imported line',
         category: 'Imported Spreadsheet',
-        description: spreadsheetLabel,
+        description,
         agPartNumber: '',
         supplier: '',
         supplierItemId: '',


### PR DESCRIPTION
## Summary
- set Draft Builder spreadsheet imports to use the real imported or linked inventory description in the editable Part description field
- treat old `Imported spreadsheet row N` placeholders as recoverable import placeholders during draft normalization
- keep all original spreadsheet columns preserved in custom imported columns

## Root Cause
Imported spreadsheet rows preserved the source description in custom fields, but `buildLinesFromRows` still initialized `line.description` with `Imported spreadsheet row N`. The Parts/Request table binds its editable Part description input directly to `line.description`, so the shared display helper could not repair that visible field.

## Validation
- `git diff --check`
- `git diff --cached --check`

Full TypeScript validation was not run because this fresh worktree does not have `node_modules` installed.