### PR TITLE
Centralize versioned P2 project workflow definitions

### DIFF
--- a/server/__tests__/projectClosingGate.test.ts
+++ b/server/__tests__/projectClosingGate.test.ts
@@ -592,4 +592,30 @@ describe('legacy step transitions remain unchanged', () => {
       expect.objectContaining({ status: 'in_progress', completedAt: null })
     );
   });
+  it.each([
+    [
+      'update',
+      `/api/projects/${PROJECT_ID}/steps/s1`,
+      { status: 'in_progress' },
+    ],
+    [
+      'skip',
+      `/api/projects/${PROJECT_ID}/steps/s1/skip`,
+      { reason: 'Not applicable' },
+    ],
+    ['reopen', `/api/projects/${PROJECT_ID}/steps/s1/reopen`, {}],
+  ])('rejects p2_v2 legacy step %s actions', async (_action, url, body) => {
+    vi.mocked(storage.getProject).mockResolvedValue(
+      makeProject({ workflowVersion: 'p2_v2' })
+    );
+    const r = await request(app).patch(url).send(body);
+    expect(r.status).toBe(409);
+    expect(r.body).toEqual(
+      expect.objectContaining({
+        error: 'PROJECT_WORKFLOW_ACTION_UNAVAILABLE',
+        workflowVersion: 'p2_v2',
+      })
+    );
+    expect(storage.updateProjectStep).not.toHaveBeenCalled();
+  });
 });

