### PR TITLE
Prevent duplicate P1 production order generation

### DIFF
--- a/client/src/components/POManager.tsx
+++ b/client/src/components/POManager.tsx
@@ -181,8 +181,9 @@ function ProductionStatusBadge({ productionOrders, totalPoQuantity, poNumber }: 
   const shipped = productionOrders.filter((o: any) => getP1EffectiveStatus(o) === 'SHIPPED').length;
   const cancelled = productionOrders.filter((o: any) => getP1EffectiveStatus(o) === 'CANCELLED').length;
   const active = total - cancelled;
-  // Flag when orders outnumber the PO quantity — likely indicates duplicate generation
-  const hasDuplicates = totalPoQuantity > 0 && total > totalPoQuantity;
+  // Flag only active orders beyond PO quantity; cancelled rows remain as audit history.
+  const duplicateCount = Math.max(0, active - totalPoQuantity);
+  const hasDuplicates = totalPoQuantity > 0 && duplicateCount > 0;
 
   const filteredOrders = selectedFilter === null ? [] : selectedFilter === 'ALL'
     ? productionOrders
@@ -204,8 +205,8 @@ function ProductionStatusBadge({ productionOrders, totalPoQuantity, poNumber }: 
       <div className="flex items-center gap-1 flex-wrap">
         {/* Duplicate warning */}
         {hasDuplicates && (
-          <Badge className="bg-orange-100 text-orange-800 text-xs font-semibold" title={`${total} orders generated but PO only has ${totalPoQuantity} units — possible duplicate generation`}>
-            ⚠ {total - totalPoQuantity} Duplicate{total - totalPoQuantity !== 1 ? 's' : ''}
+          <Badge className="bg-orange-100 text-orange-800 text-xs font-semibold" title={`${active} active orders but PO only has ${totalPoQuantity} units — possible duplicate generation`}>
+            ⚠ {duplicateCount} Duplicate{duplicateCount !== 1 ? 's' : ''}
           </Badge>
         )}
         {/* Overall total */}

--- a/client/src/components/ProductionQueueManager.tsx
+++ b/client/src/components/ProductionQueueManager.tsx
@@ -220,6 +220,7 @@ export default function ProductionQueueManager() {
   const [selectedPOItems, setSelectedPOItems] = useState<Map<string, Map<number, number>>>(
     new Map()
   );
+  const [isProgressingPOItems, setIsProgressingPOItems] = useState(false);
 
   // State for "Select Next N" for regular production queue
   const [selectNextQueueCount, setSelectNextQueueCount] = useState<string>('');
@@ -744,6 +745,7 @@ export default function ProductionQueueManager() {
       });
     });
 
+    setIsProgressingPOItems(true);
     try {
       const response = await apiRequest('/api/p1-po-queue/progress', {
         method: 'POST',
@@ -751,9 +753,16 @@ export default function ProductionQueueManager() {
         headers: { 'Content-Type': 'application/json' },
       });
 
+      const requestedUnits = selections.reduce((sum, selection) => sum + selection.quantity, 0);
+      const progressedUnits = Number(response.itemsProgressed ?? 0);
+      const failedLines = Array.isArray(response.errors) ? response.errors.length : 0;
+
       toast({
-        title: 'Success',
-        description: `Progressed ${selections.length} items to Barcode (no labels needed for PO orders)`,
+        title: failedLines > 0 ? 'Partially Progressed' : 'Success',
+        description: failedLines > 0
+          ? `Progressed ${progressedUnits} of ${requestedUnits} units across ${selections.length} PO lines. ${failedLines} line(s) were blocked to prevent duplicate generation.`
+          : `Progressed ${progressedUnits} units across ${selections.length} PO lines to Barcode (no labels needed for PO orders)`,
+        variant: failedLines > 0 ? 'destructive' : undefined,
       });
 
       // Clear selections
@@ -761,6 +770,7 @@ export default function ProductionQueueManager() {
 
       // Refetch data
       refetchPOs();
+      queryClient.invalidateQueries({ queryKey: ['/api/production-queue/prioritized'] });
 
       // PO orders do not need labels printed when progressed to Barcode
       // Labels are only required for regular production orders
@@ -771,6 +781,8 @@ export default function ProductionQueueManager() {
         description: 'Failed to progress items to Barcode',
         variant: 'destructive',
       });
+    } finally {
+      setIsProgressingPOItems(false);
     }
   };
 
