### PR TITLE
Merge cutting queue syncs into newest active job

### DIFF
--- a/server/__tests__/cuttingQueueGroupingHelper.test.ts
+++ b/server/__tests__/cuttingQueueGroupingHelper.test.ts
@@ -318,6 +318,65 @@ describe('upsertGroupedCuttingQueueEntry — grouping invariants', () => {
     ).toEqual(['PO-100', 'PO-200']);
   });
 
+  it('updates the newest active grouped row for the same inventory item when packet labels or due dates drift', async () => {
+    store.rows.push(
+      {
+        id: store.nextId++,
+        inventoryItemId: CF_BASE.inventoryItemId,
+        department: 'Cutting Table',
+        quantityRequested: 228,
+        quantityCompleted: 131,
+        priority: 50,
+        status: 'IN_PROGRESS',
+        dueDate: new Date('2026-05-04T05:00:00Z'),
+        notes: JSON.stringify({
+          isP2Packet: true,
+          packetName: 'Legacy Disruptor Packet Label',
+          poNumbers: [{ poNumber: 'FC090', quantity: 1, p2PoItemId: null, p2PoId: null }],
+        }),
+        requestedBy: 'system',
+        createdAt: new Date('2026-05-04T18:44:58Z'),
+        updatedAt: new Date('2026-06-15T23:13:23Z'),
+      },
+      {
+        id: store.nextId++,
+        inventoryItemId: CF_BASE.inventoryItemId,
+        department: 'Cutting Table',
+        quantityRequested: 330,
+        quantityCompleted: 93,
+        priority: 50,
+        status: 'IN_PROGRESS',
+        dueDate: null,
+        notes: JSON.stringify({
+          isP2Packet: true,
+          packetName: '12" Blank Fuselage Tube Packet 98" long',
+          poNumbers: [{ poNumber: 'PO014332', quantity: 330, p2PoItemId: 9, p2PoId: 14 }],
+        }),
+        requestedBy: 'system',
+        createdAt: new Date('2026-05-21T20:09:01Z'),
+        updatedAt: new Date('2026-07-09T20:11:32Z'),
+      }
+    );
+
+    const result = await upsertGroupedCuttingQueueEntry({
+      ...CF_BASE,
+      packetName: '12" Blank Fuselage Tube Packet 98" long',
+      materialType: 'p2_packet',
+      dueDate: new Date('2026-07-09T12:00:00Z'),
+      items: [{ poNumber: 'PO014333', quantity: 1, p2PoItemId: 10, p2PoId: 14 }],
+    });
+
+    expect(result!.created).toBe(false);
+    expect(result!.queueItem.id).toBe(2);
+    expect(result!.addedQuantity).toBe(1);
+    expect(store.rows).toHaveLength(2);
+    expect(store.rows[1].quantityRequested).toBe(331);
+
+    const newestNotes = JSON.parse(store.rows[1].notes!);
+    expect(newestNotes.packetName).toBe('12" Blank Fuselage Tube Packet 98" long');
+    expect(newestNotes.poNumbers.map((p: { poNumber: string }) => p.poNumber)).toContain('PO014333');
+  });
+
   it('does not merge across different times of day on the same calendar bucket (uses date-only key)', async () => {
     // Two times on the same UTC day → same bucket → must merge into one row.
     await upsertGroupedCuttingQueueEntry({

--- a/server/src/utils/cuttingQueueGroupingHelper.ts
+++ b/server/src/utils/cuttingQueueGroupingHelper.ts
@@ -49,6 +49,39 @@ function itemKey(item: GroupedCuttingItem): string {
   return `po:${item.poNumber}`;
 }
 
+function parseQueueNotes(notes: string | null): Record<string, unknown> {
+  if (!notes) return {};
+  try {
+    const parsed = JSON.parse(notes);
+    return parsed && typeof parsed === 'object'
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function isActiveGroupedP2CuttingRow(row: ManufacturingQueue): boolean {
+  if (!['PENDING', 'IN_PROGRESS'].includes(row.status)) return false;
+  const parsedNotes = parseQueueNotes(row.notes);
+  return parsedNotes.isP2Packet === true;
+}
+
+function rowUpdatedTime(row: ManufacturingQueue): number {
+  const updated = row.updatedAt ? new Date(row.updatedAt).getTime() : 0;
+  if (updated) return updated;
+  const created = row.createdAt ? new Date(row.createdAt).getTime() : 0;
+  return created || 0;
+}
+
+function chooseNewestRow(rows: ManufacturingQueue[]): ManufacturingQueue | undefined {
+  return rows.slice().sort((a, b) => {
+    const timeDiff = rowUpdatedTime(b) - rowUpdatedTime(a);
+    if (timeDiff !== 0) return timeDiff;
+    return (b.id || 0) - (a.id || 0);
+  })[0];
+}
+
 async function resolveBomIdForMaterialType(materialType: string | null): Promise<string | null> {
   if (!materialType) return null;
   const packetTypeName =
@@ -134,9 +167,11 @@ async function resolveInventoryItemId(packetName: string, materialType: string |
  * Upsert a grouped cutting-table manufacturing queue row for a given packet type.
  *
  * Behavior:
- *   - Finds an existing PENDING manufacturing_queue row for the same packet type
- *     (matched by inventoryItemId + notes.packetName + notes.isP2Packet=true) and
- *     the same due-date bucket (same calendar day, or both null).
+ *   - Finds the newest active grouped manufacturing_queue row for the same
+ *     inventory item (PENDING or IN_PROGRESS, notes.isP2Packet=true). Prefer
+ *     the same packet-name/due-date bucket, but fall back to the newest active
+ *     row for the same inventory item so P2 re-syncs cannot create a duplicate
+ *     work order after operators have already started the prior one.
  *   - If found, merges the new items into notes.poNumbers (deduplicated by
  *     p2PoItemId, falling back to poNumber) and adds their quantity to
  *     quantityRequested. Re-runs with the same items are idempotent.
@@ -180,36 +215,28 @@ export async function upsertGroupedCuttingQueueEntry(
 
   const targetBucket = dueDateBucketKey(dueDate);
 
-  // Find candidate PENDING grouped rows for this packet type
+  // Find active grouped rows for this packet inventory item. This intentionally
+  // includes IN_PROGRESS rows so a P2/manual sync updates the live cutting job
+  // instead of creating a duplicate beside work already on the table.
   const candidates = await db.select()
     .from(manufacturingQueue)
     .where(and(
       eq(manufacturingQueue.department, 'Cutting Table'),
-      eq(manufacturingQueue.status, 'PENDING'),
       eq(manufacturingQueue.inventoryItemId, inventoryItemId),
     ));
 
-  const existingRow = candidates.find(row => {
+  const activeGroupedRows = candidates.filter(isActiveGroupedP2CuttingRow);
+  const exactRows = activeGroupedRows.filter(row => {
     if (dueDateBucketKey(row.dueDate) !== targetBucket) return false;
-    let parsedNotes: Record<string, unknown> = {};
-    try {
-      parsedNotes = row.notes ? JSON.parse(row.notes) : {};
-    } catch {
-      return false;
-    }
-    if (parsedNotes.isP2Packet !== true) return false;
+    const parsedNotes = parseQueueNotes(row.notes);
     const rowPacketName = typeof parsedNotes.packetName === 'string' ? parsedNotes.packetName : null;
     if (rowPacketName && rowPacketName.toLowerCase() !== packetName.toLowerCase()) return false;
     return true;
   });
+  const existingRow = chooseNewestRow(exactRows) ?? chooseNewestRow(activeGroupedRows);
 
   if (existingRow) {
-    let existingNotes: Record<string, unknown> = {};
-    try {
-      existingNotes = existingRow.notes ? JSON.parse(existingRow.notes) : {};
-    } catch {
-      existingNotes = {};
-    }
+    const existingNotes = parseQueueNotes(existingRow.notes);
 
     const existingPos: GroupedCuttingItem[] = Array.isArray(existingNotes.poNumbers)
       ? (existingNotes.poNumbers as GroupedCuttingItem[])


### PR DESCRIPTION
## Summary
- update P2 cutting queue grouping to merge new syncs into active `PENDING` or `IN_PROGRESS` grouped jobs for the same inventory item
- prefer exact packet/date matches, then fall back to the newest active grouped row so resyncs do not create a duplicate beside work already in progress
- add a regression test for drifted packet labels/due dates updating the newest active row

## Root Cause
The grouping helper only searched `PENDING` rows with matching packet-name and due-date bucket. Once a cutting job was already `IN_PROGRESS`, a later sync could create a second manufacturing queue row for the same inventory item instead of updating the active job.

## Validation
- `git diff --check origin/main..HEAD`
- `node --experimental-strip-types --check server/src/utils/cuttingQueueGroupingHelper.ts`

Note: the clean PR worktree did not have local `node_modules`, so I did not run the Vitest suite.