### PR TITLE
Fix P2 RMA customer serial display

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -6126,28 +6126,6 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                 })
                 .returning();
 
-              const rootSerial = String(item.serialNumber || item.barcode).replace(/-rma-\d+$/i, '');
-              const rmaPrefix = `${rootSerial}-rma-`;
-              const rmaRowsResult = await tx.execute(sql`
-                SELECT serial_number AS "serialNumber"
-                FROM ${p2SerializedItems}
-                WHERE lower(serial_number) LIKE ${`${rmaPrefix.toLowerCase()}%`}
-              `);
-              const rmaRows = (Array.isArray(rmaRowsResult) ? rmaRowsResult : (rmaRowsResult.rows ?? [])) as Array<{ serialNumber: string }>;
-              const maxRmaSequence = rmaRows.reduce((maxSeq, row) => {
-                const suffix = String(row.serialNumber || '').slice(rmaPrefix.length);
-                const parsed = /^\d+$/.test(suffix) ? Number(suffix) : 0;
-                return Math.max(maxSeq, parsed);
-              }, 0);
-              const rmaSerialNumber = `${rmaPrefix}${String(maxRmaSequence + 1).padStart(2, '0')}`;
-
-              const maxSequenceResult = await tx.execute(sql`
-                SELECT COALESCE(MAX(sequence_number), 0) + 1 AS "nextSequence"
-                FROM ${p2SerializedItems}
-                WHERE po_item_id = ${item.poItemId}
-              `);
-              const maxSequenceRows = (Array.isArray(maxSequenceResult) ? maxSequenceResult : (maxSequenceResult.rows ?? [])) as Array<{ nextSequence: number | string }>;
-              const nextSequence = Number(maxSequenceRows[0]?.nextSequence || 1);
               const replacementMetadata = {
                 isReplacement: true,
                 replacementForSerializedItemId: item.id,
@@ -6158,50 +6136,48 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                 nonconformingRmaId: rma.id,
                 nonconformingRmaNumber: rmaNumber,
                 rmaRequired: true,
-                rmaReplacementSerialNumber: rmaSerialNumber,
                 generatedFromScrapAt: new Date().toISOString(),
                 generatedWithoutPoQuantityIncrease: true,
               };
 
+              if (!item.poItemId) {
+                throw new Error(`Cannot allocate RMA replacement for ${item.serialNumber}: missing PO item link`);
+              }
+
+              const [allocatedReplacement] = await storage.addP2SerializedItemsForPoItem(item.poItemId, 1, tx);
+              if (!allocatedReplacement) {
+                throw new Error(`Failed to allocate replacement serial for scrapped serial ${item.serialNumber}`);
+              }
+
               const [createdReplacement] = await tx
