### PR TITLE
Fix P2 workflow registry TypeScript compatibility

### DIFF
--- a/server/__tests__/projectWorkflowRegistry.test.ts
+++ b/server/__tests__/projectWorkflowRegistry.test.ts
@@ -109,6 +109,32 @@ describe('project workflow registry', () => {
     ).not.toThrow();
   });
 
+  it('rejects duplicate step orders', () => {
+    const legacy = getProjectWorkflowDefinition('legacy_v1');
+    expect(() =>
+      validateProjectWorkflowDefinition({
+        ...legacy,
+        steps: legacy.steps.map((step, index) => ({
+          ...step,
+          order: index === 1 ? 1 : step.order,
+        })),
+      })
+    ).toThrow('legacy_v1 has duplicate step orders');
+  });
+
+  it('rejects non-contiguous step orders', () => {
+    const legacy = getProjectWorkflowDefinition('legacy_v1');
+    expect(() =>
+      validateProjectWorkflowDefinition({
+        ...legacy,
+        steps: legacy.steps.map((step, index) => ({
+          ...step,
+          order: index === legacy.steps.length - 1 ? 6 : step.order,
+        })),
+      })
+    ).toThrow('legacy_v1 step orders must be contiguous from 1');
+  });
+
   it('keeps legacy types exactly equivalent to the PostgreSQL enum', () => {
     expect(
       getOrderedProjectWorkflowSteps('legacy_v1').map((step) => step.type)

--- a/server/src/services/projectWorkflowRegistry.ts
+++ b/server/src/services/projectWorkflowRegistry.ts
@@ -195,7 +195,7 @@ function validateOrderedItems(
     throw new ProjectWorkflowDefinitionValidationError(
       `${version} has an empty ${kind} label`
     );
-  const sortedOrders = [...orders].sort((a, b) => a - b);
+  const sortedOrders = Array.from(orders).sort((a, b) => a - b);
   if (sortedOrders.some((order, index) => order !== index + 1))
     throw new ProjectWorkflowDefinitionValidationError(
       `${version} ${kind} orders must be contiguous from 1`


### PR DESCRIPTION
## What changed

- Replaced the `Set<number>` spread in workflow-definition order validation with `Array.from(orders)`.
- Added direct regression coverage proving duplicate step orders and non-contiguous step orders remain rejected.

## Why

The repository TypeScript configuration does not set an ES2015 target or `downlevelIteration`. Spreading the `Set<number>` therefore produced TS2802 in `projectWorkflowRegistry.ts`. `Array.from(orders)` preserves insertion order and produces the same sortable array without requiring iterable downlevel support.

## Safety boundaries

- No workflow definition, identifier, label, order, status, route, or error message changed.
- `legacy_v1` behavior is unchanged.
- `p2_v2` remains metadata-only, inactive, and non-initializable.
- No migration, enum, database data, UI, or Phase 3 work was added.
- PR #1504 and its branch were untouched.

## Validation

- Combined registry/version/WAD/closing/legacy suite: 63/63 passed.
- P2 release-gate suite: 12/12 passed.
- Focused client project helper suite: 21/21 passed.
- Total focused tests: 96/96 passed.
- Focused ESLint on both changed files: passed, with Windows checkout line-ending noise excluded.
- `git diff --check`: passed.
- TypeScript with `NODE_OPTIONS=--max-old-space-size=6144`: completed with the existing repository backlog. Diagnostic lines decreased from 1,501 to 1,500; `projectWorkflowRegistry` now reports zero diagnostics. Other pre-existing TS2802 diagnostics remain elsewhere in the repository.