### PR TITLE
Prevent P1 PO over-progression and preserve schedule history

### DIFF
--- a/client/src/components/ScheduleHistoryDialog.tsx
+++ b/client/src/components/ScheduleHistoryDialog.tsx
@@ -79,7 +79,7 @@ export function ScheduleHistoryDialog({ open, onClose }: ScheduleHistoryDialogPr
               <FileText className="w-16 h-16 text-gray-300 mb-4" />
               <p className="text-gray-500">No schedules found</p>
               <p className="text-sm text-gray-400 mt-1">
-                Approved schedules will appear here
+                Scheduled work will appear here
               </p>
             </div>
           ) : (

--- a/migrations/0194_layup_schedule_history.sql
+++ b/migrations/0194_layup_schedule_history.sql
@@ -1,0 +1,240 @@
+CREATE TABLE IF NOT EXISTS layup_schedule_history (
+  history_id bigserial PRIMARY KEY,
+  event_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  source_schedule_id integer NOT NULL,
+  order_id text NOT NULL,
+  scheduled_date timestamp,
+  mold_id text,
+  employee_assignments jsonb NOT NULL DEFAULT '[]'::jsonb,
+  is_override boolean DEFAULT false,
+  overridden_at timestamp,
+  overridden_by text,
+  created_at timestamp,
+  updated_at timestamp,
+  layup_day date,
+  week_locked boolean DEFAULT false,
+  customer_name text,
+  stock_model text,
+  material_type text,
+  action_length text,
+  lop_value text,
+  fb_order_number text,
+  schedule_snapshot jsonb,
+  history_action text NOT NULL CHECK (history_action IN ('INSERT', 'UPDATE', 'DELETE', 'BACKFILL')),
+  previous_row jsonb,
+  recorded_row jsonb NOT NULL,
+  transaction_id bigint NOT NULL DEFAULT txid_current(),
+  database_actor text NOT NULL DEFAULT session_user,
+  client_application text DEFAULT current_setting('application_name', true),
+  recorded_at timestamp NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT layup_schedule_history_event_id_key UNIQUE (event_id)
+);
+
+-- A safe-boot migration can run more than once. Temporarily remove the
+-- append-only guards while the migration normalizes an older table shape.
+DROP TRIGGER IF EXISTS layup_schedule_history_no_mutation ON layup_schedule_history;
+DROP TRIGGER IF EXISTS layup_schedule_history_no_truncate ON layup_schedule_history;
+
+ALTER TABLE layup_schedule_history
+  ADD COLUMN IF NOT EXISTS event_id uuid DEFAULT gen_random_uuid(),
+  ADD COLUMN IF NOT EXISTS previous_row jsonb,
+  ADD COLUMN IF NOT EXISTS recorded_row jsonb,
+  ADD COLUMN IF NOT EXISTS transaction_id bigint DEFAULT txid_current(),
+  ADD COLUMN IF NOT EXISTS database_actor text DEFAULT session_user,
+  ADD COLUMN IF NOT EXISTS client_application text DEFAULT current_setting('application_name', true);
+
+UPDATE layup_schedule_history
+SET
+  event_id = COALESCE(event_id, gen_random_uuid()),
+  recorded_row = COALESCE(recorded_row, to_jsonb(layup_schedule_history) - 'previous_row' - 'recorded_row'),
+  transaction_id = COALESCE(transaction_id, txid_current()),
+  database_actor = COALESCE(database_actor, session_user)
+WHERE event_id IS NULL
+   OR recorded_row IS NULL
+   OR transaction_id IS NULL
+   OR database_actor IS NULL;
+
+ALTER TABLE layup_schedule_history
+  ALTER COLUMN event_id SET NOT NULL,
+  ALTER COLUMN recorded_row SET NOT NULL,
+  ALTER COLUMN transaction_id SET NOT NULL,
+  ALTER COLUMN database_actor SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS layup_schedule_history_event_id_idx
+  ON layup_schedule_history (event_id);
+
+CREATE INDEX IF NOT EXISTS layup_schedule_history_layup_day_idx
+  ON layup_schedule_history (layup_day);
+
+CREATE INDEX IF NOT EXISTS layup_schedule_history_order_id_idx
+  ON layup_schedule_history (order_id);
+
+CREATE INDEX IF NOT EXISTS layup_schedule_history_source_schedule_id_idx
+  ON layup_schedule_history (source_schedule_id);
+
+CREATE OR REPLACE FUNCTION capture_layup_schedule_history()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  schedule_row layup_schedule%ROWTYPE;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    schedule_row := OLD;
+  ELSE
+    schedule_row := NEW;
+  END IF;
+
+  INSERT INTO layup_schedule_history (
+    source_schedule_id,
+    order_id,
+    scheduled_date,
+    mold_id,
+    employee_assignments,
+    is_override,
+    overridden_at,
+    overridden_by,
+    created_at,
+    updated_at,
+    layup_day,
+    week_locked,
+    customer_name,
+    stock_model,
+    material_type,
+    action_length,
+    lop_value,
+    fb_order_number,
+    schedule_snapshot,
+    history_action,
+    previous_row,
+    recorded_row,
+    transaction_id,
+    database_actor,
+    client_application
+  )
+  VALUES (
+    schedule_row.id,
+    schedule_row.order_id,
+    schedule_row.scheduled_date,
+    schedule_row.mold_id,
+    schedule_row.employee_assignments,
+    schedule_row.is_override,
+    schedule_row.overridden_at,
+    schedule_row.overridden_by,
+    schedule_row.created_at,
+    schedule_row.updated_at,
+    schedule_row.layup_day,
+    schedule_row.week_locked,
+    schedule_row.customer_name,
+    schedule_row.stock_model,
+    schedule_row.material_type,
+    schedule_row.action_length,
+    schedule_row.lop_value,
+    schedule_row.fb_order_number,
+    schedule_row.schedule_snapshot,
+    TG_OP,
+    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) ELSE NULL END,
+    to_jsonb(schedule_row),
+    txid_current(),
+    session_user,
+    current_setting('application_name', true)
+  );
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS layup_schedule_history_trigger ON layup_schedule;
+
+CREATE TRIGGER layup_schedule_history_trigger
+AFTER INSERT OR UPDATE OR DELETE ON layup_schedule
+FOR EACH ROW
+EXECUTE FUNCTION capture_layup_schedule_history();
+
+CREATE OR REPLACE FUNCTION reject_layup_schedule_history_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'layup_schedule_history is append-only; % is not permitted', TG_OP
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS layup_schedule_history_no_mutation ON layup_schedule_history;
+CREATE TRIGGER layup_schedule_history_no_mutation
+BEFORE UPDATE OR DELETE ON layup_schedule_history
+FOR EACH ROW
+EXECUTE FUNCTION reject_layup_schedule_history_mutation();
+
+DROP TRIGGER IF EXISTS layup_schedule_history_no_truncate ON layup_schedule_history;
+CREATE TRIGGER layup_schedule_history_no_truncate
+BEFORE TRUNCATE ON layup_schedule_history
+FOR EACH STATEMENT
+EXECUTE FUNCTION reject_layup_schedule_history_mutation();
+
+INSERT INTO layup_schedule_history (
+  source_schedule_id,
+  order_id,
+  scheduled_date,
+  mold_id,
+  employee_assignments,
+  is_override,
+  overridden_at,
+  overridden_by,
+  created_at,
+  updated_at,
+  layup_day,
+  week_locked,
+  customer_name,
+  stock_model,
+  material_type,
+  action_length,
+  lop_value,
+  fb_order_number,
+  schedule_snapshot,
+  history_action,
+  previous_row,
+  recorded_row,
+  transaction_id,
+  database_actor,
+  client_application,
+  recorded_at
+)
+SELECT
+  ls.id,
+  ls.order_id,
+  ls.scheduled_date,
+  ls.mold_id,
+  ls.employee_assignments,
+  ls.is_override,
+  ls.overridden_at,
+  ls.overridden_by,
+  ls.created_at,
+  ls.updated_at,
+  ls.layup_day,
+  ls.week_locked,
+  ls.customer_name,
+  ls.stock_model,
+  ls.material_type,
+  ls.action_length,
+  ls.lop_value,
+  ls.fb_order_number,
+  ls.schedule_snapshot,
+  'BACKFILL',
+  NULL,
+  to_jsonb(ls),
+  txid_current(),
+  session_user,
+  current_setting('application_name', true),
+  COALESCE(ls.updated_at, ls.created_at, now())
+FROM layup_schedule ls
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM layup_schedule_history history
+  WHERE history.source_schedule_id = ls.id
+);

