### PR TITLE
Add P2 V2 workflow instance foundation

### DIFF
--- a/migrations/0202_project_workflow_instances.sql
+++ b/migrations/0202_project_workflow_instances.sql
@@ -1,0 +1,105 @@
+-- Phase 3: additive storage for inactive p2_v2 workflow instances.
+-- Intentionally contains no backfill and does not modify projects or project_steps rows.
+CREATE TABLE IF NOT EXISTS project_workflow_instances (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  workflow_version TEXT NOT NULL,
+  definition_version INTEGER NOT NULL DEFAULT 1 CHECK (definition_version > 0),
+  status TEXT NOT NULL DEFAULT 'ACTIVE' CHECK (status IN ('DRAFT','ACTIVE','BLOCKED','COMPLETE','SUPERSEDED','CANCELLED')),
+  initialized_at TIMESTAMP NOT NULL DEFAULT now(),
+  initialized_by INTEGER REFERENCES employees(id) ON DELETE SET NULL,
+  initialized_by_display_name TEXT,
+  activated_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  superseded_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_workflow_instances_version_check CHECK (workflow_version = 'p2_v2'),
+  CONSTRAINT project_workflow_instances_id_project_unique UNIQUE (id, project_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS project_workflow_instances_active_unique
+  ON project_workflow_instances(project_id, workflow_version)
+  WHERE status NOT IN ('SUPERSEDED','CANCELLED');
+CREATE INDEX IF NOT EXISTS project_workflow_instances_project_idx ON project_workflow_instances(project_id);
+
+CREATE TABLE IF NOT EXISTS project_workflow_step_instances (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workflow_instance_id UUID NOT NULL,
+  project_id UUID NOT NULL,
+  step_type TEXT NOT NULL,
+  step_order INTEGER NOT NULL CHECK (step_order > 0),
+  label_snapshot TEXT NOT NULL,
+  description_snapshot TEXT,
+  status TEXT NOT NULL CHECK (status IN ('NOT_STARTED','IN_PROGRESS','PENDING_APPROVAL','APPROVED','COMPLETE','BLOCKED','NOT_APPLICABLE','SUPERSEDED','CANCELLED')),
+  applicability TEXT NOT NULL DEFAULT 'REQUIRED' CHECK (applicability IN ('REQUIRED','CONDITIONAL','NOT_APPLICABLE')),
+  applicability_reason TEXT,
+  applicability_source TEXT,
+  applicability_decided_by INTEGER REFERENCES employees(id) ON DELETE SET NULL,
+  applicability_decided_by_display_name TEXT,
+  applicability_decided_at TIMESTAMP,
+  owner_employee_id INTEGER REFERENCES employees(id) ON DELETE SET NULL,
+  owner_role TEXT,
+  due_date DATE,
+  started_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  completed_by INTEGER REFERENCES employees(id) ON DELETE SET NULL,
+  completed_by_display_name TEXT,
+  blocked_reason TEXT,
+  revision_reference TEXT,
+  effectivity_reference TEXT,
+  notes TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_workflow_steps_instance_project_fk FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_workflow_steps_type_unique UNIQUE (workflow_instance_id, step_type),
+  CONSTRAINT project_workflow_steps_order_unique UNIQUE (workflow_instance_id, step_order),
+  CONSTRAINT project_workflow_steps_id_project_unique UNIQUE (id, project_id)
+);
+CREATE INDEX IF NOT EXISTS project_workflow_steps_project_idx ON project_workflow_step_instances(project_id);
+CREATE INDEX IF NOT EXISTS project_workflow_steps_instance_idx ON project_workflow_step_instances(workflow_instance_id, step_order);
+
+CREATE TABLE IF NOT EXISTS project_workflow_step_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workflow_step_instance_id UUID NOT NULL,
+  project_id UUID NOT NULL,
+  record_type TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  relationship_type TEXT NOT NULL CHECK (relationship_type IN ('PRIMARY','SUPPORTING','EVIDENCE','SATISFIES_REQUIREMENT','SUPERSEDES')),
+  is_authoritative BOOLEAN NOT NULL DEFAULT false,
+  record_revision TEXT,
+  effectivity_reference TEXT,
+  linked_by INTEGER REFERENCES employees(id) ON DELETE SET NULL,
+  linked_by_display_name TEXT,
+  linked_at TIMESTAMP NOT NULL DEFAULT now(),
+  unlinked_at TIMESTAMP,
+  unlink_reason TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_workflow_links_step_project_fk FOREIGN KEY (workflow_step_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, project_id) ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS project_workflow_links_step_idx ON project_workflow_step_links(workflow_step_instance_id);
+
+CREATE TABLE IF NOT EXISTS project_workflow_step_approvals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workflow_step_instance_id UUID NOT NULL,
+  project_id UUID NOT NULL,
+  approval_type TEXT NOT NULL,
+  decision TEXT NOT NULL CHECK (decision IN ('APPROVED','REJECTED','RETURNED','WAIVED','NOT_APPLICABLE_APPROVED')),
+  signature_meaning TEXT NOT NULL,
+  reason TEXT,
+  actor_employee_id INTEGER REFERENCES employees(id) ON DELETE SET NULL,
+  actor_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  actor_display_name TEXT NOT NULL,
+  actor_role TEXT,
+  decided_at TIMESTAMP NOT NULL DEFAULT now(),
+  step_revision_snapshot TEXT,
+  evidence_snapshot JSONB,
+  superseded_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_workflow_approvals_step_project_fk FOREIGN KEY (workflow_step_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, project_id) ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS project_workflow_approvals_step_idx ON project_workflow_step_approvals(workflow_step_instance_id);

--- a/server/__tests__/projectWorkflowInstance.test.ts
+++ b/server/__tests__/projectWorkflowInstance.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  getInternalP2V2InitializationStages,
+  P2_V2_DEFINITION_VERSION,
+} from '../src/services/projectWorkflowRegistry';
+import { validateWorkflowInstanceIntegrity } from '../src/services/projectWorkflowInstanceIntegrity';
+
+const root = resolve(__dirname, '../..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+const migration = read('migrations/0202_project_workflow_instances.sql');
+
+describe('Phase 3 additive migration safety', () => {
+  it('adds four V2 evidence tables without mutating legacy data or enum definitions', () => {
+    for (const table of [
+      'project_workflow_instances',
+      'project_workflow_step_instances',
+      'project_workflow_step_links',
+      'project_workflow_step_approvals',
+    ]) {
+      expect(migration).toMatch(
+        new RegExp(`CREATE TABLE IF NOT EXISTS ${table}`, 'i')
+      );
+    }
+    expect(migration).not.toMatch(/UPDATE\s+(?:projects|project_steps)\b/i);
+    expect(
+      migration.replace(/ON DELETE (?:RESTRICT|SET NULL)/gi, '')
+    ).not.toMatch(/\b(?:DELETE|DROP|ALTER\s+TYPE)\b/i);
+    expect(migration).not.toContain('project_step_type');
+  });
+
+  it('keeps evidence through restrictive foreign keys and project-matching composite keys', () => {
+    expect(
+      migration.match(/ON DELETE RESTRICT/g)?.length
+    ).toBeGreaterThanOrEqual(3);
+    expect(migration).toContain(
+      'FOREIGN KEY (workflow_instance_id, project_id)'
+    );
+    expect(migration).toContain(
+      'FOREIGN KEY (workflow_step_instance_id, project_id)'
+    );
+    expect(migration).toContain("workflow_version = 'p2_v2'");
+  });
+});
+
+describe('p2_v2 workflow instance snapshots and integrity', () => {
+  const stages = getInternalP2V2InitializationStages();
+  const instance = {
+    project_id: 'project-1',
+    workflow_version: 'p2_v2',
+    definition_version: P2_V2_DEFINITION_VERSION,
+  };
+  const validSteps = stages.map((stage) => ({
+    project_id: 'project-1',
+    step_type: stage.type,
+    step_order: stage.order,
+    label_snapshot: stage.label,
+    description_snapshot: stage.description,
+  }));
+
+  it('exposes the exact immutable ten-stage initialization snapshot', () => {
+    expect(Object.isFrozen(stages)).toBe(true);
+    expect(stages.map((stage) => stage.type)).toEqual([
+      'rfq_risk_assessment',
+      'estimate_quote',
+      'contract_review',
+      'design_applicability',
+      'production_planning',
+      'wad_authorization',
+      'preproduction_release',
+      'production_quality',
+      'final_release_shipping',
+      'project_closing',
+    ]);
+    expect(stages.every((stage) => stage.label && stage.description)).toBe(
+      true
+    );
+  });
+
+  it('accepts a complete registry-matching instance', () => {
+    expect(validateWorkflowInstanceIntegrity(instance, validSteps)).toEqual([]);
+  });
+
+  it('reports missing, duplicate, order, project, unknown, definition, and version corruption', () => {
+    const corrupt = [
+      ...validSteps.slice(1),
+      { ...validSteps[1], project_id: 'wrong-project' },
+      { ...validSteps[2], step_type: 'unknown_stage', step_order: 2 },
+      { ...validSteps[4], label_snapshot: 'Changed live label' },
+    ];
+    const codes = validateWorkflowInstanceIntegrity(
+      { ...instance, workflow_version: 'legacy_v1' },
+      corrupt
+    ).map((issue) => issue.code);
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        'WRONG_WORKFLOW_VERSION',
+        'MISSING_STAGE',
+        'DUPLICATE_STAGE',
+        'DUPLICATE_ORDER',
+        'PROJECT_MISMATCH',
+        'UNKNOWN_STEP_TYPE',
+        'REGISTRY_DEFINITION_MISMATCH',
+      ])
+    );
+  });
+});
+
+describe('Phase 3 activation isolation', () => {
+  const service = read('server/src/services/projectWorkflowInstanceService.ts');
+  const projectsRoute = read('server/src/routes/projects.ts');
+  const quotesRoute = read('server/src/routes/quotes.ts');
+
+  it('keeps initialization internal and rejects legacy-effective projects', () => {
+    expect(service).toContain("version !== 'p2_v2'");
+    expect(projectsRoute).not.toContain('initializeV2Workflow');
+    expect(quotesRoute).not.toContain('initializeV2Workflow');
+  });
+
+  it('does not write project_steps or project workflow progress fields', () => {
+    expect(service).not.toMatch(/INSERT INTO project_steps/i);
+    expect(service).not.toMatch(/UPDATE\s+projects/i);
+    expect(service).not.toMatch(/current_stage\s*=|current_step_type\s*=/i);
+  });
+
+  it('initializes the first stage in progress and leaves later stages not started', () => {
+    expect(service).toContain(
+      "stage.order === 1 ? 'IN_PROGRESS' : 'NOT_STARTED'"
+    );
+    expect(service).toContain("'REQUIRED'");
+    expect(service).toContain('P2_V2_WORKFLOW_INITIALIZED');
+  });
+});

