### PR TITLE
Record traveler timers in oven cure logs

### DIFF
--- a/client/src/pages/P2TravelerPage.tsx
+++ b/client/src/pages/P2TravelerPage.tsx
@@ -2180,6 +2180,8 @@ export default function P2TravelerPage() {
         defaultSerialNumber={verificationData?.serializedItem?.serialNumber || activeTask?.barcode || ''}
         navigateToStation={false}
         badgeId={badgeInput || undefined}
+        travelerTaskId={activeTask?.id}
+        departmentName={activeTask?.department || verificationData?.nextDepartment}
         onTimerStarted={() => {
           toast({
             title: 'Timer Started',

--- a/migrations/0192_backfill_routed_timer_oven_cure_logs.sql
+++ b/migrations/0192_backfill_routed_timer_oven_cure_logs.sql
@@ -1,0 +1,84 @@
+-- Backfill Oven/Cure timer history into the traveler cure log.
+-- Idempotency is anchored on production_program_runs.linked_log_id and the
+-- timerRunId stored in cure-log metadata.
+WITH eligible_runs AS (
+  SELECT DISTINCT ON (r.id)
+    r.id AS run_id,
+    s.id AS serialized_item_id,
+    s.barcode,
+    s.part_number,
+    COALESCE(r.department_name, ts.department_name) AS department_name,
+    r.oven_number,
+    r.oven_slot,
+    r.started_at,
+    r.completed_at,
+    r.total_elapsed_seconds,
+    r.status,
+    r.traveler_id,
+    r.traveler_step_id,
+    r.traveler_task_id,
+    r.program_id,
+    p.name AS program_name
+  FROM production_program_runs r
+  JOIN production_programs p ON p.id = r.program_id
+  LEFT JOIN travelers t ON t.id = r.traveler_id
+  LEFT JOIN traveler_steps ts ON ts.id = r.traveler_step_id
+  JOIN p2_serialized_items s ON (
+    lower(s.serial_number) = lower(COALESCE(t.serial_number, t.lot_number, r.serial_number))
+    OR lower(s.barcode) = lower(COALESCE(t.serial_number, t.lot_number, r.serial_number))
+    OR lower(s.traveler_barcode) = lower(COALESCE(t.serial_number, t.lot_number, r.serial_number))
+  )
+  WHERE (r.traveler_id IS NOT NULL OR r.traveler_step_id IS NOT NULL)
+    AND lower(regexp_replace(COALESCE(r.department_name, ts.department_name, ''), '[^a-zA-Z0-9]+', ' ', 'g'))
+        ~ '(^| )(oven|cure|curing)( |$)'
+    AND r.linked_log_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM p2_oven_cure_logs existing
+      WHERE existing.metadata->>'timerRunId' = r.id::text
+    )
+  ORDER BY r.id, s.created_at DESC
+), inserted_logs AS (
+  INSERT INTO p2_oven_cure_logs (
+    serialized_item_id, barcode, part_number, department, oven_id,
+    start_time, end_time, actual_duration, result, notes, metadata
+  )
+  SELECT
+    serialized_item_id,
+    barcode,
+    part_number,
+    COALESCE(department_name, 'Oven Cure'),
+    CASE WHEN oven_number IS NOT NULL THEN 'Oven ' || oven_number::text END,
+    started_at,
+    completed_at,
+    CASE
+      WHEN completed_at IS NOT NULL THEN GREATEST(0, CEIL(EXTRACT(EPOCH FROM (completed_at - started_at)) / 60.0)::integer)
+      WHEN total_elapsed_seconds > 0 THEN CEIL(total_elapsed_seconds / 60.0)::integer
+      ELSE NULL
+    END,
+    CASE status::text
+      WHEN 'completed' THEN 'PASS'
+      WHEN 'stopped' THEN 'STOPPED'
+      ELSE 'PENDING'
+    END,
+    'Backfilled from routed timer run ' || run_id::text || ' - program: ' || program_name,
+    jsonb_build_object(
+      'source', 'timer_station_backfill',
+      'timerRunId', run_id,
+      'timerProgramId', program_id,
+      'timerProgramName', program_name,
+      'travelerId', traveler_id,
+      'travelerStepId', traveler_step_id,
+      'travelerTaskId', traveler_task_id,
+      'ovenNumber', oven_number,
+      'ovenSlot', oven_slot
+    )
+  FROM eligible_runs
+  RETURNING id, metadata
+)
+UPDATE production_program_runs r
+SET linked_log_id = inserted_logs.id,
+    linked_log_type = 'oven_cure',
+    updated_at = now()
+FROM inserted_logs
+WHERE r.id::text = inserted_logs.metadata->>'timerRunId';

--- a/server/src/lib/timerTraceability.ts
+++ b/server/src/lib/timerTraceability.ts
@@ -1,0 +1,15 @@
+export function isRoutingConnectedOvenCureRun(run: {
+  departmentName?: string | null;
+  travelerId?: string | null;
+  travelerStepId?: string | null;
+  travelerTaskId?: string | null;
+}): boolean {
+  if (!run.travelerId && !run.travelerStepId && !run.travelerTaskId) return false;
+
+  const department = (run.departmentName || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+  return /(^| )(oven|cure|curing)( |$)/.test(department);
+}

--- a/server/src/routes/productionTimers.test.ts
+++ b/server/src/routes/productionTimers.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { isRoutingConnectedOvenCureRun } from '../lib/timerTraceability';
+
+describe('isRoutingConnectedOvenCureRun', () => {
+  it.each(['Oven Cure', 'OVEN/CURE', 'Curing', 'Oven 1']) (
+    'recognizes routed cure department %s',
+    (departmentName) => {
+      expect(isRoutingConnectedOvenCureRun({ departmentName, travelerId: 'traveler-1' })).toBe(true);
+    },
+  );
+
+  it('does not infer cure traceability without a traveler connection', () => {
+    expect(isRoutingConnectedOvenCureRun({ departmentName: 'Oven Cure' })).toBe(false);
+  });
+
+  it('recognizes the active P2 traveler task passed by the traveler timer', () => {
+    expect(isRoutingConnectedOvenCureRun({
+      departmentName: 'Oven/Cure',
+      travelerTaskId: 'work-task-1',
+    })).toBe(true);
+  });
+
+  it('does not turn unrelated routed departments into cure logs', () => {
+    expect(isRoutingConnectedOvenCureRun({ departmentName: 'Layup', travelerStepId: 'step-1' })).toBe(false);
+  });
+});

--- a/server/src/routes/productionTimers.ts
+++ b/server/src/routes/productionTimers.ts
@@ -19,6 +19,7 @@ import { eq, and, desc, or, inArray, ilike } from 'drizzle-orm';
 import { z } from 'zod';
 import { authenticateToken, optionalAuth } from '../../middleware/auth';
 import { validateActionToken } from '../../middleware/actionToken';
+import { isRoutingConnectedOvenCureRun } from '../lib/timerTraceability';
 
 // ── Auto-logging helpers ──────────────────────────────────────────────────────
 // Resolves serialized item from run serial number / sku for log creation
@@ -72,7 +73,12 @@ async function autoCreateLinkedLog(
   program: any,
   userId: number | null,
 ): Promise<{ linkedLogId: string | null; linkedLogType: string | null }> {
-  const logType: string = program.logType || 'none';
+  // Routing is the source of truth for process traceability. An Oven/Cure
+  // routing step must create a cure record even when the reusable timer
+  // program was left with its legacy `none` log type.
+  const logType: string = isRoutingConnectedOvenCureRun(run)
+    ? 'oven_cure'
+    : (program.logType || 'none');
   if (logType === 'none') return { linkedLogId: null, linkedLogType: null };
 
   const item = await lookupSerializedItem(run.serialNumber, run.sku, run.travelerId || null);
@@ -159,8 +165,9 @@ async function autoCloseLinkedLog(run: any, result: 'PASS' | 'STOPPED', endTime:
   if (!run.linkedLogId || !run.linkedLogType) return;
   try {
     if (run.linkedLogType === 'oven_cure') {
+      const actualDuration = Math.max(0, Math.ceil((endTime.getTime() - new Date(run.startedAt).getTime()) / 60000));
       await db.update(p2OvenCureLogs)
-        .set({ endTime, result, updatedAt: endTime })
+        .set({ endTime, actualDuration, result, updatedAt: endTime })
         .where(eq(p2OvenCureLogs.id, run.linkedLogId));
     } else if (run.linkedLogType === 'vacuum_leak_test') {
       await db.update(p2VacuumLeakTests)


### PR DESCRIPTION
## What changed

- pass the active traveler task and department into timers launched from the P2 traveler
- classify routed Oven/Cure traveler timers as oven cure traceability records even when the reusable timer program has a legacy `none` log type
- close linked oven cure records with the timer's actual elapsed duration and result
- backfill eligible historical routed Oven/Cure timer runs into traveler cure logs
- add focused coverage for traveler-connected Oven/Cure classification

## Why

Timers started inside a traveler previously sent only the serialized-item number. Without traveler task and department context, the timer backend could not recognize the run as the routed Oven/Cure operation, so no record appeared in the traveler viewer's Oven Cure Log.

## Impact

Operators can continue using the production timer from the traveler. Oven/Cure timer starts now create a pending cure-log entry for that serialized item, and completing or stopping the timer records its end time, actual duration, and result in the traveler viewer.

## Validation

- `git diff --check`
- `git diff --cached --check`
- focused unit coverage added for traveler ID, traveler step, active P2 traveler task, and unrelated-department cases
- full automated tests were unavailable because this focused worktree has no installed project dependencies
