### PR TITLE
Show PO production rows in P1 queue

### DIFF
--- a/server/__tests__/p1ProductionOrdersQueueVisibility.test.ts
+++ b/server/__tests__/p1ProductionOrdersQueueVisibility.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('P1 production order queue visibility', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'server/src/routes/productionQueue.ts'),
+    'utf8',
+  );
+
+  it('includes pending Purchase Order Management children in the prioritized queue', () => {
+    expect(source).toContain('FROM production_orders p');
+    expect(source).toContain(
+      "UPPER(COALESCE(p.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')",
+    );
+  });
+
+  it('deduplicates production children already mirrored into all_orders', () => {
+    expect(source).toContain('AND NOT EXISTS (');
+    expect(source).toContain('WHERE mirrored.order_id = p.order_id');
+  });
+});

--- a/server/src/routes/productionQueue.ts
+++ b/server/src/routes/productionQueue.ts
@@ -470,57 +470,109 @@ router.get('/prioritized', async (req: Request, res: Response) => {
     console.log('🧹 CLEANUP: Processing orders that need attention...');
     await autoMoveInvalidStockModelOrders(storage);
 
-    // Schema-safe query: avoid referencing columns that may not exist in all environments
-    // UNIFIED PRIORITY MODEL: Include all priority-related fields for computeEffectivePriority()
-    // NOTE: P1 PO orders are handled separately in their dedicated P1 Purchase Orders queue
-    // This query only includes regular customer orders from all_orders
+    // Unified read model: sales orders live in all_orders, while Purchase Order
+    // Management creates its production children in production_orders. Include
+    // both sources so generated PO demand is actually actionable in this queue.
+    // The NOT EXISTS guard prevents duplicate display when another release path
+    // has already mirrored the production order into all_orders.
     const queueQuery = `
-      SELECT 
-        o.order_id as orderId,
-        o.fb_order_number as fbOrderNumber,
-        o.model_id as modelId,
-        o.model_id as stockModelId,
-        o.due_date as dueDate,
-        o.order_date as orderDate,
-        o.current_department as currentDepartment,
-        o.status,
-        o.customer_id as customerId,
-        o.features,
-        o.urgency,
-        o.is_manual_urgency as isManualUrgency,
-        NULL as manual_priority_override,
-        NULL as prioritySource,
-        'ready' as productionReadinessStatus,
-        0 as queuePosition,
-        o.created_at as createdAt,
-        COALESCE(c.name, 'Customer ' || o.customer_id) as customerName,
-        'SALES' as orderSource,
-        o.is_flattop as "isFlattop"
-      FROM all_orders o
-      LEFT JOIN customers c ON o.customer_id ~ '^[0-9]+$' AND CAST(o.customer_id AS INTEGER) = c.id
-      WHERE o.current_department = 'P1 Production Queue'
-        AND o.status IN ('FINALIZED', 'Active', 'IN_PROGRESS')
-        AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
-        AND o.model_id IS NOT NULL 
-        AND o.model_id != '' 
-        AND o.model_id != 'None'
-        AND LOWER(o.model_id) != 'no stock'
-        AND LOWER(o.model_id) != 'no_stock'
-        AND (
-          LOWER(COALESCE(
-            o.features->>'action_length',
-            o.features->>'actionLength',
-            o.features->'specifications'->>'action_length',
-            o.features->'specifications'->>'actionLength',
-            ''
-          )) NOT IN ('', 'null')
-          OR LOWER(o.model_id) LIKE '%m1a%'
-          OR LOWER(o.model_id) LIKE '%tikka%'
-          OR o.is_flattop = true
-        )
-      ORDER BY 
-        o.due_date ASC,
-        o.created_at ASC
+      WITH queue_orders AS (
+        SELECT
+          o.order_id as orderId,
+          o.fb_order_number as fbOrderNumber,
+          o.model_id as modelId,
+          o.model_id as stockModelId,
+          o.due_date as dueDate,
+          o.order_date as orderDate,
+          o.current_department as currentDepartment,
+          o.status,
+          o.customer_id as customerId,
+          o.features,
+          o.urgency,
+          o.is_manual_urgency as isManualUrgency,
+          NULL as manual_priority_override,
+          NULL as prioritySource,
+          'ready' as productionReadinessStatus,
+          0 as queuePosition,
+          o.created_at as createdAt,
+          COALESCE(c.name, 'Customer ' || o.customer_id) as customerName,
+          'SALES' as orderSource,
+          o.is_flattop as "isFlattop"
+        FROM all_orders o
+        LEFT JOIN customers c ON o.customer_id ~ '^[0-9]+$' AND CAST(o.customer_id AS INTEGER) = c.id
+        WHERE o.current_department = 'P1 Production Queue'
+          AND o.status IN ('FINALIZED', 'Active', 'IN_PROGRESS')
+          AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
+          AND o.model_id IS NOT NULL
+          AND o.model_id != ''
+          AND o.model_id != 'None'
+          AND LOWER(o.model_id) != 'no stock'
+          AND LOWER(o.model_id) != 'no_stock'
+          AND (
+            LOWER(COALESCE(
+              o.features->>'action_length',
+              o.features->>'actionLength',
+              o.features->'specifications'->>'action_length',
+              o.features->'specifications'->>'actionLength',
+              ''
+            )) NOT IN ('', 'null')
+            OR LOWER(o.model_id) LIKE '%m1a%'
+            OR LOWER(o.model_id) LIKE '%tikka%'
+            OR o.is_flattop = true
+          )
+
+        UNION ALL
+
+        SELECT
+          p.order_id as orderId,
+          NULL::text as fbOrderNumber,
+          p.item_id as modelId,
+          p.item_id as stockModelId,
+          p.due_date as dueDate,
+          p.order_date as orderDate,
+          p.current_department as currentDepartment,
+          p.production_status as status,
+          p.customer_id as customerId,
+          p.specifications as features,
+          NULL::text as urgency,
+          false as isManualUrgency,
+          NULL as manual_priority_override,
+          NULL as prioritySource,
+          'ready' as productionReadinessStatus,
+          0 as queuePosition,
+          p.created_at as createdAt,
+          COALESCE(NULLIF(p.customer_name, ''), 'Customer ' || p.customer_id) as customerName,
+          'PO_RELEASE' as orderSource,
+          false as "isFlattop"
+        FROM production_orders p
+        WHERE p.current_department = 'P1 Production Queue'
+          AND UPPER(COALESCE(p.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')
+          AND p.item_id IS NOT NULL
+          AND p.item_id != ''
+          AND LOWER(p.item_id) NOT IN ('none', 'no stock', 'no_stock')
+          AND (
+            LOWER(COALESCE(
+              p.specifications->>'action_length',
+              p.specifications->>'actionLength',
+              ''
+            )) NOT IN ('', 'null')
+            OR LOWER(p.item_id) LIKE '%m1a%'
+            OR LOWER(p.item_id) LIKE '%tikka%'
+            OR LOWER(COALESCE(
+              p.specifications->>'flat_top',
+              p.specifications->>'flatTop',
+              'false'
+            )) IN ('true', '1', 'yes')
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM all_orders mirrored
+            WHERE mirrored.order_id = p.order_id
+          )
+      )
+      SELECT *
+      FROM queue_orders
+      ORDER BY dueDate ASC, createdAt ASC
     `;
 
     const queueResult = await pool.query(queueQuery);


### PR DESCRIPTION
## What changed

- Build the prioritized P1 queue from both regular `all_orders` rows and Purchase Order Management `production_orders` rows.
- Include pending, active, and in-progress PO production children currently assigned to P1 Production Queue.
- Preserve the readiness checks for stock model, action length, Tikka/M1A, and flat-top orders.
- Deduplicate PO production children that already have an `all_orders` mirror.
- Add focused regression coverage for visibility and deduplication.

## Root cause

Purchase Order Management creates production children in `production_orders`, but the prioritized P1 queue only queried `all_orders`. The generated units existed in the database but could not appear in the actionable production queue.

## Impact

Existing and newly created PO production units will appear in Regular Production Queue without regenerating or modifying the underlying records. The P1 Purchase Orders badge continues to represent unreleased demand rather than pending production units.

## Validation

- Focused P1 regression suite: 29 tests passed.
- `git diff --check` — passed.