### PR TITLE
Register form builder documents in project packages

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -1068,9 +1068,14 @@ export default function ProjectDetailPage() {
 
   // ── Project manual document attachments ──
   interface ProjectDoc {
-    id: number; project_id: string; label: string | null; original_file_name: string;
+    id: number | string; project_id: string; label: string | null; original_file_name: string;
     file_name: string | null; mime_type: string; file_size: number | null;
     media_library_id: number | null; uploaded_by: string | null; created_at: string;
+    source?: 'manual' | 'work_instruction' | 'spec_sheet';
+    document_type?: string | null;
+    part_number?: string | null;
+    department_name?: string | null;
+    has_file?: boolean;
   }
   interface MediaItem {
     id: number; filename: string; title: string | null; mimeType: string;
@@ -1092,6 +1097,8 @@ export default function ProjectDetailPage() {
     queryFn: () => fetch(`/api/projects/${id}/documents`).then(r => r.json()),
     enabled: !!id,
   });
+  const manufacturingProjectDocs = projectDocs.filter((doc) => doc.source === 'work_instruction' || doc.source === 'spec_sheet');
+  const manualProjectDocs = projectDocs.filter((doc) => !doc.source || doc.source === 'manual');
 
   const { data: mediaSearchResults = [] } = useQuery<MediaItem[]>({
     queryKey: ['/api/media', mediaSearch],
@@ -5735,15 +5742,69 @@ export default function ProjectDetailPage() {
                     )}
 
                     {/* ── Manual attachments ── */}
-                    {projectDocs.length > 0 && (
+                    {manufacturingProjectDocs.length > 0 && (
+                      <>
+                        <div className="flex items-center gap-2 pt-2">
+                          <div className="flex-1 border-t" />
+                          <span className="text-xs text-muted-foreground px-2">Work Instructions & Spec Sheets</span>
+                          <div className="flex-1 border-t" />
+                        </div>
+                        {manufacturingProjectDocs.map(doc => (
+                          <div key={String(doc.id)} className="flex items-center justify-between py-2 px-3 rounded-lg border">
+                            <div className="flex items-center gap-3 min-w-0">
+                              {doc.source === 'spec_sheet' ? (
+                                <FileText className="h-4 w-4 text-blue-600 flex-shrink-0" />
+                              ) : (
+                                <ClipboardList className="h-4 w-4 text-green-600 flex-shrink-0" />
+                              )}
+                              <div className="min-w-0">
+                                <p className="text-sm font-medium truncate">{doc.label || doc.original_file_name}</p>
+                                <div className="flex flex-wrap items-center gap-1.5 mt-1">
+                                  <Badge variant="secondary" className="text-xs">
+                                    {doc.source === 'spec_sheet' ? 'Spec Sheet' : 'Work Instruction'}
+                                  </Badge>
+                                  {doc.part_number && (
+                                    <Badge variant="outline" className="text-xs font-mono">{doc.part_number}</Badge>
+                                  )}
+                                  {doc.department_name && (
+                                    <Badge variant="outline" className="text-xs">{doc.department_name}</Badge>
+                                  )}
+                                </div>
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-1 flex-shrink-0">
+                              {doc.has_file && (
+                                <>
+                                  <Button size="sm" variant="ghost" title="Preview"
+                                    onClick={() => { setPdfPreviewUrl(`/api/projects/${id}/documents/${encodeURIComponent(String(doc.id))}/file`); setPdfPreviewTitle(doc.label || doc.original_file_name); }}>
+                                    <Eye className="h-3.5 w-3.5" />
+                                  </Button>
+                                  <Button size="sm" variant="ghost" title="Download" asChild>
+                                    <a href={`/api/projects/${id}/documents/${encodeURIComponent(String(doc.id))}/file`} download={doc.original_file_name}>
+                                      <Download className="h-3.5 w-3.5" />
+                                    </a>
+                                  </Button>
+                                </>
+                              )}
+                              <Button size="sm" variant="ghost" title="Revise in builder"
+                                onClick={() => setLocation(`/forms/document-builder?partNumber=${encodeURIComponent(doc.part_number || '')}`)}>
+                                <Edit className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          </div>
+                        ))}
+                      </>
+                    )}
+
+                    {manualProjectDocs.length > 0 && (
                       <>
                         <div className="flex items-center gap-2 pt-2">
                           <div className="flex-1 border-t" />
                           <span className="text-xs text-muted-foreground px-2">Manual Attachments</span>
                           <div className="flex-1 border-t" />
                         </div>
-                        {projectDocs.map(doc => (
-                          <div key={doc.id} className="flex items-center justify-between py-2 px-3 rounded-lg border">
+                        {manualProjectDocs.map(doc => (
+                          <div key={String(doc.id)} className="flex items-center justify-between py-2 px-3 rounded-lg border">
                             <div className="flex items-center gap-3">
                               <Paperclip className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                               <div className="min-w-0">
@@ -5767,7 +5828,7 @@ export default function ProjectDetailPage() {
                                 </a>
                               </Button>
                               <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" title="Remove"
-                                onClick={() => deleteDocMutation.mutate(doc.id)}
+                                onClick={() => deleteDocMutation.mutate(Number(doc.id))}
                                 disabled={deleteDocMutation.isPending}>
                                 <Trash2 className="h-3.5 w-3.5" />
                               </Button>

--- a/client/src/pages/RoutingDocumentManagement.tsx
+++ b/client/src/pages/RoutingDocumentManagement.tsx
@@ -140,6 +140,7 @@ export default function RoutingDocumentManagement() {
   const [generateForm, setGenerateForm] = useState({
     partNumber: '',
     partName: '',
+    departmentName: '',
     documentType: 'work_instruction',
     templateId: '',
   });
@@ -339,7 +340,7 @@ export default function RoutingDocumentManagement() {
   });
 
   const generateMutation = useMutation({
-    mutationFn: async (data: { partNumber: string; partName: string; documentType: string; templateId?: string; referenceDocumentIds?: string[] }) => {
+    mutationFn: async (data: { partNumber: string; partName: string; departmentName: string; documentType: string; templateId?: string; referenceDocumentIds?: string[] }) => {
       return apiRequest('/api/routing-documents/ai-generate', {
         method: 'POST',
         body: data,
@@ -349,8 +350,10 @@ export default function RoutingDocumentManagement() {
     onSuccess: () => {
       toast({ title: 'Form Generated', description: 'New form or instruction document has been created from AI analysis' });
       queryClient.invalidateQueries({ queryKey: ['/api/routing-documents'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/routing-documents/spec-sheets'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/controlled-documents'] });
       setShowGenerateDialog(false);
-      setGenerateForm({ partNumber: '', partName: '', documentType: 'work_instruction', templateId: '' });
+      setGenerateForm({ partNumber: '', partName: '', departmentName: '', documentType: 'work_instruction', templateId: '' });
     },
     onError: (error: any) => {
       toast({ title: 'Error', description: error.message || 'Failed to generate document', variant: 'destructive' });
@@ -681,6 +684,7 @@ export default function RoutingDocumentManagement() {
     generateMutation.mutate({
       partNumber: generateForm.partNumber,
       partName: generateForm.partName,
+      departmentName: generateForm.departmentName,
       documentType: generateForm.documentType,
       templateId: generateForm.templateId || undefined,
       referenceDocumentIds: selectedDocuments.length > 0 ? selectedDocuments : undefined,
@@ -1292,6 +1296,14 @@ export default function RoutingDocumentManagement() {
                 value={generateForm.partName}
                 onChange={(e) => setGenerateForm({ ...generateForm, partName: e.target.value })}
                 placeholder="e.g., Carbon Fiber Stock, Weekly CNC Maintenance"
+              />
+            </div>
+            <div>
+              <Label>Department</Label>
+              <Input
+                value={generateForm.departmentName}
+                onChange={(e) => setGenerateForm({ ...generateForm, departmentName: e.target.value })}
+                placeholder="e.g., Layup, CNC, Finish, Quality Control"
               />
             </div>
             <div>

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -39,6 +39,24 @@ const uploadProjectDoc = multer({
 
 const router = Router();
 
+type ProjectDocumentRef = {
+  id: string | number;
+  project_id: string;
+  label: string | null;
+  original_file_name: string;
+  file_name: string | null;
+  mime_type: string;
+  file_size: number | null;
+  media_library_id: number | null;
+  uploaded_by: string | null;
+  created_at: string;
+  source: 'manual' | 'work_instruction' | 'spec_sheet';
+  document_type?: string | null;
+  part_number?: string | null;
+  department_name?: string | null;
+  has_file?: boolean;
+};
+
 let projectRevisionSchemaReady = false;
 let projectClinSchemaReady = false;
 
@@ -87,6 +105,122 @@ function normalizeRomCategories(raw: unknown): Record<string, any> {
     escalationAndInflation: normalizeCategory('escalationAndInflation', ['budgetAmount']),
     profitFee: normalizeCategory('profitFee', ['budgetAmount']),
   };
+}
+
+function normalizeProjectPartNumber(value: unknown) {
+  return String(value ?? '').trim();
+}
+
+function resolveBuilderAssetPath(fileUrl: string | null | undefined) {
+  if (!fileUrl) return null;
+  if (/^https?:\/\//i.test(fileUrl)) return fileUrl;
+  if (fileUrl.startsWith('/assets/documents/')) {
+    const filename = fileUrl.replace('/assets/documents/', '');
+    return path.join(process.cwd(), 'server/src/assets/documents', filename);
+  }
+  if (path.isAbsolute(fileUrl)) return fileUrl;
+  return null;
+}
+
+async function getProjectManufacturingDocumentRefs(projectId: string): Promise<ProjectDocumentRef[]> {
+  const projectRows = await pool.query<{ id: string; po_id: number | null }>(
+    `SELECT id, po_id FROM projects WHERE id = $1 LIMIT 1`,
+    [projectId],
+  );
+  const project = projectRows[0];
+  if (!project) return [];
+
+  const partRows = project.po_id
+    ? await pool.query<{ part_number: string | null }>(
+        `SELECT DISTINCT part_number
+           FROM p2_purchase_order_items
+          WHERE po_id = $1
+            AND NULLIF(TRIM(part_number), '') IS NOT NULL`,
+        [project.po_id],
+      )
+    : [];
+  const routingRows = await pool.query<{ id: string; part_number: string | null }>(
+    `SELECT id::text, part_number
+       FROM part_routings
+      WHERE project_id = $1::uuid
+         OR (
+           NULLIF(TRIM(part_number), '') IS NOT NULL
+           AND part_number = ANY($2::text[])
+         )`,
+    [projectId, partRows.map((row) => normalizeProjectPartNumber(row.part_number)).filter(Boolean)],
+  );
+  const partNumbers = Array.from(new Set([
+    ...partRows.map((row) => normalizeProjectPartNumber(row.part_number)),
+    ...routingRows.map((row) => normalizeProjectPartNumber(row.part_number)),
+  ].filter(Boolean)));
+  const routingIds = routingRows.map((row) => row.id).filter(Boolean);
+
+  if (partNumbers.length === 0 && routingIds.length === 0) return [];
+
+  const workInstructionRows = await pool.query<any>(
+    `SELECT id::text, title, file_name, file_url, file_type, file_size,
+            document_type, part_number, department_name, created_by, created_at
+       FROM routing_documents
+      WHERE is_active = true
+        AND COALESCE(is_template, false) = false
+        AND document_type <> 'spec_sheet'
+        AND (
+          part_number = ANY($1::text[])
+          OR part_routing_id = ANY($2::uuid[])
+        )
+      ORDER BY created_at DESC`,
+    [partNumbers, routingIds],
+  );
+  const specSheetRows = await pool.query<any>(
+    `SELECT id::text, title, file_name, file_url, file_type, file_size,
+            part_number, created_by, created_at
+       FROM spec_sheets
+      WHERE is_active = true
+        AND COALESCE(is_template, false) = false
+        AND (
+          part_number = ANY($1::text[])
+          OR part_routing_id = ANY($2::uuid[])
+        )
+      ORDER BY created_at DESC`,
+    [partNumbers, routingIds],
+  );
+
+  return [
+    ...workInstructionRows.map((doc: any): ProjectDocumentRef => ({
+      id: `routing:${doc.id}`,
+      project_id: projectId,
+      label: doc.title,
+      original_file_name: doc.file_name || `${doc.title}.pdf`,
+      file_name: doc.file_name,
+      mime_type: doc.file_type || 'application/pdf',
+      file_size: doc.file_size ?? null,
+      media_library_id: null,
+      uploaded_by: doc.created_by ?? null,
+      created_at: doc.created_at,
+      source: 'work_instruction',
+      document_type: doc.document_type,
+      part_number: doc.part_number,
+      department_name: doc.department_name,
+      has_file: !!doc.file_url,
+    })),
+    ...specSheetRows.map((doc: any): ProjectDocumentRef => ({
+      id: `spec:${doc.id}`,
+      project_id: projectId,
+      label: doc.title,
+      original_file_name: doc.file_name || `${doc.title}.pdf`,
+      file_name: doc.file_name,
+      mime_type: doc.file_type || 'application/pdf',
+      file_size: doc.file_size ?? null,
+      media_library_id: null,
+      uploaded_by: doc.created_by ?? null,
+      created_at: doc.created_at,
+      source: 'spec_sheet',
+      document_type: 'spec_sheet',
+      part_number: doc.part_number,
+      department_name: null,
+      has_file: !!doc.file_url,
+    })),
+  ];
 }
 
 async function getRomLockState(projectId: string) {
@@ -3103,8 +3237,18 @@ router.get('/:id/documents', async (req, res) => {
        FROM project_documents WHERE project_id = $1 ORDER BY created_at DESC`,
       [id]
     );
-    res.json(rows);
+    const manualDocs: ProjectDocumentRef[] = rows.map((row) => ({
+      ...row,
+      source: 'manual',
+      document_type: null,
+      part_number: null,
+      department_name: null,
+      has_file: true,
+    }));
+    const manufacturingDocs = await getProjectManufacturingDocumentRefs(id);
+    res.json([...manufacturingDocs, ...manualDocs]);
   } catch (err: any) {
+    console.error('Failed to list project documents:', err);
     res.status(500).json({ message: 'Failed to list project documents' });
   }
 });
@@ -3181,6 +3325,44 @@ router.delete('/:id/documents/:docId', async (req, res) => {
 router.get('/:id/documents/:docId/file', async (req, res) => {
   try {
     const { id, docId } = req.params;
+    const generatedMatch = String(docId).match(/^(routing|spec):([0-9a-f-]{36})$/i);
+    if (generatedMatch) {
+      const [, source, generatedId] = generatedMatch;
+      const allowedRefs = await getProjectManufacturingDocumentRefs(id);
+      if (!allowedRefs.some((ref) => String(ref.id).toLowerCase() === String(docId).toLowerCase())) {
+        return res.status(404).json({ message: 'Document not found for this project' });
+      }
+      const rows = source === 'spec'
+        ? await pool.query<{
+            file_url: string | null; file_name: string | null; title: string; file_type: string | null;
+          }>(
+            `SELECT file_url, file_name, title, file_type
+               FROM spec_sheets
+              WHERE id = $1::uuid AND is_active = true
+              LIMIT 1`,
+            [generatedId],
+          )
+        : await pool.query<{
+            file_url: string | null; file_name: string | null; title: string; file_type: string | null;
+          }>(
+            `SELECT file_url, file_name, title, file_type
+               FROM routing_documents
+              WHERE id = $1::uuid AND is_active = true
+              LIMIT 1`,
+            [generatedId],
+          );
+      const generatedDoc = rows[0];
+      if (!generatedDoc) return res.status(404).json({ message: 'Document not found' });
+      const resolved = resolveBuilderAssetPath(generatedDoc.file_url);
+      if (!resolved) return res.status(404).json({ message: 'No document file is attached yet' });
+      if (/^https?:\/\//i.test(resolved)) return res.redirect(resolved);
+      if (!fs.existsSync(resolved)) return res.status(404).json({ message: 'File not found on disk' });
+
+      res.set('Content-Type', generatedDoc.file_type || 'application/pdf');
+      res.set('Content-Disposition', `inline; filename="${generatedDoc.file_name || `${generatedDoc.title}.pdf`}"`);
+      return res.sendFile(path.resolve(resolved));
+    }
+
     const rows = await pool.query<{
       file_path: string | null; file_name: string | null; original_file_name: string;
       mime_type: string; media_library_id: number | null;

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -17,6 +17,7 @@ import {
 } from '@shared/schema';
 import { eq, desc, and, ilike, sql } from 'drizzle-orm';
 import OpenAI from 'openai';
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
 import {
   getFileStorageProvider,
   getFileStorageProviderForObjectPath,
@@ -185,6 +186,104 @@ async function saveControlledDocumentFile(fileName: string, fileBuffer: Buffer) 
   const storedFileName = sanitizeFileName(fileName);
   fs.writeFileSync(path.join(uploadDir, storedFileName), fileBuffer);
   return `/assets/documents/${storedFileName}`;
+}
+
+function humanizeDocumentType(value: string) {
+  return String(value || 'Document')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function stringifyGeneratedSection(section: any) {
+  if (!section || typeof section !== 'object') return String(section ?? '');
+  const fields = Array.isArray(section.fields) && section.fields.length > 0
+    ? `\nFields: ${section.fields.map((field: any) => field.fieldLabel || field.fieldName).filter(Boolean).join(', ')}`
+    : '';
+  return `${section.name || 'Section'}\n${section.content || section.description || ''}${fields}`;
+}
+
+function wrapPdfText(text: string, maxChars = 92) {
+  const words = String(text || '').replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  const lines: string[] = [];
+  let line = '';
+  for (const word of words) {
+    if ((line + ' ' + word).trim().length > maxChars) {
+      if (line) lines.push(line);
+      line = word;
+    } else {
+      line = (line ? `${line} ` : '') + word;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.length > 0 ? lines : [''];
+}
+
+async function createGeneratedControlledPdf(params: {
+  title: string;
+  documentType: string;
+  partNumber: string;
+  partName?: string | null;
+  documentNumber: string;
+  generatedContent: any;
+}) {
+  const pdfDoc = await PDFDocument.create();
+  let page = pdfDoc.addPage([612, 792]);
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+  const margin = 48;
+  let y = 744;
+
+  const addPageIfNeeded = (height = 16) => {
+    if (y - height < 64) {
+      page = pdfDoc.addPage([612, 792]);
+      y = 744;
+    }
+  };
+  const drawLine = (text: string, options: { size?: number; bold?: boolean; color?: any; gap?: number } = {}) => {
+    addPageIfNeeded(options.gap ?? 16);
+    page.drawText(text.substring(0, 120), {
+      x: margin,
+      y,
+      size: options.size ?? 10,
+      font: options.bold ? boldFont : font,
+      color: options.color ?? rgb(0.12, 0.12, 0.12),
+    });
+    y -= options.gap ?? 16;
+  };
+  const drawWrapped = (text: string, options: { size?: number; bold?: boolean; gap?: number } = {}) => {
+    for (const line of wrapPdfText(text, options.size && options.size > 11 ? 76 : 92)) {
+      drawLine(line, options);
+    }
+  };
+
+  drawWrapped(params.title, { size: 18, bold: true, gap: 22 });
+  drawLine(`${params.documentNumber} | ${humanizeDocumentType(params.documentType)}`, { size: 10, bold: true, color: rgb(0.32, 0.32, 0.32) });
+  drawLine(`Part / Source: ${params.partNumber}${params.partName ? ` - ${params.partName}` : ''}`, { size: 10 });
+  drawLine(`Generated: ${new Date().toLocaleDateString()}`, { size: 9, color: rgb(0.42, 0.42, 0.42), gap: 24 });
+
+  const sections = Array.isArray(params.generatedContent?.sections) ? params.generatedContent.sections : [];
+  if (sections.length > 0) {
+    sections.forEach((section: any, index: number) => {
+      drawLine(`${index + 1}. ${section?.name || 'Section'}`, { size: 12, bold: true, gap: 18 });
+      drawWrapped(section?.content || section?.description || stringifyGeneratedSection(section), { size: 10 });
+      y -= 6;
+    });
+  } else {
+    drawWrapped(JSON.stringify(params.generatedContent, null, 2), { size: 9 });
+  }
+
+  pdfDoc.getPages().forEach((pdfPage) => {
+    pdfPage.drawText(`Doc #: ${params.documentNumber} | Version: 1.0 | Date: ${new Date().toLocaleDateString()}`, {
+      x: margin,
+      y: 28,
+      size: 8,
+      font,
+      color: rgb(0.42, 0.42, 0.42),
+    });
+  });
+
+  const pdfBytes = await pdfDoc.save();
+  return Buffer.from(pdfBytes);
 }
 
 // Helper to format UUID bytes to string if needed
@@ -1318,10 +1417,13 @@ router.post('/:id/ai-parse', async (req: Request, res: Response) => {
 // AI Generate new document from templates
 router.post('/ai-generate', async (req: Request, res: Response) => {
   try {
-    const { templateId, partNumber, partName, documentType, customFields, referenceDocumentIds } = req.body;
+    const { templateId, partNumber, partName, departmentName, documentType, customFields, referenceDocumentIds } = req.body;
     const finalDocumentType = typeof documentType === 'string' && documentType.trim()
       ? documentType.trim()
       : 'work_instruction';
+    const finalDepartment = typeof departmentName === 'string' && departmentName.trim()
+      ? departmentName.trim()
+      : 'Manufacturing';
     
     if (!partNumber) {
       return res.status(400).json({ error: 'Reference, part, or equipment ID is required' });
@@ -1391,6 +1493,7 @@ Return a JSON object with:
 Document Type: ${finalDocumentType}
 Reference / Part / Equipment ID: ${partNumber || 'Not specified'}
 Subject / Part Name: ${partName || 'Not specified'}
+Department: ${finalDepartment}
 Custom Requirements: ${JSON.stringify(customFields || {})}
 
 ${referenceContent ? `Reference Documents:\n${referenceContent}` : ''}
@@ -1407,21 +1510,90 @@ ${templateContent ? `\nTemplate:\n${templateContent}` : ''}`;
     });
     
     const generatedContent = JSON.parse(response.choices[0]?.message?.content || '{}');
-    
+    const documentTitle = generatedContent.title || `${humanizeDocumentType(finalDocumentType)} for ${partNumber}`;
+    const documentNumber = await generateControlledTemplateNumber();
+    const createdBy = (req as any).user?.username || 'system';
+    const pdfBuffer = await createGeneratedControlledPdf({
+      title: documentTitle,
+      documentType: finalDocumentType,
+      partNumber,
+      partName,
+      documentNumber,
+      generatedContent,
+    });
+    const pdfFileName = `${documentNumber}-${documentTitle}.pdf`;
+    const fileUrl = await saveControlledDocumentFile(pdfFileName, pdfBuffer);
+    const expirationDate = new Date();
+    expirationDate.setFullYear(expirationDate.getFullYear() + 1);
+
     // Create new routing document with generated content
     const [newDocument] = await db.insert(routingDocuments).values({
-      title: generatedContent.title || `Generated Document for ${partNumber}`,
+      title: documentTitle,
       partNumber,
+      departmentName: finalDepartment,
       documentType: finalDocumentType,
       sourceType: 'generated',
+      fileUrl,
+      fileName: pdfFileName,
+      fileType: 'application/pdf',
+      fileSize: pdfBuffer.length,
       aiExtractedContent: generatedContent,
       aiExtractedFields: generatedContent.fields || [],
       aiProcessedAt: new Date(),
       isTemplate: false,
-      createdBy: (req as any).user?.username || 'system',
+      description: `Controlled generated document ${documentNumber}`,
+      createdBy,
     }).returning();
+
+    let specSheet = null;
+    if (finalDocumentType === 'spec_sheet' || finalDocumentType === 'specification') {
+      [specSheet] = await db.insert(specSheets).values({
+        title: documentTitle,
+        partNumber,
+        partRoutingId: null,
+        description: `Controlled generated spec sheet ${documentNumber}`,
+        sourceType: 'generated',
+        fileUrl,
+        fileName: pdfFileName,
+        fileType: 'application/pdf',
+        fileSize: pdfBuffer.length,
+        specifications: generatedContent,
+        aiExtractedContent: generatedContent,
+        aiExtractedFields: generatedContent.fields || [],
+        aiProcessedAt: new Date(),
+        isTemplate: false,
+        createdBy,
+      }).returning();
+    }
+
+    const [controlledDocument] = await db.insert(controlledDocuments).values({
+      documentNumber,
+      documentName: documentTitle,
+      documentType: finalDocumentType,
+      department: finalDepartment,
+      category: specSheet ? 'Form & Document Builder Spec Sheet' : 'Form & Document Builder Work Instruction',
+      description: `${humanizeDocumentType(finalDocumentType)} generated from Form & Document Builder for ${partNumber}`,
+      currentVersion: '1.0',
+      status: 'pending',
+      retentionLength: 'controlled',
+      documentOwner: createdBy,
+      filePath: fileUrl,
+      createdBy,
+      expirationDate: expirationDate.toISOString().split('T')[0],
+    }).returning();
+
+    await db.insert(documentVersionHistory).values({
+      documentId: controlledDocument.id,
+      versionNumber: '1.0',
+      changeDescription: 'Initial generated document created from Form & Document Builder',
+      changeType: 'major',
+      filePath: fileUrl,
+      status: 'pending',
+      createdBy,
+      expirationDate: expirationDate.toISOString().split('T')[0],
+    });
     
-    res.status(201).json({ document: newDocument, generatedContent });
+    res.status(201).json({ document: newDocument, specSheet, controlledDocument, generatedContent });
   } catch (error) {
     console.error('Error generating document with AI:', error);
     res.status(500).json({ error: 'Failed to generate document' });


### PR DESCRIPTION
## Summary
- Registers Form & Document Builder templates and generated part documents in the Master Document Register with controlled document/version records.
- Adds department-aware generation for work instructions and spec sheets, including saved controlled PDFs with Doc # / Version / Date footers.
- Surfaces matching part-number/routing work instructions and spec sheets automatically in project document packages alongside manual attachments.

## Impact
- Users can select/build the document type they need in Form & Document Builder, keep generated work instructions/spec sheets in the UI, and have the same controlled document represented in the Master Document Register.
- Projects started from a source part number now pull in the relevant work instructions and spec sheets like BOM/routing evidence, with preview/download and a path back to revise in the builder.

## Validation
- `git diff --cached --check` passed before commit.
- `git diff --check` passed after edits.
- TypeScript parser check passed for the four touched files.
- Full `tsc` did not complete locally: one run hit Node heap OOM, and a higher-heap run stayed silent too long and was stopped.