### PR TITLE
Keep P1 purchase order progression status-only

### DIFF
--- a/client/src/components/ProductionQueueManager.tsx
+++ b/client/src/components/ProductionQueueManager.tsx
@@ -916,6 +916,46 @@ export default function ProductionQueueManager() {
 
   // Ensure p1PurchaseOrders is always an array
   const safePurchaseOrders = Array.isArray(p1PurchaseOrders) ? p1PurchaseOrders : [];
+
+  // A refetch can remove or reduce PO demand after another operator releases it.
+  // Keep the selection state aligned with the currently visible, server-backed
+  // remaining quantities so an old checkbox cannot submit duplicate demand.
+  useEffect(() => {
+    const availableByPo = new Map<string, Map<number, number>>();
+    safePurchaseOrders.forEach((customer) => {
+      customer.purchaseOrders.forEach((po) => {
+        availableByPo.set(
+          po.poNumber,
+          new Map(po.items.map((item) => [item.id, item.quantity])),
+        );
+      });
+    });
+
+    setSelectedPOItems((previous) => {
+      const next = new Map<string, Map<number, number>>();
+      previous.forEach((items, poNumber) => {
+        const availableItems = availableByPo.get(poNumber);
+        if (!availableItems) return;
+
+        const validItems = new Map<number, number>();
+        items.forEach((selectedQuantity, itemId) => {
+          const availableQuantity = availableItems.get(itemId) ?? 0;
+          const validQuantity = Math.min(selectedQuantity, availableQuantity);
+          if (validQuantity > 0) validItems.set(itemId, validQuantity);
+        });
+        if (validItems.size > 0) next.set(poNumber, validItems);
+      });
+
+      const unchanged =
+        next.size === previous.size &&
+        Array.from(next).every(([poNumber, items]) => {
+          const oldItems = previous.get(poNumber);
+          return oldItems?.size === items.size &&
+            Array.from(items).every(([itemId, quantity]) => oldItems.get(itemId) === quantity);
+        });
+      return unchanged ? previous : next;
+    });
+  }, [p1PurchaseOrders]);
   
   // Debug: Log what's being received from API
   console.log('🛒 P1 Purchase Orders received:', {

--- a/server/src/routes/p1POQueue.ts
+++ b/server/src/routes/p1POQueue.ts
@@ -849,9 +849,11 @@ router.post('/progress', async (req: Request, res: Response) => {
   } catch (error) {
     await client.query('ROLLBACK');
     console.error('Error progressing orders:', error);
-    res.status(500).json({
-      error: 'Failed to progress orders',
-      details: (error as any).message,
+    const details = error instanceof Error ? error.message : 'Failed to progress orders';
+    const isQuantityConflict = /^Selected \d+ unit\(s\)/.test(details);
+    res.status(isQuantityConflict ? 409 : 500).json({
+      error: isQuantityConflict ? details : 'Failed to progress orders',
+      details,
     });
   } finally {
     client.release();


### PR DESCRIPTION
## What changed

- Preserve the original P1 purchase-order lines and purchased quantities in the P1 PO UI.
- Track available-to-generate quantity separately from the immutable purchased quantity.
- Make progression of an existing production unit change only its displayed PO-line status.
- Stop layup/production schedule replacement from incrementing or decrementing `purchase_order_items.order_count`.
- Prune stale client selections against the server-backed available quantity.
- Return quantity conflicts as HTTP 409 with the actionable server message.

## Root cause

The schedule save path treated schedule membership as ownership of PO demand. Replacing schedule rows decremented and re-incremented the PO line count, allowing production-queue activity to make demand appear in the P1 PO UI. The PO read model also represented only remaining units, causing original lines to disappear instead of retaining their identity and updating status.

## Impact

The P1 Purchase Order UI remains the stable record of the original PO. Generating production demand consumes only the separate available quantity, and progressing a generated unit changes only its status, such as `P1 Production Queue` to `Barcode`.

## Validation

- 44 focused P1 queue tests pass across three test files.
- Added an exact regression asserting progression changes only `status` on the PO item object.
- Added a regression preventing layup schedule replacement from mutating PO demand counts.
- `git diff --cached --check` passed before commit.
- Repository-wide TypeScript checking was attempted with 2 GB and 4 GB Node heaps; both exhausted the heap without reporting a TypeScript diagnostic.
