### PR TITLE
Fix P1 PO production workflow boundary

### DIFF
--- a/server/__tests__/p1ProductionOrdersQueueVisibility.test.ts
+++ b/server/__tests__/p1ProductionOrdersQueueVisibility.test.ts
@@ -2,21 +2,43 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-describe('P1 production order queue visibility', () => {
-  const source = readFileSync(
+describe('P1 production order workflow boundary', () => {
+  const productionQueueSource = readFileSync(
     join(process.cwd(), 'server/src/routes/productionQueue.ts'),
     'utf8',
   );
+  const p1QueueSource = readFileSync(
+    join(process.cwd(), 'server/src/routes/p1POQueue.ts'),
+    'utf8',
+  );
 
-  it('includes pending Purchase Order Management children in the prioritized queue', () => {
-    expect(source).toContain('FROM production_orders p');
-    expect(source).toContain(
-      "UPPER(COALESCE(p.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')",
+  it('keeps Purchase Order Management demand out of the regular production queue', () => {
+    expect(productionQueueSource).toContain(
+      "COALESCE(o.order_source, 'SALES') <> 'PO_RELEASE'",
     );
+    expect(productionQueueSource).not.toContain('FROM production_orders p');
   });
 
-  it('deduplicates production children already mirrored into all_orders', () => {
-    expect(source).toContain('AND NOT EXISTS (');
-    expect(source).toContain('WHERE mirrored.order_id = p.order_id');
+  it('creates only production_orders while scheduling PO demand', () => {
+    const scheduleStart = p1QueueSource.indexOf("router.post('/schedule'");
+    const progressStart = p1QueueSource.indexOf("router.post('/progress'");
+    const scheduleSource = p1QueueSource.slice(scheduleStart, progressStart);
+
+    expect(scheduleStart).toBeGreaterThanOrEqual(0);
+    expect(progressStart).toBeGreaterThan(scheduleStart);
+    expect(scheduleSource).toContain('INSERT INTO production_orders');
+    expect(scheduleSource).toContain('ON CONFLICT (order_id) DO NOTHING');
+    expect(scheduleSource).not.toContain('INSERT INTO all_orders');
+  });
+
+  it('does not create regular orders when retrying missing PO demand', () => {
+    const retryStart = p1QueueSource.indexOf("router.post('/retry-stuck/:poNumber'");
+    const backfillStart = p1QueueSource.indexOf("router.post('/backfill-production-orders'");
+    const retrySource = p1QueueSource.slice(retryStart, backfillStart);
+
+    expect(retryStart).toBeGreaterThanOrEqual(0);
+    expect(backfillStart).toBeGreaterThan(retryStart);
+    expect(retrySource).toContain('INSERT INTO production_orders');
+    expect(retrySource).not.toContain('INSERT INTO all_orders');
   });
 });

--- a/server/src/routes/p1POQueue.ts
+++ b/server/src/routes/p1POQueue.ts
@@ -397,6 +397,10 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
         }
 
         const specs = item.specifications || {};
+        const normalizedSpecs = {
+          ...specs,
+          action_length: specs.action_length || specs.actionLength || '',
+        };
         const dueDate = item.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
 
         // Wrap all inserts and the order_count update for this item in a transaction
@@ -431,95 +435,9 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
             // Sequence starts after existing orders so we never collide.
             const seqNum = realOrderCount + i + 1;
             const orderId = `PO-${item.po_number}-${poItemId}-${seqNum}`;
-            const notes = `PO Item: ${item.item_name || ''} - PO #${item.po_number} (Unit ${seqNum} of ${orderedQuantity})`;
-            const features = JSON.stringify({
-              po_item_id: poItemId,
-              po_number: item.po_number,
-              po_id: item.po_id,
-              specifications: specs,
-              // PO specifications exist in both legacy snake_case and current
-              // camelCase shapes. Keep the queue-facing field normalized so
-              // newly generated pending units pass the P1 readiness filter.
-              action_length: specs.action_length || specs.actionLength || '',
-            });
-
-            // Insert into all_orders table with the correct department.
-            // ON CONFLICT DO NOTHING ensures idempotency now that a unique index exists on order_id.
-            const insertOrderQuery = `
-              INSERT INTO all_orders (
-                order_id,
-                order_date,
-                due_date,
-                customer_id,
-                model_id,
-                current_department,
-                status,
-                notes,
-                features,
-                order_source,
-                source_po_id,
-                source_po_item_id,
-                department_history,
-                created_at,
-                updated_at
-              ) VALUES (
-                $1, NOW(), $2, $3, $4, $9, $10, $5, $6::jsonb,
-                'PO_RELEASE', $7, $8, '[]'::jsonb, NOW(), NOW()
-              )
-              ON CONFLICT (order_id) DO NOTHING
-              RETURNING id
-            `;
-            const allOrderResult = await client.query(insertOrderQuery, [
-              orderId,
-              dueDate,
-              item.customer_id || item.customer_name,
-              item.item_id || '',
-              notes,
-              features,
-              item.po_id,
-              poItemId,
-              targetDepartment,
-              targetStatus,
-            ]);
-
-            // RC-3 FIX: Only proceed with downstream inserts/audit for rows that were actually
-            // inserted. When ON CONFLICT DO NOTHING fires (order already exists), track the
-            // skip explicitly so operators see an accurate count in the API response.
-            if (!allOrderResult.rows || allOrderResult.rows.length === 0) {
-              console.warn(`⚠️  P1 PO Schedule: order ${orderId} already exists in all_orders, skipping`);
-              skippedOrders.push({ orderId, reason: 'already_exists' });
-              continue;
-            }
-
-            insertedCount++;
-
-            await client.query(
-              `INSERT INTO admin_audit_log
-                 (order_id, field_name, field_label, old_value, new_value, changed_by, user_role, change_type, reason, ip_address, user_agent, timestamp)
-               VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, $8, $9, $10, $11, NOW())`,
-              [
-                orderId,
-                'ORDER_CREATED',
-                'Order Created',
-                JSON.stringify(null),
-                JSON.stringify({
-                  order_id: orderId,
-                  current_department: targetDepartment,
-                  status: targetStatus,
-                  order_source: 'PO_RELEASE',
-                  source_po_id: item.po_id,
-                  source_po_item_id: poItemId,
-                }),
-                (req as any).user?.username || 'SYSTEM',
-                (req as any).user?.role || 'SYSTEM',
-                'ORDER_CREATE',
-                `Order created from PO release: PO #${item.po_number}`,
-                req.ip ?? null,
-                req.headers['user-agent'] ?? null,
-              ]
-            );
-
-            // Also create a production_orders record for queue visibility
+            // PO demand belongs only to production_orders while it is in P1.
+            // Barcode progression creates/updates the all_orders mirror only
+            // when the exact production unit actually leaves this queue.
             const insertProductionOrderQuery = `
               INSERT INTO production_orders (
                 order_id,
@@ -544,13 +462,10 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
                 $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, NOW(), $11,
                 $12, $13, $14, '[]'::jsonb, NOW(), NOW()
               )
-              ON CONFLICT (order_id) DO UPDATE
-              SET current_department = $13,
-                  production_status = $12,
-                  material_canonical = $14,
-                  updated_at = NOW()
+              ON CONFLICT (order_id) DO NOTHING
+              RETURNING id
             `;
-            await client.query(insertProductionOrderQuery, [
+            const productionOrderResult = await client.query(insertProductionOrderQuery, [
               orderId,
               item.po_id,
               poItemId,
@@ -560,12 +475,46 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
               specs.item_type || 'Stock',
               item.item_id || '',
               resolveItemDisplayName(item.item_name || ''),
-              JSON.stringify(specs),
+              JSON.stringify(normalizedSpecs),
               dueDate,
               targetStatus,
               targetDepartment,
               materialCanonical,
             ]);
+
+            if (!productionOrderResult.rows || productionOrderResult.rows.length === 0) {
+              console.warn(`P1 PO Schedule: production order ${orderId} already exists, skipping`);
+              skippedOrders.push({ orderId, reason: 'already_exists' });
+              continue;
+            }
+
+            insertedCount++;
+
+            await client.query(
+              `INSERT INTO admin_audit_log
+                 (order_id, field_name, field_label, old_value, new_value, changed_by, user_role, change_type, reason, ip_address, user_agent, timestamp)
+               VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, $8, $9, $10, $11, NOW())`,
+              [
+                orderId,
+                'ORDER_CREATED',
+                'Production Order Created',
+                JSON.stringify(null),
+                JSON.stringify({
+                  order_id: orderId,
+                  current_department: targetDepartment,
+                  production_status: targetStatus,
+                  record_source: 'production_orders',
+                  source_po_id: item.po_id,
+                  source_po_item_id: poItemId,
+                }),
+                (req as any).user?.username || 'SYSTEM',
+                (req as any).user?.role || 'SYSTEM',
+                'ORDER_CREATE',
+                `Production order created from PO release: PO #${item.po_number}`,
+                req.ip ?? null,
+                req.headers['user-agent'] ?? null,
+              ]
+            );
 
             // Only manufactured stocks belong on the layup scheduler. Metal
             // accessories skip manufacturing and go directly to Shipping QC.
@@ -1009,80 +958,9 @@ router.post('/retry-stuck/:poNumber', async (req: Request, res: Response) => {
         // Generate the same order IDs as /schedule (i+1, not currentOrderCount+i+1)
         for (let i = 0; i < quantity; i++) {
           const orderId = `PO-${sel.po_number}-${poItemId}-${i + 1}`;
-          const notes = `PO Item: ${sel.item_name || ''} - PO #${sel.po_number} (Unit ${i + 1} of ${quantity}) [RETRIED]`;
-          const features = JSON.stringify({
-            po_item_id: poItemId,
-            po_number: sel.po_number,
-            po_id: sel.purchase_order_id,
-            specifications: specs,
-            action_length: specs.action_length || '',
-          });
-
-          // Check each table independently for per-table idempotency.
-          // A partial failure (e.g., all_orders OK, production_orders failed) is
-          // repaired by inserting only the missing rows.
-
-          // all_orders — insert only if missing
-          const allOrdersExists = await pool.query(
-            `SELECT id FROM all_orders WHERE order_id = $1 LIMIT 1`,
-            [orderId]
-          );
-          const allOrdersExistsRows = Array.isArray(allOrdersExists) ? allOrdersExists : (allOrdersExists as any).rows || [];
-          if (allOrdersExistsRows.length === 0) {
-            await pool.query(`
-              INSERT INTO all_orders (
-                order_id, order_date, due_date, customer_id, model_id,
-                current_department, status, notes, features, order_source,
-                source_po_id, source_po_item_id, department_history, created_at, updated_at
-              ) VALUES (
-                $1, NOW(), $2, $3, $4, $9, 'IN_PROGRESS', $5, $6::jsonb,
-                'PO_RELEASE', $7, $8, '[]'::jsonb, NOW(), NOW()
-              )
-            `, [
-              orderId,
-              dueDate,
-              sel.customer_id || sel.customer_name,
-              sel.item_id || '',
-              notes,
-              features,
-              sel.purchase_order_id,
-              poItemId,
-              targetDepartment,
-            ]);
-
-            await pool.query(
-              `INSERT INTO admin_audit_log
-                 (order_id, field_name, field_label, old_value, new_value, changed_by, user_role, change_type, reason, ip_address, user_agent, timestamp)
-               VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, $8, $9, $10, $11, NOW())`,
-              [
-                orderId,
-                'ORDER_CREATED',
-                'Order Created',
-                JSON.stringify(null),
-                JSON.stringify({
-                  order_id: orderId,
-                  current_department: targetDepartment,
-                  status: 'IN_PROGRESS',
-                  order_source: 'PO_RELEASE',
-                  source_po_id: sel.purchase_order_id,
-                  source_po_item_id: poItemId,
-                  retry: true,
-                  selection_id: sel.selection_id,
-                }),
-                (req as any).user?.username || 'SYSTEM',
-                (req as any).user?.role || 'SYSTEM',
-                'ORDER_CREATE',
-                `Order created via retry for stuck batch selection (PO #${sel.po_number})`,
-                req.ip ?? null,
-                req.headers['user-agent'] ?? null,
-              ]
-            );
-          } else {
-            console.log(`🔄 Retry: all_orders already has ${orderId}, skipping insert`);
-          }
-
-          // production_orders — insert only if missing (DO NOTHING avoids resetting
-          // progress for orders that have already advanced through departments)
+          // Retry repairs only the missing P1 production record. It must not
+          // create a regular all_orders row before Barcode progression.
+          // DO NOTHING also avoids resetting units that already advanced.
           const prodInsertResult = await pool.query(`
             INSERT INTO production_orders (
               order_id, po_id, po_item_id, customer_id, customer_name,

--- a/server/src/routes/productionQueue.ts
+++ b/server/src/routes/productionQueue.ts
@@ -470,109 +470,55 @@ router.get('/prioritized', async (req: Request, res: Response) => {
     console.log('🧹 CLEANUP: Processing orders that need attention...');
     await autoMoveInvalidStockModelOrders(storage);
 
-    // Unified read model: sales orders live in all_orders, while Purchase Order
-    // Management creates its production children in production_orders. Include
-    // both sources so generated PO demand is actually actionable in this queue.
-    // The NOT EXISTS guard prevents duplicate display when another release path
-    // has already mirrored the production order into all_orders.
+    // This is the regular sales-order queue. Purchase Order Management demand
+    // remains in production_orders until it is explicitly progressed to Barcode.
+    // Exclude historical PO_RELEASE mirrors so they do not leak back into P1.
     const queueQuery = `
-      WITH queue_orders AS (
-        SELECT
-          o.order_id as orderId,
-          o.fb_order_number as fbOrderNumber,
-          o.model_id as modelId,
-          o.model_id as stockModelId,
-          o.due_date as dueDate,
-          o.order_date as orderDate,
-          o.current_department as currentDepartment,
-          o.status,
-          o.customer_id as customerId,
-          o.features,
-          o.urgency,
-          o.is_manual_urgency as isManualUrgency,
-          NULL as manual_priority_override,
-          NULL as prioritySource,
-          'ready' as productionReadinessStatus,
-          0 as queuePosition,
-          o.created_at as createdAt,
-          COALESCE(c.name, 'Customer ' || o.customer_id) as customerName,
-          'SALES' as orderSource,
-          o.is_flattop as "isFlattop"
-        FROM all_orders o
-        LEFT JOIN customers c ON o.customer_id ~ '^[0-9]+$' AND CAST(o.customer_id AS INTEGER) = c.id
-        WHERE o.current_department = 'P1 Production Queue'
-          AND o.status IN ('FINALIZED', 'Active', 'IN_PROGRESS')
-          AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
-          AND o.model_id IS NOT NULL
-          AND o.model_id != ''
-          AND o.model_id != 'None'
-          AND LOWER(o.model_id) != 'no stock'
-          AND LOWER(o.model_id) != 'no_stock'
-          AND (
-            LOWER(COALESCE(
-              o.features->>'action_length',
-              o.features->>'actionLength',
-              o.features->'specifications'->>'action_length',
-              o.features->'specifications'->>'actionLength',
-              ''
-            )) NOT IN ('', 'null')
-            OR LOWER(o.model_id) LIKE '%m1a%'
-            OR LOWER(o.model_id) LIKE '%tikka%'
-            OR o.is_flattop = true
-          )
-
-        UNION ALL
-
-        SELECT
-          p.order_id as orderId,
-          NULL::text as fbOrderNumber,
-          p.item_id as modelId,
-          p.item_id as stockModelId,
-          p.due_date as dueDate,
-          p.order_date as orderDate,
-          p.current_department as currentDepartment,
-          p.production_status as status,
-          p.customer_id as customerId,
-          p.specifications as features,
-          NULL::text as urgency,
-          false as isManualUrgency,
-          NULL as manual_priority_override,
-          NULL as prioritySource,
-          'ready' as productionReadinessStatus,
-          0 as queuePosition,
-          p.created_at as createdAt,
-          COALESCE(NULLIF(p.customer_name, ''), 'Customer ' || p.customer_id) as customerName,
-          'PO_RELEASE' as orderSource,
-          false as "isFlattop"
-        FROM production_orders p
-        WHERE p.current_department = 'P1 Production Queue'
-          AND UPPER(COALESCE(p.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')
-          AND p.item_id IS NOT NULL
-          AND p.item_id != ''
-          AND LOWER(p.item_id) NOT IN ('none', 'no stock', 'no_stock')
-          AND (
-            LOWER(COALESCE(
-              p.specifications->>'action_length',
-              p.specifications->>'actionLength',
-              ''
-            )) NOT IN ('', 'null')
-            OR LOWER(p.item_id) LIKE '%m1a%'
-            OR LOWER(p.item_id) LIKE '%tikka%'
-            OR LOWER(COALESCE(
-              p.specifications->>'flat_top',
-              p.specifications->>'flatTop',
-              'false'
-            )) IN ('true', '1', 'yes')
-          )
-          AND NOT EXISTS (
-            SELECT 1
-            FROM all_orders mirrored
-            WHERE mirrored.order_id = p.order_id
-          )
-      )
-      SELECT *
-      FROM queue_orders
-      ORDER BY dueDate ASC, createdAt ASC
+      SELECT
+        o.order_id as orderId,
+        o.fb_order_number as fbOrderNumber,
+        o.model_id as modelId,
+        o.model_id as stockModelId,
+        o.due_date as dueDate,
+        o.order_date as orderDate,
+        o.current_department as currentDepartment,
+        o.status,
+        o.customer_id as customerId,
+        o.features,
+        o.urgency,
+        o.is_manual_urgency as isManualUrgency,
+        NULL as manual_priority_override,
+        NULL as prioritySource,
+        'ready' as productionReadinessStatus,
+        0 as queuePosition,
+        o.created_at as createdAt,
+        COALESCE(c.name, 'Customer ' || o.customer_id) as customerName,
+        'SALES' as orderSource,
+        o.is_flattop as "isFlattop"
+      FROM all_orders o
+      LEFT JOIN customers c ON o.customer_id ~ '^[0-9]+$' AND CAST(o.customer_id AS INTEGER) = c.id
+      WHERE o.current_department = 'P1 Production Queue'
+        AND COALESCE(o.order_source, 'SALES') <> 'PO_RELEASE'
+        AND o.status IN ('FINALIZED', 'Active', 'IN_PROGRESS')
+        AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
+        AND o.model_id IS NOT NULL
+        AND o.model_id != ''
+        AND o.model_id != 'None'
+        AND LOWER(o.model_id) != 'no stock'
+        AND LOWER(o.model_id) != 'no_stock'
+        AND (
+          LOWER(COALESCE(
+            o.features->>'action_length',
+            o.features->>'actionLength',
+            o.features->'specifications'->>'action_length',
+            o.features->'specifications'->>'actionLength',
+            ''
+          )) NOT IN ('', 'null')
+          OR LOWER(o.model_id) LIKE '%m1a%'
+          OR LOWER(o.model_id) LIKE '%tikka%'
+          OR o.is_flattop = true
+        )
+      ORDER BY o.due_date ASC, o.created_at ASC
     `;
 
     const queueResult = await pool.query(queueQuery);


### PR DESCRIPTION
## What changed

- generate P1 purchase-order demand only in `production_orders`
- stop scheduling and **Create Missing Orders** retries from prematurely creating regular `all_orders` rows
- keep PO production children out of the regular prioritized production queue
- preserve the Barcode handoff that creates or updates the downstream `all_orders` record
- prevent regeneration from resetting production units that already progressed
- reconcile stale active bottom-metal children from linked PO lines and route them to Shipping QC
- make P1 PO queue quantities represent exact existing units still in `P1 Production Queue`
- progress selected P1 PO quantities through `/api/p1-po-queue/progress` instead of attempting to generate replacement demand

## Root cause

The PO queue mixed two separate operations: demand generation and production progression. Once production children existed, the screen subtracted all active rows from ordered quantity and displayed `0 of 0`, even when several exact units were still waiting in P1. The action was also wired to the demand-generation endpoints instead of the existing-unit Barcode progression endpoint.

The earlier scheduling route additionally inserted units into `all_orders` too soon, and stale legacy bottom-metal children could retain fiberglass/P1 values.

## Impact

For a line showing, for example, `4 P1 Production Queue, 3 Barcode, 1 Shipped`, operators can now select exactly four units and progress those existing records to Barcode. No new production demand is created, quantities cannot exceed the live P1 count, and the operation remains atomic server-side.

Active bottom-metal rows are corrected to `Metal Accessory / Shipping QC`; cancelled, shipped, and completed history remains unchanged.

## Validation

- `server/__tests__/p1PODemandUiBoundary.test.ts`
- `server/__tests__/p1POQueueHelper.test.ts`
- `server/__tests__/p1POQueueScheduleGuard.test.ts`
- `server/__tests__/p1ProductionOrdersQueueVisibility.test.ts`
- `server/__tests__/p1PendingQueueVisibility.test.ts`
- `server/__tests__/p1MetalAccessoryReadRepair.test.ts`

Result: **6 test files passed, 57 tests passed**
- `git diff --check` passed