### PR TITLE
Add Ready to Sell intake and production routing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1350,7 +1350,7 @@ function App() {
                     component={NonconformanceReport}
                   />
 
-                  {/* RTS (Ready to Ship) Page */}
+                  {/* RTS (Ready to Sell) Page */}
                   <Route path="/rts" component={RTSPage} />
 
                   {/* Reports */}

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -587,9 +587,9 @@ export default function Navigation() {
     },
     {
       path: '/rts',
-      label: 'RTS (Ready to Ship)',
-      icon: Truck,
-      description: 'View ready-to-ship orders and manage shipments',
+      label: 'RTS (Ready to Sell)',
+      icon: DollarSign,
+      description: 'View sellable finished stock and create RTS sales',
     },
   ];
 

--- a/client/src/components/OrderActionsDrawer.tsx
+++ b/client/src/components/OrderActionsDrawer.tsx
@@ -482,7 +482,7 @@ export function OrderActionsDrawer({
                 onCheckedChange={(checked) => setSendToRts(checked as boolean)}
               />
               <Label htmlFor="send-to-rts" className="text-sm">
-                Send stock to RTS (Ready-to-Ship) inventory
+                Send stock to RTS (Ready-to-Sell) inventory
               </Label>
             </div>
           </div>

--- a/client/src/components/RTSSalesDialog.tsx
+++ b/client/src/components/RTSSalesDialog.tsx
@@ -21,11 +21,13 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Separator } from '@/components/ui/separator';
 import CustomerSearchInput from './CustomerSearchInput';
+import { BarcodeDisplay } from './BarcodeDisplay';
 import { useToast } from '@/hooks/use-toast';
 import { Package, DollarSign, Truck, CreditCard } from 'lucide-react';
 
 interface RTSInventoryItem {
   id: string;
+  rtsNumber: string;
   stockModel: string;
   actionLength: string | null;
   action: string | null;
@@ -33,6 +35,7 @@ interface RTSInventoryItem {
   bottomMetal: string | null;
   color: string | null;
   extras: string | null;
+  lastDepartment: string | null;
   status: string;
   price: number | null;
 }
@@ -74,9 +77,11 @@ export default function RTSSalesDialog({
 
   // Shipping method
   const [shippingMethod, setShippingMethod] = useState('03'); // UPS Ground
-  
-  // Department to send order to
-  const [selectedDepartment, setSelectedDepartment] = useState('QC & Shipping');
+  const [createdOrder, setCreatedOrder] = useState<{
+    orderId: string;
+    barcode: string;
+    department: string;
+  } | null>(null);
 
   // Payment info
   const [addPayment, setAddPayment] = useState(false);
@@ -106,7 +111,6 @@ export default function RTSSalesDialog({
       setPackageWidth('12');
       setPackageHeight('6');
       setShippingMethod('03');
-      setSelectedDepartment('QC & Shipping');
       setAddPayment(false);
       setPaymentType('cash');
       setPaymentAmount('');
@@ -130,6 +134,9 @@ export default function RTSSalesDialog({
       
       const paymentMsg = response.payment ? ` Payment of $${response.payment.paymentAmount.toFixed(2)} recorded.` : '';
       const orderMsg = response.order ? ` Order ${response.order.orderId} created.` : '';
+      if (response.order) {
+        setCreatedOrder(response.order);
+      }
       
       if (response.labelError) {
         toast({
@@ -294,7 +301,6 @@ export default function RTSSalesDialog({
         rtsInventoryId: itemId,
         unitPrice: itemPrices[itemId],
       })),
-      department: selectedDepartment,
       shipTo: {
         name: shipToName,
         company: shipToCompany,
@@ -331,6 +337,7 @@ export default function RTSSalesDialog({
   };
 
   return (
+    <>
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
@@ -361,6 +368,7 @@ export default function RTSSalesDialog({
                         />
                         <div className="flex-1 grid grid-cols-3 gap-2 text-sm">
                           <div>
+                            <span className="font-mono font-semibold mr-2">{item.rtsNumber}</span>
                             <span className="font-medium">{item.stockModel}</span>
                             {item.actionLength && <span className="text-muted-foreground"> • {item.actionLength}</span>}
                           </div>
@@ -369,6 +377,7 @@ export default function RTSSalesDialog({
                           </div>
                           <div className="text-muted-foreground">
                             {item.color}
+                            {item.lastDepartment && ` • Last: ${item.lastDepartment}`}
                           </div>
                         </div>
                         {selectedItemIds.has(item.id) && (
@@ -493,36 +502,6 @@ export default function RTSSalesDialog({
                   onChange={(e) => setShipToPhone(e.target.value)}
                   data-testid="input-ship-to-phone"
                 />
-              </div>
-            </div>
-          </div>
-
-          <Separator />
-
-          {/* Department Selection */}
-          <div>
-            <h3 className="font-semibold mb-3">Send Order To Department</h3>
-            <div className="grid grid-cols-1 gap-4">
-              <div>
-                <Label htmlFor="department">Department *</Label>
-                <Select value={selectedDepartment} onValueChange={setSelectedDepartment}>
-                  <SelectTrigger data-testid="select-department">
-                    <SelectValue placeholder="Select department" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Layup/Plugging">Layup/Plugging</SelectItem>
-                    <SelectItem value="CNC">CNC</SelectItem>
-                    <SelectItem value="Gunsmith">Gunsmith</SelectItem>
-                    <SelectItem value="Finish">Finish</SelectItem>
-                    <SelectItem value="Finish QC">Finish QC</SelectItem>
-                    <SelectItem value="Paint">Paint</SelectItem>
-                    <SelectItem value="QC & Shipping">QC & Shipping</SelectItem>
-                    <SelectItem value="Shipping">Shipping</SelectItem>
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground mt-1">
-                  Orders will be sent to the selected department after sale is created
-                </p>
               </div>
             </div>
           </div>
@@ -688,5 +667,31 @@ export default function RTSSalesDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+    <Dialog open={!!createdOrder} onOpenChange={(open) => !open && setCreatedOrder(null)}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Production Order Created</DialogTitle>
+        </DialogHeader>
+        {createdOrder && (
+          <div className="space-y-4">
+            <div className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-900">
+              Order <span className="font-mono font-semibold">{createdOrder.orderId}</span> was
+              entered into the regular {createdOrder.department} queue. Print this barcode and
+              attach it to the item before sending it to production.
+            </div>
+            <BarcodeDisplay
+              orderId={createdOrder.orderId}
+              barcode={createdOrder.barcode}
+              titleLabel="Production Order Barcode"
+              printHeaderLabel="P1 ORDER"
+            />
+            <DialogFooter>
+              <Button onClick={() => setCreatedOrder(null)}>Done</Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+    </>
   );
 }

--- a/client/src/pages/DARLENEBTestDashboard.tsx
+++ b/client/src/pages/DARLENEBTestDashboard.tsx
@@ -170,7 +170,7 @@ export default function DARLENEBTestDashboard() {
               <CardContent className="p-4 text-center">
                 <Truck className="w-8 h-8 text-teal-600 mx-auto mb-3" />
                 <h3 className={`text-sm font-semibold ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>
-                  RTS (Ready to Ship)
+                  RTS (Ready to Sell)
                 </h3>
                 <p className={`text-xs mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
                   Manage shipments

--- a/client/src/pages/RTSPage.tsx
+++ b/client/src/pages/RTSPage.tsx
@@ -18,6 +18,13 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import {
   Dialog,
@@ -34,14 +41,17 @@ import {
   Plus,
   DollarSign,
   Edit,
+  QrCode,
   Truck,
   Factory,
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import RTSSalesDialog from '@/components/RTSSalesDialog';
+import { BarcodeDisplay } from '@/components/BarcodeDisplay';
 
 interface RTSInventoryItem {
   id: string;
+  rtsNumber: string;
   stockModel: string;
   actionLength: string | null;
   action: string | null;
@@ -49,6 +59,7 @@ interface RTSInventoryItem {
   bottomMetal: string | null;
   color: string | null;
   extras: string | null;
+  lastDepartment: string | null;
   status: string;
   currentDepartment: string | null;
   returnReason: string | null;
@@ -58,6 +69,28 @@ interface RTSInventoryItem {
   price: number | null;
 }
 
+const RTS_LAST_DEPARTMENTS = [
+  'Layup/Plugging',
+  'Barcode',
+  'CNC',
+  'Gunsmith',
+  'Finish',
+  'Finish QC',
+  'Paint',
+  'Shipping QC',
+] as const;
+
+const RTS_NEXT_DEPARTMENT: Record<(typeof RTS_LAST_DEPARTMENTS)[number], string> = {
+  'Layup/Plugging': 'Barcode',
+  Barcode: 'CNC',
+  CNC: 'Gunsmith',
+  Gunsmith: 'Finish',
+  Finish: 'Finish QC',
+  'Finish QC': 'Paint',
+  Paint: 'Shipping QC',
+  'Shipping QC': 'Shipping',
+};
+
 export default function RTSPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [addItemDialog, setAddItemDialog] = useState(false);
@@ -65,6 +98,7 @@ export default function RTSPage() {
     isOpen: boolean;
     item: RTSInventoryItem | null;
   }>({ isOpen: false, item: null });
+  const [barcodeItem, setBarcodeItem] = useState<RTSInventoryItem | null>(null);
   const [salesDialogOpen, setSalesDialogOpen] = useState(false);
   const [newItem, setNewItem] = useState({
     stockModel: '',
@@ -74,6 +108,7 @@ export default function RTSPage() {
     bottomMetal: '',
     color: '',
     extras: '',
+    lastDepartment: '',
   });
   const [editItem, setEditItem] = useState({
     stockModel: '',
@@ -83,6 +118,7 @@ export default function RTSPage() {
     bottomMetal: '',
     color: '',
     extras: '',
+    lastDepartment: '',
     price: '',
   });
 
@@ -105,7 +141,8 @@ export default function RTSPage() {
       item.barrel?.toLowerCase().includes(searchLower) ||
       item.bottomMetal?.toLowerCase().includes(searchLower) ||
       item.color?.toLowerCase().includes(searchLower) ||
-      item.extras?.toLowerCase().includes(searchLower)
+      item.extras?.toLowerCase().includes(searchLower) ||
+      item.rtsNumber?.toLowerCase().includes(searchLower)
     );
   });
 
@@ -117,13 +154,14 @@ export default function RTSPage() {
         body: JSON.stringify(item),
       });
     },
-    onSuccess: () => {
+    onSuccess: (createdItem: RTSInventoryItem) => {
       queryClient.invalidateQueries({ queryKey: ['/api/rts-inventory'] });
       toast({
         title: 'Item Added',
-        description: 'RTS inventory item has been added successfully.',
+        description: `${createdItem.rtsNumber} was added and is ready for a stock label.`,
       });
       setAddItemDialog(false);
+      setBarcodeItem(createdItem);
       setNewItem({
         stockModel: '',
         actionLength: '',
@@ -132,12 +170,13 @@ export default function RTSPage() {
         bottomMetal: '',
         color: '',
         extras: '',
+        lastDepartment: '',
       });
     },
-    onError: () => {
+    onError: (error: any) => {
       toast({
         title: 'Error',
-        description: 'Failed to add RTS inventory item.',
+        description: error.message || 'Failed to add RTS inventory item.',
         variant: 'destructive',
       });
     },
@@ -166,13 +205,14 @@ export default function RTSPage() {
         bottomMetal: '',
         color: '',
         extras: '',
+        lastDepartment: '',
         price: '',
       });
     },
-    onError: () => {
+    onError: (error: any) => {
       toast({
         title: 'Error',
-        description: 'Failed to update RTS inventory item.',
+        description: error.message || 'Failed to update RTS inventory item.',
         variant: 'destructive',
       });
     },
@@ -228,9 +268,9 @@ export default function RTSPage() {
         <div className="flex items-center gap-3">
           <Package className="h-8 w-8 text-primary" />
           <div>
-            <h1 className="text-3xl font-bold">Ready to Ship (RTS)</h1>
+            <h1 className="text-3xl font-bold">Ready to Sell (RTS)</h1>
             <p className="text-sm text-gray-600">
-              Finished stock inventory ready for shipment or production triage
+              Finished stock inventory available for sale or production re-entry
             </p>
           </div>
         </div>
@@ -268,7 +308,7 @@ export default function RTSPage() {
             <div className="flex-1 relative">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
               <Input
-                placeholder="Search by stock model, action, barrel, color, etc..."
+                placeholder="Search by RTS number, stock model, action, barrel, color..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10"
@@ -304,6 +344,7 @@ export default function RTSPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
+                    <TableHead>RTS Number</TableHead>
                     <TableHead>Stock Model</TableHead>
                     <TableHead>Action Length</TableHead>
                     <TableHead>Action</TableHead>
@@ -311,6 +352,7 @@ export default function RTSPage() {
                     <TableHead>Bottom Metal</TableHead>
                     <TableHead>Color</TableHead>
                     <TableHead>Extras</TableHead>
+                    <TableHead>Last Department</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead>Actions</TableHead>
                   </TableRow>
@@ -318,6 +360,7 @@ export default function RTSPage() {
                 <TableBody>
                   {availableInventory.map((item) => (
                     <TableRow key={item.id} data-testid={`row-rts-${item.id}`}>
+                      <TableCell className="font-mono font-semibold">{item.rtsNumber}</TableCell>
                       <TableCell className="font-medium" data-testid={`text-stock-model-${item.id}`}>
                         {item.stockModel}
                       </TableCell>
@@ -327,6 +370,14 @@ export default function RTSPage() {
                       <TableCell>{item.bottomMetal || 'N/A'}</TableCell>
                       <TableCell>{item.color || 'N/A'}</TableCell>
                       <TableCell>{item.extras || 'N/A'}</TableCell>
+                      <TableCell>
+                        <div>{item.lastDepartment || 'Not set'}</div>
+                        {item.lastDepartment && (
+                          <div className="text-xs text-muted-foreground">
+                            Resumes in {RTS_NEXT_DEPARTMENT[item.lastDepartment as keyof typeof RTS_NEXT_DEPARTMENT]}
+                          </div>
+                        )}
+                      </TableCell>
                       <TableCell>{getStatusBadge(item.status)}</TableCell>
                       <TableCell>
                         <div className="flex gap-2">
@@ -343,6 +394,7 @@ export default function RTSPage() {
                                 bottomMetal: item.bottomMetal || '',
                                 color: item.color || '',
                                 extras: item.extras || '',
+                                lastDepartment: item.lastDepartment || '',
                                 price: item.price?.toString() || '',
                               });
                             }}
@@ -351,6 +403,16 @@ export default function RTSPage() {
                           >
                             <Edit className="h-3 w-3" />
                             Edit
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setBarcodeItem(item)}
+                            className="flex items-center gap-1"
+                            data-testid={`button-print-barcode-${item.id}`}
+                          >
+                            <QrCode className="h-3 w-3" />
+                            Barcode
                           </Button>
                         </div>
                       </TableCell>
@@ -460,6 +522,28 @@ export default function RTSPage() {
                 data-testid="input-extras"
               />
             </div>
+
+            <div>
+              <Label htmlFor="lastDepartment">Last Department Item Finished *</Label>
+              <Select
+                value={newItem.lastDepartment}
+                onValueChange={(lastDepartment) => setNewItem({ ...newItem, lastDepartment })}
+              >
+                <SelectTrigger id="lastDepartment" data-testid="select-last-department">
+                  <SelectValue placeholder="Select the last completed department" />
+                </SelectTrigger>
+                <SelectContent>
+                  {RTS_LAST_DEPARTMENTS.map((department) => (
+                    <SelectItem key={department} value={department}>{department}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground mt-1">
+                {newItem.lastDepartment
+                  ? `When purchased, the production order will enter ${RTS_NEXT_DEPARTMENT[newItem.lastDepartment as keyof typeof RTS_NEXT_DEPARTMENT]}.`
+                  : 'This determines where the item resumes as a regular production order.'}
+              </p>
+            </div>
           </div>
           <DialogFooter>
             <Button
@@ -474,6 +558,7 @@ export default function RTSPage() {
                   bottomMetal: '',
                   color: '',
                   extras: '',
+                  lastDepartment: '',
                 });
               }}
             >
@@ -481,7 +566,7 @@ export default function RTSPage() {
             </Button>
             <Button
               onClick={() => addItemMutation.mutate(newItem)}
-              disabled={addItemMutation.isPending || !newItem.stockModel.trim()}
+              disabled={addItemMutation.isPending || !newItem.stockModel.trim() || !newItem.lastDepartment}
               data-testid="button-confirm-add-item"
             >
               {addItemMutation.isPending ? 'Adding...' : 'Add Item'}
@@ -619,6 +704,23 @@ export default function RTSPage() {
                 data-testid="input-edit-price"
               />
             </div>
+
+            <div>
+              <Label htmlFor="edit-lastDepartment">Last Department Item Finished *</Label>
+              <Select
+                value={editItem.lastDepartment}
+                onValueChange={(lastDepartment) => setEditItem({ ...editItem, lastDepartment })}
+              >
+                <SelectTrigger id="edit-lastDepartment" data-testid="select-edit-last-department">
+                  <SelectValue placeholder="Select the last completed department" />
+                </SelectTrigger>
+                <SelectContent>
+                  {RTS_LAST_DEPARTMENTS.map((department) => (
+                    <SelectItem key={department} value={department}>{department}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
           <DialogFooter>
             <Button
@@ -633,6 +735,7 @@ export default function RTSPage() {
                   bottomMetal: '',
                   color: '',
                   extras: '',
+                  lastDepartment: '',
                   price: '',
                 });
               }}
@@ -648,12 +751,31 @@ export default function RTSPage() {
                   });
                 }
               }}
-              disabled={editItemMutation.isPending || !editItem.stockModel.trim()}
+              disabled={editItemMutation.isPending || !editItem.stockModel.trim() || !editItem.lastDepartment}
               data-testid="button-confirm-edit-item"
             >
               {editItemMutation.isPending ? 'Updating...' : 'Update Item'}
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!barcodeItem} onOpenChange={(open) => !open && setBarcodeItem(null)}>
+        <DialogContent className="max-w-4xl">
+          <DialogHeader>
+            <DialogTitle>RTS Stock Barcode</DialogTitle>
+          </DialogHeader>
+          {barcodeItem && (
+            <BarcodeDisplay
+              orderId={barcodeItem.rtsNumber}
+              barcode={barcodeItem.rtsNumber}
+              stockModel={barcodeItem.stockModel}
+              actionLength={barcodeItem.actionLength || undefined}
+              color={barcodeItem.color || undefined}
+              titleLabel="Ready to Sell Item"
+              printHeaderLabel="RTS STOCK"
+            />
+          )}
         </DialogContent>
       </Dialog>
 

--- a/migrations/0193_rts_ready_to_sell_item_identity.sql
+++ b/migrations/0193_rts_ready_to_sell_item_identity.sql
@@ -1,0 +1,17 @@
+CREATE SEQUENCE IF NOT EXISTS rts_item_number_seq;
+
+ALTER TABLE rts_inventory
+  ADD COLUMN IF NOT EXISTS rts_number TEXT,
+  ADD COLUMN IF NOT EXISTS last_department TEXT;
+
+UPDATE rts_inventory
+SET rts_number = 'RTS-I-LEGACY-' || upper(left(replace(id::text, '-', ''), 12))
+WHERE rts_number IS NULL OR btrim(rts_number) = '';
+
+ALTER TABLE rts_inventory
+  ALTER COLUMN rts_number SET DEFAULT
+    ('RTS-I-' || to_char(CURRENT_DATE, 'YYYY') || '-' || lpad(nextval('rts_item_number_seq')::text, 6, '0')),
+  ALTER COLUMN rts_number SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rts_inventory_rts_number_unique
+  ON rts_inventory (rts_number);

--- a/server/__tests__/rtsProductionRouting.test.ts
+++ b/server/__tests__/rtsProductionRouting.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getNextRtsDepartment } from '../src/lib/rtsProductionRouting';
+
+describe('getNextRtsDepartment', () => {
+  it.each([
+    ['Layup/Plugging', 'Barcode'],
+    ['Barcode', 'CNC'],
+    ['CNC', 'Gunsmith'],
+    ['Gunsmith', 'Finish'],
+    ['Finish', 'Finish QC'],
+    ['Finish QC', 'Paint'],
+    ['Paint', 'Shipping QC'],
+    ['Shipping QC', 'Shipping'],
+  ])('resumes after %s in %s', (lastDepartment, nextDepartment) => {
+    expect(getNextRtsDepartment(lastDepartment)).toBe(nextDepartment);
+  });
+
+  it.each([null, undefined, '', 'Shipping', 'Unknown'])(
+    'rejects an unroutable completion point: %s',
+    (lastDepartment) => {
+      expect(getNextRtsDepartment(lastDepartment)).toBeNull();
+    },
+  );
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -945,9 +945,13 @@ export const partsRequestStatusHistory = pgTable('parts_request_status_history',
   createdAt: timestamp('created_at').defaultNow(),
 });
 
-// Ready to Ship (RTS) Inventory - Finished products on hand
+// Ready to Sell (RTS) Inventory - Finished products on hand
 export const rtsInventory = pgTable('rts_inventory', {
   id: uuid('id').defaultRandom().primaryKey(),
+  rtsNumber: text('rts_number')
+    .notNull()
+    .unique()
+    .default(sql`'RTS-I-' || to_char(CURRENT_DATE, 'YYYY') || '-' || lpad(nextval('rts_item_number_seq')::text, 6, '0')`),
   stockModel: text('stock_model').notNull(),
   actionLength: text('action_length'),
   action: text('action'),
@@ -955,6 +959,7 @@ export const rtsInventory = pgTable('rts_inventory', {
   bottomMetal: text('bottom_metal'),
   color: text('color'),
   extras: text('extras'), // Order/identifier codes
+  lastDepartment: text('last_department'), // Last completed production department before RTS
   price: real('price'), // Sale price for this item
   status: text('status').notNull().default('AVAILABLE'), // AVAILABLE, SHIPPED, IN_PRODUCTION, SOLD
   currentDepartment: text('current_department'), // If sent back to production

--- a/server/src/lib/rtsProductionRouting.ts
+++ b/server/src/lib/rtsProductionRouting.ts
@@ -1,0 +1,20 @@
+export const RTS_DEPARTMENT_FLOW = [
+  'Layup/Plugging',
+  'Barcode',
+  'CNC',
+  'Gunsmith',
+  'Finish',
+  'Finish QC',
+  'Paint',
+  'Shipping QC',
+  'Shipping',
+] as const;
+
+export function getNextRtsDepartment(lastDepartment: string | null | undefined): string | null {
+  const lastDepartmentIndex = (RTS_DEPARTMENT_FLOW as readonly string[])
+    .indexOf(lastDepartment || '');
+
+  return lastDepartmentIndex >= 0 && lastDepartmentIndex < RTS_DEPARTMENT_FLOW.length - 1
+    ? RTS_DEPARTMENT_FLOW[lastDepartmentIndex + 1]
+    : null;
+}

--- a/server/src/routes/rtsInventory.ts
+++ b/server/src/routes/rtsInventory.ts
@@ -4,9 +4,20 @@ import { rtsInventory, rtsInventoryHistory, insertRtsInventorySchema } from '../
 import { eq, desc } from 'drizzle-orm';
 import XLSX from 'xlsx';
 import multer from 'multer';
+import { z } from 'zod';
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
+const rtsLastDepartmentSchema = z.enum([
+  'Layup/Plugging',
+  'Barcode',
+  'CNC',
+  'Gunsmith',
+  'Finish',
+  'Finish QC',
+  'Paint',
+  'Shipping QC',
+]);
 
 // Get all RTS inventory items
 router.get('/', async (req, res) => {
@@ -77,8 +88,10 @@ router.get('/:id/history', async (req, res) => {
 // Create a new RTS inventory item manually
 router.post('/', async (req, res) => {
   try {
+    const lastDepartment = rtsLastDepartmentSchema.parse(req.body.lastDepartment);
     const validatedData = insertRtsInventorySchema.parse({
       ...req.body,
+      lastDepartment,
       status: 'AVAILABLE',
     });
 
@@ -95,8 +108,54 @@ router.post('/', async (req, res) => {
 
     res.json(inserted);
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: 'A valid last department is required' });
+    }
     console.error('Error creating RTS inventory item:', error);
     res.status(500).json({ error: 'Failed to create item' });
+  }
+});
+
+// Update sellable-stock details and the saved production resume point.
+router.patch('/:id', async (req, res) => {
+  try {
+    const lastDepartment = rtsLastDepartmentSchema.parse(req.body.lastDepartment);
+    const price = req.body.price === '' || req.body.price == null
+      ? null
+      : Number(req.body.price);
+
+    if (price !== null && !Number.isFinite(price)) {
+      return res.status(400).json({ error: 'Price must be a valid number' });
+    }
+
+    const [updated] = await db
+      .update(rtsInventory)
+      .set({
+        stockModel: req.body.stockModel,
+        actionLength: req.body.actionLength || null,
+        action: req.body.action || null,
+        barrel: req.body.barrel || null,
+        bottomMetal: req.body.bottomMetal || null,
+        color: req.body.color || null,
+        extras: req.body.extras || null,
+        lastDepartment,
+        price,
+        updatedAt: new Date(),
+      })
+      .where(eq(rtsInventory.id, req.params.id))
+      .returning();
+
+    if (!updated) {
+      return res.status(404).json({ error: 'Item not found' });
+    }
+
+    res.json(updated);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: 'A valid last department is required' });
+    }
+    console.error('Error updating RTS inventory item:', error);
+    res.status(500).json({ error: 'Failed to update item' });
   }
 });
 
@@ -115,6 +174,7 @@ router.post('/import', upload.single('file'), async (req, res) => {
     const insertedItems = [];
 
     for (const row of data) {
+      const lastDepartment = rtsLastDepartmentSchema.parse((row as any)['Last Department']);
       const item = {
         stockModel: (row as any)['Stock Model'] || '',
         actionLength: (row as any)['Action Length'] || null,
@@ -123,6 +183,7 @@ router.post('/import', upload.single('file'), async (req, res) => {
         bottomMetal: (row as any)['Bottom Metal'] || null,
         color: (row as any)['Color'] || null,
         extras: (row as any)['Extras'] || null,
+        lastDepartment,
         status: 'AVAILABLE',
       };
 
@@ -145,6 +206,11 @@ router.post('/import', upload.single('file'), async (req, res) => {
       items: insertedItems,
     });
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        error: 'Every imported item requires a valid Last Department value',
+      });
+    }
     console.error('Error importing RTS inventory:', error);
     res.status(500).json({ error: 'Failed to import inventory' });
   }

--- a/server/src/routes/rtsSales.ts
+++ b/server/src/routes/rtsSales.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import { createShipment } from '../utils/upsShipping';
 import { storage } from '../../storage';
 import { recordOrderCreatedEvent } from '../services/orderActivityService';
+import { getNextRtsDepartment } from '../lib/rtsProductionRouting';
 
 const router = Router();
 
@@ -67,7 +68,6 @@ const createSaleSchema = z.object({
     unitPrice: z.number(),
     quantity: z.number().default(1),
   })).min(1),
-  department: z.string().default('QC & Shipping'), // Department to send order to
   shipTo: z.object({
     name: z.string(),
     company: z.string().optional(),
@@ -118,6 +118,24 @@ router.post('/', async (req, res) => {
     if (selectedItems.length !== data.items.length) {
       return res.status(400).json({ error: 'Some selected items are not available' });
     }
+
+    const unroutableItem = selectedItems.find(item => !getNextRtsDepartment(item.lastDepartment));
+    if (unroutableItem) {
+      return res.status(400).json({
+        error: `${unroutableItem.rtsNumber} needs a valid last department before it can re-enter production`,
+      });
+    }
+
+    const nextDepartments = new Set(
+      selectedItems.map(item => getNextRtsDepartment(item.lastDepartment)),
+    );
+    if (nextDepartments.size !== 1) {
+      return res.status(400).json({
+        error: 'Selected RTS items resume in different departments. Create separate sales for each department flow.',
+      });
+    }
+    const nextDepartment = Array.from(nextDepartments)[0]!;
+    const lastDepartments = Array.from(new Set(selectedItems.map(item => item.lastDepartment)));
 
     // Calculate totals
     const subtotal = data.items.reduce((sum, item) => sum + (item.unitPrice * item.quantity), 0);
@@ -192,7 +210,7 @@ router.post('/', async (req, res) => {
       });
     }
 
-    // Create an order in allOrders that goes directly to Shipping QC
+    // Create a normal production order after the saved RTS completion point.
     // Generate unique order ID using atomic sequence (shared with regular orders)
     const newOrderId = await storage.generateNextOrderId();
 
@@ -205,13 +223,14 @@ router.post('/', async (req, res) => {
     const order = await db.transaction(async (tx) => {
       const [insertedOrder] = await tx.insert(allOrders).values({
         orderId: newOrderId,
+        barcode: `P1-${newOrderId}`,
         orderDate: new Date(),
         dueDate: new Date(), // Due today since it's ready to ship
         customerId: data.customerId,
         modelId: firstItem.stockModel, // Use stock model as modelId
         status: 'IN_PROGRESS',
-        currentDepartment: data.department, // Send to selected department
-        notes: `RTS Sale: ${saleNumber}. ${modelDescription}`,
+        currentDepartment: nextDepartment,
+        notes: `RTS Sale: ${saleNumber}. ${modelDescription}. Stock: ${selectedItems.map(item => item.rtsNumber).join(', ')}`,
         isRtsOrder: true, // Mark as RTS order
         rtsSaleId: sale.id, // Link to RTS sale
         priceOverride: subtotal, // Store RTS sale subtotal as price override for display in OrderEntry
@@ -242,10 +261,16 @@ router.post('/', async (req, res) => {
           source: 'rts_sales',
           sourceRoute: '/api/rts-sales',
           reasonCode: 'RTS_SALE',
-          reasonText: `RTS Sale ${saleNumber} — initial department: ${data.department}`,
+          reasonText: `RTS Sale ${saleNumber} — resumed after ${lastDepartments.join(', ')} in ${nextDepartment}`,
           relatedEntityType: 'rts_sale',
           relatedEntityId: String(sale.id),
-          metadata: { saleNumber, rtsSaleId: sale.id },
+          metadata: {
+            saleNumber,
+            rtsSaleId: sale.id,
+            rtsNumbers: selectedItems.map(item => item.rtsNumber),
+            lastDepartments,
+            resumedDepartment: nextDepartment,
+          },
         }
       );
 
@@ -325,7 +350,7 @@ router.post('/', async (req, res) => {
 
         res.json({
           sale: { ...sale, orderId: newOrderId, trackingNumber: labelResult.trackingNumber, shippingLabelUrl: labelData },
-          order: { orderId: newOrderId },
+          order: { orderId: newOrderId, barcode: `P1-${newOrderId}`, department: nextDepartment },
           label: labelResult,
           payment: paymentRecord,
         });
@@ -334,7 +359,7 @@ router.post('/', async (req, res) => {
         // Sale was created successfully, but label generation failed
         res.json({
           sale: { ...sale, orderId: newOrderId },
-          order: { orderId: newOrderId },
+          order: { orderId: newOrderId, barcode: `P1-${newOrderId}`, department: nextDepartment },
           labelError: labelError.message || 'Failed to generate shipping label',
           payment: paymentRecord,
         });
@@ -342,7 +367,7 @@ router.post('/', async (req, res) => {
     } else {
       res.json({ 
         sale: { ...sale, orderId: newOrderId },
-        order: { orderId: newOrderId },
+        order: { orderId: newOrderId, barcode: `P1-${newOrderId}`, department: nextDepartment },
         payment: paymentRecord,
       });
     }


### PR DESCRIPTION
## What changed

- renames the Order Management RTS surface from Ready to Ship to Ready to Sell
- requires the last completed department when adding or editing sellable stock
- assigns each new RTS item a durable number such as `RTS-I-2026-000001`
- makes the RTS number searchable and displays the saved and next production departments
- adds immediate RTS stock-barcode printing after intake and from each inventory row
- derives the production resume department on the server instead of asking at sale time
- creates the purchased item as a normal P1 production order in the next department
- opens a printable P1 production barcode after the sale creates the order
- adds a migration and focused department-routing regression test

## Why

RTS inventory previously had no operator-friendly stock identity, did not retain where an item had finished production, and asked users to choose a destination department during the sale. That made it difficult to locate physical stock and allowed items to resume in the wrong queue.

## User impact

Operators can label an RTS item as soon as it enters sellable inventory, find it by its permanent RTS number, and record its last completed department. When purchased, the system automatically places the generated regular order into the correct next production queue and provides the production barcode needed to move the physical item through that queue.

## Validation

- `git diff --check`
- focused routing test added for every supported department transition and invalid completion points
- branch rebased onto current `origin/main`
- full TypeScript and test execution unavailable because this clean worktree does not have project dependencies or PATH Node tooling installed
