### PR TITLE
Harden manufacturing queue and project document reads

### DIFF
--- a/server/src/routes/manufacturingQueue.ts
+++ b/server/src/routes/manufacturingQueue.ts
@@ -9,6 +9,77 @@ import { generateRequirementsFromRouting } from '../services/requirementGenerato
 
 const router = Router();
 
+async function publicColumnsExist(tableName: string, columnNames: string[]): Promise<boolean> {
+  if (columnNames.length === 0) return true;
+  const rows = await pool.query<{ column_name: string }>(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = $1
+        AND column_name = ANY($2::text[])`,
+    [tableName, columnNames]
+  );
+  const existingColumns = new Set(rows.map((row) => row.column_name));
+  return columnNames.every((columnName) => existingColumns.has(columnName));
+}
+
+async function loadProjectContextByQueueItemId(ids: number[]) {
+  const projectByItemId = new Map<number, { projectId: string; projectCode: string }>();
+  if (ids.length === 0) return projectByItemId;
+
+  try {
+    const canJoinProjects =
+      await publicColumnsExist('manufacturing_queue', ['p2_po_id']) &&
+      await publicColumnsExist('projects', ['po_id', 'project_code']);
+
+    if (!canJoinProjects) return projectByItemId;
+
+    const projectRows = await pool.query<{ id: number; projectId: string; projectCode: string }>(
+      `SELECT mq.id, p.id AS "projectId", p.project_code AS "projectCode"
+         FROM manufacturing_queue mq
+         JOIN projects p ON p.po_id = mq.p2_po_id
+        WHERE mq.id = ANY($1)`,
+      [ids]
+    );
+    for (const row of projectRows) {
+      projectByItemId.set(row.id, { projectId: row.projectId, projectCode: row.projectCode });
+    }
+  } catch (error) {
+    console.warn('Skipping manufacturing queue project enrichment:', error);
+  }
+
+  return projectByItemId;
+}
+
+async function loadWorkOrderContextByQueueItemId(ids: number[]) {
+  const workOrderByItemId = new Map<number, { workOrderId: string; workOrderNumber: string }>();
+  if (ids.length === 0) return workOrderByItemId;
+
+  try {
+    const canJoinWorkOrders =
+      await publicColumnsExist('manufacturing_queue', ['source_id', 'source_type']) &&
+      await publicColumnsExist('production_work_orders', ['work_order_number']);
+
+    if (!canJoinWorkOrders) return workOrderByItemId;
+
+    const workOrderRows = await pool.query<{ id: number; workOrderId: string; workOrderNumber: string }>(
+      `SELECT mq.id, wo.id AS "workOrderId", wo.work_order_number AS "workOrderNumber"
+         FROM manufacturing_queue mq
+         JOIN production_work_orders wo ON wo.id::text = mq.source_id
+        WHERE mq.source_type = 'production_work_order'
+          AND mq.id = ANY($1)`,
+      [ids]
+    );
+    for (const row of workOrderRows) {
+      workOrderByItemId.set(row.id, { workOrderId: row.workOrderId, workOrderNumber: row.workOrderNumber });
+    }
+  } catch (error) {
+    console.warn('Skipping manufacturing queue work order enrichment:', error);
+  }
+
+  return workOrderByItemId;
+}
+
 // Get manufacturing queue items.
 // DEMAND ROUTING — additive signal for `?department=` queries:
 // When `?department=<legacyDept>` is provided, records are matched by:
@@ -110,30 +181,8 @@ router.get('/', async (req, res) => {
     const ids = items.map((i: any) => i.id);
 
     // Enrich with project context (via p2_po_id → projects.po_id)
-    const projectRows = await pool.query<{ id: number; projectId: string; projectCode: string }>(
-      `SELECT mq.id, p.id AS "projectId", p.project_code AS "projectCode"
-       FROM manufacturing_queue mq
-       JOIN projects p ON p.po_id = mq.p2_po_id
-       WHERE mq.id = ANY($1)`,
-      [ids]
-    );
-    const projectByItemId = new Map<number, { projectId: string; projectCode: string }>();
-    for (const r of projectRows) {
-      projectByItemId.set(r.id, { projectId: r.projectId, projectCode: r.projectCode });
-    }
-
-    // Enrich with work order context (via source_id where source_type = 'production_work_order')
-    const woRows = await pool.query<{ id: number; workOrderId: string; workOrderNumber: string }>(
-      `SELECT mq.id, wo.id AS "workOrderId", wo.work_order_number AS "workOrderNumber"
-       FROM manufacturing_queue mq
-       JOIN production_work_orders wo ON wo.id::text = mq.source_id
-       WHERE mq.source_type = 'production_work_order' AND mq.id = ANY($1)`,
-      [ids]
-    );
-    const woByItemId = new Map<number, { workOrderId: string; workOrderNumber: string }>();
-    for (const r of woRows) {
-      woByItemId.set(r.id, { workOrderId: r.workOrderId, workOrderNumber: r.workOrderNumber });
-    }
+    const projectByItemId = await loadProjectContextByQueueItemId(ids);
+    const woByItemId = await loadWorkOrderContextByQueueItemId(ids);
 
     const enriched = items.map((item: any) => ({
       ...item,
@@ -217,29 +266,8 @@ router.get('/by-dashboard/:dashboard', async (req, res) => {
 
     const ids = items.map((i: any) => i.id);
 
-    const projectRows = await pool.query<{ id: number; projectId: string; projectCode: string }>(
-      `SELECT mq.id, p.id AS "projectId", p.project_code AS "projectCode"
-       FROM manufacturing_queue mq
-       JOIN projects p ON p.po_id = mq.p2_po_id
-       WHERE mq.id = ANY($1)`,
-      [ids]
-    );
-    const projectByItemId = new Map<number, { projectId: string; projectCode: string }>();
-    for (const r of projectRows) {
-      projectByItemId.set(r.id, { projectId: r.projectId, projectCode: r.projectCode });
-    }
-
-    const woRows = await pool.query<{ id: number; workOrderId: string; workOrderNumber: string }>(
-      `SELECT mq.id, wo.id AS "workOrderId", wo.work_order_number AS "workOrderNumber"
-       FROM manufacturing_queue mq
-       JOIN production_work_orders wo ON wo.id::text = mq.source_id
-       WHERE mq.source_type = 'production_work_order' AND mq.id = ANY($1)`,
-      [ids]
-    );
-    const woByItemId = new Map<number, { workOrderId: string; workOrderNumber: string }>();
-    for (const r of woRows) {
-      woByItemId.set(r.id, { workOrderId: r.workOrderId, workOrderNumber: r.workOrderNumber });
-    }
+    const projectByItemId = await loadProjectContextByQueueItemId(ids);
+    const woByItemId = await loadWorkOrderContextByQueueItemId(ids);
 
     res.json(items.map((item: any) => ({
       ...item,

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -67,6 +67,73 @@ type ProjectDocumentRef = {
 let projectRevisionSchemaReady = false;
 let projectClinSchemaReady = false;
 
+type ProjectDocumentRow = {
+  id: number | null;
+  project_id: string;
+  label: string | null;
+  original_file_name: string;
+  file_name: string | null;
+  mime_type: string;
+  file_size: number | null;
+  media_library_id: number | null;
+  uploaded_by: string | null;
+  created_at: string | null;
+};
+
+async function getPublicTableColumns(tableName: string): Promise<Set<string>> {
+  const rows = await pool.query<{ column_name: string }>(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = $1`,
+    [tableName]
+  );
+  return new Set(rows.map((row) => row.column_name));
+}
+
+function projectDocumentSelect(columns: Set<string>, columnName: string, fallback: string, alias = columnName) {
+  return columns.has(columnName) ? `pd.${columnName}` : `${fallback} AS ${alias}`;
+}
+
+async function listProjectDocuments(projectId: string): Promise<ProjectDocumentRow[]> {
+  try {
+    const columns = await getPublicTableColumns('project_documents');
+    if (!columns.has('project_id')) return [];
+
+    const originalNameSelect = columns.has('original_file_name')
+      ? 'pd.original_file_name'
+      : columns.has('file_name')
+      ? 'pd.file_name AS original_file_name'
+      : `'Document'::text AS original_file_name`;
+    const orderBy = columns.has('created_at')
+      ? 'ORDER BY pd.created_at DESC'
+      : columns.has('id')
+      ? 'ORDER BY pd.id DESC'
+      : '';
+
+    return await pool.query<ProjectDocumentRow>(
+      `SELECT
+          ${projectDocumentSelect(columns, 'id', 'NULL::integer')},
+          pd.project_id,
+          ${projectDocumentSelect(columns, 'label', 'NULL::text')},
+          ${originalNameSelect},
+          ${projectDocumentSelect(columns, 'file_name', 'NULL::text')},
+          ${projectDocumentSelect(columns, 'mime_type', `'application/octet-stream'::text`)},
+          ${projectDocumentSelect(columns, 'file_size', 'NULL::integer')},
+          ${projectDocumentSelect(columns, 'media_library_id', 'NULL::integer')},
+          ${projectDocumentSelect(columns, 'uploaded_by', 'NULL::text')},
+          ${projectDocumentSelect(columns, 'created_at', 'NULL::timestamp')}
+         FROM project_documents pd
+        WHERE pd.project_id = $1
+        ${orderBy}`,
+      [projectId]
+    );
+  } catch (error) {
+    console.warn('Skipping project document list due to schema/read error:', error);
+    return [];
+  }
+}
+
 const ROM_LOCK_STAGES = new Set(['po_received', 'p2_release', 'production', 'completed']);
 const ROM_EDITABLE_PO_STATUSES = new Set(['OPEN', 'DRAFT', 'CREATED']);
 
