### PR TITLE
Gate receiving completion on putaway readiness

### DIFF
--- a/client/src/__tests__/rccReceivingProgress.component.test.tsx
+++ b/client/src/__tests__/rccReceivingProgress.component.test.tsx
@@ -42,6 +42,7 @@ function makeUnit(id: number): NonNullable<Receipt['units']>[number] {
     barcode: `UNIT-${id}`,
     disposition: 'accepted',
     quantity: '1',
+    location: 'Conex 1',
   };
 }
 
@@ -394,7 +395,23 @@ describe('PutawayStep — completeReceiptMutation invalidates the correct query 
     fireEvent.click(screen.getByText('Complete Receipt'));
 
     await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Failed to complete receipt');
+      expect(mockToastError).toHaveBeenCalledWith('Server error');
     });
+  });
+
+  it('locks completion and lists accepted units that still need putaway', () => {
+    renderPutawayStep(makeReceipt({
+      units: [
+        { ...makeUnit(1), location: undefined, freezerNumber: undefined },
+        makeUnit(2),
+      ],
+    }));
+
+    expect(screen.getByTestId('putaway-completion-blockers').textContent).toContain('UNIT-1');
+    expect(screen.getByText('Complete Receipt')).toHaveAttribute('disabled');
+    expect(mockApiRequest).not.toHaveBeenCalledWith('/api/receipts/1', expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'complete' }),
+    }));
   });
 });

--- a/client/src/pages/InventoryReceivingControlCenter.tsx
+++ b/client/src/pages/InventoryReceivingControlCenter.tsx
@@ -2838,6 +2838,26 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
   const renderProjectTargetLabel = (project: ReceivingProjectTarget) =>
     `${project.projectCode} - ${project.projectName}${project.customerName ? ` (${project.customerName})` : ''}`;
 
+  const needsPutaway = (unit: ReceivedUnit) =>
+    unit.disposition === 'accepted' &&
+    !unit.location?.trim() &&
+    unit.freezerNumber == null;
+
+  const pendingInspectionUnits = units.filter(u => u.disposition === 'pending_inspection');
+  const putawayBlockers = units.filter(needsPutaway);
+  const canCompleteReceipt =
+    units.length > 0 &&
+    pendingInspectionUnits.length === 0 &&
+    putawayBlockers.length === 0 &&
+    !deptApplyPending &&
+    !batchPending;
+
+  const summarizeUnitList = (blockedUnits: ReceivedUnit[]) => {
+    const labels = blockedUnits.slice(0, 6).map(unit => unit.barcode || `Unit ${unit.id}`);
+    const extra = blockedUnits.length - labels.length;
+    return `${labels.join(', ')}${extra > 0 ? `, +${extra} more` : ''}`;
+  };
+
   const applyDeptDefaults = async (dept: InventoryDepartment | null, newLocation: string | null, newFreezer: number | null, silent = false) => {
     if (!dept || (newLocation == null && newFreezer == null)) return;
     const unitsToFill = units.filter(u => (newLocation != null && !u.location) || (newFreezer != null && u.freezerNumber == null));
@@ -2944,10 +2964,19 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
   };
 
   const completeReceiptMutation = useMutation({
-    mutationFn: () => apiRequest(`/api/receipts/${receipt.id}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ status: 'complete' }),
-    }),
+    mutationFn: () => {
+      if (!canCompleteReceipt) {
+        const message = putawayBlockers.length > 0
+          ? `Put away ${putawayBlockers.length} accepted unit(s) before completing this receipt.`
+          : `Inspect all units before completing this receipt.`;
+        throw new Error(message);
+      }
+
+      return apiRequest(`/api/receipts/${receipt.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ status: 'complete' }),
+      });
+    },
     onSuccess: (data) => {
       onUpdate({ ...receipt, ...data });
       for (const key of getRccCompleteInvalidationKeys(receipt.vendorPoId)) {
@@ -2955,7 +2984,7 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
       }
       onComplete();
     },
-    onError: () => toast.error('Failed to complete receipt'),
+    onError: (err: any) => toast.error(err?.message ?? 'Failed to complete receipt'),
   });
 
   return (
@@ -3056,6 +3085,23 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
       {units.length === 0 && (
         <div className="text-center text-xs text-gray-500 py-4">No units to assign location</div>
       )}
+      {(pendingInspectionUnits.length > 0 || putawayBlockers.length > 0) && (
+        <div
+          data-testid="putaway-completion-blockers"
+          className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700 px-3 py-2 text-amber-800 dark:text-amber-300 text-xs space-y-1"
+        >
+          <div className="flex items-center gap-2 font-medium">
+            <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+            Complete receipt is locked until every accepted unit has a location or freezer.
+          </div>
+          {putawayBlockers.length > 0 && (
+            <div>Needs putaway: {summarizeUnitList(putawayBlockers)}</div>
+          )}
+          {pendingInspectionUnits.length > 0 && (
+            <div>Still needs disposition: {summarizeUnitList(pendingInspectionUnits)}</div>
+          )}
+        </div>
+      )}
       {units.map(unit => (
         <div key={unit.id} className="border rounded-lg p-3 space-y-2">
           <div className="flex items-center justify-between">
@@ -3130,7 +3176,7 @@ export function PutawayStep({ receipt, onComplete, onUpdate }: {
           size="sm"
           className="w-full bg-green-600 hover:bg-green-700 mt-2"
           onClick={() => completeReceiptMutation.mutate()}
-          disabled={completeReceiptMutation.isPending}
+          disabled={completeReceiptMutation.isPending || !canCompleteReceipt}
         >
           {completeReceiptMutation.isPending ? <Loader2 className="w-3 h-3 animate-spin mr-1" /> : <Check className="w-3 h-3 mr-1" />}
           Complete Receipt


### PR DESCRIPTION
## Summary
- Block the Receiving UI complete action when accepted units still need putaway details.
- Show the specific unit barcodes that need location/freezer assignment or disposition before completion.
- Preserve the server's specific completion error message in the toast instead of replacing it with a generic failure.
- Update the PutawayStep component test fixture and add coverage for the new completion lock.

## Root Cause
The server correctly rejects receipt completion when accepted units have no location or freezer, returning `putaway_required` blockers. The UI still allowed the completion action and then collapsed the detailed server response into a generic "Failed to complete receipt" toast, leaving the receiver without the actionable barcode list.

## Validation
- `git diff --check`
- `git diff --cached --check`

Vitest was not run locally because this clean worktree has no `node_modules` and `npm` is not available on PATH.