--- a/migrations/0195_production_order_transition_history.sql
+++ b/migrations/0195_production_order_transition_history.sql
@@ -1,0 +1,143 @@
+CREATE TABLE IF NOT EXISTS production_order_transition_history (
+  history_id bigserial PRIMARY KEY,
+  event_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  production_order_id integer NOT NULL,
+  order_id text NOT NULL,
+  po_number text,
+  transition_action text NOT NULL CHECK (transition_action IN ('INSERT', 'UPDATE', 'BACKFILL')),
+  old_department text,
+  new_department text,
+  old_status text,
+  new_status text,
+  old_is_fulfilled boolean,
+  new_is_fulfilled boolean,
+  previous_row jsonb,
+  recorded_row jsonb NOT NULL,
+  transaction_id bigint NOT NULL DEFAULT txid_current(),
+  database_actor text NOT NULL DEFAULT session_user,
+  client_application text DEFAULT current_setting('application_name', true),
+  recorded_at timestamp NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS production_order_transition_history_event_idx
+  ON production_order_transition_history (event_id);
+CREATE INDEX IF NOT EXISTS production_order_transition_history_order_idx
+  ON production_order_transition_history (order_id, recorded_at);
+CREATE INDEX IF NOT EXISTS production_order_transition_history_po_idx
+  ON production_order_transition_history (po_number, recorded_at);
+
+CREATE OR REPLACE FUNCTION capture_production_order_transition()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+     AND OLD.current_department IS NOT DISTINCT FROM NEW.current_department
+     AND OLD.production_status IS NOT DISTINCT FROM NEW.production_status
+     AND OLD.is_fulfilled IS NOT DISTINCT FROM NEW.is_fulfilled THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO production_order_transition_history (
+    production_order_id,
+    order_id,
+    po_number,
+    transition_action,
+    old_department,
+    new_department,
+    old_status,
+    new_status,
+    old_is_fulfilled,
+    new_is_fulfilled,
+    previous_row,
+    recorded_row,
+    transaction_id,
+    database_actor,
+    client_application
+  )
+  VALUES (
+    NEW.id,
+    NEW.order_id,
+    NEW.po_number,
+    TG_OP,
+    CASE WHEN TG_OP = 'UPDATE' THEN OLD.current_department END,
+    NEW.current_department,
+    CASE WHEN TG_OP = 'UPDATE' THEN OLD.production_status END,
+    NEW.production_status,
+    CASE WHEN TG_OP = 'UPDATE' THEN OLD.is_fulfilled END,
+    NEW.is_fulfilled,
+    CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) END,
+    to_jsonb(NEW),
+    txid_current(),
+    session_user,
+    current_setting('application_name', true)
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS production_order_transition_capture ON production_orders;
+CREATE TRIGGER production_order_transition_capture
+AFTER INSERT OR UPDATE OF current_department, production_status, is_fulfilled
+ON production_orders
+FOR EACH ROW
+EXECUTE FUNCTION capture_production_order_transition();
+
+CREATE OR REPLACE FUNCTION reject_production_order_transition_history_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'production_order_transition_history is append-only; % is not permitted', TG_OP
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS production_order_transition_history_no_mutation
+  ON production_order_transition_history;
+CREATE TRIGGER production_order_transition_history_no_mutation
+BEFORE UPDATE OR DELETE ON production_order_transition_history
+FOR EACH ROW
+EXECUTE FUNCTION reject_production_order_transition_history_mutation();
+
+DROP TRIGGER IF EXISTS production_order_transition_history_no_truncate
+  ON production_order_transition_history;
+CREATE TRIGGER production_order_transition_history_no_truncate
+BEFORE TRUNCATE ON production_order_transition_history
+FOR EACH STATEMENT
+EXECUTE FUNCTION reject_production_order_transition_history_mutation();
+
+INSERT INTO production_order_transition_history (
+  production_order_id,
+  order_id,
+  po_number,
+  transition_action,
+  new_department,
+  new_status,
+  new_is_fulfilled,
+  recorded_row,
+  transaction_id,
+  database_actor,
+  client_application,
+  recorded_at
+)
+SELECT
+  po.id,
+  po.order_id,
+  po.po_number,
+  'BACKFILL',
+  po.current_department,
+  po.production_status,
+  po.is_fulfilled,
+  to_jsonb(po),
+  txid_current(),
+  session_user,
+  current_setting('application_name', true),
+  COALESCE(po.updated_at, po.created_at, now())
+FROM production_orders po
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM production_order_transition_history history
+  WHERE history.production_order_id = po.id
+);

