### PR TITLE
Show SMR on Snowy Mountain medium action badges

### DIFF
--- a/client/src/__tests__/deriveOrderLabels.test.ts
+++ b/client/src/__tests__/deriveOrderLabels.test.ts
@@ -73,3 +73,21 @@ describe('deriveOrderLabels - material derivation', () => {
     });
   });
 });
+
+describe('deriveOrderLabels - action badge derivation', () => {
+  it('marks Def XM Snowy Mountain medium actions as SMR', () => {
+    const order = {
+      orderId: 'SMR001',
+      modelId: 'm1a_carbon',
+      features: {
+        action_inlet: 'Def XM - Snowy Mtn Med',
+      },
+    };
+
+    const labels = deriveOrderLabels(order);
+
+    expect(labels.actionLengthRaw).toBe('medium');
+    expect(labels.actionBadgeLabel).toBe('Medium (SMR)');
+    expect(labels.actionLabel).toBe('Medium (SMR) Action');
+  });
+});

--- a/client/src/components/ProductionQueueManager.tsx
+++ b/client/src/components/ProductionQueueManager.tsx
@@ -71,6 +71,7 @@ import type { P1POQueueCustomer } from '@shared/schema';
 import { LayupSchedulePreview } from './LayupSchedulePreview';
 import { ScheduleHistoryDialog } from './ScheduleHistoryDialog';
 import { MoldSettings } from './MoldSettings';
