### PR TITLE
Update Draft Builder summary and status colors

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -2200,7 +2200,7 @@ export default function DraftBOMBuilderPage() {
 
   const totals = useMemo(() => {
     const selectedLineIds = new Set(selectedLines.map((line) => line.id));
-    const materialTotal = partsRequestLines.reduce((sum, line) => sum + summaryLineTotal(line), 0);
+    const partsRequestMaterialTotal = partsRequestLines.reduce((sum, line) => sum + summaryLineTotal(line), 0);
     const selectedTotal = partsRequestLines
       .filter((line) => selectedLineIds.has(line.id))
       .reduce((sum, line) => sum + summaryLineTotal(line), 0);
@@ -2221,6 +2221,7 @@ export default function DraftBOMBuilderPage() {
     const customerFacingNrcTotal = (draft.nrcRows ?? [])
       .filter((row) => row.includeInCustomerPrice && !row.internalOnly)
       .reduce((sum, row) => sum + nrcRowTotal(row), 0);
+    const materialTotal = partsRequestMaterialTotal + nrcTotal;
 
     return {
       materialTotal,


### PR DESCRIPTION
## Summary
- make the Draft Builder `Total Material / Tooling` card add Parts/Request material totals plus NRC tab totals
- keep the standalone `NRC Estimate` metric available as the NRC-only detail
- color Parts/Request status controls and status badges so ordered/inbound/RFQ statuses are yellow, on-hand is green, and all other statuses are red

## Root cause
The summary fix in #1416 moved material totals to the Parts/Request source, but the `Total Material / Tooling` label also needs to include tooling/NRC values from the NRC tab. The Parts/Request status column also needed a clearer visual priority map for order state.

## Validation
- `git diff --check`
- `git diff --cached --check`

Full `npm run check` was not run because the clean worktree does not have `node_modules` installed.