### PR TITLE
Fix PostgreSQL array inserts for templates

### DIFF
--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -56,6 +56,10 @@ function valueSqlForPublicColumn(columns: Map<string, string>, key: string, valu
     const serialized = typeof value === 'string' ? value : JSON.stringify(value);
     return dataType === 'jsonb' ? sql`${serialized}::jsonb` : sql`${serialized}::json`;
   }
+  if (dataType?.toLowerCase() === 'array' && Array.isArray(value)) {
+    const serialized = JSON.stringify(value.map((entry) => String(entry)));
+    return sql`ARRAY(SELECT jsonb_array_elements_text(${serialized}::jsonb))`;
+  }
   return sql`${value}`;
 }
 


### PR DESCRIPTION
## What changed

- serialize schema-aware PostgreSQL array values through a JSONB-to-text-array expression
- handle both empty and populated `source_document_ids` arrays safely
- apply the fix centrally to manual, AI-learned, uploaded, and spec-sheet template creation

## Root cause

After the template-table migration deployed, production returned:

`syntax error at or near ")"`

The schema-aware insert helper passed JavaScript arrays directly into a dynamically assembled SQL expression. An empty array was rendered as invalid empty SQL syntax.

## User impact

Manual template creation can persist an empty source-document list, while learned and uploaded templates can persist their source document IDs.

## Validation

- `git diff --check`
- verified the generated expression returns a valid PostgreSQL `text[]` for both `[]` and populated JSON arrays