+import { deriveOrderLabels } from '@/utils/deriveOrderLabels';
 
 interface ProductionQueueOrder {
   orderId: string;
@@ -1971,19 +1972,10 @@ export default function ProductionQueueManager() {
                     </TableHeader>
                     <TableBody>
                       {filteredProductionQueue.map((order, index) => {
-                        // Get action length
-                        let actionLength = order.features?.action_length;
-                        if (!actionLength || actionLength === 'none') {
-                          // Try to derive from action_inlet
-                          const actionInlet = order.features?.action_inlet;
-                          if (actionInlet) {
-                            if (actionInlet.toLowerCase().includes('short'))
-                              actionLength = 'Short';
-                            else if (actionInlet.toLowerCase().includes('long'))
-                              actionLength = 'Long';
-                          }
-                        }
-                        const hasActionLength = actionLength && actionLength !== 'none';
+                        const orderLabels = deriveOrderLabels(order);
+                        const actionLength = orderLabels.actionLengthRaw;
+                        const actionLengthDisplay = orderLabels.actionBadgeLabel;
+                        const hasActionLength = actionLength !== 'unknown';
                         const isTikkaModel = (order.modelId || '').toLowerCase().includes('tikka');
 
                         // Check if bottom metal contains "adl"
@@ -2076,7 +2068,7 @@ export default function ProductionQueueManager() {
                                   variant="secondary"
                                   className="font-medium"
                                 >
-                                  {actionLength}
+                                  {actionLengthDisplay}
                                 </Badge>
                               ) : order.isFlattop ? (
                                 <Badge

--- a/client/src/pages/BarcodeQueuePage.tsx
+++ b/client/src/pages/BarcodeQueuePage.tsx
@@ -323,6 +323,18 @@ export default function BarcodeQueuePage() {
     return model?.displayName || model?.name || modelId;
   };
 
+  const getActionBadgeLabel = (orderLabels: ReturnType<typeof deriveOrderLabels>) => {
+    return orderLabels.actionBadgeLabel || (
+      orderLabels.actionLengthRaw === 'short'
+        ? 'Short'
+        : orderLabels.actionLengthRaw === 'medium'
+          ? 'Medium'
+          : orderLabels.actionLengthRaw === 'long'
+            ? 'Long'
+            : 'Unknown'
+    );
+  };
+
   // Categorize orders by stock model only, sorted by due date
   const categorizedOrders = useMemo(() => {
     const categories: Record<string, any[]> = {};
@@ -1013,7 +1025,7 @@ export default function BarcodeQueuePage() {
                             {isRegularFlatTop && <Badge variant="outline" className="text-xs border-purple-500 text-purple-700 bg-purple-50 font-semibold">Flat Top</Badge>}
                             {isTikka && <Badge variant="outline" className="text-xs border-purple-600 text-purple-700 bg-purple-50 font-semibold">Tikka</Badge>}
                             <Badge variant="outline" className={`text-xs ${actionLength === 'short' ? 'border-red-500 text-red-700 bg-red-50' : actionLength === 'medium' ? 'border-orange-500 text-orange-700 bg-orange-50' : actionLength === 'long' ? 'border-blue-500 text-blue-700 bg-blue-50' : 'border-gray-500 text-gray-700 bg-gray-50'}`}>
-                              {actionLength === 'short' ? 'Short' : actionLength === 'medium' ? 'Medium' : actionLength === 'long' ? 'Long' : 'Unknown'} Action
+                              {getActionBadgeLabel(orderLabels)} Action
                             </Badge>
                             {lopVal && <Badge variant="outline" className="text-xs border-teal-600 text-teal-700 bg-teal-50 font-semibold">LOP {lopVal}</Badge>}
                             {hasHeavyFill && <Badge variant="outline" className="text-xs border-orange-600 text-orange-700 bg-orange-50 font-semibold">Heavy Fill</Badge>}
@@ -1123,7 +1135,7 @@ export default function BarcodeQueuePage() {
                         </td>
                         <td className="px-3 py-2">
                           <Badge variant="outline" className={`text-[10px] px-1.5 py-0 ${actionLength === 'short' ? 'border-red-500 text-red-700 bg-red-50' : actionLength === 'medium' ? 'border-orange-500 text-orange-700 bg-orange-50' : actionLength === 'long' ? 'border-blue-500 text-blue-700 bg-blue-50' : 'border-gray-500 text-gray-700 bg-gray-50'}`}>
-                            {actionLength === 'short' ? 'Short' : actionLength === 'medium' ? 'Medium' : actionLength === 'long' ? 'Long' : '—'}
+                            {actionLength === 'unknown' ? '—' : getActionBadgeLabel(orderLabels)}
                           </Badge>
                         </td>
                         <td className="px-3 py-2">
@@ -1371,14 +1383,7 @@ export default function BarcodeQueuePage() {
                                               : 'border-gray-500 text-gray-700 bg-gray-50'
                                       }`}
                                     >
-                                      {actionLength === 'short'
-                                        ? 'Short'
-                                        : actionLength === 'medium'
-                                          ? 'Medium'
-                                          : actionLength === 'long'
-                                            ? 'Long'
-                                            : 'Unknown'}{' '}
-                                      Action
+                                      {getActionBadgeLabel(orderLabels)} Action
                                     </Badge>
                                     {lopVal && <Badge variant="outline" className="text-xs border-teal-600 text-teal-700 bg-teal-50 font-semibold">LOP {lopVal}</Badge>}
                                     {hasHeavyFill && <Badge variant="outline" className="text-xs border-orange-600 text-orange-700 bg-orange-50 font-semibold">Heavy Fill</Badge>}
@@ -1691,14 +1696,7 @@ export default function BarcodeQueuePage() {
                                                   : 'border-gray-500 text-gray-700 bg-gray-50'
                                           }`}
                                         >
-                                          {actionLength === 'short'
-                                            ? 'Short'
-                                            : actionLength === 'medium'
-                                              ? 'Medium'
-                                              : actionLength === 'long'
-                                                ? 'Long'
-                                                : 'Unknown'}{' '}
-                                          Action
+                                          {getActionBadgeLabel(orderLabels2)} Action
                                         </Badge>
                                         {/* Flattop badge for P1 PO orders */}
                                         {isPOOrder && (order.features?.flattop === true || order.features?.flattop === 'true') && (

--- a/client/src/utils/deriveOrderLabels.ts
+++ b/client/src/utils/deriveOrderLabels.ts
@@ -1,6 +1,7 @@
 export interface DerivedOrderLabels {
   materialLabel: string;
   actionLabel: string;
+  actionBadgeLabel: string;
   actionLengthRaw: string;
   modelBadgeLabel: string | null;
   isTikka: boolean;
@@ -215,6 +216,50 @@ function deriveActionLength(order: any, debugReasons: string[]): string {
   return 'unknown';
 }
 
+function normalizeDescriptor(raw: unknown): string {
+  return typeof raw === 'string'
+    ? raw.toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim()
+    : '';
+}
+
+function deriveActionDescriptor(order: any): string {
+  const features = order.features || {};
+  const parsedSpecs = order.parsedSpecs || order.specifications || {};
+
+  return [
+    features.action_inlet,
+    features.actionInlet,
+    features.action,
+    parsedSpecs.action_inlet,
+    parsedSpecs.actionInlet,
+    parsedSpecs.action,
+    parsedSpecs.inlet,
+  ]
+    .map(normalizeDescriptor)
+    .filter(Boolean)
+    .join(' ');
+}
+
+function shouldShowSmrActionSuffix(order: any, actionLengthRaw: string, debugReasons: string[]): boolean {
+  if (actionLengthRaw !== 'medium') return false;
+
+  const actionDescriptor = deriveActionDescriptor(order);
+  if (!actionDescriptor) return false;
+
+  const isSnowyMountainDefianceXm =
+    actionDescriptor.includes('def') &&
+    actionDescriptor.includes('xm') &&
+    actionDescriptor.includes('snowy') &&
+    (actionDescriptor.includes('mtn') || actionDescriptor.includes('mountain')) &&
+    (actionDescriptor.includes('med') || actionDescriptor.includes('medium'));
+
+  if (isSnowyMountainDefianceXm) {
+    debugReasons.push(`SMR action suffix from action descriptor: "${actionDescriptor}"`);
+  }
+
+  return isSnowyMountainDefianceXm;
+}
+
 function deriveTikka(order: any, debugReasons: string[]): boolean {
   if (order.tikkaOption) {
     debugReasons.push('tikka from order.tikkaOption');
@@ -272,14 +317,28 @@ export function deriveOrderLabels(order: any): DerivedOrderLabels {
 
   const materialLabel = deriveMaterial(order, debugReasons);
   const actionLengthRaw = deriveActionLength(order, debugReasons);
+  const showSmrActionSuffix = shouldShowSmrActionSuffix(order, actionLengthRaw, debugReasons);
   const isTikka = deriveTikka(order, debugReasons);
   const modelBadgeLabel = deriveModelBadge(order, isTikka, debugReasons);
+
+  const actionBadgeLabel =
+    actionLengthRaw === 'short'
+      ? 'Short'
+      : actionLengthRaw === 'medium'
+        ? showSmrActionSuffix
+          ? 'Medium (SMR)'
+          : 'Medium'
+        : actionLengthRaw === 'long'
+          ? 'Long'
+          : 'Unknown';
 
   const actionLabel =
     actionLengthRaw === 'short'
       ? 'Short Action'
       : actionLengthRaw === 'medium'
-        ? 'Medium Action'
+        ? showSmrActionSuffix
+          ? 'Medium (SMR) Action'
+          : 'Medium Action'
         : actionLengthRaw === 'long'
           ? 'Long Action'
           : 'Unknown Action';
@@ -287,6 +346,7 @@ export function deriveOrderLabels(order: any): DerivedOrderLabels {
   return {
     materialLabel,
     actionLabel,
+    actionBadgeLabel,
     actionLengthRaw,
     modelBadgeLabel,
     isTikka,


### PR DESCRIPTION
## Summary
- Add a shared action badge label for Def XM / Snowy Mtn / medium action orders so they render as `Medium (SMR)`.
- Use the shared label in the P1 Production Queue and all Barcode queue views.
- Add a focused unit test for the Def XM Snowy Mountain medium action case.

## Root Cause
The queue UIs derived action-length badge text separately and only rendered the generic `Medium` label, so the SMR signal was not shown beside the medium badge for the Snowy Mountain medium action path.

## Validation
- `git diff --check`
- `git diff --cached --check`
- GitHub compare verified as 1 commit / 4 files

Note: Vitest was not run in the clean publish worktree because it has no `node_modules`; the original checkout also could not run Vitest due missing `@vitest/utils` in its local install.