### PR TITLE
Fix P2 packet demand unit counts

### DIFF
--- a/client/src/pages/cutting/CuttingWeeklySchedule.tsx
+++ b/client/src/pages/cutting/CuttingWeeklySchedule.tsx
@@ -85,6 +85,10 @@ type WeeklyCuttingQueueItem = {
   packetsNeeded: number;
   inventoryApplied?: number;
   packetsToCut?: number;
+  originalQuantity?: number;
+  unitDemandQuantity?: number;
+  serializedQuantity?: number;
+  committedQuantity?: number;
   usesInventory: boolean;
   requiresNewCut: boolean;
   bomId?: string;
@@ -131,7 +135,7 @@ export default function CuttingWeeklySchedule() {
   const [currentWeek] = useState(getMondayOfWeek(new Date()));
   const [queueFilter, setQueueFilter] = useState<CuttingQueueFilterValue>("all");
   const [scheduleQuantities, setScheduleQuantities] = useState<Record<string, number>>({});
-  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({ p1: true, p2: true });
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({ p1: true, p2: false });
   const [customDemand, setCustomDemand] = useState({
     poNumber: '',
     packetType: '',
@@ -265,7 +269,7 @@ export default function CuttingWeeklySchedule() {
   const p2Demand = useMemo(() => {
     if (!weeklyQueueData?.items) return [];
     
-    const p2Items = weeklyQueueData.items.filter(i => i.source === 'P2');
+    const p2Items = weeklyQueueData.items.filter(i => i.source === 'P2' && Math.max(0, Number(i.packetsNeeded) || 0) > 0);
     
     const poMap: Record<string, {
       poId: string;
@@ -284,12 +288,13 @@ export default function CuttingWeeklySchedule() {
           total: 0,
         };
       }
+      const packetQty = Math.max(0, Number(item.packetsNeeded) || 0);
       poMap[poId].items.push({
         name: item.stockModel,
-        qty: item.packetsNeeded,
+        qty: packetQty,
         materialType: item.materialType,
       });
-      poMap[poId].total += item.packetsNeeded;
+      poMap[poId].total += packetQty;
     });
     
     return Object.values(poMap).sort((a, b) => b.total - a.total);

--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -2440,14 +2440,26 @@ router.get('/weekly-cutting-queue', async (req, res) => {
               COALESCE(p2_units.serialized_count, 0) as "serializedQuantity",
               COALESCE(committed_packets.committed_count, 0) as "committedQuantity",
               CASE
+                WHEN COALESCE(p2_units.serialized_count, 0) > 0
+                THEN COALESCE(p2_units.serialized_count, 0)
+                ELSE 1
+              END as "unitDemandQuantity",
+              CASE
                 WHEN COALESCE(committed_packets.committed_count, 0) > 0
-                  AND COALESCE(NULLIF(p2_units.serialized_count, 0), po.quantity) > COALESCE(committed_packets.committed_count, 0)
                 THEN GREATEST(
-                  COALESCE(NULLIF(p2_units.serialized_count, 0), po.quantity)
+                  CASE
+                    WHEN COALESCE(p2_units.serialized_count, 0) > 0
+                    THEN COALESCE(p2_units.serialized_count, 0)
+                    ELSE 1
+                  END
                     - COALESCE(committed_packets.committed_count, 0),
                   0
                 )
-                ELSE COALESCE(NULLIF(p2_units.serialized_count, 0), po.quantity)
+                ELSE CASE
+                  WHEN COALESCE(p2_units.serialized_count, 0) > 0
+                  THEN COALESCE(p2_units.serialized_count, 0)
+                  ELSE 1
+                END
               END as "openQuantity"
             FROM p2_production_orders po
             LEFT JOIN p2_purchase_orders p2 ON po.p2_po_id = p2.id
@@ -2607,6 +2619,7 @@ router.get('/weekly-cutting-queue', async (req, res) => {
           priority: 60,
           packetsNeeded: item.openQuantity ?? item.quantity ?? 1,
           originalQuantity: item.originalQuantity || item.quantity || 1,
+          unitDemandQuantity: item.unitDemandQuantity ?? item.openQuantity ?? 1,
           serializedQuantity: item.serializedQuantity || 0,
           committedQuantity: item.committedQuantity || 0,
           usesInventory: false,


### PR DESCRIPTION
## Summary
- Correct P2 packet demand so weekly queue cards use packet/unit demand instead of exploded BOM component quantities.
- Subtract committed serial-linked packets even when committed count exactly matches open demand.
- Default the P2 Demand by PO accordion closed and omit zero-open P2 rows from the card/table grouping.

## Root cause
The weekly cutting queue was using `p2_production_orders.quantity` as the fallback P2 packet quantity. That table is generated from BOM expansion, so `quantity` can represent component demand rather than the packet/unit demand shown on the P2 PO Packet Demand card.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `node --experimental-strip-types --check server/src/routes/cuttingTable.ts`