### PR TITLE
Protect P2 project workflow versions

### DIFF
--- a/migrations/0199_project_workflow_version.sql
+++ b/migrations/0199_project_workflow_version.sql
@@ -1,0 +1,16 @@
+-- Existing NULL values are intentionally preserved and resolve to legacy_v1 in application code.
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS workflow_version TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'projects_workflow_version_check'
+      AND conrelid = 'projects'::regclass
+  ) THEN
+    ALTER TABLE projects
+      ADD CONSTRAINT projects_workflow_version_check
+      CHECK (workflow_version IS NULL OR workflow_version IN ('legacy_v1', 'p2_v2'));
+  END IF;
+END $$;

--- a/server/__tests__/projectWorkflowVersion.test.ts
+++ b/server/__tests__/projectWorkflowVersion.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getWorkflowVersionForNewProject,
+  ProjectWorkflowVersionError,
+  resolveProjectWorkflowVersion,
+  serializeProjectWorkflowVersion,
+} from '../src/services/projectWorkflowVersionService';
+
+const root = resolve(__dirname, '../..');
+const read = (relativePath: string) =>
+  readFileSync(resolve(root, relativePath), 'utf8');
+
+describe('project workflow version resolution', () => {
+  it.each([null, undefined])('treats %s as legacy_v1', (value) => {
+    expect(resolveProjectWorkflowVersion(value)).toBe('legacy_v1');
+  });
+
+  it('accepts both known explicit versions', () => {
+    expect(resolveProjectWorkflowVersion('legacy_v1')).toBe('legacy_v1');
+    expect(resolveProjectWorkflowVersion('p2_v2')).toBe('p2_v2');
+  });
+
+  it('rejects an unknown non-null version with a structured error', () => {
+    expect.assertions(3);
+    try {
+      resolveProjectWorkflowVersion('future_v3');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProjectWorkflowVersionError);
+      expect((error as ProjectWorkflowVersionError).toJSON()).toEqual(
+        expect.objectContaining({
+          error: 'UNKNOWN_PROJECT_WORKFLOW_VERSION',
+          workflowVersion: 'future_v3',
+        })
+      );
+      expect((error as Error).message).toContain('future_v3');
+    }
+  });
+
+  it('serializes stored NULL separately from its effective legacy version', () => {
+    expect(serializeProjectWorkflowVersion({ workflowVersion: null })).toEqual({
+      workflowVersion: null,
+      effectiveWorkflowVersion: 'legacy_v1',
+    });
+  });
+
+  it.each([undefined, 'false', 'invalid', 'true'])(
+    'keeps new creation fail-closed for flag %s',
+    (flag) => {
+      const warning = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+      expect(getWorkflowVersionForNewProject(flag)).toBe('legacy_v1');
+      warning.mockRestore();
+    }
+  );
+});
+
+describe('Phase 1 additive migration and repair guards', () => {
+  const migration = read('migrations/0199_project_workflow_version.sql');
+  const startup = read('server/index.ts');
+
+  it('adds a nullable column with no default and no project data update', () => {
+    expect(migration).toMatch(
+      /ADD COLUMN IF NOT EXISTS workflow_version TEXT/i
+    );
+    expect(migration).not.toMatch(
+      /workflow_version TEXT\s+(?:NOT NULL|DEFAULT)/i
+    );
+    expect(migration).not.toMatch(/UPDATE\s+projects\b/i);
+  });
+
+  it('limits stored non-null versions to legacy_v1 and p2_v2', () => {
+    expect(migration).toContain("workflow_version IN ('legacy_v1', 'p2_v2')");
+  });
+
+  it('keeps NULL and legacy_v1 eligible for legacy step repair while excluding p2_v2', () => {
+    expect(startup).toContain(
+      "COALESCE(p.workflow_version, 'legacy_v1') = 'legacy_v1'"
+    );
+  });
+});
+
+describe('legacy creation and response compatibility guards', () => {
+  const projectsRoute = read('server/src/routes/projects.ts');
+  const quotesRoute = read('server/src/routes/quotes.ts');
+  const legacyStepOrder = [
+    'rfq_risk_assessment',
+    'quote',
+    'purchase_review_checklist',
+    'preproduction_checklist',
+    'p2_order',
+  ];
+
+  it.each([
+    ['manual', projectsRoute],
+    ['accepted quote', quotesRoute],
+  ])(
+    '%s creation explicitly stores the fail-closed workflow version',
+    (_name, source) => {
+      expect(source).toContain(
+        'workflowVersion: getWorkflowVersionForNewProject()'
+      );
+    }
+  );
+
+  it.each([
+    ['manual', projectsRoute],
+    ['accepted quote', quotesRoute],
+  ])(
+    '%s creation retains the exact five legacy step definitions',
+    (_name, source) => {
+      const positions = legacyStepOrder.map((step) =>
+        source.indexOf(`type: '${step}'`)
+      );
+      expect(positions.every((position) => position >= 0)).toBe(true);
+      expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    }
+  );
+
+  it('preserves the two existing initial-status expressions', () => {
+    expect(projectsRoute).toContain(
+      "status: stepType.order === 1 ? 'in_progress' : 'pending'"
+    );
+    expect(projectsRoute).toContain(
+      "isQuoteStep && quoteId ? { linkedQuoteId: quoteId, status: 'completed'"
+    );
+    expect(quotesRoute).toContain(
+      "status: stepDef.order === 1 ? 'in_progress' : 'pending'"
+    );
+  });
+
+  it('adds version serialization without replacing existing project response fields', () => {
+    expect(
+      projectsRoute.match(/\.\.\.serializeProjectWorkflowVersion\(project\)/g)
+        ?.length
+    ).toBeGreaterThanOrEqual(3);
+    expect(projectsRoute).toContain('...project,');
+    expect(projectsRoute).toContain('steps,');
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -5195,7 +5195,8 @@ async function initializeBackgroundServices() {
         const projectsMissingSteps = await pool.query<{ id: string; project_code: string }>(
           `SELECT p.id, p.project_code
            FROM projects p
-           WHERE (SELECT COUNT(*) FROM project_steps ps WHERE ps.project_id = p.id) < 5`
+           WHERE COALESCE(p.workflow_version, 'legacy_v1') = 'legacy_v1'
+             AND (SELECT COUNT(*) FROM project_steps ps WHERE ps.project_id = p.id) < 5`
         );
 
         let repairedCount = 0;

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -11743,6 +11743,7 @@ export const projects = pgTable('projects', {
   customerId: text('customer_id').notNull(), // Reference to customer
   description: text('description'),
   status: projectStatusEnum('status').default('active'),
+  workflowVersion: text('workflow_version'),
   currentStepType: projectStepTypeEnum('current_step_type').default('rfq_risk_assessment'),
   targetShipDate: date('target_ship_date'),
   actualShipDate: date('actual_ship_date'),

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -221,6 +221,7 @@ export const safeMigrationFiles = [
   '0196_document_template_builder_tables.sql',
   '0197_route_p1_metal_accessories_to_shipping_qc.sql',
   '0198_repair_p1_metal_accessory_classification.sql',
+  '0199_project_workflow_version.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -12,6 +12,11 @@ import {
 } from '../../schema';
 import { createEmployeeIdentitySnapshot } from '../../identity/userIdentity';
 import { validateProjectClosing, deriveClosingStatus } from '../lib/projectClosingValidation';
+import {
+  getWorkflowVersionForNewProject,
+  ProjectWorkflowVersionError,
+  serializeProjectWorkflowVersion,
+} from '../services/projectWorkflowVersionService';
 import { ensureProjectHasWAD } from '../lib/wadHelper';
 import { evaluateDocumentationRequirements } from '../lib/documentationRequirementsEngine';
 import { cancelWadWorkOrdersSupersededByP2 } from '../services/wadSupersedeService';
@@ -574,6 +579,7 @@ router.get('/', async (req, res) => {
           
           return {
             ...project,
+            ...serializeProjectWorkflowVersion(project),
             steps,
             customer,
             projectManager,
@@ -582,9 +588,11 @@ router.get('/', async (req, res) => {
             linkedRfqNumber,
           };
         } catch (enrichErr) {
+          if (enrichErr instanceof ProjectWorkflowVersionError) throw enrichErr;
           console.error(`Error enriching project ${project.id}:`, enrichErr);
           return {
             ...project,
+            ...serializeProjectWorkflowVersion(project),
             steps: [],
             customer: null,
             projectManager: null,
@@ -597,6 +605,9 @@ router.get('/', async (req, res) => {
     
     res.json(projectsWithSteps);
   } catch (error) {
+    if (error instanceof ProjectWorkflowVersionError) {
+      return res.status(500).json(error.toJSON());
+    }
     console.error('Error fetching projects:', error);
     res.status(500).json({ message: 'Failed to fetch projects' });
   }
@@ -1519,6 +1530,7 @@ router.get('/:id', async (req, res) => {
     
     res.json({
       ...project,
+      ...serializeProjectWorkflowVersion(project),
       steps,
       customer,
       projectManager,
@@ -1526,6 +1538,9 @@ router.get('/:id', async (req, res) => {
       closingStatus: deriveClosingStatus(closing),
     });
   } catch (error) {
+    if (error instanceof ProjectWorkflowVersionError) {
+      return res.status(500).json(error.toJSON());
+    }
     console.error('Error fetching project:', error);
     res.status(500).json({ message: 'Failed to fetch project' });
   }
@@ -1552,6 +1567,7 @@ router.post('/', async (req, res) => {
     const projectData = {
       ...projectFields,
       projectCode: nextCode,
+      workflowVersion: getWorkflowVersionForNewProject(),
       customersIntegerId,
       ...(customerNameSnapshot ? { customerNameSnapshot } : {}),
     };

--- a/server/src/routes/quotes.ts
+++ b/server/src/routes/quotes.ts
@@ -50,6 +50,7 @@ import fs from 'fs';
 import { z } from 'zod';
 import { storage } from '../../storage';
 import { createQuoteSnapshot } from '../services/quoteContractService';
+import { getWorkflowVersionForNewProject } from '../services/projectWorkflowVersionService';
 
 type ProjectStepTypeValue = typeof projectStepTypeEnum.enumValues[number];
 
@@ -709,6 +710,7 @@ router.patch('/api/quotes/:id/status', async (req: Request, res: Response) => {
             customerId: lockedQuote.customerId,
             description: lockedQuote.description ?? null,
             status: 'active',
+            workflowVersion: getWorkflowVersionForNewProject(),
             // Carry the bridge FK from the quote so the project retains a resolvable
             // integer FK to the master customers table even though customerId is text.
             customersIntegerId: lockedQuote.customersIntegerId ?? null,

--- a/server/src/services/projectWorkflowVersionService.ts
+++ b/server/src/services/projectWorkflowVersionService.ts
@@ -1,0 +1,59 @@
+export const PROJECT_WORKFLOW_VERSIONS = ['legacy_v1', 'p2_v2'] as const;
+
+export type ProjectWorkflowVersion = (typeof PROJECT_WORKFLOW_VERSIONS)[number];
+
+export class ProjectWorkflowVersionError extends Error {
+  readonly code = 'UNKNOWN_PROJECT_WORKFLOW_VERSION';
+  readonly storedWorkflowVersion: unknown;
+
+  constructor(value: unknown) {
+    super(`Unknown project workflow version: ${String(value)}`);
+    this.name = 'ProjectWorkflowVersionError';
+    this.storedWorkflowVersion = value;
+  }
+
+  toJSON() {
+    return {
+      error: this.code,
+      message: this.message,
+      workflowVersion: this.storedWorkflowVersion,
+    };
+  }
+}
+
+export function resolveProjectWorkflowVersion(
+  projectOrValue: { workflowVersion?: unknown } | unknown
+): ProjectWorkflowVersion {
+  const value =
+    typeof projectOrValue === 'object' && projectOrValue !== null
+      ? (projectOrValue as { workflowVersion?: unknown }).workflowVersion
+      : projectOrValue;
+
+  if (value === null || value === undefined || value === 'legacy_v1')
+    return 'legacy_v1';
+  if (value === 'p2_v2') return 'p2_v2';
+  throw new ProjectWorkflowVersionError(value);
+}
+
+export function serializeProjectWorkflowVersion<
+  T extends { workflowVersion?: unknown },
+>(project: T) {
+  return {
+    workflowVersion: project.workflowVersion ?? null,
+    effectiveWorkflowVersion: resolveProjectWorkflowVersion(project),
+  };
+}
+
+// Phase 1 is deliberately fail-closed until the p2_v2 initializer exists.
+export function getWorkflowVersionForNewProject(
+  flagValue = process.env.P2_V2_WORKFLOW_CREATION_ENABLED
+): ProjectWorkflowVersion {
+  const requested =
+    typeof flagValue === 'string' && flagValue.trim().toLowerCase() === 'true';
+  if (requested) {
+    console.warn(
+      '[Projects] P2_V2_WORKFLOW_CREATION_ENABLED requested, but p2_v2 initialization is unavailable; creating legacy_v1'
+    );
+  }
+  return 'legacy_v1';
+}


### PR DESCRIPTION
## What changed

- add nullable `projects.workflow_version` through migration `0199`, constrained to `legacy_v1` and `p2_v2`
- centralize NULL-to-`legacy_v1` resolution and structured rejection of unknown versions
- expose stored and effective workflow versions in project list/detail responses
- keep both manual and accepted-quote project creation fail-closed on `legacy_v1`
- prevent the startup five-step repair from touching `p2_v2` projects
- add focused migration, resolver, creation, response, and repair regression tests

## Safety boundaries

- no existing project rows are backfilled
- no existing project steps are changed, renamed, reordered, or deleted
- no V2 steps, gates, UI, conversion tooling, or creation behavior are activated
- the existing five-step legacy workflow and release gate remain unchanged

## Validation

- `server/__tests__/projectWorkflowVersion.test.ts`: 18/18 passed
- targeted ESLint for the two new TypeScript files: passed
- `git diff --check` and staged `git diff --cached --check`: passed
- full TypeScript check reached the repository's existing 2 GB heap ceiling without emitting a compiler diagnostic
- existing WAD/closing suites remain blocked by stale schema mocks (`productionWorkOrders`/`customers`) and existing closing authorization 403s

## Rollback

Disable future workflow-version-aware creation behavior while retaining the nullable column, constraint, and stored `legacy_v1` values. Continue interpreting NULL as `legacy_v1`; do not delete project or step data.
