### PR TITLE
Connect Design Control to manufacturing evidence

### DIFF
--- a/client/src/pages/QMSDesignControlPage.tsx
+++ b/client/src/pages/QMSDesignControlPage.tsx
@@ -122,14 +122,63 @@ type DesignControlStepRecord = {
   metadata?: Record<string, unknown> | null;
 };
 
+type ManufacturingEvidenceStatus =
+  | 'NOT_CONFIGURED'
+  | 'NOT_STARTED'
+  | 'IN_PROGRESS'
+  | 'NEEDS_REVIEW'
+  | 'APPROVED'
+  | 'RELEASED'
+  | 'BLOCKED'
+  | 'NOT_APPLICABLE';
+
+type ManufacturingEvidenceSource = {
+  key: string;
+  label: string;
+  sourceModule: string;
+  managedBy: 'SOURCE_MODULE' | 'DESIGN_CONTROL';
+  sourceAvailable: boolean;
+  status: ManufacturingEvidenceStatus;
+  ready: boolean;
+  recordId?: string | null;
+  revision?: string | null;
+  approvedBy?: string | null;
+  approvedAt?: string | null;
+  releasedBy?: string | null;
+  releasedAt?: string | null;
+  updatedAt?: string | null;
+  openUrl?: string | null;
+  explanation: string;
+  missingItems: string[];
+  applicability?: {
+    applicable: boolean;
+    justification?: string | null;
+    approvedBy?: string | null;
+    approvedRole?: string | null;
+    approvedAt?: string | null;
+    approved: boolean;
+  };
+};
+
+type DesignManufacturingEvidence = {
+  rdProjectId: string | null;
+  designControlRecordId: string;
+  overallStatus: ManufacturingEvidenceStatus;
+  ready: boolean;
+  missingItems: string[];
+  sources: ManufacturingEvidenceSource[];
+};
+
 type DesignControlReadiness = {
   ready: boolean;
   missingItems: string[];
   sourceOfTruthPrinciple?: string;
+  manufacturingEvidence?: DesignManufacturingEvidence | null;
   manufacturingSourceStatuses?: Array<{
     requirement: string;
     source: string;
     ready: boolean;
+    status?: ManufacturingEvidenceStatus;
   }>;
   steps: Array<{ key: string; title: string; status: string }>;
 };
@@ -434,6 +483,28 @@ const workflowStatusClasses: Record<WorkflowStatus, string> = {
   approved: 'border-emerald-300 bg-emerald-50 text-emerald-700',
 };
 
+const manufacturingEvidenceLabels: Record<ManufacturingEvidenceStatus, string> = {
+  NOT_CONFIGURED: 'Source not configured',
+  NOT_STARTED: 'Not started',
+  IN_PROGRESS: 'In progress',
+  NEEDS_REVIEW: 'Needs review',
+  APPROVED: 'Approved',
+  RELEASED: 'Released',
+  BLOCKED: 'Blocked',
+  NOT_APPLICABLE: 'Not applicable',
+};
+
+const manufacturingEvidenceClasses: Record<ManufacturingEvidenceStatus, string> = {
+  NOT_CONFIGURED: 'border-slate-300 bg-slate-50 text-slate-700',
+  NOT_STARTED: 'border-slate-300 bg-slate-50 text-slate-700',
+  IN_PROGRESS: 'border-blue-300 bg-blue-50 text-blue-700',
+  NEEDS_REVIEW: 'border-amber-300 bg-amber-50 text-amber-800',
+  APPROVED: 'border-emerald-300 bg-emerald-50 text-emerald-700',
+  RELEASED: 'border-emerald-300 bg-emerald-50 text-emerald-700',
+  BLOCKED: 'border-red-300 bg-red-50 text-red-700',
+  NOT_APPLICABLE: 'border-zinc-300 bg-zinc-50 text-zinc-700',
+};
+
 const lifecycleMetrics = [
   { label: 'Open design projects', value: designProjects.length, icon: Route },
   { label: 'Open risks', value: risks.length, icon: AlertTriangle },
@@ -720,25 +791,6 @@ const designWorkflowSteps: DesignWorkflowStep[] = [
   },
 ];
 
