### PR TITLE
Persist receiving documents in durable storage

### DIFF
--- a/client/src/pages/InventoryReceivingControlCenter.tsx
+++ b/client/src/pages/InventoryReceivingControlCenter.tsx
@@ -212,6 +212,7 @@ interface ReceiptDocument {
   id: number;
   receiptId: number;
   receivedUnitId?: number;
+  mediaId?: string;
   docType?: string;
   filename?: string;
   storagePath?: string;
@@ -3405,9 +3406,11 @@ function DocumentsTab({ receipt, onUpdate }: { receipt: Receipt; onUpdate: (r: R
                 <span className="font-medium truncate max-w-[120px]">{doc.filename ?? 'Document'}</span>
               </div>
               <div className="flex items-center gap-1 shrink-0">
-                {doc.storagePath && (
+                {(doc.mediaId || doc.storagePath) && (
                   <a
-                    href={`/api/media/download?path=${encodeURIComponent(doc.storagePath)}`}
+                    href={doc.mediaId
+                      ? `/api/media/${doc.mediaId}/download`
+                      : `/api/media/download?path=${encodeURIComponent(doc.storagePath!)}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center h-6 w-6 rounded hover:bg-gray-100 justify-center text-blue-500"

--- a/server/src/routes/receiving.ts
+++ b/server/src/routes/receiving.ts
@@ -41,7 +41,7 @@ import { z } from 'zod';
 import multer from 'multer';
 import { generateBarcodeImage, generateReceivingUnitBarcodeValue } from '../utils/barcodeGenerator';
 import { requireRole } from '../../middleware/auth';
-import { getStorageErrorResponse } from '../services/fileStorageProvider';
+import { getFileStorageProvider, getStorageErrorResponse } from '../services/fileStorageProvider';
 import { createInventoryEvent } from '../services/inventoryEventService';
 import { recordInventoryLedgerEntry } from '../services/inventoryTransactionLedgerService';
 import { ensureInventoryItemForReceipt } from '../services/ensureInventoryItemForReceipt';
@@ -82,13 +82,37 @@ function sanitizeUploadFilename(filename: string): string {
   return `${Date.now()}-${randomUUID()}-${baseName}${ext}`;
 }
 
-async function saveReceivingMediaFile(file: Express.Multer.File): Promise<string> {
+async function saveReceivingMediaFileLocally(file: Express.Multer.File): Promise<string> {
   const storedFilename = sanitizeUploadFilename(file.originalname);
   const storagePath = path.posix.join('uploads', 'media-library', 'receiving', storedFilename);
   const absoluteDir = path.join(process.cwd(), RECEIVING_MEDIA_STORAGE_DIR);
   await fs.mkdir(absoluteDir, { recursive: true });
   await fs.writeFile(path.join(absoluteDir, storedFilename), file.buffer);
   return storagePath;
+}
+
+async function saveReceivingMediaFile(file: Express.Multer.File, receiptId: number): Promise<string> {
+  try {
+    return await getFileStorageProvider().uploadBuffer({
+      buffer: file.buffer,
+      fileName: file.originalname,
+      contentType: file.mimetype || 'application/octet-stream',
+      scope: 'receiving',
+      entityId: String(receiptId),
+    });
+  } catch (error) {
+    const { reason, message } = getStorageErrorResponse(error);
+    if (process.env.NODE_ENV === 'production') {
+      throw error;
+    }
+    console.warn('Receiving document durable upload unavailable outside production; using local fallback', {
+      receiptId,
+      filename: file.originalname,
+      reason,
+      message,
+    });
+    return saveReceivingMediaFileLocally(file);
+  }
 }
 
 async function getOrCreateReceivingMediaFolder(user: AuthUser, displayName: string): Promise<string | null> {
@@ -1463,7 +1487,7 @@ router.post('/:id/documents', requireReceivingAccess, uploadReceiptDocument, asy
       mimeType = req.file.mimetype;
       fileSize = req.file.size;
 
-      storagePath = await saveReceivingMediaFile(req.file);
+      storagePath = await saveReceivingMediaFile(req.file, receiptId);
       const receivingFolderId = await getOrCreateReceivingMediaFolder(user, displayName);
 
       // Create media_library record for cross-system traceability


### PR DESCRIPTION
## What changed

- Persist Receiving document uploads through the configured durable file-storage provider.
- Refuse production uploads when durable storage fails instead of silently writing a disposable local file.
- Retain local fallback only for non-production development environments.
- Open linked receipt documents through their stable Media Library ID when available, with the legacy path route retained for older records.

## Why

Receiving documents were written to the deployment's local filesystem while their metadata remained in the database. A deployment replacement could therefore leave a visible document record whose file returned `404 File Not Available`.

## User impact

New Receiving documents survive deployments and open through the Media Library download route. Existing records whose file bytes are already missing still require one re-upload because the database cannot reconstruct the lost file.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Scoped source review of the upload, Media Library record, and download-link paths
- Full TypeScript checking was unavailable because dependencies are not installed in the clean worktree.
