### PR TITLE
Route P1 metal accessories to Shipping QC

### DIFF
--- a/client/src/components/POManager.tsx
+++ b/client/src/components/POManager.tsx
@@ -499,7 +499,7 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
     },
   });
 
-  const METAL_ACCESSORY_PREFIXES = ['AGM5', 'AGBDL', 'AGBM', 'AGPIC', 'AGARCA'];
+  const METAL_ACCESSORY_PREFIXES = ['AGM5', 'AGMS5', 'AGBDL', 'AGBM', 'AGPIC', 'AGARCA'];
   const hasMetalAccessoryOrders = (productionOrders as any[]).some((o: any) => {
     const id = (o.itemId || o.itemName || '').toUpperCase();
     return METAL_ACCESSORY_PREFIXES.some(p => id.startsWith(p));

--- a/migrations/0197_route_p1_metal_accessories_to_shipping_qc.sql
+++ b/migrations/0197_route_p1_metal_accessories_to_shipping_qc.sql
@@ -1,0 +1,43 @@
+-- P1 metal accessories do not require the manufacturing department sequence.
+-- Route existing active rows that are still at the initial P1 queue directly to
+-- Shipping QC. The SKU checks cover both compact and hyphenated formats and the
+-- WHERE clauses make this migration idempotent and safe on an empty database.
+
+UPDATE production_orders
+SET item_id = COALESCE(NULLIF(TRIM(poi.item_id), ''), NULLIF(TRIM(poi.item_name), ''), production_orders.item_id),
+    item_name = COALESCE(NULLIF(TRIM(poi.item_name), ''), NULLIF(TRIM(poi.item_id), ''), production_orders.item_name),
+    current_department = 'Shipping QC',
+    production_status = 'IN_PROGRESS',
+    material_canonical = 'Metal Accessory',
+    updated_at = NOW()
+FROM purchase_order_items poi
+WHERE production_orders.po_item_id = poi.id
+  AND production_orders.current_department = 'P1 Production Queue'
+  AND UPPER(COALESCE(production_orders.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')
+  AND (
+    REGEXP_REPLACE(UPPER(COALESCE(poi.item_id, '')), '[-_]', '', 'g') LIKE ANY (ARRAY[
+      'AGM5%', 'AGMS5%', 'AGBDL%', 'AGBM%', 'AGPIC%', 'AGARCA%'
+    ])
+    OR REGEXP_REPLACE(UPPER(COALESCE(poi.item_name, '')), '[-_]', '', 'g') LIKE ANY (ARRAY[
+      'AGM5%', 'AGMS5%', 'AGBDL%', 'AGBM%', 'AGPIC%', 'AGARCA%'
+    ])
+  );
+
+UPDATE all_orders ao
+SET current_department = 'Shipping QC',
+    status = 'IN_PROGRESS',
+    updated_at = NOW()
+WHERE ao.current_department = 'P1 Production Queue'
+  AND UPPER(COALESCE(ao.status, '')) NOT IN ('CANCELLED', 'SHIPPED', 'COMPLETED')
+  AND (
+    REGEXP_REPLACE(UPPER(COALESCE(ao.model_id, '')), '[-_]', '', 'g') LIKE ANY (ARRAY[
+      'AGM5%', 'AGMS5%', 'AGBDL%', 'AGBM%', 'AGPIC%', 'AGARCA%'
+    ])
+    OR EXISTS (
+      SELECT 1
+      FROM production_orders po
+      WHERE po.order_id = ao.order_id
+        AND po.current_department = 'Shipping QC'
+        AND po.material_canonical = 'Metal Accessory'
+    )
+  );

--- a/server/__tests__/p1POQueueScheduleGuard.test.ts
+++ b/server/__tests__/p1POQueueScheduleGuard.test.ts
@@ -545,6 +545,13 @@ describe('isMetalAccessorySku — routing guard', () => {
 
   it('returns true when itemName starts with AGARCA prefix', () => {
     expect(isMetalAccessorySku('AGARCA-base', '', 'stock_model')).toBe(true);
+    expect(isMetalAccessorySku('AGARCA08', '', 'stock_model')).toBe(true);
+  });
+
+  it('recognizes the production SKUs shown on bottom-metal PO lines', () => {
+    expect(isMetalAccessorySku('AGMS5AA01', 'AGMS5AA01', 'stock_model')).toBe(true);
+    expect(isMetalAccessorySku('AGBDLSA01', 'AGBDLSA01', 'stock_model')).toBe(true);
+    expect(isMetalAccessorySku('AGARCA08', 'AGARCA08', 'stock_model')).toBe(true);
   });
 
   it('returns true when itemId (not itemName) starts with a metal prefix', () => {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -219,6 +219,7 @@ export const safeMigrationFiles = [
   '0194_layup_schedule_history.sql',
   '0195_production_order_transition_history.sql',
   '0196_document_template_builder_tables.sql',
+  '0197_route_p1_metal_accessories_to_shipping_qc.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -10077,7 +10077,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   // Metal accessory prefixes — normalize hyphens/underscores before testing so both
   // hyphenated (AG-M5-*) and non-hyphenated (AGM5*) formats are detected.
-  const METAL_ACCESSORY_NORMALIZED_PREFIXES = ['AGM5', 'AGBDL', 'AGBM', 'AGPIC', 'AGARCA'];
+  const METAL_ACCESSORY_NORMALIZED_PREFIXES = ['AGM5', 'AGMS5', 'AGBDL', 'AGBM', 'AGPIC', 'AGARCA'];
 
   const isMetalAccessorySku = (value: string): boolean => {
     if (!value) return false;
@@ -10283,11 +10283,13 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           // Metal accessories skip manufacturing and ship directly; all others enter P1 queue.
           const initialDepartment = isMetal ? 'Shipping QC' : 'P1 Production Queue';
 
-          // Use a descriptive display name for metal accessories when no stock model name is available.
+          // Preserve the exact PO line identity. stockModelName can be stale after a line's
+          // product code changes, which made the production child display another product.
           const resolvedItemName =
-            item.stockModelName ||
-            (isMetal ? deriveMetalAccessoryDisplayName(stockModelForOrder) : null) ||
             item.itemName ||
+            item.itemId ||
+            (isMetal ? deriveMetalAccessoryDisplayName(stockModelForOrder) : null) ||
+            item.stockModelName ||
             stockModelForOrder;
 
           const sourceSnapshot = {
@@ -10379,7 +10381,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const { sql } = await import('drizzle-orm');
 
       const METAL_ACCESSORY_PATTERNS = [
-        'AGM5%', 'AGBDL%', 'AGBM%', 'AGPIC%', 'AGARCA%',
+        'AGM5%', 'AGMS5%', 'AGBDL%', 'AGBM%', 'AGPIC%', 'AGARCA%',
         'AG-M5-%', 'AG-BDL-%', 'AG-BM-%', 'AG-PIC-%', 'AG-ARCA-%',
       ];
 

--- a/server/src/routes/p1POQueue.ts
+++ b/server/src/routes/p1POQueue.ts
@@ -9,7 +9,7 @@ import { resolveItemDisplayName } from '../utils/resolveItemDisplayName';
 
 const router = Router();
 
-const METAL_ACCESSORY_PREFIXES = ['AGBM', 'AGBDL', 'AGM5', 'AGPIC', 'AGARCA'];
+const METAL_ACCESSORY_PREFIXES = ['AGBM', 'AGBDL', 'AGM5', 'AGMS5', 'AGPIC', 'AGARCA'];
 
 function normalizeSkuForMatch(sku: string): string {
   return sku.toUpperCase().replace(/[-_]/g, '');
@@ -936,6 +936,7 @@ router.post('/retry-stuck/:poNumber', async (req: Request, res: Response) => {
         poi.id as poi_id,
         poi.item_id,
         poi.item_name,
+        poi.item_type,
         poi.specifications,
         poi.due_date,
         poi.order_count,
@@ -983,6 +984,11 @@ router.post('/retry-stuck/:poNumber', async (req: Request, res: Response) => {
         const specs = sel.specifications || {};
         const dueDate = sel.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
         const scheduledDate = targetWeek ? new Date(targetWeek) : new Date(dueDate);
+        const targetDepartment = isMetalAccessorySku(
+          sel.item_name || '',
+          sel.item_id || '',
+          sel.item_type || undefined,
+        ) ? 'Shipping QC' : 'P1 Production Queue';
 
         // Generate the same order IDs as /schedule (i+1, not currentOrderCount+i+1)
         for (let i = 0; i < quantity; i++) {
@@ -1013,7 +1019,7 @@ router.post('/retry-stuck/:poNumber', async (req: Request, res: Response) => {
                 current_department, status, notes, features, order_source,
                 source_po_id, source_po_item_id, department_history, created_at, updated_at
               ) VALUES (
-                $1, NOW(), $2, $3, $4, 'P1 Production Queue', 'IN_PROGRESS', $5, $6::jsonb,
+                $1, NOW(), $2, $3, $4, $9, 'IN_PROGRESS', $5, $6::jsonb,
                 'PO_RELEASE', $7, $8, '[]'::jsonb, NOW(), NOW()
               )
             `, [
@@ -1025,6 +1031,7 @@ router.post('/retry-stuck/:poNumber', async (req: Request, res: Response) => {
               features,
               sel.purchase_order_id,
               poItemId,
+              targetDepartment,
             ]);
 
             await pool.query(
@@ -1038,7 +1045,7 @@ router.post('/retry-stuck/:poNumber', async (req: Request, res: Response) => {
                 JSON.stringify(null),
                 JSON.stringify({
                   order_id: orderId,
-                  current_department: 'P1 Production Queue',
+                  current_department: targetDepartment,
                   status: 'IN_PROGRESS',
                   order_source: 'PO_RELEASE',
                   source_po_id: sel.purchase_order_id,
@@ -1068,7 +1075,7 @@ router.post('/retry-stuck/:poNumber', async (req: Request, res: Response) => {
               department_history, created_at, updated_at
             ) VALUES (
               $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, NOW(), $11,
-              'PENDING', 'P1 Production Queue', '[]'::jsonb, NOW(), NOW()
+              $12, $13, '[]'::jsonb, NOW(), NOW()
             )
             ON CONFLICT (order_id) DO NOTHING
             RETURNING order_id
@@ -1084,18 +1091,22 @@ router.post('/retry-stuck/:poNumber', async (req: Request, res: Response) => {
             resolveItemDisplayName(sel.item_name || ''),
             JSON.stringify(specs),
             dueDate,
+            targetDepartment === 'Shipping QC' ? 'IN_PROGRESS' : 'PENDING',
+            targetDepartment,
           ]);
           const prodInsertRows = Array.isArray(prodInsertResult) ? prodInsertResult : (prodInsertResult as any).rows || [];
           const prodOrderCreated = prodInsertRows.length > 0;
 
           // layup_schedule — insert only if missing (DO NOTHING to preserve any
           // existing schedule date for orders already in flight)
-          await pool.query(`
-            INSERT INTO layup_schedule (
-              order_id, scheduled_date, priority_score, is_locked, created_at, updated_at
-            ) VALUES ($1, $2, 1500, false, NOW(), NOW())
-            ON CONFLICT (order_id) DO NOTHING
-          `, [orderId, scheduledDate.toISOString()]);
+          if (targetDepartment === 'P1 Production Queue') {
+            await pool.query(`
+              INSERT INTO layup_schedule (
+                order_id, scheduled_date, priority_score, is_locked, created_at, updated_at
+              ) VALUES ($1, $2, 1500, false, NOW(), NOW())
+              ON CONFLICT (order_id) DO NOTHING
+            `, [orderId, scheduledDate.toISOString()]);
+          }
 
           // Count as recovered only if the production_orders row was newly created
           if (prodOrderCreated) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -13506,7 +13506,7 @@ export class DatabaseStorage implements IStorage {
         const inv = inventoryMatch[0];
 
         // Check if item is a metal accessory by SKU prefix (itemName or itemId take priority over stockModelId)
-        const metalSkuPrefixes = ['AGBM', 'AGBDL', 'AGM5', 'AGPIC', 'AGARCA'];
+        const metalSkuPrefixes = ['AGBM', 'AGBDL', 'AGM5', 'AGMS5', 'AGPIC', 'AGARCA'];
         const normalizeSkuForMetal = (s: string) => s.toUpperCase().replace(/[-_]/g, '');
         const isMetalSkuByName =
           metalSkuPrefixes.some((p) => normalizeSkuForMetal(item.itemName || '').startsWith(p)) ||


### PR DESCRIPTION
## What changed

- route P1 bottom-metal and metal-accessory SKUs directly to Shipping QC
- include the AGMS5 SKU family alongside AGM5, AGBDL, AGBM, AGPIC, and AGARCA
- keep retry/recovery generation from inserting metal accessories into the layup schedule
- copy the production-order item identity from the exact linked PO line
- repair existing active metal rows that are in P1 Production Queue or carry stale PO-line names

## Root cause

The normal generation path recognized most metal prefixes, but retry and recovery paths still hard-coded P1 Production Queue. AGMS5 was also missing from the prefix list. Separately, generation preferred a stale stockModelName over the current purchase-order line item name, producing the visible Mismatch badge even when po_item_id was correct.

## Impact

Bottom metals bypass manufacturing and begin at Shipping QC. Existing affected rows are corrected idempotently during safe-boot migrations, and production rows remain aligned with their linked PO line.

## Validation

- `server/__tests__/p1POQueueScheduleGuard.test.ts`: 22 passed
- `git diff --cached --check`: passed before commit
- DB-backed migration safety tests were not run because `DATABASE_URL` is unavailable locally