### PR TITLE
Clarify Design Control source ownership

### DIFF
--- a/client/src/pages/QMSDesignControlPage.tsx
+++ b/client/src/pages/QMSDesignControlPage.tsx
@@ -125,6 +125,12 @@ type DesignControlStepRecord = {
 type DesignControlReadiness = {
   ready: boolean;
   missingItems: string[];
+  sourceOfTruthPrinciple?: string;
+  manufacturingSourceStatuses?: Array<{
+    requirement: string;
+    source: string;
+    ready: boolean;
+  }>;
   steps: Array<{ key: string; title: string; status: string }>;
 };
 
@@ -714,6 +720,25 @@ const designWorkflowSteps: DesignWorkflowStep[] = [
   },
 ];
 
+const releaseGateSourceModules: Record<string, string> = {
+  'Released CAD': 'Design Outputs / CAD vault',
+  'Released drawings': 'Document Control / released drawings',
+  'Released BOM': 'BOM module',
+  'Approved routing': 'Routing module',
+  'Approved traveler requirement': 'Traveler module',
+  'Approved work instructions': 'Work Instructions module',
+  'Approved inspection plan': 'Inspection / QC module',
+  'Approved test procedure': 'Verification / Test module',
+  'Required certifications identified': 'Certifications / Quality module',
+  'Supplier requirements flowed down': 'Supplier Quality / Procurement module',
+  'Material requirements approved': 'Material / Inventory module',
+  'Tooling/fixtures ready': 'Manufacturing Engineering module',
+  'CNC programs approved, if applicable': 'CNC / Manufacturing module',
+  'Training/certifications complete': 'Training module',
+  'Packaging/shipping requirements defined': 'Shipping / Packaging module',
+  'Design revision baseline locked': 'Document Control / Revision baseline',
+};
+
 function createInitialWorkflowData() {
   return designWorkflowSteps.reduce<Record<string, WorkflowStepData>>((acc, step) => {
     acc[step.id] = {
@@ -1056,6 +1081,10 @@ export default function QMSDesignControlPage() {
             title: step.title,
             purpose: step.purpose,
             source: '/qms/design-control',
+            sourceOfTruthPrinciple: step.id === '12'
+              ? 'R&D Project owns engineering process; Design Control orchestrates; manufacturing modules own their own data and Design Control evaluates their status.'
+              : undefined,
+            manufacturingSourceModules: step.id === '12' ? releaseGateSourceModules : undefined,
           },
         },
       }) as { readiness: DesignControlReadiness };
@@ -1401,7 +1430,16 @@ export default function QMSDesignControlPage() {
 
                 {selectedWorkflowStep.checklist && selectedWorkflowStep.checklist.length > 0 && (
                   <div className="space-y-3">
-                    <div className="text-sm font-medium">Checklist</div>
+                    <div>
+                      <div className="text-sm font-medium">
+                        {selectedWorkflowStep.id === '12' ? 'Manufacturing source status' : 'Checklist'}
+                      </div>
+                      {selectedWorkflowStep.id === '12' && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Design Control evaluates these source-of-truth modules. It should not duplicate BOM, routing, traveler, work-instruction, inspection, or P2 manufacturing data.
+                        </p>
+                      )}
+                    </div>
                     <div className="grid gap-2 md:grid-cols-2">
                       {selectedWorkflowStep.checklist.map((item) => (
                         <label key={item} className="flex cursor-pointer items-start gap-3 rounded-md border bg-white px-3 py-2 text-sm hover:bg-gray-50">
@@ -1409,7 +1447,14 @@ export default function QMSDesignControlPage() {
                             checked={selectedWorkflowData.checklist[item] === true}
                             onCheckedChange={(checked) => updateWorkflowChecklist(selectedWorkflowStep.id, item, checked === true)}
                           />
-                          <span>{item}</span>
+                          <span>
+                            {item}
+                            {selectedWorkflowStep.id === '12' && releaseGateSourceModules[item] && (
+                              <span className="mt-1 block text-xs text-muted-foreground">
+                                Source: {releaseGateSourceModules[item]}
+                              </span>
+                            )}
+                          </span>
                         </label>
                       ))}
                     </div>
@@ -1460,6 +1505,27 @@ export default function QMSDesignControlPage() {
                 </div>
               </CardHeader>
               <CardContent>
+                {serverReadiness?.manufacturingSourceStatuses && serverReadiness.manufacturingSourceStatuses.length > 0 && (
+                  <div className="mb-4 space-y-3">
+                    <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                      {serverReadiness.sourceOfTruthPrinciple
+                        ?? 'R&D Project owns engineering process; Design Control orchestrates; manufacturing modules own their own data and Design Control evaluates their status.'}
+                    </div>
+                    <div className="grid gap-2 md:grid-cols-2">
+                      {serverReadiness.manufacturingSourceStatuses.map((status) => (
+                        <div key={`${status.source}-${status.requirement}`} className="flex items-start justify-between gap-3 rounded-md border bg-white px-3 py-2 text-sm">
+                          <div>
+                            <div className="font-medium">{status.requirement}</div>
+                            <div className="text-xs text-muted-foreground">{status.source}</div>
+                          </div>
+                          <Badge variant="outline" className={status.ready ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-amber-200 bg-amber-50 text-amber-700'}>
+                            {status.ready ? 'Ready' : 'Needs source'}
+                          </Badge>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
                 {releaseReadinessItems.length === 0 ? (
                   <div className="flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
                     <CheckCircle2 className="h-4 w-4" />

--- a/server/__tests__/qmsDesignControlReleaseGate.test.ts
+++ b/server/__tests__/qmsDesignControlReleaseGate.test.ts
@@ -52,7 +52,7 @@ describe('QMS design control release gate validation', () => {
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toContain(
-      'Step 12 Design Production Release Gate checklist incomplete: released CAD',
+      'Step 12 Design Production Release Gate source status incomplete: released CAD (Design Outputs / CAD vault)',
     );
     expect(readiness.missingItems).toContain(
       'Step 12 Design Production Release Gate approval missing: engineering release approval',
@@ -73,8 +73,8 @@ describe('QMS design control release gate validation', () => {
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toEqual(
       expect.arrayContaining([
-        'Step 12 Design Production Release Gate checklist incomplete: released drawings',
-        'Step 12 Design Production Release Gate checklist incomplete: approved routing',
+        'Step 12 Design Production Release Gate source status incomplete: released drawings (Document Control / released drawings)',
+        'Step 12 Design Production Release Gate source status incomplete: approved routing (Routing module)',
       ]),
     );
   });
@@ -128,7 +128,30 @@ describe('QMS design control release gate validation', () => {
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toContain(
-      'Step 12 Design Production Release Gate checklist incomplete: material requirements approved',
+      'Step 12 Design Production Release Gate source status incomplete: material requirements approved (Material / Inventory module)',
+    );
+  });
+
+  it('reports manufacturing module source status without duplicating source data', () => {
+    const readiness = buildReadinessFromSteps([
+      ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
+      { stepKey: '12', status: 'needs_approval', formData: {}, checklist: {}, approvals: {} },
+    ]);
+
+    expect(readiness.sourceOfTruthPrinciple).toMatch(/manufacturing modules own their own data/i);
+    expect(readiness.manufacturingSourceStatuses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          requirement: 'released BOM',
+          source: 'BOM module',
+          ready: false,
+        }),
+        expect.objectContaining({
+          requirement: 'approved traveler requirement',
+          source: 'Traveler module',
+          ready: false,
+        }),
+      ]),
     );
   });
 
@@ -153,7 +176,7 @@ describe('QMS design control release gate validation', () => {
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toContain(
-      'Step 12 Design Production Release Gate checklist incomplete: released BOM',
+      'Step 12 Design Production Release Gate source status incomplete: released BOM (BOM module)',
     );
   });
 

--- a/server/src/routes/qmsDesignControl.ts
+++ b/server/src/routes/qmsDesignControl.ts
@@ -281,6 +281,24 @@ const workflowSteps = [
 ];
 
 const requiredStepKeys = workflowSteps.filter((step) => step.key !== '12').map((step) => step.key);
+const releaseGateSourceRequirements = [
+  { item: 'released CAD', source: 'Design Outputs / CAD vault' },
+  { item: 'released drawings', source: 'Document Control / released drawings' },
+  { item: 'released BOM', source: 'BOM module' },
+  { item: 'approved routing', source: 'Routing module' },
+  { item: 'approved traveler requirement', source: 'Traveler module' },
+  { item: 'approved work instructions', source: 'Work Instructions module' },
+  { item: 'approved inspection plan', source: 'Inspection / QC module' },
+  { item: 'approved test procedure', source: 'Verification / Test module' },
+  { item: 'required certifications identified', source: 'Certifications / Quality module' },
+  { item: 'supplier requirements flowed down', source: 'Supplier Quality / Procurement module' },
+  { item: 'material requirements approved', source: 'Material / Inventory module' },
+  { item: 'tooling and fixtures ready', source: 'Manufacturing Engineering module' },
+  { item: 'CNC programs approved when applicable', source: 'CNC / Manufacturing module' },
+  { item: 'training and certifications complete', source: 'Training module' },
+  { item: 'packaging and shipping requirements defined', source: 'Shipping / Packaging module' },
+  { item: 'design revision baseline locked', source: 'Document Control / Revision baseline' },
+];
 type WorkflowStepDefinition = typeof workflowSteps[number];
 type StepMissingEvidence = ReturnType<typeof missingForStep>;
 type PersistedWorkflowStep = {
@@ -386,18 +404,35 @@ function deriveStatus(step: WorkflowStepDefinition, payload: StepPayload) {
 function formatMissingItems(step: WorkflowStepDefinition, missing: StepMissingEvidence) {
   return [
     ...missing.fields.map((field) => `Step ${step.key} ${step.title} field missing: ${field}`),
-    ...missing.checklist.map((item) => `Step ${step.key} ${step.title} checklist incomplete: ${item}`),
+    ...missing.checklist.map((item) => {
+      const sourceRequirement = releaseGateSourceRequirements.find((requirement) => normalizeKey(requirement.item) === normalizeKey(item));
+      if (step.key === '12' && sourceRequirement) {
+        return `Step ${step.key} ${step.title} source status incomplete: ${item} (${sourceRequirement.source})`;
+      }
+      return `Step ${step.key} ${step.title} checklist incomplete: ${item}`;
+    }),
     ...missing.approvals.map((approval) => `Step ${step.key} ${step.title} approval missing: ${approval}`),
   ];
 }
 
 function formatStepRequirementError(step: WorkflowStepDefinition, missing: StepMissingEvidence) {
+  const missingSourceStatuses = step.key === '12'
+    ? missing.checklist.map((item) => {
+      const sourceRequirement = releaseGateSourceRequirements.find((requirement) => normalizeKey(requirement.item) === normalizeKey(item));
+      return {
+        item,
+        source: sourceRequirement?.source ?? 'External source of truth',
+      };
+    })
+    : [];
+
   return {
     error: 'Step requirements are incomplete',
     stepKey: step.key,
     missingFormFields: missing.fields,
     missingChecklistItems: missing.checklist,
     missingApprovals: missing.approvals,
+    missingSourceStatuses,
     missingItems: formatMissingItems(step, missing),
   };
 }
@@ -442,6 +477,18 @@ function buildReadinessFromSteps(steps: PersistedWorkflowStep[]) {
   return {
     ready: missingItems.length === 0,
     missingItems,
+    sourceOfTruthPrinciple: 'R&D Project owns engineering process; Design Control orchestrates; manufacturing modules own their own data and Design Control evaluates their status.',
+    manufacturingSourceStatuses: releaseGateSourceRequirements.map((requirement) => ({
+      requirement: requirement.item,
+      source: requirement.source,
+      ready: releaseStep
+        ? !missingForStep(workflowSteps.find((step) => step.key === '12')!, {
+          formData: normalizeJsonObject(releaseStep.formData),
+          checklist: normalizeJsonObject(releaseStep.checklist),
+          approvals: normalizeJsonObject(releaseStep.approvals),
+        }).checklist.some((item) => normalizeKey(item) === normalizeKey(requirement.item))
+        : false,
+    })),
     steps: workflowSteps.map((step) => ({
       key: step.key,
       title: step.title,
@@ -828,6 +875,7 @@ router.get('/:id/readiness', async (req: Request, res: Response) => {
 export const qmsDesignControlTestInternals = {
   workflowSteps,
   requiredStepKeys,
+  releaseGateSourceRequirements,
   buildReadinessFromSteps,
   createDesignControlRecordWithInitialWorkflow,
   deriveStatus,


### PR DESCRIPTION
## Summary
- Make the Design Control ownership boundary explicit: R&D owns engineering process, Design Control orchestrates, and manufacturing modules own their own data.
- Change Step 12 release readiness messaging so BOM, routing, travelers, work instructions, inspection, certifications, material, CNC, training, and shipping are shown as source-of-truth status checks rather than duplicated Design Control data.
- Add a Release Readiness source-status panel in `/qms/design-control` that displays the owning module for each manufacturing readiness requirement.
- Extend focused server tests to verify manufacturing source-status reporting.

## Validation
- `git diff --check origin/main...HEAD`
- `node.exe --check server/src/routes/qmsDesignControl.ts`
- `server/__tests__/qmsDesignControlReleaseGate.test.ts` passed, 12 tests

## Notes
- No P2 release gate changes.
- `/api/projects/:id/release-to-p2` remains untouched.
- This is a follow-up because PR #1454 was already merged before this principle-hardening commit could be included.