### PR TITLE
Fix Robust BOM label import

### DIFF
--- a/client/src/pages/RobustBOMAdministration.tsx
+++ b/client/src/pages/RobustBOMAdministration.tsx
@@ -15,6 +15,7 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Switch } from '@/components/ui/switch';


### PR DESCRIPTION
## Summary
- Import the shared `Label` component in `RobustBOMAdministration` so the P2 PO BOM edit drawer can render its form labels.
- Unblocks the Robust BOM UI path used to inspect/edit BOMs promoted from Draft Builder wizard records.

## Root Cause
The P2 PO BOM edit surface used `<Label>` elements but the page only imported `FormLabel`, causing `Label is not defined` at runtime.

## Validation
- `git diff --check`
- `git diff --cached --check`

Note: `npm`/local `node_modules` and `gh` were not available in this clean worktree, so full TypeScript/build validation was not run locally.