### PR TITLE
Stabilize legacy P2 workflow regression tests

### DIFF
--- a/server/__tests__/projectClosingGate.test.ts
+++ b/server/__tests__/projectClosingGate.test.ts
@@ -1,8 +1,13 @@
+/* eslint-disable import/order -- test resolver inconsistently classifies supertest in this workspace */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import express, { type Request, type Response, type NextFunction } from 'express';
-import request from 'supertest';
+import express, {
+  type Request,
+  type Response,
+  type NextFunction,
+} from 'express';
 
-import type { Project, ProjectClosing } from '../schema';
+import request from 'supertest';
+import { type Project, type ProjectClosing } from '../schema';
 
 const PROJECT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 const CLOSING_ID = 7;
@@ -11,11 +16,21 @@ const APPROVER_EMPLOYEE_ID = 42;
 vi.mock('../storage', () => ({
   storage: {
     getProject: vi.fn<(id: string) => Promise<Project | undefined>>(),
-    getProjectClosingByProjectId: vi.fn<(projectId: string) => Promise<ProjectClosing | null>>(),
-    updateProject: vi.fn<(id: string, data: Partial<Project>) => Promise<Project>>(),
-    updateProjectClosing: vi.fn<(id: number, data: Partial<ProjectClosing>) => Promise<ProjectClosing>>(),
-    createProjectActivityLog: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+    getProjectClosingByProjectId:
+      vi.fn<(projectId: string) => Promise<ProjectClosing | null>>(),
+    updateProject:
+      vi.fn<(id: string, data: Partial<Project>) => Promise<Project>>(),
+    updateProjectClosing:
+      vi.fn<
+        (id: number, data: Partial<ProjectClosing>) => Promise<ProjectClosing>
+      >(),
+    createProjectActivityLog: vi
+      .fn<(...args: unknown[]) => Promise<void>>()
+      .mockResolvedValue(undefined),
+    createProjectNotification: vi.fn().mockResolvedValue(undefined),
     getProjectSteps: vi.fn().mockResolvedValue([]),
+    getWorkOrdersByProject: vi.fn().mockResolvedValue([]),
+    updateProjectStep: vi.fn(),
     getEmployee: vi.fn().mockResolvedValue(null),
     getP2CustomerByCustomerId: vi.fn().mockResolvedValue(null),
     getProjectStepAttachmentsByProject: vi.fn().mockResolvedValue([]),
@@ -24,17 +39,47 @@ vi.mock('../storage', () => ({
 
 vi.mock('../db', () => ({
   db: {
-    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })) })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+    })),
     insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue([]) })),
-    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })) })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+    })),
   },
