### PR TITLE
Fix P1 PO completion and P2 document builder workflows

### DIFF
--- a/migrations/0201_close_fully_shipped_p1_purchase_orders.sql
+++ b/migrations/0201_close_fully_shipped_p1_purchase_orders.sql
@@ -1,0 +1,22 @@
+-- Move open P1 purchase orders to Completed POs when every non-cancelled
+-- production unit has shipped. Cancelled rows remain as audit history and do
+-- not prevent completion.
+
+UPDATE purchase_orders AS purchase
+SET status = 'CLOSED',
+    updated_at = NOW()
+WHERE UPPER(COALESCE(purchase.status, '')) = 'OPEN'
+  AND EXISTS (
+    SELECT 1
+    FROM production_orders AS production
+    WHERE production.po_id = purchase.id
+      AND UPPER(COALESCE(production.production_status, ''))
+        NOT IN ('CANCELLED', 'CANCELED', 'SCRAPPED')
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM production_orders AS production
+    WHERE production.po_id = purchase.id
+      AND UPPER(COALESCE(production.production_status, ''))
+        NOT IN ('CANCELLED', 'CANCELED', 'SCRAPPED', 'SHIPPED')
+  );

--- a/server/__tests__/p1PurchaseOrderAutoCompletion.test.ts
+++ b/server/__tests__/p1PurchaseOrderAutoCompletion.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { safeMigrationFiles } from '../scripts/migrations/runSafeBootMigrations';
+
+describe('P1 purchase order auto-completion', () => {
+  const migrationName = '0201_close_fully_shipped_p1_purchase_orders.sql';
+  const migration = readFileSync(join(process.cwd(), 'migrations', migrationName), 'utf8');
+  const shippingRoute = readFileSync(join(process.cwd(), 'server/src/routes/poShippingQC.ts'), 'utf8');
+
+  it('reads PostgreSQL QueryResult rows before evaluating completion counts', () => {
+    expect(shippingRoute).toContain("const row = rowsOf<{\n      total: string;");
+    expect(shippingRoute).toContain('}>(rows)[0];');
+  });
+
+  it('reconciles existing open POs during safe boot', () => {
+    expect(safeMigrationFiles).toContain(migrationName);
+    expect(migration).toContain("SET status = 'CLOSED'");
+  });
+
+  it('ignores cancelled history but requires every active unit to be shipped', () => {
+    expect(migration).toContain("NOT IN ('CANCELLED', 'CANCELED', 'SCRAPPED')");
+    expect(migration).toContain("NOT IN ('CANCELLED', 'CANCELED', 'SCRAPPED', 'SHIPPED')");
+  });
+});

--- a/server/__tests__/p2ProjectDocumentCoverageBuilderBoundary.test.ts
+++ b/server/__tests__/p2ProjectDocumentCoverageBuilderBoundary.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('P2 project document coverage builder boundary', () => {
+  const projectsRoute = readFileSync(join(process.cwd(), 'server/src/routes/projects.ts'), 'utf8');
+
+  it('labels the combined work-instruction and spec-sheet requirement', () => {
+    expect(projectsRoute).toContain("label: 'Work Instructions / Spec Sheet'");
+    expect(projectsRoute).toContain("source: 'Form & Document Builder'");
+  });
+
+  it('opens the Form & Document Builder for the project', () => {
+    expect(projectsRoute).toContain('route: `/forms/document-builder?projectId=${encodeURIComponent(id)}`');
+  });
+
+  it('counts builder documents as part coverage', () => {
+    expect(projectsRoute).toContain('getProjectManufacturingDocumentRefs(id).catch(() => [])');
+    expect(projectsRoute).toContain('builderDocumentParts.has(String(partNumber).trim().toLowerCase())');
+  });
+});