@@ -1733,13 +1745,14 @@ export default function ProductionQueueManager() {
                         <Button
                           className="bg-green-600 hover:bg-green-700 text-white"
                           size="sm"
+                          disabled={isProgressingPOItems}
                           onClick={() => {
                             handleProgressToBarcode();
                           }}
                           data-testid="button-progress-to-barcode"
                         >
                           <ArrowRight className="w-4 h-4 mr-2" />
-                          Progress to Barcode
+                          {isProgressingPOItems ? 'Progressing...' : 'Progress to Barcode'}
                         </Button>
                       </div>
                     </div>

--- a/server/__tests__/p1POQueueHelper.test.ts
+++ b/server/__tests__/p1POQueueHelper.test.ts
@@ -129,15 +129,15 @@ describe('buildFulfillmentMap', () => {
 
 describe('isPoItemFullyFulfilled', () => {
   it('returns true when all production orders are fulfilled', () => {
-    expect(isPoItemFullyFulfilled({ total: 3, fulfilled: 3 })).toBe(true);
+    expect(isPoItemFullyFulfilled({ total: 3, active: 3, fulfilled: 3, activeP1Queue: 0 })).toBe(true);
   });
 
   it('returns false when some production orders remain unfulfilled', () => {
-    expect(isPoItemFullyFulfilled({ total: 3, fulfilled: 2 })).toBe(false);
+    expect(isPoItemFullyFulfilled({ total: 3, active: 3, fulfilled: 2, activeP1Queue: 0 })).toBe(false);
   });
 
   it('returns false when there are no production orders', () => {
-    expect(isPoItemFullyFulfilled({ total: 0, fulfilled: 0 })).toBe(false);
+    expect(isPoItemFullyFulfilled({ total: 0, active: 0, fulfilled: 0, activeP1Queue: 0 })).toBe(false);
   });
 });
 
@@ -148,7 +148,7 @@ describe('isPoItemFullyFulfilled', () => {
 describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
   // RC-5 FIX: Items in Shipping QC are NOT fulfilled — they must remain in the
   // release queue so operators can re-release if QC rejects the unit.
-  it('keeps a PO in the queue when all production orders are in Shipping QC (RC-5)', () => {
+  it('does not regenerate production orders that already exist in Shipping QC', () => {
     const po = makePO();
     const item = makeItem();
     const itemsByPoId = new Map([[po.id, [item]]]);
@@ -159,12 +159,10 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
 
     const result = computeP1Queue([po], itemsByPoId, prodRows);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].customerName).toBe('Acme Corp');
-    expect(result[0].purchaseOrders[0].poNumber).toBe('PO-001');
+    expect(result).toHaveLength(0);
   });
 
-  it('keeps a PO in the queue when only some production orders are in Shipping QC', () => {
+  it('does not regenerate production orders that already exist in production', () => {
     const po = makePO();
     const item = makeItem();
     const itemsByPoId = new Map([[po.id, [item]]]);
@@ -175,10 +173,7 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
 
     const result = computeP1Queue([po], itemsByPoId, prodRows);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].customerName).toBe('Acme Corp');
-    expect(result[0].purchaseOrders[0].poNumber).toBe('PO-001');
-    expect(result[0].purchaseOrders[0].items).toHaveLength(1);
+    expect(result).toHaveLength(0);
   });
 
   it('excludes a PO when all production orders are Shipped or Completed (baseline)', () => {
@@ -229,7 +224,7 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
   });
 
   // RC-5 regression guard: items in Shipping QC must keep Alpha's PO in the queue
-  it('keeps both POs in queue when Shipping QC orders exist (RC-5 regression guard)', () => {
+  it('shows only units that do not already have production orders', () => {
     const poA = makePO({ id: 1, poNumber: 'PO-001', customerName: 'Alpha' });
     const poB = makePO({ id: 2, poNumber: 'PO-002', customerName: 'Beta', customerId: 200 });
     const itemA = makeItem({ id: 10 });
@@ -246,8 +241,8 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     const result = computeP1Queue([poA, poB], itemsByPoId, prodRows);
 
     expect(result).toHaveLength(2);
-    const customerNames = result.map((c) => c.customerName).sort();
-    expect(customerNames).toEqual(['Alpha', 'Beta']);
+    expect(result[0].purchaseOrders[0].items[0].quantity).toBe(1);
+    expect(result[1].purchaseOrders[0].items[0].quantity).toBe(1);
   });
 
   it('filters out items that are not stock_model type', () => {
@@ -270,7 +265,7 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('keeps released PO production orders that are still in P1 Production Queue visible', () => {
+  it('does not expose released PO production orders as new PO demand', () => {
     const po = makePO({ poNumber: 'P18261' });
     const item = makeItem({
       id: 18,
@@ -290,13 +285,17 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
 
     const result = computeP1Queue([po], itemsByPoId, prodRows);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].purchaseOrders[0].poNumber).toBe('P18261');
-    expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
-      id: 18,
-      productName: 'AG-CRB-PV105-ER',
-      quantity: 1,
-    });
+    expect(result).toHaveLength(0);
+  });
+
+  it('uses real active production rows instead of a stale cached order count', () => {
+    const po = makePO();
+    const item = makeItem({ quantity: 3, orderCount: 3 });
+    const itemsByPoId = new Map([[po.id, [item]]]);
+
+    const result = computeP1Queue([po], itemsByPoId, [makeProdRow()]);
+
+    expect(result[0].purchaseOrders[0].items[0].quantity).toBe(2);
   });
 
   it('returns empty when given no POs', () => {

--- a/server/src/helpers/p1POQueueHelper.ts
+++ b/server/src/helpers/p1POQueueHelper.ts
@@ -13,6 +13,7 @@ export interface ProductionOrderRow {
 
 export interface FulfillmentStats {
   total: number;
+  active: number;
   fulfilled: number;
   activeP1Queue: number;
 }
@@ -52,10 +53,13 @@ export function buildFulfillmentMap(
     const itemMap = poFulfillmentMap.get(poId)!;
 
     if (!itemMap.has(poItemId)) {
-      itemMap.set(poItemId, { total: 0, fulfilled: 0, activeP1Queue: 0 });
+      itemMap.set(poItemId, { total: 0, active: 0, fulfilled: 0, activeP1Queue: 0 });
     }
     const stats = itemMap.get(poItemId)!;
     stats.total++;
+    if ((row.production_status ?? '').toUpperCase() !== 'CANCELLED') {
+      stats.active++;
+    }
     if (isProductionOrderFulfilled(row)) {
       stats.fulfilled++;
     }
@@ -148,12 +152,16 @@ export function computeP1Queue(
           (specs.stockModel as string | null) ??
           (specs.stock_model as string | null) ??
           null;
-        const orderCount = item.orderCount ?? 0;
+        const cachedOrderCount = item.orderCount ?? 0;
         const fulfillmentStats = itemFulfillmentMap.get(item.id);
-        const remainingQuantity = Math.max(
-          item.quantity - orderCount,
-          fulfillmentStats?.activeP1Queue ?? 0,
-        );
+        // This list generates production orders that do not exist yet. Existing
+        // unit rows in P1 Production Queue belong in the production queue above,
+        // not back in this PO-demand list. Treating active queue rows as fresh
+        // demand allowed the same PO units to be generated more than once.
+        const existingOrderCount = fulfillmentStats
+          ? fulfillmentStats.active
+          : cachedOrderCount;
+        const remainingQuantity = Math.max(item.quantity - existingOrderCount, 0);
 
         return {
           id: item.id,

--- a/server/src/routes/p1POQueue.ts
+++ b/server/src/routes/p1POQueue.ts
@@ -719,7 +719,7 @@ router.post('/progress', async (req: Request, res: Response) => {
     for (const selection of selectionsToProgress) {
       try {
         const poItemId = selection.poProductId; // Actually purchase_order_items.id
-        const quantity = selection.quantity || 1;
+        const quantity = Number(selection.quantity || 1);
 
         // Get the purchase order item details
         const poItemQuery = `
@@ -737,54 +737,82 @@ router.post('/progress', async (req: Request, res: Response) => {
 
         const item = poItem[0];
         const specs = item.specifications || {};
-        
-        // Use a default due date if none is provided (30 days from now)
         const dueDate = item.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
-        
-        // Create production orders for the selected quantity
-        for (let i = 0; i < quantity; i++) {
-          // CENTRALIZED: Use atomic order ID generator instead of inline pattern
-          const orderId = await storage.generateNextOrderId();
-          
-          const insertProdQuery = `
-            INSERT INTO production_orders (
-              order_id, po_id, po_item_id, customer_id, customer_name,
-              po_number, item_type, item_id, item_name, specifications,
-              order_date, due_date, production_status, current_department,
-              created_at, updated_at
-            ) VALUES (
-              $1, $2, $3, $4, $5, $6, 'stock', $7, $8, $9,
-              NOW(), $10, 'IN_PROGRESS', 'Barcode', NOW(), NOW()
-            )
-            ON CONFLICT (order_id) DO UPDATE
-            SET current_department = 'Barcode',
-                production_status = 'IN_PROGRESS',
-                updated_at = NOW()
-          `;
-          await pool.query(insertProdQuery, [
-            orderId,
-            item.po_id,
-            poItemId,
-            item.customer_id || '',
-            item.customer_name,
-            item.po_number,
-            item.item_id || '',
-            resolveItemDisplayName(item.item_name || ''),
-            JSON.stringify(specs),
-            dueDate,
-          ]);
 
-          progressedOrders.push(orderId);
+        // Serialize generation for a PO line and validate against real production
+        // rows. The cached order_count can drift, and returned P1 queue rows are
+        // existing units â€” they must never become permission to generate again.
+        const client = await pool.connect();
+        const lineOrderIds: string[] = [];
+        try {
+          await client.query('BEGIN');
+          const lockedItemResult = await client.query(
+            `SELECT quantity
+             FROM purchase_order_items
+             WHERE id = $1
+             FOR UPDATE`,
+            [poItemId],
+          );
+          const orderedQuantity = Number(lockedItemResult.rows[0]?.quantity ?? 0);
+          const activeCountResult = await client.query(
+            `SELECT COUNT(*)::int AS count
+             FROM production_orders
+             WHERE po_item_id = $1
+               AND UPPER(COALESCE(production_status, '')) != 'CANCELLED'`,
+            [poItemId],
+          );
+          const activeOrderCount = Number(activeCountResult.rows[0]?.count ?? 0);
+          const remainingQuantity = Math.max(orderedQuantity - activeOrderCount, 0);
+
+          if (!Number.isInteger(quantity) || quantity < 1 || quantity > remainingQuantity) {
+            throw new Error(
+              `Requested ${quantity} unit(s), but only ${remainingQuantity} unit(s) remain ungenerated ` +
+              `for PO item ${poItemId} (${activeOrderCount} of ${orderedQuantity} already exist)`,
+            );
+          }
+
+          for (let i = 0; i < quantity; i++) {
+            const orderId = await storage.generateNextOrderId();
+            await client.query(
+              `INSERT INTO production_orders (
+                order_id, po_id, po_item_id, customer_id, customer_name,
+                po_number, item_type, item_id, item_name, specifications,
+                order_date, due_date, production_status, current_department,
+                created_at, updated_at
+              ) VALUES (
+                $1, $2, $3, $4, $5, $6, 'stock', $7, $8, $9,
+                NOW(), $10, 'IN_PROGRESS', 'Barcode', NOW(), NOW()
+              )`,
+              [
+                orderId,
+                item.po_id,
+                poItemId,
+                item.customer_id || '',
+                item.customer_name,
+                item.po_number,
+                item.item_id || '',
+                resolveItemDisplayName(item.item_name || ''),
+                JSON.stringify(specs),
+                dueDate,
+              ],
+            );
+            lineOrderIds.push(orderId);
+          }
+
+          await client.query(
+            `UPDATE purchase_order_items
+             SET order_count = $1, updated_at = NOW()
+             WHERE id = $2`,
+            [activeOrderCount + lineOrderIds.length, poItemId],
+          );
+          await client.query('COMMIT');
+          progressedOrders.push(...lineOrderIds);
+        } catch (lineError) {
+          await client.query('ROLLBACK');
+          throw lineError;
+        } finally {
+          client.release();
         }
-
-        // Update the orderCount in purchase_order_items to reflect scheduled quantity
-        const newOrderCount = (item.order_count || 0) + quantity;
-        const updatePoQuery = `
-          UPDATE purchase_order_items
-          SET order_count = $1, updated_at = NOW()
-          WHERE id = $2
-        `;
-        await pool.query(updatePoQuery, [newOrderCount, poItemId]);
         
       } catch (error) {
         console.error(`Error progressing PO item ${selection.poProductId}:`, error);
@@ -795,14 +823,22 @@ router.post('/progress', async (req: Request, res: Response) => {
       }
     }
 
-    res.json({
-      success: true,
+    const requestedUnits = selectionsToProgress.reduce(
+      (sum: number, selection: { quantity?: number }) => sum + (selection.quantity || 1),
+      0,
+    );
+    const responseBody = {
+      success: errors.length === 0,
+      partialSuccess: progressedOrders.length > 0 && errors.length > 0,
       message: `Progressed ${progressedOrders.length} items to Barcode`,
+      requestedUnits,
+      requestedLines: selectionsToProgress.length,
       itemsProgressed: progressedOrders.length,
       targetDepartment: 'Barcode',
       orderIds: progressedOrders,
       errors: errors.length > 0 ? errors : undefined,
-    });
+    };
+    res.json(responseBody);
   } catch (error) {
     console.error('Error progressing orders:', error);
     res.status(500).json({


### PR DESCRIPTION
## What changed

- Calculate P1 PO release quantity from real, non-cancelled production-order rows instead of treating existing rows in P1 Production Queue as fresh demand.
- Lock each PO item during `/api/p1-po-queue/progress` and reject requests that would exceed the ordered quantity.
- Create each production order with a plain insert so an ID conflict cannot silently mutate an existing order.
- Report progressed unit count separately from selected PO-line count and surface partial duplicate-prevention failures.
- Exclude cancelled audit-history rows from the live duplicate badge.

## Root cause

Existing production orders returned to `P1 Production Queue` were counted as quantity available to generate. Selecting those PO lines called the generation endpoint, which created new `production_orders` rows rather than progressing the existing unit rows. The endpoint trusted the submitted quantity and cached `order_count`, so it had no server-side ceiling tied to the PO quantity.

## Impact

Returned production units remain visible in the production queue but no longer reappear as ungenerated PO demand. Concurrent or stale release requests are serialized per PO line and blocked before they can create excess active orders.

This PR prevents new duplicates. Existing excess rows should be repaired separately by cancelling only confirmed newly generated extras so their audit history remains intact.

## Validation

- `vitest run --config vitest.config.server.ts server/__tests__/p1POQueueHelper.test.ts` (23 tests passed)
- `tsc --noEmit` (passed with `NODE_OPTIONS=--max-old-space-size=4096`)
- `git diff --check`
