### PR TITLE
Show recursive BOM assembly tree in P2 projects

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -72,6 +72,37 @@ import { format, formatDistanceToNow } from 'date-fns';
 
 const DRAFT_TAB_HANDOFF_KEY = 'epoch:draft-builder-tab-handoff';
 
+function BomAssemblyTreeNode({ node, isRoot = false }: { node: any; isRoot?: boolean }) {
+  return (
+    <div className={isRoot ? '' : 'ml-4 border-l pl-4'}>
+      <div className="rounded-md border bg-background p-3">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="font-mono text-sm font-semibold">{node.partNumber}</p>
+            <p className="truncate text-xs text-muted-foreground">{node.partName || 'No part description'}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {!isRoot && <Badge variant="outline">Qty {Number(node.quantityPerParent ?? 1).toLocaleString()}</Badge>}
+            <Badge variant={node.isManufactured ? 'default' : 'secondary'}>
+              {node.isManufactured ? 'Manufactured' : 'Component'}
+            </Badge>
+            {node.hasBom && (
+              <Badge variant="outline">BOM{node.revisionCode ? ` Rev ${node.revisionCode}` : ''}</Badge>
+            )}
+          </div>
+        </div>
+      </div>
+      {Array.isArray(node.children) && node.children.length > 0 && (
+        <div className="mt-2 space-y-2">
+          {node.children.map((child: any) => (
+            <BomAssemblyTreeNode key={child.key} node={child} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 const ROM_CATEGORY_CONFIG = [
   { key: 'labor', label: 'Labor', field: 'quotedHours', kind: 'hours', detail: 'Direct labor estimate from ROM/quote feedback' },
   { key: 'material', label: 'Material', field: 'budgetAmount', kind: 'currency', detail: 'Material budget that will seed the WAD' },
@@ -886,6 +917,7 @@ export default function ProjectDetailPage() {
   const hubBomRouting = hubTabs.bomRouting ?? {};
   const bomRoutingSummary = hubBomRouting.summary ?? {};
   const bomRoutingRecords = Array.isArray(hubBomRouting.bomRecords) ? hubBomRouting.bomRecords : [];
+  const bomAssemblyTree = Array.isArray(hubBomRouting.assemblyTree) ? hubBomRouting.assemblyTree : [];
   const assemblyBomRecords = Array.isArray(productionAssemblyTree.bomRecords) ? productionAssemblyTree.bomRecords : bomRoutingRecords;
   const bomRoutingRoutings = Array.isArray(hubBomRouting.routings) ? hubBomRouting.routings : [];
   const bomRoutingSourceParts = Array.isArray(hubBomRouting.sourceParts) ? hubBomRouting.sourceParts : [];
@@ -3257,7 +3289,7 @@ export default function ProjectDetailPage() {
                   BOM Records
                 </CardTitle>
                 <CardDescription>
-                  BOMs found for manufactured parts on the linked PO family.
+                  BOMs for the manufactured PO part and every manufactured child assembly.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -3288,6 +3320,27 @@ export default function ProjectDetailPage() {
                     ))}
                   </div>
                 )}
+
+                <Separator />
+                <div className="space-y-3">
+                  <div>
+                    <h4 className="font-medium">Assembly Tree</h4>
+                    <p className="text-xs text-muted-foreground">
+                      Build flow from each PO assembly through manufactured children and component parts.
+                    </p>
+                  </div>
+                  {bomAssemblyTree.length === 0 ? (
+                    <div className="rounded-md border border-dashed p-5 text-center text-sm text-muted-foreground">
+                      No assembly structure is available for the linked PO parts yet.
+                    </div>
+                  ) : (
+                    <div className="space-y-4 rounded-md bg-muted/30 p-3">
+                      {bomAssemblyTree.map((root: any) => (
+                        <BomAssemblyTreeNode key={root.key} node={root} isRoot />
+                      ))}
+                    </div>
+                  )}
+                </div>
               </CardContent>
             </Card>
 

--- a/server/__tests__/projectBomAssembly.test.ts
+++ b/server/__tests__/projectBomAssembly.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { buildProjectBomAssemblyTree, type ProjectBomAssemblyRow } from '../src/services/projectBomAssembly';
+
+const row = (overrides: Partial<ProjectBomAssemblyRow>): ProjectBomAssemblyRow => ({
+  node_key: ['root:1000'],
+  parent_key: null,
+  root_part_number: '1000',
+  part_number: '1000',
+  part_name: 'Final assembly',
+  item_type: 'MANUFACTURED',
+  qty_per: 1,
+  operation_seq: null,
+  depth: 0,
+  bom_id: 'bom-root',
+  latest_revision_id: 'rev-root',
+  ...overrides,
+});
+
+describe('buildProjectBomAssemblyTree', () => {
+  it('nests manufactured child BOMs and leaf components in assembly order', () => {
+    const tree = buildProjectBomAssemblyTree([
+      row({
+        node_key: ['root:1000', 'line:2'],
+        parent_key: ['root:1000'],
+        part_number: '3000',
+        part_name: 'Purchased fastener',
+        item_type: 'PURCHASED',
+        qty_per: '4',
+        operation_seq: 20,
+        depth: 1,
+        bom_id: null,
+        latest_revision_id: null,
+      }),
+      row({}),
+      row({
+        node_key: ['root:1000', 'line:1'],
+        parent_key: ['root:1000'],
+        part_number: '2000',
+        part_name: 'Manufactured child',
+        item_type: 'MANUFACTURED',
+        qty_per: '2',
+        operation_seq: 10,
+        depth: 1,
+        bom_id: 'bom-child',
+        latest_revision_id: 'rev-child',
+      }),
+      row({
+        node_key: ['root:1000', 'line:1', 'line:3'],
+        parent_key: ['root:1000', 'line:1'],
+        part_number: '4000',
+        part_name: 'Child material',
+        item_type: 'PURCHASED',
+        qty_per: '3',
+        operation_seq: 10,
+        depth: 2,
+        bom_id: null,
+        latest_revision_id: null,
+      }),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].partNumber).toBe('1000');
+    expect(tree[0].children.map((child) => child.partNumber)).toEqual(['2000', '3000']);
+    expect(tree[0].children[0]).toMatchObject({ isManufactured: true, hasBom: true, quantityPerParent: 2 });
+    expect(tree[0].children[0].children[0]).toMatchObject({ partNumber: '4000', isManufactured: false });
+  });
+
+  it('treats a part with a BOM as manufactured when inventory classification is absent', () => {
+    const tree = buildProjectBomAssemblyTree([row({ item_type: null })]);
+    expect(tree[0]).toMatchObject({ isManufactured: true, hasBom: true });
+  });
+});

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -32,6 +32,7 @@ import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
 import { getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
+import { buildProjectBomAssemblyTree, type ProjectBomAssemblyRow } from '../services/projectBomAssembly';
 
 // ── Project document upload setup ──────────────────────────────────────────
 const projectDocsDir = path.join(process.cwd(), 'uploads', 'project-documents');
@@ -2621,6 +2622,10 @@ router.get('/:id/p2-hub', async (req, res) => {
         .map((item: any) => poInventoryPartById.get(Number(item.inventory_item_id)))
         .filter(Boolean),
     ]));
+    const assemblySourceItems = activePoId ? poItems.filter((item: any) => item.po_id === activePoId) : poItems;
+    const assemblyRootPartNumbers = Array.from(new Set(assemblySourceItems
+      .map((item: any) => poInventoryPartById.get(Number(item.inventory_item_id)) || item.part_number)
+      .filter(Boolean)));
 
     const [
       productionOrders,
@@ -2836,6 +2841,89 @@ router.get('/:id/p2-hub', async (req, res) => {
         [id],
       ),
     ]);
+
+    const assemblyRows = assemblyRootPartNumbers.length > 0
+      ? await optionalHubQuery<ProjectBomAssemblyRow>(
+          'BOM assembly tree',
+          `WITH RECURSIVE ranked_boms AS (
+             SELECT b.id AS bom_id, b.parent_part_ag_number, b.code AS bom_code,
+                    b.description AS bom_description, b.is_active AS bom_is_active,
+                    br.id AS latest_revision_id, br.rev_code AS latest_rev_code,
+                    br.created_at AS latest_rev_created_at,
+                    COUNT(bl.id)::int AS line_count,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY b.parent_part_ag_number
+                      ORDER BY b.is_active DESC, br.created_at DESC NULLS LAST, b.created_at DESC
+                    ) AS bom_rank
+             FROM boms b
+             LEFT JOIN LATERAL (
+               SELECT id, rev_code, created_at
+               FROM bom_revisions
+               WHERE bom_id = b.id
+               ORDER BY created_at DESC
+               LIMIT 1
+             ) br ON true
+             LEFT JOIN bom_lines bl ON bl.revision_id = br.id
+             GROUP BY b.id, br.id, br.rev_code, br.created_at
+           ), selected_boms AS (
+             SELECT * FROM ranked_boms WHERE bom_rank = 1
+           ), assembly_tree AS (
+             SELECT ARRAY['root:' || root.part_number]::text[] AS node_key,
+                    NULL::text[] AS parent_key,
+                    root.part_number AS root_part_number,
+                    root.part_number AS part_number,
+                    inventory.name AS part_name,
+                    COALESCE(inventory.item_type::text, inventory.type) AS item_type,
+                    1::numeric AS qty_per, NULL::int AS operation_seq, 0 AS depth,
+                    ARRAY[root.part_number]::text[] AS part_path,
+                    sb.bom_id, sb.bom_code, sb.bom_description, sb.bom_is_active,
+                    sb.latest_revision_id, sb.latest_rev_code, sb.latest_rev_created_at, sb.line_count
+             FROM unnest($1::text[]) AS root(part_number)
+             LEFT JOIN inventory_items inventory ON inventory.ag_part_number = root.part_number
+             LEFT JOIN selected_boms sb ON sb.parent_part_ag_number = root.part_number
+             UNION ALL
+             SELECT tree.node_key || ('line:' || line.id::text), tree.node_key,
+                    tree.root_part_number, line.child_part_ag_number,
+                    inventory.name,
+                    COALESCE(inventory.item_type::text, inventory.type),
+                    line.qty_per, line.operation_seq, tree.depth + 1,
+                    tree.part_path || line.child_part_ag_number,
+                    child_bom.bom_id, child_bom.bom_code, child_bom.bom_description,
+                    child_bom.bom_is_active, child_bom.latest_revision_id,
+                    child_bom.latest_rev_code, child_bom.latest_rev_created_at, child_bom.line_count
+             FROM assembly_tree tree
+             JOIN bom_lines line ON line.revision_id = tree.latest_revision_id
+             LEFT JOIN inventory_items inventory ON inventory.ag_part_number = line.child_part_ag_number
+             LEFT JOIN selected_boms child_bom ON child_bom.parent_part_ag_number = line.child_part_ag_number
+             WHERE NOT line.child_part_ag_number = ANY(tree.part_path)
+           )
+           SELECT node_key, parent_key, root_part_number, part_number, part_name, item_type,
+                  qty_per, operation_seq, depth, bom_id, bom_code, bom_description,
+                  bom_is_active, latest_revision_id, latest_rev_code,
+                  latest_rev_created_at, line_count
+           FROM assembly_tree
+           ORDER BY root_part_number, node_key`,
+          [assemblyRootPartNumbers],
+        )
+      : [];
+    const assemblyTree = buildProjectBomAssemblyTree(assemblyRows);
+    const recursiveBomRecords = Array.from(new Map(assemblyRows
+      .filter((row) => row.bom_id)
+      .map((row) => [row.bom_id, {
+        id: row.bom_id,
+        parent_part_ag_number: row.part_number,
+        code: row.bom_code,
+        description: row.bom_description,
+        is_active: row.bom_is_active,
+        latest_revision_id: row.latest_revision_id,
+        latest_rev_code: row.latest_rev_code,
+        latest_rev_created_at: row.latest_rev_created_at,
+        line_count: row.line_count,
+      }])).values());
+    const allBomRecords = Array.from(new Map([
+      ...bomRecords.map((bom: any) => [bom.id, bom] as const),
+      ...recursiveBomRecords.map((bom: any) => [bom.id, bom] as const),
+    ]).values());
 
     const routingIds = projectRoutings.map((routing: any) => routing.id).filter(Boolean);
     const routingOperationSummaries = routingIds.length > 0
@@ -3275,11 +3363,12 @@ router.get('/:id/p2-hub', async (req, res) => {
         },
         bomRouting: {
           summary: {
-            bomCount: bomRecords.length,
+            bomCount: allBomRecords.length,
             routingCount: projectRoutings.length,
             manufacturedLineCount: poItems.length,
           },
-          bomRecords,
+          bomRecords: allBomRecords,
+          assemblyTree,
           routings: projectRoutings,
           sourcePartNumbers: partNumbers,
           sourceParts,

--- a/server/src/services/projectBomAssembly.ts
+++ b/server/src/services/projectBomAssembly.ts
@@ -1,0 +1,82 @@
+export type ProjectBomAssemblyRow = {
+  node_key: string[];
+  parent_key: string[] | null;
+  root_part_number: string;
+  part_number: string;
+  part_name?: string | null;
+  item_type?: string | null;
+  qty_per?: string | number | null;
+  operation_seq?: number | null;
+  depth: number;
+  bom_id?: string | null;
+  bom_code?: string | null;
+  bom_description?: string | null;
+  bom_is_active?: boolean | null;
+  latest_revision_id?: string | null;
+  latest_rev_code?: string | null;
+  latest_rev_created_at?: string | null;
+  line_count?: number | null;
+};
+
+export type ProjectBomAssemblyNode = {
+  key: string;
+  partNumber: string;
+  partName: string | null;
+  quantityPerParent: number;
+  operationSequence: number | null;
+  depth: number;
+  isManufactured: boolean;
+  hasBom: boolean;
+  bomId: string | null;
+  bomCode: string | null;
+  revisionId: string | null;
+  revisionCode: string | null;
+  children: ProjectBomAssemblyNode[];
+};
+
+const keyFor = (segments: string[]) => segments.join('/');
+
+export function buildProjectBomAssemblyTree(rows: ProjectBomAssemblyRow[]): ProjectBomAssemblyNode[] {
+  const nodes = new Map<string, ProjectBomAssemblyNode>();
+  const parentKeys = new Map<string, string | null>();
+
+  [...rows]
+    .sort((left, right) => {
+      const depthDifference = left.depth - right.depth;
+      if (depthDifference !== 0) return depthDifference;
+      const parentDifference = keyFor(left.parent_key ?? []).localeCompare(keyFor(right.parent_key ?? []));
+      if (parentDifference !== 0) return parentDifference;
+      const operationDifference = Number(left.operation_seq ?? 0) - Number(right.operation_seq ?? 0);
+      return operationDifference || keyFor(left.node_key).localeCompare(keyFor(right.node_key));
+    })
+    .forEach((row) => {
+      const key = keyFor(row.node_key);
+      const normalizedType = String(row.item_type ?? '').trim().toUpperCase();
+      nodes.set(key, {
+        key,
+        partNumber: row.part_number,
+        partName: row.part_name ?? null,
+        quantityPerParent: Number(row.qty_per ?? 1),
+        operationSequence: row.operation_seq ?? null,
+        depth: Number(row.depth),
+        isManufactured: normalizedType === 'MANUFACTURED' || Boolean(row.bom_id),
+        hasBom: Boolean(row.bom_id),
+        bomId: row.bom_id ?? null,
+        bomCode: row.bom_code ?? null,
+        revisionId: row.latest_revision_id ?? null,
+        revisionCode: row.latest_rev_code ?? null,
+        children: [],
+      });
+      parentKeys.set(key, row.parent_key ? keyFor(row.parent_key) : null);
+    });
+
+  const roots: ProjectBomAssemblyNode[] = [];
+  nodes.forEach((node, key) => {
+    const parentKey = parentKeys.get(key);
+    const parent = parentKey ? nodes.get(parentKey) : null;
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+  });
+
+  return roots;
+}


### PR DESCRIPTION
## What changed

- recursively loads BOMs for the current P2 PO manufactured assembly and manufactured child assemblies
- adds an assembly tree to the BOM Records card with quantities, BOM revisions, and component leaves
- preserves current latest-revision behavior and prevents circular BOM traversal
- adds focused tree-construction tests

## Why

The P2 project hub previously queried BOMs only for PO-level part numbers, so manufactured child BOMs and the assembly flow were absent from the BOM/Routing tab.

## Validation

- focused Vitest: 2 passed
- focused ESLint: passed
- TypeScript: no changed-file diagnostics
- git diff --check: passed