--- a/server/__tests__/layupScheduleHistoryMigration.test.ts
+++ b/server/__tests__/layupScheduleHistoryMigration.test.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath = path.resolve(
+  process.cwd(),
+  'migrations/0194_layup_schedule_history.sql'
+);
+const migration = fs.readFileSync(migrationPath, 'utf8');
+
+describe('layup schedule history migration', () => {
+  it('captures every live schedule mutation at the database layer', () => {
+    expect(migration).toContain(
+      'AFTER INSERT OR UPDATE OR DELETE ON layup_schedule'
+    );
+    expect(migration).toContain('EXECUTE FUNCTION capture_layup_schedule_history()');
+    expect(migration).toContain(
+      "CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) ELSE NULL END"
+    );
+    expect(migration).toContain('to_jsonb(schedule_row)');
+  });
+
+  it('makes recorded history append-only', () => {
+    expect(migration).toContain(
+      'BEFORE UPDATE OR DELETE ON layup_schedule_history'
+    );
+    expect(migration).toContain('BEFORE TRUNCATE ON layup_schedule_history');
+    expect(migration).toContain(
+      "RAISE EXCEPTION 'layup_schedule_history is append-only;"
+    );
+  });
+
+  it('records durable event and transaction metadata', () => {
+    expect(migration).toContain('event_id uuid NOT NULL DEFAULT gen_random_uuid()');
+    expect(migration).toContain('transaction_id bigint NOT NULL DEFAULT txid_current()');
+    expect(migration).toContain('database_actor text NOT NULL DEFAULT session_user');
+    expect(migration).toContain('client_application text');
+  });
+});