-  pool: {},
+  pool: { query: vi.fn().mockResolvedValue([]) },
 }));
 
 vi.mock('../schema', () => ({
   projects: {},
   projectClosings: {},
   employees: {},
+  productionWorkOrders: {
+    id: {},
+    workOrderNumber: {},
+    projectId: {},
+    partNumber: {},
+    description: {},
+    quantity: {},
+    status: {},
+    departmentBudgets: {},
+    totalBudgetHours: {},
+    materialBudgetAmount: {},
+    startDate: {},
+    dueDate: {},
+    warningThreshold: {},
+    blockedThreshold: {},
+    defaultChargeCodeId: {},
+    dashboardType: {},
+    queueType: {},
+    assignedDepartment: {},
+    assignedDashboardRoute: {},
+    manufacturingQueueId: {},
+    wadStatus: {},
+    wizardData: {},
+    createdAt: {},
+    updatedAt: {},
+  },
   insertProjectSchema: { safeParse: vi.fn(), parse: vi.fn() },
   insertProjectStepSchema: { safeParse: vi.fn(), parse: vi.fn() },
   insertProjectActivityLogSchema: { safeParse: vi.fn(), parse: vi.fn() },
@@ -52,7 +97,43 @@ vi.mock('../src/services/connectorHealthService', () => ({
   startConnectorHealthEvaluator: vi.fn(),
 }));
 
+vi.mock('../src/lib/productionWorkflowReadiness', () => ({
+  ensureProductionWorkflowReadSchema: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../src/services/auditService', () => ({
+  auditService: { logEvent: vi.fn().mockResolvedValue(undefined) },
+}));
+const releaseMocks = vi.hoisted(() => ({
+  documentationPackage: {
+    samplingPlanId: 'SP-1',
+    gates: { routingApproval: { requiresSamplingPlan: false } },
+  } as any,
+}));
+vi.mock('../src/lib/documentationRequirementsEngine', () => ({
+  evaluateDocumentationRequirements: vi.fn(
+    () => releaseMocks.documentationPackage
+  ),
+}));
+vi.mock('../src/services/quoteContractService', () => ({
+  getQuoteContractReviewGate: vi.fn().mockResolvedValue({
+    key: 'contract_review',
+    label: 'Contract Review',
+    passed: true,
+  }),
+}));
+vi.mock('../src/services/permissionService', () => ({
+  getUserPermissions: vi.fn(async (_userId: number, role: string) => ({
+    permissionSet: new Set(
+      role === 'MANAGER' ? ['projects.close', 'projects.approve_closing'] : []
+    ),
+  })),
+  userHasScopedCapability: vi.fn(
+    async (_userId: number, role: string) => role === 'MANAGER'
+  ),
+}));
+
 import { storage } from '../storage';
+import { pool } from '../db';
 
 function makeProject(overrides: Partial<Project> = {}): Project {
   return {
@@ -120,7 +201,8 @@ async function attachProjectsRouter(app: express.Express): Promise<void> {
 }
 
 async function attachClosingsRouter(app: express.Express): Promise<void> {
-  const closingsRouter = (await import('../src/routes/projectClosings')).default;
+  const closingsRouter = (await import('../src/routes/projectClosings'))
+    .default;
   app.use('/api/projects/:projectId/closing', closingsRouter);
 }
 
@@ -158,7 +240,7 @@ describe('PATCH /api/projects/:id — closing gate', () => {
         strengths: 'Great team',
         opportunities: 'Better tooling',
         nextProjectRecommendations: null,
-      }),
+      })
     );
 
     const res = await request(app)
@@ -175,7 +257,7 @@ describe('PATCH /api/projects/:id — closing gate', () => {
   it('returns 403 when the closing record is complete but not yet approved', async () => {
     vi.mocked(storage.getProject).mockResolvedValue(makeProject());
     vi.mocked(storage.getProjectClosingByProjectId).mockResolvedValue(
-      makeClosing({ approvedBy: null }),
+      makeClosing({ approvedBy: null })
     );
 
     const res = await request(app)
@@ -189,9 +271,14 @@ describe('PATCH /api/projects/:id — closing gate', () => {
   it('returns 200 and status=completed when closing is complete and approved', async () => {
     vi.mocked(storage.getProject).mockResolvedValue(makeProject());
     vi.mocked(storage.getProjectClosingByProjectId).mockResolvedValue(
-      makeClosing({ approvedBy: APPROVER_EMPLOYEE_ID, approvedAt: new Date('2026-04-10') }),
+      makeClosing({
+        approvedBy: APPROVER_EMPLOYEE_ID,
+        approvedAt: new Date('2026-04-10'),
+      })
     );
-    vi.mocked(storage.updateProject).mockResolvedValue(makeProject({ status: 'completed' }));
+    vi.mocked(storage.updateProject).mockResolvedValue(
+      makeProject({ status: 'completed' })
+    );
 
     const res = await request(app)
       .patch(`/api/projects/${PROJECT_ID}`)
@@ -220,7 +307,9 @@ describe('PATCH /api/projects/:id — closing gate', () => {
     await attachProjectsRouter(adminApp);
 
     vi.mocked(storage.getProject).mockResolvedValue(makeProject());
-    vi.mocked(storage.updateProject).mockResolvedValue(makeProject({ status: 'completed' }));
+    vi.mocked(storage.updateProject).mockResolvedValue(
+      makeProject({ status: 'completed' })
+    );
 
     const res = await request(adminApp)
       .patch(`/api/projects/${PROJECT_ID}`)
@@ -252,7 +341,9 @@ describe('POST /api/projects/:projectId/closing/approve', () => {
       approvedAt: new Date('2026-04-16T12:00:00Z'),
     });
 
-    vi.mocked(storage.getProjectClosingByProjectId).mockResolvedValue(closingBefore);
+    vi.mocked(storage.getProjectClosingByProjectId).mockResolvedValue(
+      closingBefore
+    );
     vi.mocked(storage.updateProjectClosing).mockResolvedValue(closingAfter);
 
     const res = await request(app)
@@ -263,11 +354,11 @@ describe('POST /api/projects/:projectId/closing/approve', () => {
     expect(res.body.approvedBy).toBe(APPROVER_EMPLOYEE_ID);
     expect(storage.updateProjectClosing).toHaveBeenCalledWith(
       CLOSING_ID,
-      expect.objectContaining({ approvedBy: APPROVER_EMPLOYEE_ID }),
+      expect.objectContaining({ approvedBy: APPROVER_EMPLOYEE_ID })
     );
     expect(storage.updateProjectClosing).toHaveBeenCalledWith(
       CLOSING_ID,
-      expect.objectContaining({ approvedAt: expect.any(Date) }),
+      expect.objectContaining({ approvedAt: expect.any(Date) })
     );
   });
 
@@ -291,5 +382,214 @@ describe('POST /api/projects/:projectId/closing/approve', () => {
       .send({ approvedBy: APPROVER_EMPLOYEE_ID });
 
     expect(res.status).toBe(404);
+  });
+});
+
+describe('legacy P2 release gate outcomes', () => {
+  let app: express.Express;
+  let poStatus = 'open';
+  const steps = (review = 'completed', prepro = 'completed') =>
+    [
+      {
+        id: 'q',
+        stepType: 'quote',
+        status: 'completed',
+        stepOrder: 2,
+        linkedQuoteId: null,
+      },
+      {
+        id: 'r',
+        stepType: 'purchase_review_checklist',
+        status: review,
+        stepOrder: 3,
+      },
+      {
+        id: 'p',
+        stepType: 'preproduction_checklist',
+        status: prepro,
+        stepOrder: 4,
+      },
+    ] as any;
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    poStatus = 'open';
+    releaseMocks.documentationPackage = {
+      samplingPlanId: 'SP-1',
+      gates: { routingApproval: { requiresSamplingPlan: false } },
+    };
+    vi.mocked(pool.query).mockImplementation(async (query: any) => {
+      const text = String(query);
+      if (text.includes('SELECT status FROM p2_purchase_orders'))
+        return [{ status: poStatus }] as any;
+      if (text.includes('FROM production_work_orders'))
+        return [
+          {
+            id: 'wad',
+            workOrderNumber: 'WAD-1',
+            status: 'RELEASED',
+            wadStatus: 'APPROVED',
+            wizardData: {},
+          },
+        ] as any;
+      return [] as any;
+    });
+    vi.mocked(storage.getProject).mockResolvedValue(
+      makeProject({ poId: 77, currentStage: 'po_received' })
+    );
+    vi.mocked(storage.getProjectSteps).mockResolvedValue(steps());
+    vi.mocked(storage.getWorkOrdersByProject).mockResolvedValue([
+      { status: 'RELEASED' },
+    ] as any);
+    vi.mocked(storage.updateProject).mockImplementation(async (_id, data) =>
+      makeProject({ poId: 77, currentStage: 'po_received', ...data })
+    );
+    app = buildApp();
+    await attachProjectsRouter(app);
+  });
+  afterEach(() => vi.resetModules());
+  const release = () =>
+    request(app).post(`/api/projects/${PROJECT_ID}/release-to-p2`).send({});
+  it('rejects missing PO', async () => {
+    vi.mocked(storage.getProject).mockResolvedValue(
+      makeProject({ poId: null })
+    );
+    const r = await release();
+    expect(r.status).toBe(422);
+    expect(r.body.code).toBe('PO_REQUIRED');
+  });
+  it('rejects incomplete PO review', async () => {
+    vi.mocked(storage.getProjectSteps).mockResolvedValue(steps('pending'));
+    const r = await release();
+    expect(r.status).toBe(422);
+    expect(r.body.failedGates).toContain('PO Review');
+  });
+  it('rejects incomplete preproduction', async () => {
+    vi.mocked(storage.getProjectSteps).mockResolvedValue(
+      steps('completed', 'pending')
+    );
+    const r = await release();
+    expect(r.status).toBe(422);
+    expect(r.body.failedGates).toContain('Preproduction');
+  });
+  it('rejects missing WAD approval', async () => {
+    vi.mocked(storage.getWorkOrdersByProject).mockResolvedValue([]);
+    const r = await release();
+    expect(r.status).toBe(422);
+    expect(r.body.failedGates).toContain('WAD (Work Authorization Document)');
+  });
+  it('rejects missing required sampling plan', async () => {
+    releaseMocks.documentationPackage = {
+      samplingPlanId: null,
+      gates: { routingApproval: { requiresSamplingPlan: true } },
+    };
+    const r = await release();
+    expect(r.status).toBe(422);
+    expect(r.body.failedGates).toContain('WAD Documentation Package');
+  });
+  it('stages the first release', async () => {
+    const r = await release();
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual(
+      expect.objectContaining({
+        stage: 'p2_release',
+        poStatus: 'ready_for_p2_release',
+      })
+    );
+  });
+  it('launches production from staged', async () => {
+    poStatus = 'ready_for_p2_release';
+    const r = await release();
+    expect(r.status).toBe(200);
+    expect(r.body).toEqual(
+      expect.objectContaining({
+        stage: 'production',
+        poStatus: 'in_production',
+      })
+    );
+  });
+  it('rejects repeated production release', async () => {
+    poStatus = 'in_production';
+    expect((await release()).status).toBe(409);
+  });
+});
+
+describe('legacy step transitions remain unchanged', () => {
+  let app: express.Express;
+  const step = (status: string, extra: Record<string, unknown> = {}) =>
+    ({
+      id: 's1',
+      projectId: PROJECT_ID,
+      stepType: 'rfq_risk_assessment',
+      stepOrder: 1,
+      status,
+      notes: null,
+      startedAt: null,
+      completedAt: null,
+      ...extra,
+    }) as any;
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(storage.getProject).mockResolvedValue(
+      makeProject({ currentStage: 'rfq_received' })
+    );
+    vi.mocked(storage.updateProjectStep).mockImplementation(async (id, data) =>
+      step(String((data as any).status), { id, ...data })
+    );
+    app = buildApp();
+    await attachProjectsRouter(app);
+  });
+  afterEach(() => vi.resetModules());
+  it('starts pending', async () => {
+    vi.mocked(storage.getProjectSteps).mockResolvedValue([step('pending')]);
+    const r = await request(app)
+      .patch(`/api/projects/${PROJECT_ID}/steps/s1`)
+      .send({ status: 'in_progress' });
+    expect(r.status).toBe(200);
+    expect(storage.updateProjectStep).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({
+        status: 'in_progress',
+        startedAt: expect.any(Date),
+      })
+    );
+  });
+  it('completes and starts next', async () => {
+    const next = step('pending', { id: 's2', stepType: 'quote', stepOrder: 2 });
+    vi.mocked(storage.getProjectSteps)
+      .mockResolvedValueOnce([step('in_progress'), next])
+      .mockResolvedValueOnce([step('completed'), next]);
+    const r = await request(app)
+      .patch(`/api/projects/${PROJECT_ID}/steps/s1`)
+      .send({ status: 'completed' });
+    expect(r.status).toBe(200);
+    expect(storage.updateProjectStep).toHaveBeenCalledWith(
+      's2',
+      expect.objectContaining({ status: 'in_progress' })
+    );
+  });
+  it('skips with reason', async () => {
+    vi.mocked(storage.getProjectSteps).mockResolvedValue([step('pending')]);
+    const r = await request(app)
+      .patch(`/api/projects/${PROJECT_ID}/steps/s1/skip`)
+      .send({ reason: 'Legacy exception' });
+    expect(r.status).toBe(200);
+    expect(storage.updateProjectStep).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({
+        status: 'skipped',
+        notes: '[Skipped] Legacy exception',
+      })
+    );
+  });
+  it('reopens completed', async () => {
+    vi.mocked(storage.getProjectSteps).mockResolvedValue([step('completed')]);
+    const r = await request(app)
+      .patch(`/api/projects/${PROJECT_ID}/steps/s1/reopen`)
+      .send({});
+    expect(r.status).toBe(200);
+    expect(storage.updateProjectStep).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ status: 'in_progress', completedAt: null })
+    );
   });
 });

--- a/server/__tests__/wadAutoCreation.test.ts
+++ b/server/__tests__/wadAutoCreation.test.ts
@@ -1,7 +1,14 @@
+/* eslint-disable import/order -- test resolver inconsistently classifies supertest in this workspace */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
+
 import request from 'supertest';
-import type { Project, ProjectStep, ProjectActivityLog, ProductionWorkOrder } from '../schema';
+import {
+  type Project,
+  type ProjectStep,
+  type ProjectActivityLog,
+  type ProductionWorkOrder,
+} from '../schema';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Typed interfaces for db query chain mocks
@@ -16,7 +23,8 @@ interface SelectOrderByChain {
 interface SelectAnyWhereChain {
   where: (
     cond: unknown
-  ) => Promise<Record<string, unknown>[]> | SelectLimitChain | SelectOrderByChain;
+  ) =>
+    Promise<Record<string, unknown>[]> | SelectLimitChain | SelectOrderByChain;
 }
 interface SelectFromChain {
   from: (table: unknown) => SelectAnyWhereChain;
@@ -40,10 +48,13 @@ vi.mock('../storage', () => ({
     getNextProjectCode: vi.fn<() => Promise<string>>(),
     createProject: vi.fn<(data: unknown) => Promise<Project>>(),
     createProjectStep: vi.fn<(data: unknown) => Promise<ProjectStep>>(),
-    createProjectActivityLog: vi.fn<(data: unknown) => Promise<ProjectActivityLog>>(),
+    createProjectActivityLog:
+      vi.fn<(data: unknown) => Promise<ProjectActivityLog>>(),
     getProjectSteps: vi.fn<(id: string) => Promise<ProjectStep[]>>(),
-    getWorkOrdersByProject: vi.fn<(id: string) => Promise<ProductionWorkOrder[]>>(),
-    createProductionWorkOrder: vi.fn<(data: unknown) => Promise<ProductionWorkOrder>>(),
+    getWorkOrdersByProject:
+      vi.fn<(id: string) => Promise<ProductionWorkOrder[]>>(),
+    createProductionWorkOrder:
+      vi.fn<(data: unknown) => Promise<ProductionWorkOrder>>(),
     getProject: vi.fn(),
     getP2CustomerByCustomerId: vi.fn(),
     getEmployee: vi.fn(),
@@ -58,11 +69,14 @@ vi.mock('../db', () => ({
     update: vi.fn<(table: unknown) => UpdateFromChain>(),
     insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue([]) })),
     delete: vi.fn(),
+    transaction: vi.fn(),
   },
   pool: { query: vi.fn() },
 }));
 
 vi.mock('../schema', () => ({
+  customers: { id: {}, customerKey: {}, name: {} },
+  projects: { projectCode: {} },
   quotes: {},
   quoteLineItems: {},
   projectSteps: { projectId: {}, linkedQuoteId: {} },
@@ -75,7 +89,32 @@ vi.mock('../schema', () => ({
   insertProjectNotificationSchema: { parse: vi.fn() },
   insertQuoteSchema: { parse: vi.fn() },
   insertQuoteLineItemSchema: { parse: vi.fn() },
-  productionWorkOrders: {},
+  productionWorkOrders: {
+    id: {},
+    workOrderNumber: {},
+    projectId: {},
+    partNumber: {},
+    description: {},
+    quantity: {},
+    status: {},
+    departmentBudgets: {},
+    totalBudgetHours: {},
+    materialBudgetAmount: {},
+    startDate: {},
+    dueDate: {},
+    warningThreshold: {},
+    blockedThreshold: {},
+    defaultChargeCodeId: {},
+    dashboardType: {},
+    queueType: {},
+    assignedDepartment: {},
+    assignedDashboardRoute: {},
+    manufacturingQueueId: {},
+    wadStatus: {},
+    wizardData: {},
+    createdAt: {},
+    updatedAt: {},
+  },
   apiIntegrationKeys: {},
 }));
 
@@ -95,6 +134,12 @@ vi.mock('../utils/fileUpload', () => ({
 
 import { storage } from '../storage';
 import { db } from '../db';
+import {
+  productionWorkOrders,
+  projectSteps,
+  projects,
+  quoteLineItems,
+} from '../schema';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Typed mock chain builder functions
@@ -105,9 +150,11 @@ import { db } from '../db';
  * Used for the quote fetch: db.select().from(quotes).where(eq(quotes.id, id))
  */
 function selectDirect(rows: Record<string, unknown>[]): SelectFromChain {
-  const whereFn = vi.fn<(cond: unknown) => Promise<Record<string, unknown>[]>>()
+  const whereFn = vi
+    .fn<(cond: unknown) => Promise<Record<string, unknown>[]>>()
     .mockResolvedValue(rows);
-  const fromFn = vi.fn<(table: unknown) => SelectAnyWhereChain>()
+  const fromFn = vi
+    .fn<(table: unknown) => SelectAnyWhereChain>()
     .mockReturnValue({ where: whereFn });
   return { from: fromFn };
 }
@@ -117,11 +164,14 @@ function selectDirect(rows: Record<string, unknown>[]): SelectFromChain {
  * Used for the project-step lookup: db.select({projectId:...}).from(projectSteps).where(...).limit(1)
  */
 function selectLimit(rows: Record<string, unknown>[]): SelectFromChain {
-  const limitFn = vi.fn<(n: number) => Promise<Record<string, unknown>[]>>()
+  const limitFn = vi
+    .fn<(n: number) => Promise<Record<string, unknown>[]>>()
     .mockResolvedValue(rows);
-  const whereFn = vi.fn<(cond: unknown) => SelectLimitChain>()
+  const whereFn = vi
+    .fn<(cond: unknown) => SelectLimitChain>()
     .mockReturnValue({ limit: limitFn });
-  const fromFn = vi.fn<(table: unknown) => SelectAnyWhereChain>()
+  const fromFn = vi
+    .fn<(table: unknown) => SelectAnyWhereChain>()
     .mockReturnValue({ where: whereFn });
   return { from: fromFn };
 }
@@ -131,11 +181,14 @@ function selectLimit(rows: Record<string, unknown>[]): SelectFromChain {
  * Used for the line-item fetch: db.select().from(quoteLineItems).where(...).orderBy(...)
  */
 function selectOrderBy(rows: Record<string, unknown>[]): SelectFromChain {
-  const orderByFn = vi.fn<(col: unknown) => Promise<Record<string, unknown>[]>>()
+  const orderByFn = vi
+    .fn<(col: unknown) => Promise<Record<string, unknown>[]>>()
     .mockResolvedValue(rows);
-  const whereFn = vi.fn<(cond: unknown) => SelectOrderByChain>()
+  const whereFn = vi
+    .fn<(cond: unknown) => SelectOrderByChain>()
     .mockReturnValue({ orderBy: orderByFn });
-  const fromFn = vi.fn<(table: unknown) => SelectAnyWhereChain>()
+  const fromFn = vi
+    .fn<(table: unknown) => SelectAnyWhereChain>()
     .mockReturnValue({ where: whereFn });
   return { from: fromFn };
 }
@@ -144,11 +197,14 @@ function selectOrderBy(rows: Record<string, unknown>[]): SelectFromChain {
  * db.update(table).set({...}).where(cond).returning() → Promise<rows>
  */
 function updateReturning(rows: Record<string, unknown>[]): UpdateFromChain {
-  const returningFn = vi.fn<() => Promise<Record<string, unknown>[]>>()
+  const returningFn = vi
+    .fn<() => Promise<Record<string, unknown>[]>>()
     .mockResolvedValue(rows);
-  const whereFn = vi.fn<(cond: unknown) => UpdateWhereReturningChain>()
+  const whereFn = vi
+    .fn<(cond: unknown) => UpdateWhereReturningChain>()
     .mockReturnValue({ returning: returningFn });
-  const setFn = vi.fn<(data: unknown) => UpdateSetChain>()
+  const setFn = vi
+    .fn<(data: unknown) => UpdateSetChain>()
     .mockReturnValue({ where: whereFn });
   return { set: setFn };
 }
@@ -178,7 +234,9 @@ function makeProject(overrides: Partial<Project> = {}): Project {
   } as Project;
 }
 
-function makeWad(overrides: Partial<ProductionWorkOrder> = {}): ProductionWorkOrder {
+function makeWad(
+  overrides: Partial<ProductionWorkOrder> = {}
+): ProductionWorkOrder {
   return {
     id: 'wad-new-1',
     workOrderNumber: 'WAD-99999',
@@ -196,10 +254,13 @@ function setupStorageForProjectCreation(): void {
   vi.mocked(storage.getNextProjectCode).mockResolvedValue('PROJ-001');
   vi.mocked(storage.createProject).mockResolvedValue(makeProject());
   vi.mocked(storage.createProjectStep).mockResolvedValue({} as ProjectStep);
-  vi.mocked(storage.createProjectActivityLog).mockResolvedValue({} as ProjectActivityLog);
+  vi.mocked(storage.createProjectActivityLog).mockResolvedValue(
+    {} as ProjectActivityLog
+  );
   vi.mocked(storage.getProjectSteps).mockResolvedValue([]);
   vi.mocked(storage.getWorkOrdersByProject).mockResolvedValue([]);
   vi.mocked(storage.createProductionWorkOrder).mockResolvedValue(makeWad());
+  vi.mocked(db.select).mockReturnValue(selectLimit([]));
 }
 
 /**
@@ -210,6 +271,10 @@ function setupStorageForProjectCreation(): void {
  *   3. select line items ordered by line number
  *   4. update quote status (returning)
  */
+let transactionInsertValues: Array<{
+  table: unknown;
+  value: Record<string, unknown>;
+}> = [];
 function setupDbForAccept(quoteStatus: 'SENT' | 'ACCEPTED' = 'SENT'): void {
   const mockQuote = {
     id: QUOTE_ID,
@@ -219,15 +284,57 @@ function setupDbForAccept(quoteStatus: 'SENT' | 'ACCEPTED' = 'SENT'): void {
     status: quoteStatus,
     description: null,
     updatedAt: null,
+    projectId: quoteStatus === 'ACCEPTED' ? PROJECT_ID : null,
   };
   const updatedQuote = { ...mockQuote, status: 'ACCEPTED' };
 
   vi.mocked(db.select)
     .mockReturnValueOnce(selectDirect([mockQuote]))
-    .mockReturnValueOnce(selectLimit([]))
-    .mockReturnValueOnce(selectOrderBy([]));
-
-  vi.mocked(db.update).mockReturnValueOnce(updateReturning([updatedQuote]));
+    .mockReturnValueOnce(
+      selectDirect([{ ...updatedQuote, projectId: PROJECT_ID }])
+    );
+  if (quoteStatus === 'ACCEPTED')
+    vi.mocked(db.update).mockReturnValueOnce(
+      updateReturning([{ ...updatedQuote, projectId: PROJECT_ID }])
+    );
+  transactionInsertValues = [];
+  const tx = {
+    select: vi.fn((selection?: unknown) => ({
+      from: vi.fn((table: unknown) => {
+        if (table === projects && selection)
+          return Promise.resolve([{ maxCode: null }]);
+        if (table === productionWorkOrders)
+          return {
+            where: vi.fn(() => ({
+              limit: vi.fn().mockResolvedValue([{ id: 'wad-existing' }]),
+            })),
+          };
+        if (table === projectSteps) return selectLimit([]).from(table);
+        if (table === quoteLineItems) return selectOrderBy([]).from(table);
+        return {
+          where: vi.fn(() => ({
+            for: vi.fn().mockResolvedValue([mockQuote]),
+            orderBy: vi.fn().mockResolvedValue([]),
+          })),
+        };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+    })),
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn((value: Record<string, unknown>) => {
+        transactionInsertValues.push({ table, value });
+        return table === projects
+          ? { returning: vi.fn().mockResolvedValue([makeProject()]) }
+          : Promise.resolve([]);
+      }),
+    })),
+  };
+  vi.mocked(db.transaction as any).mockImplementation(
+    async (callback: (transaction: typeof tx) => Promise<string>) =>
+      callback(tx)
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -255,6 +362,26 @@ describe('POST /api/projects — WAD auto-creation', () => {
 
     expect(res.status).toBe(201);
     expect(storage.createProject).toHaveBeenCalledOnce();
+    expect(storage.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowVersion: 'legacy_v1' })
+    );
+    const steps = vi
+      .mocked(storage.createProjectStep)
+      .mock.calls.map(([value]) => value as any);
+    expect(steps.map((step) => step.stepType)).toEqual([
+      'rfq_risk_assessment',
+      'quote',
+      'purchase_review_checklist',
+      'preproduction_checklist',
+      'p2_order',
+    ]);
+    expect(steps.map((step) => step.status)).toEqual([
+      'in_progress',
+      'pending',
+      'pending',
+      'pending',
+      'pending',
+    ]);
 
     expect(storage.createProductionWorkOrder).toHaveBeenCalledOnce();
     const wadArg = vi.mocked(storage.createProductionWorkOrder).mock
@@ -311,15 +438,33 @@ describe('PATCH /api/quotes/:id/status → ACCEPTED — WAD auto-creation', () =
       consoleSpy.mock.calls.filter((c) => String(c[0]).includes('[WAD] Failed'))
     ).toHaveLength(0);
 
-    expect(storage.createProject).toHaveBeenCalledOnce();
-    const projectArg = vi.mocked(storage.createProject).mock
-      .calls[0][0] as Record<string, unknown>;
+    const projectArg = transactionInsertValues.find(
+      ({ table }) => table === projects
+    )?.value!;
     expect(projectArg.projectName).toContain('Acme Corp');
     expect(projectArg.status).toBe('active');
+    expect(projectArg.workflowVersion).toBe('legacy_v1');
+    const stepArgs = transactionInsertValues
+      .filter(({ table }) => table === projectSteps)
+      .map(({ value }) => value);
+    expect(stepArgs.map((step) => step.stepType)).toEqual([
+      'rfq_risk_assessment',
+      'quote',
+      'purchase_review_checklist',
+      'preproduction_checklist',
+      'p2_order',
+    ]);
+    expect(stepArgs.map((step) => step.status)).toEqual([
+      'in_progress',
+      'pending',
+      'pending',
+      'pending',
+      'pending',
+    ]);
 
-    expect(storage.createProductionWorkOrder).toHaveBeenCalledOnce();
-    const wadArg = vi.mocked(storage.createProductionWorkOrder).mock
-      .calls[0][0] as Record<string, unknown>;
+    const wadArg = transactionInsertValues.find(
+      ({ table }) => table === productionWorkOrders
+    )?.value!;
     expect(wadArg.status).toBe('PLANNED');
     expect(wadArg.projectId).toBe(PROJECT_ID);
 
@@ -334,7 +479,11 @@ describe('PATCH /api/quotes/:id/status → ACCEPTED — WAD auto-creation', () =
       .patch(`/api/quotes/${QUOTE_ID}/status`)
       .send({ status: 'ACCEPTED' });
     expect(res1.status).toBe(200);
-    expect(storage.createProductionWorkOrder).toHaveBeenCalledOnce();
+    expect(
+      transactionInsertValues.filter(
+        ({ table }) => table === productionWorkOrders
+      )
+    ).toHaveLength(1);
 
     setupDbForAccept('ACCEPTED');
     const res2 = await request(app)
@@ -342,7 +491,11 @@ describe('PATCH /api/quotes/:id/status → ACCEPTED — WAD auto-creation', () =
       .send({ status: 'ACCEPTED' });
     expect(res2.status).toBe(200);
 
-    expect(storage.createProductionWorkOrder).toHaveBeenCalledOnce();
+    expect(
+      transactionInsertValues.filter(
+        ({ table }) => table === productionWorkOrders
+      )
+    ).toHaveLength(0);
 
     expect(
       consoleSpy.mock.calls.filter((c) => String(c[0]).includes('[WAD] Failed'))

--- a/server/__tests__/wadHelper.test.ts
+++ b/server/__tests__/wadHelper.test.ts
@@ -7,6 +7,36 @@ vi.mock('../storage', () => ({
   },
 }));
 
+vi.mock('../db', () => ({ db: {}, pool: { query: vi.fn() } }));
+vi.mock('../schema', () => ({
+  productionWorkOrders: {
+    id: {},
+    workOrderNumber: {},
+    projectId: {},
+    partNumber: {},
+    description: {},
+    quantity: {},
+    status: {},
+    departmentBudgets: {},
+    totalBudgetHours: {},
+    materialBudgetAmount: {},
+    startDate: {},
+    dueDate: {},
+    warningThreshold: {},
+    blockedThreshold: {},
+    defaultChargeCodeId: {},
+    dashboardType: {},
+    queueType: {},
+    assignedDepartment: {},
+    assignedDashboardRoute: {},
+    manufacturingQueueId: {},
+    wadStatus: {},
+    wizardData: {},
+    createdAt: {},
+    updatedAt: {},
+  },
+}));
+
 import { ensureProjectHasWAD } from '../src/lib/wadHelper';
 import { storage } from '../storage';
 
@@ -19,12 +49,16 @@ describe('ensureProjectHasWAD', () => {
 
   it('creates a WAD with status PLANNED when none exist', async () => {
     vi.mocked(storage.getWorkOrdersByProject).mockResolvedValue([]);
-    vi.mocked(storage.createProductionWorkOrder).mockResolvedValue({ id: 'wad-1', status: 'PLANNED' });
+    vi.mocked(storage.createProductionWorkOrder).mockResolvedValue({
+      id: 'wad-1',
+      status: 'PLANNED',
+    });
 
     await ensureProjectHasWAD(PROJECT_ID, { projectName: 'Test Project' });
 
     expect(storage.createProductionWorkOrder).toHaveBeenCalledOnce();
-    const callArg = vi.mocked(storage.createProductionWorkOrder).mock.calls[0][0] as Record<string, unknown>;
+    const callArg = vi.mocked(storage.createProductionWorkOrder).mock
+      .calls[0][0] as Record<string, unknown>;
     expect(callArg.status).toBe('PLANNED');
     expect(callArg.projectId).toBe(PROJECT_ID);
     expect(callArg.partNumber).toBe('TBD');
@@ -35,16 +69,22 @@ describe('ensureProjectHasWAD', () => {
 
   it('includes the project name in the description when provided', async () => {
     vi.mocked(storage.getWorkOrdersByProject).mockResolvedValue([]);
-    vi.mocked(storage.createProductionWorkOrder).mockResolvedValue({ id: 'wad-1', status: 'PLANNED' });
+    vi.mocked(storage.createProductionWorkOrder).mockResolvedValue({
+      id: 'wad-1',
+      status: 'PLANNED',
+    });
 
     await ensureProjectHasWAD(PROJECT_ID, { projectName: 'Acme Widget' });
 
-    const callArg = vi.mocked(storage.createProductionWorkOrder).mock.calls[0][0] as Record<string, unknown>;
+    const callArg = vi.mocked(storage.createProductionWorkOrder).mock
+      .calls[0][0] as Record<string, unknown>;
     expect(String(callArg.description)).toContain('Acme Widget');
   });
 
   it('skips creation (duplicate guard) when a WAD already exists for the same projectId', async () => {
-    vi.mocked(storage.getWorkOrdersByProject).mockResolvedValue([{ id: 'wad-existing', status: 'PLANNED' }]);
+    vi.mocked(storage.getWorkOrdersByProject).mockResolvedValue([
+      { id: 'wad-existing', status: 'PLANNED' },
+    ]);
 
     await ensureProjectHasWAD(PROJECT_ID, { projectName: 'Test Project' });
 
@@ -55,7 +95,10 @@ describe('ensureProjectHasWAD', () => {
     vi.mocked(storage.getWorkOrdersByProject)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: 'wad-1', status: 'PLANNED' }]);
-    vi.mocked(storage.createProductionWorkOrder).mockResolvedValue({ id: 'wad-1', status: 'PLANNED' });
+    vi.mocked(storage.createProductionWorkOrder).mockResolvedValue({
+      id: 'wad-1',
+      status: 'PLANNED',
+    });
 
     await ensureProjectHasWAD(PROJECT_ID, { projectName: 'Test Project' });
     await ensureProjectHasWAD(PROJECT_ID, { projectName: 'Test Project' });


### PR DESCRIPTION
## What changed

- Stabilized legacy P2 project closing, release-gate, and workflow-transition regression coverage.
- Updated WAD creation fixtures for current database-backed customer and quote-acceptance behavior.
- Added explicit assertions that legacy projects use `legacy_v1` and preserve the five existing project steps.
- Updated authorization and readiness mocks to match current production dependencies.

## Why

Phase 1 workflow-version protection exposed stale test fixtures and mocks around WAD creation, project closing, and P2 release behavior. These were test-harness failures rather than production regressions. This follow-up aligns the tests with the current application seams and locks in legacy behavior before Phase 2 begins.

## Impact

Test-only changes. No production workflow logic, database migration, existing project data, legacy step name, status, link, gate, or record is changed.

## Validation

- Server workflow/WAD/closing suite: 47/47 passed
- Client workflow helper suite: 21/21 passed
- Project creation dialog suite: 9/9 passed
- Focused ESLint: 0 errors; 11 test-mock typing warnings
- `git diff --check`: passed
- Full TypeScript check at 6 GB completed with existing repository-wide diagnostics unrelated to these test-only changes
