### PR TITLE
Restore server boot for salaried punch ledger entries

### DIFF
--- a/migrations/0062_punch_ledger_check_constraints.sql
+++ b/migrations/0062_punch_ledger_check_constraints.sql
@@ -6,6 +6,6 @@ ALTER TABLE public.punch_ledger
 
 ALTER TABLE public.punch_ledger
   ADD CONSTRAINT punch_ledger_source_check
-    CHECK (source IN ('KIOSK', 'PORTAL', 'TRAVELER')),
+    CHECK (source IN ('KIOSK', 'PORTAL', 'TRAVELER', 'SALARIED_ENTRY')),
   ADD CONSTRAINT punch_ledger_labor_class_check
     CHECK (labor_class IN ('REGULAR', 'OVERTIME', 'DOUBLE_TIME', 'BREAK'));

--- a/server/__tests__/punchLedgerSourceConstraint.test.ts
+++ b/server/__tests__/punchLedgerSourceConstraint.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('punch ledger source constraint', () => {
+  it('allows every source written by the application', () => {
+    const migration = readFileSync(
+      join(process.cwd(), 'migrations/0062_punch_ledger_check_constraints.sql'),
+      'utf8',
+    );
+
+    for (const source of ['KIOSK', 'PORTAL', 'TRAVELER', 'SALARIED_ENTRY']) {
+      expect(migration).toContain(`'${source}'`);
+    }
+  });
+});


### PR DESCRIPTION
## What changed

- allow `SALARIED_ENTRY` in the replayed `punch_ledger_source_check` constraint
- add a regression test covering every punch ledger source written by the application

## Root cause

Safe boot migration `0062_punch_ledger_check_constraints.sql` is replayed during deployment but still allowed only `KIOSK`, `PORTAL`, and `TRAVELER`. Existing valid salaried rows therefore caused the constraint recreation to fail, route registration to abort, and `/api/auth/login` to return `503`.

## Impact

After merge and republish, the boot migration can complete against existing salaried ledger rows and API routes, including login, can register normally.

## Validation

- `git diff --check`
- direct SQL source-contract validation for `KIOSK`, `PORTAL`, `TRAVELER`, and `SALARIED_ENTRY`

Full Vitest execution was unavailable because the clean worktree does not have project dependencies installed.