### PR TITLE
Create reusable controlled document workflow

### DIFF
--- a/client/src/pages/RoutingDocumentManagement.tsx
+++ b/client/src/pages/RoutingDocumentManagement.tsx
@@ -83,6 +83,14 @@ interface InventoryItem {
   manufacturedCategory?: string | null;
 }
 
+interface ProjectOption {
+  id: string;
+  projectNumber?: string | null;
+  project_number?: string | null;
+  name?: string | null;
+  title?: string | null;
+}
+
 const FORM_DOCUMENT_TYPES = [
   { value: 'work_instruction', label: 'Work Instruction' },
   { value: 'assembly_instruction', label: 'Assembly Instruction' },
@@ -241,6 +249,7 @@ export default function RoutingDocumentManagement() {
     partNumber: '',
     partName: '',
     sku: '',
+    projectId: '',
     fieldValues: {} as Record<string, string>,
   });
   const [showGenerateRoutingDialog, setShowGenerateRoutingDialog] = useState(false);
@@ -302,6 +311,11 @@ export default function RoutingDocumentManagement() {
 
   const { data: inventoryItems = [] } = useQuery<InventoryItem[]>({
     queryKey: ['/api/inventory/items'],
+  });
+
+  const { data: projects = [] } = useQuery<ProjectOption[]>({
+    queryKey: ['/api/projects'],
+    queryFn: () => apiRequest('/api/projects'),
   });
 
   const manufacturedParts = inventoryItems.filter((item) =>
@@ -500,7 +514,7 @@ export default function RoutingDocumentManagement() {
 
   const createFilledSpecSheetMutation = useMutation({
     mutationFn: async (data: typeof fillSpecSheetForm) => {
-      return apiRequest('/api/routing-documents/spec-sheets/from-template', {
+      return apiRequest('/api/routing-documents/documents/from-template', {
         method: 'POST',
         body: {
           templateId: data.templateId,
@@ -510,6 +524,7 @@ export default function RoutingDocumentManagement() {
           sku: data.sku,
           title: data.title,
           fieldValues: data.fieldValues,
+          projectId: data.projectId || null,
         },
         timeout: 120000,
       });
@@ -517,17 +532,17 @@ export default function RoutingDocumentManagement() {
     onSuccess: (response: any) => {
       const docNumber = response?.documentNumber || response?.controlledDocument?.documentNumber || response?.controlledDocument?.document_number;
       toast({
-        title: 'Spec Sheet Saved',
-        description: docNumber ? `Saved to Master Document List as ${docNumber}` : 'Saved to Master Document List and central storage',
+        title: 'Document Saved',
+        description: docNumber ? `Saved to central storage and the Master Document List as ${docNumber}` : 'Saved to central storage and the Master Document List',
       });
       queryClient.invalidateQueries({ queryKey: ['/api/routing-documents/spec-sheets'] });
       queryClient.invalidateQueries({ queryKey: ['/api/controlled-documents'] });
       setShowFillSpecSheetDialog(false);
       setSelectedTemplate(null);
-      setActiveTab('specsheets');
+      setActiveTab('documents');
     },
     onError: (error: any) => {
-      toast({ title: 'Error', description: error.message || 'Failed to save filled spec sheet', variant: 'destructive' });
+      toast({ title: 'Error', description: error.message || 'Failed to create document from template', variant: 'destructive' });
     },
   });
 
@@ -921,24 +936,14 @@ export default function RoutingDocumentManagement() {
       partNumber: fieldValues.partNumber || '',
       partName: fieldValues.partName || '',
       sku: fieldValues.sku || '',
+      projectId: '',
       fieldValues,
     });
     setShowFillSpecSheetDialog(true);
   };
 
   const handleUseTemplate = (template: DocumentTemplate) => {
-    if (template.templateType === 'spec_sheet') {
-      openFillSpecSheetDialog(template);
-      return;
-    }
-
-    setGenerateForm({
-      partNumber: '',
-      partName: '',
-      documentType: template.templateType || 'work_instruction',
-      templateId: template.id,
-    });
-    setShowGenerateDialog(true);
+    openFillSpecSheetDialog(template);
   };
 
   const handleManufacturedPartChange = (value: string) => {
@@ -983,8 +988,11 @@ export default function RoutingDocumentManagement() {
       toast({ title: 'Error', description: 'Please select a template', variant: 'destructive' });
       return;
     }
-    if (!fillSpecSheetForm.partNumber && !fillSpecSheetForm.inventoryItemId) {
-      toast({ title: 'Error', description: 'Please link a manufactured part or enter a part number', variant: 'destructive' });
+    const missingRequired = (selectedTemplate?.defaultFields || []).find((field: any) =>
+      field.isRequired && !String(fillSpecSheetForm.fieldValues[field.fieldName] || '').trim()
+    );
+    if (missingRequired) {
+      toast({ title: 'Required Field', description: `${missingRequired.fieldLabel || missingRequired.fieldName} is required`, variant: 'destructive' });
       return;
     }
 
@@ -1575,15 +1583,15 @@ export default function RoutingDocumentManagement() {
       <Dialog open={showFillSpecSheetDialog} onOpenChange={setShowFillSpecSheetDialog}>
         <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Fill CNC Spec Sheet</DialogTitle>
+            <DialogTitle>Create {typeLabel(selectedTemplate?.templateType)}</DialogTitle>
             <DialogDescription>
-              Fill the spec sheet fields, link the manufactured part, and save the finished PDF to the Master Document List
+              Complete the reusable template. The finished PDF will be saved in central storage and registered in the Master Document List.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-5">
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <Label>Manufactured Part</Label>
+                <Label>Manufactured Part (optional)</Label>
                 <Select value={fillSpecSheetForm.inventoryItemId} onValueChange={handleManufacturedPartChange}>
                   <SelectTrigger>
                     <SelectValue placeholder="Link manufactured part" />
@@ -1598,11 +1606,11 @@ export default function RoutingDocumentManagement() {
                 </Select>
               </div>
               <div>
-                <Label>Sheet Title</Label>
+                <Label>Document Title</Label>
                 <Input
                   value={fillSpecSheetForm.title}
                   onChange={(e) => setFillSpecSheetForm({ ...fillSpecSheetForm, title: e.target.value })}
-                  placeholder="SPEC Sheet - Wing Box Rib Part #26006"
+                  placeholder={`${typeLabel(selectedTemplate?.templateType)} title`}
                 />
               </div>
               <div>
@@ -1632,6 +1640,25 @@ export default function RoutingDocumentManagement() {
                     }));
                   }}
                 />
+              </div>
+              <div className="col-span-2">
+                <Label>Attach to Project (optional)</Label>
+                <Select
+                  value={fillSpecSheetForm.projectId || 'none'}
+                  onValueChange={(value) => setFillSpecSheetForm({ ...fillSpecSheetForm, projectId: value === 'none' ? '' : value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Do not attach to a project</SelectItem>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.projectNumber || project.project_number || project.id} - {project.name || project.title || 'Project'}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
 
@@ -1682,7 +1709,7 @@ export default function RoutingDocumentManagement() {
               ) : (
                 <FileSpreadsheet className="h-4 w-4 mr-2" />
               )}
-              Save Spec Sheet
+              Create and Save Document
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -13,6 +13,7 @@ import { requireStepUp } from '../../../server/middleware/auth';
 import { writeAccessLog } from './vault';
 import { fileURLToPath } from 'url';
 import { PDFDocument, PDFFont, StandardFonts, rgb } from 'pdf-lib';
+import { getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
 
 const router = Router();
 
@@ -733,6 +734,17 @@ router.get('/:id/view', requireAuth, requireStepUp(), async (req: Request, res: 
       return res.redirect(externalRedirectUrl);
     }
 
+    if (doc.filePath.startsWith('/objects/') || doc.filePath.startsWith('/supabase-objects/')) {
+      const stampedPdf = await addControlledDocumentFooter(
+        await getFileStorageProviderForObjectPath(doc.filePath).downloadBuffer(doc.filePath),
+        doc,
+      );
+      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'view', ipAddress });
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `inline; filename="${doc.documentNumber}.pdf"`);
+      return res.send(stampedPdf);
+    }
+
     const filePath = resolveControlledDocumentFile(doc.filePath);
     if (!filePath) {
       return res.status(422).json({ error: 'Document file path is not a supported app-accessible location' });
@@ -812,6 +824,17 @@ router.get('/:id/download', requireAuth, requireStepUp(), async (req: Request, r
     if (externalRedirectUrl) {
       await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
       return res.redirect(externalRedirectUrl);
+    }
+
+    if (doc.filePath.startsWith('/objects/') || doc.filePath.startsWith('/supabase-objects/')) {
+      const stampedPdf = await addControlledDocumentFooter(
+        await getFileStorageProviderForObjectPath(doc.filePath).downloadBuffer(doc.filePath),
+        doc,
+      );
+      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="${doc.documentNumber}.pdf"`);
+      return res.send(stampedPdf);
     }
 
     const filePath = resolveControlledDocumentFile(doc.filePath);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -22,6 +22,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
+import { getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
 
 // ── Project document upload setup ──────────────────────────────────────────
 const projectDocsDir = path.join(process.cwd(), 'uploads', 'project-documents');
@@ -3710,6 +3711,12 @@ router.get('/:id/documents/:docId/file', async (req, res) => {
           );
       const generatedDoc = rows[0];
       if (!generatedDoc) return res.status(404).json({ message: 'Document not found' });
+      if (generatedDoc.file_url?.startsWith('/objects/') || generatedDoc.file_url?.startsWith('/supabase-objects/')) {
+        return getFileStorageProviderForObjectPath(generatedDoc.file_url).downloadObject(generatedDoc.file_url, res, {
+          contentType: generatedDoc.file_type || 'application/pdf',
+          contentDisposition: `inline; filename="${generatedDoc.file_name || `${generatedDoc.title}.pdf`}"`,
+        });
+      }
       const resolved = resolveBuilderAssetPath(generatedDoc.file_url);
       if (!resolved) return res.status(404).json({ message: 'No document file is attached yet' });
       if (/^https?:\/\//i.test(resolved)) return res.redirect(resolved);
@@ -3734,6 +3741,13 @@ router.get('/:id/documents/:docId/file', async (req, res) => {
     if (doc.media_library_id) {
       // Redirect to existing media serve endpoint
       return res.redirect(`/api/media/${doc.media_library_id}/download`);
+    }
+
+    if (doc.file_path?.startsWith('/objects/') || doc.file_path?.startsWith('/supabase-objects/')) {
+      return getFileStorageProviderForObjectPath(doc.file_path).downloadObject(doc.file_path, res, {
+        contentType: doc.mime_type || 'application/pdf',
+        contentDisposition: `inline; filename="${doc.original_file_name}"`,
+      });
     }
 
     if (!doc.file_path || !fs.existsSync(doc.file_path)) {

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -35,6 +35,7 @@ const TEMPLATE_UPLOAD_TABLES = new Set([
   'template_fields',
   'controlled_documents',
   'document_version_history',
+  'project_documents',
 ]);
 
 async function getPublicTableColumns(tableName: string) {
@@ -338,11 +339,13 @@ async function generateControlledTemplateNumber() {
 }
 
 async function saveControlledDocumentFile(fileName: string, fileBuffer: Buffer) {
-  const uploadDir = path.join(process.cwd(), 'server/src/assets/documents');
-  fs.mkdirSync(uploadDir, { recursive: true });
   const storedFileName = sanitizeFileName(fileName);
-  fs.writeFileSync(path.join(uploadDir, storedFileName), fileBuffer);
-  return `/assets/documents/${storedFileName}`;
+  return getFileStorageProvider().uploadBuffer({
+    fileName: storedFileName,
+    contentType: 'application/pdf',
+    scope: 'controlled-documents',
+    buffer: fileBuffer,
+  });
 }
 
 function humanizeDocumentType(value: string) {
@@ -537,11 +540,13 @@ async function renderSpecSheetPdf(input: {
 }
 
 async function saveSpecSheetPdfFile(fileName: string, fileBuffer: Buffer) {
-  const uploadDir = path.join(process.cwd(), 'server/src/assets/documents/spec-sheets');
-  fs.mkdirSync(uploadDir, { recursive: true });
   const storedFileName = normalizeSpecSheetFileName(fileName, null);
-  fs.writeFileSync(path.join(uploadDir, storedFileName), fileBuffer);
-  return `/assets/documents/spec-sheets/${storedFileName}`;
+  return getFileStorageProvider().uploadBuffer({
+    fileName: storedFileName,
+    contentType: 'application/pdf',
+    scope: 'form-document-builder',
+    buffer: fileBuffer,
+  });
 }
 
 // Helper to format UUID bytes to string if needed
@@ -2118,8 +2123,9 @@ router.post('/spec-sheets/complete-upload', async (req: Request, res: Response) 
   }
 });
 
-// Fill a spec sheet template, link it to a manufactured part, save the PDF, and register it in MDR
-router.post('/spec-sheets/from-template', async (req: Request, res: Response) => {
+// Fill any reusable template, save the finished PDF in central storage, register it in MDR,
+// and optionally attach it directly to a project.
+const createDocumentFromTemplate = async (req: Request, res: Response) => {
   try {
     const {
       templateId,
@@ -2130,6 +2136,7 @@ router.post('/spec-sheets/from-template', async (req: Request, res: Response) =>
       title,
       fieldValues,
       description,
+      projectId,
     } = req.body;
     const user = (req as any).user;
     const createdBy = user?.username || 'system';
@@ -2189,11 +2196,16 @@ router.post('/spec-sheets/from-template', async (req: Request, res: Response) =>
     const resolvedPartNumber = finalPartNumber || manufacturedPart?.agPartNumber || null;
     const resolvedPartName = finalPartName || manufacturedPart?.name || null;
     const resolvedSku = finalSku || manufacturedPart?.sku || null;
-    const finalTitle = String(title || `SPEC Sheet - ${resolvedPartName || 'Part'}${resolvedPartNumber ? ` Part #${resolvedPartNumber}` : ''}`).trim();
+    const templateType = String(template.template_type ?? template.templateType ?? 'work_instruction');
+    const finalDepartment = String(template.department_name ?? template.departmentName ?? (templateType === 'spec_sheet' ? 'CNC' : 'Manufacturing'));
+    const fallbackTitle = `${humanizeDocumentType(templateType)} - ${resolvedPartName || resolvedPartNumber || 'New Document'}`;
+    const resolvedTitle = String(title || fallbackTitle).trim();
     const templateSections = Array.isArray(template.sections) ? template.sections : [];
-    const documentNumber = await generateSpecSheetDocumentNumber();
+    const documentNumber = templateType === 'spec_sheet' || templateType === 'specification'
+      ? await generateSpecSheetDocumentNumber()
+      : await generateControlledTemplateNumber();
     const pdfBuffer = await renderSpecSheetPdf({
-      title: finalTitle,
+      title: resolvedTitle,
       sku: resolvedSku,
       partNumber: resolvedPartNumber,
       partName: resolvedPartName,
@@ -2203,7 +2215,7 @@ router.post('/spec-sheets/from-template', async (req: Request, res: Response) =>
       templateFields,
       documentNumber,
     });
-    const fileName = normalizeSpecSheetFileName(finalTitle, resolvedPartNumber);
+    const fileName = normalizeSpecSheetFileName(resolvedTitle, resolvedPartNumber || templateType);
     const fileUrl = await saveSpecSheetPdfFile(fileName, pdfBuffer);
     const specifications = {
       templateId,
@@ -2219,30 +2231,51 @@ router.post('/spec-sheets/from-template', async (req: Request, res: Response) =>
       controlledDocumentNumber: documentNumber,
     };
 
-    const [specSheet] = await db.insert(specSheets).values({
+    const [routingDocument] = await db.insert(routingDocuments).values({
       partNumber: resolvedPartNumber,
-      title: finalTitle,
+      title: resolvedTitle,
       version: 1,
-      description: description || `Filled CNC spec sheet from template ${template.template_name ?? template.templateName}`,
-      specifications,
+      description: description || `Filled ${humanizeDocumentType(templateType)} from template ${template.template_name ?? template.templateName}`,
+      departmentName: finalDepartment,
+      documentType: templateType,
       sourceType: 'generated',
       fileUrl,
       fileName: path.basename(fileUrl),
       fileType: 'application/pdf',
       fileSize: pdfBuffer.length,
+      aiExtractedContent: specifications,
+      aiExtractedFields: templateFields,
       isTemplate: false,
       createdBy,
     }).returning();
+
+    let specSheet = null;
+    if (templateType === 'spec_sheet' || templateType === 'specification') {
+      [specSheet] = await db.insert(specSheets).values({
+        partNumber: resolvedPartNumber,
+        title: resolvedTitle,
+        version: 1,
+        description: description || `Filled spec sheet from template ${template.template_name ?? template.templateName}`,
+        specifications,
+        sourceType: 'generated',
+        fileUrl,
+        fileName: path.basename(fileUrl),
+        fileType: 'application/pdf',
+        fileSize: pdfBuffer.length,
+        isTemplate: false,
+        createdBy,
+      }).returning();
+    }
 
     const expirationDate = new Date();
     expirationDate.setFullYear(expirationDate.getFullYear() + 1);
     const [controlledDocument] = await db.insert(controlledDocuments).values({
       documentNumber,
-      documentName: finalTitle,
-      documentType: 'spec_sheet',
-      department: 'CNC',
-      category: 'Spec Sheet',
-      description: description || `Manufactured part spec sheet${resolvedPartNumber ? ` for ${resolvedPartNumber}` : ''}`,
+      documentName: resolvedTitle,
+      documentType: templateType,
+      department: finalDepartment,
+      category: templateType === 'spec_sheet' ? 'Spec Sheet' : 'Form & Document Builder',
+      description: description || `${humanizeDocumentType(templateType)} created from reusable template${resolvedPartNumber ? ` for ${resolvedPartNumber}` : ''}`,
       currentVersion: '1.0',
       status: 'pending',
       retentionLength: 'controlled',
@@ -2255,7 +2288,7 @@ router.post('/spec-sheets/from-template', async (req: Request, res: Response) =>
     await db.insert(documentVersionHistory).values({
       documentId: controlledDocument.id,
       versionNumber: '1.0',
-      changeDescription: 'Initial filled spec sheet created from Form & Document Builder template',
+      changeDescription: `Initial ${humanizeDocumentType(templateType)} created from reusable Form & Document Builder template`,
       changeType: 'major',
       filePath: fileUrl,
       status: 'pending',
@@ -2263,17 +2296,37 @@ router.post('/spec-sheets/from-template', async (req: Request, res: Response) =>
       expirationDate: expirationDate.toISOString().split('T')[0],
     });
 
+    let projectDocument = null;
+    if (projectId) {
+      projectDocument = await insertPublicRowReturning('project_documents', {
+        project_id: projectId,
+        label: resolvedTitle,
+        original_file_name: path.basename(fileUrl),
+        file_name: path.basename(fileUrl),
+        file_path: fileUrl,
+        mime_type: 'application/pdf',
+        file_size: pdfBuffer.length,
+        uploaded_by: createdBy,
+        created_at: new Date(),
+      }, ['project_id']);
+    }
+
     res.status(201).json({
+      document: routingDocument,
       specSheet,
       controlledDocument,
+      projectDocument,
       fileUrl,
       documentNumber,
     });
   } catch (error) {
-    console.error('Error creating filled spec sheet:', error);
-    res.status(500).json({ error: 'Failed to create filled spec sheet' });
+    console.error('Error creating document from template:', error);
+    res.status(500).json({ error: 'Failed to create document from template' });
   }
-});
+};
+
+router.post('/documents/from-template', createDocumentFromTemplate);
+router.post('/spec-sheets/from-template', createDocumentFromTemplate);
 
 // Create Distribution Log
 router.post('/distribution-logs', async (req: Request, res: Response) => {


### PR DESCRIPTION
## What changed

- make every reusable Form & Document Builder template open as a fillable form
- generate a finished controlled PDF from user-entered template fields
- optionally attach the generated document directly to a project
- save generated documents through durable central object storage
- register generated documents in the Master Document List and routing document library
- allow Master Document Register and Project Document viewers to serve centrally stored files

## Why

Only spec-sheet templates previously had a real fill-and-save workflow. Work-instruction and other template types were redirected into an unrelated AI generation dialog, and generated files were written to deployment-local source folders that were not durable.

## User impact

Any user can select a reusable work-instruction, specification, checklist, procedure, or other document template, enter its fields, generate a PDF, and retrieve that document later from central storage, the Master Document List, or the linked project.

## Validation

- `git diff --check`
- scoped review of the four changed files
- full TypeScript checking was unavailable in the clean worktree because dependencies are not installed
