### PR TITLE
Add P2 V2 design applicability control

### DIFF
--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -6,7 +6,7 @@ import P2V2ProjectWorkflow from '../components/projects/P2V2ProjectWorkflow';
 
 const stages = Array.from({ length: 10 }, (_, index) => ({
   id: `step-${index + 1}`,
-  stepType: `stage_${index + 1}`,
+  stepType: index === 3 ? 'design_applicability' : `stage_${index + 1}`,
   stepOrder: index + 1,
   label: `Stage ${index + 1}`,
   description: `Description ${index + 1}`,
@@ -128,6 +128,17 @@ describe('P2V2ProjectWorkflow', () => {
     expect(screen.getByTestId('v2-active-link')).toHaveTextContent('Q-1');
     expect(screen.getByTestId('v2-superseded-link')).toHaveTextContent('Q-0');
     expect(screen.getByTestId('v2-approval')).toHaveTextContent('REJECTED');
+  });
+
+  it('makes only Design Applicability writable from the ten-stage summary', async () => {
+    renderWorkflow(initialized);
+    expect(
+      await screen.findByTestId('open-design-applicability')
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: 'Open Design Applicability' })
+    ).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Details' })).toHaveLength(10);
   });
 
   it('shows an explicit not-initialized state without an initialize action', async () => {

--- a/client/src/components/projects/P2V2DesignApplicability.tsx
+++ b/client/src/components/projects/P2V2DesignApplicability.tsx
@@ -1,0 +1,588 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ExternalLink } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+
+type Responsibility =
+  | 'CUSTOMER_BUILD_TO_PRINT'
+  | 'AG_DESIGN_RESPONSIBLE'
+  | 'SHARED_DESIGN_RESPONSIBILITY';
+type Decision = {
+  id: string;
+  revision_number: number;
+  status: string;
+  responsibility_type: Responsibility;
+  ag_design_scope?: string | null;
+  customer_design_scope?: string | null;
+  responsibility_boundary?: string | null;
+  requirement_source?: string | null;
+  customer_drawing_number?: string | null;
+  customer_drawing_revision?: string | null;
+  customer_specifications?: unknown;
+  linked_design_project_id?: string | null;
+  justification?: string | null;
+  created_at: string;
+};
+type ApprovalEvidence = {
+  id: string;
+  approval_type: string;
+  decision: string;
+  signature_meaning: string;
+  actor_display_name: string;
+  actor_role?: string | null;
+  decided_at: string;
+  superseded_at?: string | null;
+  reason?: string | null;
+};
+type ReleaseState = {
+  designProject?: { project_name?: string | null } | null;
+  release?: {
+    release_status: string;
+    release_revision: string;
+    effective_date?: string | null;
+    release_number: string;
+  } | null;
+};
+type Model = {
+  decision: Decision | null;
+  history: Decision[];
+  approvals: ApprovalEvidence[];
+  approvalHistory: ApprovalEvidence[];
+  release: ReleaseState;
+  readiness: { ready: boolean; blockers: string[] };
+};
+type DesignProject = {
+  id: string;
+  name?: string;
+  projectName?: string;
+  engineeringStatus?: string;
+  status?: string;
+};
+const emptyForm = {
+  responsibilityType: 'CUSTOMER_BUILD_TO_PRINT' as Responsibility,
+  agDesignScope: '',
+  customerDesignScope: '',
+  responsibilityBoundary: '',
+  requirementSource: '',
+  customerDrawingNumber: '',
+  customerDrawingRevision: '',
+  customerSpecifications: '',
+  linkedDesignProjectId: '',
+  justification: '',
+};
+
+async function jsonRequest(url: string, method = 'GET', body?: unknown) {
+  const response = await fetch(url, {
+    method,
+    credentials: 'include',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok)
+    throw new Error(data.message || data.error || 'Request failed');
+  return data;
+}
+
+export default function P2V2DesignApplicability({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(emptyForm);
+  const [actionError, setActionError] = useState('');
+  const queryClient = useQueryClient();
+  const key = [
+    '/api/projects',
+    projectId,
+    'workflow-v2',
+    'design-applicability',
+  ];
+  const { data, isLoading } = useQuery<Model>({
+    queryKey: key,
+    queryFn: () =>
+      jsonRequest(
+        `/api/projects/${projectId}/workflow-v2/design-applicability`
+      ),
+    enabled: open,
+  });
+  const { data: permissions } = useQuery<{ permissions: string[] }>({
+    queryKey: ['/api/permissions/me'],
+    queryFn: () => jsonRequest('/api/permissions/me'),
+  });
+  const { data: designProjects = [] } = useQuery<DesignProject[]>({
+    queryKey: ['/api/rd-projects'],
+    queryFn: () => jsonRequest('/api/rd-projects'),
+    enabled: open,
+  });
+  const permissionSet = useMemo(
+    () => new Set(permissions?.permissions ?? []),
+    [permissions]
+  );
+  const canManage = permissionSet.has('projects.design_applicability.manage');
+  const canEngineering = permissionSet.has(
+    'projects.design_applicability.engineering_decide'
+  );
+  const canQuality = permissionSet.has(
+    'projects.design_applicability.quality_decide'
+  );
+  useEffect(() => {
+    if (!data?.decision) return;
+    const d = data.decision;
+    setForm({
+      responsibilityType: d.responsibility_type,
+      agDesignScope: d.ag_design_scope ?? '',
+      customerDesignScope: d.customer_design_scope ?? '',
+      responsibilityBoundary: d.responsibility_boundary ?? '',
+      requirementSource: d.requirement_source ?? '',
+      customerDrawingNumber: d.customer_drawing_number ?? '',
+      customerDrawingRevision: d.customer_drawing_revision ?? '',
+      customerSpecifications: Array.isArray(d.customer_specifications)
+        ? d.customer_specifications.join(', ')
+        : '',
+      linkedDesignProjectId: d.linked_design_project_id ?? '',
+      justification: d.justification ?? '',
+    });
+  }, [data?.decision]);
+  const payload = () => ({
+    ...form,
+    customerSpecifications: form.customerSpecifications
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+    linkedDesignProjectId: form.linkedDesignProjectId || null,
+  });
+  const mutation = useMutation({
+    mutationFn: ({
+      url,
+      method,
+      body,
+    }: {
+      url: string;
+      method?: string;
+      body?: unknown;
+    }) => jsonRequest(url, method, body),
+    onSuccess: async () => {
+      setActionError('');
+      await queryClient.invalidateQueries({ queryKey: key });
+      await queryClient.invalidateQueries({
+        queryKey: ['/api/projects', projectId, 'workflow-v2'],
+      });
+    },
+    onError: (error: Error) => setActionError(error.message),
+  });
+  const save = () =>
+    mutation.mutate({
+      url: data?.decision
+        ? `/api/projects/${projectId}/workflow-v2/design-applicability/${data.decision.id}`
+        : `/api/projects/${projectId}/workflow-v2/design-applicability`,
+      method: data?.decision ? 'PATCH' : 'POST',
+      body: payload(),
+    });
+  const approve = (
+    capacity: 'engineering' | 'quality',
+    decision: 'APPROVED' | 'REJECTED'
+  ) => {
+    if (!data?.decision) return;
+    const signatureMeaning = window.prompt(
+      'Signature meaning (required):',
+      decision === 'APPROVED'
+        ? `I approve the ${capacity} Design Applicability determination.`
+        : `I return the ${capacity} Design Applicability determination for revision.`
+    );
+    if (!signatureMeaning) return;
+    const reason =
+      window.prompt(
+        decision === 'APPROVED' ? 'Comments (optional):' : 'Reason (required):',
+        ''
+      ) ?? '';
+    if (decision !== 'APPROVED' && !reason.trim()) return;
+    mutation.mutate({
+      url: `/api/projects/${projectId}/workflow-v2/design-applicability/${data.decision.id}/${capacity}-decision`,
+      method: 'POST',
+      body: { decision, signatureMeaning, reason },
+    });
+  };
+  const responsibility = form.responsibilityType;
+  const editable = !data?.decision || data.decision.status === 'DRAFT';
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        data-testid="open-design-applicability"
+      >
+        Open Design Applicability
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="max-h-[90vh] max-w-5xl overflow-y-auto"
+          data-testid="design-applicability-dialog"
+        >
+          <DialogHeader>
+            <DialogTitle>Design Applicability</DialogTitle>
+            <DialogDescription>
+              Controlled determination of customer and AG design responsibility.
+              All other V2 stages remain read-only.
+            </DialogDescription>
+          </DialogHeader>
+          {isLoading ? (
+            <p>Loading Design Applicability…</p>
+          ) : (
+            <div className="space-y-6">
+              {data?.decision && (
+                <div className="flex flex-wrap gap-2">
+                  <Badge>Revision {data.decision.revision_number}</Badge>
+                  <Badge variant="outline">{data.decision.status}</Badge>
+                  <Badge variant="outline">
+                    {data.decision.responsibility_type.replaceAll('_', ' ')}
+                  </Badge>
+                </div>
+              )}
+              {data?.readiness.blockers.length ? (
+                <div className="rounded border border-amber-300 bg-amber-50 p-3">
+                  <p className="font-medium">Readiness blockers</p>
+                  <ul className="list-disc pl-5 text-sm">
+                    {data.readiness.blockers.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : (
+                <div className="rounded border border-green-300 bg-green-50 p-3">
+                  Design Applicability readiness requirements are satisfied.
+                </div>
+              )}
+              <fieldset
+                disabled={!editable || !canManage || mutation.isPending}
+                className="grid gap-4 md:grid-cols-2"
+              >
+                <div className="space-y-2">
+                  <Label>Design responsibility</Label>
+                  <Select
+                    value={responsibility}
+                    onValueChange={(value: Responsibility) =>
+                      setForm({ ...form, responsibilityType: value })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="CUSTOMER_BUILD_TO_PRINT">
+                        Customer build-to-print
+                      </SelectItem>
+                      <SelectItem value="AG_DESIGN_RESPONSIBLE">
+                        AG design responsible
+                      </SelectItem>
+                      <SelectItem value="SHARED_DESIGN_RESPONSIBILITY">
+                        Shared design responsibility
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Requirement source</Label>
+                  <Input
+                    value={form.requirementSource}
+                    onChange={(e) =>
+                      setForm({ ...form, requirementSource: e.target.value })
+                    }
+                  />
+                </div>
+                <div className="space-y-2 md:col-span-2">
+                  <Label>
+                    AG design scope{' '}
+                    {responsibility === 'CUSTOMER_BUILD_TO_PRINT' &&
+                      '(state none or limited)'}
+                  </Label>
+                  <Textarea
+                    value={form.agDesignScope}
+                    onChange={(e) =>
+                      setForm({ ...form, agDesignScope: e.target.value })
+                    }
+                  />
+                </div>
+                {responsibility === 'SHARED_DESIGN_RESPONSIBILITY' && (
+                  <>
+                    <div className="space-y-2 md:col-span-2">
+                      <Label>Customer design scope</Label>
+                      <Textarea
+                        value={form.customerDesignScope}
+                        onChange={(e) =>
+                          setForm({
+                            ...form,
+                            customerDesignScope: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2 md:col-span-2">
+                      <Label>Responsibility boundary</Label>
+                      <Textarea
+                        value={form.responsibilityBoundary}
+                        onChange={(e) =>
+                          setForm({
+                            ...form,
+                            responsibilityBoundary: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                  </>
+                )}
+                {(responsibility !== 'AG_DESIGN_RESPONSIBLE' ||
+                  form.customerDrawingNumber) && (
+                  <>
+                    <div className="space-y-2">
+                      <Label>Customer drawing/specification number</Label>
+                      <Input
+                        value={form.customerDrawingNumber}
+                        onChange={(e) =>
+                          setForm({
+                            ...form,
+                            customerDrawingNumber: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Customer revision</Label>
+                      <Input
+                        value={form.customerDrawingRevision}
+                        onChange={(e) =>
+                          setForm({
+                            ...form,
+                            customerDrawingRevision: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                  </>
+                )}
+                <div className="space-y-2 md:col-span-2">
+                  <Label>Specifications (comma separated)</Label>
+                  <Input
+                    value={form.customerSpecifications}
+                    onChange={(e) =>
+                      setForm({
+                        ...form,
+                        customerSpecifications: e.target.value,
+                      })
+                    }
+                  />
+                </div>
+                {responsibility !== 'CUSTOMER_BUILD_TO_PRINT' && (
+                  <div className="space-y-2 md:col-span-2">
+                    <Label>Linked Design Project</Label>
+                    <Select
+                      value={form.linkedDesignProjectId}
+                      onValueChange={(value) =>
+                        setForm({ ...form, linkedDesignProjectId: value })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select the Design Control project" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {designProjects.map((project) => (
+                          <SelectItem key={project.id} value={project.id}>
+                            {project.projectName || project.name || project.id}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+                <div className="space-y-2 md:col-span-2">
+                  <Label>Justification</Label>
+                  <Textarea
+                    value={form.justification}
+                    onChange={(e) =>
+                      setForm({ ...form, justification: e.target.value })
+                    }
+                  />
+                </div>
+              </fieldset>
+              {actionError && (
+                <p className="text-sm text-red-700">{actionError}</p>
+              )}
+              <div className="flex flex-wrap gap-2">
+                {editable && canManage && (
+                  <Button onClick={save} disabled={mutation.isPending}>
+                    {data?.decision ? 'Save Draft' : 'Create Draft'}
+                  </Button>
+                )}
+                {data?.decision?.status === 'DRAFT' && canManage && (
+                  <Button
+                    variant="secondary"
+                    onClick={() =>
+                      mutation.mutate({
+                        url: `/api/projects/${projectId}/workflow-v2/design-applicability/${data.decision.id}/submit`,
+                        method: 'POST',
+                      })
+                    }
+                  >
+                    Submit for Approval
+                  </Button>
+                )}
+                {['APPROVED', 'REJECTED'].includes(data?.decision?.status) &&
+                  canManage && (
+                    <Button
+                      variant="secondary"
+                      onClick={() =>
+                        mutation.mutate({
+                          url: `/api/projects/${projectId}/workflow-v2/design-applicability/${data!.decision!.id}/revise`,
+                          method: 'POST',
+                          body: payload(),
+                        })
+                      }
+                    >
+                      Create New Revision
+                    </Button>
+                  )}
+                {form.linkedDesignProjectId && (
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      window.location.assign(
+                        `/design/rd-projects?projectId=${encodeURIComponent(form.linkedDesignProjectId)}&tab=engineering-release`
+                      )
+                    }
+                  >
+                    <ExternalLink className="mr-1 h-4 w-4" />
+                    Open Design Project
+                  </Button>
+                )}
+              </div>
+              <section className="space-y-2">
+                <h3 className="font-semibold">Engineering approval</h3>
+                {data?.approvalHistory
+                  .filter(
+                    (a) =>
+                      a.approval_type === 'DESIGN_APPLICABILITY_ENGINEERING'
+                  )
+                  .map((a) => (
+                    <Approval key={a.id} item={a} />
+                  ))}
+                {data?.decision?.status === 'PENDING_APPROVAL' &&
+                  canEngineering && (
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => approve('engineering', 'APPROVED')}
+                      >
+                        Approve
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => approve('engineering', 'REJECTED')}
+                      >
+                        Reject / Return
+                      </Button>
+                    </div>
+                  )}
+              </section>
+              <section className="space-y-2">
+                <h3 className="font-semibold">Quality approval</h3>
+                {data?.approvalHistory
+                  .filter(
+                    (a) => a.approval_type === 'DESIGN_APPLICABILITY_QUALITY'
+                  )
+                  .map((a) => (
+                    <Approval key={a.id} item={a} />
+                  ))}
+                {data?.decision?.status === 'PENDING_APPROVAL' &&
+                  canQuality && (
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => approve('quality', 'APPROVED')}
+                      >
+                        Approve
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => approve('quality', 'REJECTED')}
+                      >
+                        Reject / Return
+                      </Button>
+                    </div>
+                  )}
+              </section>
+              {data?.release.designProject && (
+                <section className="rounded border p-3">
+                  <h3 className="font-semibold">Design Control release</h3>
+                  <p>
+                    {data.release.designProject.project_name} ·{' '}
+                    {data.release.release?.release_status || 'Not released'}
+                  </p>
+                  {data.release.release && (
+                    <p className="text-sm">
+                      Revision {data.release.release.release_revision} ·
+                      Effectivity{' '}
+                      {data.release.release.effective_date ||
+                        data.release.release.release_number}
+                    </p>
+                  )}
+                </section>
+              )}
+              <section>
+                <h3 className="font-semibold">Revision history</h3>
+                <div className="space-y-2">
+                  {data?.history.map((item) => (
+                    <div key={item.id} className="rounded border p-2 text-sm">
+                      Revision {item.revision_number} · {item.status} ·{' '}
+                      {item.responsibility_type.replaceAll('_', ' ')} · created{' '}
+                      {new Date(item.created_at).toLocaleString()}
+                    </div>
+                  ))}
+                </div>
+              </section>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function Approval({ item }: { item: ApprovalEvidence }) {
+  return (
+    <div className="rounded border p-2 text-sm">
+      <div className="flex gap-2">
+        <Badge variant="outline">{item.decision}</Badge>
+        {item.superseded_at && <Badge variant="secondary">Superseded</Badge>}
+      </div>
+      <p>{item.signature_meaning}</p>
+      <p className="text-muted-foreground">
+        {item.actor_display_name} · {item.actor_role || 'Role not recorded'} ·{' '}
+        {new Date(item.decided_at).toLocaleString()}
+      </p>
+      {item.reason && <p>{item.reason}</p>}
+    </div>
+  );
+}

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -10,6 +10,8 @@ import {
   ShieldAlert,
 } from 'lucide-react';
 
+import P2V2DesignApplicability from './P2V2DesignApplicability';
+
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -365,6 +367,11 @@ export default function P2V2ProjectWorkflow({
                 <Eye className="mr-1 h-4 w-4" />
                 Details
               </Button>
+              {stage.stepType === 'design_applicability' && (
+                <div className="mt-3">
+                  <P2V2DesignApplicability projectId={projectId} />
+                </div>
+              )}
             </CardContent>
           </Card>
         ))}

--- a/migrations/0203_project_design_applicability_decisions.sql
+++ b/migrations/0203_project_design_applicability_decisions.sql
@@ -1,0 +1,65 @@
+-- Phase 5: additive, revision-controlled p2_v2 Design Applicability decisions.
+-- No legacy rows are backfilled and no legacy project_steps are modified.
+DO $$ BEGIN
+  ALTER TABLE project_workflow_step_instances
+    ADD CONSTRAINT project_workflow_steps_id_instance_project_unique
+    UNIQUE (id, workflow_instance_id, project_id);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS project_design_applicability_decisions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  workflow_instance_id UUID NOT NULL,
+  workflow_step_instance_id UUID NOT NULL,
+  workflow_step_type TEXT NOT NULL DEFAULT 'design_applicability' CHECK (workflow_step_type = 'design_applicability'),
+  revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+  status TEXT NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT','PENDING_APPROVAL','APPROVED','REJECTED','SUPERSEDED')),
+  responsibility_type TEXT NOT NULL CHECK (responsibility_type IN ('CUSTOMER_BUILD_TO_PRINT','AG_DESIGN_RESPONSIBLE','SHARED_DESIGN_RESPONSIBILITY')),
+  ag_design_scope TEXT,
+  customer_design_scope TEXT,
+  responsibility_boundary TEXT,
+  requirement_source TEXT NOT NULL,
+  customer_drawing_number TEXT,
+  customer_drawing_revision TEXT,
+  customer_specifications JSONB NOT NULL DEFAULT '[]'::jsonb,
+  linked_design_project_id TEXT REFERENCES rd_projects(id) ON DELETE RESTRICT,
+  design_control_required BOOLEAN NOT NULL,
+  justification TEXT NOT NULL,
+  submitted_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  submitted_by_display_name TEXT,
+  submitted_at TIMESTAMP,
+  superseded_at TIMESTAMP,
+  superseded_by_decision_id UUID REFERENCES project_design_applicability_decisions(id) ON DELETE RESTRICT,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_design_applicability_instance_project_fk FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_design_applicability_step_identity_fk FOREIGN KEY (workflow_step_instance_id, workflow_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, workflow_instance_id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_design_applicability_revision_unique UNIQUE (project_id, workflow_instance_id, revision_number)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS project_design_applicability_current_unique
+  ON project_design_applicability_decisions(project_id, workflow_instance_id)
+  WHERE status <> 'SUPERSEDED';
+CREATE INDEX IF NOT EXISTS project_design_applicability_project_idx
+  ON project_design_applicability_decisions(project_id, revision_number DESC);
+
+INSERT INTO perm_capabilities (key, description, category) VALUES
+  ('projects.design_applicability.manage', 'Draft, edit, submit and revise P2 V2 Design Applicability decisions', 'projects'),
+  ('projects.design_applicability.engineering_decide', 'Record the Engineering Design Applicability decision', 'engineering'),
+  ('projects.design_applicability.quality_decide', 'Record the Quality Design Applicability decision', 'quality')
+ON CONFLICT (key) DO UPDATE SET description = EXCLUDED.description, category = EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT pr.id, pc.id
+FROM perm_roles pr
+JOIN perm_capabilities pc ON (
+  (pr.name IN ('ADMIN','OWNER') AND pc.key = 'projects.design_applicability.manage')
+  OR (pr.name IN ('ENGINEERING','ENGINEER','ENGINEERING_MANAGER') AND pc.key IN ('projects.design_applicability.manage','projects.design_applicability.engineering_decide'))
+  OR (pr.name IN ('QUALITY','QC','QUALITY_MANAGER') AND pc.key = 'projects.design_applicability.quality_decide')
+)
+ON CONFLICT (role_id, capability_id) DO NOTHING;

--- a/server/__tests__/projectDesignApplicability.test.ts
+++ b/server/__tests__/projectDesignApplicability.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ProjectDesignApplicabilityError,
+  validateDesignApplicabilityInput,
+} from '../src/services/projectDesignApplicabilityValidation';
+
+const root = resolve(__dirname, '../..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+const migration = read(
+  'migrations/0203_project_design_applicability_decisions.sql'
+);
+const service = read(
+  'server/src/services/projectDesignApplicabilityService.ts'
+);
+const routes = read('server/src/routes/projects.ts');
+
+describe('Phase 5 additive storage', () => {
+  it('retains revision evidence without legacy backfill or destructive cascades', () => {
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS project_design_applicability_decisions'
+    );
+    expect(migration).toContain('project_design_applicability_current_unique');
+    expect(migration).toContain(
+      'UNIQUE (project_id, workflow_instance_id, revision_number)'
+    );
+    expect(migration).toContain("workflow_step_type = 'design_applicability'");
+    expect(migration).toContain(
+      'FOREIGN KEY (workflow_step_instance_id, workflow_instance_id, project_id)'
+    );
+    expect(migration).not.toMatch(/UPDATE\s+(?:projects|project_steps)\b/i);
+    expect(migration).not.toMatch(/ON DELETE CASCADE/i);
+  });
+});
+
+describe('responsibility-specific submission validation', () => {
+  const base = {
+    requirementSource: 'Customer PO',
+    justification: 'Responsibility reviewed',
+  };
+
+  it('requires the controlling drawing, revision, and explicit AG scope for build-to-print', () => {
+    expect(() =>
+      validateDesignApplicabilityInput({
+        ...base,
+        responsibilityType: 'CUSTOMER_BUILD_TO_PRINT',
+      })
+    ).toThrow(ProjectDesignApplicabilityError);
+    expect(() =>
+      validateDesignApplicabilityInput({
+        ...base,
+        responsibilityType: 'CUSTOMER_BUILD_TO_PRINT',
+        customerDrawingNumber: 'DWG-1',
+        customerDrawingRevision: 'C',
+        agDesignScope: 'None',
+      })
+    ).not.toThrow();
+  });
+
+  it('requires a Design Project and AG scope for AG-owned design', () => {
+    expect(() =>
+      validateDesignApplicabilityInput({
+        ...base,
+        responsibilityType: 'AG_DESIGN_RESPONSIBLE',
+        agDesignScope: 'Tooling',
+      })
+    ).toThrow(/linkedDesignProjectId/);
+    expect(() =>
+      validateDesignApplicabilityInput({
+        ...base,
+        responsibilityType: 'AG_DESIGN_RESPONSIBLE',
+        agDesignScope: 'Tooling',
+        linkedDesignProjectId: 'DC-1',
+      })
+    ).not.toThrow();
+  });
+
+  it('requires both scopes, their boundary, and a Design Project for shared design', () => {
+    expect(() =>
+      validateDesignApplicabilityInput({
+        ...base,
+        responsibilityType: 'SHARED_DESIGN_RESPONSIBILITY',
+        agDesignScope: 'Bracket',
+        linkedDesignProjectId: 'DC-1',
+      })
+    ).toThrow(/customerDesignScope, responsibilityBoundary/);
+    expect(() =>
+      validateDesignApplicabilityInput({
+        ...base,
+        responsibilityType: 'SHARED_DESIGN_RESPONSIBILITY',
+        agDesignScope: 'Bracket',
+        customerDesignScope: 'Interface',
+        responsibilityBoundary:
+          'Customer controls interfaces; AG controls bracket',
+        linkedDesignProjectId: 'DC-1',
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('controlled mutation boundaries', () => {
+  it('has scoped actions and no generic stage status endpoint', () => {
+    for (const action of [
+      'design-applicability',
+      '/submit',
+      '/engineering-decision',
+      '/quality-decision',
+      '/revise',
+    ])
+      expect(routes).toContain(action);
+    expect(routes).not.toMatch(/workflow-v2\/[^'"]*stage-status/);
+    expect(service).toContain(
+      "decision.responsibility_type === 'CUSTOMER_BUILD_TO_PRINT'"
+    );
+    expect(service).toContain("status='NOT_APPLICABLE'");
+    expect(service).toContain("status='COMPLETE'");
+    expect(service).toContain('SEGREGATION_OF_DUTIES');
+    expect(service).toContain("release_status = 'RELEASED'");
+    expect(service).toContain('step_order < 4');
+  });
+});

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1641,27 +1641,7 @@ router.get('/:id/workflow-v2', async (req, res) => {
     const instance = await getActiveWorkflowInstanceForProject(project.id);
     if (!instance) return res.json(buildUninitializedP2V2Response(project.id));
     const model = await getWorkflowReadModel(String(instance.id));
-    const response = buildP2V2WorkflowResponse(project.id, model);
-    const design = await getCurrentDesignApplicability(project.id);
-    if (
-      design.decision?.status === 'APPROVED' &&
-      design.decision.responsibility_type !== 'CUSTOMER_BUILD_TO_PRINT' &&
-      !design.release.released
-    ) {
-      response.stages = response.stages.map((stage) =>
-        stage.stepType === 'design_applicability'
-          ? {
-              ...stage,
-              status: 'BLOCKED',
-              blockedReason: design.release.blockers.join(' '),
-            }
-          : stage
-      );
-      response.blockedStages = response.stages.filter(
-        (stage) => stage.status === 'BLOCKED'
-      ).length;
-    }
-    return res.json(response);
+    return res.json(buildP2V2WorkflowResponse(project.id, model));
   } catch (error) {
     if (error instanceof ProjectWorkflowVersionError) return res.status(409).json(error.toJSON());
     console.error('Error fetching P2 V2 workflow:', error);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,4 +1,4 @@
-import { Router, type Response } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { z } from 'zod';
 import { storage } from '../../storage';
 import { db, pool } from '../../db';
@@ -15,6 +15,7 @@ import { validateProjectClosing, deriveClosingStatus } from '../lib/projectClosi
 import {
   getWorkflowVersionForNewProject,
   ProjectWorkflowVersionError,
+  resolveProjectWorkflowVersion,
   serializeProjectWorkflowVersion,
 } from '../services/projectWorkflowVersionService';
 import {
@@ -35,6 +36,18 @@ import { getFileStorageProviderForObjectPath } from '../services/fileStorageProv
 import { buildProjectBomAssemblyTree, type ProjectBomAssemblyRow } from '../services/projectBomAssembly';
 import { getActiveWorkflowInstanceForProject, getWorkflowReadModel } from '../services/projectWorkflowInstanceService';
 import { buildP2V2WorkflowResponse, buildUninitializedP2V2Response } from '../services/projectWorkflowV2ReadModel';
+import { getUserPermissions } from '../services/permissionService';
+import {
+  createDraft as createDesignApplicabilityDraft,
+  getCurrentDesignApplicability,
+  ProjectDesignApplicabilityError,
+  recordEngineeringDecision,
+  recordQualityDecision,
+  reviseDecision as reviseDesignApplicabilityDecision,
+  submitForApproval as submitDesignApplicability,
+  updateDraft as updateDesignApplicabilityDraft,
+  type DesignActor,
+} from '../services/projectDesignApplicabilityService';
 
 // ── Project document upload setup ──────────────────────────────────────────
 const projectDocsDir = path.join(process.cwd(), 'uploads', 'project-documents');
@@ -1514,6 +1527,101 @@ router.patch('/:id/clins/:clinId', async (req, res) => {
     console.error('Update project CLIN error:', error);
     res.status(500).json({ error: 'Failed to update project CLIN' });
   }
+});
+
+const designApplicabilityInputSchema = z.object({
+  responsibilityType: z.enum(['CUSTOMER_BUILD_TO_PRINT', 'AG_DESIGN_RESPONSIBLE', 'SHARED_DESIGN_RESPONSIBILITY']),
+  agDesignScope: z.string().nullable().optional(),
+  customerDesignScope: z.string().nullable().optional(),
+  responsibilityBoundary: z.string().nullable().optional(),
+  requirementSource: z.string(),
+  customerDrawingNumber: z.string().nullable().optional(),
+  customerDrawingRevision: z.string().nullable().optional(),
+  customerSpecifications: z.array(z.unknown()).optional(),
+  linkedDesignProjectId: z.string().nullable().optional(),
+  justification: z.string(),
+});
+const designApprovalSchema = z.object({
+  decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+  signatureMeaning: z.string().min(1),
+  reason: z.string().optional().default(''),
+});
+
+function designActor(req: Request): DesignActor {
+  if (!req.user?.id || !req.user?.username || !req.user?.role) {
+    throw new ProjectDesignApplicabilityError(
+      'ACTOR_REQUIRED',
+      'An authenticated actor identity is required.',
+      401
+    );
+  }
+  return {
+    userId: req.user.id,
+    employeeId: req.user.employeeId ?? null,
+    username: req.user.username,
+    displayName: req.user.username,
+    role: req.user.role,
+  };
+}
+async function requireDesignCapability(req: Request, capability: string) {
+  const actor = designActor(req);
+  const { permissionSet } = await getUserPermissions(actor.userId, actor.role);
+  if (!permissionSet.has(capability)) throw new ProjectDesignApplicabilityError('FORBIDDEN', `The ${capability} capability is required.`, 403);
+  return actor;
+}
+function sendDesignError(res: Response, error: unknown) {
+  if (error instanceof ProjectDesignApplicabilityError) return res.status(error.status).json({ error: error.code, message: error.message, ...error.details });
+  if (error instanceof ProjectWorkflowVersionError) return res.status(409).json(error.toJSON());
+  console.error('P2 V2 Design Applicability error:', error);
+  return res.status(500).json({ error: 'DESIGN_APPLICABILITY_FAILED', message: 'The Design Applicability action failed.' });
+}
+
+router.get('/:id/workflow-v2/design-applicability', async (req, res) => {
+  try {
+    const model = await getCurrentDesignApplicability(req.params.id);
+    res.json(model);
+  } catch (error) { sendDesignError(res, error); }
+});
+router.post('/:id/workflow-v2/design-applicability', async (req, res) => {
+  try {
+    const actor = await requireDesignCapability(req, 'projects.design_applicability.manage');
+    const input = designApplicabilityInputSchema.parse(req.body);
+    res.status(201).json(await createDesignApplicabilityDraft(req.params.id, input, actor));
+  } catch (error) { if (error instanceof z.ZodError) return res.status(400).json({ error: 'INVALID_INPUT', details: error.flatten() }); sendDesignError(res, error); }
+});
+router.patch('/:id/workflow-v2/design-applicability/:decisionId', async (req, res) => {
+  try {
+    const actor = await requireDesignCapability(req, 'projects.design_applicability.manage');
+    const input = designApplicabilityInputSchema.parse(req.body);
+    res.json(await updateDesignApplicabilityDraft(req.params.id, req.params.decisionId, input, actor));
+  } catch (error) { if (error instanceof z.ZodError) return res.status(400).json({ error: 'INVALID_INPUT', details: error.flatten() }); sendDesignError(res, error); }
+});
+router.post('/:id/workflow-v2/design-applicability/:decisionId/submit', async (req, res) => {
+  try {
+    const actor = await requireDesignCapability(req, 'projects.design_applicability.manage');
+    res.json(await submitDesignApplicability(req.params.id, req.params.decisionId, actor));
+  } catch (error) { sendDesignError(res, error); }
+});
+router.post('/:id/workflow-v2/design-applicability/:decisionId/engineering-decision', async (req, res) => {
+  try {
+    const actor = await requireDesignCapability(req, 'projects.design_applicability.engineering_decide');
+    const body = designApprovalSchema.parse(req.body);
+    res.json(await recordEngineeringDecision(req.params.id, req.params.decisionId, body.decision, body.signatureMeaning, body.reason, actor));
+  } catch (error) { if (error instanceof z.ZodError) return res.status(400).json({ error: 'INVALID_INPUT', details: error.flatten() }); sendDesignError(res, error); }
+});
+router.post('/:id/workflow-v2/design-applicability/:decisionId/quality-decision', async (req, res) => {
+  try {
+    const actor = await requireDesignCapability(req, 'projects.design_applicability.quality_decide');
+    const body = designApprovalSchema.parse(req.body);
+    res.json(await recordQualityDecision(req.params.id, req.params.decisionId, body.decision, body.signatureMeaning, body.reason, actor));
+  } catch (error) { if (error instanceof z.ZodError) return res.status(400).json({ error: 'INVALID_INPUT', details: error.flatten() }); sendDesignError(res, error); }
+});
+router.post('/:id/workflow-v2/design-applicability/:decisionId/revise', async (req, res) => {
+  try {
+    const actor = await requireDesignCapability(req, 'projects.design_applicability.manage');
+    const input = designApplicabilityInputSchema.parse(req.body);
+    res.status(201).json(await reviseDesignApplicabilityDecision(req.params.id, req.params.decisionId, input, actor));
+  } catch (error) { if (error instanceof z.ZodError) return res.status(400).json({ error: 'INVALID_INPUT', details: error.flatten() }); sendDesignError(res, error); }
 });
 
 router.get('/:id/workflow-v2', async (req, res) => {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1641,7 +1641,27 @@ router.get('/:id/workflow-v2', async (req, res) => {
     const instance = await getActiveWorkflowInstanceForProject(project.id);
     if (!instance) return res.json(buildUninitializedP2V2Response(project.id));
     const model = await getWorkflowReadModel(String(instance.id));
-    return res.json(buildP2V2WorkflowResponse(project.id, model));
+    const response = buildP2V2WorkflowResponse(project.id, model);
+    const design = await getCurrentDesignApplicability(project.id);
+    if (
+      design.decision?.status === 'APPROVED' &&
+      design.decision.responsibility_type !== 'CUSTOMER_BUILD_TO_PRINT' &&
+      !design.release.released
+    ) {
+      response.stages = response.stages.map((stage) =>
+        stage.stepType === 'design_applicability'
+          ? {
+              ...stage,
+              status: 'BLOCKED',
+              blockedReason: design.release.blockers.join(' '),
+            }
+          : stage
+      );
+      response.blockedStages = response.stages.filter(
+        (stage) => stage.status === 'BLOCKED'
+      ).length;
+    }
+    return res.json(response);
   } catch (error) {
     if (error instanceof ProjectWorkflowVersionError) return res.status(409).json(error.toJSON());
     console.error('Error fetching P2 V2 workflow:', error);

--- a/server/src/services/engineeringReleaseService.ts
+++ b/server/src/services/engineeringReleaseService.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto';
+
 import { and, desc, eq, sql } from 'drizzle-orm';
 
 import { db } from '../../db';
@@ -15,6 +16,7 @@ import {
   engineeringReleaseBaselineItems,
   engineeringReleaseBaselines,
   engineeringReleases,
+  projects,
   rdProjects,
 } from '../../schema';
 import {
@@ -63,8 +65,18 @@ export type EngineeringReleasePreview = {
   finalDesignReviewStatus: string;
   engineeringChangeStatus: string;
   manufacturingEvidenceStatus: string;
-  requiredApprovals: Array<{ role: string; approved: boolean; approvedBy?: string | null; approvedAt?: string | null }>;
-  completedApprovals: Array<{ role: string; approved: boolean; approvedBy?: string | null; approvedAt?: string | null }>;
+  requiredApprovals: Array<{
+    role: string;
+    approved: boolean;
+    approvedBy?: string | null;
+    approvedAt?: string | null;
+  }>;
+  completedApprovals: Array<{
+    role: string;
+    approved: boolean;
+    approvedBy?: string | null;
+    approvedAt?: string | null;
+  }>;
   missingEvidence: string[];
   baselineItems: EngineeringBaselineItemPreview[];
   changedSinceReleaseWarnings: string[];
@@ -141,7 +153,9 @@ function jsonRecord(value: unknown): Record<string, unknown> {
 function canonicalValue(values: unknown, label: string) {
   const record = jsonRecord(values);
   const target = normalizeKey(label);
-  const found = Object.entries(record).find(([key]) => normalizeKey(key) === target);
+  const found = Object.entries(record).find(
+    ([key]) => normalizeKey(key) === target
+  );
   return found?.[1];
 }
 
@@ -162,7 +176,10 @@ function stableStringify(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
   if (value instanceof Date) return JSON.stringify(value.toISOString());
   if (!isRecord(value)) return JSON.stringify(value);
-  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+    .join(',')}}`;
 }
 
 function stableHash(value: unknown) {
@@ -171,39 +188,67 @@ function stableHash(value: unknown) {
 
 function sourceTableFor(source: ManufacturingEvidenceSource) {
   if (source.key === 'released_bom') return 'draft_bom_drafts';
-  if (source.sourceModule.includes('Engineering Controlled Revisions')) return 'engineering_controlled_revisions';
+  if (source.sourceModule.includes('Engineering Controlled Revisions'))
+    return 'engineering_controlled_revisions';
   return null;
 }
 
 function statusIsOpen(status: string | null | undefined) {
   const normalized = normalizeKey(status ?? '');
-  return !['approved', 'closed', 'complete', 'completed', 'accepted', 'released', 'not applicable', 'resolved'].includes(normalized);
+  return ![
+    'approved',
+    'closed',
+    'complete',
+    'completed',
+    'accepted',
+    'released',
+    'not applicable',
+    'resolved',
+  ].includes(normalized);
 }
 
 function severityIsHigh(value: unknown) {
   const normalized = normalizeKey(String(value ?? ''));
-  return normalized.includes('high') || normalized.includes('critical') || normalized.includes('severe');
+  return (
+    normalized.includes('high') ||
+    normalized.includes('critical') ||
+    normalized.includes('severe')
+  );
 }
 
 function riskIsBlocking(risk: typeof designControlRisks.$inferSelect) {
   const formData = jsonRecord(risk.formData);
   const metadata = jsonRecord(risk.metadata);
-  const severity = formData.severity ?? formData.Severity ?? metadata.severity ?? metadata.Severity;
+  const severity =
+    formData.severity ??
+    formData.Severity ??
+    metadata.severity ??
+    metadata.Severity;
   return severityIsHigh(severity) && statusIsOpen(risk.status);
 }
 
 function manufacturingEvidenceScopeErrors(context: ReleaseContext) {
   const errors: string[] = [];
-  if (context.manufacturingEvidence.designControlRecordId !== context.record.id) {
-    errors.push('manufacturing-source evidence belongs to a different Design Control record');
+  if (
+    context.manufacturingEvidence.designControlRecordId !== context.record.id
+  ) {
+    errors.push(
+      'manufacturing-source evidence belongs to a different Design Control record'
+    );
   }
-  if (context.manufacturingEvidence.rdProjectId !== context.record.rdProjectId) {
-    errors.push('manufacturing-source evidence belongs to a different R&D project');
+  if (
+    context.manufacturingEvidence.rdProjectId !== context.record.rdProjectId
+  ) {
+    errors.push(
+      'manufacturing-source evidence belongs to a different R&D project'
+    );
   }
   return errors;
 }
 
-function sourceBaselineItem(source: ManufacturingEvidenceSource): EngineeringBaselineItemPreview {
+function sourceBaselineItem(
+  source: ManufacturingEvidenceSource
+): EngineeringBaselineItemPreview {
   const capturedAt = new Date().toISOString();
   const metadata = {
     key: source.key,
@@ -249,25 +294,44 @@ function collectApprovers(step12: DesignControlStep | undefined) {
   return releaseApprovalLabels.map((label) => ({
     role: label,
     approved: approved(approvals, label),
-    approvedBy: textValue(step12?.metadata, [`${label} by`, 'approvedBy']) ?? null,
+    approvedBy:
+      textValue(step12?.metadata, [`${label} by`, 'approvedBy']) ?? null,
     approvedAt: step12?.approvedAt ? step12.approvedAt.toISOString() : null,
   }));
 }
 
-function proposedRevision(record: DesignControlRecord, step12: DesignControlStep | undefined) {
-  return textValue(step12?.formData, ['Release revision', 'Locked design revision baseline', 'Configuration baseline'])
-    ?? textValue(record.metadata, ['releaseRevision', 'release_revision'])
-    ?? 'A';
+function proposedRevision(
+  record: DesignControlRecord,
+  step12: DesignControlStep | undefined
+) {
+  return (
+    textValue(step12?.formData, [
+      'Release revision',
+      'Locked design revision baseline',
+      'Configuration baseline',
+    ]) ??
+    textValue(record.metadata, ['releaseRevision', 'release_revision']) ??
+    'A'
+  );
 }
 
-function productName(record: DesignControlRecord, rdProject: RdProject | null, step1?: DesignControlStep, step12?: DesignControlStep) {
-  return textValue(step1?.formData, ['Product name'])
-    ?? textValue(step12?.formData, ['Product name'])
-    ?? rdProject?.projectName
-    ?? record.title;
+function productName(
+  record: DesignControlRecord,
+  rdProject: RdProject | null,
+  step1?: DesignControlStep,
+  step12?: DesignControlStep
+) {
+  return (
+    textValue(step1?.formData, ['Product name']) ??
+    textValue(step12?.formData, ['Product name']) ??
+    rdProject?.projectName ??
+    record.title
+  );
 }
 
-function buildBaselineItems(context: ReleaseContext): EngineeringBaselineItemPreview[] {
+function buildBaselineItems(
+  context: ReleaseContext
+): EngineeringBaselineItemPreview[] {
   const stepItems = context.steps.map((step) => {
     const capturedAt = new Date().toISOString();
     const snapshot = {
@@ -297,12 +361,36 @@ function buildBaselineItems(context: ReleaseContext): EngineeringBaselineItemPre
   });
 
   const registerItems = [
-    { category: 'requirements', sourceTable: 'design_control_requirements', records: context.requirements },
-    { category: 'risks', sourceTable: 'design_control_risks', records: context.risks },
-    { category: 'design_reviews', sourceTable: 'design_control_reviews', records: context.reviews },
-    { category: 'verification', sourceTable: 'design_control_verification', records: context.verification },
-    { category: 'validation', sourceTable: 'design_control_validation', records: context.validation },
-    { category: 'engineering_changes', sourceTable: 'design_control_changes', records: context.changes },
+    {
+      category: 'requirements',
+      sourceTable: 'design_control_requirements',
+      records: context.requirements,
+    },
+    {
+      category: 'risks',
+      sourceTable: 'design_control_risks',
+      records: context.risks,
+    },
+    {
+      category: 'design_reviews',
+      sourceTable: 'design_control_reviews',
+      records: context.reviews,
+    },
+    {
+      category: 'verification',
+      sourceTable: 'design_control_verification',
+      records: context.verification,
+    },
+    {
+      category: 'validation',
+      sourceTable: 'design_control_validation',
+      records: context.validation,
+    },
+    {
+      category: 'engineering_changes',
+      sourceTable: 'design_control_changes',
+      records: context.changes,
+    },
   ].map(({ category, sourceTable, records }) => {
     const capturedAt = new Date().toISOString();
     const snapshot = {
@@ -312,7 +400,14 @@ function buildBaselineItems(context: ReleaseContext): EngineeringBaselineItemPre
         title: record.title ?? null,
         status: record.status ?? null,
         updatedAt: record.updatedAt ?? null,
-        key: record.requirementKey ?? record.riskKey ?? record.reviewType ?? record.verificationKey ?? record.validationKey ?? record.changeKey ?? null,
+        key:
+          record.requirementKey ??
+          record.riskKey ??
+          record.reviewType ??
+          record.verificationKey ??
+          record.validationKey ??
+          record.changeKey ??
+          null,
       })),
       capturedAt,
     };
@@ -323,7 +418,9 @@ function buildBaselineItems(context: ReleaseContext): EngineeringBaselineItemPre
       sourceModule: 'Design Control',
       sourceRecordId: context.record.id,
       sourceRevision: null,
-      sourceStatus: records.some((record: any) => statusIsOpen(record.status)) ? 'OPEN' : 'CONTROLLED',
+      sourceStatus: records.some((record: any) => statusIsOpen(record.status))
+        ? 'OPEN'
+        : 'CONTROLLED',
       capturedAt,
       immutableSnapshot: snapshot,
       sourceChecksum: checksum,
@@ -349,7 +446,10 @@ function buildBaselineItems(context: ReleaseContext): EngineeringBaselineItemPre
       sourceModule: 'R&D Project',
       sourceRecordId: context.rdProject?.id ?? context.record.rdProjectId,
       sourceRevision: null,
-      sourceStatus: context.rdProject?.engineeringStatus ?? context.rdProject?.status ?? null,
+      sourceStatus:
+        context.rdProject?.engineeringStatus ??
+        context.rdProject?.status ??
+        null,
       capturedAt: projectCapturedAt,
       immutableSnapshot: projectSnapshot,
       sourceChecksum: projectChecksum,
@@ -366,31 +466,55 @@ function changedWarningsFromRelease(
   release: EngineeringRelease | null,
   currentBaselineItems: EngineeringBaselineItemPreview[]
 ) {
-  const previousItems = Array.isArray(release?.sourceEvidenceSnapshot?.baselineItems)
-    ? release!.sourceEvidenceSnapshot.baselineItems as EngineeringBaselineItemPreview[]
+  const previousItems = Array.isArray(
+    release?.sourceEvidenceSnapshot?.baselineItems
+  )
+    ? (release!.sourceEvidenceSnapshot
+        .baselineItems as EngineeringBaselineItemPreview[])
     : [];
-  const previousByCategory = new Map(previousItems.map((item) => [item.baselineCategory, item]));
+  const previousByCategory = new Map(
+    previousItems.map((item) => [item.baselineCategory, item])
+  );
   return currentBaselineItems.flatMap((item) => {
     const previous = previousByCategory.get(item.baselineCategory);
-    if (!previous) return `${item.baselineCategory}: baseline source record was removed or no longer resolves`;
+    if (!previous)
+      return `${item.baselineCategory}: baseline source record was removed or no longer resolves`;
     if (previous.sourceChecksum === item.sourceChecksum) return [];
-    if (item.baselineCategory === 'released_bom') return 'BOM revision changed since Engineering Release';
-    if (item.baselineCategory === 'released_drawings') return 'Controlled drawing revision changed since Engineering Release';
-    if (item.baselineCategory === 'released_cad') return 'CAD revision changed since Engineering Release';
-    if (item.baselineCategory === 'verification') return 'Verification evidence changed since Engineering Release';
-    if (item.baselineCategory === 'validation') return 'Validation evidence changed since Engineering Release';
-    if (item.baselineCategory === 'design_step_12') return 'Engineering Release approval state changed since release';
-    if (item.baselineCategory === 'engineering_changes') return 'Engineering Change state changed since release';
+    if (item.baselineCategory === 'released_bom')
+      return 'BOM revision changed since Engineering Release';
+    if (item.baselineCategory === 'released_drawings')
+      return 'Controlled drawing revision changed since Engineering Release';
+    if (item.baselineCategory === 'released_cad')
+      return 'CAD revision changed since Engineering Release';
+    if (item.baselineCategory === 'verification')
+      return 'Verification evidence changed since Engineering Release';
+    if (item.baselineCategory === 'validation')
+      return 'Validation evidence changed since Engineering Release';
+    if (item.baselineCategory === 'design_step_12')
+      return 'Engineering Release approval state changed since release';
+    if (item.baselineCategory === 'engineering_changes')
+      return 'Engineering Change state changed since release';
     return `${item.baselineCategory}: Changed since release`;
   });
 }
 
-async function loadContext(recordId: string, client: DbClient = db): Promise<ReleaseContext | null> {
-  const [record] = await client.select().from(designControlRecords).where(eq(designControlRecords.id, recordId)).limit(1);
+async function loadContext(
+  recordId: string,
+  client: DbClient = db
+): Promise<ReleaseContext | null> {
+  const [record] = await client
+    .select()
+    .from(designControlRecords)
+    .where(eq(designControlRecords.id, recordId))
+    .limit(1);
   if (!record) return null;
 
   const [rdProject] = record.rdProjectId
-    ? await client.select().from(rdProjects).where(eq(rdProjects.id, record.rdProjectId)).limit(1)
+    ? await client
+        .select()
+        .from(rdProjects)
+        .where(eq(rdProjects.id, record.rdProjectId))
+        .limit(1)
     : [];
 
   const [
@@ -403,14 +527,38 @@ async function loadContext(recordId: string, client: DbClient = db): Promise<Rel
     changes,
     manufacturingEvidence,
   ] = await Promise.all([
-    client.select().from(designControlSteps).where(eq(designControlSteps.recordId, record.id)),
-    client.select().from(designControlRequirements).where(eq(designControlRequirements.recordId, record.id)),
-    client.select().from(designControlRisks).where(eq(designControlRisks.recordId, record.id)),
-    client.select().from(designControlReviews).where(eq(designControlReviews.recordId, record.id)),
-    client.select().from(designControlVerification).where(eq(designControlVerification.recordId, record.id)),
-    client.select().from(designControlValidation).where(eq(designControlValidation.recordId, record.id)),
-    client.select().from(designControlChanges).where(eq(designControlChanges.recordId, record.id)),
-    getDesignManufacturingEvidence({ rdProjectId: record.rdProjectId, designControlRecordId: record.id }, client),
+    client
+      .select()
+      .from(designControlSteps)
+      .where(eq(designControlSteps.recordId, record.id)),
+    client
+      .select()
+      .from(designControlRequirements)
+      .where(eq(designControlRequirements.recordId, record.id)),
+    client
+      .select()
+      .from(designControlRisks)
+      .where(eq(designControlRisks.recordId, record.id)),
+    client
+      .select()
+      .from(designControlReviews)
+      .where(eq(designControlReviews.recordId, record.id)),
+    client
+      .select()
+      .from(designControlVerification)
+      .where(eq(designControlVerification.recordId, record.id)),
+    client
+      .select()
+      .from(designControlValidation)
+      .where(eq(designControlValidation.recordId, record.id)),
+    client
+      .select()
+      .from(designControlChanges)
+      .where(eq(designControlChanges.recordId, record.id)),
+    getDesignManufacturingEvidence(
+      { rdProjectId: record.rdProjectId, designControlRecordId: record.id },
+      client
+    ),
   ]);
 
   return {
@@ -444,33 +592,56 @@ export function buildEngineeringReleasePreviewFromContext(
 
   const blockingRisks = context.risks.filter(riskIsBlocking);
   if (blockingRisks.length > 0) {
-    missingEvidence.push(`open high risk: ${blockingRisks.map((risk) => risk.title ?? risk.riskKey ?? risk.id).join(', ')}`);
+    missingEvidence.push(
+      `open high risk: ${blockingRisks.map((risk) => risk.title ?? risk.riskKey ?? risk.id).join(', ')}`
+    );
   }
 
-  const openChanges = context.changes.filter((change) => statusIsOpen(change.status));
+  const openChanges = context.changes.filter((change) =>
+    statusIsOpen(change.status)
+  );
   if (openChanges.length > 0) {
-    missingEvidence.push(`engineering changes not dispositioned: ${openChanges.map((change) => change.title ?? change.changeKey ?? change.id).join(', ')}`);
+    missingEvidence.push(
+      `engineering changes not dispositioned: ${openChanges.map((change) => change.title ?? change.changeKey ?? change.id).join(', ')}`
+    );
   }
 
   if (!context.manufacturingEvidence.ready) {
-    missingEvidence.push(...context.manufacturingEvidence.missingItems.map((item) => `manufacturing-source evidence: ${item}`));
+    missingEvidence.push(
+      ...context.manufacturingEvidence.missingItems.map(
+        (item) => `manufacturing-source evidence: ${item}`
+      )
+    );
   }
   missingEvidence.push(...manufacturingEvidenceScopeErrors(context));
 
-  const baselineLocked = context.manufacturingEvidence.sources.some((source) => (
-    source.key === 'design_revision_baseline_locked' && source.ready
-  )) || Boolean(textValue(step12?.formData, ['Locked design revision baseline']));
+  const baselineLocked =
+    context.manufacturingEvidence.sources.some(
+      (source) =>
+        source.key === 'design_revision_baseline_locked' && source.ready
+    ) ||
+    Boolean(textValue(step12?.formData, ['Locked design revision baseline']));
   if (!baselineLocked) {
     missingEvidence.push('locked configuration baseline');
   }
 
   const approvers = collectApprovers(step12);
-  missingEvidence.push(...approvers.filter((approval) => !approval.approved).map((approval) => approval.role));
+  missingEvidence.push(
+    ...approvers
+      .filter((approval) => !approval.approved)
+      .map((approval) => approval.role)
+  );
 
   const baselineItems = buildBaselineItems(context);
-  const releasedBom = context.manufacturingEvidence.sources.find((source) => source.key === 'released_bom');
-  const drawings = context.manufacturingEvidence.sources.filter((source) => source.key === 'released_drawings' && source.revision);
-  const cad = context.manufacturingEvidence.sources.find((source) => source.key === 'released_cad');
+  const releasedBom = context.manufacturingEvidence.sources.find(
+    (source) => source.key === 'released_bom'
+  );
+  const drawings = context.manufacturingEvidence.sources.filter(
+    (source) => source.key === 'released_drawings' && source.revision
+  );
+  const cad = context.manufacturingEvidence.sources.find(
+    (source) => source.key === 'released_cad'
+  );
   const proposedReleaseRevision = proposedRevision(context.record, step12);
   const proposedReleaseNumber = `ER-${context.record.rdProjectId ?? context.record.id}-${proposedReleaseRevision}`;
   const history = releaseHistory.map((release) => ({
@@ -487,7 +658,12 @@ export function buildEngineeringReleasePreviewFromContext(
     rdProjectId: context.record.rdProjectId,
     rdProjectName: context.rdProject?.projectName ?? null,
     designControlRecordId: context.record.id,
-    productName: productName(context.record, context.rdProject, byStep.get('1'), step12),
+    productName: productName(
+      context.record,
+      context.rdProject,
+      byStep.get('1'),
+      step12
+    ),
     proposedReleaseNumber,
     proposedReleaseRevision,
     effectiveDate: new Date().toISOString().slice(0, 10),
@@ -497,66 +673,105 @@ export function buildEngineeringReleasePreviewFromContext(
       status: byStep.get(stepKey)?.status ?? 'missing',
     })),
     requirementsSummary: `${context.requirements.length} persisted requirement record(s); step 3 is ${byStep.get('3')?.status ?? 'missing'}.`,
-    riskSummary: blockingRisks.length > 0 ? `${blockingRisks.length} open high risk item(s)` : 'No open high risk items detected.',
-    prototypeIdentifier: textValue(byStep.get('8')?.formData, ['Prototype serial number', 'Prototype identifier']),
+    riskSummary:
+      blockingRisks.length > 0
+        ? `${blockingRisks.length} open high risk item(s)`
+        : 'No open high risk items detected.',
+    prototypeIdentifier: textValue(byStep.get('8')?.formData, [
+      'Prototype serial number',
+      'Prototype identifier',
+    ]),
     bomRevision: releasedBom?.revision ?? null,
-    drawingRevisions: drawings.map((source) => source.revision!).filter(Boolean),
+    drawingRevisions: drawings
+      .map((source) => source.revision!)
+      .filter(Boolean),
     cadRevision: cad?.revision ?? null,
     verificationStatus: byStep.get('9')?.status ?? 'missing',
     validationStatus: byStep.get('10')?.status ?? 'missing',
     finalDesignReviewStatus: byStep.get('11')?.status ?? 'missing',
-    engineeringChangeStatus: openChanges.length > 0 ? 'open_changes' : 'dispositioned',
+    engineeringChangeStatus:
+      openChanges.length > 0 ? 'open_changes' : 'dispositioned',
     manufacturingEvidenceStatus: context.manufacturingEvidence.overallStatus,
     requiredApprovals: approvers,
     completedApprovals: approvers.filter((approval) => approval.approved),
     missingEvidence,
     baselineItems,
-    changedSinceReleaseWarnings: changedWarningsFromRelease(existingRelease, baselineItems),
+    changedSinceReleaseWarnings: changedWarningsFromRelease(
+      existingRelease,
+      baselineItems
+    ),
     releaseHistory: history,
     existingRelease: existingRelease
       ? {
-        id: existingRelease.id,
-        releaseNumber: existingRelease.releaseNumber,
-        releaseRevision: existingRelease.releaseRevision,
-        releaseStatus: existingRelease.releaseStatus,
-        releasedBy: existingRelease.releasedBy,
-        releasedAt: existingRelease.releasedAt ? existingRelease.releasedAt.toISOString() : null,
-      }
+          id: existingRelease.id,
+          releaseNumber: existingRelease.releaseNumber,
+          releaseRevision: existingRelease.releaseRevision,
+          releaseStatus: existingRelease.releaseStatus,
+          releasedBy: existingRelease.releasedBy,
+          releasedAt: existingRelease.releasedAt
+            ? existingRelease.releasedAt.toISOString()
+            : null,
+        }
       : null,
   };
 }
 
-export async function getEngineeringReleasePreview(recordId: string, client: DbClient = db) {
+export async function getEngineeringReleasePreview(
+  recordId: string,
+  client: DbClient = db
+) {
   const context = await loadContext(recordId, client);
   if (!context) return null;
-  const releaseRevision = proposedRevision(context.record, context.steps.find((step) => step.stepKey === '12'));
+  const releaseRevision = proposedRevision(
+    context.record,
+    context.steps.find((step) => step.stepKey === '12')
+  );
   const releaseHistory = context.record.rdProjectId
     ? await client
-      .select()
-      .from(engineeringReleases)
-      .where(and(
-        eq(engineeringReleases.rdProjectId, context.record.rdProjectId),
-        eq(engineeringReleases.designControlRecordId, context.record.id)
-      ))
-      .orderBy(desc(engineeringReleases.releasedAt), desc(engineeringReleases.createdAt))
+        .select()
+        .from(engineeringReleases)
+        .where(
+          and(
+            eq(engineeringReleases.rdProjectId, context.record.rdProjectId),
+            eq(engineeringReleases.designControlRecordId, context.record.id)
+          )
+        )
+        .orderBy(
+          desc(engineeringReleases.releasedAt),
+          desc(engineeringReleases.createdAt)
+        )
     : [];
-  const existingRelease = releaseHistory.find((release) => release.releaseRevision === releaseRevision) ?? null;
-  return buildEngineeringReleasePreviewFromContext(context, existingRelease, releaseHistory);
+  const existingRelease =
+    releaseHistory.find(
+      (release) => release.releaseRevision === releaseRevision
+    ) ?? null;
+  return buildEngineeringReleasePreviewFromContext(
+    context,
+    existingRelease,
+    releaseHistory
+  );
 }
 
-export async function submitEngineeringRelease(input: {
-  recordId: string;
-  actor: string;
-  effectiveDate?: string | null;
-}, client: DbClient = db) {
+export async function submitEngineeringRelease(
+  input: {
+    recordId: string;
+    actor: string;
+    effectiveDate?: string | null;
+  },
+  client: DbClient = db
+) {
   return client.transaction(async (tx) => {
-    await tx.execute(sql`SELECT id FROM design_control_records WHERE id = ${input.recordId} FOR UPDATE`);
+    await tx.execute(
+      sql`SELECT id FROM design_control_records WHERE id = ${input.recordId} FOR UPDATE`
+    );
     const context = await loadContext(input.recordId, tx as DbClient);
     if (!context) return { status: 'not_found' as const };
     if (!context.record.rdProjectId) {
       return {
         status: 'blocked' as const,
-        missingEvidence: ['Design Control record is not linked to an R&D project'],
+        missingEvidence: [
+          'Design Control record is not linked to an R&D project',
+        ],
       };
     }
 
@@ -564,18 +779,27 @@ export async function submitEngineeringRelease(input: {
     const [existingRelease] = await tx
       .select()
       .from(engineeringReleases)
-      .where(and(
-        eq(engineeringReleases.rdProjectId, context.record.rdProjectId),
-        eq(engineeringReleases.designControlRecordId, context.record.id),
-        eq(engineeringReleases.releaseRevision, preview.proposedReleaseRevision)
-      ))
+      .where(
+        and(
+          eq(engineeringReleases.rdProjectId, context.record.rdProjectId),
+          eq(engineeringReleases.designControlRecordId, context.record.id),
+          eq(
+            engineeringReleases.releaseRevision,
+            preview.proposedReleaseRevision
+          )
+        )
+      )
       .limit(1);
 
     if (existingRelease) {
       return {
         status: 'existing' as const,
         release: existingRelease,
-        preview: buildEngineeringReleasePreviewFromContext(context, existingRelease, [existingRelease]),
+        preview: buildEngineeringReleasePreviewFromContext(
+          context,
+          existingRelease,
+          [existingRelease]
+        ),
       };
     }
 
@@ -588,42 +812,50 @@ export async function submitEngineeringRelease(input: {
     }
 
     const now = new Date();
-    const effectiveDate = input.effectiveDate ? new Date(input.effectiveDate) : now;
-    const [release] = await tx.insert(engineeringReleases).values({
-      rdProjectId: context.record.rdProjectId,
-      designControlRecordId: context.record.id,
-      releaseNumber: preview.proposedReleaseNumber,
-      releaseRevision: preview.proposedReleaseRevision,
-      releaseStatus: 'RELEASED',
-      productName: preview.productName,
-      effectiveDate,
-      releasedBy: input.actor,
-      releasedAt: now,
-      readinessSnapshot: preview as unknown as Record<string, unknown>,
-      sourceEvidenceSnapshot: {
-        manufacturingEvidence: context.manufacturingEvidence,
-        baselineItems: preview.baselineItems,
-      },
-      approvalSnapshot: { approvers: preview.requiredApprovals },
-      metadata: {
-        source: 'engineering-release-gate',
-        nextAction: 'Create Manufactured Inventory Item',
-      },
-    }).returning();
+    const effectiveDate = input.effectiveDate
+      ? new Date(input.effectiveDate)
+      : now;
+    const [release] = await tx
+      .insert(engineeringReleases)
+      .values({
+        rdProjectId: context.record.rdProjectId,
+        designControlRecordId: context.record.id,
+        releaseNumber: preview.proposedReleaseNumber,
+        releaseRevision: preview.proposedReleaseRevision,
+        releaseStatus: 'RELEASED',
+        productName: preview.productName,
+        effectiveDate,
+        releasedBy: input.actor,
+        releasedAt: now,
+        readinessSnapshot: preview as unknown as Record<string, unknown>,
+        sourceEvidenceSnapshot: {
+          manufacturingEvidence: context.manufacturingEvidence,
+          baselineItems: preview.baselineItems,
+        },
+        approvalSnapshot: { approvers: preview.requiredApprovals },
+        metadata: {
+          source: 'engineering-release-gate',
+          nextAction: 'Create Manufactured Inventory Item',
+        },
+      })
+      .returning();
 
-    const [baseline] = await tx.insert(engineeringReleaseBaselines).values({
-      engineeringReleaseId: release.id,
-      rdProjectId: context.record.rdProjectId,
-      designControlRecordId: context.record.id,
-      baselineStatus: 'LOCKED',
-      baselineRevision: preview.proposedReleaseRevision,
-      lockedAt: now,
-      lockedBy: input.actor,
-      metadata: {
-        releaseNumber: release.releaseNumber,
-        immutable: true,
-      },
-    }).returning();
+    const [baseline] = await tx
+      .insert(engineeringReleaseBaselines)
+      .values({
+        engineeringReleaseId: release.id,
+        rdProjectId: context.record.rdProjectId,
+        designControlRecordId: context.record.id,
+        baselineStatus: 'LOCKED',
+        baselineRevision: preview.proposedReleaseRevision,
+        lockedAt: now,
+        lockedBy: input.actor,
+        metadata: {
+          releaseNumber: release.releaseNumber,
+          immutable: true,
+        },
+      })
+      .returning();
 
     for (const item of preview.baselineItems) {
       await tx.insert(engineeringReleaseBaselineItems).values({
@@ -644,20 +876,28 @@ export async function submitEngineeringRelease(input: {
     }
 
     for (const approval of preview.requiredApprovals) {
-      await tx.insert(engineeringReleaseApprovals).values({
-        engineeringReleaseId: release.id,
-        approvalRole: approval.role,
-        approvedBy: approval.approvedBy ?? input.actor,
-        approvedAt: approval.approvedAt ? new Date(approval.approvedAt) : now,
-        approvalStatus: 'APPROVED',
-        metadata: approval,
-      }).onConflictDoNothing();
+      await tx
+        .insert(engineeringReleaseApprovals)
+        .values({
+          engineeringReleaseId: release.id,
+          approvalRole: approval.role,
+          approvedBy: approval.approvedBy ?? input.actor,
+          approvedAt: approval.approvedAt ? new Date(approval.approvedAt) : now,
+          approvalStatus: 'APPROVED',
+          metadata: approval,
+        })
+        .onConflictDoNothing();
     }
 
     await tx
       .update(designControlSteps)
       .set({ status: 'approved', approvedAt: now, updatedAt: now })
-      .where(and(eq(designControlSteps.recordId, context.record.id), eq(designControlSteps.stepKey, '12')));
+      .where(
+        and(
+          eq(designControlSteps.recordId, context.record.id),
+          eq(designControlSteps.stepKey, '12')
+        )
+      );
 
     await tx
       .update(designControlRecords)
@@ -666,8 +906,25 @@ export async function submitEngineeringRelease(input: {
 
     await tx
       .update(rdProjects)
-      .set({ status: 'released', engineeringStatus: 'RELEASED', updatedAt: now })
+      .set({
+        status: 'released',
+        engineeringStatus: 'RELEASED',
+        updatedAt: now,
+      })
       .where(eq(rdProjects.id, context.record.rdProjectId));
+
+    if (context.record.projectId) {
+      const [linkedProject] = await tx
+        .select({ workflowVersion: projects.workflowVersion })
+        .from(projects)
+        .where(eq(projects.id, context.record.projectId))
+        .limit(1);
+      if (linkedProject?.workflowVersion === 'p2_v2') {
+        const { synchronizeDesignStageStatus } =
+          await import('./projectDesignApplicabilityService');
+        await synchronizeDesignStageStatus(context.record.projectId, tx);
+      }
+    }
 
     return {
       status: 'created' as const,
@@ -681,10 +938,16 @@ export async function submitEngineeringRelease(input: {
   });
 }
 
-export async function listEngineeringReleasesForRdProject(rdProjectId: string, client: DbClient = db) {
+export async function listEngineeringReleasesForRdProject(
+  rdProjectId: string,
+  client: DbClient = db
+) {
   return client
     .select()
     .from(engineeringReleases)
     .where(eq(engineeringReleases.rdProjectId, rdProjectId))
-    .orderBy(desc(engineeringReleases.releasedAt), desc(engineeringReleases.createdAt));
+    .orderBy(
+      desc(engineeringReleases.releasedAt),
+      desc(engineeringReleases.createdAt)
+    );
 }

--- a/server/src/services/engineeringReleaseService.ts
+++ b/server/src/services/engineeringReleaseService.ts
@@ -15,6 +15,7 @@ import {
   engineeringReleaseBaselineItems,
   engineeringReleaseBaselines,
   engineeringReleases,
+  projects,
   rdProjects,
 } from '../../schema';
 import {
@@ -668,6 +669,20 @@ export async function submitEngineeringRelease(input: {
       .update(rdProjects)
       .set({ status: 'released', engineeringStatus: 'RELEASED', updatedAt: now })
       .where(eq(rdProjects.id, context.record.rdProjectId));
+
+    if (context.record.projectId) {
+      const [linkedProject] = await tx
+        .select({ workflowVersion: projects.workflowVersion })
+        .from(projects)
+        .where(eq(projects.id, context.record.projectId))
+        .limit(1);
+      if (linkedProject?.workflowVersion === 'p2_v2') {
+        const { synchronizeDesignStageStatus } = await import(
+          './projectDesignApplicabilityService'
+        );
+        await synchronizeDesignStageStatus(context.record.projectId, tx);
+      }
+    }
 
     return {
       status: 'created' as const,

--- a/server/src/services/engineeringReleaseService.ts
+++ b/server/src/services/engineeringReleaseService.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'crypto';
-
 import { and, desc, eq, sql } from 'drizzle-orm';
 
 import { db } from '../../db';
@@ -16,7 +15,6 @@ import {
   engineeringReleaseBaselineItems,
   engineeringReleaseBaselines,
   engineeringReleases,
-  projects,
   rdProjects,
 } from '../../schema';
 import {
@@ -65,18 +63,8 @@ export type EngineeringReleasePreview = {
   finalDesignReviewStatus: string;
   engineeringChangeStatus: string;
   manufacturingEvidenceStatus: string;
-  requiredApprovals: Array<{
-    role: string;
-    approved: boolean;
-    approvedBy?: string | null;
-    approvedAt?: string | null;
-  }>;
-  completedApprovals: Array<{
-    role: string;
-    approved: boolean;
-    approvedBy?: string | null;
-    approvedAt?: string | null;
-  }>;
+  requiredApprovals: Array<{ role: string; approved: boolean; approvedBy?: string | null; approvedAt?: string | null }>;
+  completedApprovals: Array<{ role: string; approved: boolean; approvedBy?: string | null; approvedAt?: string | null }>;
   missingEvidence: string[];
   baselineItems: EngineeringBaselineItemPreview[];
   changedSinceReleaseWarnings: string[];
@@ -153,9 +141,7 @@ function jsonRecord(value: unknown): Record<string, unknown> {
 function canonicalValue(values: unknown, label: string) {
   const record = jsonRecord(values);
   const target = normalizeKey(label);
-  const found = Object.entries(record).find(
-    ([key]) => normalizeKey(key) === target
-  );
+  const found = Object.entries(record).find(([key]) => normalizeKey(key) === target);
   return found?.[1];
 }
 
@@ -176,10 +162,7 @@ function stableStringify(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
   if (value instanceof Date) return JSON.stringify(value.toISOString());
   if (!isRecord(value)) return JSON.stringify(value);
-  return `{${Object.keys(value)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
-    .join(',')}}`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
 }
 
 function stableHash(value: unknown) {
@@ -188,67 +171,39 @@ function stableHash(value: unknown) {
 
 function sourceTableFor(source: ManufacturingEvidenceSource) {
   if (source.key === 'released_bom') return 'draft_bom_drafts';
-  if (source.sourceModule.includes('Engineering Controlled Revisions'))
-    return 'engineering_controlled_revisions';
+  if (source.sourceModule.includes('Engineering Controlled Revisions')) return 'engineering_controlled_revisions';
   return null;
 }
 
 function statusIsOpen(status: string | null | undefined) {
   const normalized = normalizeKey(status ?? '');
-  return ![
-    'approved',
-    'closed',
-    'complete',
-    'completed',
-    'accepted',
-    'released',
-    'not applicable',
-    'resolved',
-  ].includes(normalized);
+  return !['approved', 'closed', 'complete', 'completed', 'accepted', 'released', 'not applicable', 'resolved'].includes(normalized);
 }
 
 function severityIsHigh(value: unknown) {
   const normalized = normalizeKey(String(value ?? ''));
-  return (
-    normalized.includes('high') ||
-    normalized.includes('critical') ||
-    normalized.includes('severe')
-  );
+  return normalized.includes('high') || normalized.includes('critical') || normalized.includes('severe');
 }
 
 function riskIsBlocking(risk: typeof designControlRisks.$inferSelect) {
   const formData = jsonRecord(risk.formData);
   const metadata = jsonRecord(risk.metadata);
-  const severity =
-    formData.severity ??
-    formData.Severity ??
-    metadata.severity ??
-    metadata.Severity;
+  const severity = formData.severity ?? formData.Severity ?? metadata.severity ?? metadata.Severity;
   return severityIsHigh(severity) && statusIsOpen(risk.status);
 }
 
 function manufacturingEvidenceScopeErrors(context: ReleaseContext) {
   const errors: string[] = [];
-  if (
-    context.manufacturingEvidence.designControlRecordId !== context.record.id
-  ) {
-    errors.push(
-      'manufacturing-source evidence belongs to a different Design Control record'
-    );
+  if (context.manufacturingEvidence.designControlRecordId !== context.record.id) {
+    errors.push('manufacturing-source evidence belongs to a different Design Control record');
   }
-  if (
-    context.manufacturingEvidence.rdProjectId !== context.record.rdProjectId
-  ) {
-    errors.push(
-      'manufacturing-source evidence belongs to a different R&D project'
-    );
+  if (context.manufacturingEvidence.rdProjectId !== context.record.rdProjectId) {
+    errors.push('manufacturing-source evidence belongs to a different R&D project');
   }
   return errors;
 }
 
-function sourceBaselineItem(
-  source: ManufacturingEvidenceSource
-): EngineeringBaselineItemPreview {
+function sourceBaselineItem(source: ManufacturingEvidenceSource): EngineeringBaselineItemPreview {
   const capturedAt = new Date().toISOString();
   const metadata = {
     key: source.key,
@@ -294,44 +249,25 @@ function collectApprovers(step12: DesignControlStep | undefined) {
   return releaseApprovalLabels.map((label) => ({
     role: label,
     approved: approved(approvals, label),
-    approvedBy:
-      textValue(step12?.metadata, [`${label} by`, 'approvedBy']) ?? null,
+    approvedBy: textValue(step12?.metadata, [`${label} by`, 'approvedBy']) ?? null,
     approvedAt: step12?.approvedAt ? step12.approvedAt.toISOString() : null,
   }));
 }
 
-function proposedRevision(
-  record: DesignControlRecord,
-  step12: DesignControlStep | undefined
-) {
-  return (
-    textValue(step12?.formData, [
-      'Release revision',
-      'Locked design revision baseline',
-      'Configuration baseline',
-    ]) ??
-    textValue(record.metadata, ['releaseRevision', 'release_revision']) ??
-    'A'
-  );
+function proposedRevision(record: DesignControlRecord, step12: DesignControlStep | undefined) {
+  return textValue(step12?.formData, ['Release revision', 'Locked design revision baseline', 'Configuration baseline'])
+    ?? textValue(record.metadata, ['releaseRevision', 'release_revision'])
+    ?? 'A';
 }
 
-function productName(
-  record: DesignControlRecord,
-  rdProject: RdProject | null,
-  step1?: DesignControlStep,
-  step12?: DesignControlStep
-) {
-  return (
-    textValue(step1?.formData, ['Product name']) ??
-    textValue(step12?.formData, ['Product name']) ??
-    rdProject?.projectName ??
-    record.title
-  );
+function productName(record: DesignControlRecord, rdProject: RdProject | null, step1?: DesignControlStep, step12?: DesignControlStep) {
+  return textValue(step1?.formData, ['Product name'])
+    ?? textValue(step12?.formData, ['Product name'])
+    ?? rdProject?.projectName
+    ?? record.title;
 }
 
-function buildBaselineItems(
-  context: ReleaseContext
-): EngineeringBaselineItemPreview[] {
+function buildBaselineItems(context: ReleaseContext): EngineeringBaselineItemPreview[] {
   const stepItems = context.steps.map((step) => {
     const capturedAt = new Date().toISOString();
     const snapshot = {
@@ -361,36 +297,12 @@ function buildBaselineItems(
   });
 
   const registerItems = [
-    {
-      category: 'requirements',
-      sourceTable: 'design_control_requirements',
-      records: context.requirements,
-    },
-    {
-      category: 'risks',
-      sourceTable: 'design_control_risks',
-      records: context.risks,
-    },
-    {
-      category: 'design_reviews',
-      sourceTable: 'design_control_reviews',
-      records: context.reviews,
-    },
-    {
-      category: 'verification',
-      sourceTable: 'design_control_verification',
-      records: context.verification,
-    },
-    {
-      category: 'validation',
-      sourceTable: 'design_control_validation',
-      records: context.validation,
-    },
-    {
-      category: 'engineering_changes',
-      sourceTable: 'design_control_changes',
-      records: context.changes,
-    },
+    { category: 'requirements', sourceTable: 'design_control_requirements', records: context.requirements },
+    { category: 'risks', sourceTable: 'design_control_risks', records: context.risks },
+    { category: 'design_reviews', sourceTable: 'design_control_reviews', records: context.reviews },
+    { category: 'verification', sourceTable: 'design_control_verification', records: context.verification },
+    { category: 'validation', sourceTable: 'design_control_validation', records: context.validation },
+    { category: 'engineering_changes', sourceTable: 'design_control_changes', records: context.changes },
   ].map(({ category, sourceTable, records }) => {
     const capturedAt = new Date().toISOString();
     const snapshot = {
@@ -400,14 +312,7 @@ function buildBaselineItems(
         title: record.title ?? null,
         status: record.status ?? null,
         updatedAt: record.updatedAt ?? null,
-        key:
-          record.requirementKey ??
-          record.riskKey ??
-          record.reviewType ??
-          record.verificationKey ??
-          record.validationKey ??
-          record.changeKey ??
-          null,
+        key: record.requirementKey ?? record.riskKey ?? record.reviewType ?? record.verificationKey ?? record.validationKey ?? record.changeKey ?? null,
       })),
       capturedAt,
     };
@@ -418,9 +323,7 @@ function buildBaselineItems(
       sourceModule: 'Design Control',
       sourceRecordId: context.record.id,
       sourceRevision: null,
-      sourceStatus: records.some((record: any) => statusIsOpen(record.status))
-        ? 'OPEN'
-        : 'CONTROLLED',
+      sourceStatus: records.some((record: any) => statusIsOpen(record.status)) ? 'OPEN' : 'CONTROLLED',
       capturedAt,
       immutableSnapshot: snapshot,
       sourceChecksum: checksum,
@@ -446,10 +349,7 @@ function buildBaselineItems(
       sourceModule: 'R&D Project',
       sourceRecordId: context.rdProject?.id ?? context.record.rdProjectId,
       sourceRevision: null,
-      sourceStatus:
-        context.rdProject?.engineeringStatus ??
-        context.rdProject?.status ??
-        null,
+      sourceStatus: context.rdProject?.engineeringStatus ?? context.rdProject?.status ?? null,
       capturedAt: projectCapturedAt,
       immutableSnapshot: projectSnapshot,
       sourceChecksum: projectChecksum,
@@ -466,55 +366,31 @@ function changedWarningsFromRelease(
   release: EngineeringRelease | null,
   currentBaselineItems: EngineeringBaselineItemPreview[]
 ) {
-  const previousItems = Array.isArray(
-    release?.sourceEvidenceSnapshot?.baselineItems
-  )
-    ? (release!.sourceEvidenceSnapshot
-        .baselineItems as EngineeringBaselineItemPreview[])
+  const previousItems = Array.isArray(release?.sourceEvidenceSnapshot?.baselineItems)
+    ? release!.sourceEvidenceSnapshot.baselineItems as EngineeringBaselineItemPreview[]
     : [];
-  const previousByCategory = new Map(
-    previousItems.map((item) => [item.baselineCategory, item])
-  );
+  const previousByCategory = new Map(previousItems.map((item) => [item.baselineCategory, item]));
   return currentBaselineItems.flatMap((item) => {
     const previous = previousByCategory.get(item.baselineCategory);
-    if (!previous)
-      return `${item.baselineCategory}: baseline source record was removed or no longer resolves`;
+    if (!previous) return `${item.baselineCategory}: baseline source record was removed or no longer resolves`;
     if (previous.sourceChecksum === item.sourceChecksum) return [];
-    if (item.baselineCategory === 'released_bom')
-      return 'BOM revision changed since Engineering Release';
-    if (item.baselineCategory === 'released_drawings')
-      return 'Controlled drawing revision changed since Engineering Release';
-    if (item.baselineCategory === 'released_cad')
-      return 'CAD revision changed since Engineering Release';
-    if (item.baselineCategory === 'verification')
-      return 'Verification evidence changed since Engineering Release';
-    if (item.baselineCategory === 'validation')
-      return 'Validation evidence changed since Engineering Release';
-    if (item.baselineCategory === 'design_step_12')
-      return 'Engineering Release approval state changed since release';
-    if (item.baselineCategory === 'engineering_changes')
-      return 'Engineering Change state changed since release';
+    if (item.baselineCategory === 'released_bom') return 'BOM revision changed since Engineering Release';
+    if (item.baselineCategory === 'released_drawings') return 'Controlled drawing revision changed since Engineering Release';
+    if (item.baselineCategory === 'released_cad') return 'CAD revision changed since Engineering Release';
+    if (item.baselineCategory === 'verification') return 'Verification evidence changed since Engineering Release';
+    if (item.baselineCategory === 'validation') return 'Validation evidence changed since Engineering Release';
+    if (item.baselineCategory === 'design_step_12') return 'Engineering Release approval state changed since release';
+    if (item.baselineCategory === 'engineering_changes') return 'Engineering Change state changed since release';
     return `${item.baselineCategory}: Changed since release`;
   });
 }
 
-async function loadContext(
-  recordId: string,
-  client: DbClient = db
-): Promise<ReleaseContext | null> {
-  const [record] = await client
-    .select()
-    .from(designControlRecords)
-    .where(eq(designControlRecords.id, recordId))
-    .limit(1);
+async function loadContext(recordId: string, client: DbClient = db): Promise<ReleaseContext | null> {
+  const [record] = await client.select().from(designControlRecords).where(eq(designControlRecords.id, recordId)).limit(1);
   if (!record) return null;
 
   const [rdProject] = record.rdProjectId
-    ? await client
-        .select()
-        .from(rdProjects)
-        .where(eq(rdProjects.id, record.rdProjectId))
-        .limit(1)
+    ? await client.select().from(rdProjects).where(eq(rdProjects.id, record.rdProjectId)).limit(1)
     : [];
 
   const [
@@ -527,38 +403,14 @@ async function loadContext(
     changes,
     manufacturingEvidence,
   ] = await Promise.all([
-    client
-      .select()
-      .from(designControlSteps)
-      .where(eq(designControlSteps.recordId, record.id)),
-    client
-      .select()
-      .from(designControlRequirements)
-      .where(eq(designControlRequirements.recordId, record.id)),
-    client
-      .select()
-      .from(designControlRisks)
-      .where(eq(designControlRisks.recordId, record.id)),
-    client
-      .select()
-      .from(designControlReviews)
-      .where(eq(designControlReviews.recordId, record.id)),
-    client
-      .select()
-      .from(designControlVerification)
-      .where(eq(designControlVerification.recordId, record.id)),
-    client
-      .select()
-      .from(designControlValidation)
-      .where(eq(designControlValidation.recordId, record.id)),
-    client
-      .select()
-      .from(designControlChanges)
-      .where(eq(designControlChanges.recordId, record.id)),
-    getDesignManufacturingEvidence(
-      { rdProjectId: record.rdProjectId, designControlRecordId: record.id },
-      client
-    ),
+    client.select().from(designControlSteps).where(eq(designControlSteps.recordId, record.id)),
+    client.select().from(designControlRequirements).where(eq(designControlRequirements.recordId, record.id)),
+    client.select().from(designControlRisks).where(eq(designControlRisks.recordId, record.id)),
+    client.select().from(designControlReviews).where(eq(designControlReviews.recordId, record.id)),
+    client.select().from(designControlVerification).where(eq(designControlVerification.recordId, record.id)),
+    client.select().from(designControlValidation).where(eq(designControlValidation.recordId, record.id)),
+    client.select().from(designControlChanges).where(eq(designControlChanges.recordId, record.id)),
+    getDesignManufacturingEvidence({ rdProjectId: record.rdProjectId, designControlRecordId: record.id }, client),
   ]);
 
   return {
@@ -592,56 +444,33 @@ export function buildEngineeringReleasePreviewFromContext(
 
   const blockingRisks = context.risks.filter(riskIsBlocking);
   if (blockingRisks.length > 0) {
-    missingEvidence.push(
-      `open high risk: ${blockingRisks.map((risk) => risk.title ?? risk.riskKey ?? risk.id).join(', ')}`
-    );
+    missingEvidence.push(`open high risk: ${blockingRisks.map((risk) => risk.title ?? risk.riskKey ?? risk.id).join(', ')}`);
   }
 
-  const openChanges = context.changes.filter((change) =>
-    statusIsOpen(change.status)
-  );
+  const openChanges = context.changes.filter((change) => statusIsOpen(change.status));
   if (openChanges.length > 0) {
-    missingEvidence.push(
-      `engineering changes not dispositioned: ${openChanges.map((change) => change.title ?? change.changeKey ?? change.id).join(', ')}`
-    );
+    missingEvidence.push(`engineering changes not dispositioned: ${openChanges.map((change) => change.title ?? change.changeKey ?? change.id).join(', ')}`);
   }
 
   if (!context.manufacturingEvidence.ready) {
-    missingEvidence.push(
-      ...context.manufacturingEvidence.missingItems.map(
-        (item) => `manufacturing-source evidence: ${item}`
-      )
-    );
+    missingEvidence.push(...context.manufacturingEvidence.missingItems.map((item) => `manufacturing-source evidence: ${item}`));
   }
   missingEvidence.push(...manufacturingEvidenceScopeErrors(context));
 
-  const baselineLocked =
-    context.manufacturingEvidence.sources.some(
-      (source) =>
-        source.key === 'design_revision_baseline_locked' && source.ready
-    ) ||
-    Boolean(textValue(step12?.formData, ['Locked design revision baseline']));
+  const baselineLocked = context.manufacturingEvidence.sources.some((source) => (
+    source.key === 'design_revision_baseline_locked' && source.ready
+  )) || Boolean(textValue(step12?.formData, ['Locked design revision baseline']));
   if (!baselineLocked) {
     missingEvidence.push('locked configuration baseline');
   }
 
   const approvers = collectApprovers(step12);
-  missingEvidence.push(
-    ...approvers
-      .filter((approval) => !approval.approved)
-      .map((approval) => approval.role)
-  );
+  missingEvidence.push(...approvers.filter((approval) => !approval.approved).map((approval) => approval.role));
 
   const baselineItems = buildBaselineItems(context);
-  const releasedBom = context.manufacturingEvidence.sources.find(
-    (source) => source.key === 'released_bom'
-  );
-  const drawings = context.manufacturingEvidence.sources.filter(
-    (source) => source.key === 'released_drawings' && source.revision
-  );
-  const cad = context.manufacturingEvidence.sources.find(
-    (source) => source.key === 'released_cad'
-  );
+  const releasedBom = context.manufacturingEvidence.sources.find((source) => source.key === 'released_bom');
+  const drawings = context.manufacturingEvidence.sources.filter((source) => source.key === 'released_drawings' && source.revision);
+  const cad = context.manufacturingEvidence.sources.find((source) => source.key === 'released_cad');
   const proposedReleaseRevision = proposedRevision(context.record, step12);
   const proposedReleaseNumber = `ER-${context.record.rdProjectId ?? context.record.id}-${proposedReleaseRevision}`;
   const history = releaseHistory.map((release) => ({
@@ -658,12 +487,7 @@ export function buildEngineeringReleasePreviewFromContext(
     rdProjectId: context.record.rdProjectId,
     rdProjectName: context.rdProject?.projectName ?? null,
     designControlRecordId: context.record.id,
-    productName: productName(
-      context.record,
-      context.rdProject,
-      byStep.get('1'),
-      step12
-    ),
+    productName: productName(context.record, context.rdProject, byStep.get('1'), step12),
     proposedReleaseNumber,
     proposedReleaseRevision,
     effectiveDate: new Date().toISOString().slice(0, 10),
@@ -673,105 +497,66 @@ export function buildEngineeringReleasePreviewFromContext(
       status: byStep.get(stepKey)?.status ?? 'missing',
     })),
     requirementsSummary: `${context.requirements.length} persisted requirement record(s); step 3 is ${byStep.get('3')?.status ?? 'missing'}.`,
-    riskSummary:
-      blockingRisks.length > 0
-        ? `${blockingRisks.length} open high risk item(s)`
-        : 'No open high risk items detected.',
-    prototypeIdentifier: textValue(byStep.get('8')?.formData, [
-      'Prototype serial number',
-      'Prototype identifier',
-    ]),
+    riskSummary: blockingRisks.length > 0 ? `${blockingRisks.length} open high risk item(s)` : 'No open high risk items detected.',
+    prototypeIdentifier: textValue(byStep.get('8')?.formData, ['Prototype serial number', 'Prototype identifier']),
     bomRevision: releasedBom?.revision ?? null,
-    drawingRevisions: drawings
-      .map((source) => source.revision!)
-      .filter(Boolean),
+    drawingRevisions: drawings.map((source) => source.revision!).filter(Boolean),
     cadRevision: cad?.revision ?? null,
     verificationStatus: byStep.get('9')?.status ?? 'missing',
     validationStatus: byStep.get('10')?.status ?? 'missing',
     finalDesignReviewStatus: byStep.get('11')?.status ?? 'missing',
-    engineeringChangeStatus:
-      openChanges.length > 0 ? 'open_changes' : 'dispositioned',
+    engineeringChangeStatus: openChanges.length > 0 ? 'open_changes' : 'dispositioned',
     manufacturingEvidenceStatus: context.manufacturingEvidence.overallStatus,
     requiredApprovals: approvers,
     completedApprovals: approvers.filter((approval) => approval.approved),
     missingEvidence,
     baselineItems,
-    changedSinceReleaseWarnings: changedWarningsFromRelease(
-      existingRelease,
-      baselineItems
-    ),
+    changedSinceReleaseWarnings: changedWarningsFromRelease(existingRelease, baselineItems),
     releaseHistory: history,
     existingRelease: existingRelease
       ? {
-          id: existingRelease.id,
-          releaseNumber: existingRelease.releaseNumber,
-          releaseRevision: existingRelease.releaseRevision,
-          releaseStatus: existingRelease.releaseStatus,
-          releasedBy: existingRelease.releasedBy,
-          releasedAt: existingRelease.releasedAt
-            ? existingRelease.releasedAt.toISOString()
-            : null,
-        }
+        id: existingRelease.id,
+        releaseNumber: existingRelease.releaseNumber,
+        releaseRevision: existingRelease.releaseRevision,
+        releaseStatus: existingRelease.releaseStatus,
+        releasedBy: existingRelease.releasedBy,
+        releasedAt: existingRelease.releasedAt ? existingRelease.releasedAt.toISOString() : null,
+      }
       : null,
   };
 }
 
-export async function getEngineeringReleasePreview(
-  recordId: string,
-  client: DbClient = db
-) {
+export async function getEngineeringReleasePreview(recordId: string, client: DbClient = db) {
   const context = await loadContext(recordId, client);
   if (!context) return null;
-  const releaseRevision = proposedRevision(
-    context.record,
-    context.steps.find((step) => step.stepKey === '12')
-  );
+  const releaseRevision = proposedRevision(context.record, context.steps.find((step) => step.stepKey === '12'));
   const releaseHistory = context.record.rdProjectId
     ? await client
-        .select()
-        .from(engineeringReleases)
-        .where(
-          and(
-            eq(engineeringReleases.rdProjectId, context.record.rdProjectId),
-            eq(engineeringReleases.designControlRecordId, context.record.id)
-          )
-        )
-        .orderBy(
-          desc(engineeringReleases.releasedAt),
-          desc(engineeringReleases.createdAt)
-        )
+      .select()
+      .from(engineeringReleases)
+      .where(and(
+        eq(engineeringReleases.rdProjectId, context.record.rdProjectId),
+        eq(engineeringReleases.designControlRecordId, context.record.id)
+      ))
+      .orderBy(desc(engineeringReleases.releasedAt), desc(engineeringReleases.createdAt))
     : [];
-  const existingRelease =
-    releaseHistory.find(
-      (release) => release.releaseRevision === releaseRevision
-    ) ?? null;
-  return buildEngineeringReleasePreviewFromContext(
-    context,
-    existingRelease,
-    releaseHistory
-  );
+  const existingRelease = releaseHistory.find((release) => release.releaseRevision === releaseRevision) ?? null;
+  return buildEngineeringReleasePreviewFromContext(context, existingRelease, releaseHistory);
 }
 
-export async function submitEngineeringRelease(
-  input: {
-    recordId: string;
-    actor: string;
-    effectiveDate?: string | null;
-  },
-  client: DbClient = db
-) {
+export async function submitEngineeringRelease(input: {
+  recordId: string;
+  actor: string;
+  effectiveDate?: string | null;
+}, client: DbClient = db) {
   return client.transaction(async (tx) => {
-    await tx.execute(
-      sql`SELECT id FROM design_control_records WHERE id = ${input.recordId} FOR UPDATE`
-    );
+    await tx.execute(sql`SELECT id FROM design_control_records WHERE id = ${input.recordId} FOR UPDATE`);
     const context = await loadContext(input.recordId, tx as DbClient);
     if (!context) return { status: 'not_found' as const };
     if (!context.record.rdProjectId) {
       return {
         status: 'blocked' as const,
-        missingEvidence: [
-          'Design Control record is not linked to an R&D project',
-        ],
+        missingEvidence: ['Design Control record is not linked to an R&D project'],
       };
     }
 
@@ -779,27 +564,18 @@ export async function submitEngineeringRelease(
     const [existingRelease] = await tx
       .select()
       .from(engineeringReleases)
-      .where(
-        and(
-          eq(engineeringReleases.rdProjectId, context.record.rdProjectId),
-          eq(engineeringReleases.designControlRecordId, context.record.id),
-          eq(
-            engineeringReleases.releaseRevision,
-            preview.proposedReleaseRevision
-          )
-        )
-      )
+      .where(and(
+        eq(engineeringReleases.rdProjectId, context.record.rdProjectId),
+        eq(engineeringReleases.designControlRecordId, context.record.id),
+        eq(engineeringReleases.releaseRevision, preview.proposedReleaseRevision)
+      ))
       .limit(1);
 
     if (existingRelease) {
       return {
         status: 'existing' as const,
         release: existingRelease,
-        preview: buildEngineeringReleasePreviewFromContext(
-          context,
-          existingRelease,
-          [existingRelease]
-        ),
+        preview: buildEngineeringReleasePreviewFromContext(context, existingRelease, [existingRelease]),
       };
     }
 
@@ -812,50 +588,42 @@ export async function submitEngineeringRelease(
     }
 
     const now = new Date();
-    const effectiveDate = input.effectiveDate
-      ? new Date(input.effectiveDate)
-      : now;
-    const [release] = await tx
-      .insert(engineeringReleases)
-      .values({
-        rdProjectId: context.record.rdProjectId,
-        designControlRecordId: context.record.id,
-        releaseNumber: preview.proposedReleaseNumber,
-        releaseRevision: preview.proposedReleaseRevision,
-        releaseStatus: 'RELEASED',
-        productName: preview.productName,
-        effectiveDate,
-        releasedBy: input.actor,
-        releasedAt: now,
-        readinessSnapshot: preview as unknown as Record<string, unknown>,
-        sourceEvidenceSnapshot: {
-          manufacturingEvidence: context.manufacturingEvidence,
-          baselineItems: preview.baselineItems,
-        },
-        approvalSnapshot: { approvers: preview.requiredApprovals },
-        metadata: {
-          source: 'engineering-release-gate',
-          nextAction: 'Create Manufactured Inventory Item',
-        },
-      })
-      .returning();
+    const effectiveDate = input.effectiveDate ? new Date(input.effectiveDate) : now;
+    const [release] = await tx.insert(engineeringReleases).values({
+      rdProjectId: context.record.rdProjectId,
+      designControlRecordId: context.record.id,
+      releaseNumber: preview.proposedReleaseNumber,
+      releaseRevision: preview.proposedReleaseRevision,
+      releaseStatus: 'RELEASED',
+      productName: preview.productName,
+      effectiveDate,
+      releasedBy: input.actor,
+      releasedAt: now,
+      readinessSnapshot: preview as unknown as Record<string, unknown>,
+      sourceEvidenceSnapshot: {
+        manufacturingEvidence: context.manufacturingEvidence,
+        baselineItems: preview.baselineItems,
+      },
+      approvalSnapshot: { approvers: preview.requiredApprovals },
+      metadata: {
+        source: 'engineering-release-gate',
+        nextAction: 'Create Manufactured Inventory Item',
+      },
+    }).returning();
 
-    const [baseline] = await tx
-      .insert(engineeringReleaseBaselines)
-      .values({
-        engineeringReleaseId: release.id,
-        rdProjectId: context.record.rdProjectId,
-        designControlRecordId: context.record.id,
-        baselineStatus: 'LOCKED',
-        baselineRevision: preview.proposedReleaseRevision,
-        lockedAt: now,
-        lockedBy: input.actor,
-        metadata: {
-          releaseNumber: release.releaseNumber,
-          immutable: true,
-        },
-      })
-      .returning();
+    const [baseline] = await tx.insert(engineeringReleaseBaselines).values({
+      engineeringReleaseId: release.id,
+      rdProjectId: context.record.rdProjectId,
+      designControlRecordId: context.record.id,
+      baselineStatus: 'LOCKED',
+      baselineRevision: preview.proposedReleaseRevision,
+      lockedAt: now,
+      lockedBy: input.actor,
+      metadata: {
+        releaseNumber: release.releaseNumber,
+        immutable: true,
+      },
+    }).returning();
 
     for (const item of preview.baselineItems) {
       await tx.insert(engineeringReleaseBaselineItems).values({
@@ -876,28 +644,20 @@ export async function submitEngineeringRelease(
     }
 
     for (const approval of preview.requiredApprovals) {
-      await tx
-        .insert(engineeringReleaseApprovals)
-        .values({
-          engineeringReleaseId: release.id,
-          approvalRole: approval.role,
-          approvedBy: approval.approvedBy ?? input.actor,
-          approvedAt: approval.approvedAt ? new Date(approval.approvedAt) : now,
-          approvalStatus: 'APPROVED',
-          metadata: approval,
-        })
-        .onConflictDoNothing();
+      await tx.insert(engineeringReleaseApprovals).values({
+        engineeringReleaseId: release.id,
+        approvalRole: approval.role,
+        approvedBy: approval.approvedBy ?? input.actor,
+        approvedAt: approval.approvedAt ? new Date(approval.approvedAt) : now,
+        approvalStatus: 'APPROVED',
+        metadata: approval,
+      }).onConflictDoNothing();
     }
 
     await tx
       .update(designControlSteps)
       .set({ status: 'approved', approvedAt: now, updatedAt: now })
-      .where(
-        and(
-          eq(designControlSteps.recordId, context.record.id),
-          eq(designControlSteps.stepKey, '12')
-        )
-      );
+      .where(and(eq(designControlSteps.recordId, context.record.id), eq(designControlSteps.stepKey, '12')));
 
     await tx
       .update(designControlRecords)
@@ -906,25 +666,8 @@ export async function submitEngineeringRelease(
 
     await tx
       .update(rdProjects)
-      .set({
-        status: 'released',
-        engineeringStatus: 'RELEASED',
-        updatedAt: now,
-      })
+      .set({ status: 'released', engineeringStatus: 'RELEASED', updatedAt: now })
       .where(eq(rdProjects.id, context.record.rdProjectId));
-
-    if (context.record.projectId) {
-      const [linkedProject] = await tx
-        .select({ workflowVersion: projects.workflowVersion })
-        .from(projects)
-        .where(eq(projects.id, context.record.projectId))
-        .limit(1);
-      if (linkedProject?.workflowVersion === 'p2_v2') {
-        const { synchronizeDesignStageStatus } =
-          await import('./projectDesignApplicabilityService');
-        await synchronizeDesignStageStatus(context.record.projectId, tx);
-      }
-    }
 
     return {
       status: 'created' as const,
@@ -938,16 +681,10 @@ export async function submitEngineeringRelease(
   });
 }
 
-export async function listEngineeringReleasesForRdProject(
-  rdProjectId: string,
-  client: DbClient = db
-) {
+export async function listEngineeringReleasesForRdProject(rdProjectId: string, client: DbClient = db) {
   return client
     .select()
     .from(engineeringReleases)
     .where(eq(engineeringReleases.rdProjectId, rdProjectId))
-    .orderBy(
-      desc(engineeringReleases.releasedAt),
-      desc(engineeringReleases.createdAt)
-    );
+    .orderBy(desc(engineeringReleases.releasedAt), desc(engineeringReleases.createdAt));
 }

--- a/server/src/services/projectDesignApplicabilityService.ts
+++ b/server/src/services/projectDesignApplicabilityService.ts
@@ -158,13 +158,10 @@ async function releaseState(
       AND lower(status) NOT IN ('approved','complete','completed','closed','not_applicable','not applicable')`)
   );
   const blockers: string[] = [];
-  const rdReleased = ['released', 'engineering_released'].includes(
-    String(designProject.engineering_status ?? '').toLowerCase()
-  );
   if (
     !release ||
     designProject.design_control_status !== 'engineering_released' ||
-    !rdReleased
+    designProject.engineering_status !== 'engineering_released'
   )
     blockers.push(
       'The linked Design Project has not reached formal Engineering Release or has been reopened.'
@@ -178,7 +175,7 @@ async function releaseState(
     released:
       Boolean(release) &&
       designProject.design_control_status === 'engineering_released' &&
-      rdReleased &&
+      designProject.engineering_status === 'engineering_released' &&
       openReviews.length === 0,
     blockers,
     designProject,

--- a/server/src/services/projectDesignApplicabilityService.ts
+++ b/server/src/services/projectDesignApplicabilityService.ts
@@ -1,0 +1,701 @@
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+import {
+  ProjectDesignApplicabilityError,
+  validateDesignApplicabilityInput,
+  type DesignInput,
+} from './projectDesignApplicabilityValidation';
+
+export {
+  ProjectDesignApplicabilityError,
+  validateDesignApplicabilityInput,
+} from './projectDesignApplicabilityValidation';
+
+type Executor = AuditLedgerTx;
+// SQL rows are intentionally dynamic at this raw-query integration boundary.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+export type DesignActor = {
+  userId: number;
+  employeeId?: number | null;
+  username: string;
+  displayName: string;
+  role: string;
+};
+
+const resultRows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+const clean = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : '';
+
+async function context(projectId: string, tx: Executor, lock = false) {
+  const projects = resultRows(
+    await tx.execute(
+      sql`SELECT id, workflow_version FROM projects WHERE id = ${projectId} ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  );
+  if (!projects[0])
+    throw new ProjectDesignApplicabilityError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.',
+      404
+    );
+  const version = resolveProjectWorkflowVersion(projects[0].workflow_version);
+  if (version !== 'p2_v2')
+    throw new ProjectDesignApplicabilityError(
+      'P2_V2_REQUIRED',
+      'Design Applicability mutations require an explicit p2_v2 project.',
+      409,
+      { effectiveWorkflowVersion: version }
+    );
+  const instances = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_instances WHERE project_id = ${projectId} AND workflow_version = 'p2_v2' AND status NOT IN ('SUPERSEDED','CANCELLED') ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  );
+  if (!instances[0])
+    throw new ProjectDesignApplicabilityError(
+      'WORKFLOW_INSTANCE_REQUIRED',
+      'An active P2 V2 workflow instance is required.',
+      409
+    );
+  if (instances.length > 1)
+    throw new ProjectDesignApplicabilityError(
+      'DUPLICATE_ACTIVE_INSTANCES',
+      'Multiple active workflow instances exist.',
+      409
+    );
+  const steps = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_instances WHERE workflow_instance_id = ${instances[0].id} ORDER BY step_order`
+    )
+  );
+  const issues = validateWorkflowInstanceIntegrity(instances[0], steps);
+  if (issues.length)
+    throw new ProjectDesignApplicabilityError(
+      'WORKFLOW_INTEGRITY_FAILED',
+      'The V2 workflow instance failed integrity validation.',
+      409,
+      { issues }
+    );
+  const step = steps.find((item) => item.step_type === 'design_applicability');
+  if (!step)
+    throw new ProjectDesignApplicabilityError(
+      'DESIGN_APPLICABILITY_STAGE_REQUIRED',
+      'The Design Applicability stage is missing.',
+      409
+    );
+  return { instance: instances[0], step, steps };
+}
+
+async function current(projectId: string, tx: Executor) {
+  return (
+    resultRows(
+      await tx.execute(
+        sql`SELECT * FROM project_design_applicability_decisions WHERE project_id = ${projectId} AND status <> 'SUPERSEDED' ORDER BY revision_number DESC LIMIT 1`
+      )
+    )[0] ?? null
+  );
+}
+
+async function releaseState(
+  projectId: string,
+  designProjectId: string | null,
+  tx: Executor
+) {
+  if (!designProjectId)
+    return {
+      valid: false,
+      released: false,
+      blockers: ['A linked Design Project is required.'],
+      designProject: null,
+      release: null,
+    };
+  const designProject = resultRows(
+    await tx.execute(sql`
+    SELECT rp.id, rp.project_name, rp.status, rp.engineering_status, dcr.id AS design_control_record_id, dcr.status AS design_control_status
+    FROM rd_projects rp
+    LEFT JOIN design_control_records dcr ON dcr.rd_project_id = rp.id AND dcr.project_id = ${projectId}
+    WHERE rp.id = ${designProjectId}
+    ORDER BY dcr.created_at DESC NULLS LAST LIMIT 1`)
+  )[0];
+  if (!designProject)
+    return {
+      valid: false,
+      released: false,
+      blockers: ['The selected Design Project does not exist.'],
+      designProject: null,
+      release: null,
+    };
+  if (!designProject.design_control_record_id)
+    return {
+      valid: false,
+      released: false,
+      blockers: [
+        'The selected Design Project is not linked to this P2 project through Design Control.',
+      ],
+      designProject,
+      release: null,
+    };
+  const release =
+    resultRows(
+      await tx.execute(sql`
+    SELECT id, release_number, release_revision, release_status, effective_date, released_at
+    FROM engineering_releases
+    WHERE rd_project_id = ${designProjectId} AND design_control_record_id = ${designProject.design_control_record_id} AND release_status = 'RELEASED'
+    ORDER BY released_at DESC NULLS LAST, created_at DESC LIMIT 1`)
+    )[0] ?? null;
+  const openReviews = resultRows(
+    await tx.execute(sql`
+    SELECT id, title, status FROM design_control_reviews
+    WHERE record_id = ${designProject.design_control_record_id}
+      AND lower(status) NOT IN ('approved','complete','completed','closed','not_applicable','not applicable')`)
+  );
+  const blockers: string[] = [];
+  if (
+    !release ||
+    designProject.design_control_status !== 'engineering_released' ||
+    designProject.engineering_status !== 'engineering_released'
+  )
+    blockers.push(
+      'The linked Design Project has not reached formal Engineering Release or has been reopened.'
+    );
+  if (openReviews.length)
+    blockers.push(
+      `${openReviews.length} Design Control review action(s) remain open.`
+    );
+  return {
+    valid: true,
+    released:
+      Boolean(release) &&
+      designProject.design_control_status === 'engineering_released' &&
+      designProject.engineering_status === 'engineering_released' &&
+      openReviews.length === 0,
+    blockers,
+    designProject,
+    release,
+    openReviews,
+  };
+}
+
+async function approvals(decisionId: string, stepId: string, tx: Executor) {
+  return resultRows(
+    await tx.execute(sql`
+    SELECT * FROM project_workflow_step_approvals
+    WHERE workflow_step_instance_id = ${stepId} AND evidence_snapshot->>'decisionId' = ${decisionId}
+    ORDER BY decided_at`)
+  );
+}
+
+async function readModel(projectId: string, tx: Executor) {
+  const ctx = await context(projectId, tx);
+  const decision = await current(projectId, tx);
+  const history = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_design_applicability_decisions WHERE project_id = ${projectId} ORDER BY revision_number DESC`
+    )
+  );
+  const decisionApprovals = decision
+    ? await approvals(decision.id, ctx.step.id, tx)
+    : [];
+  const approvalHistory = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_approvals WHERE workflow_step_instance_id = ${ctx.step.id} AND approval_type IN ('DESIGN_APPLICABILITY_ENGINEERING','DESIGN_APPLICABILITY_QUALITY','DESIGN_APPLICABILITY') ORDER BY decided_at DESC`
+    )
+  );
+  const links = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_links WHERE workflow_step_instance_id = ${ctx.step.id} ORDER BY linked_at DESC`
+    )
+  );
+  const release = await releaseState(
+    projectId,
+    decision?.linked_design_project_id ?? null,
+    tx
+  );
+  const blockers: string[] = [];
+  if (!decision) blockers.push('Create a Design Applicability decision.');
+  else {
+    if (decision.status !== 'APPROVED')
+      blockers.push(
+        `Decision revision ${decision.revision_number} is ${decision.status}.`
+      );
+    const eng = decisionApprovals.some(
+      (a) =>
+        a.approval_type === 'DESIGN_APPLICABILITY_ENGINEERING' &&
+        a.decision === 'APPROVED' &&
+        !a.superseded_at
+    );
+    const quality = decisionApprovals.some(
+      (a) =>
+        a.approval_type === 'DESIGN_APPLICABILITY_QUALITY' &&
+        a.decision === 'APPROVED' &&
+        !a.superseded_at
+    );
+    if (!eng) blockers.push('Engineering approval is required.');
+    if (!quality) blockers.push('Quality approval is required.');
+    if (decision.responsibility_type !== 'CUSTOMER_BUILD_TO_PRINT')
+      blockers.push(...release.blockers);
+  }
+  const predecessors = ctx.steps.filter((s) => s.step_order < 4);
+  const incomplete = predecessors.filter(
+    (s) =>
+      s.status !== 'COMPLETE' &&
+      !(s.step_type === 'estimate_quote' && s.status === 'APPROVED')
+  );
+  if (incomplete.length)
+    blockers.push(
+      `Predecessor stages must complete: ${incomplete.map((s) => s.label_snapshot).join(', ')}.`
+    );
+  return {
+    decision,
+    history,
+    approvals: decisionApprovals,
+    approvalHistory,
+    links,
+    release,
+    stage: ctx.step,
+    readiness: { ready: blockers.length === 0, blockers },
+  };
+}
+
+async function audit(
+  eventType: string,
+  decision: Row,
+  actor: DesignActor,
+  tx: Executor,
+  reason?: string
+) {
+  await recordAuditEvent(
+    {
+      eventType,
+      subjectType: 'project_design_applicability_decision',
+      subjectId: decision.id,
+      sourceService: 'projectDesignApplicabilityService',
+      actor: { id: actor.userId, username: actor.username, role: actor.role },
+      reason,
+      payload: {
+        projectId: decision.project_id,
+        workflowInstanceId: decision.workflow_instance_id,
+        workflowStepInstanceId: decision.workflow_step_instance_id,
+        revisionNumber: decision.revision_number,
+        responsibilityType: decision.responsibility_type,
+      },
+    },
+    tx
+  );
+}
+
+async function insertDecision(
+  projectId: string,
+  input: DesignInput,
+  actor: DesignActor,
+  tx: Executor,
+  revision: number
+) {
+  const ctx = await context(projectId, tx, true);
+  const needsDesignControl =
+    input.responsibilityType !== 'CUSTOMER_BUILD_TO_PRINT';
+  if (needsDesignControl) {
+    const state = await releaseState(
+      projectId,
+      clean(input.linkedDesignProjectId),
+      tx
+    );
+    if (!state.valid)
+      throw new ProjectDesignApplicabilityError(
+        'INVALID_DESIGN_PROJECT',
+        state.blockers[0],
+        400
+      );
+  }
+  return resultRows(
+    await tx.execute(sql`
+    INSERT INTO project_design_applicability_decisions
+      (project_id, workflow_instance_id, workflow_step_instance_id, revision_number, status, responsibility_type, ag_design_scope, customer_design_scope, responsibility_boundary, requirement_source, customer_drawing_number, customer_drawing_revision, customer_specifications, linked_design_project_id, design_control_required, justification, created_by, created_by_display_name)
+    VALUES (${projectId}, ${ctx.instance.id}, ${ctx.step.id}, ${revision}, 'DRAFT', ${input.responsibilityType}, ${clean(input.agDesignScope) || null}, ${clean(input.customerDesignScope) || null}, ${clean(input.responsibilityBoundary) || null}, ${clean(input.requirementSource)}, ${clean(input.customerDrawingNumber) || null}, ${clean(input.customerDrawingRevision) || null}, ${JSON.stringify(input.customerSpecifications ?? [])}::jsonb, ${clean(input.linkedDesignProjectId) || null}, ${needsDesignControl}, ${clean(input.justification)}, ${actor.userId}, ${actor.displayName}) RETURNING *`)
+  )[0];
+}
+
+export async function getCurrentDesignApplicability(
+  projectId: string,
+  tx: Executor = db
+) {
+  return readModel(projectId, tx);
+}
+export async function getDesignApplicabilityHistory(
+  projectId: string,
+  tx: Executor = db
+) {
+  await context(projectId, tx);
+  return resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_design_applicability_decisions WHERE project_id = ${projectId} ORDER BY revision_number DESC`
+    )
+  );
+}
+
+export async function createDraft(
+  projectId: string,
+  input: DesignInput,
+  actor: DesignActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    if (await current(projectId, tx))
+      throw new ProjectDesignApplicabilityError(
+        'CURRENT_DECISION_EXISTS',
+        'Revise the current decision instead of creating another.',
+        409
+      );
+    const decision = await insertDecision(projectId, input, actor, tx, 1);
+    await audit(
+      'P2_V2_DESIGN_APPLICABILITY_DRAFT_CREATED',
+      decision,
+      actor,
+      tx
+    );
+    return readModel(projectId, tx);
+  });
+}
+
+export async function updateDraft(
+  projectId: string,
+  decisionId: string,
+  input: DesignInput,
+  actor: DesignActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const decision = await current(projectId, tx);
+    if (!decision || decision.id !== decisionId)
+      throw new ProjectDesignApplicabilityError(
+        'CURRENT_DECISION_NOT_FOUND',
+        'Current decision not found.',
+        404
+      );
+    if (decision.status !== 'DRAFT')
+      throw new ProjectDesignApplicabilityError(
+        'DRAFT_REQUIRED',
+        'Only a draft decision can be edited.',
+        409
+      );
+    if (input.responsibilityType !== 'CUSTOMER_BUILD_TO_PRINT') {
+      const state = await releaseState(
+        projectId,
+        clean(input.linkedDesignProjectId),
+        tx
+      );
+      if (!state.valid)
+        throw new ProjectDesignApplicabilityError(
+          'INVALID_DESIGN_PROJECT',
+          state.blockers[0],
+          400
+        );
+    }
+    await tx.execute(
+      sql`UPDATE project_design_applicability_decisions SET responsibility_type=${input.responsibilityType}, ag_design_scope=${clean(input.agDesignScope) || null}, customer_design_scope=${clean(input.customerDesignScope) || null}, responsibility_boundary=${clean(input.responsibilityBoundary) || null}, requirement_source=${clean(input.requirementSource)}, customer_drawing_number=${clean(input.customerDrawingNumber) || null}, customer_drawing_revision=${clean(input.customerDrawingRevision) || null}, customer_specifications=${JSON.stringify(input.customerSpecifications ?? [])}::jsonb, linked_design_project_id=${clean(input.linkedDesignProjectId) || null}, design_control_required=${input.responsibilityType !== 'CUSTOMER_BUILD_TO_PRINT'}, justification=${clean(input.justification)}, updated_at=now() WHERE id=${decisionId}`
+    );
+    await audit(
+      'P2_V2_DESIGN_APPLICABILITY_DRAFT_UPDATED',
+      decision,
+      actor,
+      tx
+    );
+    return readModel(projectId, tx);
+  });
+}
+
+export async function submitForApproval(
+  projectId: string,
+  decisionId: string,
+  actor: DesignActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const decision = await current(projectId, tx);
+    if (!decision || decision.id !== decisionId)
+      throw new ProjectDesignApplicabilityError(
+        'CURRENT_DECISION_NOT_FOUND',
+        'Current decision not found.',
+        404
+      );
+    if (decision.status !== 'DRAFT')
+      throw new ProjectDesignApplicabilityError(
+        'DRAFT_REQUIRED',
+        'Only a draft can be submitted.',
+        409
+      );
+    validateDesignApplicabilityInput({
+      responsibilityType: decision.responsibility_type,
+      agDesignScope: decision.ag_design_scope,
+      customerDesignScope: decision.customer_design_scope,
+      responsibilityBoundary: decision.responsibility_boundary,
+      requirementSource: decision.requirement_source,
+      customerDrawingNumber: decision.customer_drawing_number,
+      customerDrawingRevision: decision.customer_drawing_revision,
+      customerSpecifications: decision.customer_specifications,
+      linkedDesignProjectId: decision.linked_design_project_id,
+      justification: decision.justification,
+    });
+    if (decision.responsibility_type !== 'CUSTOMER_BUILD_TO_PRINT') {
+      const state = await releaseState(
+        projectId,
+        decision.linked_design_project_id,
+        tx
+      );
+      if (!state.valid)
+        throw new ProjectDesignApplicabilityError(
+          'INVALID_DESIGN_PROJECT',
+          state.blockers[0],
+          400
+        );
+      const oldLinks = resultRows(
+        await tx.execute(
+          sql`UPDATE project_workflow_step_links SET unlinked_at=now(), unlink_reason='Superseded by Design Applicability revision ' || ${String(decision.revision_number)}, updated_at=now() WHERE workflow_step_instance_id=${ctx.step.id} AND record_type='DESIGN_PROJECT' AND is_authoritative=true AND unlinked_at IS NULL AND record_id<>${decision.linked_design_project_id} RETURNING *`
+        )
+      );
+      await tx.execute(
+        sql`INSERT INTO project_workflow_step_links (workflow_step_instance_id, project_id, record_type, record_id, relationship_type, is_authoritative, linked_by, linked_by_display_name) SELECT ${ctx.step.id}, ${projectId}, 'DESIGN_PROJECT', ${decision.linked_design_project_id}, 'PRIMARY', true, ${actor.employeeId ?? null}, ${actor.displayName} WHERE NOT EXISTS (SELECT 1 FROM project_workflow_step_links WHERE workflow_step_instance_id=${ctx.step.id} AND record_type='DESIGN_PROJECT' AND is_authoritative=true AND unlinked_at IS NULL AND record_id=${decision.linked_design_project_id})`
+      );
+      void oldLinks;
+    }
+    await tx.execute(
+      sql`UPDATE project_design_applicability_decisions SET status='PENDING_APPROVAL', submitted_by=${actor.userId}, submitted_by_display_name=${actor.displayName}, submitted_at=now(), updated_at=now() WHERE id=${decisionId}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='PENDING_APPROVAL', applicability='CONDITIONAL', blocked_reason=NULL, updated_at=now() WHERE id=${ctx.step.id}`
+    );
+    await audit('P2_V2_DESIGN_APPLICABILITY_SUBMITTED', decision, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+async function recordDecision(
+  projectId: string,
+  decisionId: string,
+  capacity: 'ENGINEERING' | 'QUALITY',
+  choice: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: DesignActor
+) {
+  if (!clean(signatureMeaning))
+    throw new ProjectDesignApplicabilityError(
+      'SIGNATURE_MEANING_REQUIRED',
+      'Signature meaning is required.'
+    );
+  if (choice !== 'APPROVED' && !clean(reason))
+    throw new ProjectDesignApplicabilityError(
+      'REASON_REQUIRED',
+      'A rejection/return reason is required.'
+    );
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const decision = await current(projectId, tx);
+    if (!decision || decision.id !== decisionId)
+      throw new ProjectDesignApplicabilityError(
+        'CURRENT_DECISION_NOT_FOUND',
+        'Current decision not found.',
+        404
+      );
+    if (decision.status !== 'PENDING_APPROVAL')
+      throw new ProjectDesignApplicabilityError(
+        'PENDING_APPROVAL_REQUIRED',
+        'The decision is not pending approval.',
+        409
+      );
+    const existing = await approvals(decisionId, ctx.step.id, tx);
+    if (
+      existing.some(
+        (a) => a.approval_type === `DESIGN_APPLICABILITY_${capacity}`
+      )
+    )
+      throw new ProjectDesignApplicabilityError(
+        'DECISION_ALREADY_RECORDED',
+        `${capacity} already decided this revision.`,
+        409
+      );
+    const other = existing.find(
+      (a) =>
+        a.approval_type !== `DESIGN_APPLICABILITY_${capacity}` &&
+        a.decision === 'APPROVED'
+    );
+    if (other && other.actor_user_id === actor.userId)
+      throw new ProjectDesignApplicabilityError(
+        'SEGREGATION_OF_DUTIES',
+        'The same user cannot provide both Engineering and Quality approvals.',
+        403
+      );
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_approvals (workflow_step_instance_id, project_id, approval_type, decision, signature_meaning, reason, actor_employee_id, actor_user_id, actor_display_name, actor_role, step_revision_snapshot, evidence_snapshot) VALUES (${ctx.step.id}, ${projectId}, ${`DESIGN_APPLICABILITY_${capacity}`}, ${choice}, ${clean(signatureMeaning)}, ${clean(reason) || null}, ${actor.employeeId ?? null}, ${actor.userId}, ${actor.displayName}, ${actor.role}, ${String(decision.revision_number)}, ${JSON.stringify({ decisionId, responsibilityType: decision.responsibility_type, capacity })}::jsonb)`
+    );
+    if (choice !== 'APPROVED') {
+      await tx.execute(
+        sql`UPDATE project_design_applicability_decisions SET status='REJECTED', updated_at=now() WHERE id=${decisionId}`
+      );
+      await tx.execute(
+        sql`UPDATE project_workflow_step_instances SET status='BLOCKED', blocked_reason=${`${capacity} ${choice.toLowerCase()}: ${clean(reason)}`}, updated_at=now() WHERE id=${ctx.step.id}`
+      );
+    } else {
+      const all = await approvals(decisionId, ctx.step.id, tx);
+      const approved = ['ENGINEERING', 'QUALITY'].every((role) =>
+        all.some(
+          (a) =>
+            a.approval_type === `DESIGN_APPLICABILITY_${role}` &&
+            a.decision === 'APPROVED'
+        )
+      );
+      if (approved)
+        await tx.execute(
+          sql`UPDATE project_design_applicability_decisions SET status='APPROVED', updated_at=now() WHERE id=${decisionId}`
+        );
+    }
+    await audit(
+      `P2_V2_DESIGN_APPLICABILITY_${capacity}_DECIDED`,
+      decision,
+      actor,
+      tx,
+      clean(reason) || undefined
+    );
+    await synchronizeDesignStageStatus(projectId, tx, actor);
+    return readModel(projectId, tx);
+  });
+}
+
+export const recordEngineeringDecision = (
+  projectId: string,
+  decisionId: string,
+  choice: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: DesignActor
+) =>
+  recordDecision(
+    projectId,
+    decisionId,
+    'ENGINEERING',
+    choice,
+    signatureMeaning,
+    reason,
+    actor
+  );
+export const recordQualityDecision = (
+  projectId: string,
+  decisionId: string,
+  choice: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: DesignActor
+) =>
+  recordDecision(
+    projectId,
+    decisionId,
+    'QUALITY',
+    choice,
+    signatureMeaning,
+    reason,
+    actor
+  );
+
+export async function reviseDecision(
+  projectId: string,
+  decisionId: string,
+  input: DesignInput,
+  actor: DesignActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const prior = await current(projectId, tx);
+    if (!prior || prior.id !== decisionId)
+      throw new ProjectDesignApplicabilityError(
+        'CURRENT_DECISION_NOT_FOUND',
+        'Current decision not found.',
+        404
+      );
+    if (!['APPROVED', 'REJECTED'].includes(prior.status))
+      throw new ProjectDesignApplicabilityError(
+        'REVISION_NOT_ALLOWED',
+        'Only an approved or rejected decision can be revised.',
+        409
+      );
+    await tx.execute(
+      sql`UPDATE project_design_applicability_decisions SET status='SUPERSEDED', superseded_at=now(), updated_at=now() WHERE id=${prior.id}`
+    );
+    const next = await insertDecision(
+      projectId,
+      input,
+      actor,
+      tx,
+      Number(prior.revision_number) + 1
+    );
+    await tx.execute(
+      sql`UPDATE project_design_applicability_decisions SET superseded_by_decision_id=${next.id}, updated_at=now() WHERE id=${prior.id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_approvals SET superseded_at=now() WHERE workflow_step_instance_id=${prior.workflow_step_instance_id} AND evidence_snapshot->>'decisionId'=${prior.id} AND superseded_at IS NULL`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='IN_PROGRESS', applicability='CONDITIONAL', blocked_reason=NULL, completed_at=NULL, completed_by=NULL, completed_by_display_name=NULL, updated_at=now() WHERE id=${prior.workflow_step_instance_id}`
+    );
+    await audit('P2_V2_DESIGN_APPLICABILITY_REVISED', next, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function evaluateDesignApplicabilityReadiness(
+  projectId: string,
+  tx: Executor = db
+) {
+  return (await readModel(projectId, tx)).readiness;
+}
+
+export async function synchronizeDesignStageStatus(
+  projectId: string,
+  tx: Executor = db,
+  actor?: DesignActor
+) {
+  const model = await readModel(projectId, tx);
+  const decision = model.decision;
+  if (!decision || !['APPROVED'].includes(decision.status)) return model;
+  const predecessorBlocked = model.readiness.blockers.some((b: string) =>
+    b.startsWith('Predecessor stages')
+  );
+  const approvalBlocked = model.readiness.blockers.some((b: string) =>
+    b.includes('approval is required')
+  );
+  const ready =
+    !predecessorBlocked &&
+    !approvalBlocked &&
+    (decision.responsibility_type === 'CUSTOMER_BUILD_TO_PRINT' ||
+      model.release.released);
+  if (ready && decision.responsibility_type === 'CUSTOMER_BUILD_TO_PRINT') {
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_approvals (workflow_step_instance_id, project_id, approval_type, decision, signature_meaning, actor_user_id, actor_display_name, actor_role, step_revision_snapshot, evidence_snapshot) SELECT ${model.stage.id}, ${projectId}, 'DESIGN_APPLICABILITY', 'NOT_APPLICABLE_APPROVED', 'Approved determination that AS9100 design control is not applicable to customer-controlled build-to-print scope', ${actor?.userId ?? null}, ${actor?.displayName ?? 'System readiness evaluation'}, ${actor?.role ?? 'SYSTEM'}, ${String(decision.revision_number)}, ${JSON.stringify({ decisionId: decision.id, customerDrawingNumber: decision.customer_drawing_number, customerDrawingRevision: decision.customer_drawing_revision })}::jsonb WHERE NOT EXISTS (SELECT 1 FROM project_workflow_step_approvals WHERE workflow_step_instance_id=${model.stage.id} AND decision='NOT_APPLICABLE_APPROVED' AND evidence_snapshot->>'decisionId'=${decision.id})`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='NOT_APPLICABLE', applicability='NOT_APPLICABLE', applicability_reason=${decision.justification}, applicability_source='APPROVED_DESIGN_APPLICABILITY', applicability_decided_by=${actor?.employeeId ?? null}, applicability_decided_by_display_name=${actor?.displayName ?? null}, applicability_decided_at=now(), blocked_reason=NULL, completed_at=now(), completed_by=${actor?.employeeId ?? null}, completed_by_display_name=${actor?.displayName ?? null}, revision_reference=${decision.customer_drawing_revision}, effectivity_reference=${decision.customer_drawing_number}, updated_at=now() WHERE id=${model.stage.id}`
+    );
+  } else if (ready) {
+    await tx.execute(
+      sql`UPDATE project_workflow_step_links SET record_revision=${model.release.release.release_revision}, effectivity_reference=COALESCE(${model.release.release.effective_date}, ${model.release.release.release_number}), updated_at=now() WHERE workflow_step_instance_id=${model.stage.id} AND record_type='DESIGN_PROJECT' AND is_authoritative=true AND unlinked_at IS NULL`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='COMPLETE', applicability='REQUIRED', blocked_reason=NULL, completed_at=now(), completed_by=${actor?.employeeId ?? null}, completed_by_display_name=${actor?.displayName ?? null}, revision_reference=${model.release.release.release_revision}, effectivity_reference=COALESCE(${model.release.release.effective_date}, ${model.release.release.release_number}), updated_at=now() WHERE id=${model.stage.id}`
+    );
+  } else if (
+    decision.responsibility_type !== 'CUSTOMER_BUILD_TO_PRINT' &&
+    !model.release.released
+  ) {
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='BLOCKED', blocked_reason=${model.release.blockers.join(' ')}, completed_at=NULL, completed_by=NULL, completed_by_display_name=NULL, updated_at=now() WHERE id=${model.stage.id}`
+    );
+  }
+  return readModel(projectId, tx);
+}

--- a/server/src/services/projectDesignApplicabilityService.ts
+++ b/server/src/services/projectDesignApplicabilityService.ts
@@ -158,10 +158,13 @@ async function releaseState(
       AND lower(status) NOT IN ('approved','complete','completed','closed','not_applicable','not applicable')`)
   );
   const blockers: string[] = [];
+  const rdReleased = ['released', 'engineering_released'].includes(
+    String(designProject.engineering_status ?? '').toLowerCase()
+  );
   if (
     !release ||
     designProject.design_control_status !== 'engineering_released' ||
-    designProject.engineering_status !== 'engineering_released'
+    !rdReleased
   )
     blockers.push(
       'The linked Design Project has not reached formal Engineering Release or has been reopened.'
@@ -175,7 +178,7 @@ async function releaseState(
     released:
       Boolean(release) &&
       designProject.design_control_status === 'engineering_released' &&
-      designProject.engineering_status === 'engineering_released' &&
+      rdReleased &&
       openReviews.length === 0,
     blockers,
     designProject,

--- a/server/src/services/projectDesignApplicabilityValidation.ts
+++ b/server/src/services/projectDesignApplicabilityValidation.ts
@@ -1,0 +1,70 @@
+export type DesignResponsibility =
+  | 'CUSTOMER_BUILD_TO_PRINT'
+  | 'AG_DESIGN_RESPONSIBLE'
+  | 'SHARED_DESIGN_RESPONSIBILITY';
+
+export type DesignInput = {
+  responsibilityType: DesignResponsibility;
+  agDesignScope?: string | null;
+  customerDesignScope?: string | null;
+  responsibilityBoundary?: string | null;
+  requirementSource: string;
+  customerDrawingNumber?: string | null;
+  customerDrawingRevision?: string | null;
+  customerSpecifications?: unknown[];
+  linkedDesignProjectId?: string | null;
+  justification: string;
+};
+
+export class ProjectDesignApplicabilityError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly status = 400,
+    public readonly details: Record<string, unknown> = {}
+  ) {
+    super(message);
+    this.name = 'ProjectDesignApplicabilityError';
+  }
+}
+
+const clean = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : '';
+
+export function validateDesignApplicabilityInput(input: DesignInput) {
+  const missing: string[] = [];
+  if (
+    ![
+      'CUSTOMER_BUILD_TO_PRINT',
+      'AG_DESIGN_RESPONSIBLE',
+      'SHARED_DESIGN_RESPONSIBILITY',
+    ].includes(input.responsibilityType)
+  )
+    missing.push('responsibilityType');
+  if (!clean(input.requirementSource)) missing.push('requirementSource');
+  if (!clean(input.justification)) missing.push('justification');
+  if (input.responsibilityType === 'CUSTOMER_BUILD_TO_PRINT') {
+    if (!clean(input.customerDrawingNumber))
+      missing.push('customerDrawingNumber');
+    if (!clean(input.customerDrawingRevision))
+      missing.push('customerDrawingRevision');
+    if (!clean(input.agDesignScope)) missing.push('agDesignScope');
+  }
+  if (input.responsibilityType !== 'CUSTOMER_BUILD_TO_PRINT') {
+    if (!clean(input.agDesignScope)) missing.push('agDesignScope');
+    if (!clean(input.linkedDesignProjectId))
+      missing.push('linkedDesignProjectId');
+  }
+  if (input.responsibilityType === 'SHARED_DESIGN_RESPONSIBILITY') {
+    if (!clean(input.customerDesignScope)) missing.push('customerDesignScope');
+    if (!clean(input.responsibilityBoundary))
+      missing.push('responsibilityBoundary');
+  }
+  if (missing.length)
+    throw new ProjectDesignApplicabilityError(
+      'DESIGN_APPLICABILITY_FIELDS_REQUIRED',
+      `Required Design Applicability fields are missing: ${missing.join(', ')}.`,
+      400,
+      { missing }
+    );
+}


### PR DESCRIPTION
## What changed
- add migration 0203 with revision-controlled Design Applicability decisions and scoped capabilities
- add guarded service/API actions for draft, submit, separate Engineering and Quality decisions, rejection, revision, readiness, and stage synchronization
- reuse authoritative R&D Design Projects, Design Control records, Engineering Releases, workflow links, approvals, and audit ledger
- make only the p2_v2 Design Applicability stage writable; keep the other nine V2 stages and every legacy workflow unchanged
- add the focused Design Applicability dialog with responsibility-specific fields, blockers, separate approvals, release evidence, safe Design Project navigation, and revision history

## Control behavior
- build-to-print closes only as approved NOT_APPLICABLE with drawing/revision plus separate Engineering and Quality evidence
- AG-owned/shared design cannot complete without a validated project relationship, formal Engineering Release, closed design review actions, and completed predecessor stages
- decisions, approvals, release evidence, and superseded Design Project links are retained
- no generic stage-status, skip, manual-complete, public initializer, V2 creation activation, or legacy conversion path was added

## Validation
- Phase 5 + Phase 1-4 workflow/Engineering Release: 58 passed
- WAD, Project Closing, and P2 release gates: 44 passed
- focused component suite: 4 passed
- final Phase 5 service suite: 5 passed
- focused ESLint on new/changed service, validation, component, and tests: clean
- projects.ts retains its pre-existing file-wide lint backlog; the new route block adds no new semantic diagnostics
- git diff --check: clean
- TypeScript with 6144 MB heap: no diagnostics matched the changed Phase 5 files; unrelated repository diagnostics remain, so this does not claim repository-wide type cleanliness

## Scope safeguards
- no legacy data backfill or project_steps mutation
- no legacy gate or UI behavior change
- p2_v2 normal creation remains disabled
- only Design Applicability became writable