### PR TITLE
Repair made packet fabric, serial links, and scanning

### DIFF
--- a/client/src/pages/cutting/CuttingOperatorDashboard.tsx
+++ b/client/src/pages/cutting/CuttingOperatorDashboard.tsx
@@ -2748,7 +2748,7 @@ export default function CuttingOperatorDashboard() {
                                 )}
                                 {packet.allocatedSerializedItem ? (
                                   <span className="text-xs text-muted-foreground">
-                                    Serial: <span className="font-mono">{packet.allocatedSerializedItem.serialNumber}</span>
+                                    Used for serial: <span className="font-mono">{packet.allocatedSerializedItem.serialNumber}</span>
                                     {packet.allocatedSerializedItem.travelerBarcode ? ` (${packet.allocatedSerializedItem.travelerBarcode})` : ''}
                                   </span>
                                 ) : packet.allocatedToOrder && (

--- a/server/__tests__/packetResolution.test.ts
+++ b/server/__tests__/packetResolution.test.ts
@@ -142,6 +142,44 @@ describe('resolvePacketBarcode — Task #43 sibling-packet leak guard', () => {
     expect(result!.packetRecord?.packetNumber).toBe(46);
   });
 
+  it('normalizes a lowercase MFG scan before resolving the built packet', async () => {
+    const queueItem = {
+      id: 254,
+      inventoryItemId: null,
+      materialDetails: null,
+      fabricLot: null,
+      fabricBatch: null,
+      fabricRoll: null,
+      completedAt: null,
+      startedAt: null,
+      parentProductionOrderId: null,
+      sourceId: null,
+    };
+    const realPacket = {
+      id: 97,
+      barcode: 'PKT-97-254-330-1700000000000',
+      packetNumber: 330,
+      buildDate: new Date('2026-07-13'),
+      status: 'AVAILABLE',
+      isMixedFabric: false,
+      allocatedToOrder: null,
+    };
+
+    sequenceDbSelects(
+      [],
+      [queueItem],
+      [],
+      [realPacket],
+    );
+
+    const result = await resolvePacketBarcode('mfg-254-97-330');
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('built_packet');
+    expect(result!.packetRecord?.id).toBe(97);
+    expect(result!.barcode).toBe('MFG-254-97-330');
+  });
+
   it('keeps source as manufacturing_queue even when the backfill side-effect succeeds', async () => {
     // When the helper falls through to the queue branch and the on-the-fly backfill
     // actually creates a built_packet row, it must NOT reclassify the response as

--- a/server/src/lib/packetResolution.ts
+++ b/server/src/lib/packetResolution.ts
@@ -119,10 +119,13 @@ export async function backfillPacketFromQueue(
 }
 
 export async function resolvePacketBarcode(barcode: string): Promise<PacketResolutionResult | null> {
+  const normalizedBarcode = barcode.trim().toUpperCase();
+  if (!normalizedBarcode) return null;
+
   const [directPacket] = await db
     .select()
     .from(cuttingBuiltPackets)
-    .where(eq(cuttingBuiltPackets.barcode, barcode))
+    .where(eq(cuttingBuiltPackets.barcode, normalizedBarcode))
     .limit(1);
 
   if (directPacket) {
@@ -130,14 +133,14 @@ export async function resolvePacketBarcode(barcode: string): Promise<PacketResol
       source: 'built_packet',
       packetRecord: directPacket,
       queueItem: null,
-      barcode,
+      barcode: normalizedBarcode,
       packetNumber: directPacket.packetNumber ?? 1,
       backfillAttempted: false,
       backfillResult: null,
     };
   }
 
-  const mfgMatch = barcode.match(/^MFG-(\d+)-([^-]+)(?:-(\d+))?$/);
+  const mfgMatch = normalizedBarcode.match(/^MFG-(\d+)-([^-]+)(?:-(\d+))?$/);
   if (!mfgMatch) {
     return null;
   }
@@ -160,7 +163,7 @@ export async function resolvePacketBarcode(barcode: string): Promise<PacketResol
   const [exactPacket] = await db
     .select()
     .from(cuttingBuiltPackets)
-    .where(eq(cuttingBuiltPackets.barcode, barcode))
+    .where(eq(cuttingBuiltPackets.barcode, normalizedBarcode))
     .limit(1);
   builtPacketForQueue = exactPacket;
 
@@ -189,7 +192,7 @@ export async function resolvePacketBarcode(barcode: string): Promise<PacketResol
       source: 'built_packet',
       packetRecord: builtPacketForQueue,
       queueItem,
-      barcode,
+      barcode: normalizedBarcode,
       packetNumber: builtPacketForQueue.packetNumber ?? 1,
       backfillAttempted: false,
       backfillResult: null,
@@ -240,14 +243,14 @@ export async function resolvePacketBarcode(barcode: string): Promise<PacketResol
   // queue-derived and surface the same warning path as before any backfill ran.  See Task #43.
   let backfillResult: 'created' | 'existed' | 'skipped' | null = null;
   if (fabricRolls.length > 0) {
-    backfillResult = await backfillPacketFromQueue(queueItem, barcode, packetNumber, fabricRolls);
+    backfillResult = await backfillPacketFromQueue(queueItem, normalizedBarcode, packetNumber, fabricRolls);
   }
 
   return {
     source: 'manufacturing_queue',
     packetRecord: null,
     queueItem,
-    barcode,
+    barcode: normalizedBarcode,
     packetNumber,
     backfillAttempted: fabricRolls.length > 0,
     backfillResult,

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from 'express';
 import { storage } from '../../storage';
 import { db } from '../../db';
 import { manufacturingQueue, inventoryItems, p2ProductionOrders, p2PurchaseOrders, p2SerializedItems, cuttingPacketBOMs, cuttingPacketBOMMaterials, cuttingPacketBOMParts, cuttingFabricInventory, cuttingFabricInventoryTransactions, cuttingBuiltPackets, cuttingBuiltPacketFabricSources, cuttingProductCategories, getDashboardCategories, supplySourceDashboardToLegacyDept } from '../../schema';
-import { eq, and, or, asc, desc, inArray, like, count } from 'drizzle-orm';
+import { eq, and, or, asc, desc, inArray, like, count, isNull } from 'drizzle-orm';
 import {
   adjustPacketInventoryForMaterial,
   getP1PacketName,
@@ -246,7 +246,27 @@ async function ensureBuiltPacketsForCompletedQueueRows(): Promise<void> {
     inArray(inventoryItems.manufacturedCategory, cuttingTableCategories)
   );
 
-  const completedRows = await db
+  // Source-less packets can belong to an older queue row that has fallen outside
+  // the recent-row repair window. Resolve those queue IDs first so packet fabric
+  // traceability is repairable regardless of the queue row's age.
+  const sourceLessPackets = await db
+    .select({ barcode: cuttingBuiltPackets.barcode })
+    .from(cuttingBuiltPackets)
+    .leftJoin(
+      cuttingBuiltPacketFabricSources,
+      eq(cuttingBuiltPacketFabricSources.builtPacketId, cuttingBuiltPackets.id)
+    )
+    .where(and(
+      like(cuttingBuiltPackets.barcode, 'PKT-%'),
+      isNull(cuttingBuiltPacketFabricSources.id)
+    ));
+  const sourceLessQueueIds = [...new Set(
+    sourceLessPackets
+      .map((packet) => parseQueueIdFromBuiltPacketBarcode(packet.barcode))
+      .filter((queueId): queueId is number => queueId !== null)
+  )];
+
+  let completedRows = await db
     .select({
       queue: manufacturingQueue,
       item: inventoryItems,
@@ -262,6 +282,28 @@ async function ensureBuiltPacketsForCompletedQueueRows(): Promise<void> {
     ))
     .orderBy(desc(manufacturingQueue.completedAt), desc(manufacturingQueue.updatedAt))
     .limit(250);
+
+  if (sourceLessQueueIds.length > 0) {
+    const sourceLessQueueRows = await db
+      .select({
+        queue: manufacturingQueue,
+        item: inventoryItems,
+      })
+      .from(manufacturingQueue)
+      .leftJoin(inventoryItems, eq(manufacturingQueue.inventoryItemId, inventoryItems.id))
+      .where(and(
+        routingSignal,
+        or(
+          eq(manufacturingQueue.status, 'COMPLETED'),
+          eq(manufacturingQueue.status, 'IN_PROGRESS')
+        ),
+        inArray(manufacturingQueue.id, sourceLessQueueIds)
+      ));
+    const recentQueueIds = new Set(completedRows.map((row) => row.queue.id));
+    completedRows = completedRows.concat(
+      sourceLessQueueRows.filter((row) => !recentQueueIds.has(row.queue.id))
+    );
+  }
 
   for (const row of completedRows) {
     const completedQuantity = row.queue.quantityCompleted || 0;

--- a/server/src/routes/cuttingTableManufacturingQueue.ts
+++ b/server/src/routes/cuttingTableManufacturingQueue.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express';
 import { storage } from '../../storage';
 import { db } from '../../db';
-import { manufacturingQueue, inventoryItems, p2ProductionOrders, p2PurchaseOrders, p2SerializedItems, cuttingPacketBOMs, cuttingPacketBOMMaterials, cuttingPacketBOMParts, cuttingFabricInventory, cuttingFabricInventoryTransactions, cuttingBuiltPackets, cuttingBuiltPacketFabricSources, cuttingProductCategories, getDashboardCategories, supplySourceDashboardToLegacyDept } from '../../schema';
+import { manufacturingQueue, inventoryItems, p2ProductionOrders, p2PurchaseOrders, p2SerializedItems, p2SerializedItemTraceability, cuttingPacketBOMs, cuttingPacketBOMMaterials, cuttingPacketBOMParts, cuttingFabricInventory, cuttingFabricInventoryTransactions, cuttingBuiltPackets, cuttingBuiltPacketFabricSources, cuttingProductCategories, getDashboardCategories, supplySourceDashboardToLegacyDept } from '../../schema';
 import { eq, and, or, asc, desc, inArray, like, count, isNull } from 'drizzle-orm';
 import {
   adjustPacketInventoryForMaterial,
@@ -2659,12 +2659,46 @@ router.get('/built-packets', async (req: Request, res: Response) => {
       });
     }
 
-    const allocationRefs = [...new Set(
-      visiblePackets
+    const packetIdByTraceReference = new Map<string, number>();
+    visiblePackets.forEach((packet) => {
+      const references = [String(packet.id), packet.barcode];
+      if (packet.queueId && packet.sku) {
+        references.push(`MFG-${packet.queueId}-${packet.sku}-${packet.printedPacketNumber ?? packet.packetNumber}`);
+      }
+      references.forEach((reference) => {
+        const normalized = reference.trim().toUpperCase();
+        if (normalized) packetIdByTraceReference.set(normalized, packet.id);
+      });
+    });
+    const packetTraceReferences = [...packetIdByTraceReference.keys()];
+    const packetTraceRows = packetTraceReferences.length > 0
+      ? await db
+        .select({
+          serializedItemId: p2SerializedItemTraceability.serializedItemId,
+          inventoryPartId: p2SerializedItemTraceability.inventoryPartId,
+          inventoryPartNumber: p2SerializedItemTraceability.inventoryPartNumber,
+          traceabilityValue: p2SerializedItemTraceability.traceabilityValue,
+          createdAt: p2SerializedItemTraceability.createdAt,
+        })
+        .from(p2SerializedItemTraceability)
+        .where(and(
+          eq(p2SerializedItemTraceability.traceabilityType, 'packet_barcode'),
+          or(
+            inArray(p2SerializedItemTraceability.inventoryPartId, packetTraceReferences),
+            inArray(p2SerializedItemTraceability.inventoryPartNumber, packetTraceReferences),
+            inArray(p2SerializedItemTraceability.traceabilityValue, packetTraceReferences)
+          )
+        ))
+        .orderBy(desc(p2SerializedItemTraceability.createdAt))
+      : [];
+
+    const allocationRefs = [...new Set([
+      ...visiblePackets
         .map(packet => packet.allocatedToOrder)
         .filter((value): value is string => typeof value === 'string' && value.trim() !== '')
-        .map(value => value.trim())
-    )];
+        .map(value => value.trim()),
+      ...packetTraceRows.map(row => row.serializedItemId),
+    ])];
     const allocationUuids = allocationRefs.filter(isUuid);
     const allocationConditions = [
       inArray(p2SerializedItems.barcode, allocationRefs),
@@ -2690,6 +2724,17 @@ router.get('/built-packets', async (req: Request, res: Response) => {
       serializedByAllocationRef.set(item.id, item);
       serializedByAllocationRef.set(item.barcode, item);
       serializedByAllocationRef.set(item.serialNumber, item);
+    });
+    const serializedByPacketId = new Map<number, any>();
+    packetTraceRows.forEach((trace) => {
+      const packetId = [trace.inventoryPartId, trace.inventoryPartNumber, trace.traceabilityValue]
+        .map(value => String(value || '').trim().toUpperCase())
+        .map(value => packetIdByTraceReference.get(value))
+        .find((value): value is number => value !== undefined);
+      const serializedItem = serializedByAllocationRef.get(trace.serializedItemId);
+      if (packetId !== undefined && serializedItem && !serializedByPacketId.has(packetId)) {
+        serializedByPacketId.set(packetId, serializedItem);
+      }
     });
 
     // Compute displayPacketNumber: rank each packet within its queueId group,
@@ -2738,9 +2783,12 @@ router.get('/built-packets', async (req: Request, res: Response) => {
       const derivedSources = packetSources.length === 0 && packet.queueId
         ? parseStoredMaterialSources(queueMeta[packet.queueId]?.materialDetails ?? null, packet.id)
         : [];
-      const allocatedSerializedItem = packet.allocatedToOrder
+      const directlyAllocatedSerializedItem = packet.allocatedToOrder
         ? serializedByAllocationRef.get(packet.allocatedToOrder.trim()) ?? null
         : null;
+      const allocatedSerializedItem = directlyAllocatedSerializedItem
+        ?? serializedByPacketId.get(packet.id)
+        ?? null;
 
       return {
         ...packet,


### PR DESCRIPTION
## What changed

- Find existing `PKT-` built packets that have no fabric-source rows.
- Resolve their manufacturing queue IDs and include older queue rows outside the normal 250-row maintenance window.
- Restore missing Made Packets serial associations from append-only P2 packet-barcode traceability when `allocatedToOrder` is blank or stale.
- Label the card association as `Used for serial` while retaining the traveler barcode.
- Normalize packet scans before shared packet resolution so lowercase scanner input such as `mfg-254-97-330` resolves identically to the uppercase label.
- Add a regression test for lowercase MFG packet resolution.

## Why

Queue 254 has four known packets—94 through 97 of 330—that exist in Made Packets but are not attached to material. Older source-less packets could remain outside the previous repair window. The card also relied only on the mutable packet allocation field for its serial display, even though historical traveler traceability records which serialized item used a packet.

Production logs also showed material validation returning 200 for lowercase `mfg-254-97-330`, followed by task completion returning `PACKET_BARCODE_NOT_FOUND`. The validation route was case-insensitive while the shared completion resolver required uppercase `MFG-`, producing a false error after the browser had already captured the material chips.

## Impact

Opening Made Packets can restore saved fabric traceability for older existing packets and show the serial number that used a packet. P2 traveler completion now accepts lowercase scanner input consistently with material validation, allowing the traceability task to complete instead of displaying the false inventory error.

The material repair does not invent traceability when the completed cutting record contains no saved material evidence.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Added focused coverage in `server/__tests__/packetResolution.test.ts`.
- Focused test execution and full typecheck were unavailable because this clean worktree has no installed `node_modules`.
