### PR TITLE
Harden QMS design control R&D linkage

### DIFF
--- a/client/src/pages/QMSDesignControlPage.tsx
+++ b/client/src/pages/QMSDesignControlPage.tsx
@@ -443,33 +443,6 @@ const lifecycleStages = [
   { stage: 'Release', owner: 'Manufacturing', state: 'Manufacturing packet, WAD, and P2 release gates aligned' },
 ];
 
-const productionReleaseFlow = [
-  {
-    step: 'Project / PO / WAD',
-    owner: 'Program + Operations',
-    status: 'Source context',
-    description: 'Project scope, linked customer PO, and WAD authorization establish the controlled build context.',
-  },
-  {
-    step: 'Design Workflow',
-    owner: 'Engineering + Quality',
-    status: 'Design control',
-    description: 'Inputs, outputs, reviews, risks, verification, validation, changes, and DHF evidence move together.',
-  },
-  {
-    step: 'Design Production Release Gate',
-    owner: 'Quality + Manufacturing Engineering',
-    status: 'Gate decision',
-    description: 'Design evidence, production packet, WAD readiness, and P2 release conditions are checked before handoff.',
-  },
-  {
-    step: 'P2 Manufacturing',
-    owner: 'Manufacturing',
-    status: 'Released build',
-    description: 'Released work flows into P2 manufacturing with traveler, inspection, and production controls aligned.',
-  },
-];
-
 const designWorkflowSteps: DesignWorkflowStep[] = [
   {
     id: '1',
@@ -1293,44 +1266,6 @@ export default function QMSDesignControlPage() {
                 <div className="font-medium">DHF Control</div>
                 <div className="text-muted-foreground">Design history file evidence is grouped by project and record.</div>
               </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-lg">
-              <Route className="h-5 w-5 text-primary" />
-              Design Production Release Flow
-            </CardTitle>
-            <CardDescription>
-              The controlled handoff from project context through design evidence and release gating into P2 manufacturing.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="grid gap-3 lg:grid-cols-[1fr_auto_1fr_auto_1fr_auto_1fr]">
-              {productionReleaseFlow.map((item, index) => (
-                <div key={item.step} className="contents">
-                  <div className="rounded-md border bg-white p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <div className="font-semibold">{item.step}</div>
-                        <div className="mt-1 text-xs font-medium uppercase text-muted-foreground">{item.owner}</div>
-                      </div>
-                      <Badge variant="outline" className="shrink-0">
-                        {item.status}
-                      </Badge>
-                    </div>
-                    <p className="mt-3 text-sm text-muted-foreground">{item.description}</p>
-                  </div>
-                  {index < productionReleaseFlow.length - 1 && (
-                    <div className="flex items-center justify-center text-muted-foreground">
-                      <ArrowRight className="hidden h-5 w-5 lg:block" />
-                      <div className="h-5 border-l lg:hidden" />
-                    </div>
-                  )}
-                </div>
-              ))}
             </div>
           </CardContent>
         </Card>

--- a/client/src/pages/QMSDesignControlPage.tsx
+++ b/client/src/pages/QMSDesignControlPage.tsx
@@ -104,6 +104,7 @@ type DesignControlRecord = {
   recordNumber?: string | null;
   title: string;
   status: string;
+  rdProjectId?: string | null;
   projectId?: string | null;
   productionWorkOrderId?: string | null;
   p2PurchaseOrderId?: number | null;
@@ -897,6 +898,10 @@ function SectionHeader({
 }
 
 export default function QMSDesignControlPage() {
+  const routeParams = new URLSearchParams(window.location.search);
+  const rdProjectIdParam = routeParams.get('rdProjectId');
+  const rdProjectNameParam = routeParams.get('rdProjectName');
+  const recordIdParam = routeParams.get('recordId');
   const [selectedRecord, setSelectedRecord] = useState<RegisterRow | RiskRow | ReleaseRow | null>(null);
   const [recordType, setRecordType] = useState('design-input');
   const [draftRecordTitle, setDraftRecordTitle] = useState('');
@@ -946,10 +951,12 @@ export default function QMSDesignControlPage() {
       setIsLoadingRecords(true);
       setLoadError(null);
       try {
-        const response = await apiRequest('/api/qms/design-control') as { records: DesignControlRecord[] };
+        const params = new URLSearchParams();
+        if (rdProjectIdParam) params.set('rdProjectId', rdProjectIdParam);
+        const response = await apiRequest(`/api/qms/design-control${params.toString() ? `?${params.toString()}` : ''}`) as { records: DesignControlRecord[] };
         if (cancelled) return;
         setDesignControlRecords(response.records ?? []);
-        setActiveDesignControlRecordId((current) => current ?? response.records?.[0]?.id ?? null);
+        setActiveDesignControlRecordId((current) => current ?? recordIdParam ?? response.records?.[0]?.id ?? null);
       } catch (error: any) {
         if (!cancelled) setLoadError(error.message || 'Failed to load design control records.');
       } finally {
@@ -961,7 +968,7 @@ export default function QMSDesignControlPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [rdProjectIdParam, recordIdParam]);
 
   useEffect(() => {
     if (!activeDesignControlRecordId) {
@@ -1006,9 +1013,11 @@ export default function QMSDesignControlPage() {
         method: 'POST',
         body: {
           title: title?.trim() || draftRecordTitle.trim() || 'New Design Control Record',
+          rdProjectId: rdProjectIdParam,
           metadata: {
             recordType,
             owner: draftRecordOwner.trim() || null,
+            rdProjectName: rdProjectNameParam,
             source: '/qms/design-control',
           },
         },

--- a/client/src/pages/RDProjectsPage.tsx
+++ b/client/src/pages/RDProjectsPage.tsx
@@ -6,6 +6,7 @@ import {
   Boxes,
   CheckCircle2,
   ChevronRight,
+  ExternalLink,
   FilePlus2,
   FlaskConical,
   FolderOpen,
@@ -13,6 +14,7 @@ import {
   PackageCheck,
   Pencil,
   Plus,
+  ShieldCheck,
   Trash2,
   UserCheck,
 } from 'lucide-react';
@@ -161,6 +163,15 @@ interface RDProject {
   draftTabIds: string[];
   deletedDraftTabIds?: string[];
   description: string;
+}
+
+interface DesignControlProjectRecord {
+  id: string;
+  title: string;
+  status: string;
+  rdProjectId?: string | null;
+  updatedAt?: string | null;
+  releasedAt?: string | null;
 }
 
 const R_AND_D_PROJECT_STORAGE_KEY = 'epoch.rdProjects.v1';
@@ -777,6 +788,7 @@ export default function RDProjectsPage() {
   const [localProjects, setLocalProjects] = useState<RDProject[]>(() =>
     readJsonStorage(R_AND_D_PROJECT_STORAGE_KEY, [])
   );
+  const [isCreatingDesignControlRecord, setIsCreatingDesignControlRecord] = useState(false);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
     () => new URLSearchParams(window.location.search).get('projectId')
   );
@@ -845,6 +857,27 @@ export default function RDProjectsPage() {
     () => employees.filter((employee) => employee.isActive !== false),
     [employees]
   );
+  const {
+    data: selectedDesignControlPayload,
+    isLoading: isLoadingDesignControlRecords,
+  } = useQuery<{ records: DesignControlProjectRecord[] }>({
+    queryKey: ['/api/qms/design-control', 'rd-project', selectedProject?.id],
+    enabled: Boolean(selectedProject?.id),
+    retry: false,
+    queryFn: async () => {
+      if (!selectedProject?.id) return { records: [] };
+      const params = new URLSearchParams({ rdProjectId: selectedProject.id });
+      const response = await fetch(`/api/qms/design-control?${params.toString()}`, {
+        credentials: 'include',
+      });
+      if (!response.ok) return { records: [] };
+      const payload = await response.json();
+      return {
+        records: Array.isArray(payload.records) ? payload.records : [],
+      };
+    },
+  });
+  const selectedDesignControlRecords = selectedDesignControlPayload?.records ?? [];
 
   useEffect(() => {
     writeJsonStorage(R_AND_D_PROJECT_STORAGE_KEY, localProjects);
@@ -1102,6 +1135,50 @@ export default function RDProjectsPage() {
     }
   };
 
+  const designControlUrl = (project: RDProject, recordId?: string) => {
+    const params = new URLSearchParams({
+      rdProjectId: project.id,
+      rdProjectName: project.projectName,
+    });
+    if (recordId) params.set('recordId', recordId);
+    return `/qms/design-control?${params.toString()}`;
+  };
+
+  const createDesignControlRecordForProject = async () => {
+    if (!selectedProject) return;
+    setIsCreatingDesignControlRecord(true);
+    try {
+      const response = await fetch('/api/qms/design-control', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: `${selectedProject.projectName} Design Control`,
+          rdProjectId: selectedProject.id,
+          metadata: {
+            rdProjectName: selectedProject.projectName,
+            source: '/design/rd-projects',
+            downstreamIntent: 'released-design-to-manufactured-inventory-item',
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to create design control record');
+      }
+
+      const payload = await response.json();
+      await queryClient.invalidateQueries({
+        queryKey: ['/api/qms/design-control', 'rd-project', selectedProject.id],
+      });
+      setLocation(designControlUrl(selectedProject, payload.record?.id));
+    } catch (error) {
+      console.error('Failed to create R&D design control record:', error);
+    } finally {
+      setIsCreatingDesignControlRecord(false);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="mx-auto max-w-7xl space-y-6">
@@ -1316,12 +1393,15 @@ export default function RDProjectsPage() {
                 </CardHeader>
                 <CardContent>
                   <Tabs value={activeProjectTab} onValueChange={changeProjectTab} className="space-y-4">
-                    <TabsList className="grid w-full grid-cols-2 md:grid-cols-6">
+                    <TabsList className="grid w-full grid-cols-2 md:grid-cols-7">
                       <TabsTrigger value="overview">Overview</TabsTrigger>
                       <TabsTrigger value="files">Files</TabsTrigger>
                       <TabsTrigger value="bom">BOM</TabsTrigger>
                       <TabsTrigger value="material">Material</TabsTrigger>
                       <TabsTrigger value="labor">Labor</TabsTrigger>
+                      <TabsTrigger value="design-control">
+                        Design Control
+                      </TabsTrigger>
                       <TabsTrigger value="assembly-tree">
                         Assembly Tree
                       </TabsTrigger>
@@ -1636,6 +1716,87 @@ export default function RDProjectsPage() {
                           ))}
                         </div>
                       )}
+                    </TabsContent>
+
+                    <TabsContent value="design-control" className="space-y-4">
+                      <Card>
+                        <CardHeader className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                          <div>
+                            <CardTitle className="flex items-center gap-2 text-base">
+                              <ShieldCheck className="h-4 w-4 text-primary" />
+                              Design Control
+                            </CardTitle>
+                            <CardDescription>
+                              Design-control records linked to this R&amp;D project only.
+                            </CardDescription>
+                          </div>
+                          <Button
+                            className="gap-2 self-start"
+                            onClick={createDesignControlRecordForProject}
+                            disabled={isCreatingDesignControlRecord}
+                          >
+                            <Plus className="h-4 w-4" />
+                            {isCreatingDesignControlRecord ? 'Creating...' : 'Create Design Control'}
+                          </Button>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                          <div className="rounded-md border bg-white px-3 py-2 text-sm text-muted-foreground">
+                            When this design is released, its R&amp;D data can become the source package for a manufactured inventory item. That released item can later be selected from P2 when a PO is received.
+                          </div>
+                          {isLoadingDesignControlRecords ? (
+                            <div className="rounded-md border bg-white px-3 py-4 text-sm text-muted-foreground">
+                              Loading design-control records...
+                            </div>
+                          ) : selectedDesignControlRecords.length === 0 ? (
+                            <div className="flex flex-col items-start gap-3 rounded-md border bg-white px-3 py-4 text-sm text-muted-foreground">
+                              No design-control record is linked to this R&amp;D project yet.
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="gap-2"
+                                onClick={createDesignControlRecordForProject}
+                                disabled={isCreatingDesignControlRecord}
+                              >
+                                <FilePlus2 className="h-4 w-4" />
+                                Create Linked Record
+                              </Button>
+                            </div>
+                          ) : (
+                            <div className="grid gap-3 md:grid-cols-2">
+                              {selectedDesignControlRecords.map((record) => (
+                                <div key={record.id} className="rounded-md border bg-white px-3 py-3">
+                                  <div className="flex items-start justify-between gap-3">
+                                    <div className="min-w-0">
+                                      <p className="truncate text-sm font-medium text-slate-950">
+                                        {record.title}
+                                      </p>
+                                      <p className="mt-1 text-xs text-muted-foreground">
+                                        {record.releasedAt
+                                          ? 'Released design control'
+                                          : `Status: ${record.status}`}
+                                      </p>
+                                    </div>
+                                    <Badge variant="outline">
+                                      {record.status}
+                                    </Badge>
+                                  </div>
+                                  <div className="mt-3 flex justify-end">
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      className="gap-2"
+                                      onClick={() => setLocation(designControlUrl(selectedProject, record.id))}
+                                    >
+                                      <ExternalLink className="h-4 w-4" />
+                                      Open
+                                    </Button>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </CardContent>
+                      </Card>
                     </TabsContent>
                   </Tabs>
                 </CardContent>

--- a/migrations/0189_design_control_workflow.sql
+++ b/migrations/0189_design_control_workflow.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS design_control_records (
   record_number text,
   title text NOT NULL,
   status text NOT NULL DEFAULT 'draft',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -18,6 +19,7 @@ CREATE TABLE IF NOT EXISTS design_control_records (
 );
 
 CREATE INDEX IF NOT EXISTS design_control_records_project_id_idx ON design_control_records(project_id);
+CREATE INDEX IF NOT EXISTS design_control_records_rd_project_id_idx ON design_control_records(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_records_pwo_id_idx ON design_control_records(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_records_p2_po_id_idx ON design_control_records(p2_purchase_order_id);
 CREATE INDEX IF NOT EXISTS design_control_records_status_idx ON design_control_records(status);
@@ -28,6 +30,7 @@ CREATE TABLE IF NOT EXISTS design_control_steps (
   step_key text NOT NULL,
   title text NOT NULL,
   status text NOT NULL DEFAULT 'incomplete',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -44,6 +47,7 @@ CREATE TABLE IF NOT EXISTS design_control_steps (
 
 CREATE INDEX IF NOT EXISTS design_control_steps_record_id_idx ON design_control_steps(record_id);
 CREATE INDEX IF NOT EXISTS design_control_steps_status_idx ON design_control_steps(status);
+CREATE INDEX IF NOT EXISTS design_control_steps_rd_project_id_idx ON design_control_steps(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_steps_project_id_idx ON design_control_steps(project_id);
 CREATE INDEX IF NOT EXISTS design_control_steps_pwo_id_idx ON design_control_steps(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_steps_p2_po_id_idx ON design_control_steps(p2_purchase_order_id);
@@ -54,6 +58,7 @@ CREATE TABLE IF NOT EXISTS design_control_requirements (
   requirement_key text,
   title text,
   status text NOT NULL DEFAULT 'draft',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -67,6 +72,7 @@ CREATE TABLE IF NOT EXISTS design_control_requirements (
 );
 
 CREATE INDEX IF NOT EXISTS design_control_requirements_record_id_idx ON design_control_requirements(record_id);
+CREATE INDEX IF NOT EXISTS design_control_requirements_rd_project_id_idx ON design_control_requirements(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_requirements_project_id_idx ON design_control_requirements(project_id);
 CREATE INDEX IF NOT EXISTS design_control_requirements_pwo_id_idx ON design_control_requirements(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_requirements_p2_po_id_idx ON design_control_requirements(p2_purchase_order_id);
@@ -77,6 +83,7 @@ CREATE TABLE IF NOT EXISTS design_control_risks (
   risk_key text,
   title text,
   status text NOT NULL DEFAULT 'draft',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -90,6 +97,7 @@ CREATE TABLE IF NOT EXISTS design_control_risks (
 );
 
 CREATE INDEX IF NOT EXISTS design_control_risks_record_id_idx ON design_control_risks(record_id);
+CREATE INDEX IF NOT EXISTS design_control_risks_rd_project_id_idx ON design_control_risks(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_risks_project_id_idx ON design_control_risks(project_id);
 CREATE INDEX IF NOT EXISTS design_control_risks_pwo_id_idx ON design_control_risks(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_risks_p2_po_id_idx ON design_control_risks(p2_purchase_order_id);
@@ -100,6 +108,7 @@ CREATE TABLE IF NOT EXISTS design_control_reviews (
   review_type text,
   title text,
   status text NOT NULL DEFAULT 'draft',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -114,6 +123,7 @@ CREATE TABLE IF NOT EXISTS design_control_reviews (
 );
 
 CREATE INDEX IF NOT EXISTS design_control_reviews_record_id_idx ON design_control_reviews(record_id);
+CREATE INDEX IF NOT EXISTS design_control_reviews_rd_project_id_idx ON design_control_reviews(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_reviews_project_id_idx ON design_control_reviews(project_id);
 CREATE INDEX IF NOT EXISTS design_control_reviews_pwo_id_idx ON design_control_reviews(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_reviews_p2_po_id_idx ON design_control_reviews(p2_purchase_order_id);
@@ -124,6 +134,7 @@ CREATE TABLE IF NOT EXISTS design_control_verification (
   verification_key text,
   title text,
   status text NOT NULL DEFAULT 'draft',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -138,6 +149,7 @@ CREATE TABLE IF NOT EXISTS design_control_verification (
 );
 
 CREATE INDEX IF NOT EXISTS design_control_verification_record_id_idx ON design_control_verification(record_id);
+CREATE INDEX IF NOT EXISTS design_control_verification_rd_project_id_idx ON design_control_verification(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_verification_project_id_idx ON design_control_verification(project_id);
 CREATE INDEX IF NOT EXISTS design_control_verification_pwo_id_idx ON design_control_verification(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_verification_p2_po_id_idx ON design_control_verification(p2_purchase_order_id);
@@ -148,6 +160,7 @@ CREATE TABLE IF NOT EXISTS design_control_validation (
   validation_key text,
   title text,
   status text NOT NULL DEFAULT 'draft',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -162,6 +175,7 @@ CREATE TABLE IF NOT EXISTS design_control_validation (
 );
 
 CREATE INDEX IF NOT EXISTS design_control_validation_record_id_idx ON design_control_validation(record_id);
+CREATE INDEX IF NOT EXISTS design_control_validation_rd_project_id_idx ON design_control_validation(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_validation_project_id_idx ON design_control_validation(project_id);
 CREATE INDEX IF NOT EXISTS design_control_validation_pwo_id_idx ON design_control_validation(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_validation_p2_po_id_idx ON design_control_validation(p2_purchase_order_id);
@@ -172,6 +186,7 @@ CREATE TABLE IF NOT EXISTS design_control_changes (
   change_key text,
   title text,
   status text NOT NULL DEFAULT 'draft',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -186,6 +201,7 @@ CREATE TABLE IF NOT EXISTS design_control_changes (
 );
 
 CREATE INDEX IF NOT EXISTS design_control_changes_record_id_idx ON design_control_changes(record_id);
+CREATE INDEX IF NOT EXISTS design_control_changes_rd_project_id_idx ON design_control_changes(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_changes_project_id_idx ON design_control_changes(project_id);
 CREATE INDEX IF NOT EXISTS design_control_changes_pwo_id_idx ON design_control_changes(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_changes_p2_po_id_idx ON design_control_changes(p2_purchase_order_id);
@@ -194,6 +210,7 @@ CREATE TABLE IF NOT EXISTS design_control_release_gate (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   record_id uuid NOT NULL REFERENCES design_control_records(id) ON DELETE CASCADE,
   gate_status text NOT NULL DEFAULT 'not_ready',
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
   project_id uuid REFERENCES projects(id) ON DELETE SET NULL,
   production_work_order_id uuid REFERENCES production_work_orders(id) ON DELETE SET NULL,
   p2_purchase_order_id integer REFERENCES p2_purchase_orders(id) ON DELETE SET NULL,
@@ -211,6 +228,7 @@ CREATE TABLE IF NOT EXISTS design_control_release_gate (
 
 CREATE INDEX IF NOT EXISTS design_control_release_gate_record_id_idx ON design_control_release_gate(record_id);
 CREATE INDEX IF NOT EXISTS design_control_release_gate_status_idx ON design_control_release_gate(gate_status);
+CREATE INDEX IF NOT EXISTS design_control_release_gate_rd_project_id_idx ON design_control_release_gate(rd_project_id);
 CREATE INDEX IF NOT EXISTS design_control_release_gate_project_id_idx ON design_control_release_gate(project_id);
 CREATE INDEX IF NOT EXISTS design_control_release_gate_pwo_id_idx ON design_control_release_gate(production_work_order_id);
 CREATE INDEX IF NOT EXISTS design_control_release_gate_p2_po_id_idx ON design_control_release_gate(p2_purchase_order_id);

--- a/server/__tests__/qmsDesignControlReleaseGate.test.ts
+++ b/server/__tests__/qmsDesignControlReleaseGate.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {},
+}));
+
+import { qmsDesignControlTestInternals } from '../src/routes/qmsDesignControl';
+
+const {
+  buildReadinessFromSteps,
+  createDesignControlRecordWithInitialWorkflow,
+  deriveStatus,
+  workflowSteps,
+} = qmsDesignControlTestInternals;
+
+function stepByKey(key: string) {
+  const step = workflowSteps.find((item) => item.key === key);
+  if (!step) throw new Error(`Missing workflow step ${key}`);
+  return step;
+}
+
+function completePayloadForStep(step: ReturnType<typeof stepByKey>) {
+  return {
+    formData: Object.fromEntries(step.requiredFields.map((field) => [field, `value for ${field}`])),
+    checklist: Object.fromEntries(step.requiredChecklist.map((item) => [item, true])),
+    approvals: Object.fromEntries(step.requiredApprovals.map((approval) => [approval, true])),
+  };
+}
+
+function persistedStep(key: string, overrides: Record<string, unknown> = {}) {
+  const step = stepByKey(key);
+  return {
+    stepKey: key,
+    status: key === '12' ? 'needs_approval' : 'approved',
+    ...completePayloadForStep(step),
+    ...overrides,
+  };
+}
+
+function completePersistedSteps() {
+  return workflowSteps.map((step) => persistedStep(step.key));
+}
+
+describe('QMS design control release gate validation', () => {
+  it('reports empty Step 12 as not ready with canonical missing evidence', () => {
+    const steps = [
+      ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
+      { stepKey: '12', status: 'incomplete', formData: {}, checklist: {}, approvals: {} },
+    ];
+
+    const readiness = buildReadinessFromSteps(steps);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.missingItems).toContain(
+      'Step 12 Design Production Release Gate checklist incomplete: released CAD',
+    );
+    expect(readiness.missingItems).toContain(
+      'Step 12 Design Production Release Gate approval missing: engineering release approval',
+    );
+  });
+
+  it('reports Steps 1-11 approved but Step 12 incomplete as not ready', () => {
+    const step12 = persistedStep('12', {
+      checklist: { 'released CAD': true },
+      approvals: completePayloadForStep(stepByKey('12')).approvals,
+    });
+
+    const readiness = buildReadinessFromSteps([
+      ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
+      step12,
+    ]);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.missingItems).toEqual(
+      expect.arrayContaining([
+        'Step 12 Design Production Release Gate checklist incomplete: released drawings',
+        'Step 12 Design Production Release Gate checklist incomplete: approved routing',
+      ]),
+    );
+  });
+
+  it('rejects client-supplied APPROVED when required evidence is missing', () => {
+    const result = deriveStatus(stepByKey('3'), { status: 'APPROVED', formData: {}, checklist: {}, approvals: {} });
+
+    expect(result.rejectedApproval).toBe(true);
+    expect(result.status).toBe('needs_approval');
+    expect(result.missing.fields).toContain('Requirement ID');
+    expect(result.missing.checklist).toContain('Customer requirements captured');
+    expect(result.missing.approvals).toContain('Requirements owner approval');
+  });
+
+  it('treats an invalid stepKey as rejected by the canonical step registry', () => {
+    expect(workflowSteps.some((step) => step.key === 'NOT_A_STEP')).toBe(false);
+  });
+
+  it('reports a missing Step 12 approval', () => {
+    const step12 = persistedStep('12', {
+      approvals: {
+        ...completePayloadForStep(stepByKey('12')).approvals,
+        'quality release approval': false,
+      },
+    });
+
+    const readiness = buildReadinessFromSteps([
+      ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
+      step12,
+    ]);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.missingItems).toContain(
+      'Step 12 Design Production Release Gate approval missing: quality release approval',
+    );
+  });
+
+  it('reports a missing Step 12 checklist item even when other checklist entries are complete', () => {
+    const step12Payload = completePayloadForStep(stepByKey('12'));
+    const step12 = persistedStep('12', {
+      checklist: {
+        ...step12Payload.checklist,
+        'material requirements approved': false,
+      },
+    });
+
+    const readiness = buildReadinessFromSteps([
+      ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
+      step12,
+    ]);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.missingItems).toContain(
+      'Step 12 Design Production Release Gate checklist incomplete: material requirements approved',
+    );
+  });
+
+  it('blocks submit-release readiness when Steps 1-11 are incomplete', () => {
+    const steps = completePersistedSteps();
+    const firstStep = steps.find((step) => step.stepKey === '1');
+    if (firstStep) firstStep.status = 'needs_approval';
+
+    const readiness = buildReadinessFromSteps(steps);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.missingItems).toContain(
+      'Step 1 Design Project Intake: approval required before Design Production Release Gate',
+    );
+  });
+
+  it('blocks submit-release readiness when Step 12 is incomplete', () => {
+    const readiness = buildReadinessFromSteps([
+      ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
+      { stepKey: '12', status: 'needs_approval', formData: {}, checklist: {}, approvals: {} },
+    ]);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.missingItems).toContain(
+      'Step 12 Design Production Release Gate checklist incomplete: released BOM',
+    );
+  });
+
+  it('allows submit-release readiness when all canonical requirements are satisfied', () => {
+    const readiness = buildReadinessFromSteps(completePersistedSteps());
+
+    expect(readiness.ready).toBe(true);
+    expect(readiness.missingItems).toEqual([]);
+  });
+});
+
+describe('QMS design control record creation transaction', () => {
+  function makeTransactionalClient(options: { failFirstStepInsert?: boolean } = {}) {
+    const createdRecord = {
+      id: 'record-1',
+      rdProjectId: 'rd-1',
+      projectId: null,
+      productionWorkOrderId: null,
+      p2PurchaseOrderId: null,
+    };
+    let insertCount = 0;
+    let stepInsertCount = 0;
+    let releaseGateUpsertCount = 0;
+    let rolledBack = false;
+    let committed = false;
+
+    const tx = {
+      insert: vi.fn(() => {
+        insertCount += 1;
+        if (insertCount === 1) {
+          return {
+            values: vi.fn(() => ({
+              returning: vi.fn(async () => [createdRecord]),
+            })),
+          };
+        }
+
+        if (insertCount <= workflowSteps.length + 1) {
+          return {
+            values: vi.fn(() => ({
+              onConflictDoNothing: vi.fn(async () => {
+                stepInsertCount += 1;
+                if (options.failFirstStepInsert && stepInsertCount === 1) {
+                  throw new Error('initial step insert failed');
+                }
+              }),
+            })),
+          };
+        }
+
+        return {
+          values: vi.fn(() => ({
+            onConflictDoUpdate: vi.fn(async () => {
+              releaseGateUpsertCount += 1;
+            }),
+          })),
+        };
+      }),
+    };
+
+    const client = {
+      transaction: vi.fn(async (callback: (transactionClient: typeof tx) => Promise<unknown>) => {
+        try {
+          const result = await callback(tx);
+          committed = true;
+          return result;
+        } catch (error) {
+          rolledBack = true;
+          throw error;
+        }
+      }),
+    };
+
+    return {
+      client,
+      stats: () => ({ committed, rolledBack, releaseGateUpsertCount, stepInsertCount }),
+    };
+  }
+
+  it('upserts the initial release gate inside record creation', async () => {
+    const { client, stats } = makeTransactionalClient();
+
+    await createDesignControlRecordWithInitialWorkflow({ title: 'Test design' } as any, client as any);
+
+    expect(client.transaction).toHaveBeenCalledTimes(1);
+    expect(stats()).toMatchObject({
+      committed: true,
+      rolledBack: false,
+      stepInsertCount: workflowSteps.length,
+      releaseGateUpsertCount: 1,
+    });
+  });
+
+  it('rolls back record creation when initial step creation fails', async () => {
+    const { client, stats } = makeTransactionalClient({ failFirstStepInsert: true });
+
+    await expect(
+      createDesignControlRecordWithInitialWorkflow({ title: 'Test design' } as any, client as any),
+    ).rejects.toThrow('initial step insert failed');
+
+    expect(client.transaction).toHaveBeenCalledTimes(1);
+    expect(stats()).toMatchObject({
+      committed: false,
+      rolledBack: true,
+      releaseGateUpsertCount: 0,
+    });
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -17328,6 +17328,7 @@ export const designControlRecords = pgTable('design_control_records', {
   recordNumber: text('record_number'),
   title: text('title').notNull(),
   status: text('status').notNull().default('draft'),
+  rdProjectId: text('rd_project_id').references(() => rdProjects.id, { onDelete: 'set null' }),
   projectId: uuid('project_id').references(() => projects.id, { onDelete: 'set null' }),
   productionWorkOrderId: uuid('production_work_order_id').references(() => productionWorkOrders.id, { onDelete: 'set null' }),
   p2PurchaseOrderId: integer('p2_purchase_order_id').references(() => p2PurchaseOrders.id, { onDelete: 'set null' }),
@@ -17342,12 +17343,14 @@ export const designControlRecords = pgTable('design_control_records', {
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (table) => ({
   projectIdx: index('design_control_records_project_id_idx').on(table.projectId),
+  rdProjectIdx: index('design_control_records_rd_project_id_idx').on(table.rdProjectId),
   productionWorkOrderIdx: index('design_control_records_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_records_p2_po_id_idx').on(table.p2PurchaseOrderId),
   statusIdx: index('design_control_records_status_idx').on(table.status),
 }));
 
 const designControlTraceabilityColumns = () => ({
+  rdProjectId: text('rd_project_id').references(() => rdProjects.id, { onDelete: 'set null' }),
   projectId: uuid('project_id').references(() => projects.id, { onDelete: 'set null' }),
   productionWorkOrderId: uuid('production_work_order_id').references(() => productionWorkOrders.id, { onDelete: 'set null' }),
   p2PurchaseOrderId: integer('p2_purchase_order_id').references(() => p2PurchaseOrders.id, { onDelete: 'set null' }),
@@ -17376,6 +17379,7 @@ export const designControlSteps = pgTable('design_control_steps', {
   recordStepUnique: uniqueIndex('design_control_steps_record_step_unique').on(table.recordId, table.stepKey),
   recordIdx: index('design_control_steps_record_id_idx').on(table.recordId),
   statusIdx: index('design_control_steps_status_idx').on(table.status),
+  rdProjectIdx: index('design_control_steps_rd_project_id_idx').on(table.rdProjectId),
   projectIdx: index('design_control_steps_project_id_idx').on(table.projectId),
   productionWorkOrderIdx: index('design_control_steps_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_steps_p2_po_id_idx').on(table.p2PurchaseOrderId),
@@ -17393,6 +17397,7 @@ export const designControlRequirements = pgTable('design_control_requirements', 
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (table) => ({
   recordIdx: index('design_control_requirements_record_id_idx').on(table.recordId),
+  rdProjectIdx: index('design_control_requirements_rd_project_id_idx').on(table.rdProjectId),
   projectIdx: index('design_control_requirements_project_id_idx').on(table.projectId),
   productionWorkOrderIdx: index('design_control_requirements_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_requirements_p2_po_id_idx').on(table.p2PurchaseOrderId),
@@ -17410,6 +17415,7 @@ export const designControlRisks = pgTable('design_control_risks', {
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (table) => ({
   recordIdx: index('design_control_risks_record_id_idx').on(table.recordId),
+  rdProjectIdx: index('design_control_risks_rd_project_id_idx').on(table.rdProjectId),
   projectIdx: index('design_control_risks_project_id_idx').on(table.projectId),
   productionWorkOrderIdx: index('design_control_risks_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_risks_p2_po_id_idx').on(table.p2PurchaseOrderId),
@@ -17428,6 +17434,7 @@ export const designControlReviews = pgTable('design_control_reviews', {
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (table) => ({
   recordIdx: index('design_control_reviews_record_id_idx').on(table.recordId),
+  rdProjectIdx: index('design_control_reviews_rd_project_id_idx').on(table.rdProjectId),
   projectIdx: index('design_control_reviews_project_id_idx').on(table.projectId),
   productionWorkOrderIdx: index('design_control_reviews_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_reviews_p2_po_id_idx').on(table.p2PurchaseOrderId),
@@ -17446,6 +17453,7 @@ export const designControlVerification = pgTable('design_control_verification', 
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (table) => ({
   recordIdx: index('design_control_verification_record_id_idx').on(table.recordId),
+  rdProjectIdx: index('design_control_verification_rd_project_id_idx').on(table.rdProjectId),
   projectIdx: index('design_control_verification_project_id_idx').on(table.projectId),
   productionWorkOrderIdx: index('design_control_verification_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_verification_p2_po_id_idx').on(table.p2PurchaseOrderId),
@@ -17464,6 +17472,7 @@ export const designControlValidation = pgTable('design_control_validation', {
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (table) => ({
   recordIdx: index('design_control_validation_record_id_idx').on(table.recordId),
+  rdProjectIdx: index('design_control_validation_rd_project_id_idx').on(table.rdProjectId),
   projectIdx: index('design_control_validation_project_id_idx').on(table.projectId),
   productionWorkOrderIdx: index('design_control_validation_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_validation_p2_po_id_idx').on(table.p2PurchaseOrderId),
@@ -17482,6 +17491,7 @@ export const designControlChanges = pgTable('design_control_changes', {
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (table) => ({
   recordIdx: index('design_control_changes_record_id_idx').on(table.recordId),
+  rdProjectIdx: index('design_control_changes_rd_project_id_idx').on(table.rdProjectId),
   projectIdx: index('design_control_changes_project_id_idx').on(table.projectId),
   productionWorkOrderIdx: index('design_control_changes_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_changes_p2_po_id_idx').on(table.p2PurchaseOrderId),
@@ -17501,6 +17511,7 @@ export const designControlReleaseGate = pgTable('design_control_release_gate', {
   recordUnique: uniqueIndex('design_control_release_gate_record_unique').on(table.recordId),
   recordIdx: index('design_control_release_gate_record_id_idx').on(table.recordId),
   gateStatusIdx: index('design_control_release_gate_status_idx').on(table.gateStatus),
+  rdProjectIdx: index('design_control_release_gate_rd_project_id_idx').on(table.rdProjectId),
   projectIdx: index('design_control_release_gate_project_id_idx').on(table.projectId),
   productionWorkOrderIdx: index('design_control_release_gate_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_release_gate_p2_po_id_idx').on(table.p2PurchaseOrderId),

--- a/server/src/routes/qmsDesignControl.ts
+++ b/server/src/routes/qmsDesignControl.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../../db';
 import {
@@ -265,10 +265,10 @@ const workflowSteps = [
       'required certifications identified',
       'supplier requirements flowed down',
       'material requirements approved',
-      'tooling/fixtures ready',
-      'CNC programs approved if applicable',
-      'training/certifications complete',
-      'packaging/shipping requirements defined',
+      'tooling and fixtures ready',
+      'CNC programs approved when applicable',
+      'training and certifications complete',
+      'packaging and shipping requirements defined',
       'design revision baseline locked',
     ],
     requiredApprovals: [
@@ -282,6 +282,14 @@ const workflowSteps = [
 
 const requiredStepKeys = workflowSteps.filter((step) => step.key !== '12').map((step) => step.key);
 type WorkflowStepDefinition = typeof workflowSteps[number];
+type StepMissingEvidence = ReturnType<typeof missingForStep>;
+type PersistedWorkflowStep = {
+  stepKey: string;
+  status?: string | null;
+  formData?: unknown;
+  checklist?: unknown;
+  approvals?: unknown;
+};
 
 function isRecordObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -375,12 +383,23 @@ function deriveStatus(step: WorkflowStepDefinition, payload: StepPayload) {
   };
 }
 
-function formatMissingItems(step: WorkflowStepDefinition, missing: ReturnType<typeof missingForStep>) {
+function formatMissingItems(step: WorkflowStepDefinition, missing: StepMissingEvidence) {
   return [
     ...missing.fields.map((field) => `Step ${step.key} ${step.title} field missing: ${field}`),
     ...missing.checklist.map((item) => `Step ${step.key} ${step.title} checklist incomplete: ${item}`),
     ...missing.approvals.map((approval) => `Step ${step.key} ${step.title} approval missing: ${approval}`),
   ];
+}
+
+function formatStepRequirementError(step: WorkflowStepDefinition, missing: StepMissingEvidence) {
+  return {
+    error: 'Step requirements are incomplete',
+    stepKey: step.key,
+    missingFormFields: missing.fields,
+    missingChecklistItems: missing.checklist,
+    missingApprovals: missing.approvals,
+    missingItems: formatMissingItems(step, missing),
+  };
 }
 
 async function getRecord(id: string) {
@@ -392,30 +411,7 @@ async function getSteps(recordId: string) {
   return db.select().from(designControlSteps).where(eq(designControlSteps.recordId, recordId));
 }
 
-async function ensureWorkflowSteps(record: typeof designControlRecords.$inferSelect, client: typeof db = db) {
-  for (const step of workflowSteps) {
-    await client
-      .insert(designControlSteps)
-      .values({
-        recordId: record.id,
-        stepKey: step.key,
-        title: step.title,
-        status: 'incomplete',
-        projectId: record.projectId,
-        productionWorkOrderId: record.productionWorkOrderId,
-        p2PurchaseOrderId: record.p2PurchaseOrderId,
-        formData: {},
-        checklist: {},
-        approvals: {},
-        attachments: [],
-        metadata: { source: 'qms-design-control' },
-      })
-      .onConflictDoNothing();
-  }
-}
-
-async function buildReadiness(recordId: string) {
-  const steps = await getSteps(recordId);
+function buildReadinessFromSteps(steps: PersistedWorkflowStep[]) {
   const byKey = new Map(steps.map((step) => [step.stepKey, step]));
   const missingItems: string[] = [];
 
@@ -454,6 +450,34 @@ async function buildReadiness(recordId: string) {
   };
 }
 
+async function ensureWorkflowSteps(record: typeof designControlRecords.$inferSelect, client: typeof db = db) {
+  for (const step of workflowSteps) {
+    await client
+      .insert(designControlSteps)
+      .values({
+        recordId: record.id,
+        stepKey: step.key,
+        title: step.title,
+        status: 'incomplete',
+        rdProjectId: record.rdProjectId,
+        projectId: record.projectId,
+        productionWorkOrderId: record.productionWorkOrderId,
+        p2PurchaseOrderId: record.p2PurchaseOrderId,
+        formData: {},
+        checklist: {},
+        approvals: {},
+        attachments: [],
+        metadata: { source: 'qms-design-control' },
+      })
+      .onConflictDoNothing();
+  }
+}
+
+async function buildReadiness(recordId: string) {
+  const steps = await getSteps(recordId);
+  return buildReadinessFromSteps(steps);
+}
+
 async function upsertReleaseGate(
   record: typeof designControlRecords.$inferSelect,
   payload: StepPayload,
@@ -464,6 +488,7 @@ async function upsertReleaseGate(
   const values = {
     recordId: record.id,
     gateStatus,
+    rdProjectId: record.rdProjectId,
     projectId: record.projectId,
     productionWorkOrderId: record.productionWorkOrderId,
     p2PurchaseOrderId: record.p2PurchaseOrderId,
@@ -485,12 +510,38 @@ async function upsertReleaseGate(
     });
 }
 
+async function createDesignControlRecordWithInitialWorkflow(
+  data: typeof designControlRecords.$inferInsert,
+  client: typeof db = db
+) {
+  return client.transaction(async (tx) => {
+    const [createdRecord] = await tx.insert(designControlRecords).values(data).returning();
+    await ensureWorkflowSteps(createdRecord, tx as typeof db);
+    await upsertReleaseGate(createdRecord, {}, 'not_ready', tx as typeof db);
+    return createdRecord;
+  });
+}
+
 router.get('/', async (_req: Request, res: Response) => {
   try {
-    const records = await db
-      .select()
-      .from(designControlRecords)
-      .orderBy(desc(designControlRecords.updatedAt), desc(designControlRecords.createdAt));
+    const conditions: SQL[] = [];
+    if (typeof _req.query.rdProjectId === 'string' && _req.query.rdProjectId.trim()) {
+      conditions.push(eq(designControlRecords.rdProjectId, _req.query.rdProjectId.trim()));
+    }
+    if (typeof _req.query.projectId === 'string' && _req.query.projectId.trim()) {
+      conditions.push(eq(designControlRecords.projectId, _req.query.projectId.trim()));
+    }
+
+    const records = conditions.length > 0
+      ? await db
+        .select()
+        .from(designControlRecords)
+        .where(and(...conditions))
+        .orderBy(desc(designControlRecords.updatedAt), desc(designControlRecords.createdAt))
+      : await db
+        .select()
+        .from(designControlRecords)
+        .orderBy(desc(designControlRecords.updatedAt), desc(designControlRecords.createdAt));
     res.json({ records });
   } catch (error) {
     console.error('[qms-design-control] Failed to list records', error);
@@ -504,6 +555,7 @@ router.post('/', async (req: Request, res: Response) => {
       title: req.body?.title || 'New Design Control Record',
       recordNumber: req.body?.recordNumber ?? null,
       status: req.body?.status || 'draft',
+      rdProjectId: req.body?.rdProjectId ?? null,
       projectId: req.body?.projectId ?? null,
       productionWorkOrderId: req.body?.productionWorkOrderId ?? null,
       p2PurchaseOrderId: req.body?.p2PurchaseOrderId ?? null,
@@ -519,12 +571,7 @@ router.post('/', async (req: Request, res: Response) => {
       return;
     }
 
-    const record = await db.transaction(async (tx) => {
-      const [createdRecord] = await tx.insert(designControlRecords).values(parsed.data).returning();
-      await ensureWorkflowSteps(createdRecord, tx as typeof db);
-      await upsertReleaseGate(createdRecord, {}, 'not_ready', tx as typeof db);
-      return createdRecord;
-    });
+    const record = await createDesignControlRecordWithInitialWorkflow(parsed.data);
 
     res.status(201).json({ record });
   } catch (error) {
@@ -589,7 +636,11 @@ router.patch('/:id/steps/:stepKey', async (req: Request, res: Response) => {
 
     const step = workflowSteps.find((item) => item.key === req.params.stepKey);
     if (!step) {
-      res.status(404).json({ message: 'Design control step not found' });
+      res.status(400).json({
+        error: 'Invalid design control step',
+        stepKey: req.params.stepKey,
+        validStepKeys: workflowSteps.map((item) => item.key),
+      });
       return;
     }
 
@@ -610,7 +661,7 @@ router.patch('/:id/steps/:stepKey', async (req: Request, res: Response) => {
     if (derived.rejectedApproval) {
       res.status(400).json({
         message: `Step ${step.key} cannot be approved until required evidence is complete`,
-        missingItems: formatMissingItems(step, derived.missing),
+        ...formatStepRequirementError(step, derived.missing),
       });
       return;
     }
@@ -656,6 +707,7 @@ router.patch('/:id/steps/:stepKey', async (req: Request, res: Response) => {
       stepKey: step.key,
       title: step.title,
       status,
+      rdProjectId: record.rdProjectId,
       projectId: record.projectId,
       productionWorkOrderId: record.productionWorkOrderId,
       p2PurchaseOrderId: record.p2PurchaseOrderId,
@@ -772,5 +824,15 @@ router.get('/:id/readiness', async (req: Request, res: Response) => {
     res.status(500).json({ message: 'Failed to compute design control readiness' });
   }
 });
+
+export const qmsDesignControlTestInternals = {
+  workflowSteps,
+  requiredStepKeys,
+  buildReadinessFromSteps,
+  createDesignControlRecordWithInitialWorkflow,
+  deriveStatus,
+  formatStepRequirementError,
+  missingForStep,
+};
 
 export default router;


### PR DESCRIPTION
## Summary
- Link QMS Design Control records to Design/R&D projects via `rd_project_id` while preserving the existing Project / PO / WAD / P2 flow.
- Add the Design Control tab to `/design/rd-projects` so linked records are created/opened from the R&D project UI only.
- Harden server-side design-control approval and release readiness logic, including canonical Step 12 checklist and approval requirements.
- Add focused server tests covering readiness blocking, invalid approval attempts, release gate completeness, initial release-gate upsert, and transaction rollback.

## Validation
- `git diff --check origin/main...HEAD`
- `git diff --cached --check`
- `server/__tests__/qmsDesignControlReleaseGate.test.ts` passed, 11 tests
- `node_modules\.bin\vite.CMD build` passed with `NODE_OPTIONS=--max-old-space-size=4096`

## Notes
- `pnpm-lock.yaml` and `package.json` are unchanged.
- `/api/projects/:id/release-to-p2` is unchanged.
- P2 release remains unblocked by Design Control in this PR.
- Full `tsc` at default heap hit Node heap OOM; with 4096 MB heap it remained silent for about 150 seconds and was stopped cleanly.