-const releaseGateSourceModules: Record<string, string> = {
-  'Released CAD': 'Design Outputs / CAD vault',
-  'Released drawings': 'Document Control / released drawings',
-  'Released BOM': 'BOM module',
-  'Approved routing': 'Routing module',
-  'Approved traveler requirement': 'Traveler module',
-  'Approved work instructions': 'Work Instructions module',
-  'Approved inspection plan': 'Inspection / QC module',
-  'Approved test procedure': 'Verification / Test module',
-  'Required certifications identified': 'Certifications / Quality module',
-  'Supplier requirements flowed down': 'Supplier Quality / Procurement module',
-  'Material requirements approved': 'Material / Inventory module',
-  'Tooling/fixtures ready': 'Manufacturing Engineering module',
-  'CNC programs approved, if applicable': 'CNC / Manufacturing module',
-  'Training/certifications complete': 'Training module',
-  'Packaging/shipping requirements defined': 'Shipping / Packaging module',
-  'Design revision baseline locked': 'Document Control / Revision baseline',
-};
-
 function createInitialWorkflowData() {
   return designWorkflowSteps.reduce<Record<string, WorkflowStepData>>((acc, step) => {
     acc[step.id] = {
@@ -952,10 +1004,16 @@ export default function QMSDesignControlPage() {
     return Math.round((complete / allRows.length) * 100);
   }, []);
 
-  const workflowStatuses = useMemo(
-    () => Object.fromEntries(designWorkflowSteps.map((step) => [step.id, getWorkflowStepStatus(step, workflowData)])) as Record<string, WorkflowStatus>,
-    [workflowData]
-  );
+  const workflowStatuses = useMemo(() => {
+    const serverStatusByStep = new Map((serverReadiness?.steps ?? []).map((step) => [step.key, step.status]));
+    return Object.fromEntries(designWorkflowSteps.map((step) => {
+      const serverStatus = serverStatusByStep.get(step.id);
+      if (serverStatus === 'approved') return [step.id, 'approved'];
+      if (serverStatus === 'needs_approval') return [step.id, 'needs_approval'];
+      if (serverStatus === 'blocked') return [step.id, 'blocked'];
+      return [step.id, getWorkflowStepStatus(step, workflowData)];
+    })) as Record<string, WorkflowStatus>;
+  }, [serverReadiness?.steps, workflowData]);
   const selectedWorkflowStep = designWorkflowSteps.find((step) => step.id === selectedWorkflowStepId) ?? designWorkflowSteps[0];
   const selectedWorkflowData = workflowData[selectedWorkflowStep.id];
   const approvedWorkflowCount = designWorkflowSteps.filter((step) => workflowStatuses[step.id] === 'approved').length;
@@ -968,6 +1026,7 @@ export default function QMSDesignControlPage() {
     return getMissingWorkflowItems(step, workflowData).map((item) => `Release Gate ${item}`);
   });
   const releaseReadinessItems = serverReadiness?.missingItems ?? localReleaseReadinessItems;
+  const manufacturingEvidence = serverReadiness?.manufacturingEvidence ?? null;
 
   useEffect(() => {
     let cancelled = false;
@@ -1075,7 +1134,7 @@ export default function QMSDesignControlPage() {
         body: {
           status: workflowStatuses[step.id],
           formData: data.fields,
-          checklist: data.checklist,
+          checklist: step.id === '12' ? {} : data.checklist,
           approvals: data.approvals,
           metadata: {
             title: step.title,
@@ -1084,7 +1143,6 @@ export default function QMSDesignControlPage() {
             sourceOfTruthPrinciple: step.id === '12'
               ? 'R&D Project owns engineering process; Design Control orchestrates; manufacturing modules own their own data and Design Control evaluates their status.'
               : undefined,
-            manufacturingSourceModules: step.id === '12' ? releaseGateSourceModules : undefined,
           },
         },
       }) as { readiness: DesignControlReadiness };
@@ -1096,6 +1154,7 @@ export default function QMSDesignControlPage() {
         setServerReadiness({
           ready: false,
           missingItems: error.responseData.missingItems,
+          manufacturingEvidence: error.responseData.manufacturingEvidence ?? serverReadiness?.manufacturingEvidence ?? null,
           steps: serverReadiness?.steps ?? [],
         });
       }
@@ -1126,6 +1185,7 @@ export default function QMSDesignControlPage() {
         setServerReadiness({
           ready: false,
           missingItems: error.responseData.missingItems,
+          manufacturingEvidence: error.responseData.manufacturingEvidence ?? serverReadiness?.manufacturingEvidence ?? null,
           steps: serverReadiness?.steps ?? [],
         });
       }
@@ -1428,17 +1488,74 @@ export default function QMSDesignControlPage() {
                   </div>
                 )}
 
-                {selectedWorkflowStep.checklist && selectedWorkflowStep.checklist.length > 0 && (
+                {selectedWorkflowStep.id === '12' && (
                   <div className="space-y-3">
                     <div>
-                      <div className="text-sm font-medium">
-                        {selectedWorkflowStep.id === '12' ? 'Manufacturing source status' : 'Checklist'}
+                      <div className="text-sm font-medium">Manufacturing source status</div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Design Control evaluates these source-of-truth modules. It does not duplicate BOM, routing, traveler, work-instruction, inspection, training, or P2 manufacturing data.
+                      </p>
+                    </div>
+                    {manufacturingEvidence?.sources?.length ? (
+                      <div className="grid gap-3 md:grid-cols-2">
+                        {manufacturingEvidence.sources.map((source) => (
+                          <div key={source.key} className="rounded-md border bg-white p-3 text-sm">
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <div className="font-medium">{source.label}</div>
+                                <div className="mt-1 text-xs text-muted-foreground">{source.sourceModule}</div>
+                              </div>
+                              <Badge variant="outline" className={manufacturingEvidenceClasses[source.status]}>
+                                {manufacturingEvidenceLabels[source.status]}
+                              </Badge>
+                            </div>
+                            <p className="mt-3 text-xs text-muted-foreground">{source.explanation}</p>
+                            <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                              {source.revision && <Badge variant="secondary">Rev {source.revision}</Badge>}
+                              {source.approvedBy && <Badge variant="secondary">Approved by {source.approvedBy}</Badge>}
+                              {source.releasedBy && <Badge variant="secondary">Released by {source.releasedBy}</Badge>}
+                              {source.applicability?.applicable === false && (
+                                <Badge variant="secondary">
+                                  N/A {source.applicability.approved ? 'approved' : 'pending approval'}
+                                </Badge>
+                              )}
+                            </div>
+                            {source.missingItems.length > 0 && (
+                              <div className="mt-3 space-y-1">
+                                {source.missingItems.map((item) => (
+                                  <div key={item} className="flex items-start gap-2 text-xs text-amber-700">
+                                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                                    <span>{item}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                            {source.openUrl && (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="mt-3 h-8"
+                                onClick={() => window.location.assign(source.openUrl!)}
+                              >
+                                Open source
+                              </Button>
+                            )}
+                          </div>
+                        ))}
                       </div>
-                      {selectedWorkflowStep.id === '12' && (
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          Design Control evaluates these source-of-truth modules. It should not duplicate BOM, routing, traveler, work-instruction, inspection, or P2 manufacturing data.
-                        </p>
-                      )}
+                    ) : (
+                      <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                        Source evidence will load after a persistent design control record is selected.
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {selectedWorkflowStep.id !== '12' && selectedWorkflowStep.checklist && selectedWorkflowStep.checklist.length > 0 && (
+                  <div className="space-y-3">
+                    <div>
+                      <div className="text-sm font-medium">Checklist</div>
                     </div>
                     <div className="grid gap-2 md:grid-cols-2">
                       {selectedWorkflowStep.checklist.map((item) => (
@@ -1447,14 +1564,7 @@ export default function QMSDesignControlPage() {
                             checked={selectedWorkflowData.checklist[item] === true}
                             onCheckedChange={(checked) => updateWorkflowChecklist(selectedWorkflowStep.id, item, checked === true)}
                           />
-                          <span>
-                            {item}
-                            {selectedWorkflowStep.id === '12' && releaseGateSourceModules[item] && (
-                              <span className="mt-1 block text-xs text-muted-foreground">
-                                Source: {releaseGateSourceModules[item]}
-                              </span>
-                            )}
-                          </span>
+                          <span>{item}</span>
                         </label>
                       ))}
                     </div>
@@ -1505,21 +1615,21 @@ export default function QMSDesignControlPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                {serverReadiness?.manufacturingSourceStatuses && serverReadiness.manufacturingSourceStatuses.length > 0 && (
+                {manufacturingEvidence?.sources && manufacturingEvidence.sources.length > 0 && (
                   <div className="mb-4 space-y-3">
                     <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
                       {serverReadiness.sourceOfTruthPrinciple
                         ?? 'R&D Project owns engineering process; Design Control orchestrates; manufacturing modules own their own data and Design Control evaluates their status.'}
                     </div>
                     <div className="grid gap-2 md:grid-cols-2">
-                      {serverReadiness.manufacturingSourceStatuses.map((status) => (
-                        <div key={`${status.source}-${status.requirement}`} className="flex items-start justify-between gap-3 rounded-md border bg-white px-3 py-2 text-sm">
+                      {manufacturingEvidence.sources.map((source) => (
+                        <div key={source.key} className="flex items-start justify-between gap-3 rounded-md border bg-white px-3 py-2 text-sm">
                           <div>
-                            <div className="font-medium">{status.requirement}</div>
-                            <div className="text-xs text-muted-foreground">{status.source}</div>
+                            <div className="font-medium">{source.label}</div>
+                            <div className="text-xs text-muted-foreground">{source.sourceModule}</div>
                           </div>
-                          <Badge variant="outline" className={status.ready ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-amber-200 bg-amber-50 text-amber-700'}>
-                            {status.ready ? 'Ready' : 'Needs source'}
+                          <Badge variant="outline" className={manufacturingEvidenceClasses[source.status]}>
+                            {manufacturingEvidenceLabels[source.status]}
                           </Badge>
                         </div>
                       ))}

--- a/migrations/0190_design_control_requirement_applicability.sql
+++ b/migrations/0190_design_control_requirement_applicability.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS design_control_requirement_applicability (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  record_id uuid NOT NULL REFERENCES design_control_records(id) ON DELETE CASCADE,
+  rd_project_id text REFERENCES rd_projects(id) ON DELETE SET NULL,
+  requirement_key text NOT NULL,
+  applicable boolean NOT NULL DEFAULT true,
+  justification text,
+  approved_by text,
+  approved_role text,
+  approved_at timestamp,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now(),
+  CONSTRAINT design_control_requirement_applicability_record_requirement_unique UNIQUE (record_id, requirement_key)
+);
+
+CREATE INDEX IF NOT EXISTS design_control_req_app_record_id_idx
+  ON design_control_requirement_applicability(record_id);
+
+CREATE INDEX IF NOT EXISTS design_control_req_app_rd_project_id_idx
+  ON design_control_requirement_applicability(rd_project_id);
+
+CREATE INDEX IF NOT EXISTS design_control_req_app_requirement_key_idx
+  ON design_control_requirement_applicability(requirement_key);
+
+CREATE INDEX IF NOT EXISTS design_control_req_app_applicable_idx
+  ON design_control_requirement_applicability(applicable);

--- a/server/__tests__/designManufacturingEvidenceService.test.ts
+++ b/server/__tests__/designManufacturingEvidenceService.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {},
+}));
+
+import {
+  buildDesignManufacturingEvidence,
+  canonicalManufacturingEvidenceRequirements,
+} from '../src/services/designManufacturingEvidenceService';
+
+function rdProject(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'rd-1',
+    projectName: 'R&D Test Project',
+    owner: 'Engineering',
+    status: 'active',
+    signoffRequired: false,
+    signoffUserId: '',
+    draftTabIds: ['bom-1'],
+    description: '',
+    createdByUserId: null,
+    createdByDisplayName: 'test',
+    updatedByUserId: null,
+    updatedByDisplayName: 'test',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  } as any;
+}
+
+function draftBom(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'bom-1',
+    name: 'Released R&D BOM',
+    revision: 'B',
+    project: 'R&D Test Project',
+    projectId: 'rd-1',
+    projectCode: null,
+    projectName: 'R&D Test Project',
+    projectType: 'rd',
+    data: {},
+    visibility: 'public',
+    allowPublicEdit: false,
+    createdByUserId: null,
+    createdByDisplayName: 'test',
+    updatedByUserId: null,
+    updatedByDisplayName: 'test',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+    ...overrides,
+  } as any;
+}
+
+function applicability(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'na-1',
+    recordId: 'dc-1',
+    rdProjectId: 'rd-1',
+    requirementKey: 'cnc_programs_approved',
+    applicable: false,
+    justification: 'No CNC operations are used for this design.',
+    approvedBy: 'Quality Lead',
+    approvedRole: 'Quality',
+    approvedAt: new Date('2026-01-03T00:00:00Z'),
+    metadata: {},
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  } as any;
+}
+
+describe('design manufacturing evidence service', () => {
+  it('returns all canonical Step 12 evidence requirements', () => {
+    const evidence = buildDesignManufacturingEvidence({
+      rdProjectId: 'rd-1',
+      designControlRecordId: 'dc-1',
+      rdProject: rdProject(),
+      draftBoms: [],
+    });
+
+    expect(evidence.sources.map((source) => source.key)).toEqual(
+      canonicalManufacturingEvidenceRequirements.map((requirement) => requirement.key),
+    );
+  });
+
+  it('blocks an unapproved linked BOM', () => {
+    const evidence = buildDesignManufacturingEvidence({
+      rdProjectId: 'rd-1',
+      designControlRecordId: 'dc-1',
+      rdProject: rdProject(),
+      draftBoms: [draftBom({ data: { releaseStatus: 'draft' } })],
+    });
+
+    const bom = evidence.sources.find((source) => source.key === 'released_bom');
+    expect(bom).toMatchObject({
+      sourceAvailable: true,
+      status: 'IN_PROGRESS',
+      ready: false,
+    });
+    expect(evidence.ready).toBe(false);
+    expect(evidence.missingItems).toContain('released BOM: linked BOM is not approved or released');
+  });
+
+  it('reports a missing source as NOT_CONFIGURED', () => {
+    const evidence = buildDesignManufacturingEvidence({
+      rdProjectId: 'rd-1',
+      designControlRecordId: 'dc-1',
+      rdProject: rdProject(),
+      draftBoms: [],
+    });
+
+    const routing = evidence.sources.find((source) => source.key === 'approved_routing');
+    expect(routing).toMatchObject({
+      status: 'NOT_CONFIGURED',
+      sourceAvailable: false,
+      ready: false,
+    });
+  });
+
+  it('returns approved source details from a released BOM', () => {
+    const evidence = buildDesignManufacturingEvidence({
+      rdProjectId: 'rd-1',
+      designControlRecordId: 'dc-1',
+      rdProject: rdProject(),
+      draftBoms: [
+        draftBom({
+          data: {
+            releaseStatus: 'released',
+            approvedBy: 'Engineering Lead',
+            approvedAt: '2026-01-02T00:00:00Z',
+            releasedBy: 'Document Control',
+            releasedAt: '2026-01-02T12:00:00Z',
+          },
+        }),
+      ],
+    });
+
+    const bom = evidence.sources.find((source) => source.key === 'released_bom');
+    expect(bom).toMatchObject({
+      status: 'RELEASED',
+      ready: true,
+      revision: 'B',
+      approvedBy: 'Engineering Lead',
+      releasedBy: 'Document Control',
+    });
+  });
+
+  it('requires justification and Engineering or Quality approval for not-applicable requirements', () => {
+    const pending = buildDesignManufacturingEvidence({
+      rdProjectId: 'rd-1',
+      designControlRecordId: 'dc-1',
+      rdProject: rdProject(),
+      applicability: [applicability({ justification: '', approvedRole: 'Quality' })],
+    });
+    const pendingCnc = pending.sources.find((source) => source.key === 'cnc_programs_approved');
+    expect(pendingCnc).toMatchObject({
+      status: 'BLOCKED',
+      ready: false,
+      applicability: expect.objectContaining({ approved: false }),
+    });
+
+    const approved = buildDesignManufacturingEvidence({
+      rdProjectId: 'rd-1',
+      designControlRecordId: 'dc-1',
+      rdProject: rdProject(),
+      applicability: [applicability()],
+    });
+    const approvedCnc = approved.sources.find((source) => source.key === 'cnc_programs_approved');
+    expect(approvedCnc).toMatchObject({
+      status: 'NOT_APPLICABLE',
+      ready: true,
+      applicability: expect.objectContaining({ approved: true }),
+    });
+  });
+
+  it('rejects a BOM linked to a different R&D project', () => {
+    const evidence = buildDesignManufacturingEvidence({
+      rdProjectId: 'rd-1',
+      designControlRecordId: 'dc-1',
+      rdProject: rdProject({ draftTabIds: [] }),
+      draftBoms: [
+        draftBom({
+          id: 'bom-other',
+          projectId: 'rd-other',
+          data: { releaseStatus: 'released' },
+        }),
+      ],
+    });
+
+    const bom = evidence.sources.find((source) => source.key === 'released_bom');
+    expect(bom).toMatchObject({
+      status: 'NOT_CONFIGURED',
+      sourceAvailable: false,
+      ready: false,
+    });
+  });
+});

--- a/server/__tests__/qmsDesignControlReleaseGate.test.ts
+++ b/server/__tests__/qmsDesignControlReleaseGate.test.ts
@@ -5,6 +5,11 @@ vi.mock('../db', () => ({
 }));
 
 import { qmsDesignControlTestInternals } from '../src/routes/qmsDesignControl';
+import {
+  canonicalManufacturingEvidenceRequirements,
+  type DesignManufacturingEvidence,
+  type ManufacturingEvidenceSource,
+} from '../src/services/designManufacturingEvidenceService';
 
 const {
   buildReadinessFromSteps,
@@ -41,6 +46,50 @@ function completePersistedSteps() {
   return workflowSteps.map((step) => persistedStep(step.key));
 }
 
+function evidenceSource(key: string, overrides: Partial<ManufacturingEvidenceSource> = {}): ManufacturingEvidenceSource {
+  const requirement = canonicalManufacturingEvidenceRequirements.find((item) => item.key === key)
+    ?? canonicalManufacturingEvidenceRequirements[0];
+
+  return {
+    key: requirement.key,
+    label: requirement.label,
+    sourceModule: requirement.sourceModule,
+    managedBy: 'SOURCE_MODULE',
+    sourceAvailable: true,
+    status: 'RELEASED',
+    ready: true,
+    explanation: `${requirement.label} is released.`,
+    missingItems: [],
+    ...overrides,
+  };
+}
+
+function manufacturingEvidence(overrides: Record<string, Partial<ManufacturingEvidenceSource>> = {}): DesignManufacturingEvidence {
+  const sources = canonicalManufacturingEvidenceRequirements.map((requirement) => evidenceSource(requirement.key, overrides[requirement.key]));
+  const missingItems = sources.flatMap((source) => source.missingItems);
+  return {
+    rdProjectId: 'rd-1',
+    designControlRecordId: 'record-1',
+    overallStatus: missingItems.length === 0 ? 'RELEASED' : 'BLOCKED',
+    ready: missingItems.length === 0,
+    missingItems,
+    sources,
+  };
+}
+
+function blockedEvidenceFor(...keys: string[]) {
+  return manufacturingEvidence(Object.fromEntries(keys.map((key) => {
+    const requirement = canonicalManufacturingEvidenceRequirements.find((item) => item.key === key)!;
+    return [key, {
+      sourceAvailable: false,
+      status: 'NOT_CONFIGURED' as const,
+      ready: false,
+      explanation: `${requirement.label} source missing.`,
+      missingItems: [`${requirement.label}: source module is not configured for this R&D project`],
+    }];
+  })));
+}
+
 describe('QMS design control release gate validation', () => {
   it('reports empty Step 12 as not ready with canonical missing evidence', () => {
     const steps = [
@@ -48,11 +97,11 @@ describe('QMS design control release gate validation', () => {
       { stepKey: '12', status: 'incomplete', formData: {}, checklist: {}, approvals: {} },
     ];
 
-    const readiness = buildReadinessFromSteps(steps);
+    const readiness = buildReadinessFromSteps(steps, blockedEvidenceFor('released_cad'));
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toContain(
-      'Step 12 Design Production Release Gate source status incomplete: released CAD (Design Outputs / CAD vault)',
+      'Step 12 Design Production Release Gate source incomplete: released CAD: source module is not configured for this R&D project',
     );
     expect(readiness.missingItems).toContain(
       'Step 12 Design Production Release Gate approval missing: engineering release approval',
@@ -68,13 +117,13 @@ describe('QMS design control release gate validation', () => {
     const readiness = buildReadinessFromSteps([
       ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
       step12,
-    ]);
+    ], blockedEvidenceFor('released_drawings', 'approved_routing'));
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toEqual(
       expect.arrayContaining([
-        'Step 12 Design Production Release Gate source status incomplete: released drawings (Document Control / released drawings)',
-        'Step 12 Design Production Release Gate source status incomplete: approved routing (Routing module)',
+        'Step 12 Design Production Release Gate source incomplete: released drawings: source module is not configured for this R&D project',
+        'Step 12 Design Production Release Gate source incomplete: approved routing: source module is not configured for this R&D project',
       ]),
     );
   });
@@ -104,7 +153,7 @@ describe('QMS design control release gate validation', () => {
     const readiness = buildReadinessFromSteps([
       ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
       step12,
-    ]);
+    ], manufacturingEvidence());
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toContain(
@@ -112,23 +161,23 @@ describe('QMS design control release gate validation', () => {
     );
   });
 
-  it('reports a missing Step 12 checklist item even when other checklist entries are complete', () => {
+  it('does not allow manual Step 12 checklist values to override source evidence', () => {
     const step12Payload = completePayloadForStep(stepByKey('12'));
     const step12 = persistedStep('12', {
       checklist: {
         ...step12Payload.checklist,
-        'material requirements approved': false,
+        'material requirements approved': true,
       },
     });
 
     const readiness = buildReadinessFromSteps([
       ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
       step12,
-    ]);
+    ], blockedEvidenceFor('material_requirements_approved'));
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toContain(
-      'Step 12 Design Production Release Gate source status incomplete: material requirements approved (Material / Inventory module)',
+      'Step 12 Design Production Release Gate source incomplete: material requirements approved: source module is not configured for this R&D project',
     );
   });
 
@@ -136,14 +185,14 @@ describe('QMS design control release gate validation', () => {
     const readiness = buildReadinessFromSteps([
       ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
       { stepKey: '12', status: 'needs_approval', formData: {}, checklist: {}, approvals: {} },
-    ]);
+    ], blockedEvidenceFor('released_bom', 'approved_traveler_requirement'));
 
     expect(readiness.sourceOfTruthPrinciple).toMatch(/manufacturing modules own their own data/i);
     expect(readiness.manufacturingSourceStatuses).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           requirement: 'released BOM',
-          source: 'BOM module',
+          source: 'Draft Builder BOM / BOM module',
           ready: false,
         }),
         expect.objectContaining({
@@ -160,7 +209,7 @@ describe('QMS design control release gate validation', () => {
     const firstStep = steps.find((step) => step.stepKey === '1');
     if (firstStep) firstStep.status = 'needs_approval';
 
-    const readiness = buildReadinessFromSteps(steps);
+    const readiness = buildReadinessFromSteps(steps, manufacturingEvidence());
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toContain(
@@ -172,16 +221,16 @@ describe('QMS design control release gate validation', () => {
     const readiness = buildReadinessFromSteps([
       ...workflowSteps.filter((step) => step.key !== '12').map((step) => persistedStep(step.key)),
       { stepKey: '12', status: 'needs_approval', formData: {}, checklist: {}, approvals: {} },
-    ]);
+    ], blockedEvidenceFor('released_bom'));
 
     expect(readiness.ready).toBe(false);
     expect(readiness.missingItems).toContain(
-      'Step 12 Design Production Release Gate source status incomplete: released BOM (BOM module)',
+      'Step 12 Design Production Release Gate source incomplete: released BOM: source module is not configured for this R&D project',
     );
   });
 
   it('allows submit-release readiness when all canonical requirements are satisfied', () => {
-    const readiness = buildReadinessFromSteps(completePersistedSteps());
+    const readiness = buildReadinessFromSteps(completePersistedSteps(), manufacturingEvidence());
 
     expect(readiness.ready).toBe(true);
     expect(readiness.missingItems).toEqual([]);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -17518,6 +17518,27 @@ export const designControlReleaseGate = pgTable('design_control_release_gate', {
   p2PurchaseOrderIdx: index('design_control_release_gate_p2_po_id_idx').on(table.p2PurchaseOrderId),
 }));
 
+export const designControlRequirementApplicability = pgTable('design_control_requirement_applicability', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  recordId: uuid('record_id').notNull().references(() => designControlRecords.id, { onDelete: 'cascade' }),
+  rdProjectId: text('rd_project_id').references(() => rdProjects.id, { onDelete: 'set null' }),
+  requirementKey: text('requirement_key').notNull(),
+  applicable: boolean('applicable').notNull().default(true),
+  justification: text('justification'),
+  approvedBy: text('approved_by'),
+  approvedRole: text('approved_role'),
+  approvedAt: timestamp('approved_at'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().default(sql`'{}'::jsonb`).notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+}, (table) => ({
+  recordRequirementUnique: uniqueIndex('design_control_requirement_applicability_record_requirement_unique').on(table.recordId, table.requirementKey),
+  recordIdx: index('design_control_req_app_record_id_idx').on(table.recordId),
+  rdProjectIdx: index('design_control_req_app_rd_project_id_idx').on(table.rdProjectId),
+  requirementKeyIdx: index('design_control_req_app_requirement_key_idx').on(table.requirementKey),
+  applicableIdx: index('design_control_req_app_applicable_idx').on(table.applicable),
+}));
+
 export const insertDesignControlRecordSchema = createInsertSchema(designControlRecords).omit({
   id: true,
   submittedAt: true,

--- a/server/src/routes/qmsDesignControl.ts
+++ b/server/src/routes/qmsDesignControl.ts
@@ -14,6 +14,11 @@ import {
   designControlVerification,
   insertDesignControlRecordSchema,
 } from '../../schema';
+import {
+  canonicalManufacturingEvidenceRequirements,
+  getDesignManufacturingEvidence,
+  type DesignManufacturingEvidence,
+} from '../services/designManufacturingEvidenceService';
 
 const router = Router();
 
@@ -281,24 +286,10 @@ const workflowSteps = [
 ];
 
 const requiredStepKeys = workflowSteps.filter((step) => step.key !== '12').map((step) => step.key);
-const releaseGateSourceRequirements = [
-  { item: 'released CAD', source: 'Design Outputs / CAD vault' },
-  { item: 'released drawings', source: 'Document Control / released drawings' },
-  { item: 'released BOM', source: 'BOM module' },
-  { item: 'approved routing', source: 'Routing module' },
-  { item: 'approved traveler requirement', source: 'Traveler module' },
-  { item: 'approved work instructions', source: 'Work Instructions module' },
-  { item: 'approved inspection plan', source: 'Inspection / QC module' },
-  { item: 'approved test procedure', source: 'Verification / Test module' },
-  { item: 'required certifications identified', source: 'Certifications / Quality module' },
-  { item: 'supplier requirements flowed down', source: 'Supplier Quality / Procurement module' },
-  { item: 'material requirements approved', source: 'Material / Inventory module' },
-  { item: 'tooling and fixtures ready', source: 'Manufacturing Engineering module' },
-  { item: 'CNC programs approved when applicable', source: 'CNC / Manufacturing module' },
-  { item: 'training and certifications complete', source: 'Training module' },
-  { item: 'packaging and shipping requirements defined', source: 'Shipping / Packaging module' },
-  { item: 'design revision baseline locked', source: 'Document Control / Revision baseline' },
-];
+const releaseGateSourceRequirements = canonicalManufacturingEvidenceRequirements.map((requirement) => ({
+  item: requirement.label,
+  source: requirement.sourceModule,
+}));
 type WorkflowStepDefinition = typeof workflowSteps[number];
 type StepMissingEvidence = ReturnType<typeof missingForStep>;
 type PersistedWorkflowStep = {
@@ -350,14 +341,15 @@ function hasFilledCanonicalValue(values: Record<string, unknown>, canonicalKey: 
   return String(value ?? '').trim().length > 0;
 }
 
-function missingForStep(step: WorkflowStepDefinition, payload: StepPayload) {
+function missingForStep(step: WorkflowStepDefinition, payload: StepPayload, options: { includeChecklist?: boolean } = {}) {
   const formData = normalizeJsonObject(payload.formData);
   const checklist = normalizeJsonObject(payload.checklist);
   const approvals = normalizeJsonObject(payload.approvals);
+  const includeChecklist = options.includeChecklist ?? true;
 
   return {
     fields: step.requiredFields.filter((field) => !hasFilledCanonicalValue(formData, field)),
-    checklist: step.requiredChecklist.filter((item) => !isTruthyCanonical(checklist, item)),
+    checklist: includeChecklist ? step.requiredChecklist.filter((item) => !isTruthyCanonical(checklist, item)) : [],
     approvals: step.requiredApprovals.filter((approval) => !isTruthyCanonical(approvals, approval)),
   };
 }
@@ -373,9 +365,9 @@ function hasAnyStepEvidence(payload: StepPayload) {
   );
 }
 
-function deriveStatus(step: WorkflowStepDefinition, payload: StepPayload) {
+function deriveStatus(step: WorkflowStepDefinition, payload: StepPayload, options: { includeChecklist?: boolean } = {}) {
   const requestedStatus = typeof payload.status === 'string' ? payload.status.trim().toLowerCase() : '';
-  const missing = missingForStep(step, payload);
+  const missing = missingForStep(step, payload, options);
   const complete = missing.fields.length === 0 && missing.checklist.length === 0 && missing.approvals.length === 0;
 
   if (requestedStatus === 'approved' && !complete) {
@@ -446,7 +438,7 @@ async function getSteps(recordId: string) {
   return db.select().from(designControlSteps).where(eq(designControlSteps.recordId, recordId));
 }
 
-function buildReadinessFromSteps(steps: PersistedWorkflowStep[]) {
+function buildReadinessFromSteps(steps: PersistedWorkflowStep[], manufacturingEvidence?: DesignManufacturingEvidence | null) {
   const byKey = new Map(steps.map((step) => [step.stepKey, step]));
   const missingItems: string[] = [];
 
@@ -470,24 +462,31 @@ function buildReadinessFromSteps(steps: PersistedWorkflowStep[]) {
       formData: normalizeJsonObject(releaseStep.formData),
       checklist: normalizeJsonObject(releaseStep.checklist),
       approvals: normalizeJsonObject(releaseStep.approvals),
-    });
-    missingItems.push(...formatMissingItems(releaseDefinition, missing));
+    }, { includeChecklist: false });
+    missingItems.push(
+      ...missing.fields.map((field) => `Step ${releaseDefinition.key} ${releaseDefinition.title} field missing: ${field}`),
+      ...missing.approvals.map((approval) => `Step ${releaseDefinition.key} ${releaseDefinition.title} approval missing: ${approval}`)
+    );
+  }
+
+  if (manufacturingEvidence) {
+    missingItems.push(...manufacturingEvidence.missingItems.map((item) => `Step 12 Design Production Release Gate source incomplete: ${item}`));
+  } else {
+    missingItems.push(...canonicalManufacturingEvidenceRequirements.map((requirement) => (
+      `Step 12 Design Production Release Gate source incomplete: ${requirement.label}: source evidence has not been evaluated`
+    )));
   }
 
   return {
     ready: missingItems.length === 0,
     missingItems,
     sourceOfTruthPrinciple: 'R&D Project owns engineering process; Design Control orchestrates; manufacturing modules own their own data and Design Control evaluates their status.',
-    manufacturingSourceStatuses: releaseGateSourceRequirements.map((requirement) => ({
-      requirement: requirement.item,
-      source: requirement.source,
-      ready: releaseStep
-        ? !missingForStep(workflowSteps.find((step) => step.key === '12')!, {
-          formData: normalizeJsonObject(releaseStep.formData),
-          checklist: normalizeJsonObject(releaseStep.checklist),
-          approvals: normalizeJsonObject(releaseStep.approvals),
-        }).checklist.some((item) => normalizeKey(item) === normalizeKey(requirement.item))
-        : false,
+    manufacturingEvidence: manufacturingEvidence ?? null,
+    manufacturingSourceStatuses: (manufacturingEvidence?.sources ?? []).map((source) => ({
+      requirement: source.label,
+      source: source.sourceModule,
+      ready: source.ready,
+      status: source.status,
     })),
     steps: workflowSteps.map((step) => ({
       key: step.key,
@@ -521,8 +520,12 @@ async function ensureWorkflowSteps(record: typeof designControlRecords.$inferSel
 }
 
 async function buildReadiness(recordId: string) {
+  const record = await getRecord(recordId);
   const steps = await getSteps(recordId);
-  return buildReadinessFromSteps(steps);
+  const manufacturingEvidence = record
+    ? await getDesignManufacturingEvidence({ rdProjectId: record.rdProjectId, designControlRecordId: record.id })
+    : null;
+  return buildReadinessFromSteps(steps, manufacturingEvidence);
 }
 
 async function upsertReleaseGate(
@@ -701,7 +704,7 @@ router.patch('/:id/steps/:stepKey', async (req: Request, res: Response) => {
       metadata: normalizeJsonObject(req.body?.metadata),
       status: req.body?.status,
     };
-    const derived = deriveStatus(step, payload);
+    const derived = deriveStatus(step, payload, { includeChecklist: step.key !== '12' });
     const requestedStatus = typeof req.body?.status === 'string' ? req.body.status.trim().toLowerCase() : '';
     let status = derived.status;
 
@@ -738,12 +741,15 @@ router.patch('/:id/steps/:stepKey', async (req: Request, res: Response) => {
     }
 
     if (step.key === '12' && status === 'approved') {
-      const readiness = await buildReadiness(record.id);
-      const missingPrerequisites = readiness.missingItems.filter((item) => item.startsWith('Step ') && !item.startsWith('Step 12 '));
-      if (missingPrerequisites.length > 0) {
+      const manufacturingEvidence = await getDesignManufacturingEvidence({
+        rdProjectId: record.rdProjectId,
+        designControlRecordId: record.id,
+      });
+      if (!manufacturingEvidence.ready) {
         res.status(422).json({
-          message: 'Step 12 cannot be approved until steps 1-11 are approved',
-          missingItems: missingPrerequisites,
+          message: 'Step 12 cannot be approved until manufacturing source evidence is ready',
+          missingItems: manufacturingEvidence.missingItems,
+          manufacturingEvidence,
         });
         return;
       }
@@ -853,6 +859,24 @@ router.post('/:id/submit-release', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('[qms-design-control] Failed to submit release gate', error);
     res.status(500).json({ message: 'Failed to submit design production release gate' });
+  }
+});
+
+router.get('/:id/manufacturing-evidence', async (req: Request, res: Response) => {
+  try {
+    const record = await getRecord(req.params.id);
+    if (!record) {
+      res.status(404).json({ message: 'Design control record not found' });
+      return;
+    }
+
+    res.json(await getDesignManufacturingEvidence({
+      rdProjectId: record.rdProjectId,
+      designControlRecordId: record.id,
+    }));
+  } catch (error) {
+    console.error('[qms-design-control] Failed to compute manufacturing evidence', error);
+    res.status(500).json({ message: 'Failed to compute design manufacturing evidence' });
   }
 });
 

--- a/server/src/services/designManufacturingEvidenceService.ts
+++ b/server/src/services/designManufacturingEvidenceService.ts
@@ -1,0 +1,482 @@
+import { desc, eq, inArray, sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import {
+  designControlRequirementApplicability,
+  draftBomDrafts,
+  engineeringControlledRevisions,
+  rdProjects,
+} from '../../schema';
+
+export type ManufacturingEvidenceStatus =
+  | 'NOT_CONFIGURED'
+  | 'NOT_STARTED'
+  | 'IN_PROGRESS'
+  | 'NEEDS_REVIEW'
+  | 'APPROVED'
+  | 'RELEASED'
+  | 'BLOCKED'
+  | 'NOT_APPLICABLE';
+
+export type ManufacturingEvidenceSource = {
+  key: string;
+  label: string;
+  sourceModule: string;
+  managedBy: 'SOURCE_MODULE' | 'DESIGN_CONTROL';
+  sourceAvailable: boolean;
+  status: ManufacturingEvidenceStatus;
+  ready: boolean;
+  recordId?: string | null;
+  revision?: string | null;
+  approvedBy?: string | null;
+  approvedAt?: string | null;
+  releasedBy?: string | null;
+  releasedAt?: string | null;
+  updatedAt?: string | null;
+  openUrl?: string | null;
+  explanation: string;
+  missingItems: string[];
+  applicability?: {
+    applicable: boolean;
+    justification?: string | null;
+    approvedBy?: string | null;
+    approvedRole?: string | null;
+    approvedAt?: string | null;
+    approved: boolean;
+  };
+};
+
+export type DesignManufacturingEvidence = {
+  rdProjectId: string | null;
+  designControlRecordId: string;
+  overallStatus: ManufacturingEvidenceStatus;
+  ready: boolean;
+  missingItems: string[];
+  sources: ManufacturingEvidenceSource[];
+};
+
+type DraftBom = typeof draftBomDrafts.$inferSelect;
+type RdProject = typeof rdProjects.$inferSelect;
+type ControlledRevision = typeof engineeringControlledRevisions.$inferSelect;
+type ApplicabilityRecord = typeof designControlRequirementApplicability.$inferSelect;
+
+type EvidenceBuilderInput = {
+  rdProjectId: string | null;
+  designControlRecordId: string;
+  rdProject?: RdProject | null;
+  draftBoms?: DraftBom[];
+  controlledRevisions?: ControlledRevision[];
+  applicability?: ApplicabilityRecord[];
+};
+
+export const canonicalManufacturingEvidenceRequirements = [
+  {
+    key: 'released_cad',
+    label: 'released CAD',
+    sourceModule: 'Engineering Controlled Revisions / CAD or SPEC',
+    artifactTypes: ['SPEC'],
+  },
+  {
+    key: 'released_drawings',
+    label: 'released drawings',
+    sourceModule: 'Engineering Controlled Revisions / Document Control',
+    artifactTypes: ['SPEC'],
+  },
+  {
+    key: 'released_bom',
+    label: 'released BOM',
+    sourceModule: 'Draft Builder BOM / BOM module',
+    artifactTypes: ['BOM'],
+  },
+  {
+    key: 'approved_routing',
+    label: 'approved routing',
+    sourceModule: 'Routing module',
+    artifactTypes: ['ROUTING'],
+  },
+  {
+    key: 'approved_traveler_requirement',
+    label: 'approved traveler requirement',
+    sourceModule: 'Traveler module',
+    artifactTypes: ['TRAVELER_TEMPLATE'],
+  },
+  {
+    key: 'approved_work_instructions',
+    label: 'approved work instructions',
+    sourceModule: 'Work Instructions module',
+    artifactTypes: ['WORK_INSTRUCTION'],
+  },
+  {
+    key: 'approved_inspection_plan',
+    label: 'approved inspection plan',
+    sourceModule: 'Inspection / QC module',
+    artifactTypes: ['QC_FORM'],
+  },
+  {
+    key: 'approved_test_procedure',
+    label: 'approved test procedure',
+    sourceModule: 'Verification / Test module',
+    artifactTypes: ['QC_FORM', 'SPEC'],
+  },
+  {
+    key: 'required_certifications_identified',
+    label: 'required certifications identified',
+    sourceModule: 'Certifications / Quality module',
+    artifactTypes: [],
+  },
+  {
+    key: 'supplier_requirements_flowed_down',
+    label: 'supplier requirements flowed down',
+    sourceModule: 'Supplier Quality / Procurement module',
+    artifactTypes: [],
+  },
+  {
+    key: 'material_requirements_approved',
+    label: 'material requirements approved',
+    sourceModule: 'Material / Inventory module',
+    artifactTypes: [],
+  },
+  {
+    key: 'tooling_and_fixtures_ready',
+    label: 'tooling/fixtures ready',
+    sourceModule: 'Manufacturing Engineering module',
+    artifactTypes: [],
+  },
+  {
+    key: 'cnc_programs_approved',
+    label: 'CNC programs approved if applicable',
+    sourceModule: 'CNC / Manufacturing module',
+    artifactTypes: [],
+  },
+  {
+    key: 'training_certifications_complete',
+    label: 'training/certifications complete',
+    sourceModule: 'Training module',
+    artifactTypes: [],
+  },
+  {
+    key: 'packaging_shipping_requirements_defined',
+    label: 'packaging/shipping requirements defined',
+    sourceModule: 'Shipping / Packaging module',
+    artifactTypes: [],
+  },
+  {
+    key: 'design_revision_baseline_locked',
+    label: 'design revision baseline locked',
+    sourceModule: 'Engineering Controlled Revisions / Revision baseline',
+    artifactTypes: ['BOM', 'ROUTING', 'TRAVELER_TEMPLATE', 'WORK_INSTRUCTION', 'SPEC', 'QC_FORM'],
+  },
+] as const;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function valueAtPath(data: Record<string, unknown>, path: string[]) {
+  let current: unknown = data;
+  for (const part of path) {
+    if (!asRecord(current) || !(part in asRecord(current))) return undefined;
+    current = asRecord(current)[part];
+  }
+  return current;
+}
+
+function firstString(data: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const direct = asString(data[key]);
+    if (direct) return direct;
+    const metadata = asString(valueAtPath(data, ['metadata', key]));
+    if (metadata) return metadata;
+    const release = asString(valueAtPath(data, ['release', key]));
+    if (release) return release;
+    const approval = asString(valueAtPath(data, ['approval', key]));
+    if (approval) return approval;
+  }
+  return '';
+}
+
+function firstDateString(data: Record<string, unknown>, keys: string[]) {
+  const raw = firstString(data, keys);
+  if (raw) return raw;
+  for (const key of keys) {
+    const value = data[key] ?? valueAtPath(data, ['metadata', key]) ?? valueAtPath(data, ['release', key]) ?? valueAtPath(data, ['approval', key]);
+    if (value instanceof Date) return value.toISOString();
+  }
+  return null;
+}
+
+function hasBooleanTrue(data: Record<string, unknown>, keys: string[]) {
+  return keys.some((key) => data[key] === true || valueAtPath(data, ['metadata', key]) === true || valueAtPath(data, ['release', key]) === true);
+}
+
+function statusFromReleaseState(state: string): ManufacturingEvidenceStatus {
+  const normalized = state.toLowerCase();
+  if (normalized.includes('released')) return 'RELEASED';
+  if (normalized.includes('approved')) return 'APPROVED';
+  if (normalized.includes('review')) return 'NEEDS_REVIEW';
+  if (normalized.includes('draft') || normalized.includes('started')) return 'IN_PROGRESS';
+  return 'IN_PROGRESS';
+}
+
+function releaseDetailsFromData(data: Record<string, unknown>) {
+  const statusText = firstString(data, [
+    'manufacturingReleaseStatus',
+    'releaseStatus',
+    'approvalStatus',
+    'status',
+    'state',
+  ]);
+  const status = hasBooleanTrue(data, ['manufacturingReleased', 'released', 'isReleased'])
+    ? 'RELEASED'
+    : hasBooleanTrue(data, ['approved', 'isApproved'])
+      ? 'APPROVED'
+      : statusText
+        ? statusFromReleaseState(statusText)
+        : 'IN_PROGRESS';
+
+  return {
+    status,
+    approvedBy: firstString(data, ['approvedBy', 'approvalBy']) || null,
+    approvedAt: firstDateString(data, ['approvedAt', 'approvalAt']),
+    releasedBy: firstString(data, ['releasedBy', 'releaseBy']) || null,
+    releasedAt: firstDateString(data, ['releasedAt', 'releaseAt']),
+  };
+}
+
+function isReady(status: ManufacturingEvidenceStatus) {
+  return status === 'APPROVED' || status === 'RELEASED' || status === 'NOT_APPLICABLE';
+}
+
+function approvedApplicability(record: ApplicabilityRecord) {
+  const role = asString(record.approvedRole).toLowerCase();
+  const hasApprovedRole = role.includes('engineering') || role.includes('quality');
+  return Boolean(record.justification?.trim() && record.approvedBy?.trim() && record.approvedAt && hasApprovedRole);
+}
+
+function applyNotApplicable(
+  source: ManufacturingEvidenceSource,
+  applicabilityByKey: Map<string, ApplicabilityRecord>
+): ManufacturingEvidenceSource {
+  const applicability = applicabilityByKey.get(source.key);
+  if (!applicability || applicability.applicable !== false) return source;
+
+  const approved = approvedApplicability(applicability);
+  return {
+    ...source,
+    status: approved ? 'NOT_APPLICABLE' : 'BLOCKED',
+    ready: approved,
+    sourceAvailable: source.sourceAvailable,
+    explanation: approved
+      ? 'This manufacturing evidence requirement has a controlled Engineering or Quality approved not-applicable disposition.'
+      : 'Not-applicable disposition is incomplete.',
+    missingItems: approved
+      ? []
+      : [`${source.label}: not-applicable disposition requires justification and Engineering or Quality approval`],
+    applicability: {
+      applicable: false,
+      justification: applicability.justification,
+      approvedBy: applicability.approvedBy,
+      approvedRole: applicability.approvedRole,
+      approvedAt: applicability.approvedAt ? applicability.approvedAt.toISOString() : null,
+      approved,
+    },
+  };
+}
+
+function sourceFromControlledRevision(
+  requirement: typeof canonicalManufacturingEvidenceRequirements[number],
+  controlledRevisions: ControlledRevision[]
+): ManufacturingEvidenceSource | null {
+  if (requirement.artifactTypes.length === 0) return null;
+
+  const revisions = controlledRevisions.filter((revision) => requirement.artifactTypes.includes(revision.artifactType as any));
+  if (revisions.length === 0) return null;
+
+  const released = revisions.find((revision) => revision.releaseState === 'released');
+  const approved = revisions.find((revision) => revision.releaseState === 'approved');
+  const review = revisions.find((revision) => revision.releaseState === 'review');
+  const selected = released ?? approved ?? review ?? revisions[0];
+  const status = statusFromReleaseState(selected.releaseState);
+
+  return {
+    key: requirement.key,
+    label: requirement.label,
+    sourceModule: requirement.sourceModule,
+    managedBy: 'SOURCE_MODULE',
+    sourceAvailable: true,
+    status,
+    ready: isReady(status),
+    recordId: selected.id,
+    revision: selected.revision,
+    approvedBy: selected.approvedBy ?? null,
+    approvedAt: selected.approvedAt ? selected.approvedAt.toISOString() : null,
+    releasedBy: selected.releasedBy ?? null,
+    releasedAt: selected.releasedAt ? selected.releasedAt.toISOString() : null,
+    updatedAt: selected.updatedAt ? selected.updatedAt.toISOString() : null,
+    openUrl: '/engineering/change-control',
+    explanation: `${selected.title} is ${selected.releaseState}.`,
+    missingItems: isReady(status) ? [] : [`${requirement.label}: linked controlled revision is ${selected.releaseState}`],
+  };
+}
+
+function sourceFromDraftBom(
+  requirement: typeof canonicalManufacturingEvidenceRequirements[number],
+  draftBoms: DraftBom[]
+): ManufacturingEvidenceSource | null {
+  if (requirement.key !== 'released_bom') return null;
+
+  if (draftBoms.length === 0) {
+    return {
+      key: requirement.key,
+      label: requirement.label,
+      sourceModule: requirement.sourceModule,
+      managedBy: 'SOURCE_MODULE',
+      sourceAvailable: false,
+      status: 'NOT_CONFIGURED',
+      ready: false,
+      explanation: 'No linked Draft Builder BOM was found for this R&D project.',
+      missingItems: [`${requirement.label}: no linked Draft Builder BOM source is configured`],
+      openUrl: '/estimating/bom-drafts',
+    };
+  }
+
+  const ranked = draftBoms
+    .map((draft) => {
+      const details = releaseDetailsFromData(asRecord(draft.data));
+      return { draft, details };
+    })
+    .sort((left, right) => {
+      const rank = (status: ManufacturingEvidenceStatus) => ({ RELEASED: 4, APPROVED: 3, NEEDS_REVIEW: 2, IN_PROGRESS: 1 }[status] ?? 0);
+      return rank(right.details.status) - rank(left.details.status);
+    });
+
+  const selected = ranked[0];
+  const status = selected.details.status;
+  return {
+    key: requirement.key,
+    label: requirement.label,
+    sourceModule: requirement.sourceModule,
+    managedBy: 'SOURCE_MODULE',
+    sourceAvailable: true,
+    status,
+    ready: isReady(status),
+    recordId: selected.draft.id,
+    revision: selected.draft.revision,
+    approvedBy: selected.details.approvedBy,
+    approvedAt: selected.details.approvedAt,
+    releasedBy: selected.details.releasedBy,
+    releasedAt: selected.details.releasedAt,
+    updatedAt: selected.draft.updatedAt ? selected.draft.updatedAt.toISOString() : null,
+    openUrl: `/estimating/bom-drafts?draftId=${encodeURIComponent(selected.draft.id)}`,
+    explanation: isReady(status)
+      ? `${selected.draft.name} is ${status.toLowerCase()} for manufacturing release.`
+      : `${selected.draft.name} is linked but does not carry an approved or released manufacturing status.`,
+    missingItems: isReady(status) ? [] : [`${requirement.label}: linked BOM is not approved or released`],
+  };
+}
+
+function sourceNotConfigured(requirement: typeof canonicalManufacturingEvidenceRequirements[number]): ManufacturingEvidenceSource {
+  return {
+    key: requirement.key,
+    label: requirement.label,
+    sourceModule: requirement.sourceModule,
+    managedBy: 'SOURCE_MODULE',
+    sourceAvailable: false,
+    status: 'NOT_CONFIGURED',
+    ready: false,
+    explanation: `${requirement.sourceModule} is the source of truth, but no R&D-project-linked source record is configured for this requirement.`,
+    missingItems: [`${requirement.label}: source module is not configured for this R&D project`],
+  };
+}
+
+function draftBomBelongsToRdProject(draft: DraftBom, rdProjectId: string | null, rdProject?: RdProject | null) {
+  if (!rdProjectId) return false;
+  const draftTabIds = Array.isArray(rdProject?.draftTabIds) ? rdProject.draftTabIds : [];
+  return draft.projectId === rdProjectId || draftTabIds.includes(draft.id);
+}
+
+export function buildDesignManufacturingEvidence(input: EvidenceBuilderInput): DesignManufacturingEvidence {
+  const applicabilityByKey = new Map((input.applicability ?? []).map((record) => [record.requirementKey, record]));
+  const linkedDraftBoms = (input.draftBoms ?? []).filter((draft) => (
+    draftBomBelongsToRdProject(draft, input.rdProjectId, input.rdProject)
+  ));
+
+  const sources = canonicalManufacturingEvidenceRequirements.map((requirement) => {
+    const source = sourceFromDraftBom(requirement, linkedDraftBoms)
+      ?? sourceFromControlledRevision(requirement, input.controlledRevisions ?? [])
+      ?? sourceNotConfigured(requirement);
+
+    if (!input.rdProject && input.rdProjectId) {
+      return applyNotApplicable({
+        ...source,
+        status: 'BLOCKED',
+        ready: false,
+        explanation: `R&D project ${input.rdProjectId} was not found; source evidence cannot be evaluated.`,
+        missingItems: [`${requirement.label}: R&D project was not found`],
+      }, applicabilityByKey);
+    }
+
+    return applyNotApplicable(source, applicabilityByKey);
+  });
+
+  const missingItems = sources.flatMap((source) => source.missingItems);
+  return {
+    rdProjectId: input.rdProjectId,
+    designControlRecordId: input.designControlRecordId,
+    overallStatus: missingItems.length === 0 ? 'RELEASED' : 'BLOCKED',
+    ready: missingItems.length === 0,
+    missingItems,
+    sources,
+  };
+}
+
+export async function getDesignManufacturingEvidence(params: {
+  rdProjectId: string | null;
+  designControlRecordId: string;
+}, client: typeof db = db): Promise<DesignManufacturingEvidence> {
+  const rdProjectId = params.rdProjectId?.trim() || null;
+
+  const [rdProject] = rdProjectId
+    ? await client.select().from(rdProjects).where(eq(rdProjects.id, rdProjectId)).limit(1)
+    : [];
+
+  const draftTabIds = Array.isArray(rdProject?.draftTabIds) ? rdProject.draftTabIds : [];
+  const draftBomRowsByProject = rdProjectId
+    ? await client.select().from(draftBomDrafts).where(eq(draftBomDrafts.projectId, rdProjectId)).orderBy(desc(draftBomDrafts.updatedAt))
+    : [];
+  const draftBomRowsByTab = draftTabIds.length > 0
+    ? await client.select().from(draftBomDrafts).where(inArray(draftBomDrafts.id, draftTabIds)).orderBy(desc(draftBomDrafts.updatedAt))
+    : [];
+  const draftBoms = Array.from(new Map([...draftBomRowsByProject, ...draftBomRowsByTab].map((draft) => [draft.id, draft])).values());
+
+  const controlledRevisions = rdProjectId
+    ? await client
+      .select()
+      .from(engineeringControlledRevisions)
+      .where(sql`
+        metadata->>'rdProjectId' = ${rdProjectId}
+        OR metadata->>'rd_project_id' = ${rdProjectId}
+        OR metadata->>'designControlRecordId' = ${params.designControlRecordId}
+        OR metadata->>'design_control_record_id' = ${params.designControlRecordId}
+      `)
+      .orderBy(desc(engineeringControlledRevisions.updatedAt))
+    : [];
+
+  const applicability = await client
+    .select()
+    .from(designControlRequirementApplicability)
+    .where(eq(designControlRequirementApplicability.recordId, params.designControlRecordId));
+
+  return buildDesignManufacturingEvidence({
+    rdProjectId,
+    designControlRecordId: params.designControlRecordId,
+    rdProject: rdProject ?? null,
+    draftBoms,
+    controlledRevisions,
+    applicability,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds server-computed Design Production Release Gate manufacturing evidence for Design Control records linked to R&D projects.
- Replaces Step 12 manual manufacturing checklist behavior with read-only source-status cards in `/qms/design-control`.
- Adds controlled not-applicable persistence for canonical release requirements with Engineering/Quality approval requirements.
- Keeps `/api/projects/:id/release-to-p2` and P2 release behavior unchanged.

## Validation
- `git diff --check origin/main...HEAD`
- `node_modules\.bin\vitest.CMD run --config vitest.config.server.ts server/__tests__/qmsDesignControlReleaseGate.test.ts server/__tests__/designManufacturingEvidenceService.test.ts` (18 passed)
- `node_modules\.bin\vite.CMD build` (passed; existing chunk-size warnings)
- `node_modules\.bin\tsc.CMD` attempted, but full repo typecheck OOMed at default heap and again with `NODE_OPTIONS=--max-old-space-size=4096` before emitting diagnostics

## Notes
- Design Control now evaluates manufacturing sources instead of duplicating source-owned data.
- Missing module links are reported as `NOT_CONFIGURED` until the relevant source modules expose R&D-project-linked records.
- P2 is not blocked by this PR.