--- a/server/src/services/projectWorkflowInstanceIntegrity.ts
+++ b/server/src/services/projectWorkflowInstanceIntegrity.ts
@@ -1,0 +1,82 @@
+import {
+  getInternalP2V2InitializationStages,
+  P2_V2_DEFINITION_VERSION,
+} from './projectWorkflowRegistry';
+
+type Row = Record<string, unknown>;
+
+export type WorkflowIntegrityIssue = {
+  code:
+    | 'MISSING_STAGE'
+    | 'DUPLICATE_STAGE'
+    | 'DUPLICATE_ORDER'
+    | 'PROJECT_MISMATCH'
+    | 'UNKNOWN_STEP_TYPE'
+    | 'REGISTRY_DEFINITION_MISMATCH'
+    | 'WRONG_WORKFLOW_VERSION';
+  message: string;
+};
+
+export function validateWorkflowInstanceIntegrity(
+  instance: Row,
+  steps: Row[]
+): WorkflowIntegrityIssue[] {
+  const definition = getInternalP2V2InitializationStages();
+  const issues: WorkflowIntegrityIssue[] = [];
+  if (instance.workflow_version !== 'p2_v2')
+    issues.push({
+      code: 'WRONG_WORKFLOW_VERSION',
+      message: 'Workflow instance is not p2_v2.',
+    });
+  const byType = new Map<string, Row[]>();
+  const byOrder = new Map<number, Row[]>();
+  for (const step of steps) {
+    const type = String(step.step_type);
+    const order = Number(step.step_order);
+    byType.set(type, [...(byType.get(type) ?? []), step]);
+    byOrder.set(order, [...(byOrder.get(order) ?? []), step]);
+    if (step.project_id !== instance.project_id)
+      issues.push({
+        code: 'PROJECT_MISMATCH',
+        message: `Stage ${type} belongs to a different project.`,
+      });
+    if (!definition.some((stage) => stage.type === type))
+      issues.push({
+        code: 'UNKNOWN_STEP_TYPE',
+        message: `Unknown p2_v2 stage ${type}.`,
+      });
+  }
+  for (const stage of definition) {
+    const matches = byType.get(stage.type) ?? [];
+    if (matches.length === 0)
+      issues.push({
+        code: 'MISSING_STAGE',
+        message: `Missing stage ${stage.type}.`,
+      });
+    if (matches.length > 1)
+      issues.push({
+        code: 'DUPLICATE_STAGE',
+        message: `Duplicate stage ${stage.type}.`,
+      });
+    if (
+      matches.some(
+        (stored) =>
+          Number(stored.step_order) !== stage.order ||
+          stored.label_snapshot !== stage.label ||
+          stored.description_snapshot !== stage.description
+      )
+    ) {
+      issues.push({
+        code: 'REGISTRY_DEFINITION_MISMATCH',
+        message: `Stage ${stage.type} does not match definition version ${P2_V2_DEFINITION_VERSION}.`,
+      });
+    }
+  }
+  for (const [order, matches] of byOrder)
+    if (matches.length > 1)
+      issues.push({
+        code: 'DUPLICATE_ORDER',
+        message: `Duplicate stage order ${order}.`,
+      });
+  return issues;
+}

