### PR TITLE
Separate P1 demand from progression

### DIFF
--- a/client/src/components/ProductionQueueManager.tsx
+++ b/client/src/components/ProductionQueueManager.tsx
@@ -220,7 +220,7 @@ export default function ProductionQueueManager() {
   const [selectedPOItems, setSelectedPOItems] = useState<Map<string, Map<number, number>>>(
     new Map()
   );
-  const [isProgressingPOItems, setIsProgressingPOItems] = useState(false);
+  const [isGeneratingPODemand, setIsGeneratingPODemand] = useState(false);
 
   // State for "Select Next N" for regular production queue
   const [selectNextQueueCount, setSelectNextQueueCount] = useState<string>('');
@@ -414,27 +414,6 @@ export default function ProductionQueueManager() {
   // Generate layup schedule mutation
   const generateScheduleMutation = useMutation({
     mutationFn: async () => {
-      // Prepare selected P1 PO items with their selected quantities
-      const selectedPOItemsArray: any[] = [];
-      safePurchaseOrders.forEach((customer) => {
-        customer.purchaseOrders.forEach((po) => {
-          const selectedItems = selectedPOItems.get(po.poNumber);
-          if (selectedItems) {
-            po.items.forEach((item) => {
-              const selectedQuantity = selectedItems.get(item.id);
-              if (selectedQuantity && selectedQuantity > 0) {
-                selectedPOItemsArray.push({
-                  poNumber: po.poNumber,
-                  itemId: item.id,
-                  stockModel: item.stockModel || '',
-                  quantity: selectedQuantity, // Use selected quantity instead of remaining
-                });
-              }
-            });
-          }
-        });
-      });
-
       // Calculate week start date based on selected week offset
       const today = new Date();
       const nextMonday = new Date(today);
@@ -445,7 +424,9 @@ export default function ProductionQueueManager() {
         method: 'POST',
         body: {
           selectedOrderIds: Array.from(selectedQueueOrders),
-          selectedPOItems: selectedPOItemsArray,
+          // PO demand must be generated into P1 Production Queue first. The
+          // scheduler accepts only existing production-order IDs from this UI.
+          selectedPOItems: [],
           workDays: selectedDays,
           weekStart: nextMonday.toISOString(),
         },
@@ -726,41 +707,42 @@ export default function ProductionQueueManager() {
     printWindow.document.close();
   };
 
-  // Handler for progressing P1 PO items to Barcode
-  const handleProgressToBarcode = async () => {
+  // PO items create demand in P1 Production Queue. Department progression is
+  // intentionally handled only by the existing production-order controls above.
+  const handleGeneratePODemand = async () => {
     if (selectedPOItems.size === 0) {
       toast({
         title: 'No Items Selected',
-        description: 'Please select items to progress to Barcode',
+        description: 'Please select purchase-order demand to generate',
         variant: 'destructive',
       });
       return;
     }
 
     // Convert selected PO items to the format expected by the API
-    const selections: Array<{ poProductId: number; quantity: number }> = [];
+    const selections: Array<{ poProductId: number; quantitySelected: number }> = [];
     selectedPOItems.forEach((itemMap, poNumber) => {
-      itemMap.forEach((quantity, itemId) => {
-        selections.push({ poProductId: itemId, quantity });
+      itemMap.forEach((quantitySelected, itemId) => {
+        selections.push({ poProductId: itemId, quantitySelected });
       });
     });
 
-    setIsProgressingPOItems(true);
+    setIsGeneratingPODemand(true);
     try {
-      const response = await apiRequest('/api/p1-po-queue/progress', {
+      const selectionBatch = await apiRequest('/api/p1-po-queue/select', {
         method: 'POST',
         body: JSON.stringify({ selections }),
         headers: { 'Content-Type': 'application/json' },
       });
-
-      const expectedUnits = selections.reduce((sum, selection) => sum + selection.quantity, 0);
-      if (response.itemsProgressed !== expectedUnits) {
-        throw new Error(`Barcode progression only confirmed ${response.itemsProgressed || 0} of ${expectedUnits} selected units`);
-      }
+      const response = await apiRequest('/api/p1-po-queue/schedule', {
+        method: 'POST',
+        body: JSON.stringify({ batchId: selectionBatch.batchId }),
+        headers: { 'Content-Type': 'application/json' },
+      });
 
       toast({
         title: 'Success',
-        description: `Progressed all ${expectedUnits} selected PO units to Barcode (no labels needed for PO orders)`,
+        description: response.message || 'Generated purchase-order demand in P1 Production Queue',
       });
 
       // Clear selections
@@ -773,14 +755,14 @@ export default function ProductionQueueManager() {
       // PO orders do not need labels printed when progressed to Barcode
       // Labels are only required for regular production orders
     } catch (error: any) {
-      console.error('Error progressing to Barcode:', error);
+      console.error('Error generating PO demand:', error);
       toast({
         title: 'Error',
-        description: error?.message || 'Failed to progress items to Barcode',
+        description: error?.message || 'Failed to generate production demand',
         variant: 'destructive',
       });
     } finally {
-      setIsProgressingPOItems(false);
+      setIsGeneratingPODemand(false);
     }
   };
 
@@ -856,7 +838,9 @@ export default function ProductionQueueManager() {
       const newMap = new Map(prev);
       const itemMap = newMap.get(poNumber) || new Map();
       // Filter out "no stock" items from selection
-      const eligibleItems = items.filter((item) => item.stockModel !== "no stock");
+      const eligibleItems = items.filter(
+        (item) => item.stockModel !== "no stock" && item.quantity > 0,
+      );
       const allSelected = eligibleItems.every((item) => itemMap.get(item.id) === item.quantity);
       
       if (allSelected) {
@@ -1510,15 +1494,28 @@ export default function ProductionQueueManager() {
                     Progress to Barcode ({selectedQueueOrders.size})
                   </Button>
                 )}
-                <Button
-                  onClick={() => setDaySelectionDialogOpen(true)}
-                  disabled={generateScheduleMutation.isPending}
-                  className="bg-purple-600 hover:bg-purple-700 text-white border-2 border-purple-400 font-medium shadow-lg flex items-center gap-2"
-                  data-testid="button-generate-schedule-sticky"
-                >
-                  <CalendarCheck className="w-5 h-5" />
-                  Generate Schedule
-                </Button>
+                {selectedQueueOrders.size > 0 && (
+                  <Button
+                    onClick={() => setDaySelectionDialogOpen(true)}
+                    disabled={generateScheduleMutation.isPending}
+                    className="bg-purple-600 hover:bg-purple-700 text-white border-2 border-purple-400 font-medium shadow-lg flex items-center gap-2"
+                    data-testid="button-generate-schedule-sticky"
+                  >
+                    <CalendarCheck className="w-5 h-5" />
+                    Generate Schedule
+                  </Button>
+                )}
+                {Array.from(selectedPOItems.values()).some((items) => items.size > 0) && (
+                  <Button
+                    onClick={handleGeneratePODemand}
+                    disabled={isGeneratingPODemand}
+                    className="bg-emerald-600 hover:bg-emerald-700 text-white border-2 border-emerald-400 font-medium shadow-lg flex items-center gap-2"
+                    data-testid="button-generate-production-demand-sticky"
+                  >
+                    <Package className="w-5 h-5" />
+                    {isGeneratingPODemand ? 'Generating...' : 'Generate Production Demand'}
+                  </Button>
+                )}
               </div>
             </div>
           </div>
@@ -1783,14 +1780,14 @@ export default function ProductionQueueManager() {
                         <Button
                           className="bg-green-600 hover:bg-green-700 text-white"
                           size="sm"
-                          disabled={isProgressingPOItems}
+                          disabled={isGeneratingPODemand}
                           onClick={() => {
-                            handleProgressToBarcode();
+                            handleGeneratePODemand();
                           }}
-                          data-testid="button-progress-to-barcode"
+                          data-testid="button-generate-production-demand"
                         >
-                          <ArrowRight className="w-4 h-4 mr-2" />
-                          {isProgressingPOItems ? 'Progressing...' : 'Progress to Barcode'}
+                          <Package className="w-4 h-4 mr-2" />
+                          {isGeneratingPODemand ? 'Generating...' : 'Generate Production Demand'}
                         </Button>
                       </div>
                     </div>
@@ -1948,7 +1945,7 @@ export default function ProductionQueueManager() {
                                     <TableHead>Material</TableHead>
                                     <TableHead>Handedness</TableHead>
                                     <TableHead>Available Qty</TableHead>
-                                    <TableHead>Status</TableHead>
+                                    <TableHead>Production Status</TableHead>
                                     <TableHead>Notes</TableHead>
                                   </TableRow>
                                 </TableHeader>
@@ -2031,7 +2028,11 @@ export default function ProductionQueueManager() {
                                             'outline'
                                           }
                                         >
-                                          {item.status || 'pending'}
+                                          {Object.keys(item.departmentStatuses || {}).length > 0
+                                            ? Object.entries(item.departmentStatuses)
+                                                .map(([department, count]) => `${count} ${department}`)
+                                                .join(', ')
+                                            : 'Not generated'}
                                         </Badge>
                                       </TableCell>
                                       <TableCell className="text-sm text-gray-600 max-w-xs truncate">

--- a/server/__tests__/p1PODemandUiBoundary.test.ts
+++ b/server/__tests__/p1PODemandUiBoundary.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const componentPath = fileURLToPath(
+  new URL('../../client/src/components/ProductionQueueManager.tsx', import.meta.url),
+);
+
+describe('P1 PO demand and production progression boundary', () => {
+  it('never sends PO-line selections through progression or scheduling', () => {
+    const source = readFileSync(componentPath, 'utf8');
+
+    expect(source).not.toContain("apiRequest('/api/p1-po-queue/progress'");
+    expect(source).toContain("apiRequest('/api/p1-po-queue/select'");
+    expect(source).toContain("apiRequest('/api/p1-po-queue/schedule'");
+    expect(source).toContain('selectedPOItems: []');
+    expect(source).toContain('Generate Production Demand');
+  });
+});

--- a/server/__tests__/p1POQueueHelper.test.ts
+++ b/server/__tests__/p1POQueueHelper.test.ts
@@ -164,7 +164,10 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
 
     const result = computeP1Queue([po], itemsByPoId, prodRows);
 
-    expect(result).toHaveLength(0);
+    expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
+      availableQuantity: 0,
+      departmentStatuses: { 'Shipping QC': 2 },
+    });
   });
 
   it('does not regenerate production orders that already exist in production', () => {
@@ -178,7 +181,10 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
 
     const result = computeP1Queue([po], itemsByPoId, prodRows);
 
-    expect(result).toHaveLength(0);
+    expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
+      availableQuantity: 0,
+      departmentStatuses: { 'Shipping QC': 1, Assembly: 1 },
+    });
   });
 
   it('excludes a PO when all production orders are Shipped or Completed (baseline)', () => {
@@ -195,14 +201,21 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('does not show ungenerated demand as a pending production unit', () => {
+  it('shows only ungenerated PO demand as available to generate', () => {
     const po = makePO();
     const item = makeItem();
     const itemsByPoId = new Map([[po.id, [item]]]);
 
     const result = computeP1Queue([po], itemsByPoId, []);
 
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
+      orderedQuantity: 2,
+      availableQuantity: 2,
+      quantity: 2,
+      status: 'not generated',
+      departmentStatuses: {},
+    });
   });
 
   it('handles multiple POs — excludes only the fully fulfilled one', () => {
@@ -227,7 +240,7 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result[0].purchaseOrders[0].poNumber).toBe('PO-002');
   });
 
-  it('shows only existing units waiting in P1 Production Queue', () => {
+  it('keeps existing units visible as status while exposing no replacement demand', () => {
     const poA = makePO({ id: 1, poNumber: 'PO-001', customerName: 'Alpha' });
     const poB = makePO({ id: 2, poNumber: 'PO-002', customerName: 'Beta', customerId: 200 });
     const itemA = makeItem({ id: 10 });
@@ -244,8 +257,34 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     const result = computeP1Queue([poA, poB], itemsByPoId, prodRows);
 
     expect(result).toHaveLength(2);
-    expect(result[0].purchaseOrders[0].items[0].quantity).toBe(1);
-    expect(result[1].purchaseOrders[0].items[0].quantity).toBe(1);
+    expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
+      quantity: 1,
+      availableQuantity: 1,
+      departmentStatuses: { 'P1 Production Queue': 1 },
+    });
+    expect(result[1].purchaseOrders[0].items[0]).toMatchObject({
+      quantity: 1,
+      availableQuantity: 1,
+      departmentStatuses: { 'P1 Production Queue': 1 },
+    });
+  });
+
+  it('changes only the PO status read model after a production unit progresses', () => {
+    const po = makePO();
+    const item = makeItem({ quantity: 1 });
+    const itemsByPoId = new Map([[po.id, [item]]]);
+
+    const result = computeP1Queue([po], itemsByPoId, [
+      makeProdRow({ production_status: 'IN_PROGRESS', current_department: 'Barcode' }),
+    ]);
+
+    expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
+      orderedQuantity: 1,
+      availableQuantity: 0,
+      quantity: 0,
+      status: 'generated',
+      departmentStatuses: { Barcode: 1 },
+    });
   });
 
   it('filters out items that are not stock_model type', () => {
@@ -258,17 +297,17 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('filters out items with no remaining quantity', () => {
+  it('ignores stale cached order_count when no production rows exist', () => {
     const po = makePO();
     const item = makeItem({ quantity: 2, orderCount: 2 });
     const itemsByPoId = new Map([[po.id, [item]]]);
 
     const result = computeP1Queue([po], itemsByPoId, []);
 
-    expect(result).toHaveLength(0);
+    expect(result[0].purchaseOrders[0].items[0].availableQuantity).toBe(2);
   });
 
-  it('exposes an existing pending PO production unit for progression', () => {
+  it('shows an existing pending production unit as read-only PO status', () => {
     const po = makePO({ poNumber: 'P18261' });
     const item = makeItem({
       id: 18,
@@ -291,8 +330,10 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result).toHaveLength(1);
     expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
       id: 18,
-      quantity: 1,
-      status: 'pending',
+      quantity: 0,
+      availableQuantity: 0,
+      status: 'generated',
+      departmentStatuses: { 'P1 Production Queue': 1 },
     });
   });
 
@@ -305,7 +346,7 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
       makeProdRow({ production_status: 'PENDING', current_department: 'P1 Production Queue' }),
     ]);
 
-    expect(result[0].purchaseOrders[0].items[0].quantity).toBe(1);
+    expect(result[0].purchaseOrders[0].items[0].quantity).toBe(2);
   });
 
   it('returns empty when given no POs', () => {

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -7870,6 +7870,9 @@ export interface P1POQueueItem {
   paintOptions: string | null;
   texture: string | null;
   flatTop: boolean | null;
+  orderedQuantity: number;
+  availableQuantity: number;
+  departmentStatuses: Record<string, number>;
   quantity: number;
   status: string | null;
   notes: string | null;

--- a/server/src/helpers/p1POQueueHelper.ts
+++ b/server/src/helpers/p1POQueueHelper.ts
@@ -16,6 +16,7 @@ export interface FulfillmentStats {
   active: number;
   fulfilled: number;
   activeP1Queue: number;
+  departmentStatuses?: Record<string, number>;
 }
 
 /**
@@ -51,7 +52,13 @@ export function buildFulfillmentMap(
     const itemMap = poFulfillmentMap.get(poId)!;
 
     if (!itemMap.has(poItemId)) {
-      itemMap.set(poItemId, { total: 0, active: 0, fulfilled: 0, activeP1Queue: 0 });
+      itemMap.set(poItemId, {
+        total: 0,
+        active: 0,
+        fulfilled: 0,
+        activeP1Queue: 0,
+        departmentStatuses: {},
+      });
     }
     const stats = itemMap.get(poItemId)!;
     stats.total++;
@@ -61,6 +68,10 @@ export function buildFulfillmentMap(
     if (isProductionOrderFulfilled(row)) {
       stats.fulfilled++;
     }
+    const displayDepartment = String(row.current_department || row.production_status || 'Not Started').trim();
+    const departmentStatuses = stats.departmentStatuses ?? (stats.departmentStatuses = {});
+    departmentStatuses[displayDepartment] =
+      (departmentStatuses[displayDepartment] || 0) + 1;
     const department = String(row.current_department || '').trim().toLowerCase();
     const status = String(row.production_status || '').trim().toUpperCase().replace(' ', '_');
     if (
@@ -151,10 +162,11 @@ export function computeP1Queue(
           (specs.stock_model as string | null) ??
           null;
         const fulfillmentStats = itemFulfillmentMap.get(item.id);
-        // This card is a read model of existing PENDING units waiting in the P1
-        // Production Queue. Progression moves those rows; it must not interpret
-        // them as permission to generate replacement production orders.
-        const pendingQueueQuantity = fulfillmentStats?.activeP1Queue ?? 0;
+        // The PO view is the demand source. Only the difference between ordered
+        // quantity and real non-cancelled production rows may be generated.
+        // Existing rows stay visible here as a read-only department/status summary.
+        const activeQuantity = fulfillmentStats?.active ?? 0;
+        const availableQuantity = Math.max(Number(item.quantity || 0) - activeQuantity, 0);
 
         return {
           id: item.id,
@@ -196,8 +208,11 @@ export function computeP1Queue(
             (specs.flatTop as boolean | null) ??
             (specs.flat_top as boolean | null) ??
             null,
-          quantity: pendingQueueQuantity,
-          status: 'pending',
+          orderedQuantity: Number(item.quantity || 0),
+          availableQuantity,
+          departmentStatuses: fulfillmentStats?.departmentStatuses ?? {},
+          quantity: availableQuantity,
+          status: activeQuantity > 0 ? 'generated' : 'not generated',
           notes: item.notes ?? item.productionNotes ?? null,
           dueDate: item.dueDate?.toString() ?? null,
           linkedOrderId: null,
@@ -222,7 +237,7 @@ export function computeP1Queue(
         if (fulfillmentStats && isPoItemFullyFulfilled(fulfillmentStats)) {
           return false;
         }
-        return item.quantity > 0;
+        return item.orderedQuantity > 0;
       });
 
     if (poItems.length > 0) {

--- a/server/src/routes/p1POQueue.ts
+++ b/server/src/routes/p1POQueue.ts
@@ -275,7 +275,10 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
     for (const selection of selections) {
       try {
         const poItemId = selection.poProductId;
-        const quantity = selection.quantity || 1;
+        const quantity = Number(selection.quantitySelected || 1);
+        if (!Number.isInteger(quantity) || quantity <= 0) {
+          throw new Error(`Invalid demand quantity for purchase order item ${poItemId}`);
+        }
 
         // Get the purchase order item details
         const poItemQuery = `
@@ -376,13 +379,20 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
           [poItemId]
         );
         const realOrderCount = parseInt(realCountRows[0]?.cnt ?? '0', 10);
-        if (realOrderCount >= quantity) {
+        const orderedQuantity = Number(item.quantity || 0);
+        const remainingDemand = Math.max(orderedQuantity - realOrderCount, 0);
+        if (remainingDemand === 0) {
           console.warn(`⚠️  P1 PO Schedule: PO item ${poItemId} already fully released (${realOrderCount} active production orders >= quantity=${quantity}), skipping`);
           warnings.push({
             poProductId: poItemId,
             warning: `Already fully released (${realOrderCount} of ${quantity} orders exist)`,
           });
           continue;
+        }
+        if (quantity > remainingDemand) {
+          throw new Error(
+            `Requested ${quantity} unit(s) for PO item ${poItemId}, but only ${remainingDemand} unit(s) of ungenerated demand remain`,
+          );
         }
 
         const specs = item.specifications || {};
@@ -398,7 +408,7 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
 
           // Only create the orders that are still missing (quantity minus what already exists).
           // Start the sequence after the already-existing orders so IDs are deterministic.
-          const remainingToCreate = quantity - realOrderCount;
+          const remainingToCreate = quantity;
 
           // Detect metal accessories by item_name/item_id/item_type before inserting
           // Metal accessories must route to Shipping QC, not P1 Production Queue
@@ -416,7 +426,7 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
             // Sequence starts after existing orders so we never collide.
             const seqNum = realOrderCount + i + 1;
             const orderId = `PO-${item.po_number}-${poItemId}-${seqNum}`;
-            const notes = `PO Item: ${item.item_name || ''} - PO #${item.po_number} (Unit ${i + 1} of ${quantity})`;
+            const notes = `PO Item: ${item.item_name || ''} - PO #${item.po_number} (Unit ${seqNum} of ${orderedQuantity})`;
             const features = JSON.stringify({
               po_item_id: poItemId,
               po_number: item.po_number,


### PR DESCRIPTION
## What changed

- replace the P1 Purchase Order action that progressed PO lines directly to Barcode with `Generate Production Demand`
- generate only the uncreated portion of ordered PO quantity into P1 Production Queue
- prevent PO-line selections from entering the layup scheduler; scheduling and progression now operate on existing production-order IDs
- keep generated PO items visible as a read-only department status summary as units advance through production
- add regression coverage for the UI boundary and demand/status calculations

## Why

The P1 PO UI mixed two separate responsibilities. It treated PO-line quantities as progression requests, while the production queue already owned progression of individual generated units. This allowed PO actions to create or move units through the wrong path and made downstream progression appear as fresh PO demand.

The required workflow is:

`P1 PO demand -> P1 Production Queue -> Barcode -> CNC -> Finish -> Finish QC -> Paint -> Shipping QC -> Shipping`

## Impact

Purchase orders now generate demand only. Once generated, each existing production unit advances through the production queue controls, and the P1 PO UI reflects department/status counts without generating replacement items.

Server-side generation uses the ordered quantity minus real non-cancelled production rows and rejects requests above the remaining demand.

## Checks

- focused Vitest regression suite: 47 tests passed
- full TypeScript check: passed
- `git diff --cached --check`: passed