--- a/server/__tests__/layupSchedulePOUnitParsing.test.ts
+++ b/server/__tests__/layupSchedulePOUnitParsing.test.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseP1POUnitOrderId } from '../src/utils/parseP1POUnitOrderId';
+
+describe('parseP1POUnitOrderId', () => {
+  it('preserves hyphenated P1 purchase-order numbers', () => {
+    expect(parseP1POUnitOrderId('PO-RFPO-003307-175-20')).toEqual({
+      poNumber: 'RFPO-003307',
+      poItemId: 175,
+      unitNumber: 20,
+    });
+  });
+
+  it('supports older non-hyphenated PO numbers', () => {
+    expect(parseP1POUnitOrderId('PO-P18321-23-1')).toEqual({
+      poNumber: 'P18321',
+      poItemId: 23,
+      unitNumber: 1,
+    });
+  });
+
+  it('rejects malformed unit IDs', () => {
+    expect(parseP1POUnitOrderId('RFPO-003307')).toBeNull();
+    expect(parseP1POUnitOrderId('PO-RFPO-003307-item-unit')).toBeNull();
+  });
+});
+
+describe('layup schedule PO progression scope', () => {
+  const route = fs.readFileSync(
+    path.resolve(process.cwd(), 'server/src/routes/layupSchedule.ts'),
+    'utf8'
+  );
+
+  it('updates only submitted PO unit order IDs, never the entire PO', () => {
+    expect(route).toContain('const selectedPOOrderIds = new Set<string>()');
+    expect(route).toContain('WHERE order_id = ANY($1::text[])');
+    expect(route).toContain('[Array.from(selectedPOOrderIds)]');
+    expect(route).not.toContain('WHERE po_number = ANY($1::text[])');
+  });
+});