--- a/server/src/services/projectWorkflowInstanceService.ts
+++ b/server/src/services/projectWorkflowInstanceService.ts
@@ -1,0 +1,299 @@
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
+import {
+  getInternalP2V2InitializationStages,
+  P2_V2_DEFINITION_VERSION,
+} from './projectWorkflowRegistry';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+
+type Executor = AuditLedgerTx;
+type Actor = {
+  id?: number | null;
+  username?: string | null;
+  displayName?: string | null;
+  role?: string | null;
+};
+type Row = Record<string, unknown>;
+
+const rows = <T extends Row>(result: unknown): T[] => {
+  if (Array.isArray(result)) return result as T[];
+  if (
+    result &&
+    typeof result === 'object' &&
+    Array.isArray((result as { rows?: unknown }).rows)
+  )
+    return (result as { rows: T[] }).rows;
+  return [];
+};
+
+export class ProjectWorkflowInstanceError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly details: Record<string, unknown> = {}
+  ) {
+    super(message);
+    this.name = 'ProjectWorkflowInstanceError';
+  }
+}
+
+async function initialize(projectId: string, actor: Actor, executor: Executor) {
+  const projectRows = rows(
+    await executor.execute(
+      sql`SELECT id, workflow_version, status, current_stage, current_step_type FROM projects WHERE id = ${projectId} FOR UPDATE`
+    )
+  );
+  const project = projectRows[0];
+  if (!project)
+    throw new ProjectWorkflowInstanceError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.'
+    );
+  const version = resolveProjectWorkflowVersion(project.workflow_version);
+  if (version !== 'p2_v2')
+    throw new ProjectWorkflowInstanceError(
+      'P2_V2_REQUIRED',
+      'Only an explicit p2_v2 project can receive a V2 workflow instance.',
+      { effectiveVersion: version }
+    );
+  const existing = rows(
+    await executor.execute(
+      sql`SELECT id FROM project_workflow_instances WHERE project_id = ${projectId} AND workflow_version = 'p2_v2' AND status NOT IN ('SUPERSEDED','CANCELLED')`
+    )
+  );
+  if (existing.length)
+    throw new ProjectWorkflowInstanceError(
+      'WORKFLOW_INSTANCE_EXISTS',
+      'An active p2_v2 workflow instance already exists.'
+    );
+
+  const instance = rows(
+    await executor.execute(sql`
+    INSERT INTO project_workflow_instances (project_id, workflow_version, definition_version, status, initialized_by, initialized_by_display_name, activated_at)
+    VALUES (${projectId}, 'p2_v2', ${P2_V2_DEFINITION_VERSION}, 'ACTIVE', ${actor.id ?? null}, ${actor.displayName ?? actor.username ?? null}, now())
+    RETURNING *`)
+  )[0];
+  const stages = getInternalP2V2InitializationStages();
+  for (const stage of stages) {
+    await executor.execute(sql`
+      INSERT INTO project_workflow_step_instances
+        (workflow_instance_id, project_id, step_type, step_order, label_snapshot, description_snapshot, status, applicability, started_at)
+      VALUES (${instance.id}, ${projectId}, ${stage.type}, ${stage.order}, ${stage.label}, ${stage.description},
+        ${stage.order === 1 ? 'IN_PROGRESS' : 'NOT_STARTED'}, 'REQUIRED', ${stage.order === 1 ? new Date() : null})`);
+  }
+  await recordAuditEvent(
+    {
+      eventType: 'P2_V2_WORKFLOW_INITIALIZED',
+      subjectType: 'project_workflow_instance',
+      subjectId: instance.id,
+      sourceService: 'projectWorkflowInstanceService',
+      actor: {
+        id: actor.id,
+        username: actor.username ?? actor.displayName,
+        role: actor.role,
+      },
+      payload: {
+        projectId,
+        workflowVersion: 'p2_v2',
+        definitionVersion: P2_V2_DEFINITION_VERSION,
+        stageTypes: stages.map((stage) => stage.type),
+        source: 'internal_phase3_service',
+      },
+    },
+    executor
+  );
+  return getWorkflowReadModel(instance.id, executor);
+}
+
+export async function initializeV2Workflow(
+  projectId: string,
+  actor: Actor,
+  tx?: Executor
+) {
+  return tx
+    ? initialize(projectId, actor, tx)
+    : db.transaction((innerTx) => initialize(projectId, actor, innerTx));
+}
+
+export async function getWorkflowInstanceForProject(
+  projectId: string,
+  tx: Executor = db
+) {
+  const found = rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_instances WHERE project_id = ${projectId} AND workflow_version = 'p2_v2' ORDER BY created_at DESC`
+    )
+  );
+  if (
+    found.length > 1 &&
+    found.filter(
+      (item) => !['SUPERSEDED', 'CANCELLED'].includes(String(item.status))
+    ).length > 1
+  )
+    throw new ProjectWorkflowInstanceError(
+      'DUPLICATE_ACTIVE_INSTANCES',
+      'Multiple active p2_v2 instances exist.'
+    );
+  return found[0] ?? null;
+}
+
+export async function getWorkflowStepInstances(
+  workflowInstanceId: string,
+  tx: Executor = db
+) {
+  return rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_instances WHERE workflow_instance_id = ${workflowInstanceId} ORDER BY step_order`
+    )
+  );
+}
+
+export async function getWorkflowStepByType(
+  workflowInstanceId: string,
+  stepType: string,
+  tx: Executor = db
+) {
+  return (
+    (await getWorkflowStepInstances(workflowInstanceId, tx)).find(
+      (step) => step.step_type === stepType
+    ) ?? null
+  );
+}
+
+export async function getWorkflowReadModel(
+  workflowInstanceId: string,
+  tx: Executor = db
+) {
+  const instance = rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_instances WHERE id = ${workflowInstanceId}`
+    )
+  )[0];
+  if (!instance)
+    throw new ProjectWorkflowInstanceError(
+      'WORKFLOW_INSTANCE_NOT_FOUND',
+      'Workflow instance not found.'
+    );
+  const steps = await getWorkflowStepInstances(workflowInstanceId, tx);
+  const stepIds = steps.map((step) => step.id);
+  const idList = `(${stepIds.map((id) => `'${String(id).replace(/'/g, "''")}'`).join(',')})`;
+  const links = stepIds.length
+    ? rows(
+        await tx.execute(
+          sql`SELECT * FROM project_workflow_step_links WHERE workflow_step_instance_id IN ${sql.raw(idList)} ORDER BY linked_at`
+        )
+      )
+    : [];
+  const approvals = stepIds.length
+    ? rows(
+        await tx.execute(
+          sql`SELECT * FROM project_workflow_step_approvals WHERE workflow_step_instance_id IN ${sql.raw(idList)} ORDER BY decided_at`
+        )
+      )
+    : [];
+  const integrityIssues = validateWorkflowInstanceIntegrity(instance, steps);
+  return {
+    instance,
+    steps: steps.map((step) => ({
+      ...step,
+      links: links.filter((link) => link.workflow_step_instance_id === step.id),
+      approvals: approvals.filter(
+        (approval) => approval.workflow_step_instance_id === step.id
+      ),
+    })),
+    definitionVersion: instance.definition_version,
+    integrity: { valid: integrityIssues.length === 0, issues: integrityIssues },
+  };
+}
+
+async function requireStepProject(
+  stepId: string,
+  projectId: string,
+  tx: Executor
+) {
+  const step = rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_instances WHERE id = ${stepId}`
+    )
+  )[0];
+  if (!step)
+    throw new ProjectWorkflowInstanceError(
+      'WORKFLOW_STEP_NOT_FOUND',
+      'Workflow step instance not found.'
+    );
+  if (step.project_id !== projectId)
+    throw new ProjectWorkflowInstanceError(
+      'PROJECT_MISMATCH',
+      'Workflow evidence project does not match its step.'
+    );
+  return step;
+}
+
+export async function addWorkflowStepLink(
+  input: {
+    stepId: string;
+    projectId: string;
+    recordType: string;
+    recordId: string;
+    relationshipType: string;
+    isAuthoritative?: boolean;
+    actor?: Actor;
+  },
+  tx: Executor = db
+) {
+  await requireStepProject(input.stepId, input.projectId, tx);
+  return rows(
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_links (workflow_step_instance_id, project_id, record_type, record_id, relationship_type, is_authoritative, linked_by, linked_by_display_name) VALUES (${input.stepId}, ${input.projectId}, ${input.recordType}, ${input.recordId}, ${input.relationshipType}, ${input.isAuthoritative ?? false}, ${input.actor?.id ?? null}, ${input.actor?.displayName ?? input.actor?.username ?? null}) RETURNING *`
+    )
+  )[0];
+}
+
+export async function supersedeWorkflowStepLink(
+  linkId: string,
+  reason: string,
+  actor: Actor,
+  tx: Executor = db
+) {
+  if (!reason.trim())
+    throw new ProjectWorkflowInstanceError(
+      'UNLINK_REASON_REQUIRED',
+      'An unlink reason is required.'
+    );
+  return (
+    rows(
+      await tx.execute(
+        sql`UPDATE project_workflow_step_links SET unlinked_at = now(), unlink_reason = ${reason}, updated_at = now() WHERE id = ${linkId} AND unlinked_at IS NULL RETURNING *`
+      )
+    )[0] ?? null
+  );
+}
+
+export async function recordWorkflowStepApproval(
+  input: {
+    stepId: string;
+    projectId: string;
+    approvalType: string;
+    decision: string;
+    signatureMeaning: string;
+    reason?: string;
+    actor: Actor;
+    evidence?: Record<string, unknown>;
+  },
+  tx: Executor = db
+) {
+  await requireStepProject(input.stepId, input.projectId, tx);
+  if (!input.actor.displayName && !input.actor.username)
+    throw new ProjectWorkflowInstanceError(
+      'ACTOR_REQUIRED',
+      'Approval actor display name is required.'
+    );
+  return rows(
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_approvals (workflow_step_instance_id, project_id, approval_type, decision, signature_meaning, reason, actor_employee_id, actor_display_name, actor_role, evidence_snapshot) VALUES (${input.stepId}, ${input.projectId}, ${input.approvalType}, ${input.decision}, ${input.signatureMeaning}, ${input.reason ?? null}, ${input.actor.id ?? null}, ${input.actor.displayName ?? input.actor.username!}, ${input.actor.role ?? null}, ${JSON.stringify(input.evidence ?? {})}::jsonb) RETURNING *`
+    )
+  )[0];
+}