--- a/server/__tests__/routingDocumentFromTemplateSchemaFallback.test.ts
+++ b/server/__tests__/routingDocumentFromTemplateSchemaFallback.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('document-from-template production schema fallback', () => {
+  const route = readFileSync(join(process.cwd(), 'server/src/routes/routingDocuments.ts'), 'utf8');
+  const start = route.indexOf('const createDocumentFromTemplate');
+  const end = route.indexOf("router.post('/documents/from-template'", start);
+  const handler = route.slice(start, end);
+
+  it('uses schema-aware inserts for every persisted document record', () => {
+    expect(handler).toContain("insertPublicRowReturning('routing_documents'");
+    expect(handler).toContain("insertPublicRowReturning('spec_sheets'");
+    expect(handler).toContain("insertPublicRowReturning('controlled_documents'");
+    expect(handler).toContain("insertPublicRowReturning('document_version_history'");
+    expect(handler).not.toContain('db.insert(routingDocuments)');
+    expect(handler).not.toContain('db.insert(specSheets)');
+  });
+
+  it('returns the production failure detail to the client', () => {
+    expect(handler).toContain('details: error instanceof Error ? error.message : String(error)');
+  });
+});

--- a/server/__tests__/routingDocumentFromTemplateSchemaFallback.test.ts
+++ b/server/__tests__/routingDocumentFromTemplateSchemaFallback.test.ts
@@ -20,4 +20,11 @@ describe('document-from-template production schema fallback', () => {
   it('returns the production failure detail to the client', () => {
     expect(handler).toContain('details: error instanceof Error ? error.message : String(error)');
   });
+
+  it('stores the finished PDF centrally and queues it for MDR acceptance', () => {
+    expect(route).toContain('return saveControlledDocumentFile(storedFileName, fileBuffer);');
+    expect(handler).toContain("insertPublicRowReturning('controlled_documents'");
+    expect(handler).toContain("status: 'pending'");
+    expect(handler).toContain('file_path: fileUrl');
+  });
 });

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -223,6 +223,7 @@ export const safeMigrationFiles = [
   '0198_repair_p1_metal_accessory_classification.sql',
   '0199_project_workflow_version.sql',
   '0200_reconcile_oem_shipment_fulfillment.sql',
+  '0201_close_fully_shipped_p1_purchase_orders.sql',
   'investigation_308_order_duplication.sql',
 ];
 

--- a/server/src/routes/poShippingQC.ts
+++ b/server/src/routes/poShippingQC.ts
@@ -36,7 +36,11 @@ async function autoClosePOIfFullyShipped(poId: number): Promise<void> {
        WHERE po_id = $1`,
       [poId]
     );
-    const row = rows[0];
+    const row = rowsOf<{
+      total: string;
+      shipped: string;
+      cancelled: string;
+    }>(rows)[0];
     if (!row) return;
     const total = parseInt(row.total, 10);
     const shipped = parseInt(row.shipped, 10);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -2500,7 +2500,7 @@ router.get('/:id/p2-hub', async (req, res) => {
       }
     };
 
-    const [steps, projectRevisions, activityLog, workOrders, manualDocuments] = await Promise.all([
+    const [steps, projectRevisions, activityLog, workOrders, manualDocuments, manufacturingDocuments] = await Promise.all([
       storage.getProjectSteps(id).catch(() => []),
       storage.getProjectRevisions(id).catch(() => []),
       storage.getProjectActivityLog(id).catch(() => []),
@@ -2514,6 +2514,7 @@ router.get('/:id/p2-hub', async (req, res) => {
          ORDER BY created_at DESC`,
         [id],
       ),
+      getProjectManufacturingDocumentRefs(id).catch(() => []),
     ]);
 
     const linkedPoFamily = project.poId
