### PR TITLE
Restore pending P1 purchase order workflow

### DIFF
--- a/client/src/components/POManager.tsx
+++ b/client/src/components/POManager.tsx
@@ -138,7 +138,12 @@ function isP1InProgressStatus(status?: string | null): boolean {
 
 function getP1EffectiveStatus(order: any): string {
   if (order?.isFulfilled) return 'SHIPPED';
-  return String(order?.productionStatus || '');
+  const rawStatus = String(order?.productionStatus || '').toUpperCase();
+  if (rawStatus === 'CANCELLED') return 'CANCELLED';
+  if (String(order?.currentDepartment || '').trim() === 'P1 Production Queue') {
+    return 'PENDING';
+  }
+  return rawStatus;
 }
 
 function getStatusLabel(filter: StatusFilter): string {

--- a/client/src/components/ProductionQueueManager.tsx
+++ b/client/src/components/ProductionQueueManager.tsx
@@ -916,6 +916,46 @@ export default function ProductionQueueManager() {
 
   // Ensure p1PurchaseOrders is always an array
   const safePurchaseOrders = Array.isArray(p1PurchaseOrders) ? p1PurchaseOrders : [];
+
+  // A refetch can remove or reduce PO demand after another operator releases it.
+  // Keep the selection state aligned with the currently visible, server-backed
+  // remaining quantities so an old checkbox cannot submit duplicate demand.
+  useEffect(() => {
+    const availableByPo = new Map<string, Map<number, number>>();
+    safePurchaseOrders.forEach((customer) => {
+      customer.purchaseOrders.forEach((po) => {
+        availableByPo.set(
+          po.poNumber,
+          new Map(po.items.map((item) => [item.id, item.quantity])),
+        );
+      });
+    });
+
+    setSelectedPOItems((previous) => {
+      const next = new Map<string, Map<number, number>>();
+      previous.forEach((items, poNumber) => {
+        const availableItems = availableByPo.get(poNumber);
+        if (!availableItems) return;
+
+        const validItems = new Map<number, number>();
+        items.forEach((selectedQuantity, itemId) => {
+          const availableQuantity = availableItems.get(itemId) ?? 0;
+          const validQuantity = Math.min(selectedQuantity, availableQuantity);
+          if (validQuantity > 0) validItems.set(itemId, validQuantity);
+        });
+        if (validItems.size > 0) next.set(poNumber, validItems);
+      });
+
+      const unchanged =
+        next.size === previous.size &&
+        Array.from(next).every(([poNumber, items]) => {
+          const oldItems = previous.get(poNumber);
+          return oldItems?.size === items.size &&
+            Array.from(items).every(([itemId, quantity]) => oldItems.get(itemId) === quantity);
+        });
+      return unchanged ? previous : next;
+    });
+  }, [p1PurchaseOrders]);
   
   // Debug: Log what's being received from API
   console.log('🛒 P1 Purchase Orders received:', {

--- a/server/__tests__/p1POQueueHelper.test.ts
+++ b/server/__tests__/p1POQueueHelper.test.ts
@@ -64,6 +64,11 @@ describe('isProductionOrderFulfilled', () => {
     expect(isProductionOrderFulfilled(makeProdRow({ production_status: 'Completed', current_department: null }))).toBe(true);
   });
 
+  it('normalizes uppercase database terminal statuses', () => {
+    expect(isProductionOrderFulfilled(makeProdRow({ production_status: 'SHIPPED' }))).toBe(true);
+    expect(isProductionOrderFulfilled(makeProdRow({ production_status: 'COMPLETED' }))).toBe(true);
+  });
+
   // RC-5 FIX: Shipping QC must NOT count as fulfilled — if QC rejects a unit
   // it goes back for rework and must remain releasable in the P1 queue.
   it('returns false when current_department is Shipping QC (RC-5)', () => {
@@ -190,15 +195,14 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('includes a PO when there are no production orders yet', () => {
+  it('does not show ungenerated demand as a pending production unit', () => {
     const po = makePO();
     const item = makeItem();
     const itemsByPoId = new Map([[po.id, [item]]]);
 
     const result = computeP1Queue([po], itemsByPoId, []);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].purchaseOrders[0].items[0].stockModel).toBe('M700');
+    expect(result).toHaveLength(0);
   });
 
   it('handles multiple POs — excludes only the fully fulfilled one', () => {
@@ -213,7 +217,7 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     const prodRows: ProductionOrderRow[] = [
       { po_id: 1, po_item_id: 10, production_status: 'Shipped', current_department: null },
       { po_id: 1, po_item_id: 10, production_status: 'Completed', current_department: null },
-      { po_id: 2, po_item_id: 20, production_status: 'In Progress', current_department: 'Assembly' },
+      { po_id: 2, po_item_id: 20, production_status: 'PENDING', current_department: 'P1 Production Queue' },
     ];
 
     const result = computeP1Queue([poA, poB], itemsByPoId, prodRows);
@@ -223,8 +227,7 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result[0].purchaseOrders[0].poNumber).toBe('PO-002');
   });
 
-  // RC-5 regression guard: items in Shipping QC must keep Alpha's PO in the queue
-  it('shows only units that do not already have production orders', () => {
+  it('shows only existing units waiting in P1 Production Queue', () => {
     const poA = makePO({ id: 1, poNumber: 'PO-001', customerName: 'Alpha' });
     const poB = makePO({ id: 2, poNumber: 'PO-002', customerName: 'Beta', customerId: 200 });
     const itemA = makeItem({ id: 10 });
@@ -234,8 +237,8 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
       [2, [itemB]],
     ]);
     const prodRows: ProductionOrderRow[] = [
-      { po_id: 1, po_item_id: 10, production_status: 'In Progress', current_department: 'Shipping QC' },
-      { po_id: 2, po_item_id: 20, production_status: 'In Progress', current_department: 'Assembly' },
+      { po_id: 1, po_item_id: 10, production_status: 'PENDING', current_department: 'P1 Production Queue' },
+      { po_id: 2, po_item_id: 20, production_status: 'PENDING', current_department: 'P1 Production Queue' },
     ];
 
     const result = computeP1Queue([poA, poB], itemsByPoId, prodRows);
@@ -265,7 +268,7 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('does not expose released PO production orders as new PO demand', () => {
+  it('exposes an existing pending PO production unit for progression', () => {
     const po = makePO({ poNumber: 'P18261' });
     const item = makeItem({
       id: 18,
@@ -285,17 +288,24 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
 
     const result = computeP1Queue([po], itemsByPoId, prodRows);
 
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
+      id: 18,
+      quantity: 1,
+      status: 'pending',
+    });
   });
 
-  it('uses real active production rows instead of a stale cached order count', () => {
+  it('uses real pending queue rows instead of a stale cached order count', () => {
     const po = makePO();
     const item = makeItem({ quantity: 3, orderCount: 3 });
     const itemsByPoId = new Map([[po.id, [item]]]);
 
-    const result = computeP1Queue([po], itemsByPoId, [makeProdRow()]);
+    const result = computeP1Queue([po], itemsByPoId, [
+      makeProdRow({ production_status: 'PENDING', current_department: 'P1 Production Queue' }),
+    ]);
 
-    expect(result[0].purchaseOrders[0].items[0].quantity).toBe(2);
+    expect(result[0].purchaseOrders[0].items[0].quantity).toBe(1);
   });
 
   it('returns empty when given no POs', () => {

--- a/server/__tests__/p1POQueueScheduleGuard.test.ts
+++ b/server/__tests__/p1POQueueScheduleGuard.test.ts
@@ -115,6 +115,7 @@ interface MockPoItemRow {
   specifications: Record<string, string>;
   due_date: string;
   order_count: number;
+  quantity: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -150,6 +151,7 @@ function makePoItemRow(overrides: Partial<MockPoItemRow> = {}): MockPoItemRow {
     specifications: { stockModel: 'M700' },
     due_date: '2026-12-31',
     order_count: 0,
+    quantity: QUANTITY,
     ...overrides,
   };
 }
@@ -265,6 +267,59 @@ describe('POST /api/p1-po-queue/schedule — RC-3: double-scheduling guard', () 
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/Batch ID is required/i);
+  });
+});
+
+describe('POST /api/p1-po-queue/progress — progress existing pending units', () => {
+  let app: express.Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = buildApp();
+    const p1POQueueRouter = (await import('../src/routes/p1POQueue')).default;
+    app.use('/api/p1-po-queue', p1POQueueRouter);
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('moves the selected pending production row to Barcode without inserting a replacement', async () => {
+    mockClientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [makePoItemRow()] }) // locked PO item
+      .mockResolvedValueOnce({ rows: [{ order_id: 'PO-EXISTING-1' }] }) // pending unit
+      .mockResolvedValueOnce(undefined) // all_orders upsert
+      .mockResolvedValueOnce(undefined) // production_orders update
+      .mockResolvedValueOnce(undefined); // COMMIT
+
+    const res = await request(app)
+      .post('/api/p1-po-queue/progress')
+      .send({ selections: [{ poProductId: PO_ITEM_ID, quantity: 1 }] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.orderIds).toEqual(['PO-EXISTING-1']);
+    expect(res.body.itemsProgressed).toBe(1);
+
+    const sqlCalls = mockClientQuery.mock.calls.map(([query]) => String(query));
+    expect(sqlCalls.some((query) => /UPDATE production_orders/.test(query))).toBe(true);
+    expect(sqlCalls.some((query) => /INSERT INTO production_orders/.test(query))).toBe(false);
+  });
+
+  it('rolls back when fewer pending units exist than the selected quantity', async () => {
+    mockClientQuery
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [makePoItemRow({ quantity: 2 })] })
+      .mockResolvedValueOnce({ rows: [{ order_id: 'PO-EXISTING-1' }] })
+      .mockResolvedValueOnce(undefined); // ROLLBACK
+
+    const res = await request(app)
+      .post('/api/p1-po-queue/progress')
+      .send({ selections: [{ poProductId: PO_ITEM_ID, quantity: 2 }] });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/only 1 pending unit/i);
+    expect(mockClientQuery.mock.calls.some(([query]) => String(query) === 'ROLLBACK')).toBe(true);
   });
 });
 

--- a/server/src/helpers/p1POQueueHelper.ts
+++ b/server/src/helpers/p1POQueueHelper.ts
@@ -28,10 +28,8 @@ export interface FulfillmentStats {
  * PO item must remain releasable — so only terminal shipped/completed states count.
  */
 export function isProductionOrderFulfilled(row: ProductionOrderRow): boolean {
-  return (
-    row.production_status === 'Shipped' ||
-    row.production_status === 'Completed'
-  );
+  const status = String(row.production_status || '').trim().toUpperCase();
+  return status === 'SHIPPED' || status === 'COMPLETED';
 }
 
 /**
@@ -63,11 +61,11 @@ export function buildFulfillmentMap(
     if (isProductionOrderFulfilled(row)) {
       stats.fulfilled++;
     }
+    const department = String(row.current_department || '').trim().toLowerCase();
+    const status = String(row.production_status || '').trim().toUpperCase().replace(' ', '_');
     if (
-      row.current_department === 'P1 Production Queue' &&
-      ['PENDING', 'IN_PROGRESS', 'Pending', 'In Progress'].includes(
-        row.production_status ?? '',
-      )
+      department === 'p1 production queue' &&
+      ['PENDING', 'IN_PROGRESS', 'ACTIVE'].includes(status)
     ) {
       stats.activeP1Queue++;
     }
@@ -152,16 +150,11 @@ export function computeP1Queue(
           (specs.stockModel as string | null) ??
           (specs.stock_model as string | null) ??
           null;
-        const cachedOrderCount = item.orderCount ?? 0;
         const fulfillmentStats = itemFulfillmentMap.get(item.id);
-        // This list generates production orders that do not exist yet. Existing
-        // unit rows in P1 Production Queue belong in the production queue above,
-        // not back in this PO-demand list. Treating active queue rows as fresh
-        // demand allowed the same PO units to be generated more than once.
-        const existingOrderCount = fulfillmentStats
-          ? fulfillmentStats.active
-          : cachedOrderCount;
-        const remainingQuantity = Math.max(item.quantity - existingOrderCount, 0);
+        // This card is a read model of existing PENDING units waiting in the P1
+        // Production Queue. Progression moves those rows; it must not interpret
+        // them as permission to generate replacement production orders.
+        const pendingQueueQuantity = fulfillmentStats?.activeP1Queue ?? 0;
 
         return {
           id: item.id,
@@ -203,8 +196,8 @@ export function computeP1Queue(
             (specs.flatTop as boolean | null) ??
             (specs.flat_top as boolean | null) ??
             null,
-          quantity: remainingQuantity,
-          status: item.stockStatus ?? 'pending',
+          quantity: pendingQueueQuantity,
+          status: 'pending',
           notes: item.notes ?? item.productionNotes ?? null,
           dueDate: item.dueDate?.toString() ?? null,
           linkedOrderId: null,

--- a/server/src/routes/p1POQueue.ts
+++ b/server/src/routes/p1POQueue.ts
@@ -742,33 +742,29 @@ router.post('/progress', async (req: Request, res: Response) => {
 
         const item = poItem.rows[0];
         const specs = item.specifications || {};
-        const orderedQuantity = Number(item.quantity || 0);
-        // The cached order_count can drift. Count real rows while the PO item is
-        // locked so concurrent requests cannot both generate the same remaining units.
-        const productionCountsResult = await client.query(`
-          SELECT
-            COUNT(*)::int AS total_count,
-            COUNT(*) FILTER (
-              WHERE UPPER(COALESCE(production_status, '')) != 'CANCELLED'
-            )::int AS active_count
-          FROM production_orders
-          WHERE po_item_id = $1
-        `, [poItemId]);
-        const existingOrderCount = Number(productionCountsResult.rows[0]?.total_count || 0);
-        const activeOrderCount = Number(productionCountsResult.rows[0]?.active_count || 0);
-        const remainingQuantity = Math.max(orderedQuantity - activeOrderCount, 0);
-        if (quantity > remainingQuantity) {
-          throw new Error(`Selected ${quantity} unit(s) for PO item ${poItemId}, but only ${remainingQuantity} remain`);
-        }
-
-        // Use a default due date if none is provided (30 days from now)
         const dueDate = item.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
 
-        // Create production orders for the selected quantity
-        for (let i = 0; i < quantity; i++) {
-          const sequence = existingOrderCount + i + 1;
-          const orderId = `PO-${item.po_number}-${poItemId}-${sequence}`;
-          const notes = `PO Item: ${item.item_name || ''} - PO #${item.po_number} (Unit ${sequence} of ${orderedQuantity})`;
+        // Lock and progress the exact existing PENDING units. Creating rows here
+        // caused the duplicate-order bug because PO generation already created demand.
+        const pendingOrdersResult = await client.query(`
+          SELECT order_id
+          FROM production_orders
+          WHERE po_item_id = $1
+            AND current_department = 'P1 Production Queue'
+            AND UPPER(COALESCE(production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')
+          ORDER BY created_at ASC, id ASC
+          LIMIT $2
+          FOR UPDATE
+        `, [poItemId, quantity]);
+        if (pendingOrdersResult.rows.length !== quantity) {
+          throw new Error(
+            `Selected ${quantity} unit(s) for PO item ${poItemId}, but only ${pendingOrdersResult.rows.length} pending unit(s) remain in P1 Production Queue`
+          );
+        }
+
+        for (const pendingOrder of pendingOrdersResult.rows) {
+          const orderId = String(pendingOrder.order_id);
+          const notes = `PO Item: ${item.item_name || ''} - PO #${item.po_number}`;
           const features = JSON.stringify({
             po_item_id: poItemId,
             po_number: item.po_number,
@@ -790,44 +786,15 @@ router.post('/progress', async (req: Request, res: Response) => {
             SET current_department = 'Barcode', status = 'IN_PROGRESS', updated_at = NOW()
           `, [orderId, dueDate, item.customer_id || item.customer_name, item.item_id || '', notes, features, item.po_id, poItemId]);
 
-          const insertProdQuery = `
-            INSERT INTO production_orders (
-              order_id, po_id, po_item_id, customer_id, customer_name,
-              po_number, item_type, item_id, item_name, specifications,
-              order_date, due_date, production_status, current_department,
-              created_at, updated_at
-            ) VALUES (
-              $1, $2, $3, $4, $5, $6, 'stock', $7, $8, $9,
-              NOW(), $10, 'IN_PROGRESS', 'Barcode', NOW(), NOW()
-            )
-            ON CONFLICT (order_id) DO UPDATE
+          await client.query(`
+            UPDATE production_orders
             SET current_department = 'Barcode',
                 production_status = 'IN_PROGRESS',
                 updated_at = NOW()
-          `;
-          await client.query(insertProdQuery, [
-            orderId,
-            item.po_id,
-            poItemId,
-            item.customer_id || '',
-            item.customer_name,
-            item.po_number,
-            item.item_id || '',
-            resolveItemDisplayName(item.item_name || ''),
-            JSON.stringify(specs),
-            dueDate,
-          ]);
+            WHERE order_id = $1
+          `, [orderId]);
           progressedOrders.push(orderId);
         }
-
-        // Update the orderCount in purchase_order_items to reflect scheduled quantity
-        const newOrderCount = activeOrderCount + quantity;
-        const updatePoQuery = `
-          UPDATE purchase_order_items
-          SET order_count = $1, updated_at = NOW()
-          WHERE id = $2
-        `;
-        await client.query(updatePoQuery, [newOrderCount, poItemId]);
     }
 
     await client.query('COMMIT');
@@ -849,9 +816,11 @@ router.post('/progress', async (req: Request, res: Response) => {
   } catch (error) {
     await client.query('ROLLBACK');
     console.error('Error progressing orders:', error);
-    res.status(500).json({
-      error: 'Failed to progress orders',
-      details: (error as any).message,
+    const details = error instanceof Error ? error.message : 'Failed to progress orders';
+    const isQuantityConflict = /^Selected \d+ unit\(s\)/.test(details);
+    res.status(isQuantityConflict ? 409 : 500).json({
+      error: isQuantityConflict ? details : 'Failed to progress orders',
+      details,
     });
   } finally {
     client.release();


### PR DESCRIPTION
## Summary
- treat existing P1 Production Queue rows as pending PO demand
- progress the exact selected production orders to Barcode atomically instead of creating replacement rows
- normalize legacy P1 status display and reconcile stale UI selections
- reject progress requests when the selected pending quantity is no longer available

## Validation
- 51 focused P1 server tests passed across 3 test files
- git diff checks passed
- full TypeScript check exceeded the 4 GB Node heap before producing diagnostics