--- a/server/src/services/projectWorkflowRegistry.ts
+++ b/server/src/services/projectWorkflowRegistry.ts
@@ -40,6 +40,7 @@ export type ProjectWorkflowStageDefinition = Readonly<{
   type: string;
   order: number;
   label: string;
+  description: string;
 }>;
 
 export type ProjectWorkflowDefinition = Readonly<{
@@ -139,21 +140,75 @@ const LEGACY_V1_STEPS = freezeItems<ProjectWorkflowStepDefinition>([
 ]);
 
 const P2_V2_STAGES = freezeItems<ProjectWorkflowStageDefinition>([
-  { type: 'rfq_risk_assessment', order: 1, label: 'RFQ & Risk' },
-  { type: 'estimate_quote', order: 2, label: 'Estimate & Quote' },
-  { type: 'contract_review', order: 3, label: 'PO & Contract Review' },
-  { type: 'design_applicability', order: 4, label: 'Design Applicability' },
-  { type: 'production_planning', order: 5, label: 'Production Planning' },
-  { type: 'wad_authorization', order: 6, label: 'WAD Authorization' },
-  { type: 'preproduction_release', order: 7, label: 'Preproduction & Release' },
-  { type: 'production_quality', order: 8, label: 'Production & Quality' },
+  {
+    type: 'rfq_risk_assessment',
+    order: 1,
+    label: 'RFQ & Risk',
+    description: 'Capture RFQ scope and risk evidence.',
+  },
+  {
+    type: 'estimate_quote',
+    order: 2,
+    label: 'Estimate & Quote',
+    description: 'Develop and approve the estimate and quote.',
+  },
+  {
+    type: 'contract_review',
+    order: 3,
+    label: 'PO & Contract Review',
+    description: 'Review customer order and contract requirements.',
+  },
+  {
+    type: 'design_applicability',
+    order: 4,
+    label: 'Design Applicability',
+    description: 'Determine and document design-control applicability.',
+  },
+  {
+    type: 'production_planning',
+    order: 5,
+    label: 'Production Planning',
+    description: 'Establish BOM, routing, material, and production plans.',
+  },
+  {
+    type: 'wad_authorization',
+    order: 6,
+    label: 'WAD Authorization',
+    description: 'Authorize work through controlled WAD evidence.',
+  },
+  {
+    type: 'preproduction_release',
+    order: 7,
+    label: 'Preproduction & Release',
+    description: 'Complete preproduction readiness and release evidence.',
+  },
+  {
+    type: 'production_quality',
+    order: 8,
+    label: 'Production & Quality',
+    description: 'Execute production and quality controls.',
+  },
   {
     type: 'final_release_shipping',
     order: 9,
     label: 'Final Release & Shipping',
+    description: 'Complete final release, shipment, and delivery evidence.',
   },
-  { type: 'project_closing', order: 10, label: 'Project Closing' },
+  {
+    type: 'project_closing',
+    order: 10,
+    label: 'Project Closing',
+    description: 'Verify completion and close the controlled project record.',
+  },
 ]);
+
+export const P2_V2_DEFINITION_VERSION = 1;
+
+// Internal-only snapshot source for Phase 3. This does not make p2_v2 active
+// or available to normal project creation.
+export function getInternalP2V2InitializationStages(): readonly ProjectWorkflowStageDefinition[] {
+  return getProjectWorkflowDefinition('p2_v2').stages;
+}
 
 const DEFINITIONS: Readonly<
   Record<ProjectWorkflowVersion, ProjectWorkflowDefinition>


### PR DESCRIPTION
## What changed

- adds migration 0202 with separate p2_v2 workflow instance, stage, link, and approval evidence tables
- snapshots the immutable ten-stage registry definition with definition version 1
- adds an internal-only atomic initializer, integrity validator, ordered read model, audit event, append-only link supersession, and approval recording
- keeps legacy project_steps, project creation, WAD, preproduction, release, closing, and client behavior unchanged

## Initialization policy

The first V2 stage starts IN_PROGRESS; the remaining nine start NOT_STARTED. Every stage defaults to REQUIRED. Only projects explicitly stored as p2_v2 can be initialized, and no public route calls the service.

## Validation

- combined focused server regression: 86 passed
- Phase 3 + workflow registry/version tests: 39 passed
- focused ESLint: passed
- TypeScript with 6 GB heap: no diagnostics
- git diff --check: passed
- migration was not executed against shared or production data