### PR TITLE
Hide linked P1 PO units from All Orders

### DIFF
--- a/server/__tests__/p1AllOrdersListBoundary.test.ts
+++ b/server/__tests__/p1AllOrdersListBoundary.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('P1 PO All Orders list boundary', () => {
+  const storage = readFileSync(join(process.cwd(), 'server/storage.ts'), 'utf8');
+
+  it('excludes linked P1 PO units from both payment-list query paths', () => {
+    const standardStart = storage.indexOf('async getAllOrdersWithPaymentStatus(');
+    const paginatedStart = storage.indexOf('async getAllOrdersWithPaymentStatusPaginated(');
+    const nextMethodStart = storage.indexOf('async getOrdersByDepartment(', paginatedStart);
+
+    const standardMethod = storage.slice(standardStart, paginatedStart);
+    const paginatedMethod = storage.slice(paginatedStart, nextMethodStart);
+
+    for (const method of [standardMethod, paginatedMethod]) {
+      expect(method).toContain('isNull(allOrders.sourcePoId)');
+      expect(method).toContain('isNull(allOrders.sourcePoItemId)');
+    }
+  });
+});

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5555,6 +5555,11 @@ export class DatabaseStorage implements IStorage {
       sql`${allOrders.orderId} NOT LIKE 'PO%'`,
       sql`${allOrders.orderId} != 'AG1'`,
       sql`${allOrders.orderId} NOT LIKE '%PO%'`,
+      // PO-generated units can have ordinary-looking FG/FD order IDs and stale
+      // order_source values. The persisted PO links are the authoritative
+      // boundary for keeping them out of the regular All Orders payment list.
+      isNull(allOrders.sourcePoId),
+      isNull(allOrders.sourcePoItemId),
       // Exclude Production-Only Orders (PO_RELEASE) from customer-facing payment views
       sql`(${allOrders.orderSource} = 'SALES' OR ${allOrders.orderSource} = 'main_orders' OR ${allOrders.orderSource} IS NULL)`,
     ];
@@ -5929,6 +5934,8 @@ export class DatabaseStorage implements IStorage {
       sql`${allOrders.orderId} NOT LIKE 'PO%'`,
       sql`${allOrders.orderId} != 'AG1'`,
       sql`${allOrders.orderId} NOT LIKE '%PO%'`,
+      isNull(allOrders.sourcePoId),
+      isNull(allOrders.sourcePoItemId),
       sql`(${allOrders.orderSource} = 'SALES' OR ${allOrders.orderSource} = 'main_orders' OR ${allOrders.orderSource} IS NULL)`,
     ];
 


### PR DESCRIPTION
## What changed

- exclude rows linked through `source_po_id` or `source_po_item_id` from the regular All Orders payment list
- apply the same boundary to both standard and paginated All Orders queries
- keep legacy FG/FD-style P1 PO units out of All Orders even when `order_source` is stale or missing

## Root cause

The list relied on order-ID patterns and `order_source = 'PO_RELEASE'`. Older P1 PO units can have ordinary FG/FD identifiers and stale source values, so they passed those filters despite retaining authoritative purchase-order links.

## Validation

- focused P1 suite: **3 files passed, 31 tests passed**
- `git diff --check` passed