### PR TITLE
Add freezer temperature tracking

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -71,6 +71,9 @@ const TicketsPage = React.lazy(() => import('./pages/TicketsPage'));
 const TicketsCommandCenter = React.lazy(() => import('./pages/TicketsCommandCenter'));
 const PDFSignatureTool = React.lazy(() => import('./pages/PDFSignatureTool'));
 const MaintenancePage = React.lazy(() => import('./pages/MaintenancePage'));
+const FreezerTemperatureLogPage = React.lazy(
+  () => import('./pages/FreezerTemperatureLogPage')
+);
 const MaintenanceEventsPage = React.lazy(() => import('./pages/MaintenanceEventsPage'));
 const WorkOrderDetailPage = React.lazy(() => import('./pages/WorkOrderDetailPage'));
 const ProductionWorkOrderDetailPage = React.lazy(() => import('./pages/ProductionWorkOrderDetailPage'));
@@ -873,6 +876,10 @@ function App() {
                   {/* QC and Maintenance Routes */}
                   <Route path="/qc" component={QCPage} />
                   <Route path="/maintenance" component={MaintenancePage} />
+                  <Route
+                    path="/freezer-temperature-log"
+                    component={FreezerTemperatureLogPage}
+                  />
                   <Route path="/maintenance-events" component={MaintenanceEventsPage} />
                   <Route path="/maintenance-events/:id">
                     {(params) => <WorkOrderDetailPage params={params} />}

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -82,6 +82,7 @@ import {
   FlaskConical,
   Tag,
   HandCoins,
+  Thermometer,
 } from 'lucide-react';
 
 interface NavItemDef {
@@ -921,6 +922,12 @@ export default function Navigation() {
       label: 'Preventive Maintenance',
       icon: Calendar,
       description: 'Preventive maintenance schedules',
+    },
+    {
+      path: '/freezer-temperature-log',
+      label: 'Freezer Temperature Log',
+      icon: Thermometer,
+      description: 'Record and review freezer temperature checks',
     },
     {
       path: '/maintenance-events',

--- a/client/src/config/userPermissions.ts
+++ b/client/src/config/userPermissions.ts
@@ -39,7 +39,7 @@ export function getRequiredCapability(route: string): string | string[] | undefi
 export const DEFAULT_USER_ROUTES: string[] = ['/employee-portal'];
 
 // Universal routes that ALL authenticated users can access regardless of permissions
-export const UNIVERSAL_ACCESS_ROUTES: string[] = ['/communications/inbox', '/employee-portal', '/badge-scanner', '/help', '/pdf-signature-tool', '/routing-document-management', '/forms/document-builder', '/tickets', '/tickets-command-center', '/quick-notes', '/training', '/training/my-training', '/policies', '/approvals', '/pto-command-center'];
+export const UNIVERSAL_ACCESS_ROUTES: string[] = ['/communications/inbox', '/employee-portal', '/badge-scanner', '/help', '/pdf-signature-tool', '/routing-document-management', '/forms/document-builder', '/tickets', '/tickets-command-center', '/quick-notes', '/training', '/training/my-training', '/policies', '/approvals', '/pto-command-center', '/freezer-temperature-log'];
 
 // All valid navbar routes for reference (from Navigation.tsx)
 // This helps ensure permissions use correct paths
@@ -148,6 +148,7 @@ export const VALID_NAVBAR_ROUTES = [
   '/inventory/scanner',
   '/kickback-tracking',
   '/maintenance',
+  '/freezer-temperature-log',
   '/maintenance-events',
   '/qms',
   '/qms/change-control',

--- a/client/src/pages/FreezerTemperatureLogPage.tsx
+++ b/client/src/pages/FreezerTemperatureLogPage.tsx
@@ -1,0 +1,351 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Snowflake,
+  Thermometer,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { apiRequest } from '@/lib/queryClient';
+
+type TemperatureField =
+  | 'freezer1Temperature'
+  | 'freezer2Temperature'
+  | 'freezer3Temperature'
+  | 'freezer4Temperature'
+  | 'layupRoomTemperature'
+  | 'refrigeratorContainerTemperature';
+
+type FormState = Record<TemperatureField, string> & {
+  recordedAt: string;
+  notes: string;
+};
+
+type FreezerTemperatureLog = Record<TemperatureField, string> & {
+  id: number;
+  recordedAt: string;
+  notes: string | null;
+  recordedByDisplayName: string;
+  createdAt: string;
+};
+
+const temperatureFields: Array<{
+  key: TemperatureField;
+  label: string;
+  shortLabel: string;
+}> = [
+  { key: 'freezer1Temperature', label: 'Freezer 1', shortLabel: 'F1' },
+  { key: 'freezer2Temperature', label: 'Freezer 2', shortLabel: 'F2' },
+  { key: 'freezer3Temperature', label: 'Freezer 3', shortLabel: 'F3' },
+  { key: 'freezer4Temperature', label: 'Freezer 4', shortLabel: 'F4' },
+  { key: 'layupRoomTemperature', label: 'Lay-Up Room', shortLabel: 'Lay-Up' },
+  {
+    key: 'refrigeratorContainerTemperature',
+    label: 'Refrigerator Container',
+    shortLabel: 'Refrig. Container',
+  },
+];
+
+function currentLocalDateTime() {
+  const now = new Date();
+  const local = new Date(now.getTime() - now.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+function initialFormState(): FormState {
+  return {
+    recordedAt: currentLocalDateTime(),
+    freezer1Temperature: '',
+    freezer2Temperature: '',
+    freezer3Temperature: '',
+    freezer4Temperature: '',
+    layupRoomTemperature: '',
+    refrigeratorContainerTemperature: '',
+    notes: '',
+  };
+}
+
+function formatTemperature(value: string) {
+  const number = Number(value);
+  return Number.isFinite(number) ? `${number.toFixed(1)} deg F` : '--';
+}
+
+export default function FreezerTemperatureLogPage() {
+  const [form, setForm] = useState<FormState>(initialFormState);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const {
+    data: logs = [],
+    isLoading,
+    isError,
+  } = useQuery<FreezerTemperatureLog[]>({
+    queryKey: ['/api/quality/freezer-temperature-logs'],
+    queryFn: () =>
+      apiRequest('/api/quality/freezer-temperature-logs?limit=250'),
+  });
+
+  const createLog = useMutation({
+    mutationFn: () =>
+      apiRequest('/api/quality/freezer-temperature-logs', {
+        method: 'POST',
+        body: {
+          ...form,
+          recordedAt: new Date(form.recordedAt).toISOString(),
+          notes: form.notes.trim() || null,
+        },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['/api/quality/freezer-temperature-logs'],
+      });
+      setForm(initialFormState());
+      toast({
+        title: 'Temperature check saved',
+        description: 'The employee and time were recorded automatically.',
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Could not save temperature check',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const allTemperaturesEntered = temperatureFields.every(
+    ({ key }) => form[key].trim() !== '' && Number.isFinite(Number(form[key]))
+  );
+  const latest = logs[0];
+
+  return (
+    <div className="container mx-auto space-y-6 px-4 py-8">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="flex items-center gap-3 text-3xl font-bold text-gray-900">
+            <Snowflake className="h-8 w-8 text-blue-600" />
+            Freezer Temperature Log
+          </h1>
+          <p className="mt-2 text-gray-600">
+            Digital replacement for the handwritten freezer check sheet.
+          </p>
+        </div>
+        <Badge variant="outline" className="w-fit px-3 py-1 text-sm">
+          All readings in degrees Fahrenheit
+        </Badge>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Thermometer className="h-5 w-5" />
+            Record a temperature check
+          </CardTitle>
+          <CardDescription>
+            Enter all six readings from the current check. Your employee name is
+            attached automatically when the record is saved.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="space-y-5"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (allTemperaturesEntered) createLog.mutate();
+            }}
+          >
+            <div className="max-w-sm space-y-2">
+              <Label htmlFor="recorded-at">Date and time</Label>
+              <Input
+                id="recorded-at"
+                type="datetime-local"
+                required
+                value={form.recordedAt}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    recordedAt: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {temperatureFields.map(({ key, label }) => (
+                <div key={key} className="space-y-2">
+                  <Label htmlFor={key}>{label}</Label>
+                  <div className="relative">
+                    <Input
+                      id={key}
+                      type="number"
+                      inputMode="decimal"
+                      min="-200"
+                      max="200"
+                      step="0.1"
+                      required
+                      className="pr-10 text-lg font-medium"
+                      placeholder="0.0"
+                      value={form[key]}
+                      onChange={(event) =>
+                        setForm((current) => ({
+                          ...current,
+                          [key]: event.target.value,
+                        }))
+                      }
+                    />
+                    <span className="pointer-events-none absolute right-3 top-2.5 text-sm text-gray-500">
+                      deg F
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="notes">
+                Notes or corrective action (optional)
+              </Label>
+              <Textarea
+                id="notes"
+                maxLength={2000}
+                placeholder="Add details if a reading needs attention."
+                value={form.notes}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    notes: event.target.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="flex justify-end">
+              <Button
+                type="submit"
+                size="lg"
+                disabled={
+                  !allTemperaturesEntered ||
+                  !form.recordedAt ||
+                  createLog.isPending
+                }
+              >
+                {createLog.isPending ? 'Saving...' : 'Save temperature check'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {latest && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Latest readings</CardTitle>
+            <CardDescription>
+              {new Date(latest.recordedAt).toLocaleString()} by{' '}
+              {latest.recordedByDisplayName}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
+            {temperatureFields.map(({ key, shortLabel }) => (
+              <div key={key} className="rounded-lg border bg-slate-50 p-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                  {shortLabel}
+                </p>
+                <p className="mt-1 text-xl font-semibold">
+                  {formatTemperature(latest[key])}
+                </p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Temperature history</CardTitle>
+          <CardDescription>
+            Most recent 250 employee-recorded checks.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="py-8 text-center text-gray-500">
+              Loading temperature history...
+            </p>
+          ) : isError ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-red-700">
+              <AlertCircle className="h-5 w-5" />
+              Temperature history could not be loaded.
+            </div>
+          ) : logs.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-gray-500">
+              <CheckCircle2 className="h-10 w-10 text-gray-300" />
+              No checks have been recorded yet.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date / time</TableHead>
+                  {temperatureFields.map(({ key, shortLabel }) => (
+                    <TableHead key={key} className="text-right">
+                      {shortLabel}
+                    </TableHead>
+                  ))}
+                  <TableHead>Employee</TableHead>
+                  <TableHead>Notes</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {logs.map((log) => (
+                  <TableRow key={log.id}>
+                    <TableCell className="whitespace-nowrap font-medium">
+                      {new Date(log.recordedAt).toLocaleString()}
+                    </TableCell>
+                    {temperatureFields.map(({ key }) => (
+                      <TableCell
+                        key={key}
+                        className="whitespace-nowrap text-right"
+                      >
+                        {formatTemperature(log[key])}
+                      </TableCell>
+                    ))}
+                    <TableCell className="whitespace-nowrap">
+                      {log.recordedByDisplayName}
+                    </TableCell>
+                    <TableCell className="min-w-48">
+                      {log.notes || '--'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/migrations/0201_freezer_temperature_logs.sql
+++ b/migrations/0201_freezer_temperature_logs.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS "freezer_temperature_logs" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "recorded_at" timestamp with time zone NOT NULL,
+  "freezer_1_temperature" numeric(6, 2) NOT NULL,
+  "freezer_2_temperature" numeric(6, 2) NOT NULL,
+  "freezer_3_temperature" numeric(6, 2) NOT NULL,
+  "freezer_4_temperature" numeric(6, 2) NOT NULL,
+  "layup_room_temperature" numeric(6, 2) NOT NULL,
+  "refrigerator_container_temperature" numeric(6, 2) NOT NULL,
+  "notes" text,
+  "recorded_by_user_id" integer NOT NULL,
+  "recorded_by_display_name" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "freezer_temperature_logs_recorded_by_user_id_users_id_fk"
+    FOREIGN KEY ("recorded_by_user_id") REFERENCES "public"."users"("id")
+    ON DELETE no action ON UPDATE no action
+);
+
+CREATE INDEX IF NOT EXISTS "freezer_temperature_logs_recorded_at_idx"
+  ON "freezer_temperature_logs" USING btree ("recorded_at");

--- a/server/middleware/routeAuthorization.ts
+++ b/server/middleware/routeAuthorization.ts
@@ -23,6 +23,7 @@ const UNIVERSAL_ACCESS_ROUTES: string[] = [
   '/tickets-command-center',
   '/quick-notes',
   '/training',
+  '/freezer-temperature-log',
 ];
 
 const USER_PERMISSIONS: Record<string, UserPermissions> = {

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -1859,6 +1859,27 @@ export const maintenanceLogs = pgTable('maintenance_logs', {
   createdAt: timestamp('created_at').defaultNow(),
 });
 
+export const freezerTemperatureLogs = pgTable(
+  'freezer_temperature_logs',
+  {
+    id: serial('id').primaryKey(),
+    recordedAt: timestamp('recorded_at', { withTimezone: true }).notNull(),
+    freezer1Temperature: numeric('freezer_1_temperature', { precision: 6, scale: 2 }).notNull(),
+    freezer2Temperature: numeric('freezer_2_temperature', { precision: 6, scale: 2 }).notNull(),
+    freezer3Temperature: numeric('freezer_3_temperature', { precision: 6, scale: 2 }).notNull(),
+    freezer4Temperature: numeric('freezer_4_temperature', { precision: 6, scale: 2 }).notNull(),
+    layupRoomTemperature: numeric('layup_room_temperature', { precision: 6, scale: 2 }).notNull(),
+    refrigeratorContainerTemperature: numeric('refrigerator_container_temperature', { precision: 6, scale: 2 }).notNull(),
+    notes: text('notes'),
+    recordedByUserId: integer('recorded_by_user_id').references(() => users.id).notNull(),
+    recordedByDisplayName: text('recorded_by_display_name').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    recordedAtIdx: index('freezer_temperature_logs_recorded_at_idx').on(table.recordedAt),
+  })
+);
+
 // Employee Portal & Time Keeping Tables
 export const timeClockEntries = pgTable('time_clock_entries', {
   id: serial('id').primaryKey(),
@@ -2968,6 +2989,31 @@ export const insertMaintenanceLogSchema = createInsertSchema(maintenanceLogs)
     nextDueDate: z.coerce.date().optional().nullable(),
   });
 
+const freezerTemperatureValueSchema = z.coerce
+  .number()
+  .min(-200, 'Temperature must be at least -200')
+  .max(200, 'Temperature must be no more than 200');
+
+export const insertFreezerTemperatureLogSchema = createInsertSchema(
+  freezerTemperatureLogs
+)
+  .omit({
+    id: true,
+    recordedByUserId: true,
+    recordedByDisplayName: true,
+    createdAt: true,
+  })
+  .extend({
+    recordedAt: z.coerce.date(),
+    freezer1Temperature: freezerTemperatureValueSchema,
+    freezer2Temperature: freezerTemperatureValueSchema,
+    freezer3Temperature: freezerTemperatureValueSchema,
+    freezer4Temperature: freezerTemperatureValueSchema,
+    layupRoomTemperature: freezerTemperatureValueSchema,
+    refrigeratorContainerTemperature: freezerTemperatureValueSchema,
+    notes: z.string().trim().max(2000).optional().nullable(),
+  });
+
 export const insertTimeClockEntrySchema = createInsertSchema(timeClockEntries)
   .omit({
     id: true,
@@ -3304,6 +3350,10 @@ export type InsertMaintenanceSchedule = z.infer<
 export type MaintenanceSchedule = typeof maintenanceSchedules.$inferSelect;
 export type InsertMaintenanceLog = z.infer<typeof insertMaintenanceLogSchema>;
 export type MaintenanceLog = typeof maintenanceLogs.$inferSelect;
+export type InsertFreezerTemperatureLog = z.infer<
+  typeof insertFreezerTemperatureLogSchema
+>;
+export type FreezerTemperatureLog = typeof freezerTemperatureLogs.$inferSelect;
 export type InsertTimeClockEntry = z.infer<typeof insertTimeClockEntrySchema>;
 export type TimeClockEntry = typeof timeClockEntries.$inferSelect;
 export type InsertChecklistItem = z.infer<typeof insertChecklistItemSchema>;

--- a/server/src/routes/quality.ts
+++ b/server/src/routes/quality.ts
@@ -8,6 +8,7 @@ import {
   insertQcSubmissionSchema,
   insertMaintenanceScheduleSchema,
   insertMaintenanceLogSchema,
+  insertFreezerTemperatureLogSchema,
 } from '@shared/schema';
 import { and, desc, eq, sql } from 'drizzle-orm';
 
@@ -23,10 +24,12 @@ import {
   insertCalibrationEventSchema,
   maintenanceLogs,
   maintenanceSchedules,
+  freezerTemperatureLogs,
   nonconformanceRecords,
 } from '../../schema';
 import { storage } from '../../storage';
 import { requirePermission } from '../../middleware/requirePermission';
+import { resolveUserSnapshot } from '../../utils/userSnapshot';
 
 const router = Router();
 const qmsEvidenceUploadDir = path.join(process.cwd(), 'uploads', 'qms-calibration-evidence');
@@ -499,6 +502,82 @@ router.post('/maintenance/logs', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Create maintenance log error:', error);
     res.status(500).json({ error: 'Failed to create maintenance log' });
+  }
+});
+
+// Freezer temperature logs
+router.get('/freezer-temperature-logs', async (req: Request, res: Response) => {
+  try {
+    const requestedLimit = Number.parseInt(String(req.query.limit ?? '100'), 10);
+    const limit = Number.isFinite(requestedLimit)
+      ? Math.min(Math.max(requestedLimit, 1), 500)
+      : 100;
+
+    const logs = await db
+      .select({
+        id: freezerTemperatureLogs.id,
+        recordedAt: freezerTemperatureLogs.recordedAt,
+        freezer1Temperature: freezerTemperatureLogs.freezer1Temperature,
+        freezer2Temperature: freezerTemperatureLogs.freezer2Temperature,
+        freezer3Temperature: freezerTemperatureLogs.freezer3Temperature,
+        freezer4Temperature: freezerTemperatureLogs.freezer4Temperature,
+        layupRoomTemperature: freezerTemperatureLogs.layupRoomTemperature,
+        refrigeratorContainerTemperature:
+          freezerTemperatureLogs.refrigeratorContainerTemperature,
+        notes: freezerTemperatureLogs.notes,
+        recordedByDisplayName: freezerTemperatureLogs.recordedByDisplayName,
+        createdAt: freezerTemperatureLogs.createdAt,
+      })
+      .from(freezerTemperatureLogs)
+      .orderBy(desc(freezerTemperatureLogs.recordedAt))
+      .limit(limit);
+
+    res.json(logs);
+  } catch (error) {
+    console.error('Get freezer temperature logs error:', error);
+    res.status(500).json({ error: 'Failed to fetch freezer temperature logs' });
+  }
+});
+
+router.post('/freezer-temperature-logs', async (req: Request, res: Response) => {
+  try {
+    if (!req.user?.id) {
+      return res.status(401).json({ error: 'Authentication is required' });
+    }
+
+    const parsed = insertFreezerTemperatureLogSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Invalid freezer temperature entry',
+        issues: parsed.error.issues,
+      });
+    }
+    const data = parsed.data;
+    const actor = await resolveUserSnapshot(req.user.id);
+    const [log] = await db
+      .insert(freezerTemperatureLogs)
+      .values({
+        recordedAt: data.recordedAt,
+        freezer1Temperature: String(data.freezer1Temperature),
+        freezer2Temperature: String(data.freezer2Temperature),
+        freezer3Temperature: String(data.freezer3Temperature),
+        freezer4Temperature: String(data.freezer4Temperature),
+        layupRoomTemperature: String(data.layupRoomTemperature),
+        refrigeratorContainerTemperature: String(data.refrigeratorContainerTemperature),
+        notes: data.notes || null,
+        recordedByUserId: actor.userId,
+        recordedByDisplayName: actor.displayName,
+      })
+      .returning({
+        id: freezerTemperatureLogs.id,
+        recordedAt: freezerTemperatureLogs.recordedAt,
+        recordedByDisplayName: freezerTemperatureLogs.recordedByDisplayName,
+      });
+
+    res.status(201).json(log);
+  } catch (error) {
+    console.error('Create freezer temperature log error:', error);
+    res.status(500).json({ error: 'Failed to create freezer temperature log' });
   }
 });
 


### PR DESCRIPTION
## What changed

- Added an employee-facing freezer temperature log under QC & Maintenance.
- Captures Freezers 1-4, Lay-Up Room, and Refrigerator Container readings in degrees Fahrenheit.
- Records the authenticated employee and timestamp automatically.
- Added latest-reading and history views, authenticated API routes, route access, and database migration `0201_freezer_temperature_logs.sql`.

## Why

This replaces the handwritten freezer check sheet with an auditable digital record in EPOCH.

## Validation

- Rebased cleanly onto the latest `origin/main` with no conflicts.
- New page ESLint passed.
- Client and server bundle checks passed.
- `git diff --check` passed.
- Repository-wide TypeScript check was attempted but exhausted Node's 4 GB heap without producing a feature-specific diagnostic.