### PR TITLE
Route P2 schedules to the part's first department

### DIFF
--- a/server/__tests__/cuttingQueueSchedulingEndpoints.e2e.test.ts
+++ b/server/__tests__/cuttingQueueSchedulingEndpoints.e2e.test.ts
@@ -77,6 +77,7 @@ const { store, dbMock, poolQueryMock, refreshSchemaMaps } = vi.hoisted(() => {
     p2ProductionOrders: AnyRow[];
     p2PurchaseOrders: AnyRow[];
     p2SerializedItems: AnyRow[];
+    partRoutings: AnyRow[];
     reset: () => void;
   }
 
@@ -88,6 +89,7 @@ const { store, dbMock, poolQueryMock, refreshSchemaMaps } = vi.hoisted(() => {
     p2ProductionOrders: [],
     p2PurchaseOrders: [],
     p2SerializedItems: [],
+    partRoutings: [],
   });
 
   const store = Object.assign(initial(), {
@@ -110,6 +112,7 @@ const { store, dbMock, poolQueryMock, refreshSchemaMaps } = vi.hoisted(() => {
       [schema.p2ProductionOrders, 'p2ProductionOrders'],
       [schema.p2PurchaseOrders, 'p2PurchaseOrders'],
       [schema.p2SerializedItems, 'p2SerializedItems'],
+      [schema.partRoutings, 'partRoutings'],
     ];
     for (const [table, key] of mappings) {
       tableMap.set(table, key);
@@ -188,8 +191,7 @@ const { store, dbMock, poolQueryMock, refreshSchemaMaps } = vi.hoisted(() => {
     const chain = {
       then<TResult1 = AnyRow[], TResult2 = never>(
         resolve?:
-          | ((value: AnyRow[]) => TResult1 | PromiseLike<TResult1>)
-          | null,
+          ((value: AnyRow[]) => TResult1 | PromiseLike<TResult1>) | null,
         reject?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
       ): Promise<TResult1 | TResult2> {
         return exec().then(resolve as never, reject as never);
@@ -468,6 +470,30 @@ const seedFixtures = (): void => {
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe('Cutting work order grouping — endpoint integration (Done #2)', () => {
+  it('schedules an Assembly-first part into Assembly instead of Layup', async () => {
+    store.partRoutings.push({
+      id: 'routing-26247',
+      partNumber: '26247',
+      departmentSequence: ['Assembly', 'Final QC'],
+    });
+    store.p2SerializedItems.push({
+      id: 'serialized-26247',
+      poId: 26247,
+      partNumber: '26247',
+      partRoutingId: 'routing-26247',
+      status: 'ACTIVE',
+      currentDepartment: 'Pending Layup',
+    });
+
+    const response = await request(app)
+      .post('/api/p2/schedule-items')
+      .send({ itemIds: ['serialized-26247'] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.scheduled).toBe(1);
+    expect(store.p2SerializedItems[0].currentDepartment).toBe('Assembly');
+  });
+
   it('all four scheduling endpoints converge to one PENDING row per packet+bucket', async () => {
     seedFixtures();
 

--- a/server/src/routes/p2ScheduleItems.ts
+++ b/server/src/routes/p2ScheduleItems.ts
@@ -5,7 +5,8 @@
  * independently in tests (without spinning up the full registerRoutes graph).
  *
  * Responsibilities:
- *   1. Move the requested P2 serialized items from "Pending Layup" to "Layup".
+ *   1. Move requested P2 serialized items from "Pending Layup" to the first
+ *      department in their stamped part routing (falling back to Layup).
  *   2. Auto-sync cutting-table packet demand for the affected POs into
  *      grouped manufacturing_queue rows via `upsertGroupedCuttingQueueEntry`.
  *
@@ -24,13 +25,15 @@ router.post('/api/p2/schedule-items', async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Item IDs array is required' });
     }
 
-    const { ensureProductionWorkflowReadSchema } = await import('../lib/productionWorkflowReadiness');
+    const { ensureProductionWorkflowReadSchema } =
+      await import('../lib/productionWorkflowReadiness');
     await ensureProductionWorkflowReadSchema();
     const { db } = await import('../../db');
     const {
       p2SerializedItems,
       p2ProductionOrders,
       p2PurchaseOrders,
+      partRoutings,
       inventoryItems,
       cuttingPacketBOMs,
     } = await import('../../schema');
@@ -43,50 +46,116 @@ router.post('/api/p2/schedule-items', async (req: Request, res: Response) => {
       ...new Set(
         itemIds
           .map((id: unknown) => {
-            const match = typeof id === 'string'
-              ? id.match(/^legacy-p2-production-order-(\d+)(?:-\d+)?$/)
-              : null;
+            const match =
+              typeof id === 'string'
+                ? id.match(/^legacy-p2-production-order-(\d+)(?:-\d+)?$/)
+                : null;
             return match ? Number(match[1]) : null;
           })
           .filter((id: number | null): id is number => Number.isInteger(id))
       ),
     ];
 
-    // Update all items to move to Layup department (scheduled for production)
-    const result = serializedItemIds.length > 0
-      ? await db
+    const schedulableItems =
+      serializedItemIds.length > 0
+        ? await db
+            .select({
+              id: p2SerializedItems.id,
+              poId: p2SerializedItems.poId,
+              partRoutingId: p2SerializedItems.partRoutingId,
+            })
+            .from(p2SerializedItems)
+            .where(
+              and(
+                inArray(p2SerializedItems.id, serializedItemIds),
+                eq(p2SerializedItems.status, 'ACTIVE'),
+                eq(p2SerializedItems.currentDepartment, 'Pending Layup')
+              )
+            )
+        : [];
+
+    const routingIds = [
+      ...new Set(
+        schedulableItems
+          .map((item) => item.partRoutingId)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      ),
+    ];
+    const routingRows =
+      routingIds.length > 0
+        ? await db
+            .select({
+              id: partRoutings.id,
+              departmentSequence: partRoutings.departmentSequence,
+            })
+            .from(partRoutings)
+            .where(inArray(partRoutings.id, routingIds))
+        : [];
+    const firstDepartmentByRoutingId = new Map(
+      routingRows.map((routing) => {
+        const sequence = Array.isArray(routing.departmentSequence)
+          ? routing.departmentSequence
+          : [];
+        const firstDepartment = sequence.find(
+          (department): department is string =>
+            typeof department === 'string' && department.trim().length > 0
+        );
+        return [routing.id, firstDepartment?.trim() || 'Layup'] as const;
+      })
+    );
+    const itemIdsByDepartment = new Map<string, string[]>();
+    for (const item of schedulableItems) {
+      const department = item.partRoutingId
+        ? firstDepartmentByRoutingId.get(item.partRoutingId) || 'Layup'
+        : 'Layup';
+      const ids = itemIdsByDepartment.get(department) || [];
+      ids.push(item.id);
+      itemIdsByDepartment.set(department, ids);
+    }
+
+    const result: Array<{ id: string; poId: number }> = [];
+    for (const [department, ids] of itemIdsByDepartment) {
+      const updated = await db
         .update(p2SerializedItems)
         .set({
-          currentDepartment: 'Layup',
+          currentDepartment: department,
+          currentStageIndex: 0,
           updatedAt: new Date(),
         })
         .where(
           and(
-            inArray(p2SerializedItems.id, serializedItemIds),
+            inArray(p2SerializedItems.id, ids),
             eq(p2SerializedItems.status, 'ACTIVE'),
             eq(p2SerializedItems.currentDepartment, 'Pending Layup')
           )
         )
-        .returning({ id: p2SerializedItems.id, poId: p2SerializedItems.poId })
-      : [];
+        .returning({ id: p2SerializedItems.id, poId: p2SerializedItems.poId });
+      result.push(...updated);
+    }
 
-    const legacyResult = legacyProductionOrderIds.length > 0
-      ? await db
-        .update(p2ProductionOrders)
-        .set({
-          scheduledLayupDate: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            inArray(p2ProductionOrders.id, legacyProductionOrderIds),
-            eq(p2ProductionOrders.status, 'PENDING')
-          )
-        )
-        .returning({ id: p2ProductionOrders.id, poId: p2ProductionOrders.p2PoId })
-      : [];
+    const legacyResult =
+      legacyProductionOrderIds.length > 0
+        ? await db
+            .update(p2ProductionOrders)
+            .set({
+              scheduledLayupDate: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                inArray(p2ProductionOrders.id, legacyProductionOrderIds),
+                eq(p2ProductionOrders.status, 'PENDING')
+              )
+            )
+            .returning({
+              id: p2ProductionOrders.id,
+              poId: p2ProductionOrders.p2PoId,
+            })
+        : [];
 
-    console.log(`Scheduled ${result.length + legacyResult.length} items for production`);
+    console.log(
+      `Scheduled ${result.length + legacyResult.length} items for production`
+    );
 
     // Auto-sync P2 cutting table demands for the affected POs.
     // All cutting orders for the affected POs are resolved to their actual packet
@@ -99,13 +168,14 @@ router.post('/api/p2/schedule-items', async (req: Request, res: Response) => {
     let cuttingTableSynced = 0;
     try {
       const { ilike, or } = await import('drizzle-orm');
-      const { upsertGroupedCuttingQueueEntry } = await import(
-        '../utils/cuttingQueueGroupingHelper'
-      );
-      const affectedPoIds = [...new Set([
-        ...result.map((r) => r.poId),
-        ...legacyResult.map((r) => r.poId),
-      ])];
+      const { upsertGroupedCuttingQueueEntry } =
+        await import('../utils/cuttingQueueGroupingHelper');
+      const affectedPoIds = [
+        ...new Set([
+          ...result.map((r) => r.poId),
+          ...legacyResult.map((r) => r.poId),
+        ]),
+      ];
 
       // CF/FG packet items used as fallback when SKU lookup misses
       const cfPacketItem = await db


### PR DESCRIPTION
## What changed

- Resolve each selected P2 serialized item's stamped part routing before scheduling it.
- Route the item to the first configured department instead of always forcing it into Layup.
- Preserve Layup as the fallback for legacy or unrouted serialized items.
- Reset the scheduled item to routing stage index 0.
- Add a regression case for part 26247 with an `Assembly -> Final QC` routing.

## Root cause

`POST /api/p2/schedule-items` unconditionally set every newly scheduled serialized item to `Layup`, even when its stamped `part_routings.department_sequence` began with another department. This caused Assembly-first parts such as 26247 to appear in the Layup queue.

## Impact

Future scheduling from the P2 Control Center follows the selected item's authoritative routing. Existing items already misrouted into Layup are not automatically modified and can be corrected separately under controlled production review.

## Validation

- Exact Assembly-first regression: passed
- Focused ESLint for both changed files: passed
- `git diff --check`: passed

The broader existing scheduling endpoint file still has two unrelated fixture failures; the new routing regression passes independently.