--- a/server/__tests__/productionOrderTransitionHistoryMigration.test.ts
+++ b/server/__tests__/productionOrderTransitionHistoryMigration.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migration = fs.readFileSync(
+  path.resolve(
+    process.cwd(),
+    'migrations/0195_production_order_transition_history.sql'
+  ),
+  'utf8'
+);
+
+describe('production order transition history migration', () => {
+  it('automatically captures department and status changes', () => {
+    expect(migration).toContain(
+      'AFTER INSERT OR UPDATE OF current_department, production_status, is_fulfilled'
+    );
+    expect(migration).toContain('OLD.current_department');
+    expect(migration).toContain('NEW.current_department');
+    expect(migration).toContain('to_jsonb(OLD)');
+    expect(migration).toContain('to_jsonb(NEW)');
+  });
+
+  it('makes the transition ledger append-only', () => {
+    expect(migration).toContain(
+      'BEFORE UPDATE OR DELETE ON production_order_transition_history'
+    );
+    expect(migration).toContain(
+      'BEFORE TRUNCATE ON production_order_transition_history'
+    );
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -215,6 +215,7 @@ export const safeMigrationFiles = [
   '0191_engineering_releases.sql',
   '0192_engineering_packages.sql',
   '0194_layup_schedule_history.sql',
+  '0195_production_order_transition_history.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -214,6 +214,7 @@ export const safeMigrationFiles = [
   '0190_design_control_requirement_applicability.sql',
   '0191_engineering_releases.sql',
   '0192_engineering_packages.sql',
+  '0194_layup_schedule_history.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/layupSchedule.ts
+++ b/server/src/routes/layupSchedule.ts
@@ -6,6 +6,7 @@ import { molds, productionQueue, allOrders, purchaseOrderItems, poProducts, layu
 import { eq, and, inArray, sql } from 'drizzle-orm';
 import { format, addDays, startOfWeek, getDay } from 'date-fns';
 import { deriveCanonicalMaterial } from '../utils/deriveCanonicalMaterial';
+import { parseP1POUnitOrderId } from '../utils/parseP1POUnitOrderId';
 
 function normalizeMaterial(raw: string): string {
   const lower = raw.toLowerCase().trim();
@@ -824,14 +825,10 @@ router.post('/save', async (req: Request, res: Response) => {
       const existingPOCounts = new Map<string, number>();
       for (const row of (Array.isArray(existingRows) ? existingRows : [])) {
         const orderId = row.order_id;
-        if (orderId.startsWith('PO-')) {
-          const parts = orderId.split('-');
-          if (parts.length >= 3) {
-            const poNumber = parts[1];
-            const itemId = parts[2];
-            const key = `${poNumber}-${itemId}`;
-            existingPOCounts.set(key, (existingPOCounts.get(key) || 0) + 1);
-          }
+        const parsedPOUnit = parseP1POUnitOrderId(orderId);
+        if (parsedPOUnit) {
+          const key = `${parsedPOUnit.poNumber}|${parsedPOUnit.poItemId}`;
+          existingPOCounts.set(key, (existingPOCounts.get(key) || 0) + 1);
         }
       }
       
@@ -839,7 +836,7 @@ router.post('/save', async (req: Request, res: Response) => {
       if (existingPOCounts.size > 0) {
         const poItemEntries = Array.from(existingPOCounts.entries());
         for (const [key, count] of poItemEntries) {
-          const [poNumber, itemId] = key.split('-');
+          const [, itemId] = key.split('|');
           await client.query(
             `
             UPDATE purchase_order_items
@@ -867,7 +864,8 @@ router.post('/save', async (req: Request, res: Response) => {
       let savedCount = 0;
       let progressedCount = 0;
       const orderIds: string[] = [];
-      const poItemCounts = new Map<string, number>(); // Track PO item counts: "poNumber-itemId" -> count
+      const poItemCounts = new Map<string, number>(); // Track PO item counts: "poNumber|itemId" -> count
+      const selectedPOOrderIds = new Set<string>();
 
       // Save schedule entries
       for (const entry of entries) {
@@ -926,14 +924,13 @@ router.post('/save', async (req: Request, res: Response) => {
         savedCount++;
         
         // Track PO items to update their order counts
-        if (orderId.startsWith('PO-')) {
-          // Parse PO item ID: PO-{poNumber}-{itemId}-{unitNumber}
-          const parts = orderId.split('-');
-          if (parts.length >= 3) {
-            const poNumber = parts[1];
-            const itemId = parts[2];
-            const key = `${poNumber}-${itemId}`;
+        const parsedPOUnit = parseP1POUnitOrderId(orderId);
+        if (parsedPOUnit) {
+            const { poNumber, poItemId } = parsedPOUnit;
+            const itemId = String(poItemId);
+            const key = `${poNumber}|${itemId}`;
             poItemCounts.set(key, (poItemCounts.get(key) || 0) + 1);
+            selectedPOOrderIds.add(orderId);
             
             // Create/update production_orders record for this PO unit
             // This ensures the item appears in the Layup/Plugging department queue
@@ -962,7 +959,7 @@ router.post('/save', async (req: Request, res: Response) => {
                 const stockModelForPO = derivedStockModel || poItem.stock_model_id || poItem.item_name || '';
                 
                 // Upsert production_orders record
-                await client.query(`
+                const progressionResult = await client.query(`
                   INSERT INTO production_orders (
                     order_id, po_id, po_item_id, customer_id, customer_name, 
                     po_number, item_type, item_id, item_name, 
@@ -973,6 +970,7 @@ router.post('/save', async (req: Request, res: Response) => {
                     item_id = COALESCE(NULLIF($8, ''), production_orders.item_id),
                     item_name = COALESCE(NULLIF($9, ''), production_orders.item_name),
                     updated_at = NOW()
+                  RETURNING order_id
                 `, [
                   orderId,
                   poItem.po_id,
@@ -988,13 +986,25 @@ router.post('/save', async (req: Request, res: Response) => {
                   'Layup/Plugging',
                   'PENDING'
                 ]);
+
+                if (progressionResult.rowCount !== 1) {
+                  throw new Error(
+                    `Expected to progress exactly one production order for ${orderId}, updated ${progressionResult.rowCount ?? 0}`
+                  );
+                }
+                progressedCount += 1;
                 
                 console.log(`📦 Created/updated production_orders record for ${orderId} with stock model: ${stockModelForPO}`);
+              } else {
+                throw new Error(
+                  `Purchase-order item ${itemId} could not be resolved for scheduled unit ${orderId}`
+                );
               }
             } catch (poError) {
+              // Keep schedule rows and production status changes atomic.
+              throw poError;
               console.log(`⚠️ Could not create production_orders for ${orderId}:`, poError);
             }
-          }
         } else {
           // Track regular order IDs
           orderIds.push(orderId);
@@ -1010,7 +1020,7 @@ router.post('/save', async (req: Request, res: Response) => {
       if (poItemCounts.size > 0) {
         const newPOItemEntries = Array.from(poItemCounts.entries());
         for (const [key, count] of newPOItemEntries) {
-          const [poNumber, itemId] = key.split('-');
+          const [poNumber, itemId] = key.split('|');
           await client.query(
             `
             UPDATE purchase_order_items
@@ -1097,14 +1107,14 @@ router.post('/save', async (req: Request, res: Response) => {
             UPDATE production_orders
             SET current_department = 'Layup/Plugging',
                 updated_at = NOW()
-            WHERE po_number = ANY($1::text[])
+            WHERE order_id = ANY($1::text[])
             AND current_department = 'P1 Production Queue'
           `,
-            [fullyScheduledPOs]
+            [Array.from(selectedPOOrderIds)]
           );
           
           const poProgressedCount = poUpdateResult.rowCount || 0;
-          progressedCount += poProgressedCount;
+          // Exact per-unit upserts above already contributed to progressedCount.
           console.log(`📦 Moved ${poProgressedCount} production orders to Layup/Plugging (all items complete): ${fullyScheduledPOs.join(', ')}`);
         } else {
           console.log(`📦 No production orders ready to move (items still pending)`);
@@ -1380,13 +1390,12 @@ router.get('/by-schedule-date/:scheduleDate', async (req: Request, res: Response
       const poMappings: Array<{ poNumber: string; poItemId: number }> = [];
       
       for (const poUnitId of poUnitIds) {
-        const parts = poUnitId.split('-');
-        if (parts.length >= 3) {
-          const poNumber = parts[1];
-          const poItemId = parseInt(parts[2]);
-          if (!isNaN(poItemId)) {
-            poMappings.push({ poNumber, poItemId });
-          }
+        const parsedPOUnit = parseP1POUnitOrderId(poUnitId);
+        if (parsedPOUnit) {
+          poMappings.push({
+            poNumber: parsedPOUnit.poNumber,
+            poItemId: parsedPOUnit.poItemId,
+          });
         }
       }
       

--- a/server/src/routes/layupSchedule.ts
+++ b/server/src/routes/layupSchedule.ts
@@ -1442,6 +1442,17 @@ router.get('/weeks', async (req: Request, res: Response) => {
     console.log('📅 SCHEDULE WEEKS: Fetching list of weeks with schedules...');
     
     const weeks = await pool.query(`
+      WITH latest_day_states AS (
+        SELECT DISTINCT ON (source_schedule_id, layup_day)
+          source_schedule_id,
+          order_id,
+          layup_day,
+          created_at,
+          recorded_at
+        FROM layup_schedule_history
+        WHERE layup_day IS NOT NULL
+        ORDER BY source_schedule_id, layup_day, recorded_at DESC, history_id DESC
+      )
       SELECT 
         TO_CHAR(DATE_TRUNC('week', layup_day), 'YYYY-MM-DD') AS week_start,
         TO_CHAR(MIN(layup_day), 'YYYY-MM-DD') AS first_day,
@@ -1452,11 +1463,9 @@ router.get('/weeks', async (req: Request, res: Response) => {
         COUNT(DISTINCT CASE WHEN order_id NOT LIKE 'PO-%' THEN order_id END) AS regular_order_count,
         ARRAY_AGG(DISTINCT order_id ORDER BY order_id) AS order_ids,
         ARRAY_AGG(DISTINCT TO_CHAR(layup_day, 'YYYY-MM-DD') ORDER BY TO_CHAR(layup_day, 'YYYY-MM-DD')) AS schedule_days
-      FROM layup_schedule
-      WHERE layup_day IS NOT NULL
+      FROM latest_day_states
       GROUP BY DATE_TRUNC('week', layup_day)
       ORDER BY DATE_TRUNC('week', layup_day) DESC
-      LIMIT 52
     `);
     
     console.log(`✅ Found ${weeks.length} weeks with schedules`);
@@ -1487,17 +1496,30 @@ router.get('/week/:weekStart', async (req: Request, res: Response) => {
     // Get all schedule entries for this week
     const scheduleEntries = await pool.query(
       `
+      WITH latest_day_states AS (
+        SELECT DISTINCT ON (source_schedule_id, layup_day)
+          history_id,
+          order_id,
+          layup_day,
+          mold_id,
+          employee_assignments,
+          is_override,
+          created_at,
+          recorded_at
+        FROM layup_schedule_history
+        WHERE layup_day >= $1::date
+          AND layup_day < $2::date
+        ORDER BY source_schedule_id, layup_day, recorded_at DESC, history_id DESC
+      )
       SELECT 
-        ls.id,
+        ls.history_id AS id,
         ls.order_id,
         ls.layup_day AS scheduled_date,
         ls.mold_id,
         ls.employee_assignments,
         ls.is_override,
         ls.created_at
-      FROM layup_schedule ls
-      WHERE ls.layup_day >= $1::date 
-        AND ls.layup_day < $2::date
+      FROM latest_day_states ls
       ORDER BY ls.layup_day, ls.order_id
     `,
       [weekStart, weekEnd]

--- a/server/src/utils/parseP1POUnitOrderId.ts
+++ b/server/src/utils/parseP1POUnitOrderId.ts
@@ -1,0 +1,23 @@
+export function parseP1POUnitOrderId(orderId: string): {
+  poNumber: string;
+  poItemId: number;
+  unitNumber: number;
+} | null {
+  if (!orderId.startsWith('PO-')) return null;
+
+  const parts = orderId.split('-');
+  if (parts.length < 4) return null;
+
+  const unitPart = parts.at(-1) ?? '';
+  const itemPart = parts.at(-2) ?? '';
+  const poNumber = parts.slice(1, -2).join('-');
+
+  if (!poNumber || !/^\d+$/.test(itemPart) || !/^\d+$/.test(unitPart)) {
+    return null;
+  }
+
+  const unitNumber = Number.parseInt(unitPart, 10);
+  const poItemId = Number.parseInt(itemPart, 10);
+
+  return { poNumber, poItemId, unitNumber };
+}


### PR DESCRIPTION
## What changed

- Added an immutable, database-triggered layup schedule history that records inserts, updates, deletes, prior state, transaction metadata, database actor, and current state.
- Added an immutable production-order transition ledger for department, status, and fulfillment changes.
- Changed layup schedule history reads to use the latest recorded state per schedule item and day without losing historical weeks.
- Fixed P1 PO unit parsing for hyphenated PO numbers such as `RFPO-003307` and `RFPO-003285`.
- Scoped production progression to the exact submitted unit order IDs instead of updating every production row for a PO number.
- Made schedule saving and PO-unit progression transactional so unresolved units fail the save instead of silently drifting.

## Root cause

The layup save path parsed `PO-{poNumber}-{itemId}-{unit}` by fixed split positions, which breaks when the PO number itself contains hyphens. It also contained a second status update scoped by `po_number`, allowing a partial schedule selection to progress all remaining production rows on that PO.

Observed examples:

- `RFPO-003307`: 20 intended units, additional units progressed.
- `RFPO-003285`: 20 intended units, 50 progressed.

## Impact

Saving a partial P1 PO layup schedule now progresses only the explicitly submitted units. Future schedule and production-status changes are captured automatically in append-only database ledgers, even when an application route omits audit logging.

## Validation

- Focused Node parser checks for hyphenated and legacy PO unit IDs.
- Static selected-unit SQL guard check confirms the PO-wide `WHERE po_number = ANY(...)` update is absent.
- Migration guard checks confirm automatic triggers and update/delete/truncate protection.
- `git diff --check`.

Full repository typecheck was not run because this isolated worktree has no installed `node_modules`.
