### PR TITLE
Fix approval tasks and quote save schema drift

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6707,14 +6707,18 @@ async function initializeBackgroundServices() {
           description TEXT,
           total_amount REAL NOT NULL DEFAULT 0,
           status TEXT NOT NULL DEFAULT 'DRAFT',
+          project_id UUID,
           valid_until TIMESTAMP,
           quoted_by TEXT,
           notes TEXT,
           attachments TEXT[],
+          customers_integer_id INTEGER,
           created_at TIMESTAMP DEFAULT NOW(),
           updated_at TIMESTAMP DEFAULT NOW()
         )
       `);
+      await pool.query(`ALTER TABLE quotes ADD COLUMN IF NOT EXISTS project_id UUID`);
+      await pool.query(`ALTER TABLE quotes ADD COLUMN IF NOT EXISTS customers_integer_id INTEGER`);
       await pool.query(`
         CREATE TABLE IF NOT EXISTS quote_line_items (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -6726,9 +6730,13 @@ async function initializeBackgroundServices() {
           total_price REAL NOT NULL DEFAULT 0,
           inventory_item_id INTEGER,
           ag_part_number TEXT,
+          labor_hours REAL,
+          department TEXT,
           created_at TIMESTAMP DEFAULT NOW()
         )
       `);
+      await pool.query(`ALTER TABLE quote_line_items ADD COLUMN IF NOT EXISTS labor_hours REAL`);
+      await pool.query(`ALTER TABLE quote_line_items ADD COLUMN IF NOT EXISTS department TEXT`);
       await pool.query(`
         CREATE TABLE IF NOT EXISTS quote_snapshots (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -124,15 +124,16 @@ approvalsRouter.get('/my-tasks/:employeeId', async (req: Request, res: Response)
         id,
         change_number,
         proposed_change,
-        required_actions,
+        COALESCE(to_jsonb(p) -> 'required_actions', '[]'::jsonb) AS required_actions,
         submitted_by_name,
         approved_at,
         created_at,
         effective_date
-      FROM p2_production_changes
+      FROM p2_production_changes p
       WHERE status = 'APPROVED'
         AND implementation_required = true
-        AND approval_assignments @> ${JSON.stringify([{ required: true, employeeId }])}::jsonb
+        AND COALESCE(to_jsonb(p) -> 'approval_assignments', '[]'::jsonb)
+          @> ${JSON.stringify([{ required: true, employeeId }])}::jsonb
       LIMIT 100
     `);
     const approvedFollowUps = ((approvedFollowUpsResult as any)?.rows || approvedFollowUpsResult || []) as any[];


### PR DESCRIPTION
## Summary
- make `/api/approvals/my-tasks/:employeeId` tolerate older `p2_production_changes` rows/tables missing optional JSONB columns
- add startup schema guards for quote table columns used by quote save and line-item writes

## Validation
- `git diff --check`
- `git diff --cached --check`

## Notes
This targets the production console failures: `column "required_actions" does not exist` from approval tasks and generic `/api/quotes/save` 500s caused by quote schema drift.