@@ -3029,7 +3030,13 @@ router.get('/:id/p2-hub', async (req, res) => {
     const partsMissingRoutings = activePoPartNumbers.filter((partNumber: string) => (
       !routeByPartNumber.has(String(partNumber).trim().toLowerCase())
     ));
+    const builderDocumentParts = new Set(
+      manufacturingDocuments
+        .map((document: any) => String(document.part_number ?? '').trim().toLowerCase())
+        .filter(Boolean),
+    );
     const partsMissingInstructions = activePoPartNumbers.filter((partNumber: string) => {
+      if (builderDocumentParts.has(String(partNumber).trim().toLowerCase())) return false;
       const routing = routeByPartNumber.get(String(partNumber).trim().toLowerCase()) as any;
       if (!routing) return true;
       const operationSummary = routingOperationSummaryById.get(String(routing.id)) as any;
@@ -3086,15 +3093,15 @@ router.get('/:id/p2-hub', async (req, res) => {
       },
       {
         key: 'work_instructions',
-        label: 'Work Instructions',
+        label: 'Work Instructions / Spec Sheet',
         status: activePoPartNumbers.length > 0 && partsMissingInstructions.length === 0 ? 'covered_by_project_data' : 'needs_setup',
-        source: 'Part routing instruction packs',
+        source: 'Form & Document Builder',
         detail: activePoPartNumbers.length === 0
           ? 'No PO parts are linked yet.'
           : partsMissingInstructions.length === 0
-            ? 'Every PO part has routing instruction evidence.'
-            : `${partsMissingInstructions.length} PO part(s) need work instruction setup.`,
-        route: `/p2-control-center?tab=routing&projectId=${encodeURIComponent(id)}`,
+            ? 'Every PO part has work instruction or spec sheet coverage.'
+            : `${partsMissingInstructions.length} PO part(s) need a work instruction or spec sheet.`,
+        route: `/forms/document-builder?projectId=${encodeURIComponent(id)}`,
         relatedCount: Math.max(activePoPartNumbers.length - partsMissingInstructions.length, 0),
         missingParts: partsMissingInstructions,
       },

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -549,12 +549,7 @@ async function renderSpecSheetPdf(input: {
 
 async function saveSpecSheetPdfFile(fileName: string, fileBuffer: Buffer) {
   const storedFileName = normalizeSpecSheetFileName(fileName, null);
-  return getFileStorageProvider().uploadBuffer({
-    fileName: storedFileName,
-    contentType: 'application/pdf',
-    scope: 'form-document-builder',
-    buffer: fileBuffer,
-  });
+  return saveControlledDocumentFile(storedFileName, fileBuffer);
 }
 
 // Helper to format UUID bytes to string if needed

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -32,6 +32,7 @@ import { randomUUID } from 'crypto';
 const require = createRequire(import.meta.url);
 const TEMPLATE_UPLOAD_TABLES = new Set([
   'routing_documents',
+  'spec_sheets',
   'document_templates',
   'template_fields',
   'controlled_documents',
@@ -2247,70 +2248,79 @@ const createDocumentFromTemplate = async (req: Request, res: Response) => {
       controlledDocumentNumber: documentNumber,
     };
 
-    const [routingDocument] = await db.insert(routingDocuments).values({
-      partNumber: resolvedPartNumber,
+    const routingDocument = await insertPublicRowReturning('routing_documents', {
+      part_number: resolvedPartNumber,
       title: resolvedTitle,
       version: 1,
       description: description || `Filled ${humanizeDocumentType(templateType)} from template ${template.template_name ?? template.templateName}`,
-      departmentName: finalDepartment,
-      documentType: templateType,
-      sourceType: 'generated',
-      fileUrl,
-      fileName: path.basename(fileUrl),
-      fileType: 'application/pdf',
-      fileSize: pdfBuffer.length,
-      aiExtractedContent: specifications,
-      aiExtractedFields: templateFields,
-      isTemplate: false,
-      createdBy,
-    }).returning();
+      department_name: finalDepartment,
+      document_type: templateType,
+      source_type: 'generated',
+      file_url: fileUrl,
+      file_name: path.basename(fileUrl),
+      file_type: 'application/pdf',
+      file_size: pdfBuffer.length,
+      ai_extracted_content: specifications,
+      ai_extracted_fields: templateFields,
+      is_template: false,
+      is_active: true,
+      created_by: createdBy,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }, ['title', 'document_type']);
 
     let specSheet = null;
     if (templateType === 'spec_sheet' || templateType === 'specification') {
-      [specSheet] = await db.insert(specSheets).values({
-        partNumber: resolvedPartNumber,
+      specSheet = await insertPublicRowReturning('spec_sheets', {
+        part_number: resolvedPartNumber,
         title: resolvedTitle,
         version: 1,
         description: description || `Filled spec sheet from template ${template.template_name ?? template.templateName}`,
         specifications,
-        sourceType: 'generated',
-        fileUrl,
-        fileName: path.basename(fileUrl),
-        fileType: 'application/pdf',
-        fileSize: pdfBuffer.length,
-        isTemplate: false,
-        createdBy,
-      }).returning();
+        source_type: 'generated',
+        file_url: fileUrl,
+        file_name: path.basename(fileUrl),
+        file_type: 'application/pdf',
+        file_size: pdfBuffer.length,
+        is_template: false,
+        is_active: true,
+        created_by: createdBy,
+        created_at: new Date(),
+        updated_at: new Date(),
+      }, ['title']);
     }
 
     const expirationDate = new Date();
     expirationDate.setFullYear(expirationDate.getFullYear() + 1);
-    const [controlledDocument] = await db.insert(controlledDocuments).values({
-      documentNumber,
-      documentName: resolvedTitle,
-      documentType: templateType,
+    const controlledDocument = await insertPublicRowReturning('controlled_documents', {
+      document_number: documentNumber,
+      document_name: resolvedTitle,
+      document_type: templateType,
       department: finalDepartment,
       category: templateType === 'spec_sheet' ? 'Spec Sheet' : 'Form & Document Builder',
       description: description || `${humanizeDocumentType(templateType)} created from reusable template${resolvedPartNumber ? ` for ${resolvedPartNumber}` : ''}`,
-      currentVersion: '1.0',
+      current_version: '1.0',
       status: 'pending',
-      retentionLength: 'controlled',
-      documentOwner: createdBy,
-      filePath: fileUrl,
-      createdBy,
-      expirationDate: expirationDate.toISOString().split('T')[0],
-    }).returning();
+      retention_length: 'controlled',
+      document_owner: createdBy,
+      file_path: fileUrl,
+      created_by: createdBy,
+      expiration_date: expirationDate.toISOString().split('T')[0],
+      created_at: new Date(),
+      updated_at: new Date(),
+    }, ['document_number', 'document_name', 'document_type', 'department', 'current_version', 'status', 'created_by']);
 
-    await db.insert(documentVersionHistory).values({
-      documentId: controlledDocument.id,
-      versionNumber: '1.0',
-      changeDescription: `Initial ${humanizeDocumentType(templateType)} created from reusable Form & Document Builder template`,
-      changeType: 'major',
-      filePath: fileUrl,
+    await insertPublicRowReturning('document_version_history', {
+      document_id: controlledDocument.id,
+      version_number: '1.0',
+      change_description: `Initial ${humanizeDocumentType(templateType)} created from reusable Form & Document Builder template`,
+      change_type: 'major',
+      file_path: fileUrl,
       status: 'pending',
-      createdBy,
-      expirationDate: expirationDate.toISOString().split('T')[0],
-    });
+      created_by: createdBy,
+      expiration_date: expirationDate.toISOString().split('T')[0],
+      created_at: new Date(),
+    }, ['document_id', 'version_number', 'status', 'created_by']);
 
     let projectDocument = null;
     if (projectId) {
@@ -2337,7 +2347,10 @@ const createDocumentFromTemplate = async (req: Request, res: Response) => {
     });
   } catch (error) {
     console.error('Error creating document from template:', error);
-    res.status(500).json({ error: 'Failed to create document from template' });
+    res.status(500).json({
+      error: 'Failed to create document from template',
+      details: error instanceof Error ? error.message : String(error),
+    });
   }
 };
 


### PR DESCRIPTION
## What changed

### P1 purchase-order completion
- fix the shipment auto-close helper to read PostgreSQL `QueryResult.rows` correctly
- close a PO when every non-cancelled, non-scrapped production unit is shipped
- preserve cancelled rows as audit history without letting them block completion
- repair already-stuck fully shipped Open POs through migration `0201`

### P2 project document coverage
- rename the requirement to **Work Instructions / Spec Sheet**
- send the Open action to Form & Document Builder with the project ID
- count either builder work instructions or spec sheets as part coverage

### Document creation from templates
- save the completed PDF in the controlled-document central-storage scope
- create a new Master Document Register record with `pending` status for acceptance
- replace rigid ORM writes with production-schema-aware inserts for routing documents, spec sheets, controlled documents, and version history
- return the underlying server failure detail instead of only a generic 500 message

## Validation

- P1 completion suite: **4 files passed, 34 tests passed**
- focused P2 coverage/template suite: **3 files passed, 8 tests passed**
- central-storage/MDR verification: **2 files passed, 6 tests passed**
- `git diff --check` passed