### PR TITLE
Add audited removal to Ready to Sell queue

### DIFF
--- a/client/src/pages/RTSPage.tsx
+++ b/client/src/pages/RTSPage.tsx
@@ -27,6 +27,16 @@ import {
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -42,6 +52,7 @@ import {
   DollarSign,
   Edit,
   QrCode,
+  Trash2,
   Truck,
   Factory,
 } from 'lucide-react';
@@ -99,6 +110,7 @@ export default function RTSPage() {
     item: RTSInventoryItem | null;
   }>({ isOpen: false, item: null });
   const [barcodeItem, setBarcodeItem] = useState<RTSInventoryItem | null>(null);
+  const [deleteItem, setDeleteItem] = useState<RTSInventoryItem | null>(null);
   const [salesDialogOpen, setSalesDialogOpen] = useState(false);
   const [newItem, setNewItem] = useState({
     stockModel: '',
@@ -213,6 +225,29 @@ export default function RTSPage() {
       toast({
         title: 'Error',
         description: error.message || 'Failed to update RTS inventory item.',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const deleteItemMutation = useMutation({
+    mutationFn: async (item: RTSInventoryItem) => {
+      return apiRequest(`/api/rts-inventory/${item.id}`, {
+        method: 'DELETE',
+      });
+    },
+    onSuccess: (_response, item) => {
+      queryClient.invalidateQueries({ queryKey: ['/api/rts-inventory'] });
+      toast({
+        title: 'Item Removed',
+        description: `${item.rtsNumber} was removed from the Ready to Sell queue.`,
+      });
+      setDeleteItem(null);
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Unable to Remove Item',
+        description: error.message || 'Failed to remove the RTS inventory item.',
         variant: 'destructive',
       });
     },
@@ -413,6 +448,16 @@ export default function RTSPage() {
                           >
                             <QrCode className="h-3 w-3" />
                             Barcode
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setDeleteItem(item)}
+                            className="flex items-center gap-1 text-destructive hover:text-destructive"
+                            data-testid={`button-delete-${item.id}`}
+                          >
+                            <Trash2 className="h-3 w-3" />
+                            Delete
                           </Button>
                         </div>
                       </TableCell>
@@ -778,6 +823,32 @@ export default function RTSPage() {
           )}
         </DialogContent>
       </Dialog>
+
+      <AlertDialog open={!!deleteItem} onOpenChange={(open) => !open && setDeleteItem(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Ready to Sell Item?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteItem
+                ? `Remove ${deleteItem.rtsNumber} (${deleteItem.stockModel}) from the Ready to Sell queue? Its history will be retained for audit purposes.`
+                : 'Remove this item from the Ready to Sell queue?'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteItemMutation.isPending}>
+              Keep Item
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteItem && deleteItemMutation.mutate(deleteItem)}
+              disabled={!deleteItem || deleteItemMutation.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid="button-confirm-delete-rts"
+            >
+              {deleteItemMutation.isPending ? 'Removing...' : 'Remove Item'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* RTS Sales Dialog */}
       <RTSSalesDialog

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -961,7 +961,7 @@ export const rtsInventory = pgTable('rts_inventory', {
   extras: text('extras'), // Order/identifier codes
   lastDepartment: text('last_department'), // Last completed production department before RTS
   price: real('price'), // Sale price for this item
-  status: text('status').notNull().default('AVAILABLE'), // AVAILABLE, SHIPPED, IN_PRODUCTION, SOLD
+  status: text('status').notNull().default('AVAILABLE'), // AVAILABLE, SHIPPED, IN_PRODUCTION, SOLD, REMOVED
   currentDepartment: text('current_department'), // If sent back to production
   returnReason: text('return_reason'), // Why sent back to production
   returnNotes: text('return_notes'), // Notes about changes needed

--- a/server/src/routes/rtsInventory.ts
+++ b/server/src/routes/rtsInventory.ts
@@ -372,17 +372,51 @@ router.post('/:id/send-to-production', async (req, res) => {
   }
 });
 
-// Delete an item
+// Remove an item from the sellable queue while preserving its audit history.
 router.delete('/:id', async (req, res) => {
   try {
     const { id } = req.params;
+    const performedBy = req.user?.username || 'Unknown';
 
-    await db.delete(rtsInventory).where(eq(rtsInventory.id, id));
+    const [item] = await db
+      .select()
+      .from(rtsInventory)
+      .where(eq(rtsInventory.id, id));
 
-    res.json({ message: 'Item deleted successfully' });
+    if (!item) {
+      return res.status(404).json({ error: 'Item not found' });
+    }
+
+    if (item.status !== 'AVAILABLE') {
+      return res.status(400).json({ error: 'Only available RTS items can be removed' });
+    }
+
+    const removed = await db.transaction(async (tx) => {
+      const [updated] = await tx
+        .update(rtsInventory)
+        .set({
+          status: 'REMOVED',
+          updatedAt: new Date(),
+        })
+        .where(eq(rtsInventory.id, id))
+        .returning();
+
+      await tx.insert(rtsInventoryHistory).values({
+        rtsInventoryId: id,
+        action: 'REMOVED',
+        fromStatus: 'AVAILABLE',
+        toStatus: 'REMOVED',
+        performedBy,
+        notes: 'Removed from the Ready to Sell queue',
+      });
+
+      return updated;
+    });
+
+    res.json({ message: 'Item removed successfully', item: removed });
   } catch (error) {
-    console.error('Error deleting RTS inventory item:', error);
-    res.status(500).json({ error: 'Failed to delete item' });
+    console.error('Error removing RTS inventory item:', error);
+    res.status(500).json({ error: 'Failed to remove item' });
   }
 });
 


### PR DESCRIPTION
## What changed

- adds a Delete action to each available item on the Ready to Sell page
- requires confirmation showing the permanent RTS number and stock model
- removes the item from the active queue by transitioning it to `REMOVED`
- preserves an auditable RTS history entry instead of physically deleting the database record
- prevents sold, shipped, or in-production items from being removed through this action

## Why

Users need to correct mistakenly entered sellable-stock records directly from the RTS queue. The previous backend delete attempted to physically remove the inventory row even though every item already had linked history, which could violate the history foreign key and lose traceability.

## User impact

Available RTS items can now be safely removed from the queue from the row actions. The queue refreshes immediately, while the item identity and removal history remain available for audit.

## Validation

- `git diff --check`
- follow-up commit rebased onto current `origin/main`
- full TypeScript and test execution unavailable because this clean worktree does not have project dependencies or PATH Node tooling installed