--- a/server/__tests__/projectWorkflowRegistry.test.ts
+++ b/server/__tests__/projectWorkflowRegistry.test.ts
@@ -1,0 +1,200 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { projectStepTypeEnum } from '../schema';
+import {
+  getInitializableProjectWorkflowSteps,
+  getOrderedProjectWorkflowSteps,
+  getProjectWorkflowDefinition,
+  getProjectWorkflowStepDefinition,
+  isLegacyProjectWorkflow,
+  LEGACY_STARTUP_REPAIR_STEPS,
+  validateProjectWorkflowDefinition,
+} from '../src/services/projectWorkflowRegistry';
+import { ProjectWorkflowVersionError } from '../src/services/projectWorkflowVersionService';
+
+const root = resolve(__dirname, '../..');
+const read = (relativePath: string) =>
+  readFileSync(resolve(root, relativePath), 'utf8');
+
+const LEGACY_TYPES = [
+  'rfq_risk_assessment',
+  'quote',
+  'purchase_review_checklist',
+  'preproduction_checklist',
+  'p2_order',
+] as const;
+
+describe('project workflow registry', () => {
+  it('resolves legacy_v1 and NULL to the exact active legacy definition', () => {
+    const explicit = getProjectWorkflowDefinition('legacy_v1');
+    const implicit = getProjectWorkflowDefinition(null);
+    expect(explicit).toBe(implicit);
+    expect(explicit).toMatchObject({
+      version: 'legacy_v1',
+      active: true,
+      initializable: true,
+    });
+    expect(explicit.steps).toHaveLength(5);
+    expect(explicit.steps.map((step) => step.type)).toEqual(LEGACY_TYPES);
+    expect(explicit.steps.map((step) => step.order)).toEqual([1, 2, 3, 4, 5]);
+    expect(explicit.steps.map((step) => step.initialStatus)).toEqual([
+      'in_progress',
+      'pending',
+      'pending',
+      'pending',
+      'pending',
+    ]);
+    expect(isLegacyProjectWorkflow(null)).toBe(true);
+    expect(isLegacyProjectWorkflow('legacy_v1')).toBe(true);
+  });
+
+  it('defines p2_v2 as ten inactive metadata stages with no database steps', () => {
+    const definition = getProjectWorkflowDefinition('p2_v2');
+    expect(definition).toMatchObject({
+      version: 'p2_v2',
+      active: false,
+      initializable: false,
+    });
+    expect(definition.steps).toEqual([]);
+    expect(
+      definition.stages.map(({ type, label }) => ({ type, label }))
+    ).toEqual([
+      { type: 'rfq_risk_assessment', label: 'RFQ & Risk' },
+      { type: 'estimate_quote', label: 'Estimate & Quote' },
+      { type: 'contract_review', label: 'PO & Contract Review' },
+      { type: 'design_applicability', label: 'Design Applicability' },
+      { type: 'production_planning', label: 'Production Planning' },
+      { type: 'wad_authorization', label: 'WAD Authorization' },
+      { type: 'preproduction_release', label: 'Preproduction & Release' },
+      { type: 'production_quality', label: 'Production & Quality' },
+      { type: 'final_release_shipping', label: 'Final Release & Shipping' },
+      { type: 'project_closing', label: 'Project Closing' },
+    ]);
+    expect(definition.stages.map((stage) => stage.order)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ]);
+    expect(isLegacyProjectWorkflow('p2_v2')).toBe(false);
+    expect(() => getInitializableProjectWorkflowSteps('p2_v2')).toThrow(
+      'p2_v2 workflow initialization is not available'
+    );
+  });
+
+  it('rejects unknown versions with the Phase 1 structured error', () => {
+    expect(() => getProjectWorkflowDefinition('future_v3')).toThrow(
+      ProjectWorkflowVersionError
+    );
+  });
+
+  it('returns immutable definitions and nested metadata', () => {
+    const legacy = getProjectWorkflowDefinition('legacy_v1');
+    const v2 = getProjectWorkflowDefinition('p2_v2');
+    expect(Object.isFrozen(legacy)).toBe(true);
+    expect(Object.isFrozen(legacy.steps)).toBe(true);
+    expect(Object.isFrozen(legacy.steps[0])).toBe(true);
+    expect(Object.isFrozen(v2.stages)).toBe(true);
+    expect(Object.isFrozen(v2.stages[0])).toBe(true);
+  });
+
+  it('validates both registered definitions at test time', () => {
+    expect(() =>
+      validateProjectWorkflowDefinition(
+        getProjectWorkflowDefinition('legacy_v1')
+      )
+    ).not.toThrow();
+    expect(() =>
+      validateProjectWorkflowDefinition(getProjectWorkflowDefinition('p2_v2'))
+    ).not.toThrow();
+  });
+
+  it('keeps legacy types exactly equivalent to the PostgreSQL enum', () => {
+    expect(
+      getOrderedProjectWorkflowSteps('legacy_v1').map((step) => step.type)
+    ).toEqual(projectStepTypeEnum.enumValues);
+  });
+
+  it('keeps exact legacy labels and routes', () => {
+    expect(
+      getOrderedProjectWorkflowSteps('legacy_v1').map(
+        ({ type, label, route }) => ({ type, label, route })
+      )
+    ).toEqual([
+      {
+        type: 'rfq_risk_assessment',
+        label: 'RFQ Risk Assessment',
+        route: '/rfq-risk-assessment',
+      },
+      { type: 'quote', label: 'Quote', route: '/p2-quote-form' },
+      {
+        type: 'purchase_review_checklist',
+        label: 'Purchase Review Checklist',
+        route: '/purchase-review-checklist',
+      },
+      {
+        type: 'preproduction_checklist',
+        label: 'Pre-production Checklist',
+        route: '/preproduction-checklists',
+      },
+      { type: 'p2_order', label: 'P2 Order', route: '/p2-control-center' },
+    ]);
+    expect(
+      getProjectWorkflowStepDefinition('legacy_v1', 'quote')?.legacyLinkedField
+    ).toBe('linkedQuoteId');
+  });
+
+  it('keeps startup repair exactly equivalent to the registry', () => {
+    expect(LEGACY_STARTUP_REPAIR_STEPS).toEqual(
+      getOrderedProjectWorkflowSteps('legacy_v1').map(
+        ({ type, order, initialStatus }) => ({
+          type,
+          order,
+          initialStatus,
+        })
+      )
+    );
+  });
+});
+
+describe('Phase 2 isolation guards', () => {
+  const projectsRoute = read('server/src/routes/projects.ts');
+  const quotesRoute = read('server/src/routes/quotes.ts');
+  const startup = read('server/index.ts');
+  const schema = read('server/schema.ts');
+  const migrations = read('migrations/0199_project_workflow_version.sql');
+
+  it('derives both creation paths from legacy_v1 without activating p2_v2', () => {
+    expect(projectsRoute).toContain(
+      "getInitializableProjectWorkflowSteps('legacy_v1')"
+    );
+    expect(quotesRoute).toContain(
+      "getInitializableProjectWorkflowSteps('legacy_v1')"
+    );
+    expect(projectsRoute).not.toContain(
+      "getInitializableProjectWorkflowSteps('p2_v2')"
+    );
+    expect(quotesRoute).not.toContain(
+      "getInitializableProjectWorkflowSteps('p2_v2')"
+    );
+  });
+
+  it('keeps startup repair legacy-only and registry-derived', () => {
+    expect(startup).toContain('const STEP_TYPES = LEGACY_STARTUP_REPAIR_STEPS');
+    expect(startup).toContain(
+      "COALESCE(p.workflow_version, 'legacy_v1') = 'legacy_v1'"
+    );
+  });
+
+  it('does not add V2 stage identifiers to the database enum or migration', () => {
+    for (const type of getProjectWorkflowDefinition('p2_v2')
+      .stages.map((stage) => stage.type)
+      .slice(1)) {
+      expect(projectStepTypeEnum.enumValues).not.toContain(type as never);
+      expect(schema).not.toMatch(
+        new RegExp(`projectStepTypeEnum[\\s\\S]{0,300}'${type}'`)
+      );
+      expect(migrations).not.toContain(type);
+    }
+  });
+});