-                .insert(p2SerializedItems)
-                .values({
-                  serialNumber: rmaSerialNumber,
-                  barcode: rmaSerialNumber,
-                  travelerBarcode: rmaSerialNumber,
-                  poId: item.poId,
-                  poItemId: item.poItemId,
-                  poNumber: item.poNumber,
-                  partNumber: item.partNumber,
-                  partName: item.partName,
-                  customerId: item.customerId,
-                  customerName: item.customerName,
-                  sequenceNumber: nextSequence,
-                  currentDepartment: 'Pending Layup',
-                  currentStageIndex: 0,
-                  status: 'ACTIVE',
-                  metadata: replacementMetadata,
-                  partRoutingId: item.partRoutingId,
-                  partRoutingRevision: item.partRoutingRevision,
+                .update(p2SerializedItems)
+                .set({
+                  metadata: {
+                    ...((allocatedReplacement.metadata as Record<string, unknown> | null) || {}),
+                    ...replacementMetadata,
+                    replacementSerialNumber: allocatedReplacement.serialNumber,
+                  },
+                  partRoutingId: item.partRoutingId ?? allocatedReplacement.partRoutingId,
+                  partRoutingRevision: item.partRoutingRevision ?? allocatedReplacement.partRoutingRevision,
                   sku: item.sku,
                   drawingName: item.drawingName,
-                  buildFamilyKey: item.buildFamilyKey,
+                  buildFamilyKey: item.buildFamilyKey || allocatedReplacement.buildFamilyKey,
                   notes: `RMA replacement generated for scrapped serial ${item.serialNumber}`,
-                  createdAt: new Date(),
                   updatedAt: new Date(),
                 })
+                .where(eq(p2SerializedItems.id, allocatedReplacement.id))
                 .returning();
 
               replacementItem = createdReplacement;
 
               await tx.insert(p2SerializedItemEvents).values({
                 serializedItemId: createdReplacement.id,
-                barcode: rmaSerialNumber,
+                barcode: createdReplacement.barcode,
                 eventType: 'REPLACEMENT_GENERATED',
                 toDepartment: createdReplacement.currentDepartment,
                 toStageIndex: createdReplacement.currentStageIndex,
                 performedBy: performedBy || 'System',
-                notes: `RMA replacement ${rmaSerialNumber} generated for scrapped serial ${item.serialNumber}`,
+                notes: `RMA replacement ${createdReplacement.serialNumber} generated for scrapped serial ${item.serialNumber}`,
                 metadata: {
                   scrappedSerializedItemId: item.id,
                   scrappedSerialNumber: item.serialNumber,
@@ -6209,7 +6185,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                   dispositionId: disposition.id,
                   rmaId: rma.id,
                   rmaNumber,
-                  replacementSerialNumber: rmaSerialNumber,
+                  replacementSerialNumber: createdReplacement.serialNumber,
                   rmaRequired: true,
                   scrapReason: reason,
                   generatedWithoutPoQuantityIncrease: true,
@@ -6227,7 +6203,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                   rmaId: rma.id,
                   rmaNumber,
                   replacementSerializedItemId: createdReplacement.id,
-                  replacementSerialNumber: rmaSerialNumber,
+                  replacementSerialNumber: createdReplacement.serialNumber,
                   reason,
                 },
               });

--- a/server/src/routes/p2Shipping.ts
+++ b/server/src/routes/p2Shipping.ts
@@ -33,6 +33,7 @@ import {
   reserveP2InvoiceNumber,
   syncP2InvoiceSequenceFromManualNumber,
 } from '../services/p2InvoiceNumberService';
+import { formatP2CustomerSerialNumbers } from '../utils/p2CustomerSerialDisplay';
 
 const upload = multer({ storage: multer.memoryStorage() });
 
@@ -407,7 +408,7 @@ async function buildP2PackingSlipPdfData(slip: any): Promise<PackingSlipData> {
       )
     ).join(', ') || item.drawingName || item.partName || item.partNumber || 'N/A',
     quantity: item.quantity ?? (Array.isArray(item.serialNumbers) ? item.serialNumbers.length : 1),
-    serialNumbers: Array.isArray(item.serialNumbers) ? item.serialNumbers : [],
+    serialNumbers: formatP2CustomerSerialNumbers(item.serialNumbers),
     lotNumber: item.lotNumber || slip.lotNumber || undefined,
   }));
   const invoiceNumber = await getLinkedP2InvoiceNumberForPackingSlip(slip.id, slip.lotNumberId)
@@ -474,6 +475,27 @@ function assignedSkuFromSerials(serials: Array<{ sku?: string | null }>): string
   return skus.length > 0 ? skus.join(', ') : null;
 }
 
+function hasP2CustomerSerialDisplaySuffix(lineItems: unknown): boolean {
+  if (!Array.isArray(lineItems)) return false;
+
+  return lineItems.some((item) =>
+    Array.isArray((item as { serialNumbers?: unknown }).serialNumbers) &&
+    (item as { serialNumbers: unknown[] }).serialNumbers.some((serialNumber) =>
+      typeof serialNumber === 'string' &&
+      formatP2CustomerSerialNumbers([serialNumber])[0] !== serialNumber.trim()
+    )
+  );
+}
+
+function formatP2PackingSlipCustomerLineItems(lineItems: unknown): unknown {
+  if (!Array.isArray(lineItems)) return lineItems;
+
+  return lineItems.map((item) => ({
+    ...item,
+    serialNumbers: formatP2CustomerSerialNumbers((item as { serialNumbers?: unknown }).serialNumbers),
+  }));
+}
+
 async function hydratePackingSlipLineItemSkus(lineItems: any[]): Promise<any[]> {
   const serialNumbers = Array.from(
     new Set(
@@ -501,9 +523,13 @@ async function hydratePackingSlipLineItemSkus(lineItems: any[]): Promise<any[]> 
         .map((serialNumber: string) => ({ sku: skuBySerialNumber.get(serialNumber) }))
     );
 
-    return customerSku
-      ? { ...item, customerSku }
-      : item;
+    const formattedSerialNumbers = formatP2CustomerSerialNumbers(item.serialNumbers);
+
+    return {
+      ...item,
+      ...(customerSku ? { customerSku } : {}),
+      ...(formattedSerialNumbers.length > 0 ? { serialNumbers: formattedSerialNumbers } : {}),
+    };
   });
 }
 
