### PR TITLE
Add read-only P2 V2 project workflow UI

### DIFF
--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -1,0 +1,154 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import P2V2ProjectWorkflow from '../components/projects/P2V2ProjectWorkflow';
+
+const stages = Array.from({ length: 10 }, (_, index) => ({
+  id: `step-${index + 1}`,
+  stepType: `stage_${index + 1}`,
+  stepOrder: index + 1,
+  label: `Stage ${index + 1}`,
+  description: `Description ${index + 1}`,
+  status: index === 0 ? 'BLOCKED' : 'NOT_STARTED',
+  applicability: 'REQUIRED',
+  blockedReason: index === 0 ? 'Required evidence is missing' : null,
+  activeLinks:
+    index === 0
+      ? [
+          {
+            id: 'link-1',
+            recordType: 'quote',
+            recordId: 'Q-1',
+            relationshipType: 'PRIMARY',
+            isAuthoritative: true,
+            linkedByDisplayName: 'Alex',
+          },
+        ]
+      : [],
+  supersededLinks:
+    index === 0
+      ? [
+          {
+            id: 'link-2',
+            recordType: 'quote',
+            recordId: 'Q-0',
+            relationshipType: 'SUPERSEDES',
+            isAuthoritative: false,
+            supersededAt: '2026-01-01',
+            supersededReason: 'Revised',
+          },
+        ]
+      : [],
+  approvals:
+    index === 0
+      ? [
+          {
+            id: 'approval-1',
+            decision: 'REJECTED',
+            approvalType: 'QUALITY',
+            signatureMeaning: 'Reviewed',
+            actorDisplayName: 'Pat',
+            superseded: false,
+          },
+        ]
+      : [],
+  evidenceCount: index === 0 ? 3 : 0,
+  lastUpdated: '2026-01-01',
+}));
+
+const initialized = {
+  projectId: 'p1',
+  initialized: true,
+  workflowStatus: 'ACTIVE',
+  definitionVersion: 1,
+  initializedAt: '2026-01-01',
+  initializedBy: 'Tester',
+  integrityStatus: 'INVALID',
+  integrityErrors: [
+    { code: 'MISSING_STAGE', message: 'Example integrity problem' },
+  ],
+  totalStages: 10,
+  completedStages: 0,
+  blockedStages: 1,
+  pendingApprovalStages: 0,
+  percentComplete: 0,
+  stages,
+};
+
+function renderWorkflow(response: object) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: true, json: async () => response })
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <P2V2ProjectWorkflow projectId="p1" />
+    </QueryClientProvider>
+  );
+}
+
+describe('P2V2ProjectWorkflow', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('renders ten ordered, text-labelled read-only stages and integrity/blocker warnings', async () => {
+    renderWorkflow(initialized);
+    expect(
+      await screen.findByText('P2 Project Workflow V2')
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^v2-stage-\d+$/)).toHaveLength(10);
+    expect(screen.getByTestId('v2-integrity-warning')).toHaveTextContent(
+      'Example integrity problem'
+    );
+    expect(screen.getByTestId('v2-blocked-reason')).toHaveTextContent(
+      'Required evidence is missing'
+    );
+    expect(screen.getByText('BLOCKED')).toBeInTheDocument();
+    for (const forbidden of [
+      'Start',
+      'Mark Complete',
+      'Skip',
+      'Approve',
+      'Waive',
+    ])
+      expect(
+        screen.queryByRole('button', { name: forbidden })
+      ).not.toBeInTheDocument();
+  });
+
+  it('shows active, superseded, and approval evidence in stage details', async () => {
+    renderWorkflow(initialized);
+    fireEvent.click(await screen.findByTestId('v2-stage-details-1'));
+    expect(
+      await screen.findByTestId('v2-stage-details-dialog')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('v2-active-link')).toHaveTextContent('Q-1');
+    expect(screen.getByTestId('v2-superseded-link')).toHaveTextContent('Q-0');
+    expect(screen.getByTestId('v2-approval')).toHaveTextContent('REJECTED');
+  });
+
+  it('shows an explicit not-initialized state without an initialize action', async () => {
+    renderWorkflow({
+      initialized: false,
+      workflowStatus: 'NOT_INITIALIZED',
+      integrityStatus: 'NOT_EVALUATED',
+      integrityErrors: [],
+      totalStages: 0,
+      completedStages: 0,
+      blockedStages: 0,
+      pendingApprovalStages: 0,
+      percentComplete: null,
+      message: 'P2 V2 workflow has not been initialized.',
+      stages: [],
+    });
+    expect(
+      await screen.findByTestId('v2-workflow-not-initialized')
+    ).toHaveTextContent('Workflow not initialized');
+    expect(
+      screen.queryByRole('button', { name: /initialize/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -1,0 +1,479 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  AlertCircle,
+  Ban,
+  CheckCircle2,
+  Circle,
+  Clock,
+  Eye,
+  ShieldAlert,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Progress } from '@/components/ui/progress';
+
+type EvidenceLink = {
+  id: string;
+  recordType: string;
+  recordId: string;
+  relationshipType: string;
+  isAuthoritative: boolean;
+  recordRevision?: string | null;
+  effectivityReference?: string | null;
+  linkedByDisplayName?: string | null;
+  linkedAt?: string | null;
+  supersededAt?: string | null;
+  supersededReason?: string | null;
+};
+type Approval = {
+  id: string;
+  decision: string;
+  approvalType: string;
+  signatureMeaning: string;
+  actorDisplayName: string;
+  actorRole?: string | null;
+  decidedAt?: string | null;
+  reason?: string | null;
+  superseded: boolean;
+};
+type Stage = {
+  id: string;
+  stepType: string;
+  stepOrder: number;
+  label: string;
+  description?: string | null;
+  status: string;
+  applicability: string;
+  applicabilityReason?: string | null;
+  applicabilitySource?: string | null;
+  ownerEmployeeId?: number | null;
+  ownerDisplayName?: string | null;
+  ownerRole?: string | null;
+  dueDate?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  completedByDisplayName?: string | null;
+  blockedReason?: string | null;
+  revisionReference?: string | null;
+  effectivityReference?: string | null;
+  notes?: string | null;
+  activeLinks: EvidenceLink[];
+  supersededLinks: EvidenceLink[];
+  approvals: Approval[];
+  evidenceCount: number;
+  lastUpdated?: string | null;
+};
+type WorkflowResponse = {
+  projectId: string;
+  initialized: boolean;
+  workflowStatus: string;
+  definitionVersion?: number | null;
+  initializedAt?: string | null;
+  initializedBy?: string | null;
+  integrityStatus: string;
+  integrityErrors: { code?: string; message?: string }[];
+  totalStages: number;
+  completedStages: number;
+  blockedStages: number;
+  pendingApprovalStages: number;
+  percentComplete?: number | null;
+  message?: string;
+  stages: Stage[];
+};
+
+const dateLabel = (value?: string | null) =>
+  value ? new Date(value).toLocaleString() : 'Not recorded';
+const statusStyle: Record<string, string> = {
+  COMPLETE: 'bg-green-100 text-green-800',
+  APPROVED: 'bg-blue-100 text-blue-800',
+  IN_PROGRESS: 'bg-blue-100 text-blue-800',
+  PENDING_APPROVAL: 'bg-amber-100 text-amber-800',
+  BLOCKED: 'bg-red-100 text-red-800',
+  NOT_STARTED: 'bg-gray-100 text-gray-700',
+  NOT_APPLICABLE: 'bg-slate-100 text-slate-700',
+  SUPERSEDED: 'bg-gray-100 text-gray-500',
+  CANCELLED: 'bg-red-50 text-red-700',
+};
+const StatusIcon = ({ status }: { status: string }) => {
+  if (status === 'COMPLETE')
+    return <CheckCircle2 className="h-5 w-5 text-green-600" />;
+  if (status === 'BLOCKED')
+    return <AlertCircle className="h-5 w-5 text-red-600" />;
+  if (status === 'IN_PROGRESS' || status === 'PENDING_APPROVAL')
+    return <Clock className="h-5 w-5 text-blue-600" />;
+  if (status === 'CANCELLED') return <Ban className="h-5 w-5 text-red-500" />;
+  return <Circle className="h-5 w-5 text-gray-500" />;
+};
+
+function LinkList({ title, links }: { title: string; links: EvidenceLink[] }) {
+  return (
+    <section className="space-y-2">
+      <h4 className="font-medium">{title}</h4>
+      {links.length === 0 ? (
+        <p className="text-sm text-muted-foreground">None</p>
+      ) : (
+        links.map((link) => (
+          <div
+            key={link.id}
+            className="rounded border p-3 text-sm"
+            data-testid={
+              link.supersededAt ? 'v2-superseded-link' : 'v2-active-link'
+            }
+          >
+            <div className="flex flex-wrap gap-2">
+              <span className="font-medium">
+                {link.recordType}: {link.recordId}
+              </span>
+              <Badge variant="outline">{link.relationshipType}</Badge>
+              {link.isAuthoritative && <Badge>Authoritative</Badge>}
+            </div>
+            <p className="mt-1 text-muted-foreground">
+              Revision: {link.recordRevision || 'None'} · Effectivity:{' '}
+              {link.effectivityReference || 'None'}
+            </p>
+            <p className="text-muted-foreground">
+              Linked by {link.linkedByDisplayName || 'Unknown'} ·{' '}
+              {dateLabel(link.linkedAt)}
+            </p>
+            {link.supersededAt && (
+              <p className="mt-1 text-amber-700">
+                Superseded {dateLabel(link.supersededAt)}
+                {link.supersededReason ? ` — ${link.supersededReason}` : ''}
+              </p>
+            )}
+          </div>
+        ))
+      )}
+    </section>
+  );
+}
+
+export default function P2V2ProjectWorkflow({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const [selectedStage, setSelectedStage] = useState<Stage | null>(null);
+  const { data, isLoading, error } = useQuery<WorkflowResponse>({
+    queryKey: ['/api/projects', projectId, 'workflow-v2'],
+    queryFn: async () => {
+      const response = await fetch(`/api/projects/${projectId}/workflow-v2`, {
+        credentials: 'include',
+      });
+      if (!response.ok)
+        throw new Error(
+          (await response.json().catch(() => null))?.message ||
+            'Unable to load V2 workflow'
+        );
+      return response.json();
+    },
+  });
+  if (isLoading)
+    return (
+      <Card data-testid="v2-workflow-loading">
+        <CardContent className="p-6">
+          Loading P2 Project Workflow V2…
+        </CardContent>
+      </Card>
+    );
+  if (error || !data)
+    return (
+      <Card className="border-red-300" data-testid="v2-workflow-error">
+        <CardContent className="p-6 text-red-700">
+          {error instanceof Error
+            ? error.message
+            : 'Unable to load V2 workflow.'}
+        </CardContent>
+      </Card>
+    );
+  if (!data.initialized)
+    return (
+      <Card data-testid="v2-workflow-not-initialized">
+        <CardHeader>
+          <CardTitle>Workflow not initialized</CardTitle>
+          <CardDescription>{data.message}</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          No V2 workflow instance exists. Initialization is unavailable from
+          this read-only view.
+        </CardContent>
+      </Card>
+    );
+  return (
+    <div className="space-y-4" data-testid="p2-v2-project-workflow">
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <CardTitle>P2 Project Workflow V2</CardTitle>
+              <CardDescription>
+                Read-only controlled workflow evidence · Definition v
+                {data.definitionVersion}
+              </CardDescription>
+            </div>
+            <div className="flex gap-2">
+              <Badge>{data.workflowStatus}</Badge>
+              <Badge
+                variant={
+                  data.integrityStatus === 'VALID' ? 'outline' : 'destructive'
+                }
+              >
+                {data.integrityStatus}
+              </Badge>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <p className="text-xs text-muted-foreground">Initialized</p>
+              <p className="text-sm font-medium">
+                {dateLabel(data.initializedAt)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Initialized by</p>
+              <p className="text-sm font-medium">
+                {data.initializedBy || 'Unknown'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Completed</p>
+              <p className="text-sm font-medium">
+                {data.completedStages}/{data.totalStages}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">
+                Blocked / Pending approval
+              </p>
+              <p className="text-sm font-medium">
+                {data.blockedStages} / {data.pendingApprovalStages}
+              </p>
+            </div>
+          </div>
+          <div>
+            <div className="mb-1 flex justify-between text-sm">
+              <span>Overall progress</span>
+              <span>{data.percentComplete}%</span>
+            </div>
+            <Progress value={data.percentComplete ?? 0} />
+          </div>
+        </CardContent>
+      </Card>
+      {data.integrityStatus !== 'VALID' && (
+        <Card
+          className="border-red-400 bg-red-50"
+          data-testid="v2-integrity-warning"
+        >
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-red-800">
+              <ShieldAlert className="h-5 w-5" />
+              Workflow integrity warning
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="list-disc space-y-1 pl-5 text-sm text-red-700">
+              {data.integrityErrors.map((issue, index) => (
+                <li key={`${issue.code}-${index}`}>
+                  {issue.code ? `${issue.code}: ` : ''}
+                  {issue.message || 'Unknown integrity problem'}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+      <div className="space-y-3" aria-label="P2 V2 workflow stages">
+        {data.stages.map((stage) => (
+          <Card
+            key={stage.id}
+            className={stage.status === 'BLOCKED' ? 'border-red-300' : ''}
+            data-testid={`v2-stage-${stage.stepOrder}`}
+          >
+            <CardContent className="p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="flex min-w-0 gap-3">
+                  <StatusIcon status={stage.status} />
+                  <div>
+                    <p className="text-xs text-muted-foreground">
+                      Stage {stage.stepOrder}
+                    </p>
+                    <h3 className="font-semibold">{stage.label}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {stage.description}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge className={statusStyle[stage.status] || ''}>
+                    {stage.status.replaceAll('_', ' ')}
+                  </Badge>
+                  <Badge variant="outline">
+                    {stage.applicability.replaceAll('_', ' ')}
+                  </Badge>
+                </div>
+              </div>
+              {stage.blockedReason && (
+                <p
+                  className="mt-3 rounded bg-red-50 p-2 text-sm text-red-700"
+                  data-testid="v2-blocked-reason"
+                >
+                  Blocked: {stage.blockedReason}
+                </p>
+              )}
+              <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
+                <span>
+                  Owner:{' '}
+                  {stage.ownerDisplayName || stage.ownerRole || 'Unassigned'}
+                </span>
+                <span>Due: {stage.dueDate || 'Not set'}</span>
+                <span>
+                  Links / evidence / approvals: {stage.activeLinks.length} /{' '}
+                  {stage.evidenceCount} / {stage.approvals.length}
+                </span>
+                <span>Updated: {dateLabel(stage.lastUpdated)}</span>
+                <span>Revision: {stage.revisionReference || 'None'}</span>
+                <span>Effectivity: {stage.effectivityReference || 'None'}</span>
+                <span>
+                  Completion: {stage.completedByDisplayName || 'Not complete'}
+                </span>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-3"
+                onClick={() => setSelectedStage(stage)}
+                data-testid={`v2-stage-details-${stage.stepOrder}`}
+              >
+                <Eye className="mr-1 h-4 w-4" />
+                Details
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <Dialog
+        open={Boolean(selectedStage)}
+        onOpenChange={(open) => !open && setSelectedStage(null)}
+      >
+        <DialogContent
+          className="max-h-[85vh] max-w-3xl overflow-y-auto"
+          data-testid="v2-stage-details-dialog"
+        >
+          <DialogHeader>
+            <DialogTitle>{selectedStage?.label}</DialogTitle>
+            <DialogDescription>
+              Read-only workflow stage evidence
+            </DialogDescription>
+          </DialogHeader>
+          {selectedStage && (
+            <div className="space-y-5 text-sm">
+              <div className="grid gap-2 sm:grid-cols-2">
+                <p>
+                  <strong>Status:</strong> {selectedStage.status}
+                </p>
+                <p>
+                  <strong>Applicability:</strong> {selectedStage.applicability}
+                </p>
+                <p>
+                  <strong>Owner:</strong>{' '}
+                  {selectedStage.ownerDisplayName ||
+                    selectedStage.ownerRole ||
+                    'Unassigned'}
+                </p>
+                <p>
+                  <strong>Due:</strong> {selectedStage.dueDate || 'Not set'}
+                </p>
+                <p>
+                  <strong>Completed:</strong>{' '}
+                  {selectedStage.completedByDisplayName || 'No'} ·{' '}
+                  {dateLabel(selectedStage.completedAt)}
+                </p>
+                <p>
+                  <strong>Revision/effectivity:</strong>{' '}
+                  {selectedStage.revisionReference || 'None'} /{' '}
+                  {selectedStage.effectivityReference || 'None'}
+                </p>
+              </div>
+              <p>{selectedStage.description}</p>
+              {selectedStage.applicabilityReason && (
+                <p>
+                  <strong>Applicability basis:</strong>{' '}
+                  {selectedStage.applicabilityReason} (
+                  {selectedStage.applicabilitySource || 'source unknown'})
+                </p>
+              )}
+              {selectedStage.blockedReason && (
+                <p className="text-red-700">
+                  <strong>Blocked:</strong> {selectedStage.blockedReason}
+                </p>
+              )}
+              {selectedStage.notes && (
+                <p>
+                  <strong>Notes:</strong> {selectedStage.notes}
+                </p>
+              )}
+              <LinkList
+                title="Active links"
+                links={selectedStage.activeLinks}
+              />
+              <LinkList
+                title="Superseded links"
+                links={selectedStage.supersededLinks}
+              />
+              <section className="space-y-2">
+                <h4 className="font-medium">Approval history</h4>
+                {selectedStage.approvals.length === 0 ? (
+                  <p className="text-muted-foreground">None</p>
+                ) : (
+                  selectedStage.approvals.map((approval) => (
+                    <div
+                      key={approval.id}
+                      className="rounded border p-3"
+                      data-testid="v2-approval"
+                    >
+                      <div className="flex flex-wrap gap-2">
+                        <Badge variant="outline">{approval.decision}</Badge>
+                        <span className="font-medium">
+                          {approval.approvalType}
+                        </span>
+                        {approval.superseded && (
+                          <Badge variant="secondary">Superseded</Badge>
+                        )}
+                      </div>
+                      <p>{approval.signatureMeaning}</p>
+                      <p className="text-muted-foreground">
+                        {approval.actorDisplayName}
+                        {approval.actorRole
+                          ? ` · ${approval.actorRole}`
+                          : ''} · {dateLabel(approval.decidedAt)}
+                      </p>
+                      {approval.reason && <p>{approval.reason}</p>}
+                    </div>
+                  ))
+                )}
+              </section>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -18,6 +18,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useToast } from '@/hooks/use-toast';
 import P2POCreationWizard from '@/components/p2/P2POCreationWizard';
+import P2V2ProjectWorkflow from '@/components/projects/P2V2ProjectWorkflow';
 import { 
   ArrowLeft, 
   CheckCircle2, 
@@ -181,6 +182,8 @@ interface Project {
   projectManager?: { id: number; name: string };
   activityLog: ActivityLog[];
   closingStatus: 'MISSING' | 'INCOMPLETE' | 'COMPLETE' | 'APPROVED';
+  workflowVersion?: string | null;
+  effectiveWorkflowVersion?: string;
 }
 
 interface Employee {
@@ -552,6 +555,10 @@ export default function ProjectDetailPage() {
     queryKey: ['/api/projects', id],
     enabled: !!id,
   });
+  const effectiveWorkflowVersion = project?.effectiveWorkflowVersion;
+  const isP2V2Workflow = effectiveWorkflowVersion === 'p2_v2';
+  const isLegacyWorkflow = !effectiveWorkflowVersion || effectiveWorkflowVersion === 'legacy_v1';
+  const hasUnknownWorkflowVersion = Boolean(project && !isP2V2Workflow && !isLegacyWorkflow);
 
   const { data: employees = [] } = useQuery<Employee[]>({
     queryKey: ['/api/employees'],
@@ -857,7 +864,7 @@ export default function ProjectDetailPage() {
       if (!response.ok) throw new Error('Failed to fetch P2 gate status');
       return response.json();
     },
-    enabled: !!id && !!project && ['po_received', 'p2_release', 'purchase_review'].includes(project.currentStage || ''),
+    enabled: !!id && !!project && isLegacyWorkflow && ['po_received', 'p2_release', 'purchase_review'].includes(project.currentStage || ''),
   });
   const projectSteps = Array.isArray(project?.steps) ? project.steps : [];
   const allProjectStepAttachments = Array.isArray(allStepAttachments) ? allStepAttachments : [];
@@ -1982,6 +1989,7 @@ export default function ProjectDetailPage() {
         </div>
       ) : null}
 
+      {isLegacyWorkflow && <>
       <div className="space-y-2">
         <div className="flex justify-between text-sm">
           <span className="font-medium">Overall Progress</span>
@@ -2066,7 +2074,8 @@ export default function ProjectDetailPage() {
       })()}
 
       {/* P2 Release Gate Card — shown when project is approaching or at the release gate */}
-      {project && ['purchase_review', 'po_received', 'p2_release'].includes(project.currentStage || '') && (
+      </>}
+      {isLegacyWorkflow && project && ['purchase_review', 'po_received', 'p2_release'].includes(project.currentStage || '') && (
         <Card className={`border-2 ${project.currentStage === 'p2_release' ? 'border-green-400 bg-green-50 dark:bg-green-950/20' : 'border-amber-300 bg-amber-50 dark:bg-amber-950/20'}`}>
           <CardHeader className="pb-3">
             <div className="flex items-center gap-2">
@@ -2165,6 +2174,14 @@ export default function ProjectDetailPage() {
         </Card>
       )}
 
+      {isP2V2Workflow && (
+        <Card className="border-blue-200 bg-blue-50/60" data-testid="v2-release-gate-future">
+          <CardContent className="p-4 text-sm text-blue-800">
+            P2 V2 production release is read-only in this phase. The V2 release gate will be enabled in a later controlled phase.
+          </CardContent>
+        </Card>
+      )}
+
       {/* Similar Past Projects widget */}
       {(isLoadingSimilar || similarClosings.length > 0) && (
         <div className="border rounded-lg overflow-hidden">
@@ -2235,6 +2252,17 @@ export default function ProjectDetailPage() {
         </TabsList>
 
         <TabsContent value="workflow" className="space-y-4">
+          {isP2V2Workflow ? (
+            <P2V2ProjectWorkflow projectId={project.id} />
+          ) : hasUnknownWorkflowVersion ? (
+            <Card className="border-red-300" data-testid="workflow-version-configuration-error">
+              <CardHeader><CardTitle>Workflow configuration error</CardTitle></CardHeader>
+              <CardContent className="text-sm text-red-700">
+                This project has an unsupported workflow version. Legacy workflow controls are disabled.
+              </CardContent>
+            </Card>
+          ) : (
+          <>
           {/* Inline Workflow Action Cards */}
           {(() => {
             const purchaseStep = projectSteps.find(s => s.stepType === 'purchase_review_checklist');
@@ -2949,6 +2977,8 @@ export default function ProjectDetailPage() {
               )}
             </CardContent>
           </Card>
+          </>
+          )}
         </TabsContent>
 
         <TabsContent value="document-coverage" className="space-y-4">

--- a/server/__tests__/projectWorkflowV2ReadModel.test.ts
+++ b/server/__tests__/projectWorkflowV2ReadModel.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildP2V2WorkflowResponse,
+  buildUninitializedP2V2Response,
+  calculateP2V2Progress,
+} from '../src/services/projectWorkflowV2ReadModel';
+
+const root = resolve(__dirname, '../..');
+const routeSource = readFileSync(
+  resolve(root, 'server/src/routes/projects.ts'),
+  'utf8'
+);
+const projectDetailSource = readFileSync(
+  resolve(root, 'client/src/pages/ProjectDetailPage.tsx'),
+  'utf8'
+);
+
+describe('P2 V2 progress calculation', () => {
+  it('counts COMPLETE and approved NOT_APPLICABLE only', () => {
+    const progress = calculateP2V2Progress([
+      { status: 'COMPLETE', approvals: [] },
+      {
+        status: 'NOT_APPLICABLE',
+        approvals: [
+          { decision: 'NOT_APPLICABLE_APPROVED', superseded_at: null },
+        ],
+      },
+      { status: 'NOT_APPLICABLE', approvals: [] },
+      { status: 'APPROVED', approvals: [] },
+      { status: 'PENDING_APPROVAL', approvals: [] },
+    ]);
+    expect(progress).toEqual({
+      totalStages: 5,
+      completedStages: 2,
+      blockedStages: 0,
+      pendingApprovalStages: 1,
+      percentComplete: 40,
+    });
+  });
+
+  it('does not count superseded not-applicable approval evidence', () => {
+    expect(
+      calculateP2V2Progress([
+        {
+          status: 'NOT_APPLICABLE',
+          approvals: [
+            { decision: 'NOT_APPLICABLE_APPROVED', superseded_at: new Date() },
+          ],
+        },
+      ]).completedStages
+    ).toBe(0);
+  });
+});
+
+describe('P2 V2 read model', () => {
+  it('returns an explicit uninitialized model without misleading progress', () => {
+    expect(buildUninitializedP2V2Response('project-1')).toMatchObject({
+      initialized: false,
+      workflowStatus: 'NOT_INITIALIZED',
+      percentComplete: null,
+      stages: [],
+    });
+  });
+
+  it('groups active links, superseded links, approvals, and integrity errors', () => {
+    const response = buildP2V2WorkflowResponse('project-1', {
+      instance: { id: 'instance-1', status: 'ACTIVE', definition_version: 1 },
+      integrity: {
+        valid: false,
+        issues: [{ code: 'MISSING_STAGE', message: 'Missing stage' }],
+      },
+      steps: [
+        {
+          id: 'step-1',
+          step_type: 'rfq_risk_assessment',
+          step_order: 1,
+          label_snapshot: 'RFQ & Risk',
+          status: 'BLOCKED',
+          applicability: 'REQUIRED',
+          links: [
+            { id: 'a', unlinked_at: null },
+            { id: 'b', unlinked_at: new Date(), unlink_reason: 'Replaced' },
+          ],
+          approvals: [{ id: 'c', decision: 'REJECTED' }],
+        },
+      ],
+    });
+    expect(response.integrityStatus).toBe('INVALID');
+    expect(response.stages[0]).toMatchObject({
+      activeLinks: [{ id: 'a' }],
+      supersededLinks: [{ id: 'b' }],
+      evidenceCount: 3,
+    });
+  });
+});
+
+describe('read-only endpoint isolation', () => {
+  it('is version-aware and exposes no initializer or legacy step fallback', () => {
+    const endpoint = routeSource.slice(
+      routeSource.indexOf("router.get('/:id/workflow-v2'"),
+      routeSource.indexOf(
+        "router.get('/:id'",
+        routeSource.indexOf("router.get('/:id/workflow-v2'") + 1
+      )
+    );
+    expect(endpoint).toContain('resolveProjectWorkflowVersion');
+    expect(endpoint).toContain('WORKFLOW_VERSION_MISMATCH');
+    expect(endpoint).toContain('buildUninitializedP2V2Response');
+    expect(endpoint).not.toContain('initializeV2Workflow');
+    expect(endpoint).not.toContain('getProjectSteps');
+    expect(endpoint).not.toMatch(/INSERT|UPDATE|DELETE/i);
+  });
+
+  it('routes Project Detail by server-provided effective version and blocks legacy release for V2', () => {
+    expect(projectDetailSource).toContain(
+      "effectiveWorkflowVersion === 'p2_v2'"
+    );
+    expect(projectDetailSource).toContain(
+      '<P2V2ProjectWorkflow projectId={project.id} />'
+    );
+    expect(projectDetailSource).toContain('isLegacyWorkflow && project &&');
+    expect(projectDetailSource).toContain('isLegacyWorkflow && [');
+    expect(projectDetailSource).toContain('v2-release-gate-future');
+    expect(projectDetailSource).toContain(
+      'workflow-version-configuration-error'
+    );
+  });
+});

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -33,6 +33,8 @@ import fs from 'fs';
 import crypto from 'crypto';
 import { getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
 import { buildProjectBomAssemblyTree, type ProjectBomAssemblyRow } from '../services/projectBomAssembly';
+import { getActiveWorkflowInstanceForProject, getWorkflowReadModel } from '../services/projectWorkflowInstanceService';
+import { buildP2V2WorkflowResponse, buildUninitializedP2V2Response } from '../services/projectWorkflowV2ReadModel';
 
 // ── Project document upload setup ──────────────────────────────────────────
 const projectDocsDir = path.join(process.cwd(), 'uploads', 'project-documents');
@@ -1511,6 +1513,31 @@ router.patch('/:id/clins/:clinId', async (req, res) => {
     }
     console.error('Update project CLIN error:', error);
     res.status(500).json({ error: 'Failed to update project CLIN' });
+  }
+});
+
+router.get('/:id/workflow-v2', async (req, res) => {
+  try {
+    const project = await storage.getProject(req.params.id);
+    if (!project) return res.status(404).json({ error: 'PROJECT_NOT_FOUND', message: 'Project not found' });
+    const effectiveVersion = resolveProjectWorkflowVersion(project.workflowVersion);
+    if (effectiveVersion !== 'p2_v2') {
+      return res.status(409).json({
+        error: 'WORKFLOW_VERSION_MISMATCH',
+        message: 'The V2 workflow endpoint is available only for p2_v2 projects.',
+        projectId: project.id,
+        workflowVersion: project.workflowVersion ?? null,
+        effectiveWorkflowVersion: effectiveVersion,
+      });
+    }
+    const instance = await getActiveWorkflowInstanceForProject(project.id);
+    if (!instance) return res.json(buildUninitializedP2V2Response(project.id));
+    const model = await getWorkflowReadModel(String(instance.id));
+    return res.json(buildP2V2WorkflowResponse(project.id, model));
+  } catch (error) {
+    if (error instanceof ProjectWorkflowVersionError) return res.status(409).json(error.toJSON());
+    console.error('Error fetching P2 V2 workflow:', error);
+    return res.status(500).json({ error: 'P2_V2_WORKFLOW_READ_FAILED', message: 'Failed to load P2 V2 workflow' });
   }
 });
 

--- a/server/src/services/projectWorkflowInstanceService.ts
+++ b/server/src/services/projectWorkflowInstanceService.ts
@@ -140,6 +140,23 @@ export async function getWorkflowInstanceForProject(
   return found[0] ?? null;
 }
 
+export async function getActiveWorkflowInstanceForProject(
+  projectId: string,
+  tx: Executor = db
+) {
+  const active = rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_instances WHERE project_id = ${projectId} AND workflow_version = 'p2_v2' AND status NOT IN ('SUPERSEDED','CANCELLED') ORDER BY created_at DESC`
+    )
+  );
+  if (active.length > 1)
+    throw new ProjectWorkflowInstanceError(
+      'DUPLICATE_ACTIVE_INSTANCES',
+      'Multiple active p2_v2 instances exist.'
+    );
+  return active[0] ?? null;
+}
+
 export async function getWorkflowStepInstances(
   workflowInstanceId: string,
   tx: Executor = db

--- a/server/src/services/projectWorkflowV2ReadModel.ts
+++ b/server/src/services/projectWorkflowV2ReadModel.ts
@@ -1,0 +1,133 @@
+type Row = Record<string, unknown>;
+
+const text = (value: unknown) => (value == null ? null : String(value));
+const activeApproval = (approval: Row) => !approval.superseded_at;
+const approvedNotApplicable = (step: Row) =>
+  step.status === 'NOT_APPLICABLE' &&
+  ((step.approvals as Row[] | undefined) ?? []).some(
+    (approval) =>
+      activeApproval(approval) &&
+      approval.decision === 'NOT_APPLICABLE_APPROVED'
+  );
+
+export function calculateP2V2Progress(steps: Row[]) {
+  const completedStages = steps.filter(
+    (step) => step.status === 'COMPLETE' || approvedNotApplicable(step)
+  ).length;
+  return {
+    totalStages: steps.length,
+    completedStages,
+    blockedStages: steps.filter((step) => step.status === 'BLOCKED').length,
+    pendingApprovalStages: steps.filter(
+      (step) => step.status === 'PENDING_APPROVAL'
+    ).length,
+    percentComplete: steps.length
+      ? Math.round((completedStages / steps.length) * 100)
+      : 0,
+  };
+}
+
+const mapLink = (link: Row) => ({
+  id: text(link.id),
+  recordType: text(link.record_type),
+  recordId: text(link.record_id),
+  relationshipType: text(link.relationship_type),
+  isAuthoritative: Boolean(link.is_authoritative),
+  recordRevision: text(link.record_revision),
+  effectivityReference: text(link.effectivity_reference),
+  linkedBy: link.linked_by ?? null,
+  linkedByDisplayName: text(link.linked_by_display_name),
+  linkedAt: link.linked_at ?? null,
+  supersededAt: link.unlinked_at ?? null,
+  supersededReason: text(link.unlink_reason),
+});
+
+const mapApproval = (approval: Row) => ({
+  id: text(approval.id),
+  decision: text(approval.decision),
+  approvalType: text(approval.approval_type),
+  signatureMeaning: text(approval.signature_meaning),
+  actorDisplayName: text(approval.actor_display_name),
+  actorRole: text(approval.actor_role),
+  decidedAt: approval.decided_at ?? null,
+  reason: text(approval.reason),
+  superseded: Boolean(approval.superseded_at),
+  supersededAt: approval.superseded_at ?? null,
+});
+
+export function buildP2V2WorkflowResponse(projectId: string, model: Row) {
+  const instance = model.instance as Row;
+  const integrity = model.integrity as { valid: boolean; issues: unknown[] };
+  const rawSteps = (model.steps as Row[]) ?? [];
+  const stages = rawSteps.map((step) => {
+    const links = ((step.links as Row[]) ?? []).map(mapLink);
+    const approvals = ((step.approvals as Row[]) ?? []).map(mapApproval);
+    const activeLinks = links.filter((link) => !link.supersededAt);
+    const supersededLinks = links.filter((link) => Boolean(link.supersededAt));
+    return {
+      id: text(step.id),
+      stepType: text(step.step_type),
+      stepOrder: Number(step.step_order),
+      label: text(step.label_snapshot),
+      description: text(step.description_snapshot),
+      status: text(step.status),
+      applicability: text(step.applicability),
+      applicabilityReason: text(step.applicability_reason),
+      applicabilitySource: text(step.applicability_source),
+      ownerEmployeeId: step.owner_employee_id ?? null,
+      ownerDisplayName: text(step.owner_display_name),
+      ownerRole: text(step.owner_role),
+      dueDate: step.due_date ?? null,
+      startedAt: step.started_at ?? null,
+      completedAt: step.completed_at ?? null,
+      completedBy: step.completed_by ?? null,
+      completedByDisplayName: text(step.completed_by_display_name),
+      blockedReason: text(step.blocked_reason),
+      revisionReference: text(step.revision_reference),
+      effectivityReference: text(step.effectivity_reference),
+      notes: text(step.notes),
+      activeLinks,
+      supersededLinks,
+      approvals,
+      evidenceCount: links.length + approvals.length,
+      lastUpdated: step.updated_at ?? step.created_at ?? null,
+    };
+  });
+  const progress = calculateP2V2Progress(rawSteps);
+  return {
+    projectId,
+    workflowVersion: 'p2_v2',
+    definitionVersion: instance.definition_version,
+    initialized: true,
+    workflowInstanceId: text(instance.id),
+    workflowStatus: text(instance.status),
+    initializedAt: instance.initialized_at ?? null,
+    initializedBy: text(instance.initialized_by_display_name),
+    integrityStatus: integrity.valid ? 'VALID' : 'INVALID',
+    integrityErrors: integrity.issues,
+    ...progress,
+    stages,
+  };
+}
+
+export function buildUninitializedP2V2Response(projectId: string) {
+  return {
+    projectId,
+    workflowVersion: 'p2_v2',
+    definitionVersion: null,
+    initialized: false,
+    workflowInstanceId: null,
+    workflowStatus: 'NOT_INITIALIZED',
+    initializedAt: null,
+    initializedBy: null,
+    integrityStatus: 'NOT_EVALUATED',
+    integrityErrors: [],
+    totalStages: 0,
+    completedStages: 0,
+    blockedStages: 0,
+    pendingApprovalStages: 0,
+    percentComplete: null,
+    message: 'P2 V2 workflow has not been initialized.',
+    stages: [],
+  };
+}


### PR DESCRIPTION
## What changed

- adds GET /api/projects/:id/workflow-v2 as a version-aware, mutation-free V2 workflow read endpoint
- adds a conservative server-side V2 progress/read-model mapper
- adds a separate P2V2ProjectWorkflow component with ten read-only stages, integrity warnings, and evidence details
- routes Project Detail workflow rendering by the server-provided effective workflow version
- prevents V2 projects from querying or rendering the legacy release gate and controls

## Progress rules

Only COMPLETE and NOT_APPLICABLE with active NOT_APPLICABLE_APPROVED evidence count as complete. APPROVED and all other states remain incomplete.

## Validation

- combined server regression: 92 passed
- focused Phase 1-4 workflow tests: 45 passed
- V2 component tests: 3 passed
- focused ESLint: passed
- TypeScript with 6 GB heap: no diagnostics
- git diff --check: passed

## Safety

No migration or data change was added. The GET endpoint never initializes a workflow, reads project_steps as fallback, or writes activity. V2 creation and all V2 mutation actions remain disabled.