@@ -3514,29 +3581,32 @@ router.get('/:id/traceability', async (req, res) => {
 router.get('/:id/documents', async (req, res) => {
   try {
     const { id } = req.params;
-    const rows = await pool.query<{
-      id: number; project_id: string; label: string | null; original_file_name: string;
-      file_name: string | null; mime_type: string; file_size: number | null;
-      media_library_id: number | null; uploaded_by: string | null; created_at: string;
-    }>(
-      `SELECT id, project_id, label, original_file_name, file_name, mime_type, file_size,
-              media_library_id, uploaded_by, created_at
-       FROM project_documents WHERE project_id = $1 ORDER BY created_at DESC`,
-      [id]
-    );
+    const rows = await listProjectDocuments(id);
     const manualDocs: ProjectDocumentRef[] = rows.map((row) => ({
-      ...row,
+      id: row.id ?? `manual:${row.original_file_name}`,
+      project_id: row.project_id,
+      label: row.label,
+      original_file_name: row.original_file_name,
+      file_name: row.file_name,
+      mime_type: row.mime_type,
+      file_size: row.file_size,
+      media_library_id: row.media_library_id,
+      uploaded_by: row.uploaded_by,
+      created_at: row.created_at ?? '',
       source: 'manual',
       document_type: null,
       part_number: null,
       department_name: null,
       has_file: true,
     }));
-    const manufacturingDocs = await getProjectManufacturingDocumentRefs(id);
+    const manufacturingDocs = await getProjectManufacturingDocumentRefs(id).catch((error) => {
+      console.warn('Skipping project manufacturing document refs:', error);
+      return [];
+    });
     res.json([...manufacturingDocs, ...manualDocs]);
   } catch (err: any) {
-    console.error('Failed to list project documents:', err);
-    res.status(500).json({ message: 'Failed to list project documents' });
+    console.warn('Failed to list project documents:', err);
+    res.json([]);
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes the new production console errors from the latest pasted log:

- `/api/manufacturing-queue?department=Assembly` now treats project/work-order joins as optional enrichment, checking live columns and skipping only the enrichment when production schema is missing optional fields.
- `/api/projects/:id/documents` now reads manual project documents with a column-aware select and returns `[]` instead of a 500 if the optional document table/columns are unavailable.
- The project document list keeps the newer manufacturing document references, but now skips those refs if their read path errors instead of taking down the Project page.

The existing `/api/routing-documents/:id/ai-parse` 500 shown in the log was already covered by the previous document-builder hardening that has since merged.

## Validation

- `git diff --check origin/main..HEAD`
- `node --experimental-strip-types --check server/src/routes/manufacturingQueue.ts`
- `node --experimental-strip-types --check server/src/routes/projects.ts`
- GitHub compare verified branch is 1 commit ahead of `main` and 0 behind, touching only the two server route files.