@@ -1975,11 +2001,16 @@ router.get('/packing-slips/:id', async (req: Request, res: Response) => {
       poNumber: formatP2DocumentPoNumber(slip.poNumber),
       lineItems,
       originalPackingSlip: originalPackingSlip
-        ? { ...originalPackingSlip, poNumber: formatP2DocumentPoNumber(originalPackingSlip.poNumber) }
+        ? {
+            ...originalPackingSlip,
+            poNumber: formatP2DocumentPoNumber(originalPackingSlip.poNumber),
+            lineItems: formatP2PackingSlipCustomerLineItems(originalPackingSlip.lineItems),
+          }
         : null,
       replacementSlips: replacementSlips.map((replacement) => ({
         ...replacement,
         poNumber: formatP2DocumentPoNumber(replacement.poNumber),
+        lineItems: formatP2PackingSlipCustomerLineItems(replacement.lineItems),
       })),
     });
   } catch (err: any) {
@@ -2220,9 +2251,10 @@ router.get('/packing-slips/:id/pdf', async (req: Request, res: Response) => {
   try {
     const slip = await selectP2PackingSlipById(req.params.id);
     if (!slip) return res.status(404).json({ error: 'Packing slip not found' });
-    let shouldPersistSnapshot = !slip.externalPdfUrl;
+    const requiresCustomerSerialRefresh = hasP2CustomerSerialDisplaySuffix(slip.lineItems);
+    let shouldPersistSnapshot = !slip.externalPdfUrl || requiresCustomerSerialRefresh;
 
-    if (slip.externalPdfUrl) {
+    if (slip.externalPdfUrl && !requiresCustomerSerialRefresh) {
       try {
         const storedBytes = await downloadStoredBuffer(slip.externalPdfUrl);
         res.set('Content-Type', 'application/pdf');
@@ -2292,7 +2324,7 @@ router.get('/packing-slips/:id/pdf', async (req: Request, res: Response) => {
         )
       ).join(', ') || item.drawingName || item.partName || item.partNumber || 'N/A',
       quantity: item.quantity ?? (Array.isArray(item.serialNumbers) ? item.serialNumbers.length : 1),
-      serialNumbers: Array.isArray(item.serialNumbers) ? item.serialNumbers : [],
+      serialNumbers: formatP2CustomerSerialNumbers(item.serialNumbers),
       lotNumber: item.lotNumber || slip.lotNumber || undefined,
     }));
 
@@ -2647,7 +2679,7 @@ router.post('/certificates', authenticateToken, requirePermission('shipping.rele
         partNumber: assignedSku || lot.partNumber,
         partName: lot.partName,
         quantity: serials.length,
-        serialNumbers: serials.map((s) => s.serialNumber),
+        serialNumbers: formatP2CustomerSerialNumbers(serials.map((s) => s.serialNumber)),
         manufacturingDate: manufacturingDate as Date,
         shipDate: input.shipDate ? new Date(`${input.shipDate}T12:00:00`) : new Date(),
         certificationText: input.certificationText || defaultText,
@@ -2705,6 +2737,7 @@ router.get('/certificates/:id', async (req: Request, res: Response) => {
       ...cert,
       poNumber: formatP2DocumentPoNumber(cert.poNumber),
       partNumber: assignedSku || cert.partNumber,
+      serialNumbers: formatP2CustomerSerialNumbers(cert.serialNumbers),
       specialProcesses: getSpecialProcesses(cert.processRecords),
       qaMgrTitle: getQaMgrTitle(cert.traceabilityData),
     });
@@ -2850,7 +2883,7 @@ router.get('/certificates/:id/pdf', async (req: Request, res: Response) => {
     page.drawText('Serial Numbers:', { x: margin, y, size: 9, font: boldFont, color: darkGray });
     y -= 14;
 
-    const serialNums = (cert.serialNumbers as string[]) || [];
+    const serialNums = formatP2CustomerSerialNumbers(cert.serialNumbers);
     const serialsPerRow = 4;
     const serialColW = usableWidth / serialsPerRow;
     for (let i = 0; i < serialNums.length; i += serialsPerRow) {
@@ -3073,7 +3106,17 @@ router.get('/shipments/:lotId', async (req: Request, res: Response) => {
          FROM p2_packing_slips WHERE id = $1`,
         [lot.packing_slip_id]
       );
-      if (psRows.length) packingSlip = psRows[0];
+      if (psRows.length) {
+        packingSlip = {
+          ...psRows[0],
+          line_items: Array.isArray(psRows[0].line_items)
+            ? psRows[0].line_items.map((item: any) => ({
+                ...item,
+                serialNumbers: formatP2CustomerSerialNumbers(item.serialNumbers),
+              }))
+            : psRows[0].line_items,
+        };
+      }
     }
 
     // Fetch certificate if linked
@@ -3087,7 +3130,12 @@ router.get('/shipments/:lotId', async (req: Request, res: Response) => {
          FROM p2_certificates_of_conformance WHERE id = $1`,
         [lot.certificate_id]
       );
-      if (certRows.length) certificate = certRows[0];
+      if (certRows.length) {
+        certificate = {
+          ...certRows[0],
+          serial_numbers: formatP2CustomerSerialNumbers(certRows[0].serial_numbers),
+        };
+      }
     }
     if (!certificate) {
       const certRows = await pool.query(
@@ -3102,7 +3150,10 @@ router.get('/shipments/:lotId', async (req: Request, res: Response) => {
         [lot.id, lot.lot_number]
       );
       if (certRows.length) {
-        certificate = certRows[0];
+        certificate = {
+          ...certRows[0],
+          serial_numbers: formatP2CustomerSerialNumbers(certRows[0].serial_numbers),
+        };
         await pool.query(
           `UPDATE p2_lot_numbers
              SET certificate_id = $1,

--- a/server/src/routes/productLabels.ts
+++ b/server/src/routes/productLabels.ts
@@ -4,6 +4,7 @@ import { authenticateToken } from '../../middleware/auth';
 import bwipjs from 'bwip-js';
 import { pool } from '../../db';
 import { z } from 'zod';
+import { formatP2CustomerSerialNumber } from '../utils/p2CustomerSerialDisplay';
 
 const router = Router();
 
@@ -490,7 +491,7 @@ async function buildP2LabelItems(lotId: string): Promise<LabelItem[]> {
   return serialRows.map((row) => ({
     mode: 'P2',
     sku: row.sku || finalizedSku,
-    serialNumber: row.serial_number,
+    serialNumber: formatP2CustomerSerialNumber(row.serial_number),
     lotNumber: lot.lot_number,
   }));
 }

--- a/server/src/services/invoiceFromPackingSlip.ts
+++ b/server/src/services/invoiceFromPackingSlip.ts
@@ -11,6 +11,7 @@ import {
 import { eq, inArray, sql } from 'drizzle-orm';
 import { buildRevenueDimensionTags } from './productionLineAccounting';
 import { assignReservedP2InvoiceNumberToPackingSlip } from './p2InvoiceNumberService';
+import { formatP2CustomerSerialNumbers } from '../utils/p2CustomerSerialDisplay';
 
 let p2PackingSlipInvoiceNumberSchemaReady: Promise<void> | null = null;
 let p2BillingAllocationSchemaReady: Promise<void> | null = null;
@@ -160,6 +161,7 @@ export interface InvoicePreviewLine {
   billingBucketLabel?: string | null;
   customerPoLine?: string | null;
   serialNumbers?: string[];
+  internalSerialNumbers?: string[];
   description: string;
   qty: number;
   unitPrice: number;
@@ -268,9 +270,10 @@ async function hydrateInvoiceLineItemCustomerParts(lineItems: LineItem[]): Promi
         .map((serialNumber) => ({ sku: skuBySerialNumber.get(serialNumber) })),
     );
 
-    return customerSku && !item.customerSku
-      ? { ...item, customerSku }
-      : item;
+    return {
+      ...item,
+      ...(customerSku && !item.customerSku ? { customerSku } : {}),
+    };
   });
 }
 
@@ -365,7 +368,8 @@ export async function buildInvoicePreviewFromPackingSlip(
       billingAllocationId: line.billingAllocationId || null,
       billingBucketLabel: bucketLabel,
       customerPoLine: line.customerPoLine || null,
-      serialNumbers: Array.isArray(line.serialNumbers) ? line.serialNumbers : [],
+      serialNumbers: formatP2CustomerSerialNumbers(line.serialNumbers),
+      internalSerialNumbers: Array.isArray(line.serialNumbers) ? line.serialNumbers : [],
       description: bucketLabel ? `${baseDescription} (${bucketLabel})` : baseDescription,
       qty,
       unitPrice: effectiveUnitPrice,
@@ -389,6 +393,7 @@ export async function buildInvoicePreviewFromPackingSlip(
             billingBucketLabel: base?.billingBucketLabel ?? null,
             customerPoLine: base?.customerPoLine ?? null,
             serialNumbers: base?.serialNumbers ?? [],
+            internalSerialNumbers: base?.internalSerialNumbers ?? [],
             description: String(line.description ?? base?.description ?? '').trim(),
             qty,
             unitPrice,
@@ -550,7 +555,7 @@ export async function createInvoiceFromPackingSlip(
         );
       }
 
-      const serialNumbers = preview.lines.flatMap((line) => line.serialNumbers ?? []);
+      const serialNumbers = preview.lines.flatMap((line) => line.internalSerialNumbers ?? line.serialNumbers ?? []);
       if (serialNumbers.length > 0) {
         const serialNumberList = sql.join(serialNumbers.map((serialNumber) => sql`${serialNumber}`), sql`, `);
         await tx.execute(sql`

--- a/server/src/utils/p2CustomerSerialDisplay.ts
+++ b/server/src/utils/p2CustomerSerialDisplay.ts
@@ -1,0 +1,18 @@
+export function formatP2CustomerSerialNumber(serialNumber: string | null | undefined): string {
+  const trimmed = String(serialNumber ?? '').trim();
+  if (!trimmed) return '';
+
+  return trimmed.replace(/-(?:rma-\d+|r\d+)$/i, '');
+}
+
+export function formatP2CustomerSerialNumbers(serialNumbers: unknown): string[] {
+  if (!Array.isArray(serialNumbers)) return [];
+
+  return serialNumbers
+    .map((serialNumber) =>
+      typeof serialNumber === 'string'
+        ? formatP2CustomerSerialNumber(serialNumber)
+        : ''
+    )
+    .filter((serialNumber) => serialNumber.length > 0);
+}


### PR DESCRIPTION
## Summary
- Allocate production RMA replacement items through the shared P2 customer/year serial allocator instead of generating `-rma-NN` serials.
- Add a shared customer-facing P2 serial display helper that strips internal `-r1` / `-rma-01` style suffixes from customer paperwork.
- Apply the customer-facing serial display to packing slip JSON/PDFs, linked shipment document payloads, CoC JSON/PDFs, product labels, and invoice line display metadata while preserving raw serials for internal invoice locking.

## Root Cause
The production scrap/RMA path hand-built replacement serials with an RMA suffix, and several customer document surfaces rendered stored serial values directly. That leaked internal revision/RMA identity into packing slips, CoCs, labels, and invoice metadata.

## Validation
- `git diff --cached --check`
- `git diff --check`

Full TypeScript check was not completed locally because `npm` is not installed in this shell and the bundled `pnpm` attempted registry access that was blocked by sandbox/network `EACCES`.