### PR TITLE
Add WAD documentation requirements engine

### DIFF
--- a/client/src/components/wad/WADWizard.tsx
+++ b/client/src/components/wad/WADWizard.tsx
@@ -96,6 +96,24 @@ type ProductionDocumentationRequirements = Record<ProductionDocumentRequirementK
   documentationNotes: string;
 };
 
+type DocumentationRequirementState = 'required' | 'optional' | 'notRequired';
+
+interface DocumentationRequirementsEnginePackage {
+  package: Record<string, DocumentationRequirementState>;
+  requiredDocuments: string[];
+  inspectionStrategy: InspectionStrategy;
+  samplingPlanId: string;
+  qualityApprovalRequired: boolean;
+  customerApprovalRequired: boolean;
+  documentationNotes: string;
+}
+
+interface DocumentationRequirementsEngineResponse {
+  wadId: string;
+  workOrderNumber: string;
+  documentationPackage: DocumentationRequirementsEnginePackage;
+}
+
 const PRODUCTION_DOCUMENT_REQUIREMENT_ITEMS: Array<{ key: ProductionDocumentRequirementKey; label: string }> = [
   { key: 'routingRequired', label: 'Routing' },
   { key: 'travelerRequired', label: 'Traveler' },
@@ -112,6 +130,23 @@ const PRODUCTION_DOCUMENT_REQUIREMENT_ITEMS: Array<{ key: ProductionDocumentRequ
   { key: 'packagingChecklistRequired', label: 'Packaging Checklist' },
   { key: 'certificatePackageRequired', label: 'Certificate Package' },
 ];
+
+const DOCUMENT_PACKAGE_LABELS: Record<string, string> = {
+  routing: 'Routing',
+  traveler: 'Traveler',
+  inspectionSheet: 'Inspection Sheet',
+  samplingPlan: 'Sampling Plan',
+  fai: 'FAI',
+  workInstruction: 'Work Instruction',
+  cncSetupSheet: 'CNC Setup Sheet',
+  materialCutSheet: 'Material Cut Sheet',
+  layupRecord: 'Layup Record',
+  cureRecord: 'Cure Record',
+  assemblyChecklist: 'Assembly Checklist',
+  testReport: 'Test Report',
+  packagingChecklist: 'Packaging Checklist',
+  certificatePackage: 'Certificate Package',
+};
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 interface WorkBreakdownRow {
@@ -490,6 +525,11 @@ export default function WADWizard({ wadId, onClose, initialStep = null }: WADWiz
     queryFn: () => apiRequest(`/api/work-orders/production/${wadId}/wizard`),
   });
 
+  const { data: documentationRequirementsEngine } = useQuery<DocumentationRequirementsEngineResponse>({
+    queryKey: ['/api/work-orders/production', wadId, 'documentation-requirements'],
+    queryFn: () => apiRequest(`/api/work-orders/production/${wadId}/documentation-requirements`),
+  });
+
   useEffect(() => {
     if (wizardCtx?.wad?.wizardData) {
       const savedData = wizardCtx.wad.wizardData as WizardData;
@@ -528,6 +568,7 @@ export default function WADWizard({ wadId, onClose, initialStep = null }: WADWiz
         }));
       }
       queryClient.invalidateQueries({ queryKey: ['/api/work-orders/production', wadId, 'wizard'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/work-orders/production', wadId, 'documentation-requirements'] });
       queryClient.invalidateQueries({ queryKey: ['/api/work-orders', wadId] });
     },
     onError: (err: Error) => {
@@ -556,6 +597,7 @@ export default function WADWizard({ wadId, onClose, initialStep = null }: WADWiz
         }));
       }
       queryClient.invalidateQueries({ queryKey: ['/api/work-orders/production', wadId, 'wizard'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/work-orders/production', wadId, 'documentation-requirements'] });
       queryClient.invalidateQueries({ queryKey: ['/api/work-orders', wadId] });
       if (result.allApproved) {
         toast({ title: 'WAD Approved!', description: 'All required approvals collected. WAD status set to APPROVED.' });
@@ -1249,6 +1291,7 @@ export default function WADWizard({ wadId, onClose, initialStep = null }: WADWiz
               wad={wad}
               approvals={approvals}
               controlStatus={controlStatus}
+              documentationPackage={documentationRequirementsEngine?.documentationPackage ?? null}
               approvalRequests={data.approvalRequests ?? []}
               revisionHistory={data.revisionHistory ?? []}
               exceptionRequestMutation={exceptionRequestMutation}
@@ -2782,11 +2825,12 @@ function Step11Approvals({ approvals, assignments, onAssignmentsChange, wadId, a
 }
 
 // ─── Step 12: Final Review ────────────────────────────────────────────────────
-function Step12FinalReview({ data, wad, approvals, controlStatus, approvalRequests, revisionHistory, exceptionRequestMutation, onApprove, isSaving }: {
+function Step12FinalReview({ data, wad, approvals, controlStatus, documentationPackage, approvalRequests, revisionHistory, exceptionRequestMutation, onApprove, isSaving }: {
   data: WizardData;
   wad: any;
   approvals: ApprovalRecord[];
   controlStatus?: WadControlStatus;
+  documentationPackage?: DocumentationRequirementsEnginePackage | null;
   approvalRequests: ApprovalRequestRecord[];
   revisionHistory: RevisionHistoryRecord[];
   exceptionRequestMutation: any;
@@ -2807,9 +2851,18 @@ function Step12FinalReview({ data, wad, approvals, controlStatus, approvalReques
   const scopeDefined = !!(data.step2?.buildType && (data.step2?.departments ?? []).length > 0);
   const chargeCodesDefined = (data.step4?.chargeCodes ?? []).every(c => !!c.chargeCode);
   const documentationRequirements = getProductionDocumentationRequirements(data);
-  const requiredProductionDocs = PRODUCTION_DOCUMENT_REQUIREMENT_ITEMS
-    .filter(item => documentationRequirements[item.key])
-    .map(item => item.label);
+  const requiredProductionDocs = documentationPackage
+    ? Object.entries(documentationPackage.package)
+        .filter(([, state]) => state === 'required')
+        .map(([key]) => DOCUMENT_PACKAGE_LABELS[key] ?? key)
+    : PRODUCTION_DOCUMENT_REQUIREMENT_ITEMS
+        .filter(item => documentationRequirements[item.key])
+        .map(item => item.label);
+  const reviewInspectionStrategy = documentationPackage?.inspectionStrategy ?? documentationRequirements.inspectionStrategy;
+  const reviewSamplingPlanId = documentationPackage?.samplingPlanId ?? documentationRequirements.samplingPlanId;
+  const reviewQualityApprovalRequired = documentationPackage?.qualityApprovalRequired ?? documentationRequirements.qualityApprovalRequired;
+  const reviewCustomerApprovalRequired = documentationPackage?.customerApprovalRequired ?? documentationRequirements.customerApprovalRequired;
+  const reviewDocumentationNotes = documentationPackage?.documentationNotes ?? documentationRequirements.documentationNotes;
 
   const gates = [
     { label: 'PO Review Approved', ok: poReviewGate },
@@ -2978,18 +3031,18 @@ function Step12FinalReview({ data, wad, approvals, controlStatus, approvalReques
       <div className="rounded-md border p-3 space-y-2">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="font-medium text-sm">Production Documentation Requirements</p>
-          <Badge variant="outline">{documentationRequirements.inspectionStrategy.replace('_', ' ')}</Badge>
+          <Badge variant="outline">{reviewInspectionStrategy.replace('_', ' ')}</Badge>
         </div>
         <p className="text-xs text-muted-foreground">
           Required documents: {requiredProductionDocs.length ? requiredProductionDocs.join(', ') : 'None selected'}
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs text-muted-foreground">
-          <span>Sampling Plan: {documentationRequirements.samplingPlanId || 'N/A'}</span>
-          <span>Quality Approval: {documentationRequirements.qualityApprovalRequired ? 'Required' : 'Not required'}</span>
-          <span>Customer Approval: {documentationRequirements.customerApprovalRequired ? 'Required' : 'Not required'}</span>
+          <span>Sampling Plan: {reviewSamplingPlanId || 'N/A'}</span>
+          <span>Quality Approval: {reviewQualityApprovalRequired ? 'Required' : 'Not required'}</span>
+          <span>Customer Approval: {reviewCustomerApprovalRequired ? 'Required' : 'Not required'}</span>
         </div>
-        {documentationRequirements.documentationNotes && (
-          <p className="text-xs text-muted-foreground">{documentationRequirements.documentationNotes}</p>
+        {reviewDocumentationNotes && (
+          <p className="text-xs text-muted-foreground">{reviewDocumentationNotes}</p>
         )}
       </div>
       {isAlreadyApproved ? (

--- a/server/src/lib/documentationRequirementsEngine.ts
+++ b/server/src/lib/documentationRequirementsEngine.ts
@@ -1,0 +1,196 @@
+export type DocumentationRequirementState = 'required' | 'optional' | 'notRequired';
+
+export type InspectionStrategy = 'FULL' | 'SAMPLING' | 'MIXED' | 'FINAL_ONLY';
+
+export type DocumentationPackageKey =
+  | 'routing'
+  | 'traveler'
+  | 'inspectionSheet'
+  | 'samplingPlan'
+  | 'fai'
+  | 'workInstruction'
+  | 'cncSetupSheet'
+  | 'materialCutSheet'
+  | 'layupRecord'
+  | 'cureRecord'
+  | 'assemblyChecklist'
+  | 'testReport'
+  | 'packagingChecklist'
+  | 'certificatePackage';
+
+export type DocumentationPackage = Record<DocumentationPackageKey, DocumentationRequirementState>;
+
+export interface DocumentationRequirementsEngineResult {
+  package: DocumentationPackage;
+  requirements: Record<string, boolean | string>;
+  requiredDocuments: DocumentationPackageKey[];
+  optionalDocuments: DocumentationPackageKey[];
+  inspectionStrategy: InspectionStrategy;
+  samplingPlanId: string;
+  criticalFeaturesRequireFullInspection: boolean;
+  qualityApprovalRequired: boolean;
+  customerApprovalRequired: boolean;
+  documentationNotes: string;
+  gates: {
+    routingApproval: {
+      requiresQcInspectionSetup: boolean;
+      requiresSamplingPlan: boolean;
+      fullInspectionRequired: boolean;
+      sampleSizeAllowed: boolean;
+      travelerRequired: boolean;
+    };
+    travelerGeneration: {
+      required: boolean;
+      optional: boolean;
+      blockedWhenNotRequired: boolean;
+    };
+    p2ReleaseGate: {
+      requiredDocuments: DocumentationPackageKey[];
+      qualityApprovalRequired: boolean;
+      customerApprovalRequired: boolean;
+    };
+    qcFinalRelease: {
+      inspectionSheetRequired: boolean;
+      samplingPlanRequired: boolean;
+      faiRequired: boolean;
+      certificatePackageRequired: boolean;
+      fullInspectionRequired: boolean;
+    };
+  };
+}
+
+type WadLike = {
+  wizardData?: unknown;
+  wizard_data?: unknown;
+};
+
+const DOCUMENT_FIELD_MAP: Array<{
+  packageKey: DocumentationPackageKey;
+  field: string;
+  defaultRequired: boolean;
+  optionalWhenFalse?: boolean;
+}> = [
+  { packageKey: 'routing', field: 'routingRequired', defaultRequired: true },
+  { packageKey: 'traveler', field: 'travelerRequired', defaultRequired: true, optionalWhenFalse: true },
+  { packageKey: 'inspectionSheet', field: 'inspectionSheetRequired', defaultRequired: false },
+  { packageKey: 'samplingPlan', field: 'samplingPlanRequired', defaultRequired: false },
+  { packageKey: 'fai', field: 'faiRequired', defaultRequired: false },
+  { packageKey: 'workInstruction', field: 'workInstructionRequired', defaultRequired: false },
+  { packageKey: 'cncSetupSheet', field: 'cncSetupSheetRequired', defaultRequired: false },
+  { packageKey: 'materialCutSheet', field: 'materialCutSheetRequired', defaultRequired: false },
+  { packageKey: 'layupRecord', field: 'layupRecordRequired', defaultRequired: false },
+  { packageKey: 'cureRecord', field: 'cureRecordRequired', defaultRequired: false },
+  { packageKey: 'assemblyChecklist', field: 'assemblyChecklistRequired', defaultRequired: false },
+  { packageKey: 'testReport', field: 'testReportRequired', defaultRequired: false },
+  { packageKey: 'packagingChecklist', field: 'packagingChecklistRequired', defaultRequired: false },
+  { packageKey: 'certificatePackage', field: 'certificatePackageRequired', defaultRequired: false },
+];
+
+function asRecord(value: unknown): Record<string, any> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, any> : {};
+}
+
+function boolValue(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', 'yes', 'required', '1'].includes(normalized)) return true;
+    if (['false', 'no', 'not_required', 'notrequired', 'optional', '0'].includes(normalized)) return false;
+  }
+  return fallback;
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function inferInspectionStrategy(data: Record<string, any>): InspectionStrategy {
+  const explicit = stringValue(data.inspectionStrategy).toUpperCase();
+  if (['FULL', 'SAMPLING', 'MIXED', 'FINAL_ONLY'].includes(explicit)) return explicit as InspectionStrategy;
+  if (boolValue(data.step6?.finalQCOnly, false)) return 'FINAL_ONLY';
+  if (data.step7?.spotCheckSampleSize || data.step7?.spotCheckFrequency) return 'SAMPLING';
+  if (boolValue(data.step7?.inProcessQC, false) && boolValue(data.step7?.finalQC, false)) return 'MIXED';
+  return 'FULL';
+}
+
+export function evaluateDocumentationRequirements(input: WadLike | Record<string, unknown> | null | undefined): DocumentationRequirementsEngineResult {
+  const data = asRecord((input as WadLike | undefined)?.wizardData ?? (input as WadLike | undefined)?.wizard_data ?? input);
+  const inspectionStrategy = inferInspectionStrategy(data);
+  const sampleSizeAllowed = inspectionStrategy === 'SAMPLING' || inspectionStrategy === 'MIXED';
+  const fullInspectionRequired = inspectionStrategy === 'FULL';
+
+  const requirements: Record<string, boolean | string> = {
+    routingRequired: boolValue(data.routingRequired ?? data.step6?.routingRequired, true),
+    travelerRequired: boolValue(data.travelerRequired ?? data.step6?.travelerRequired, true),
+    inspectionSheetRequired: boolValue(data.inspectionSheetRequired ?? data.step7?.dimensionalReportRequired, false),
+    samplingPlanRequired: boolValue(data.samplingPlanRequired, false),
+    faiRequired: boolValue(data.faiRequired ?? data.step7?.faiRequired, false),
+    workInstructionRequired: boolValue(data.workInstructionRequired ?? data.step6?.workInstructionRequired, false),
+    cncSetupSheetRequired: boolValue(data.cncSetupSheetRequired, false),
+    materialCutSheetRequired: boolValue(data.materialCutSheetRequired, false),
+    layupRecordRequired: boolValue(data.layupRecordRequired, false),
+    cureRecordRequired: boolValue(data.cureRecordRequired, false),
+    assemblyChecklistRequired: boolValue(data.assemblyChecklistRequired, false),
+    testReportRequired: boolValue(data.testReportRequired, false),
+    packagingChecklistRequired: boolValue(data.packagingChecklistRequired, false),
+    certificatePackageRequired: boolValue(data.certificatePackageRequired ?? data.step7?.certPackageRequired, false),
+    inspectionStrategy,
+    samplingPlanId: stringValue(data.samplingPlanId),
+    criticalFeaturesRequireFullInspection: boolValue(data.criticalFeaturesRequireFullInspection, false),
+    qualityApprovalRequired: boolValue(data.qualityApprovalRequired, true),
+    customerApprovalRequired: boolValue(data.customerApprovalRequired ?? data.step7?.customerSourceInspection, false),
+    documentationNotes: stringValue(data.documentationNotes),
+  };
+
+  const docPackage = DOCUMENT_FIELD_MAP.reduce((acc, item) => {
+    const required = boolValue(requirements[item.field], item.defaultRequired);
+    acc[item.packageKey] = required ? 'required' : item.optionalWhenFalse ? 'optional' : 'notRequired';
+    return acc;
+  }, {} as DocumentationPackage);
+
+  const requiredDocuments = DOCUMENT_FIELD_MAP
+    .filter(item => docPackage[item.packageKey] === 'required')
+    .map(item => item.packageKey);
+  const optionalDocuments = DOCUMENT_FIELD_MAP
+    .filter(item => docPackage[item.packageKey] === 'optional')
+    .map(item => item.packageKey);
+
+  return {
+    package: docPackage,
+    requirements,
+    requiredDocuments,
+    optionalDocuments,
+    inspectionStrategy,
+    samplingPlanId: stringValue(requirements.samplingPlanId),
+    criticalFeaturesRequireFullInspection: boolValue(requirements.criticalFeaturesRequireFullInspection, false),
+    qualityApprovalRequired: boolValue(requirements.qualityApprovalRequired, true),
+    customerApprovalRequired: boolValue(requirements.customerApprovalRequired, false),
+    documentationNotes: stringValue(requirements.documentationNotes),
+    gates: {
+      routingApproval: {
+        requiresQcInspectionSetup: docPackage.inspectionSheet === 'required',
+        requiresSamplingPlan: docPackage.samplingPlan === 'required',
+        fullInspectionRequired,
+        sampleSizeAllowed,
+        travelerRequired: docPackage.traveler === 'required',
+      },
+      travelerGeneration: {
+        required: docPackage.traveler === 'required',
+        optional: docPackage.traveler === 'optional',
+        blockedWhenNotRequired: false,
+      },
+      p2ReleaseGate: {
+        requiredDocuments,
+        qualityApprovalRequired: boolValue(requirements.qualityApprovalRequired, true),
+        customerApprovalRequired: boolValue(requirements.customerApprovalRequired, false),
+      },
+      qcFinalRelease: {
+        inspectionSheetRequired: docPackage.inspectionSheet === 'required',
+        samplingPlanRequired: docPackage.samplingPlan === 'required',
+        faiRequired: docPackage.fai === 'required',
+        certificatePackageRequired: docPackage.certificatePackage === 'required',
+        fullInspectionRequired,
+      },
+    },
+  };
+}

--- a/server/src/routes/partRoutings.ts
+++ b/server/src/routes/partRoutings.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { storage } from '../../storage';
 import { insertPartRoutingSchema, insertRoutingOperationSchema, insertRoutingCncOperationSchema, insertRoutingDependencySchema, updateRoutingDependencySchema } from '../../schema';
 import { pool } from '../../db';
+import { evaluateDocumentationRequirements } from '../lib/documentationRequirementsEngine';
 import OpenAI from 'openai';
 
 let openaiClient: OpenAI | null = null;
@@ -222,19 +223,19 @@ router.get('/project/:projectId/wad-documentation-requirements', async (req: Req
       });
     }
 
-    const wizardData = wad.wizardData && typeof wad.wizardData === 'object' ? wad.wizardData : {};
-    const requirements = {
-      travelerRequired: wizardData.travelerRequired ?? wizardData.step6?.travelerRequired ?? true,
-      inspectionSheetRequired: wizardData.inspectionSheetRequired ?? wizardData.step7?.dimensionalReportRequired ?? false,
-      samplingPlanRequired: wizardData.samplingPlanRequired ?? false,
-      samplingPlanId: wizardData.samplingPlanId ?? '',
-      inspectionStrategy: wizardData.inspectionStrategy ?? (wizardData.step6?.finalQCOnly ? 'FINAL_ONLY' : 'FULL'),
-    };
+    const documentationPackage = evaluateDocumentationRequirements(wad);
 
     res.json({
       wadId: wad.id,
       workOrderNumber: wad.workOrderNumber,
-      requirements,
+      requirements: {
+        travelerRequired: documentationPackage.requirements.travelerRequired === true,
+        inspectionSheetRequired: documentationPackage.requirements.inspectionSheetRequired === true,
+        samplingPlanRequired: documentationPackage.requirements.samplingPlanRequired === true,
+        samplingPlanId: String(documentationPackage.requirements.samplingPlanId ?? ''),
+        inspectionStrategy: documentationPackage.inspectionStrategy,
+      },
+      documentationPackage,
     });
   } catch (error: any) {
     console.error('Error fetching WAD routing requirements:', error);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -7,6 +7,7 @@ import { insertProjectSchema, insertProjectStepSchema, insertProjectActivityLogS
 import { createEmployeeIdentitySnapshot } from '../../identity/userIdentity';
 import { validateProjectClosing, deriveClosingStatus } from '../lib/projectClosingValidation';
 import { ensureProjectHasWAD } from '../lib/wadHelper';
+import { evaluateDocumentationRequirements } from '../lib/documentationRequirementsEngine';
 import { cancelWadWorkOrdersSupersededByP2 } from '../services/wadSupersedeService';
 import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
 import { resolveCustomersIntegerId } from '../lib/customerResolver';
@@ -52,6 +53,30 @@ function currentUserSnapshot(req: any): { id: number | null; displayName: string
   return {
     id: Number.isFinite(parsedId) ? parsedId : null,
     displayName: user?.displayName || user?.username || null,
+  };
+}
+
+async function getLatestProjectWadDocumentationPackage(projectId: string) {
+  const rows = await pool.query(
+    `SELECT id::text, work_order_number AS "workOrderNumber", status, wad_status AS "wadStatus", wizard_data AS "wizardData"
+       FROM production_work_orders
+      WHERE project_id = $1
+        AND (work_order_number LIKE 'WAD-%' OR wad_status IS NOT NULL)
+      ORDER BY
+        CASE wad_status WHEN 'APPROVED' THEN 0 WHEN 'PENDING_APPROVAL' THEN 1 ELSE 2 END,
+        updated_at DESC NULLS LAST,
+        created_at DESC NULLS LAST
+      LIMIT 1`,
+    [projectId]
+  );
+  const wad = rows[0];
+  if (!wad) return null;
+  return {
+    wadId: wad.id,
+    workOrderNumber: wad.workOrderNumber,
+    status: wad.status,
+    wadStatus: wad.wadStatus,
+    documentationPackage: evaluateDocumentationRequirements(wad),
   };
 }
 
@@ -1811,6 +1836,21 @@ router.post('/:id/release-to-p2', async (req, res) => {
     const WAD_APPROVED_STATUSES = ['RELEASED', 'IN_PROGRESS', 'COMPLETE', 'CLOSED'];
     const workOrders = await storage.getWorkOrdersByProject(id);
     const wadPassed = workOrders.some(wo => WAD_APPROVED_STATUSES.includes(wo.status));
+    const wadDocumentation = await getLatestProjectWadDocumentationPackage(id);
+    const documentationIssues = wadDocumentation?.documentationPackage.gates.routingApproval.requiresSamplingPlan &&
+      !wadDocumentation.documentationPackage.samplingPlanId
+      ? ['Sampling plan is required by the WAD documentation package but no sampling plan ID is recorded.']
+      : [];
+    const documentationGate = {
+      key: 'documentation_package',
+      label: 'WAD Documentation Package',
+      passed: Boolean(wadDocumentation) && documentationIssues.length === 0,
+      status: !wadDocumentation ? 'missing_wad' : documentationIssues.length > 0 ? 'incomplete' : 'ready',
+      message: !wadDocumentation
+        ? 'No WAD documentation package is available.'
+        : documentationIssues[0] ?? 'WAD documentation package is defined.',
+      documentationPackage: wadDocumentation?.documentationPackage ?? null,
+    };
 
     const quoteStep = steps.find(s => s.stepType === 'quote');
     const contractReviewGate = await getQuoteContractReviewGate(quoteStep?.linkedQuoteId ?? null, id, project.poId);
@@ -1819,6 +1859,7 @@ router.post('/:id/release-to-p2', async (req, res) => {
       { key: 'po_review', label: 'PO Review', passed: poReviewPassed },
       contractReviewGate,
       { key: 'wad', label: 'WAD (Work Authorization Document)', passed: wadPassed },
+      documentationGate,
       { key: 'preproduction', label: 'Preproduction', passed: preproductionPassed },
     ];
 
@@ -1859,6 +1900,7 @@ router.post('/:id/release-to-p2', async (req, res) => {
         stage: 'production',
         poStatus: 'in_production',
         gates,
+        documentationPackage: wadDocumentation?.documentationPackage ?? null,
       });
     }
 
@@ -1884,6 +1926,7 @@ router.post('/:id/release-to-p2', async (req, res) => {
       stage: 'p2_release',
       poStatus: 'ready_for_p2_release',
       gates,
+      documentationPackage: wadDocumentation?.documentationPackage ?? null,
     });
   } catch (error) {
     console.error('Error in release-to-p2 gate:', error);
@@ -1913,6 +1956,21 @@ router.get('/:id/p2-gate-status', async (req, res) => {
     const WAD_APPROVED_STATUSES = ['RELEASED', 'IN_PROGRESS', 'COMPLETE', 'CLOSED'];
     const workOrders = await storage.getWorkOrdersByProject(id);
     const wadPassed = workOrders.some(wo => WAD_APPROVED_STATUSES.includes(wo.status));
+    const wadDocumentation = await getLatestProjectWadDocumentationPackage(id);
+    const documentationIssues = wadDocumentation?.documentationPackage.gates.routingApproval.requiresSamplingPlan &&
+      !wadDocumentation.documentationPackage.samplingPlanId
+      ? ['Sampling plan is required by the WAD documentation package but no sampling plan ID is recorded.']
+      : [];
+    const documentationGate = {
+      key: 'documentation_package',
+      label: 'WAD Documentation Package',
+      passed: Boolean(wadDocumentation) && documentationIssues.length === 0,
+      status: !wadDocumentation ? 'missing_wad' : documentationIssues.length > 0 ? 'incomplete' : 'ready',
+      message: !wadDocumentation
+        ? 'No WAD documentation package is available.'
+        : documentationIssues[0] ?? 'WAD documentation package is defined.',
+      documentationPackage: wadDocumentation?.documentationPackage ?? null,
+    };
 
     const quoteStep = steps.find(s => s.stepType === 'quote');
     const contractReviewGate = await getQuoteContractReviewGate(quoteStep?.linkedQuoteId ?? null, id, project.poId);
@@ -1921,6 +1979,7 @@ router.get('/:id/p2-gate-status', async (req, res) => {
       { key: 'po_review', label: 'PO Review', passed: poReviewPassed },
       contractReviewGate,
       { key: 'wad', label: 'WAD (Work Authorization Document)', passed: wadPassed },
+      documentationGate,
       { key: 'preproduction', label: 'Preproduction', passed: preproductionPassed },
     ];
 
@@ -1933,6 +1992,7 @@ router.get('/:id/p2-gate-status', async (req, res) => {
       currentStage,
       alreadyReleased,
       poId: project.poId ?? null,
+      documentationPackage: wadDocumentation?.documentationPackage ?? null,
     });
   } catch (error) {
     console.error('Error fetching P2 gate status:', error);

--- a/server/src/routes/workOrders.ts
+++ b/server/src/routes/workOrders.ts
@@ -48,6 +48,7 @@ import { requireScopedCapability, ScopedForbiddenError } from '../permissions';
 import { evaluateWorkOrderLaborStatus } from '../helpers/laborBudgetHelper';
 import { evaluateWorkOrderReadiness } from '../lib/workOrderReadiness';
 import { ensureProjectHasWADFromCanonicalSources } from '../lib/wadHelper';
+import { evaluateDocumentationRequirements } from '../lib/documentationRequirementsEngine';
 import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
 import { assignDashboardForWorkOrder } from '../lib/workOrderDashboardAssignment';
 import {
@@ -1328,6 +1329,14 @@ router.post('/:id/travelers/create', requirePermission('work_orders.release'), a
       return sendBlockedWadRevisionResponse(res, blockingRevision);
     }
 
+    const [wad] = await db
+      .select()
+      .from(productionWorkOrders)
+      .where(eq(productionWorkOrders.id, id))
+      .limit(1);
+    if (!wad) return res.status(404).json({ error: 'Production work order not found', id });
+    const documentationPackage = evaluateDocumentationRequirements(wad);
+
     let traveler: Awaited<ReturnType<typeof storage.createTravelerFromProductionWorkOrder>>;
     try {
       traveler = await storage.createTravelerFromProductionWorkOrder(id, String(createdBy));
@@ -1355,6 +1364,7 @@ router.post('/:id/travelers/create', requirePermission('work_orders.release'), a
       status: traveler.status,
       partRoutingId: traveler.partRoutingId,
       wadRevisionId: traveler.wadRevisionId,
+      documentationPackage,
     });
   } catch (error: any) {
     console.error('[WorkOrders] Error creating traveler from WAD:', error);
@@ -3029,6 +3039,26 @@ router.get('/production/:id/wizard', async (req: Request, res: Response) => {
   }
 });
 
+// GET /production/:id/documentation-requirements - shared package engine for WAD review, routing, travelers, QC, and release gates.
+router.get('/production/:id/documentation-requirements', async (req: Request, res: Response) => {
+  const { id } = req.params;
+  if (!WAD_UUID_RE.test(id)) return res.status(400).json({ error: 'Invalid WAD ID format' });
+  try {
+    const [wad] = await db.select().from(productionWorkOrders).where(eq(productionWorkOrders.id, id)).limit(1);
+    if (!wad) return res.status(404).json({ error: 'WAD not found' });
+
+    return res.json({
+      wadId: wad.id,
+      workOrderNumber: wad.workOrderNumber,
+      documentationPackage: evaluateDocumentationRequirements(wad),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[WAD Documentation Requirements] GET error:', err);
+    return res.status(500).json({ error: 'Failed to evaluate WAD documentation requirements', message: msg });
+  }
+});
+
 // PATCH /production/:id/wizard — save/update wizard data (draft save, any step).
 // Auth: authenticated session + work_orders.release capability (same as the approve route).
 // IMPORTANT: this endpoint MUST NOT be a back-door to the APPROVED state. Transitioning a
@@ -3104,6 +3134,7 @@ router.patch(
           lastEditedAt: editedAt,
         },
       };
+      mergedWizardData.__documentationRequirements = evaluateDocumentationRequirements(mergedWizardData);
 
       const updatePayload: Partial<typeof productionWorkOrders.$inferInsert> = {
         wizardData: mergedWizardData,

--- a/server/src/services/certPackageService.ts
+++ b/server/src/services/certPackageService.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import { pool } from '../../db';
+import { evaluateDocumentationRequirements } from '../lib/documentationRequirementsEngine';
 
 type QueryFn = <T = Record<string, unknown>>(sql: string, params?: unknown[]) => Promise<T[]>;
 
@@ -310,10 +311,37 @@ export async function evaluateShippingCertPackageGate(
     revision: rows.wad?.updated_at ?? null,
   });
 
+  const documentationPackage = rows.wad ? evaluateDocumentationRequirements(rows.wad) : null;
+  const qcFinalReleaseRequirements = documentationPackage?.gates.qcFinalRelease ?? null;
+  if (documentationPackage?.gates.qcFinalRelease.samplingPlanRequired && !documentationPackage.samplingPlanId) {
+    blockers.push({
+      code: 'SAMPLING_PLAN_REQUIRED',
+      message: 'The WAD documentation package requires a sampling plan before QC final release.',
+      references: [rows.wad.work_order_number || rows.wad.id],
+    });
+  }
+  evidence.push({
+    type: 'wad_documentation_package',
+    label: 'WAD documentation package',
+    status: documentationPackage ? 'present' : 'not_applicable',
+    source: 'documentation_requirements_engine',
+    reference: rows.wad?.work_order_number ?? null,
+    revision: rows.wad?.updated_at ?? null,
+    details: documentationPackage
+      ? {
+          package: documentationPackage.package,
+          requiredDocuments: documentationPackage.requiredDocuments,
+          inspectionStrategy: documentationPackage.inspectionStrategy,
+          qcFinalRelease: documentationPackage.gates.qcFinalRelease,
+        }
+      : undefined,
+  });
+
   const cert = rows.certificate;
   const cocPresent = !!cert || !!rows.lot.certificate_upload_url;
   const cocApproved = cert ? ['APPROVED', 'ISSUED'].includes(normalizeStatus(cert.status)) || !!cert.approved_at : cocPresent;
-  if (!cocApproved) {
+  const certificatePackageRequired = qcFinalReleaseRequirements?.certificatePackageRequired ?? true;
+  if (certificatePackageRequired && !cocApproved) {
     blockers.push({
       code: 'COC_MISSING',
       message: 'A certificate of conformance must be attached and approved before shipment.',
@@ -323,7 +351,7 @@ export async function evaluateShippingCertPackageGate(
   evidence.push({
     type: 'coc',
     label: 'Certificate of Conformance',
-    status: cocApproved ? 'present' : 'missing',
+    status: cocApproved ? 'present' : certificatePackageRequired ? 'missing' : 'not_applicable',
     source: cert ? 'p2_certificates_of_conformance' : 'p2_lot_numbers.certificate_upload_url',
     reference: cert?.certificate_number ?? rows.lot.certificate_upload_url ?? null,
     revision: cert?.updated_at ?? null,
@@ -343,10 +371,19 @@ export async function evaluateShippingCertPackageGate(
     source: 'p2_certificates_of_conformance.process_records',
     details: { count: jsonArray(cert?.process_records).length },
   });
+  const faiRequired = qcFinalReleaseRequirements?.faiRequired ?? false;
+  const fairPresent = hasEntries(cert?.specifications) || hasEntries(cert?.inspection_summary);
+  if (faiRequired && !fairPresent) {
+    blockers.push({
+      code: 'FAI_REQUIRED',
+      message: 'The WAD documentation package requires FAI evidence before QC final release.',
+      references: [rows.wad?.work_order_number ?? rows.lot.lot_number],
+    });
+  }
   evidence.push({
     type: 'fair',
     label: 'FAIR / first article evidence',
-    status: hasEntries(cert?.specifications) || hasEntries(cert?.inspection_summary) ? 'present' : 'not_applicable',
+    status: fairPresent ? 'present' : faiRequired ? 'missing' : 'not_applicable',
     source: 'p2_certificates_of_conformance.specifications',
   });
   evidence.push({


### PR DESCRIPTION
## Summary
- Add a shared WAD Documentation Requirements Engine that turns WAD production documentation fields into a required/optional/not-required document package.
- Use the engine in WAD review via the production WAD documentation requirements endpoint and review summary.
- Use the engine in routing approval, P2 release gate, traveler creation from WAD, and QC final release/cert package checks.
- Preserve the routing behavior that does not assume every WAD requires a traveler, and exposes sample-size/full-inspection decisions from the WAD inspection strategy.

## Validation
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Full `npm run check` was not run because `npm` is not on PATH in this local shell and this clean worktree has no `node_modules`.