### PR TITLE
Save P1 production schedules before printing

### DIFF
--- a/client/src/__tests__/layupSchedulePreview.component.test.tsx
+++ b/client/src/__tests__/layupSchedulePreview.component.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LayupSchedulePreview } from '@/components/LayupSchedulePreview';
+
+vi.mock('jsbarcode', () => ({
+  default: (element: SVGSVGElement) => {
+    element.appendChild(
+      document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+    );
+  },
+}));
+
+const scheduledItems = [
+  {
+    orderId: 'PO-RFPO-TEST-73-1',
+    fbOrderNumber: '',
+    stockModel: 'Test Stock',
+    customerName: 'Test Customer',
+    scheduledDate: '2026-07-20',
+    moldId: 'Test Stock-1',
+    dayOfWeek: 1,
+    dayName: 'Monday',
+  },
+];
+
+describe('LayupSchedulePreview printing', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('saves a newly generated schedule before writing printable content', async () => {
+    const writes: string[] = [];
+    const printDocument = {
+      write: vi.fn((value: string) => writes.push(value)),
+      open: vi.fn(),
+      close: vi.fn(),
+    };
+    const printWindow = {
+      document: printDocument,
+      close: vi.fn(),
+      print: vi.fn(),
+      onload: null,
+    };
+    vi.spyOn(window, 'open').mockReturnValue(printWindow as unknown as Window);
+
+    let finishApproval: (() => void) | undefined;
+    const onApprove = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishApproval = resolve;
+        })
+    );
+
+    render(
+      <LayupSchedulePreview
+        open
+        onClose={vi.fn()}
+        scheduledItems={scheduledItems}
+        overflowItems={[]}
+        weekStart="2026-07-20"
+        totalItems={1}
+        onApprove={onApprove}
+        isApproving={false}
+      />
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector('svg rect')).not.toBeNull()
+    );
+    fireEvent.click(screen.getByTestId('button-print-schedule'));
+
+    await waitFor(() => expect(onApprove).toHaveBeenCalledTimes(1));
+    expect(writes).toEqual([
+      '<p style="font-family: sans-serif; padding: 24px">Saving schedule before printing...</p>',
+    ]);
+
+    finishApproval?.();
+
+    await waitFor(() =>
+      expect(writes.some((value) => value.startsWith('<!DOCTYPE html>'))).toBe(
+        true
+      )
+    );
+    expect(printDocument.open).toHaveBeenCalledTimes(1);
+    expect(printDocument.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/LayupSchedulePreview.tsx
+++ b/client/src/components/LayupSchedulePreview.tsx
@@ -41,8 +41,9 @@ interface LayupSchedulePreviewProps {
   overflowItems: OverflowItem[];
   weekStart: string;
   totalItems: number;
-  onApprove: () => void;
+  onApprove: () => void | Promise<unknown>;
   isApproving: boolean;
+  isHistoricalReprint?: boolean;
 }
 
 export function LayupSchedulePreview({
@@ -54,6 +55,7 @@ export function LayupSchedulePreview({
   totalItems,
   onApprove,
   isApproving,
+  isHistoricalReprint = false,
 }: LayupSchedulePreviewProps) {
   const barcodeRef = useRef<SVGSVGElement>(null);
   const printContentRef = useRef<HTMLDivElement>(null);
@@ -122,13 +124,6 @@ export function LayupSchedulePreview({
     // Wait a bit to ensure SVG is fully rendered
     await new Promise(resolve => setTimeout(resolve, 100));
 
-    // Open a new window with just the schedule content
-    const printWindow = window.open('', '_blank', 'width=1200,height=800');
-    if (!printWindow) {
-      alert('Please allow popups to print the schedule');
-      return;
-    }
-
     // Convert SVG barcode to data URL
     let barcodeDataURL = '';
     try {
@@ -154,13 +149,34 @@ export function LayupSchedulePreview({
     } catch (error) {
       console.error('❌ Error converting barcode:', error);
       alert('Error generating barcode for printing. Please try again.');
-      printWindow.close();
       return;
     }
     
     // Generate the HTML content
     const printHTML = generatePrintHTML(barcodeDataURL);
+
+    // Open the window during the user's click so popup blockers allow it. A
+    // newly generated schedule must be committed before anything is printed;
+    // otherwise the paper schedule has no durable history record.
+    const printWindow = window.open('', '_blank', 'width=1200,height=800');
+    if (!printWindow) {
+      alert('Please allow popups to print the schedule');
+      return;
+    }
+
+    if (!isHistoricalReprint) {
+      printWindow.document.write('<p style="font-family: sans-serif; padding: 24px">Saving schedule before printing...</p>');
+
+      try {
+        await onApprove();
+      } catch (error) {
+        console.error('Failed to save schedule before printing:', error);
+        printWindow.close();
+        return;
+      }
+    }
     
+    printWindow.document.open();
     printWindow.document.write(printHTML);
     printWindow.document.close();
     
@@ -756,10 +772,11 @@ export function LayupSchedulePreview({
           <Button
             variant="outline"
             onClick={handlePrint}
+            disabled={isApproving}
             data-testid="button-print-schedule"
           >
             <Printer className="w-4 h-4 mr-2" />
-            Print Schedule
+            {isHistoricalReprint ? 'Print Schedule' : isApproving ? 'Saving...' : 'Approve, Save & Print'}
           </Button>
           <Button
             variant="outline"
@@ -768,13 +785,15 @@ export function LayupSchedulePreview({
           >
             Cancel
           </Button>
-          <Button
-            onClick={onApprove}
-            disabled={isApproving}
-            data-testid="button-approve-schedule"
-          >
-            {isApproving ? 'Approving...' : 'Approve & Progress Orders'}
-          </Button>
+          {!isHistoricalReprint && (
+            <Button
+              onClick={onApprove}
+              disabled={isApproving}
+              data-testid="button-approve-schedule"
+            >
+              {isApproving ? 'Approving...' : 'Approve & Progress Orders'}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/client/src/components/ProductionQueueManager.tsx
+++ b/client/src/components/ProductionQueueManager.tsx
@@ -2723,7 +2723,7 @@ export default function ProductionQueueManager() {
           overflowItems={generatedSchedule.overflowItems}
           weekStart={generatedSchedule.weekStart}
           totalItems={generatedSchedule.totalItems}
-          onApprove={() => approveScheduleMutation.mutate()}
+          onApprove={() => approveScheduleMutation.mutateAsync()}
           isApproving={approveScheduleMutation.isPending}
         />
       )}

--- a/client/src/components/ScheduleHistoryDialog.tsx
+++ b/client/src/components/ScheduleHistoryDialog.tsx
@@ -201,6 +201,7 @@ export function ScheduleHistoryDialog({ open, onClose }: ScheduleHistoryDialogPr
             handleCloseReprint();
           }}
           isApproving={false}
+          isHistoricalReprint
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- require a newly generated P1 schedule to save successfully before printable content is released
- keep schedule-history reprints read-only so they cannot progress orders again
- label the fresh action clearly as Approve, Save & Print

## Root cause
Generate Schedule created only an in-memory preview. Print Schedule printed that preview directly, while history was written only by the separate approval/save transaction. A user could therefore print an official schedule that had no history record.

## Validation
- focused LayupSchedulePreview component regression passed
- staged diff whitespace validation passed
- focused lint was attempted, but the legacy components report repository-wide pre-existing CRLF/format violations; no bulk formatting was performed