--- a/server/__tests__/projectWorkflowVersion.test.ts
+++ b/server/__tests__/projectWorkflowVersion.test.ts
@@ -87,13 +87,6 @@ describe('Phase 1 additive migration and repair guards', () => {
 describe('legacy creation and response compatibility guards', () => {
   const projectsRoute = read('server/src/routes/projects.ts');
   const quotesRoute = read('server/src/routes/quotes.ts');
-  const legacyStepOrder = [
-    'rfq_risk_assessment',
-    'quote',
-    'purchase_review_checklist',
-    'preproduction_checklist',
-    'p2_order',
-  ];
 
   it.each([
     ['manual', projectsRoute],
@@ -110,27 +103,18 @@ describe('legacy creation and response compatibility guards', () => {
   it.each([
     ['manual', projectsRoute],
     ['accepted quote', quotesRoute],
-  ])(
-    '%s creation retains the exact five legacy step definitions',
-    (_name, source) => {
-      const positions = legacyStepOrder.map((step) =>
-        source.indexOf(`type: '${step}'`)
-      );
-      expect(positions.every((position) => position >= 0)).toBe(true);
-      expect(positions).toEqual([...positions].sort((a, b) => a - b));
-    }
-  );
+  ])('%s creation uses the centralized legacy definition', (_name, source) => {
+    expect(source).toContain(
+      "getInitializableProjectWorkflowSteps('legacy_v1')"
+    );
+  });
 
   it('preserves the two existing initial-status expressions', () => {
-    expect(projectsRoute).toContain(
-      "status: stepType.order === 1 ? 'in_progress' : 'pending'"
-    );
+    expect(projectsRoute).toContain('status: stepType.initialStatus');
     expect(projectsRoute).toContain(
       "isQuoteStep && quoteId ? { linkedQuoteId: quoteId, status: 'completed'"
     );
-    expect(quotesRoute).toContain(
-      "status: stepDef.order === 1 ? 'in_progress' : 'pending'"
-    );
+    expect(quotesRoute).toContain('status: stepDef.initialStatus');
   });
 
   it('adds version serialization without replacing existing project response fields', () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,6 +31,7 @@ import {
   getLegacyStartupDbMaintenanceSkipMessage,
   shouldRunLegacyStartupDbMaintenance,
 } from './bootstrap/startupMaintenance';
+import { LEGACY_STARTUP_REPAIR_STEPS } from './src/services/projectWorkflowRegistry';
 
 // Build version marker - change this to verify deployment updates
 const BUILD_VERSION = '2026-01-27-v2';
@@ -5184,13 +5185,7 @@ async function initializeBackgroundServices() {
       // Backfill missing workflow steps for projects that have fewer than 5 steps
       // (repairs projects created before step-init was reliable, e.g. PRJ-007)
       try {
-        const STEP_TYPES = [
-          { type: 'rfq_risk_assessment', order: 1 },
-          { type: 'quote',               order: 2 },
-          { type: 'purchase_review_checklist', order: 3 },
-          { type: 'preproduction_checklist',   order: 4 },
-          { type: 'p2_order',            order: 5 },
-        ];
+        const STEP_TYPES = LEGACY_STARTUP_REPAIR_STEPS;
 
         const projectsMissingSteps = await pool.query<{ id: string; project_code: string }>(
           `SELECT p.id, p.project_code
@@ -5213,8 +5208,8 @@ async function initializeBackgroundServices() {
                 `INSERT INTO project_steps (id, project_id, step_type, step_order, status, started_at, created_at, updated_at)
                  VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, NOW(), NOW())`,
                 [proj.id, st.type, st.order,
-                 st.order === 1 ? 'in_progress' : 'pending',
-                 st.order === 1 ? new Date() : null]
+                 st.initialStatus,
+                 st.initialStatus === 'in_progress' ? new Date() : null]
               );
               repairedCount++;
             }

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Response } from 'express';
 import { z } from 'zod';
 import { storage } from '../../storage';
 import { db, pool } from '../../db';
@@ -17,6 +17,10 @@ import {
   ProjectWorkflowVersionError,
   serializeProjectWorkflowVersion,
 } from '../services/projectWorkflowVersionService';
+import {
+  getInitializableProjectWorkflowSteps,
+  isLegacyProjectWorkflow,
+} from '../services/projectWorkflowRegistry';
 import { ensureProjectHasWAD } from '../lib/wadHelper';
 import { evaluateDocumentationRequirements } from '../lib/documentationRequirementsEngine';
 import { cancelWadWorkOrdersSupersededByP2 } from '../services/wadSupersedeService';
@@ -473,13 +477,27 @@ router.use(async (_req, res, next) => {
   }
 });
 
-const PROJECT_STEP_TYPES = [
-  { type: 'rfq_risk_assessment', order: 1, label: 'RFQ Risk Assessment', route: '/rfq-risk-assessment' },
-  { type: 'quote', order: 2, label: 'Quote', route: '/p2-quote-form' },
-  { type: 'purchase_review_checklist', order: 3, label: 'Purchase Review Checklist', route: '/purchase-review-checklist' },
-  { type: 'preproduction_checklist', order: 4, label: 'Pre-production Checklist', route: '/preproduction-checklists' },
-  { type: 'p2_order', order: 5, label: 'P2 Order', route: '/p2-control-center' },
-];
+const PROJECT_STEP_TYPES = getInitializableProjectWorkflowSteps('legacy_v1');
+
+async function rejectNonLegacyStepMutation(
+  projectId: string,
+  res: Response
+): Promise<boolean> {
+  const project = await storage.getProject(projectId);
+  if (!project) {
+    res.status(404).json({ message: 'Project not found' });
+    return true;
+  }
+  if (!isLegacyProjectWorkflow(project.workflowVersion)) {
+    res.status(409).json({
+      error: 'PROJECT_WORKFLOW_ACTION_UNAVAILABLE',
+      message: 'Legacy project step actions are unavailable for this workflow version',
+      workflowVersion: project.workflowVersion,
+    });
+    return true;
+  }
+  return false;
+}
 
 const createProjectRequestSchema = z.object({
   projectName: z.string().min(1, 'Project name is required'),
@@ -1580,8 +1598,8 @@ router.post('/', async (req, res) => {
         projectId: project.id,
         stepType: stepType.type as any,
         stepOrder: stepType.order,
-        status: stepType.order === 1 ? 'in_progress' : 'pending',
-        startedAt: stepType.order === 1 ? new Date() : null,
+        status: stepType.initialStatus,
+        startedAt: stepType.initialStatus === 'in_progress' ? new Date() : null,
         ...(isQuoteStep && quoteId ? { linkedQuoteId: quoteId, status: 'completed', completedAt: new Date() } : {}),
       });
     }
@@ -1758,6 +1776,7 @@ router.get('/:projectId/steps', async (req, res) => {
 router.patch('/:projectId/steps/:stepId', async (req, res) => {
   try {
     const { projectId, stepId } = req.params;
+    if (await rejectNonLegacyStepMutation(projectId, res)) return;
     
     const validationResult = updateStepRequestSchema.safeParse(req.body);
     if (!validationResult.success) {
@@ -1914,6 +1933,9 @@ router.patch('/:projectId/steps/:stepId', async (req, res) => {
     
     res.json(step);
   } catch (error) {
+    if (error instanceof ProjectWorkflowVersionError) {
+      return res.status(500).json(error.toJSON());
+    }
     console.error('Error updating project step:', error);
     res.status(500).json({ message: 'Failed to update project step' });
   }
@@ -1933,6 +1955,7 @@ router.get('/:projectId/activity', async (req, res) => {
 router.patch('/:projectId/steps/:stepId/skip', async (req, res) => {
   try {
     const { projectId, stepId } = req.params;
+    if (await rejectNonLegacyStepMutation(projectId, res)) return;
     const { reason } = req.body;
 
     if (!reason || typeof reason !== 'string' || reason.trim().length === 0) {
@@ -1965,6 +1988,9 @@ router.patch('/:projectId/steps/:stepId/skip', async (req, res) => {
 
     res.json(updatedStep);
   } catch (error) {
+    if (error instanceof ProjectWorkflowVersionError) {
+      return res.status(500).json(error.toJSON());
+    }
     console.error('Error skipping project step:', error);
     res.status(500).json({ message: 'Failed to skip project step' });
   }
@@ -1973,6 +1999,7 @@ router.patch('/:projectId/steps/:stepId/skip', async (req, res) => {
 router.patch('/:projectId/steps/:stepId/reopen', async (req, res) => {
   try {
     const { projectId, stepId } = req.params;
+    if (await rejectNonLegacyStepMutation(projectId, res)) return;
 
     const allSteps = await storage.getProjectSteps(projectId);
     const step = allSteps.find(s => s.id === stepId);
@@ -2014,6 +2041,9 @@ router.patch('/:projectId/steps/:stepId/reopen', async (req, res) => {
 
     res.json(updatedStep);
   } catch (error) {
+    if (error instanceof ProjectWorkflowVersionError) {
+      return res.status(500).json(error.toJSON());
+    }
     console.error('Error reopening project step:', error);
     res.status(500).json({ message: 'Failed to reopen project step' });
   }

--- a/server/src/routes/quotes.ts
+++ b/server/src/routes/quotes.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { db, pool } from '../../db';
-import { quotes, quoteLineItems, projectSteps, projects, productionWorkOrders, projectStepTypeEnum, insertQuoteSchema, insertQuoteLineItemSchema, customers, type QuoteExecutionFeedback } from '../../schema';
+import { quotes, quoteLineItems, projectSteps, projects, productionWorkOrders, insertQuoteSchema, insertQuoteLineItemSchema, customers, type QuoteExecutionFeedback } from '../../schema';
 import { eq, desc, max } from 'drizzle-orm';
 import { resolveCustomersIntegerId } from '../lib/customerResolver';
 
@@ -51,16 +51,9 @@ import { z } from 'zod';
 import { storage } from '../../storage';
 import { createQuoteSnapshot } from '../services/quoteContractService';
 import { getWorkflowVersionForNewProject } from '../services/projectWorkflowVersionService';
+import { getInitializableProjectWorkflowSteps } from '../services/projectWorkflowRegistry';
 
-type ProjectStepTypeValue = typeof projectStepTypeEnum.enumValues[number];
-
-const PROJECT_STEP_TYPES: Array<{ type: ProjectStepTypeValue; order: number }> = [
-  { type: 'rfq_risk_assessment', order: 1 },
-  { type: 'quote', order: 2 },
-  { type: 'purchase_review_checklist', order: 3 },
-  { type: 'preproduction_checklist', order: 4 },
-  { type: 'p2_order', order: 5 },
-];
+const PROJECT_STEP_TYPES = getInitializableProjectWorkflowSteps('legacy_v1');
 
 const router = Router();
 
@@ -725,8 +718,8 @@ router.patch('/api/quotes/:id/status', async (req: Request, res: Response) => {
             projectId,
             stepType: stepDef.type,
             stepOrder: stepDef.order,
-            status: stepDef.order === 1 ? 'in_progress' : 'pending',
-            startedAt: stepDef.order === 1 ? new Date() : null,
+            status: stepDef.initialStatus,
+            startedAt: stepDef.initialStatus === 'in_progress' ? new Date() : null,
             linkedQuoteId: stepDef.type === 'quote' ? quoteId : null,
           });
         }

--- a/server/src/services/projectWorkflowRegistry.ts
+++ b/server/src/services/projectWorkflowRegistry.ts
@@ -1,0 +1,294 @@
+import {
+  PROJECT_WORKFLOW_VERSIONS,
+  type ProjectWorkflowVersion,
+  resolveProjectWorkflowVersion,
+} from './projectWorkflowVersionService';
+
+export type ProjectWorkflowStepStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'completed'
+  | 'blocked'
+  | 'skipped'
+  | 'not_applicable';
+
+export type WorkflowStepApplicabilityPolicy = 'always' | 'contextual';
+export type WorkflowStepCompletionPolicy = 'manual' | 'release_gate';
+export type LegacyProjectWorkflowStepType =
+  | 'rfq_risk_assessment'
+  | 'quote'
+  | 'purchase_review_checklist'
+  | 'preproduction_checklist'
+  | 'p2_order';
+
+export type ProjectWorkflowStepDefinition = Readonly<{
+  type: LegacyProjectWorkflowStepType;
+  order: number;
+  label: string;
+  description: string;
+  route: string;
+  initialStatus: ProjectWorkflowStepStatus;
+  linkedRecordType: string | null;
+  legacyLinkedField: string | null;
+  stage: string | null;
+  skippable: boolean;
+  applicabilityPolicy: WorkflowStepApplicabilityPolicy;
+  completionPolicy: WorkflowStepCompletionPolicy;
+}>;
+
+export type ProjectWorkflowStageDefinition = Readonly<{
+  type: string;
+  order: number;
+  label: string;
+}>;
+
+export type ProjectWorkflowDefinition = Readonly<{
+  version: ProjectWorkflowVersion;
+  label: string;
+  active: boolean;
+  initializable: boolean;
+  steps: readonly ProjectWorkflowStepDefinition[];
+  stages: readonly ProjectWorkflowStageDefinition[];
+}>;
+
+export class ProjectWorkflowDefinitionValidationError extends Error {
+  readonly code = 'INVALID_PROJECT_WORKFLOW_DEFINITION';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProjectWorkflowDefinitionValidationError';
+  }
+}
+
+const freezeItems = <T extends object>(
+  items: readonly T[]
+): readonly Readonly<T>[] =>
+  Object.freeze(items.map((item) => Object.freeze({ ...item })));
+
+const LEGACY_V1_STEPS = freezeItems<ProjectWorkflowStepDefinition>([
+  {
+    type: 'rfq_risk_assessment',
+    order: 1,
+    label: 'RFQ Risk Assessment',
+    description: 'RFQ risk assessment',
+    route: '/rfq-risk-assessment',
+    initialStatus: 'in_progress',
+    linkedRecordType: 'rfq_risk_assessment',
+    legacyLinkedField: 'linkedRfqId',
+    stage: 'rfq_received',
+    skippable: true,
+    applicabilityPolicy: 'always',
+    completionPolicy: 'manual',
+  },
+  {
+    type: 'quote',
+    order: 2,
+    label: 'Quote',
+    description: 'Quote preparation',
+    route: '/p2-quote-form',
+    initialStatus: 'pending',
+    linkedRecordType: 'quote',
+    legacyLinkedField: 'linkedQuoteId',
+    stage: 'quote_submitted',
+    skippable: true,
+    applicabilityPolicy: 'always',
+    completionPolicy: 'manual',
+  },
+  {
+    type: 'purchase_review_checklist',
+    order: 3,
+    label: 'Purchase Review Checklist',
+    description: 'Purchase review checklist',
+    route: '/purchase-review-checklist',
+    initialStatus: 'pending',
+    linkedRecordType: 'purchase_review_checklist',
+    legacyLinkedField: 'linkedPurchaseReviewId',
+    stage: 'purchase_review',
+    skippable: true,
+    applicabilityPolicy: 'always',
+    completionPolicy: 'manual',
+  },
+  {
+    type: 'preproduction_checklist',
+    order: 4,
+    label: 'Pre-production Checklist',
+    description: 'Pre-production checklist',
+    route: '/preproduction-checklists',
+    initialStatus: 'pending',
+    linkedRecordType: 'preproduction_checklist',
+    legacyLinkedField: 'linkedPreproductionChecklistId',
+    stage: 'po_received',
+    skippable: true,
+    applicabilityPolicy: 'always',
+    completionPolicy: 'manual',
+  },
+  {
+    type: 'p2_order',
+    order: 5,
+    label: 'P2 Order',
+    description: 'P2 order and release',
+    route: '/p2-control-center',
+    initialStatus: 'pending',
+    linkedRecordType: 'p2_purchase_order',
+    legacyLinkedField: 'linkedP2OrderId',
+    stage: null,
+    skippable: true,
+    applicabilityPolicy: 'always',
+    completionPolicy: 'release_gate',
+  },
+]);
+
+const P2_V2_STAGES = freezeItems<ProjectWorkflowStageDefinition>([
+  { type: 'rfq_risk_assessment', order: 1, label: 'RFQ & Risk' },
+  { type: 'estimate_quote', order: 2, label: 'Estimate & Quote' },
+  { type: 'contract_review', order: 3, label: 'PO & Contract Review' },
+  { type: 'design_applicability', order: 4, label: 'Design Applicability' },
+  { type: 'production_planning', order: 5, label: 'Production Planning' },
+  { type: 'wad_authorization', order: 6, label: 'WAD Authorization' },
+  { type: 'preproduction_release', order: 7, label: 'Preproduction & Release' },
+  { type: 'production_quality', order: 8, label: 'Production & Quality' },
+  {
+    type: 'final_release_shipping',
+    order: 9,
+    label: 'Final Release & Shipping',
+  },
+  { type: 'project_closing', order: 10, label: 'Project Closing' },
+]);
+
+const DEFINITIONS: Readonly<
+  Record<ProjectWorkflowVersion, ProjectWorkflowDefinition>
+> = Object.freeze({
+  legacy_v1: Object.freeze({
+    version: 'legacy_v1',
+    label: 'Legacy P2 Project Workflow',
+    active: true,
+    initializable: true,
+    steps: LEGACY_V1_STEPS,
+    stages: Object.freeze([]),
+  }),
+  p2_v2: Object.freeze({
+    version: 'p2_v2',
+    label: 'P2 Project Workflow V2',
+    active: false,
+    initializable: false,
+    steps: Object.freeze([]),
+    stages: P2_V2_STAGES,
+  }),
+});
+
+function validateOrderedItems(
+  version: ProjectWorkflowVersion,
+  kind: string,
+  items: readonly { type: string; order: number; label: string }[]
+): void {
+  const types = new Set(items.map((item) => item.type));
+  const orders = new Set(items.map((item) => item.order));
+  if (types.size !== items.length)
+    throw new ProjectWorkflowDefinitionValidationError(
+      `${version} has duplicate ${kind} types`
+    );
+  if (orders.size !== items.length)
+    throw new ProjectWorkflowDefinitionValidationError(
+      `${version} has duplicate ${kind} orders`
+    );
+  if (items.some((item) => item.label.trim().length === 0))
+    throw new ProjectWorkflowDefinitionValidationError(
+      `${version} has an empty ${kind} label`
+    );
+  const sortedOrders = [...orders].sort((a, b) => a - b);
+  if (sortedOrders.some((order, index) => order !== index + 1))
+    throw new ProjectWorkflowDefinitionValidationError(
+      `${version} ${kind} orders must be contiguous from 1`
+    );
+}
+
+export function validateProjectWorkflowDefinition(
+  definition: ProjectWorkflowDefinition
+): void {
+  if (!PROJECT_WORKFLOW_VERSIONS.includes(definition.version))
+    throw new ProjectWorkflowDefinitionValidationError(
+      `Unsupported workflow version: ${definition.version}`
+    );
+  validateOrderedItems(definition.version, 'step', definition.steps);
+  validateOrderedItems(definition.version, 'stage', definition.stages);
+  if (definition.version === 'legacy_v1') {
+    if (definition.steps.length !== 5)
+      throw new ProjectWorkflowDefinitionValidationError(
+        'legacy_v1 must have exactly five steps'
+      );
+    if (
+      definition.steps.some(
+        (step) => !['pending', 'in_progress'].includes(step.initialStatus)
+      )
+    )
+      throw new ProjectWorkflowDefinitionValidationError(
+        'legacy_v1 has an unsupported initial status'
+      );
+    if (definition.steps.some((step) => !step.route.startsWith('/')))
+      throw new ProjectWorkflowDefinitionValidationError(
+        'legacy_v1 has an invalid route'
+      );
+  }
+  if (definition.version === 'p2_v2') {
+    if (definition.stages.length !== 10)
+      throw new ProjectWorkflowDefinitionValidationError(
+        'p2_v2 must have exactly ten metadata stages'
+      );
+    if (definition.initializable || definition.steps.length > 0)
+      throw new ProjectWorkflowDefinitionValidationError(
+        'p2_v2 must remain inactive and non-initializable'
+      );
+  }
+}
+
+for (const definition of Object.values(DEFINITIONS))
+  validateProjectWorkflowDefinition(definition);
+
+export function getProjectWorkflowDefinition(
+  version: ProjectWorkflowVersion | unknown
+): ProjectWorkflowDefinition {
+  return DEFINITIONS[resolveProjectWorkflowVersion(version)];
+}
+
+export function getProjectWorkflowStepDefinition(
+  version: ProjectWorkflowVersion | unknown,
+  stepType: string
+): ProjectWorkflowStepDefinition | undefined {
+  return getProjectWorkflowDefinition(version).steps.find(
+    (step) => step.type === stepType
+  );
+}
+
+export function getOrderedProjectWorkflowSteps(
+  version: ProjectWorkflowVersion | unknown
+): readonly ProjectWorkflowStepDefinition[] {
+  return getProjectWorkflowDefinition(version).steps;
+}
+
+export function getInitializableProjectWorkflowSteps(
+  version: ProjectWorkflowVersion | unknown
+): readonly ProjectWorkflowStepDefinition[] {
+  const definition = getProjectWorkflowDefinition(version);
+  if (!definition.initializable) {
+    throw new ProjectWorkflowDefinitionValidationError(
+      `${definition.version} workflow initialization is not available`
+    );
+  }
+  return definition.steps;
+}
+
+export function isLegacyProjectWorkflow(
+  version: ProjectWorkflowVersion | unknown
+): boolean {
+  return resolveProjectWorkflowVersion(version) === 'legacy_v1';
+}
+
+// SQL startup repair consumes this immutable projection. Keep it exported so
+// equivalence with the central registry can be tested without database writes.
+export const LEGACY_STARTUP_REPAIR_STEPS = freezeItems(
+  LEGACY_V1_STEPS.map(({ type, order, initialStatus }) => ({
+    type,
+    order,
+    initialStatus,
+  }))
+);


### PR DESCRIPTION
## What changed

- Added a deterministic, immutable server-owned registry for `legacy_v1` and inactive `p2_v2` workflow metadata.
- Preserved the exact five legacy step identifiers, order, labels, routes, linked fields, initial statuses, and manual-versus-accepted-quote behavior.
- Defined the ten requested V2 stages as inactive metadata only, with no database step definitions and a fail-closed initializer.
- Replaced duplicated legacy step constants in manual project creation, accepted-quote promotion, and guarded startup missing-step repair.
- Rejected legacy start/complete, skip, and reopen mutations for manually present `p2_v2` projects.
- Added registry equivalence, immutability, isolation, initialization-rejection, and mutation-boundary tests.

## Safety boundaries

- No migration was added or changed.
- No PostgreSQL enum value was added.
- No project or `project_steps` data was modified or backfilled.
- No V2 database step can be created through this registry.
- No V2 project creation or UI was activated.
- No client files, release-gate behavior, WAD behavior, Preproduction behavior, Project Closing behavior, progress calculation, or pipeline-stage calculation changed.
- Startup repair remains restricted to `COALESCE(workflow_version, 'legacy_v1') = 'legacy_v1'`.

## Validation

- Phase 1 focused regression tests: 77/77 passed.
- New Phase 2 registry and V2 isolation tests: 14/14 passed.
- Total focused tests: 91/91 passed.
- Focused ESLint for new registry and regression tests: 0 errors; 9 existing test-mock `any` warnings.
- Legacy route/startup lint still reports the repository's pre-existing lint backlog.
- `git diff --check`: passed.
- TypeScript with `NODE_OPTIONS=--max-old-space-size=6144` completed without OOM and reproduced 2,279 existing repository-wide diagnostics. A targeted changed-file check found no diagnostics in the new registry or registry test files; legacy route/test diagnostics predate this phase.

## Remaining risk

The V2 data model, initializer, actions, public API exposure, and UI remain intentionally unimplemented. The repository-wide TypeScript and legacy-file lint backlogs continue to prevent a clean global static-check result.
