### PR TITLE
Link P2 BOMs to internal parts

### DIFF
--- a/client/src/pages/RobustBOMAdministration.tsx
+++ b/client/src/pages/RobustBOMAdministration.tsx
@@ -1712,6 +1712,9 @@ function P2POBOMsSection() {
     firstDept: 'Layup',
     notes: '',
   });
+  const [internalPartSearch, setInternalPartSearch] = useState('');
+  const [debouncedInternalPartSearch, setDebouncedInternalPartSearch] = useState('');
+  const [isInternalPartPopoverOpen, setIsInternalPartPopoverOpen] = useState(false);
 
   const { data: p2PoBoms, isLoading } = useQuery({
     queryKey: ['/api/robust-boms/p2-po-boms', { search: searchTerm }],
@@ -1725,13 +1728,36 @@ function P2POBOMsSection() {
   });
 
   useEffect(() => {
+    const timer = setTimeout(() => setDebouncedInternalPartSearch(internalPartSearch), 300);
+    return () => clearTimeout(timer);
+  }, [internalPartSearch]);
+
+  const internalPartsQueryUrl = `/api/robust-boms/parts?${debouncedInternalPartSearch ? `search=${encodeURIComponent(debouncedInternalPartSearch)}&` : ''}pageSize=50`;
+  const { data: internalPartsData, isFetching: isInternalPartsFetching } = useQuery({
+    queryKey: [internalPartsQueryUrl],
+    enabled: isInternalPartPopoverOpen,
+  });
+  const internalPartResults = (internalPartsData as any)?.data || [];
+  const selectedInternalPart = metadataDraft.inventoryItemId
+    ? internalPartResults.find((part: any) => part.id === metadataDraft.inventoryItemId) || {
+        id: metadataDraft.inventoryItemId,
+        agPartNumber: metadataDraft.internalPartNumber,
+        name: metadataDraft.internalPartName,
+      }
+    : null;
+
+  useEffect(() => {
     if (!bomDetail) return;
     setMetadataDraft({
       sku: bomDetail.sku || '',
       modelName: bomDetail.modelName || '',
       revision: bomDetail.revision || 'A',
       description: bomDetail.description || '',
+      inventoryItemId: bomDetail.inventoryItemId || null,
+      internalPartNumber: bomDetail.internalPartNumber || '',
+      internalPartName: bomDetail.internalPartName || '',
     });
+    setInternalPartSearch(bomDetail.internalPartNumber || '');
     setItemDrafts((bomDetail.items || []).map((item: any) => ({
       ...item,
       quantity: String(item.quantity ?? 1),
@@ -1942,17 +1968,81 @@ function P2POBOMsSection() {
                   </div>
                   <div>
                     <Label>Internal Part #</Label>
-                    {bomDetail.internalPartNumber ? (
-                      <Button
-                        variant="link"
-                        className="h-10 px-0 font-mono"
-                        onClick={() => window.open(`/inventory/manager?part=${encodeURIComponent(bomDetail.internalPartNumber)}`, '_self')}
-                      >
-                        {bomDetail.internalPartNumber} - {bomDetail.internalPartName || 'Inventory item'}
-                      </Button>
-                    ) : (
-                      <div className="flex h-10 items-center text-sm text-muted-foreground">No internal inventory part linked</div>
-                    )}
+                    <div className="flex gap-2">
+                      <Popover open={isInternalPartPopoverOpen} onOpenChange={setIsInternalPartPopoverOpen}>
+                        <PopoverTrigger asChild>
+                          <Button variant="outline" role="combobox" className="h-10 flex-1 justify-between">
+                            <span className={cn('truncate text-left', !selectedInternalPart?.agPartNumber && 'text-muted-foreground')}>
+                              {selectedInternalPart?.agPartNumber
+                                ? `${selectedInternalPart.agPartNumber} - ${selectedInternalPart.name || 'Inventory item'}`
+                                : 'Select internal inventory part'}
+                            </span>
+                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-[420px] p-0" align="start">
+                          <Command shouldFilter={false}>
+                            <CommandInput
+                              placeholder="Search internal parts..."
+                              value={internalPartSearch}
+                              onValueChange={setInternalPartSearch}
+                            />
+                            <CommandList>
+                              <CommandEmpty>
+                                {isInternalPartsFetching ? 'Searching internal parts...' : 'No internal parts found.'}
+                              </CommandEmpty>
+                              <CommandGroup>
+                                {internalPartResults.map((part: any) => (
+                                  <CommandItem
+                                    key={part.id}
+                                    value={part.agPartNumber}
+                                    onSelect={() => {
+                                      setMetadataDraft({
+                                        ...metadataDraft,
+                                        inventoryItemId: part.id,
+                                        internalPartNumber: part.agPartNumber,
+                                        internalPartName: part.name || '',
+                                      });
+                                      setInternalPartSearch(part.agPartNumber || '');
+                                      setIsInternalPartPopoverOpen(false);
+                                    }}
+                                  >
+                                    <Check
+                                      className={cn(
+                                        'mr-2 h-4 w-4',
+                                        metadataDraft.inventoryItemId === part.id ? 'opacity-100' : 'opacity-0'
+                                      )}
+                                    />
+                                    <div className="min-w-0">
+                                      <div className="font-mono text-sm">{part.agPartNumber}</div>
+                                      <div className="truncate text-xs text-muted-foreground">{part.name || 'Inventory item'}</div>
+                                    </div>
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            </CommandList>
+                          </Command>
+                        </PopoverContent>
+                      </Popover>
+                      {metadataDraft.inventoryItemId && (
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          onClick={() => {
+                            setMetadataDraft({
+                              ...metadataDraft,
+                              inventoryItemId: null,
+                              internalPartNumber: '',
+                              internalPartName: '',
+                            });
+                            setInternalPartSearch('');
+                          }}
+                          title="Unlink internal part"
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
                   </div>
                   <div className="col-span-2">
                     <Label>Description</Label>

--- a/migrations/0186_p2_bom_definition_inventory_link.sql
+++ b/migrations/0186_p2_bom_definition_inventory_link.sql
@@ -1,0 +1,14 @@
+ALTER TABLE bom_definitions
+  ADD COLUMN IF NOT EXISTS inventory_item_id integer REFERENCES inventory_items(id);
+
+CREATE INDEX IF NOT EXISTS idx_bom_definitions_inventory_item_id
+  ON bom_definitions(inventory_item_id);
+
+UPDATE bom_definitions bd
+SET inventory_item_id = ii.id
+FROM inventory_items ii
+WHERE bd.inventory_item_id IS NULL
+  AND (
+    ii.ag_part_number = bd.sku
+    OR ii.ag_part_number = regexp_replace(COALESCE(bd.sku, ''), '[[:space:]]+Rev[[:space:]]+.+$', '', 'i')
+  );

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -7939,6 +7939,7 @@ export const surveyContextTypeEnum = pgEnum('survey_context_type', [
 export const bomDefinitions = pgTable('bom_definitions', {
   id: uuid('id').defaultRandom().primaryKey(),
   sku: text('sku'),
+  inventoryItemId: integer('inventory_item_id').references(() => inventoryItems.id),
   modelName: text('model_name').notNull(),
   revision: text('revision').notNull().default('A'),
   description: text('description'),

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -6651,12 +6651,20 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       if (!bomDef) {
         const [newBom] = await db.insert(bomDefinitions).values({
           sku: canonicalPartNumber,
+          inventoryItemId: linkedPoInventoryItem?.id ?? null,
           modelName: linkedPoInventoryItem?.name || canonicalPartNumber,
           revision: 'A',
           description: `BOM for P2 part ${canonicalPartNumber}`,
           isActive: true
         }).returning();
         bomDef = newBom;
+      } else if (linkedPoInventoryItem?.id && !bomDef.inventoryItemId) {
+        const [updatedBom] = await db
+          .update(bomDefinitions)
+          .set({ inventoryItemId: linkedPoInventoryItem.id, updatedAt: new Date() })
+          .where(eq(bomDefinitions.id, bomDef.id))
+          .returning();
+        bomDef = updatedBom || bomDef;
       }
       
       // Clear existing BOM items for this definition
@@ -6693,6 +6701,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
               try {
                 const [newChildBom] = await db.insert(bomDefinitions).values({
                   sku: item.partNumber,
+                  inventoryItemId: item.inventoryItemId ?? null,
                   modelName: item.partNumber,
                   revision: 'A',
                   description: item.description || `BOM for manufactured part ${item.partNumber}`,

--- a/server/src/routes/robustBoms.ts
+++ b/server/src/routes/robustBoms.ts
@@ -414,6 +414,7 @@ router.post('/from-draft-builder', requirePermission('inventory.adjust'), async 
         ? await db
             .update(bomDefinitions)
             .set({
+              inventoryItemId: rootInventory.id,
               modelName: rootInventory.name || rootDescription || rootPartNumber,
               revision: revCode,
               description: p2BomDescription,
@@ -426,6 +427,7 @@ router.post('/from-draft-builder', requirePermission('inventory.adjust'), async 
             .insert(bomDefinitions)
             .values({
               sku: rootPartNumber,
+              inventoryItemId: rootInventory.id,
               modelName: rootInventory.name || rootDescription || rootPartNumber,
               revision: revCode,
               description: p2BomDescription,
@@ -887,7 +889,10 @@ router.get('/p2-po-boms', async (req, res) => {
       inventoryItemId: p2PurchaseOrderItems.inventoryItemId,
     })
       .from(p2PurchaseOrderItems);
-    const inventoryIds = Array.from(new Set(poItemPartNumbers.map(p => p.inventoryItemId).filter(Boolean))) as number[];
+    const inventoryIds = Array.from(new Set([
+      ...poItemPartNumbers.map(p => p.inventoryItemId).filter(Boolean),
+      ...allBomDefs.map(bom => bom.inventoryItemId).filter(Boolean),
+    ])) as number[];
     const linkedInventoryById = inventoryIds.length > 0
       ? await db.select({
           id: inventoryItems.id,
@@ -921,11 +926,17 @@ router.get('/p2-po-boms', async (req, res) => {
       if (internalPart) poPartSet.add(internalPart);
     });
 
-    const p2Boms = allBomDefs.filter(bom => 
-      bom.sku && poPartSet.has(bom.sku)
-    ).map(bom => {
+    const p2Boms = allBomDefs.filter(bom => {
+      const explicitInternalPart = bom.inventoryItemId ? inventoryById.get(bom.inventoryItemId)?.agPartNumber : null;
+      return (
+        (bom.sku && poPartSet.has(bom.sku)) ||
+        (explicitInternalPart && poPartSet.has(explicitInternalPart))
+      );
+    }).map(bom => {
       const baseSku = String(bom.sku || '').replace(/\s+Rev\s+.+$/i, '');
-      const internalPart = inventoryByPartNumber.get(String(bom.sku || '')) || inventoryByPartNumber.get(baseSku);
+      const internalPart = (
+        bom.inventoryItemId ? inventoryById.get(bom.inventoryItemId) : null
+      ) || inventoryByPartNumber.get(String(bom.sku || '')) || inventoryByPartNumber.get(baseSku);
       return {
         ...bom,
         internalPartNumber: internalPart?.agPartNumber || null,
@@ -972,7 +983,17 @@ router.get('/p2-po-boms/:id', async (req, res) => {
       .orderBy(bomItems.assemblyLevel, bomItems.partName);
 
     const baseSku = String(bom.sku || '').replace(/\s+Rev\s+.+$/i, '');
-    const [internalPart] = bom.sku
+    const [explicitInternalPart] = bom.inventoryItemId
+      ? await db.select({
+          id: inventoryItems.id,
+          agPartNumber: inventoryItems.agPartNumber,
+          name: inventoryItems.name,
+        })
+        .from(inventoryItems)
+        .where(eq(inventoryItems.id, bom.inventoryItemId))
+        .limit(1)
+      : [];
+    const [skuMatchedInternalPart] = bom.sku && !explicitInternalPart
       ? await db.select({
           id: inventoryItems.id,
           agPartNumber: inventoryItems.agPartNumber,
@@ -982,6 +1003,7 @@ router.get('/p2-po-boms/:id', async (req, res) => {
         .where(inArray(inventoryItems.agPartNumber, [bom.sku, baseSku]))
         .limit(1)
       : [];
+    const internalPart = explicitInternalPart || skuMatchedInternalPart;
 
     const poItems = bom.sku
       ? await db.select({
@@ -992,7 +1014,10 @@ router.get('/p2-po-boms/:id', async (req, res) => {
         .from(p2PurchaseOrderItems)
         .innerJoin(p2PurchaseOrders, eq(p2PurchaseOrderItems.poId, p2PurchaseOrders.id))
         .where(internalPart
-          ? inArray(p2PurchaseOrderItems.inventoryItemId, [internalPart.id])
+          ? or(
+              eq(p2PurchaseOrderItems.inventoryItemId, internalPart.id),
+              eq(p2PurchaseOrderItems.partNumber, bom.sku)
+            )
           : eq(p2PurchaseOrderItems.partNumber, bom.sku))
       : [];
 
@@ -1013,13 +1038,35 @@ router.get('/p2-po-boms/:id', async (req, res) => {
 router.put('/p2-po-boms/:id', async (req, res) => {
   try {
     const { id } = req.params;
-    const updateData = {
+    const updateData: Record<string, unknown> = {
       sku: req.body.sku,
       modelName: req.body.modelName,
       revision: req.body.revision,
       description: req.body.description,
       updatedAt: new Date(),
     };
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'inventoryItemId')) {
+      const rawInventoryItemId = req.body.inventoryItemId;
+      if (rawInventoryItemId === null || rawInventoryItemId === '') {
+        updateData.inventoryItemId = null;
+      } else {
+        const inventoryItemId = Number.parseInt(String(rawInventoryItemId), 10);
+        if (!Number.isInteger(inventoryItemId) || inventoryItemId <= 0) {
+          return res.status(400).json({ error: 'Invalid internal inventory part' });
+        }
+
+        const [inventoryItem] = await db.select({ id: inventoryItems.id })
+          .from(inventoryItems)
+          .where(eq(inventoryItems.id, inventoryItemId))
+          .limit(1);
+        if (!inventoryItem) {
+          return res.status(404).json({ error: 'Internal inventory part not found' });
+        }
+
+        updateData.inventoryItemId = inventoryItemId;
+      }
+    }
 
     const [updated] = await db.update(bomDefinitions)
       .set(updateData)


### PR DESCRIPTION
## Summary
- add a durable `inventory_item_id` link on legacy P2 BOM definitions, with a migration to backfill obvious SKU/internal-part matches
- add a searchable Internal Part # picker in the P2 Purchase Order BOM edit drawer
- persist and prefer the explicit internal inventory link in P2 BOM list/detail/update routes and capture it automatically from Draft Builder/P2 BOM saves

## Why
P2 PO BOMs could show an internal part only when the PO-facing SKU happened to match an inventory AG part number. Unlinked BOMs could not be repaired from the edit drawer, which meant future routing/BOM/labor reuse did not have a canonical internal part identity.

## Validation
- `git diff --check`
- `git diff --cached --check`
- TypeScript `transpileModule` parse check for `client/src/pages/RobustBOMAdministration.tsx`, `server/src/routes/robustBoms.ts`, `server/src/routes/index.ts`, and `server/schema.ts`

Full `npm run check` was not available in this Windows shell because `npm` is not on PATH; the bundled pnpm path hit the repo's Windows lifecycle issue during `prepare` before TypeScript ran.