### PR TITLE
Implement Phase 6 P2 v2 production planning baseline

### DIFF
--- a/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
@@ -1,0 +1,115 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import P2V2ProductionPlanning from '../components/projects/P2V2ProductionPlanning';
+
+const model = {
+  plan: {
+    id: 'plan-1',
+    revision_number: 2,
+    status: 'PENDING_APPROVAL',
+    po_number: 'PO-100',
+    po_revision_number: 3,
+    effectivity_reference: 'PO PO-100 Rev 3',
+  },
+  items: [
+    {
+      id: 'root',
+      assembly_path: 'root:1',
+      part_number: 'MAKE-100',
+      part_name: 'Final assembly',
+      is_manufactured: true,
+      extended_project_quantity: '2',
+      bom_revision: 'B',
+      bom_release_status: 'RELEASED',
+      routing_revision: '4',
+      routing_release_status: 'RELEASED',
+    },
+    {
+      id: 'leaf',
+      assembly_path: 'root:1/line:2',
+      part_number: 'BUY-20',
+      part_name: 'Purchased fastener',
+      is_manufactured: false,
+      extended_project_quantity: '8',
+      bom_release_status: 'NOT_REQUIRED_APPROVED',
+      routing_release_status: 'NOT_REQUIRED_APPROVED',
+    },
+  ],
+  history: [
+    {
+      id: 'plan-1',
+      revision_number: 2,
+      status: 'DRAFT',
+      configuration_revision: 'PO PO-100 Rev 3',
+      effectivity_reference: 'PO PO-100 Rev 3',
+    },
+    {
+      id: 'plan-0',
+      revision_number: 1,
+      status: 'SUPERSEDED',
+      configuration_revision: 'PO PO-100 Rev 2',
+      effectivity_reference: 'PO PO-100 Rev 2',
+    },
+  ],
+  approvalHistory: [],
+  readiness: {
+    ready: false,
+    stale: true,
+    blockers: ['MAKE-100: traveler decision required.'],
+    differences: ['MAKE-100: BOM revision/release changed.'],
+  },
+};
+
+function renderPlanning() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      const body = url.includes('/api/permissions/me')
+        ? {
+            permissions: [
+              'projects.production_planning.manage',
+              'projects.production_planning.engineering_decide',
+              'projects.production_planning.quality_decide',
+              'projects.production_planning.operations_decide',
+            ],
+          }
+        : model;
+      return { ok: true, json: async () => body } as Response;
+    })
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <P2V2ProductionPlanning projectId="p1" />
+    </QueryClientProvider>
+  );
+}
+
+describe('P2V2ProductionPlanning', () => {
+  beforeEach(() => vi.restoreAllMocks());
+  it('renders assembly hierarchy, purchased leaves, blockers, stale changes, decisions, approvals and revision history', async () => {
+    renderPlanning();
+    fireEvent.click(screen.getByTestId('open-production-planning'));
+    expect(
+      await screen.findByTestId('production-planning-dialog')
+    ).toBeInTheDocument();
+    expect(await screen.findByText('MAKE-100')).toBeInTheDocument();
+    expect(screen.getByText('BUY-20')).toBeInTheDocument();
+    expect(screen.getByText('MAKE')).toBeInTheDocument();
+    expect(screen.getByText('BUY')).toBeInTheDocument();
+    expect(screen.getByText(/traveler decision required/i)).toBeInTheDocument();
+    expect(screen.getByTestId('production-plan-stale')).toHaveTextContent(
+      'BOM revision/release changed'
+    );
+    expect(screen.getByText(/engineering approval/i)).toBeInTheDocument();
+    expect(screen.getByText(/quality approval/i)).toBeInTheDocument();
+    expect(screen.getByText(/operations approval/i)).toBeInTheDocument();
+    expect(screen.getByText(/Revision 1/)).toBeInTheDocument();
+    expect(screen.getAllByTestId('production-plan-item')).toHaveLength(1);
+  });
+});

--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -6,7 +6,12 @@ import P2V2ProjectWorkflow from '../components/projects/P2V2ProjectWorkflow';
 
 const stages = Array.from({ length: 10 }, (_, index) => ({
   id: `step-${index + 1}`,
-  stepType: index === 3 ? 'design_applicability' : `stage_${index + 1}`,
+  stepType:
+    index === 3
+      ? 'design_applicability'
+      : index === 4
+        ? 'production_planning'
+        : `stage_${index + 1}`,
   stepOrder: index + 1,
   label: `Stage ${index + 1}`,
   description: `Description ${index + 1}`,
@@ -130,13 +135,16 @@ describe('P2V2ProjectWorkflow', () => {
     expect(screen.getByTestId('v2-approval')).toHaveTextContent('REJECTED');
   });
 
-  it('makes only Design Applicability writable from the ten-stage summary', async () => {
+  it('makes only Design Applicability and Production Planning writable from the ten-stage summary', async () => {
     renderWorkflow(initialized);
     expect(
       await screen.findByTestId('open-design-applicability')
     ).toBeInTheDocument();
     expect(
       screen.getAllByRole('button', { name: 'Open Design Applicability' })
+    ).toHaveLength(1);
+    expect(
+      screen.getAllByRole('button', { name: 'Open Production Planning' })
     ).toHaveLength(1);
     expect(screen.getAllByRole('button', { name: 'Details' })).toHaveLength(10);
   });

--- a/client/src/components/projects/P2V2ProductionPlanning.tsx
+++ b/client/src/components/projects/P2V2ProductionPlanning.tsx
@@ -1,0 +1,703 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+
+type Row = Record<string, unknown>;
+type Model = {
+  plan: Row | null;
+  items: Row[];
+  history: Row[];
+  approvalHistory: Row[];
+  readiness: {
+    ready: boolean;
+    blockers: string[];
+    stale: boolean;
+    differences: string[];
+  };
+};
+const endpoint = (projectId: string) =>
+  `/api/projects/${projectId}/workflow-v2/production-planning`;
+async function request(url: string, method = 'GET', body?: unknown) {
+  const response = await fetch(url, {
+    method,
+    credentials: 'include',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok)
+    throw new Error(data.message || data.error || 'Request failed');
+  return data;
+}
+const value = (row: Row, key: string) => String(row[key] ?? '');
+const listValue = (row: Row, key: string) =>
+  Array.isArray(row[key]) ? (row[key] as unknown[]).join(', ') : '';
+const selectOptions = (values: string[]) =>
+  values.map((item) => (
+    <SelectItem key={item} value={item}>
+      {item.replaceAll('_', ' ')}
+    </SelectItem>
+  ));
+
+export default function P2V2ProductionPlanning({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [header, setHeader] = useState({
+    requirementSource: 'Customer PO and released engineering configuration',
+    planningBasis:
+      'Current PO revision, manufactured assembly tree, released BOMs and approved production controls',
+    effectivityReference: '',
+    notes: '',
+  });
+  const [error, setError] = useState('');
+  const client = useQueryClient();
+  const key = [
+    '/api/projects',
+    projectId,
+    'workflow-v2',
+    'production-planning',
+  ];
+  const { data, isLoading } = useQuery<Model>({
+    queryKey: key,
+    queryFn: () => request(endpoint(projectId)),
+    enabled: open,
+  });
+  const { data: permissions } = useQuery<{ permissions: string[] }>({
+    queryKey: ['/api/permissions/me'],
+    queryFn: () => request('/api/permissions/me'),
+  });
+  const allowed = useMemo(
+    () => new Set(permissions?.permissions ?? []),
+    [permissions]
+  );
+  const canManage = allowed.has('projects.production_planning.manage');
+  const mutation = useMutation({
+    mutationFn: ({
+      url,
+      method,
+      body,
+    }: {
+      url: string;
+      method?: string;
+      body?: unknown;
+    }) => request(url, method, body),
+    onSuccess: async () => {
+      setError('');
+      await client.invalidateQueries({ queryKey: key });
+      await client.invalidateQueries({
+        queryKey: ['/api/projects', projectId, 'workflow-v2'],
+      });
+    },
+    onError: (cause: Error) => setError(cause.message),
+  });
+  const planId = value(data?.plan ?? {}, 'id');
+  const status = value(data?.plan ?? {}, 'status');
+  const act = (suffix: string, method = 'POST', body?: unknown) =>
+    mutation.mutate({
+      url: `${endpoint(projectId)}/${planId}${suffix}`,
+      method,
+      body,
+    });
+  const decide = (capacity: string, decision: 'APPROVED' | 'REJECTED') => {
+    const signatureMeaning = window.prompt(
+      'Signature meaning (required):',
+      `I ${decision === 'APPROVED' ? 'approve' : 'return'} this ${capacity} production-plan revision.`
+    );
+    if (!signatureMeaning) return;
+    const reason =
+      window.prompt(
+        decision === 'APPROVED' ? 'Comments (optional):' : 'Reason (required):',
+        ''
+      ) ?? '';
+    if (decision !== 'APPROVED' && !reason.trim()) return;
+    act(`/${capacity}-decision`, 'POST', {
+      decision,
+      signatureMeaning,
+      reason,
+    });
+  };
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        data-testid="open-production-planning"
+      >
+        Open Production Planning
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="max-h-[92vh] max-w-6xl overflow-y-auto"
+          data-testid="production-planning-dialog"
+        >
+          <DialogHeader>
+            <DialogTitle>Production Planning</DialogTitle>
+            <DialogDescription>
+              Revision-controlled manufacturing configuration baseline. This
+              stage does not generate production orders, travelers, or WAD
+              records.
+            </DialogDescription>
+          </DialogHeader>
+          {isLoading ? (
+            <p>Loading production plan…</p>
+          ) : (
+            <div className="space-y-6">
+              {data?.plan ? (
+                <section className="grid gap-3 rounded border p-4 md:grid-cols-4">
+                  <div>
+                    <span className="text-xs text-muted-foreground">
+                      Plan revision
+                    </span>
+                    <p>Rev {value(data.plan, 'revision_number')}</p>
+                  </div>
+                  <div>
+                    <span className="text-xs text-muted-foreground">
+                      Status
+                    </span>
+                    <div className="mt-1">
+                      <Badge>{status}</Badge>
+                    </div>
+                  </div>
+                  <div>
+                    <span className="text-xs text-muted-foreground">
+                      PO baseline
+                    </span>
+                    <p>
+                      {value(data.plan, 'po_number')} Rev{' '}
+                      {value(data.plan, 'po_revision_number')}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-xs text-muted-foreground">
+                      Effectivity
+                    </span>
+                    <p>{value(data.plan, 'effectivity_reference')}</p>
+                  </div>
+                </section>
+              ) : (
+                <section className="grid gap-3 rounded border p-4 md:grid-cols-2">
+                  <div>
+                    <Label>Requirement source</Label>
+                    <Input
+                      value={header.requirementSource}
+                      onChange={(event) =>
+                        setHeader({
+                          ...header,
+                          requirementSource: event.target.value,
+                        })
+                      }
+                    />
+                  </div>
+                  <div>
+                    <Label>Effectivity override</Label>
+                    <Input
+                      value={header.effectivityReference}
+                      onChange={(event) =>
+                        setHeader({
+                          ...header,
+                          effectivityReference: event.target.value,
+                        })
+                      }
+                    />
+                  </div>
+                  <div className="md:col-span-2">
+                    <Label>Planning basis</Label>
+                    <Textarea
+                      value={header.planningBasis}
+                      onChange={(event) =>
+                        setHeader({
+                          ...header,
+                          planningBasis: event.target.value,
+                        })
+                      }
+                    />
+                  </div>
+                  <div className="md:col-span-2">
+                    <Label>Notes</Label>
+                    <Textarea
+                      value={header.notes}
+                      onChange={(event) =>
+                        setHeader({ ...header, notes: event.target.value })
+                      }
+                    />
+                  </div>
+                  {canManage && (
+                    <Button
+                      onClick={() =>
+                        mutation.mutate({
+                          url: endpoint(projectId),
+                          method: 'POST',
+                          body: header,
+                        })
+                      }
+                    >
+                      Build Draft From Current Configuration
+                    </Button>
+                  )}
+                </section>
+              )}
+              {data?.readiness.stale && (
+                <section
+                  className="rounded border border-red-300 bg-red-50 p-3"
+                  data-testid="production-plan-stale"
+                >
+                  <h3 className="font-semibold text-red-800">
+                    Released baseline is stale
+                  </h3>
+                  <ul className="list-disc pl-5 text-sm text-red-700">
+                    {data.readiness.differences.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+              {!!data?.readiness.blockers.length && (
+                <section className="rounded border border-amber-300 bg-amber-50 p-3">
+                  <h3 className="font-semibold">Readiness blockers</h3>
+                  <ul className="max-h-52 list-disc overflow-y-auto pl-5 text-sm">
+                    {data.readiness.blockers.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+              {!!data?.items.length && (
+                <>
+                  <section>
+                    <h3 className="font-semibold">Assembly tree</h3>
+                    <div className="mt-2 space-y-1 rounded border p-3">
+                      {data.items.map((item) => (
+                        <div
+                          key={value(item, 'id')}
+                          style={{
+                            paddingLeft: `${Math.max(0, value(item, 'assembly_path').split('/').length - 1) * 18}px`,
+                          }}
+                          className="text-sm"
+                        >
+                          <Badge
+                            variant={
+                              item.is_manufactured ? 'default' : 'outline'
+                            }
+                          >
+                            {item.is_manufactured ? 'MAKE' : 'BUY'}
+                          </Badge>{' '}
+                          <strong>{value(item, 'part_number')}</strong>{' '}
+                          {value(item, 'part_name')} · Qty{' '}
+                          {value(item, 'extended_project_quantity')} · BOM{' '}
+                          {value(item, 'bom_revision') || 'missing'} · Routing{' '}
+                          {value(item, 'routing_revision') || 'missing'}
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                  <section className="space-y-3">
+                    <h3 className="font-semibold">
+                      Manufactured-item planning
+                    </h3>
+                    {data.items
+                      .filter((item) => item.is_manufactured)
+                      .map((item) => (
+                        <PlanningItem
+                          key={value(item, 'id')}
+                          item={item}
+                          editable={status === 'DRAFT' && canManage}
+                          saving={mutation.isPending}
+                          onSave={(changes) =>
+                            act(`/items/${value(item, 'id')}`, 'PATCH', changes)
+                          }
+                        />
+                      ))}
+                  </section>
+                </>
+              )}
+              {data?.plan && (
+                <div className="flex flex-wrap gap-2">
+                  {status === 'DRAFT' && canManage && (
+                    <>
+                      <Button variant="outline" onClick={() => act('/refresh')}>
+                        Refresh Draft Configuration
+                      </Button>
+                      <Button onClick={() => act('/submit')}>
+                        Submit for Approval
+                      </Button>
+                    </>
+                  )}
+                  {['RELEASED', 'REJECTED'].includes(status) && canManage && (
+                    <Button onClick={() => act('/revise', 'POST', header)}>
+                      Create New Revision
+                    </Button>
+                  )}
+                </div>
+              )}
+              {error && <p className="text-sm text-red-700">{error}</p>}
+              {data?.plan && (
+                <section className="grid gap-4 md:grid-cols-3">
+                  {(['engineering', 'quality', 'operations'] as const).map(
+                    (capacity) => (
+                      <ApprovalPanel
+                        key={capacity}
+                        capacity={capacity}
+                        history={data.approvalHistory}
+                        canDecide={allowed.has(
+                          `projects.production_planning.${capacity}_decide`
+                        )}
+                        pending={status === 'PENDING_APPROVAL'}
+                        onDecision={(decision) => decide(capacity, decision)}
+                      />
+                    )
+                  )}
+                </section>
+              )}
+              {!!data?.history.length && (
+                <section>
+                  <h3 className="font-semibold">Revision history</h3>
+                  {data.history.map((plan) => (
+                    <div
+                      className="mt-2 rounded border p-2 text-sm"
+                      key={value(plan, 'id')}
+                    >
+                      Revision {value(plan, 'revision_number')} ·{' '}
+                      {value(plan, 'status')} ·{' '}
+                      {value(plan, 'configuration_revision')} ·{' '}
+                      {value(plan, 'effectivity_reference')}
+                    </div>
+                  ))}
+                </section>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function PlanningItem({
+  item,
+  editable,
+  saving,
+  onSave,
+}: {
+  item: Row;
+  editable: boolean;
+  saving: boolean;
+  onSave: (changes: Row) => void;
+}) {
+  const [form, setForm] = useState<Row>(() => ({ ...item }));
+  const set = (key: string, next: unknown) => setForm({ ...form, [key]: next });
+  const comma = (key: string) => listValue(form, key);
+  const setComma = (key: string, next: string) =>
+    set(
+      key,
+      next
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean)
+    );
+  return (
+    <details className="rounded border p-3" data-testid="production-plan-item">
+      <summary className="cursor-pointer font-medium">
+        {value(item, 'part_number')} — {value(item, 'part_name')}{' '}
+        <Badge variant="outline">BOM {value(item, 'bom_release_status')}</Badge>{' '}
+        <Badge variant="outline">
+          Routing {value(item, 'routing_release_status')}
+        </Badge>
+      </summary>
+      <fieldset
+        disabled={!editable || saving}
+        className="mt-4 grid gap-3 md:grid-cols-3"
+      >
+        <Field label="Drawing number">
+          <Input
+            value={value(form, 'drawing_number')}
+            onChange={(e) => set('drawing_number', e.target.value)}
+          />
+        </Field>
+        <Field label="Drawing revision">
+          <Input
+            value={value(form, 'drawing_revision')}
+            onChange={(e) => set('drawing_revision', e.target.value)}
+          />
+        </Field>
+        <Field label="Requirement source">
+          <Input
+            value={value(form, 'requirement_source')}
+            onChange={(e) => set('requirement_source', e.target.value)}
+          />
+        </Field>
+        <Choice
+          label="Routing"
+          value={value(form, 'routing_requirement')}
+          options={['REQUIRED', 'NOT_REQUIRED_APPROVED']}
+          onChange={(next) => set('routing_requirement', next)}
+        />
+        <Field label="Routing N/A reason">
+          <Input
+            value={value(form, 'routing_not_required_reason')}
+            onChange={(e) => set('routing_not_required_reason', e.target.value)}
+          />
+        </Field>
+        <Choice
+          label="Traveler"
+          value={value(form, 'traveler_requirement')}
+          options={['REQUIRED', 'NOT_REQUIRED_APPROVED']}
+          onChange={(next) => set('traveler_requirement', next)}
+        />
+        <Choice
+          label="Traveler type (batch is valid for non-serialized work)"
+          value={value(form, 'traveler_type')}
+          options={['INDIVIDUAL', 'BATCH', 'LOT']}
+          onChange={(next) => set('traveler_type', next)}
+        />
+        <Field label="Traveler N/A reason">
+          <Input
+            value={value(form, 'traveler_not_required_reason')}
+            onChange={(e) =>
+              set('traveler_not_required_reason', e.target.value)
+            }
+          />
+        </Field>
+        <Choice
+          label="Work instruction"
+          value={value(form, 'work_instruction_requirement')}
+          options={[
+            'REQUIRED',
+            'DRAWING_SPEC_SUFFICIENT',
+            'NOT_REQUIRED_APPROVED',
+          ]}
+          onChange={(next) => set('work_instruction_requirement', next)}
+        />
+        <Field label="WI basis / drawing sufficiency">
+          <Input
+            value={value(form, 'work_instruction_basis')}
+            onChange={(e) => set('work_instruction_basis', e.target.value)}
+          />
+        </Field>
+        <Field label="WI references">
+          <Input
+            value={comma('work_instruction_references')}
+            onChange={(e) =>
+              setComma('work_instruction_references', e.target.value)
+            }
+          />
+        </Field>
+        <Choice
+          label="Inspection extent"
+          value={value(form, 'inspection_extent')}
+          options={[
+            'ONE_HUNDRED_PERCENT',
+            'APPROVED_SAMPLING',
+            'FINAL_ONLY',
+            'IN_PROCESS_AND_FINAL',
+          ]}
+          onChange={(next) => set('inspection_extent', next)}
+        />
+        <Field label="Sampling plan (required only for sampling)">
+          <Input
+            value={value(form, 'sampling_plan_id')}
+            onChange={(e) => set('sampling_plan_id', e.target.value)}
+          />
+        </Field>
+        <Choice
+          label="Sampling status"
+          value={value(form, 'sampling_plan_status')}
+          options={['APPROVED', 'PENDING', 'REJECTED']}
+          onChange={(next) => set('sampling_plan_status', next)}
+        />
+        <Choice
+          label="FAI / AS9102"
+          value={value(form, 'fai_requirement')}
+          options={['FULL', 'PARTIAL', 'NOT_REQUIRED']}
+          onChange={(next) => set('fai_requirement', next)}
+        />
+        <Field label="FAI reason">
+          <Input
+            value={value(form, 'fai_reason')}
+            onChange={(e) => set('fai_reason', e.target.value)}
+          />
+        </Field>
+        <Choice
+          label="Traceability"
+          value={value(form, 'traceability_level')}
+          options={['SERIAL', 'LOT', 'BATCH', 'STANDARD']}
+          onChange={(next) => set('traceability_level', next)}
+        />
+        <Choice
+          label="Special process source"
+          value={value(form, 'special_process_source')}
+          options={['INTERNAL', 'EXTERNAL_APPROVED_SUPPLIER', 'NONE']}
+          onChange={(next) => set('special_process_source', next)}
+        />
+        <Field label="Special processes">
+          <Input
+            value={comma('special_process_requirements')}
+            onChange={(e) =>
+              setComma('special_process_requirements', e.target.value)
+            }
+          />
+        </Field>
+        <Field label="Certifications">
+          <Input
+            value={comma('required_certifications')}
+            onChange={(e) =>
+              setComma('required_certifications', e.target.value)
+            }
+          />
+        </Field>
+        <Field label="Tests">
+          <Input
+            value={comma('required_test_records')}
+            onChange={(e) => setComma('required_test_records', e.target.value)}
+          />
+        </Field>
+        <Field label="Tooling">
+          <Input
+            value={comma('tooling_requirements')}
+            onChange={(e) => setComma('tooling_requirements', e.target.value)}
+          />
+        </Field>
+        <Field label="CNC programs">
+          <Input
+            value={comma('cnc_program_requirements')}
+            onChange={(e) =>
+              setComma('cnc_program_requirements', e.target.value)
+            }
+          />
+        </Field>
+        <Choice
+          label="Packaging instruction"
+          value={value(form, 'packaging_instruction_requirement')}
+          options={['REQUIRED', 'NOT_REQUIRED_APPROVED']}
+          onChange={(next) => set('packaging_instruction_requirement', next)}
+        />
+        <Field label="Packaging reference">
+          <Input
+            value={value(form, 'packaging_instruction_reference')}
+            onChange={(e) =>
+              set('packaging_instruction_reference', e.target.value)
+            }
+          />
+        </Field>
+        <Field label="Notes / N/A basis">
+          <Textarea
+            value={value(form, 'notes')}
+            onChange={(e) => set('notes', e.target.value)}
+          />
+        </Field>
+        {editable && (
+          <Button type="button" onClick={() => onSave(form)}>
+            Save Item Decisions
+          </Button>
+        )}
+      </fieldset>
+    </details>
+  );
+}
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <Label>{label}</Label>
+      {children}
+    </div>
+  );
+}
+function Choice({
+  label,
+  value: current,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <Field label={label}>
+      <Select value={current || undefined} onValueChange={onChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Decision required" />
+        </SelectTrigger>
+        <SelectContent>{selectOptions(options)}</SelectContent>
+      </Select>
+    </Field>
+  );
+}
+function ApprovalPanel({
+  capacity,
+  history,
+  canDecide,
+  pending,
+  onDecision,
+}: {
+  capacity: string;
+  history: Row[];
+  canDecide: boolean;
+  pending: boolean;
+  onDecision: (decision: 'APPROVED' | 'REJECTED') => void;
+}) {
+  const items = history.filter(
+    (item) =>
+      value(item, 'approval_type') ===
+      `PRODUCTION_PLANNING_${capacity.toUpperCase()}`
+  );
+  return (
+    <div className="rounded border p-3">
+      <h3 className="font-semibold capitalize">{capacity} approval</h3>
+      {items.length ? (
+        items.map((item) => (
+          <div key={value(item, 'id')} className="mt-2 text-sm">
+            <Badge variant="outline">{value(item, 'decision')}</Badge>
+            <p>{value(item, 'signature_meaning')}</p>
+            <p className="text-muted-foreground">
+              {value(item, 'actor_display_name')} · {value(item, 'actor_role')}{' '}
+              · {new Date(value(item, 'decided_at')).toLocaleString()}
+            </p>
+            {item.superseded_at && (
+              <Badge variant="secondary">Superseded</Badge>
+            )}
+          </div>
+        ))
+      ) : (
+        <p className="text-sm text-muted-foreground">No decision recorded.</p>
+      )}
+      {canDecide && pending && (
+        <div className="mt-2 flex gap-2">
+          <Button size="sm" onClick={() => onDecision('APPROVED')}>
+            Approve
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={() => onDecision('REJECTED')}
+          >
+            Reject / Return
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 
 import P2V2DesignApplicability from './P2V2DesignApplicability';
+import P2V2ProductionPlanning from './P2V2ProductionPlanning';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -370,6 +371,11 @@ export default function P2V2ProjectWorkflow({
               {stage.stepType === 'design_applicability' && (
                 <div className="mt-3">
                   <P2V2DesignApplicability projectId={projectId} />
+                </div>
+              )}
+              {stage.stepType === 'production_planning' && (
+                <div className="mt-3">
+                  <P2V2ProductionPlanning projectId={projectId} />
                 </div>
               )}
             </CardContent>

--- a/migrations/0204_project_production_plans.sql
+++ b/migrations/0204_project_production_plans.sql
@@ -1,0 +1,119 @@
+-- Phase 6: additive p2_v2 Production Planning baseline.
+-- No legacy backfill and no project_steps mutation.
+CREATE TABLE IF NOT EXISTS project_production_plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  workflow_instance_id UUID NOT NULL,
+  workflow_step_instance_id UUID NOT NULL,
+  workflow_step_type TEXT NOT NULL DEFAULT 'production_planning' CHECK (workflow_step_type = 'production_planning'),
+  revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+  status TEXT NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT','PENDING_APPROVAL','APPROVED','RELEASED','REJECTED','SUPERSEDED')),
+  po_id INTEGER REFERENCES p2_purchase_orders(id) ON DELETE RESTRICT,
+  po_revision_number INTEGER,
+  po_number TEXT,
+  configuration_baseline_id TEXT,
+  configuration_revision TEXT NOT NULL,
+  design_release_id UUID REFERENCES engineering_releases(id) ON DELETE RESTRICT,
+  design_release_revision TEXT,
+  effectivity_type TEXT NOT NULL CHECK (effectivity_type IN ('PO_REVISION','DATE','SERIAL_RANGE','LOT','PROJECT')),
+  effectivity_reference TEXT NOT NULL,
+  requirement_source TEXT NOT NULL,
+  planning_basis TEXT NOT NULL,
+  notes TEXT,
+  submitted_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  submitted_by_display_name TEXT,
+  submitted_at TIMESTAMP,
+  released_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  released_by_display_name TEXT,
+  released_at TIMESTAMP,
+  superseded_at TIMESTAMP,
+  superseded_by_plan_id UUID REFERENCES project_production_plans(id) ON DELETE RESTRICT,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_production_plans_instance_project_fk FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_production_plans_step_identity_fk FOREIGN KEY (workflow_step_instance_id, workflow_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, workflow_instance_id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_production_plans_revision_unique UNIQUE (project_id, workflow_instance_id, revision_number)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_production_plans_current_unique
+  ON project_production_plans(project_id, workflow_instance_id) WHERE status <> 'SUPERSEDED';
+CREATE INDEX IF NOT EXISTS project_production_plans_project_idx ON project_production_plans(project_id, revision_number DESC);
+
+CREATE TABLE IF NOT EXISTS project_production_plan_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  production_plan_id UUID NOT NULL REFERENCES project_production_plans(id) ON DELETE RESTRICT,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  inventory_item_id INTEGER REFERENCES inventory_items(id) ON DELETE SET NULL,
+  part_number TEXT NOT NULL,
+  part_name TEXT,
+  manufacturing_level TEXT,
+  parent_part_number TEXT,
+  assembly_path TEXT NOT NULL,
+  quantity_per_parent NUMERIC(18,6) NOT NULL DEFAULT 1 CHECK (quantity_per_parent > 0),
+  extended_project_quantity NUMERIC(18,6) NOT NULL DEFAULT 1 CHECK (extended_project_quantity > 0),
+  make_buy TEXT NOT NULL CHECK (make_buy IN ('MAKE','BUY','REFERENCE')),
+  is_manufactured BOOLEAN NOT NULL,
+  drawing_number TEXT,
+  drawing_revision TEXT,
+  specification_references JSONB NOT NULL DEFAULT '[]'::jsonb,
+  bom_id UUID REFERENCES boms(id) ON DELETE RESTRICT,
+  bom_revision_id UUID REFERENCES bom_revisions(id) ON DELETE RESTRICT,
+  bom_revision TEXT,
+  bom_release_status TEXT NOT NULL DEFAULT 'MISSING' CHECK (bom_release_status IN ('RELEASED','UNRELEASED','MISSING','NOT_REQUIRED_APPROVED')),
+  routing_id UUID REFERENCES part_routings(id) ON DELETE RESTRICT,
+  routing_revision TEXT,
+  routing_release_status TEXT NOT NULL DEFAULT 'MISSING' CHECK (routing_release_status IN ('RELEASED','ACTIVE_UNAPPROVED','INACTIVE','MISSING','NOT_REQUIRED_APPROVED')),
+  effectivity_reference TEXT,
+  routing_requirement TEXT CHECK (routing_requirement IN ('REQUIRED','NOT_REQUIRED_APPROVED')),
+  routing_not_required_reason TEXT,
+  traveler_requirement TEXT CHECK (traveler_requirement IN ('REQUIRED','NOT_REQUIRED_APPROVED')),
+  traveler_type TEXT CHECK (traveler_type IN ('INDIVIDUAL','BATCH','LOT')),
+  traveler_not_required_reason TEXT,
+  work_instruction_requirement TEXT CHECK (work_instruction_requirement IN ('REQUIRED','DRAWING_SPEC_SUFFICIENT','NOT_REQUIRED_APPROVED')),
+  work_instruction_basis TEXT,
+  work_instruction_references JSONB NOT NULL DEFAULT '[]'::jsonb,
+  specification_sheet_requirement TEXT CHECK (specification_sheet_requirement IN ('REQUIRED','NOT_REQUIRED_APPROVED')),
+  inspection_requirement TEXT CHECK (inspection_requirement IN ('REQUIRED','NOT_REQUIRED_APPROVED')),
+  in_process_inspection_required BOOLEAN,
+  final_inspection_required BOOLEAN,
+  inspection_extent TEXT CHECK (inspection_extent IN ('ONE_HUNDRED_PERCENT','APPROVED_SAMPLING','FINAL_ONLY','IN_PROCESS_AND_FINAL')),
+  sampling_plan_id TEXT,
+  sampling_plan_status TEXT,
+  fai_requirement TEXT CHECK (fai_requirement IN ('FULL','PARTIAL','NOT_REQUIRED')),
+  fai_reason TEXT,
+  traceability_level TEXT CHECK (traceability_level IN ('SERIAL','LOT','BATCH','STANDARD')),
+  serialization_required BOOLEAN,
+  lot_traceability_required BOOLEAN,
+  special_process_source TEXT CHECK (special_process_source IN ('INTERNAL','EXTERNAL_APPROVED_SUPPLIER','NONE')),
+  special_process_requirements JSONB NOT NULL DEFAULT '[]'::jsonb,
+  required_certifications JSONB NOT NULL DEFAULT '[]'::jsonb,
+  required_test_records JSONB NOT NULL DEFAULT '[]'::jsonb,
+  tooling_requirements JSONB NOT NULL DEFAULT '[]'::jsonb,
+  cnc_program_requirements JSONB NOT NULL DEFAULT '[]'::jsonb,
+  packaging_instruction_requirement TEXT CHECK (packaging_instruction_requirement IN ('REQUIRED','NOT_REQUIRED_APPROVED')),
+  packaging_instruction_reference TEXT,
+  requirement_source TEXT,
+  notes TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_production_plan_items_plan_part_unique UNIQUE (production_plan_id, assembly_path)
+);
+CREATE INDEX IF NOT EXISTS project_production_plan_items_plan_idx ON project_production_plan_items(production_plan_id, assembly_path);
+
+INSERT INTO perm_capabilities (key, description, category) VALUES
+ ('projects.production_planning.manage','Draft, refresh, submit and revise P2 V2 production plans','projects'),
+ ('projects.production_planning.engineering_decide','Record Engineering production-plan decisions','engineering'),
+ ('projects.production_planning.quality_decide','Record Quality production-plan decisions','quality'),
+ ('projects.production_planning.operations_decide','Record Operations production-plan decisions','operations')
+ON CONFLICT (key) DO UPDATE SET description=EXCLUDED.description, category=EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT pr.id, pc.id FROM perm_roles pr JOIN perm_capabilities pc ON (
+ (pr.name IN ('ADMIN','OWNER') AND pc.key='projects.production_planning.manage') OR
+ (pr.name IN ('ENGINEERING','ENGINEER','ENGINEERING_MANAGER') AND pc.key IN ('projects.production_planning.manage','projects.production_planning.engineering_decide')) OR
+ (pr.name IN ('QUALITY','QC','QUALITY_MANAGER') AND pc.key='projects.production_planning.quality_decide') OR
+ (pr.name IN ('OPERATIONS','OPERATIONS_MANAGER','PRODUCTION_MANAGER','MANAGER') AND pc.key='projects.production_planning.operations_decide')
+) ON CONFLICT (role_id, capability_id) DO NOTHING;

--- a/server/__tests__/projectProductionPlanning.test.ts
+++ b/server/__tests__/projectProductionPlanning.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { productionPlanItemBlockers } from '../src/services/projectProductionPlanningValidation';
+
+const root = resolve(__dirname, '../..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+const migration = read('migrations/0204_project_production_plans.sql');
+const service = read('server/src/services/projectProductionPlanningService.ts');
+const routes = read('server/src/routes/projectProductionPlanning.ts');
+
+describe('Phase 6 additive storage', () => {
+  it('adds revision-controlled plan and item tables without legacy mutation', () => {
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS project_production_plans'
+    );
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS project_production_plan_items'
+    );
+    expect(migration).toContain("workflow_step_type = 'production_planning'");
+    expect(migration).toContain('project_production_plans_current_unique');
+    expect(migration).not.toMatch(/UPDATE\s+(?:projects|project_steps)\b/i);
+    expect(migration).not.toMatch(/ON DELETE CASCADE/i);
+  });
+  it('has no physical deletion endpoint or generic stage-status route', () => {
+    expect(routes).not.toMatch(/router\.delete/i);
+    expect(routes).not.toMatch(/stage-status/);
+    expect(service).not.toContain("status='COMPLETE' WHERE id=${req");
+  });
+});
+
+describe('production-plan readiness decisions', () => {
+  const complete = {
+    is_manufactured: true,
+    part_number: 'P-100',
+    bom_release_status: 'RELEASED',
+    routing_requirement: 'REQUIRED',
+    routing_release_status: 'RELEASED',
+    traveler_requirement: 'REQUIRED',
+    traveler_type: 'BATCH',
+    work_instruction_requirement: 'DRAWING_SPEC_SUFFICIENT',
+    work_instruction_basis: 'Released drawing defines all work',
+    inspection_extent: 'ONE_HUNDRED_PERCENT',
+    fai_requirement: 'NOT_REQUIRED',
+    fai_reason: 'No new design/configuration trigger',
+    traceability_level: 'BATCH',
+    special_process_source: 'NONE',
+    special_process_requirements: [],
+    required_certifications: [],
+    required_test_records: [],
+    tooling_requirements: [],
+    cnc_program_requirements: [],
+    packaging_instruction_requirement: 'NOT_REQUIRED_APPROVED',
+    notes: 'Customer packaging specification applies',
+  };
+  it('accepts batch travelers and 100 percent inspection without a sampling plan', () => {
+    expect(productionPlanItemBlockers(complete)).toEqual([]);
+  });
+  it('blocks sampling without an approved sampling plan', () => {
+    expect(
+      productionPlanItemBlockers({
+        ...complete,
+        inspection_extent: 'APPROVED_SAMPLING',
+        sampling_plan_id: 'SP-1',
+        sampling_plan_status: 'PENDING',
+      })
+    ).toContain('P-100: approved sampling plan required.');
+  });
+  it('requires reasons for traveler, routing, FAI, and packaging N/A decisions', () => {
+    const blockers = productionPlanItemBlockers({
+      ...complete,
+      routing_requirement: 'NOT_REQUIRED_APPROVED',
+      routing_not_required_reason: '',
+      traveler_requirement: 'NOT_REQUIRED_APPROVED',
+      traveler_not_required_reason: '',
+      fai_reason: '',
+      notes: '',
+    });
+    expect(blockers).toEqual(
+      expect.arrayContaining([
+        'P-100: routing N/A reason required.',
+        'P-100: traveler N/A reason required.',
+        'P-100: FAI N/A reason required.',
+        'P-100: packaging N/A reason required.',
+      ])
+    );
+  });
+  it('does not impose manufacturing decisions on purchased reference leaves', () => {
+    expect(
+      productionPlanItemBlockers({
+        is_manufactured: false,
+        part_number: 'BUY-1',
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('controlled configuration and approval behavior', () => {
+  it('uses the current PO, recursive cycle guard, separate approvals and immutable released revisions', () => {
+    expect(service).toContain('po.is_current_revision=true');
+    expect(service).toContain(
+      'NOT bl.child_part_ag_number=ANY(tree.cycle_path)'
+    );
+    expect(service).toMatch(/'ENGINEERING',\s*'QUALITY',\s*'OPERATIONS'/);
+    expect(service).toMatch(/plan\.status\s*!==\s*'DRAFT'/);
+    expect(service).toContain('SEGREGATION_OF_DUTIES');
+    expect(service).toContain("status='SUPERSEDED'");
+  });
+});

--- a/server/src/routes/projectProductionPlanning.ts
+++ b/server/src/routes/projectProductionPlanning.ts
@@ -1,0 +1,274 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { getUserPermissions } from '../services/permissionService';
+import {
+  createDraftFromCurrentConfiguration,
+  getCurrentProductionPlan,
+  ProjectProductionPlanningError,
+  recordEngineeringDecision,
+  recordOperationsDecision,
+  recordQualityDecision,
+  refreshDraft,
+  revisePlan,
+  submitForApproval,
+  updatePlanItemDecision,
+  type PlanningActor,
+} from '../services/projectProductionPlanningService';
+
+const router = Router({ mergeParams: true });
+const headerSchema = z.object({
+  requirementSource: z.string().min(1),
+  planningBasis: z.string().min(1),
+  effectivityType: z
+    .enum(['PO_REVISION', 'DATE', 'SERIAL_RANGE', 'LOT', 'PROJECT'])
+    .optional(),
+  effectivityReference: z.string().optional(),
+  notes: z.string().nullable().optional(),
+});
+const decisionSchema = z.object({
+  decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+  signatureMeaning: z.string().min(1),
+  reason: z.string().optional().default(''),
+});
+const itemSchema = z
+  .object({
+    drawing_number: z.string().nullable().optional(),
+    drawing_revision: z.string().nullable().optional(),
+    specification_references: z.array(z.unknown()).optional(),
+    routing_requirement: z
+      .enum(['REQUIRED', 'NOT_REQUIRED_APPROVED'])
+      .nullable()
+      .optional(),
+    routing_not_required_reason: z.string().nullable().optional(),
+    traveler_requirement: z
+      .enum(['REQUIRED', 'NOT_REQUIRED_APPROVED'])
+      .nullable()
+      .optional(),
+    traveler_type: z.enum(['INDIVIDUAL', 'BATCH', 'LOT']).nullable().optional(),
+    traveler_not_required_reason: z.string().nullable().optional(),
+    work_instruction_requirement: z
+      .enum(['REQUIRED', 'DRAWING_SPEC_SUFFICIENT', 'NOT_REQUIRED_APPROVED'])
+      .nullable()
+      .optional(),
+    work_instruction_basis: z.string().nullable().optional(),
+    work_instruction_references: z.array(z.unknown()).optional(),
+    specification_sheet_requirement: z
+      .enum(['REQUIRED', 'NOT_REQUIRED_APPROVED'])
+      .nullable()
+      .optional(),
+    inspection_requirement: z
+      .enum(['REQUIRED', 'NOT_REQUIRED_APPROVED'])
+      .nullable()
+      .optional(),
+    in_process_inspection_required: z.boolean().nullable().optional(),
+    final_inspection_required: z.boolean().nullable().optional(),
+    inspection_extent: z
+      .enum([
+        'ONE_HUNDRED_PERCENT',
+        'APPROVED_SAMPLING',
+        'FINAL_ONLY',
+        'IN_PROCESS_AND_FINAL',
+      ])
+      .nullable()
+      .optional(),
+    sampling_plan_id: z.string().nullable().optional(),
+    sampling_plan_status: z.string().nullable().optional(),
+    fai_requirement: z
+      .enum(['FULL', 'PARTIAL', 'NOT_REQUIRED'])
+      .nullable()
+      .optional(),
+    fai_reason: z.string().nullable().optional(),
+    traceability_level: z
+      .enum(['SERIAL', 'LOT', 'BATCH', 'STANDARD'])
+      .nullable()
+      .optional(),
+    serialization_required: z.boolean().nullable().optional(),
+    lot_traceability_required: z.boolean().nullable().optional(),
+    special_process_source: z
+      .enum(['INTERNAL', 'EXTERNAL_APPROVED_SUPPLIER', 'NONE'])
+      .nullable()
+      .optional(),
+    special_process_requirements: z.array(z.unknown()).optional(),
+    required_certifications: z.array(z.unknown()).optional(),
+    required_test_records: z.array(z.unknown()).optional(),
+    tooling_requirements: z.array(z.unknown()).optional(),
+    cnc_program_requirements: z.array(z.unknown()).optional(),
+    packaging_instruction_requirement: z
+      .enum(['REQUIRED', 'NOT_REQUIRED_APPROVED'])
+      .nullable()
+      .optional(),
+    packaging_instruction_reference: z.string().nullable().optional(),
+    requirement_source: z.string().nullable().optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .strict();
+
+function actor(req: Request): PlanningActor {
+  if (!req.user?.id || !req.user?.username || !req.user?.role)
+    throw new ProjectProductionPlanningError(
+      'ACTOR_REQUIRED',
+      'Authenticated actor identity is required.',
+      401
+    );
+  return {
+    userId: req.user.id,
+    employeeId: req.user.employeeId ?? null,
+    username: req.user.username,
+    displayName: req.user.username,
+    role: req.user.role,
+  };
+}
+async function requireCapability(req: Request, key: string) {
+  const value = actor(req);
+  const { permissionSet } = await getUserPermissions(value.userId, value.role);
+  if (!permissionSet.has(key))
+    throw new ProjectProductionPlanningError(
+      'FORBIDDEN',
+      `The ${key} capability is required.`,
+      403
+    );
+  return value;
+}
+function fail(res: Response, error: unknown) {
+  if (error instanceof z.ZodError)
+    return res
+      .status(400)
+      .json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error instanceof ProjectProductionPlanningError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
+  console.error('P2 V2 Production Planning error:', error);
+  return res.status(500).json({
+    error: 'PRODUCTION_PLANNING_FAILED',
+    message: 'Production Planning action failed.',
+  });
+}
+const projectId = (req: Request) => String(req.params.id);
+
+router.get('/', async (req, res) => {
+  try {
+    res.json(await getCurrentProductionPlan(projectId(req)));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_planning.manage'
+    );
+    res
+      .status(201)
+      .json(
+        await createDraftFromCurrentConfiguration(
+          projectId(req),
+          headerSchema.parse(req.body),
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:planId/refresh', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_planning.manage'
+    );
+    res.json(await refreshDraft(projectId(req), req.params.planId, user));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.patch('/:planId/items/:itemId', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_planning.manage'
+    );
+    res.json(
+      await updatePlanItemDecision(
+        projectId(req),
+        req.params.planId,
+        req.params.itemId,
+        itemSchema.parse(req.body),
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:planId/submit', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_planning.manage'
+    );
+    res.json(await submitForApproval(projectId(req), req.params.planId, user));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+for (const [path, key, handler] of [
+  [
+    'engineering-decision',
+    'projects.production_planning.engineering_decide',
+    recordEngineeringDecision,
+  ],
+  [
+    'quality-decision',
+    'projects.production_planning.quality_decide',
+    recordQualityDecision,
+  ],
+  [
+    'operations-decision',
+    'projects.production_planning.operations_decide',
+    recordOperationsDecision,
+  ],
+] as const) {
+  router.post(`/:planId/${path}`, async (req, res) => {
+    try {
+      const user = await requireCapability(req, key);
+      const body = decisionSchema.parse(req.body);
+      res.json(
+        await handler(
+          projectId(req),
+          req.params.planId,
+          body.decision,
+          body.signatureMeaning,
+          body.reason,
+          user
+        )
+      );
+    } catch (error) {
+      fail(res, error);
+    }
+  });
+}
+router.post('/:planId/revise', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_planning.manage'
+    );
+    res
+      .status(201)
+      .json(
+        await revisePlan(
+          projectId(req),
+          req.params.planId,
+          headerSchema.parse(req.body),
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+
+export default router;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -36,6 +36,8 @@ import { getFileStorageProviderForObjectPath } from '../services/fileStorageProv
 import { buildProjectBomAssemblyTree, type ProjectBomAssemblyRow } from '../services/projectBomAssembly';
 import { getActiveWorkflowInstanceForProject, getWorkflowReadModel } from '../services/projectWorkflowInstanceService';
 import { buildP2V2WorkflowResponse, buildUninitializedP2V2Response } from '../services/projectWorkflowV2ReadModel';
+import projectProductionPlanningRoutes from './projectProductionPlanning';
+import { getCurrentProductionPlan } from '../services/projectProductionPlanningService';
 import { getUserPermissions } from '../services/permissionService';
 import {
   createDraft as createDesignApplicabilityDraft,
@@ -1576,6 +1578,8 @@ function sendDesignError(res: Response, error: unknown) {
   return res.status(500).json({ error: 'DESIGN_APPLICABILITY_FAILED', message: 'The Design Applicability action failed.' });
 }
 
+router.use('/:id/workflow-v2/production-planning', projectProductionPlanningRoutes);
+
 router.get('/:id/workflow-v2/design-applicability', async (req, res) => {
   try {
     const model = await getCurrentDesignApplicability(req.params.id);
@@ -1660,6 +1664,29 @@ router.get('/:id/workflow-v2', async (req, res) => {
       response.blockedStages = response.stages.filter(
         (stage) => stage.status === 'BLOCKED'
       ).length;
+    }
+    const designStage = response.stages.find(
+      (stage) => stage.stepType === 'design_applicability'
+    );
+    if (['COMPLETE', 'NOT_APPLICABLE'].includes(designStage?.status ?? '')) {
+      const productionPlan = await getCurrentProductionPlan(project.id);
+      if (
+        productionPlan.plan?.status === 'RELEASED' &&
+        productionPlan.readiness.stale
+      ) {
+        response.stages = response.stages.map((stage) =>
+          stage.stepType === 'production_planning'
+            ? {
+                ...stage,
+                status: 'BLOCKED',
+                blockedReason: productionPlan.readiness.differences.join(' '),
+              }
+            : stage
+        );
+        response.blockedStages = response.stages.filter(
+          (stage) => stage.status === 'BLOCKED'
+        ).length;
+      }
     }
     return res.json(response);
   } catch (error) {

--- a/server/src/services/projectProductionPlanningService.ts
+++ b/server/src/services/projectProductionPlanningService.ts
@@ -1,0 +1,990 @@
+import { createHash } from 'crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+import {
+  ProjectProductionPlanningError,
+  productionPlanItemBlockers,
+} from './projectProductionPlanningValidation';
+
+export { ProjectProductionPlanningError } from './projectProductionPlanningValidation';
+type Executor = AuditLedgerTx;
+// Raw-query records deliberately mirror additive tables without expanding the central schema surface.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+export type PlanningActor = {
+  userId: number;
+  employeeId?: number | null;
+  username: string;
+  displayName: string;
+  role: string;
+};
+export type PlanHeaderInput = {
+  requirementSource: string;
+  planningBasis: string;
+  effectivityType?: string;
+  effectivityReference?: string;
+  notes?: string | null;
+};
+const resultRows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+const clean = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : '';
+
+async function context(projectId: string, tx: Executor, lock = false) {
+  const project = resultRows(
+    await tx.execute(
+      sql`SELECT id, workflow_version, po_id FROM projects WHERE id=${projectId} ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  )[0];
+  if (!project)
+    throw new ProjectProductionPlanningError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.',
+      404
+    );
+  const version = resolveProjectWorkflowVersion(project.workflow_version);
+  if (version !== 'p2_v2')
+    throw new ProjectProductionPlanningError(
+      'P2_V2_REQUIRED',
+      'Production Planning requires an explicit p2_v2 project.',
+      409,
+      { effectiveWorkflowVersion: version }
+    );
+  const instances = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_instances WHERE project_id=${projectId} AND workflow_version='p2_v2' AND status NOT IN ('SUPERSEDED','CANCELLED') ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  );
+  if (instances.length !== 1)
+    throw new ProjectProductionPlanningError(
+      instances.length
+        ? 'DUPLICATE_ACTIVE_INSTANCES'
+        : 'WORKFLOW_INSTANCE_REQUIRED',
+      instances.length
+        ? 'Multiple active V2 instances exist.'
+        : 'An active V2 workflow instance is required.',
+      409
+    );
+  const steps = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_instances WHERE workflow_instance_id=${instances[0].id} ORDER BY step_order`
+    )
+  );
+  const issues = validateWorkflowInstanceIntegrity(instances[0], steps);
+  if (issues.length)
+    throw new ProjectProductionPlanningError(
+      'WORKFLOW_INTEGRITY_FAILED',
+      'The V2 workflow failed integrity validation.',
+      409,
+      { issues }
+    );
+  const step = steps.find((row) => row.step_type === 'production_planning');
+  const design = steps.find((row) => row.step_type === 'design_applicability');
+  if (!step)
+    throw new ProjectProductionPlanningError(
+      'PRODUCTION_PLANNING_STAGE_REQUIRED',
+      'Production Planning stage is missing.',
+      409
+    );
+  if (!design || !['COMPLETE', 'NOT_APPLICABLE'].includes(design.status))
+    throw new ProjectProductionPlanningError(
+      'DESIGN_APPLICABILITY_REQUIRED',
+      'Design Applicability must be complete or approved not applicable.',
+      409
+    );
+  return { project, instance: instances[0], step, steps };
+}
+
+async function currentPlan(projectId: string, tx: Executor) {
+  return (
+    resultRows(
+      await tx.execute(
+        sql`SELECT * FROM project_production_plans WHERE project_id=${projectId} AND status<>'SUPERSEDED' ORDER BY revision_number DESC LIMIT 1`
+      )
+    )[0] ?? null
+  );
+}
+
+async function currentPo(
+  projectId: string,
+  projectPoId: number | null,
+  tx: Executor
+) {
+  return (
+    resultRows(
+      await tx.execute(sql`
+    WITH selected AS (SELECT COALESCE(parent_po_id,id) root_id FROM p2_purchase_orders WHERE id=${projectPoId})
+    SELECT po.* FROM p2_purchase_orders po LEFT JOIN selected s ON true
+    WHERE (po.project_id=${projectId} OR po.id=s.root_id OR po.parent_po_id=s.root_id) AND po.is_current_revision=true
+    ORDER BY po.revision_number DESC, po.updated_at DESC LIMIT 1`)
+    )[0] ?? null
+  );
+}
+
+async function configurationRows(
+  projectId: string,
+  poId: number,
+  tx: Executor
+) {
+  return resultRows(
+    await tx.execute(sql`
+    WITH RECURSIVE roots AS (
+      SELECT ('root:'||poi.id)::text AS assembly_path, NULL::text AS parent_part_number,
+             COALESCE(ii.ag_part_number,poi.part_number) part_number, COALESCE(ii.name,poi.part_name) part_name,
+             ii.id inventory_item_id, ii.manufacturing_level::text manufacturing_level,
+             COALESCE(ii.item_type::text,ii.type) item_type, poi.quantity::numeric qty_per, poi.quantity::numeric extended_qty,
+             ARRAY[COALESCE(ii.ag_part_number,poi.part_number)]::text[] cycle_path
+      FROM p2_purchase_order_items poi LEFT JOIN inventory_items ii ON ii.id=poi.inventory_item_id WHERE poi.po_id=${poId}
+    ), tree AS (
+      SELECT roots.*, 0 depth, selected_bom.bom_id, selected_bom.revision_id, selected_bom.rev_code, selected_bom.is_released
+      FROM roots
+      LEFT JOIN LATERAL (
+        SELECT b.id bom_id, br.id revision_id, br.rev_code, br.is_released
+        FROM boms b JOIN bom_revisions br ON br.bom_id=b.id
+        WHERE b.parent_part_ag_number=roots.part_number AND b.is_active=true
+        ORDER BY br.is_released DESC, br.effective_from DESC NULLS LAST, br.created_at DESC LIMIT 1
+      ) selected_bom ON true
+      UNION ALL
+      SELECT tree.assembly_path||'/line:'||bl.id, tree.part_number, bl.child_part_ag_number, ii.name, ii.id,
+             ii.manufacturing_level::text, COALESCE(ii.item_type::text,ii.type), bl.qty_per,
+             tree.extended_qty*bl.qty_per, tree.cycle_path||bl.child_part_ag_number, tree.depth+1,
+             child_bom.bom_id, child_bom.revision_id, child_bom.rev_code, child_bom.is_released
+      FROM tree JOIN bom_lines bl ON bl.revision_id=tree.revision_id
+      LEFT JOIN inventory_items ii ON ii.ag_part_number=bl.child_part_ag_number
+      LEFT JOIN LATERAL (
+        SELECT b.id bom_id, br.id revision_id, br.rev_code, br.is_released
+        FROM boms b JOIN bom_revisions br ON br.bom_id=b.id
+        WHERE b.parent_part_ag_number=bl.child_part_ag_number AND b.is_active=true
+        ORDER BY br.is_released DESC, br.effective_from DESC NULLS LAST, br.created_at DESC LIMIT 1
+      ) child_bom ON true
+      WHERE tree.depth<25 AND NOT bl.child_part_ag_number=ANY(tree.cycle_path)
+    )
+    SELECT tree.*,
+      routing.id routing_id, routing.routing_revision, routing.is_active routing_is_active,
+      template.approval_status routing_template_status,
+      COALESCE(upper(tree.item_type)='MANUFACTURED', tree.bom_id IS NOT NULL) is_manufactured
+    FROM tree
+    LEFT JOIN LATERAL (
+      SELECT pr.* FROM part_routings pr
+      WHERE pr.part_number=tree.part_number AND (pr.project_id=${projectId} OR pr.project_id IS NULL)
+      ORDER BY (pr.project_id=${projectId}) DESC, pr.is_active DESC, pr.routing_revision DESC LIMIT 1
+    ) routing ON true
+    LEFT JOIN production_control_templates template ON template.id=routing.created_from_template_id
+    ORDER BY tree.assembly_path`)
+  );
+}
+
+function baselineHash(po: Row, rows: Row[], designRelease?: Row | null) {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        po: [po.id, po.revision_number, po.updated_at],
+        designRelease: designRelease
+          ? [
+              designRelease.id,
+              designRelease.release_revision,
+              designRelease.release_status,
+            ]
+          : null,
+        items: rows.map((row) => [
+          row.assembly_path,
+          row.part_number,
+          row.revision_id,
+          row.rev_code,
+          row.routing_id,
+          row.routing_revision,
+        ]),
+      })
+    )
+    .digest('hex');
+}
+
+async function currentDesignRelease(projectId: string, tx: Executor) {
+  return (
+    resultRows(
+      await tx.execute(sql`
+        SELECT er.id,er.release_revision,er.release_status
+        FROM project_design_applicability_decisions decision
+        JOIN design_control_records dcr ON dcr.rd_project_id=decision.linked_design_project_id AND dcr.project_id=${projectId}
+        JOIN engineering_releases er ON er.design_control_record_id=dcr.id AND er.release_status='RELEASED'
+        WHERE decision.project_id=${projectId} AND decision.status='APPROVED'
+        ORDER BY er.released_at DESC NULLS LAST,er.created_at DESC LIMIT 1`)
+    )[0] ?? null
+  );
+}
+
+async function insertConfigurationItems(plan: Row, rows: Row[], tx: Executor) {
+  for (const row of rows) {
+    const manufactured = Boolean(row.is_manufactured);
+    const routingStatus = !row.routing_id
+      ? 'MISSING'
+      : !row.routing_is_active
+        ? 'INACTIVE'
+        : row.routing_template_status === 'APPROVED'
+          ? 'RELEASED'
+          : 'ACTIVE_UNAPPROVED';
+    await tx.execute(sql`INSERT INTO project_production_plan_items
+      (production_plan_id,project_id,inventory_item_id,part_number,part_name,manufacturing_level,parent_part_number,assembly_path,quantity_per_parent,extended_project_quantity,make_buy,is_manufactured,bom_id,bom_revision_id,bom_revision,bom_release_status,routing_id,routing_revision,routing_release_status,effectivity_reference,specification_references,work_instruction_references,special_process_requirements,required_certifications,required_test_records,tooling_requirements,cnc_program_requirements)
+      VALUES (${plan.id},${plan.project_id},${row.inventory_item_id},${row.part_number},${row.part_name},${row.manufacturing_level},${row.parent_part_number},${row.assembly_path},${row.qty_per},${row.extended_qty},${manufactured ? 'MAKE' : 'BUY'},${manufactured},${row.bom_id},${row.revision_id},${row.rev_code},${!manufactured ? 'NOT_REQUIRED_APPROVED' : !row.bom_id ? 'MISSING' : row.is_released ? 'RELEASED' : 'UNRELEASED'},${row.routing_id},${row.routing_revision == null ? null : String(row.routing_revision)},${manufactured ? routingStatus : 'NOT_REQUIRED_APPROVED'},${plan.effectivity_reference},'[]'::jsonb,'[]'::jsonb,'[]'::jsonb,'[]'::jsonb,'[]'::jsonb,'[]'::jsonb,'[]'::jsonb)`);
+  }
+}
+
+async function audit(
+  eventType: string,
+  plan: Row,
+  actor: PlanningActor,
+  tx: Executor,
+  reason?: string
+) {
+  await recordAuditEvent(
+    {
+      eventType,
+      subjectType: 'project_production_plan',
+      subjectId: plan.id,
+      sourceService: 'projectProductionPlanningService',
+      actor: { id: actor.userId, username: actor.username, role: actor.role },
+      reason,
+      payload: {
+        projectId: plan.project_id,
+        revisionNumber: plan.revision_number,
+        poId: plan.po_id,
+        poRevisionNumber: plan.po_revision_number,
+      },
+    },
+    tx
+  );
+}
+
+async function releaseAuthoritativeLinks(
+  model: Awaited<ReturnType<typeof readModel>>,
+  actor: PlanningActor,
+  tx: Executor
+) {
+  const plan = model.plan!;
+  await tx.execute(
+    sql`UPDATE project_workflow_step_links SET unlinked_at=now(),unlink_reason=${`Superseded by Production Plan revision ${plan.revision_number}`},updated_at=now() WHERE workflow_step_instance_id=${model.stage.id} AND is_authoritative=true AND unlinked_at IS NULL`
+  );
+  const links: Array<[string, string, string | null, string | null]> = [
+    [
+      'PO_REVISION',
+      String(plan.po_id),
+      String(plan.po_revision_number),
+      plan.effectivity_reference,
+    ],
+    [
+      'CONFIGURATION_BASELINE',
+      plan.configuration_baseline_id,
+      plan.configuration_revision,
+      plan.effectivity_reference,
+    ],
+  ];
+  if (plan.design_release_id)
+    links.push([
+      'ENGINEERING_RELEASE',
+      plan.design_release_id,
+      plan.design_release_revision,
+      plan.effectivity_reference,
+    ]);
+  for (const item of model.items) {
+    if (item.bom_revision_id)
+      links.push([
+        'BOM_REVISION',
+        item.bom_revision_id,
+        item.bom_revision,
+        item.effectivity_reference,
+      ]);
+    if (item.routing_id)
+      links.push([
+        'PART_ROUTING',
+        item.routing_id,
+        item.routing_revision,
+        item.effectivity_reference,
+      ]);
+    for (const reference of Array.isArray(item.work_instruction_references)
+      ? item.work_instruction_references
+      : [])
+      links.push([
+        'CONTROLLED_WORK_INSTRUCTION',
+        clean(reference),
+        null,
+        item.effectivity_reference,
+      ]);
+    if (clean(item.sampling_plan_id))
+      links.push([
+        'SAMPLING_PLAN',
+        clean(item.sampling_plan_id),
+        null,
+        item.effectivity_reference,
+      ]);
+    if (clean(item.packaging_instruction_reference))
+      links.push([
+        'PACKAGING_INSTRUCTION',
+        clean(item.packaging_instruction_reference),
+        null,
+        item.effectivity_reference,
+      ]);
+  }
+  for (const [recordType, recordId, revision, effectivity] of links.filter(
+    (link) => Boolean(link[1])
+  )) {
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_links (workflow_step_instance_id,project_id,record_type,record_id,relationship_type,is_authoritative,record_revision,effectivity_reference,linked_by,linked_by_display_name) VALUES (${model.stage.id},${plan.project_id},${recordType},${recordId},${recordType === 'PO_REVISION' || recordType === 'CONFIGURATION_BASELINE' ? 'PRIMARY' : 'EVIDENCE'},true,${revision},${effectivity},${actor.employeeId ?? null},${actor.displayName})`
+    );
+  }
+}
+
+async function approvals(planId: string, stepId: string, tx: Executor) {
+  return resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_approvals WHERE workflow_step_instance_id=${stepId} AND evidence_snapshot->>'planId'=${planId} ORDER BY decided_at`
+    )
+  );
+}
+
+async function staleness(
+  plan: Row,
+  items: Row[],
+  ctx: Awaited<ReturnType<typeof context>>,
+  tx: Executor
+) {
+  const differences: string[] = [];
+  const po = await currentPo(plan.project_id, ctx.project.po_id, tx);
+  if (
+    !po ||
+    Number(po.id) !== Number(plan.po_id) ||
+    Number(po.revision_number) !== Number(plan.po_revision_number)
+  )
+    differences.push(
+      'Current customer PO revision differs from the released planning baseline.'
+    );
+  if (plan.design_release_id) {
+    const release = resultRows(
+      await tx.execute(
+        sql`SELECT er.id,er.release_revision,er.release_status,dcr.status design_control_status FROM engineering_releases er JOIN design_control_records dcr ON dcr.id=er.design_control_record_id WHERE er.id=${plan.design_release_id}`
+      )
+    )[0];
+    if (
+      !release ||
+      release.release_status !== 'RELEASED' ||
+      release.design_control_status !== 'engineering_released' ||
+      release.release_revision !== plan.design_release_revision
+    )
+      differences.push(
+        'The controlling Engineering Release was reopened or superseded.'
+      );
+  }
+  for (const item of items.filter((row) => row.is_manufactured)) {
+    const state = resultRows(
+      await tx.execute(
+        sql`SELECT br.id revision_id, br.rev_code, br.is_released FROM boms b LEFT JOIN LATERAL (SELECT * FROM bom_revisions WHERE bom_id=b.id ORDER BY is_released DESC, created_at DESC LIMIT 1) br ON true WHERE b.parent_part_ag_number=${item.part_number} AND b.is_active=true LIMIT 1`
+      )
+    )[0];
+    if (
+      String(state?.revision_id ?? '') !== String(item.bom_revision_id ?? '') ||
+      !state?.is_released
+    )
+      differences.push(`${item.part_number}: BOM revision/release changed.`);
+    const routing = resultRows(
+      await tx.execute(
+        sql`SELECT pr.id,pr.routing_revision,pr.is_active,pct.approval_status FROM part_routings pr LEFT JOIN production_control_templates pct ON pct.id=pr.created_from_template_id WHERE pr.part_number=${item.part_number} AND (pr.project_id=${plan.project_id} OR pr.project_id IS NULL) ORDER BY (pr.project_id=${plan.project_id}) DESC,pr.is_active DESC,pr.routing_revision DESC LIMIT 1`
+      )
+    )[0];
+    if (
+      String(routing?.id ?? '') !== String(item.routing_id ?? '') ||
+      String(routing?.routing_revision ?? '') !==
+        String(item.routing_revision ?? '') ||
+      routing?.approval_status !== 'APPROVED'
+    )
+      differences.push(
+        `${item.part_number}: routing revision/release changed.`
+      );
+  }
+  return Array.from(new Set(differences));
+}
+
+async function readModel(projectId: string, tx: Executor) {
+  const ctx = await context(projectId, tx);
+  const plan = await currentPlan(projectId, tx);
+  const history = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_production_plans WHERE project_id=${projectId} ORDER BY revision_number DESC`
+    )
+  );
+  const items = plan
+    ? resultRows(
+        await tx.execute(
+          sql`SELECT * FROM project_production_plan_items WHERE production_plan_id=${plan.id} ORDER BY assembly_path`
+        )
+      )
+    : [];
+  const currentApprovals = plan
+    ? await approvals(plan.id, ctx.step.id, tx)
+    : [];
+  const approvalHistory = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_approvals WHERE workflow_step_instance_id=${ctx.step.id} AND approval_type LIKE 'PRODUCTION_PLANNING_%' ORDER BY decided_at DESC`
+    )
+  );
+  const blockers = plan
+    ? items.flatMap(productionPlanItemBlockers)
+    : ['Create a Production Planning draft.'];
+  for (const item of items.filter((row) => row.is_manufactured)) {
+    if (
+      item.inspection_extent === 'APPROVED_SAMPLING' &&
+      clean(item.sampling_plan_id)
+    ) {
+      const approved = resultRows(
+        await tx.execute(sql`
+          SELECT id FROM controlled_documents
+          WHERE (id::text=${clean(item.sampling_plan_id)} OR document_number=${clean(item.sampling_plan_id)})
+            AND lower(status)='approved'
+          UNION ALL
+          SELECT id FROM production_control_templates
+          WHERE (id::text=${clean(item.sampling_plan_id)} OR name=${clean(item.sampling_plan_id)})
+            AND template_type='QC' AND approval_status='APPROVED'
+          LIMIT 1`)
+      );
+      if (!approved.length)
+        blockers.push(
+          `${item.part_number}: sampling-plan reference is not an approved controlled record.`
+        );
+    }
+    if (item.work_instruction_requirement === 'REQUIRED') {
+      const references = Array.isArray(item.work_instruction_references)
+        ? item.work_instruction_references.map(clean).filter(Boolean)
+        : [];
+      if (!references.length)
+        blockers.push(
+          `${item.part_number}: controlled work instruction required.`
+        );
+      for (const reference of references) {
+        const approved = resultRows(
+          await tx.execute(
+            sql`SELECT id FROM controlled_documents WHERE (id::text=${reference} OR document_number=${reference}) AND lower(status)='approved' LIMIT 1`
+          )
+        );
+        if (!approved.length)
+          blockers.push(
+            `${item.part_number}: work instruction ${reference} is not approved.`
+          );
+      }
+    }
+    if (
+      item.work_instruction_requirement === 'DRAWING_SPEC_SUFFICIENT' &&
+      (!clean(item.drawing_number) || !clean(item.drawing_revision))
+    )
+      blockers.push(
+        `${item.part_number}: drawing/specification sufficiency requires drawing number and revision.`
+      );
+    if (
+      item.packaging_instruction_requirement === 'REQUIRED' &&
+      clean(item.packaging_instruction_reference)
+    ) {
+      const approved = resultRows(
+        await tx.execute(
+          sql`SELECT id FROM controlled_documents WHERE (id::text=${clean(item.packaging_instruction_reference)} OR document_number=${clean(item.packaging_instruction_reference)}) AND lower(status)='approved' LIMIT 1`
+        )
+      );
+      if (!approved.length)
+        blockers.push(
+          `${item.part_number}: packaging instruction is not an approved controlled document.`
+        );
+    }
+  }
+  if (plan && !plan.configuration_baseline_id)
+    blockers.push('Configuration baseline is required.');
+  if (plan && !clean(plan.effectivity_reference))
+    blockers.push('Configuration effectivity is required.');
+  if (plan && items.filter((item) => item.is_manufactured).length === 0)
+    blockers.push('At least one manufactured item is required.');
+  const staleDifferences = plan ? await staleness(plan, items, ctx, tx) : [];
+  if (plan?.status === 'RELEASED') blockers.push(...staleDifferences);
+  return {
+    plan,
+    items,
+    history,
+    approvals: currentApprovals,
+    approvalHistory,
+    stage: ctx.step,
+    readiness: {
+      ready: Boolean(plan) && blockers.length === 0,
+      blockers,
+      stale: staleDifferences.length > 0,
+      differences: staleDifferences,
+    },
+  };
+}
+
+export const getCurrentProductionPlan = (
+  projectId: string,
+  tx: Executor = db
+) => readModel(projectId, tx);
+export async function getProductionPlanHistory(
+  projectId: string,
+  tx: Executor = db
+) {
+  await context(projectId, tx);
+  return resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_production_plans WHERE project_id=${projectId} ORDER BY revision_number DESC`
+    )
+  );
+}
+
+async function createRevision(
+  projectId: string,
+  input: PlanHeaderInput,
+  actor: PlanningActor,
+  tx: Executor,
+  revision: number
+) {
+  const ctx = await context(projectId, tx, true);
+  const po = await currentPo(projectId, ctx.project.po_id, tx);
+  if (!po)
+    throw new ProjectProductionPlanningError(
+      'CURRENT_PO_REQUIRED',
+      'A current linked P2 PO revision is required.',
+      409
+    );
+  const rows = await configurationRows(projectId, po.id, tx);
+  if (!rows.length)
+    throw new ProjectProductionPlanningError(
+      'PO_ITEMS_REQUIRED',
+      'The current P2 PO has no configuration items.',
+      409
+    );
+  const designRelease = await currentDesignRelease(projectId, tx);
+  const baseline = baselineHash(po, rows, designRelease);
+  const plan = resultRows(
+    await tx.execute(
+      sql`INSERT INTO project_production_plans (project_id,workflow_instance_id,workflow_step_instance_id,revision_number,status,po_id,po_revision_number,po_number,configuration_baseline_id,configuration_revision,design_release_id,design_release_revision,effectivity_type,effectivity_reference,requirement_source,planning_basis,notes,created_by,created_by_display_name) VALUES (${projectId},${ctx.instance.id},${ctx.step.id},${revision},'DRAFT',${po.id},${po.revision_number},${po.po_number},${baseline},${`PO ${po.po_number} Rev ${po.revision_number}`},${designRelease?.id ?? null},${designRelease?.release_revision ?? null},${input.effectivityType ?? 'PO_REVISION'},${clean(input.effectivityReference) || `PO ${po.po_number} Rev ${po.revision_number}`},${clean(input.requirementSource)},${clean(input.planningBasis)},${clean(input.notes) || null},${actor.userId},${actor.displayName}) RETURNING *`
+    )
+  )[0];
+  await insertConfigurationItems(plan, rows, tx);
+  return plan;
+}
+
+export async function createDraftFromCurrentConfiguration(
+  projectId: string,
+  input: PlanHeaderInput,
+  actor: PlanningActor
+) {
+  if (!clean(input.requirementSource) || !clean(input.planningBasis))
+    throw new ProjectProductionPlanningError(
+      'PLAN_HEADER_REQUIRED',
+      'Requirement source and planning basis are required.'
+    );
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    if (await currentPlan(projectId, tx))
+      throw new ProjectProductionPlanningError(
+        'CURRENT_PLAN_EXISTS',
+        'Revise the current plan instead.',
+        409
+      );
+    const plan = await createRevision(projectId, input, actor, tx, 1);
+    await audit('P2_V2_PRODUCTION_PLAN_DRAFT_CREATED', plan, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function refreshDraft(
+  projectId: string,
+  planId: string,
+  actor: PlanningActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const plan = await currentPlan(projectId, tx);
+    if (!plan || plan.id !== planId)
+      throw new ProjectProductionPlanningError(
+        'CURRENT_PLAN_NOT_FOUND',
+        'Current plan not found.',
+        404
+      );
+    if (plan.status !== 'DRAFT')
+      throw new ProjectProductionPlanningError(
+        'DRAFT_REQUIRED',
+        'Only a draft can be refreshed.',
+        409
+      );
+    const po = await currentPo(projectId, ctx.project.po_id, tx);
+    if (!po)
+      throw new ProjectProductionPlanningError(
+        'CURRENT_PO_REQUIRED',
+        'Current PO revision required.',
+        409
+      );
+    const rows = await configurationRows(projectId, po.id, tx);
+    const designRelease = await currentDesignRelease(projectId, tx);
+    await tx.execute(
+      sql`DELETE FROM project_production_plan_items WHERE production_plan_id=${planId}`
+    );
+    await tx.execute(
+      sql`UPDATE project_production_plans SET po_id=${po.id},po_revision_number=${po.revision_number},po_number=${po.po_number},configuration_baseline_id=${baselineHash(po, rows, designRelease)},configuration_revision=${`PO ${po.po_number} Rev ${po.revision_number}`},design_release_id=${designRelease?.id ?? null},design_release_revision=${designRelease?.release_revision ?? null},effectivity_reference=${`PO ${po.po_number} Rev ${po.revision_number}`},updated_at=now() WHERE id=${planId}`
+    );
+    const refreshed = {
+      ...plan,
+      project_id: projectId,
+      effectivity_reference: `PO ${po.po_number} Rev ${po.revision_number}`,
+    };
+    await insertConfigurationItems(refreshed, rows, tx);
+    await audit('P2_V2_PRODUCTION_PLAN_DRAFT_REFRESHED', plan, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+const editableFields = new Set([
+  'drawing_number',
+  'drawing_revision',
+  'specification_references',
+  'routing_requirement',
+  'routing_not_required_reason',
+  'traveler_requirement',
+  'traveler_type',
+  'traveler_not_required_reason',
+  'work_instruction_requirement',
+  'work_instruction_basis',
+  'work_instruction_references',
+  'specification_sheet_requirement',
+  'inspection_requirement',
+  'in_process_inspection_required',
+  'final_inspection_required',
+  'inspection_extent',
+  'sampling_plan_id',
+  'sampling_plan_status',
+  'fai_requirement',
+  'fai_reason',
+  'traceability_level',
+  'serialization_required',
+  'lot_traceability_required',
+  'special_process_source',
+  'special_process_requirements',
+  'required_certifications',
+  'required_test_records',
+  'tooling_requirements',
+  'cnc_program_requirements',
+  'packaging_instruction_requirement',
+  'packaging_instruction_reference',
+  'requirement_source',
+  'notes',
+]);
+const jsonFields = new Set([
+  'specification_references',
+  'work_instruction_references',
+  'special_process_requirements',
+  'required_certifications',
+  'required_test_records',
+  'tooling_requirements',
+  'cnc_program_requirements',
+]);
+export async function updatePlanItemDecision(
+  projectId: string,
+  planId: string,
+  itemId: string,
+  changes: Record<string, unknown>,
+  actor: PlanningActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const plan = await currentPlan(projectId, tx);
+    if (!plan || plan.id !== planId)
+      throw new ProjectProductionPlanningError(
+        'CURRENT_PLAN_NOT_FOUND',
+        'Current plan not found.',
+        404
+      );
+    if (plan.status !== 'DRAFT')
+      throw new ProjectProductionPlanningError(
+        'DRAFT_REQUIRED',
+        'Only draft plan items may be edited.',
+        409
+      );
+    const entries = Object.entries(changes).filter(([key]) =>
+      editableFields.has(key)
+    );
+    if (!entries.length)
+      throw new ProjectProductionPlanningError(
+        'NO_EDITABLE_FIELDS',
+        'No editable planning fields supplied.'
+      );
+    for (const [key, value] of entries) {
+      if (jsonFields.has(key)) {
+        await tx.execute(
+          sql`UPDATE project_production_plan_items SET ${sql.raw(key)}=${JSON.stringify(value ?? [])}::jsonb,updated_at=now() WHERE id=${itemId} AND production_plan_id=${planId} AND project_id=${projectId}`
+        );
+      } else {
+        await tx.execute(
+          sql`UPDATE project_production_plan_items SET ${sql.raw(key)}=${value},updated_at=now() WHERE id=${itemId} AND production_plan_id=${planId} AND project_id=${projectId}`
+        );
+      }
+    }
+    await audit('P2_V2_PRODUCTION_PLAN_ITEM_UPDATED', plan, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function submitForApproval(
+  projectId: string,
+  planId: string,
+  actor: PlanningActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const plan = await currentPlan(projectId, tx);
+    if (!plan || plan.id !== planId)
+      throw new ProjectProductionPlanningError(
+        'CURRENT_PLAN_NOT_FOUND',
+        'Current plan not found.',
+        404
+      );
+    if (plan.status !== 'DRAFT')
+      throw new ProjectProductionPlanningError(
+        'DRAFT_REQUIRED',
+        'Only a draft may be submitted.',
+        409
+      );
+    const model = await readModel(projectId, tx);
+    if (model.readiness.blockers.length)
+      throw new ProjectProductionPlanningError(
+        'PLAN_NOT_READY',
+        'Production plan has readiness blockers.',
+        409,
+        { blockers: model.readiness.blockers }
+      );
+    await tx.execute(
+      sql`UPDATE project_production_plans SET status='PENDING_APPROVAL',submitted_by=${actor.userId},submitted_by_display_name=${actor.displayName},submitted_at=now(),updated_at=now() WHERE id=${planId}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='PENDING_APPROVAL',blocked_reason=NULL,updated_at=now() WHERE id=${ctx.step.id}`
+    );
+    await audit('P2_V2_PRODUCTION_PLAN_SUBMITTED', plan, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+async function recordDecision(
+  projectId: string,
+  planId: string,
+  capacity: 'ENGINEERING' | 'QUALITY' | 'OPERATIONS',
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: PlanningActor
+) {
+  if (!clean(signatureMeaning))
+    throw new ProjectProductionPlanningError(
+      'SIGNATURE_MEANING_REQUIRED',
+      'Signature meaning is required.'
+    );
+  if (decision !== 'APPROVED' && !clean(reason))
+    throw new ProjectProductionPlanningError(
+      'REASON_REQUIRED',
+      'Rejection/return reason is required.'
+    );
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const plan = await currentPlan(projectId, tx);
+    if (!plan || plan.id !== planId)
+      throw new ProjectProductionPlanningError(
+        'CURRENT_PLAN_NOT_FOUND',
+        'Current plan not found.',
+        404
+      );
+    if (plan.status !== 'PENDING_APPROVAL')
+      throw new ProjectProductionPlanningError(
+        'PENDING_APPROVAL_REQUIRED',
+        'Plan is not pending approval.',
+        409
+      );
+    const existing = await approvals(planId, ctx.step.id, tx);
+    if (
+      existing.some(
+        (a) => a.approval_type === `PRODUCTION_PLANNING_${capacity}`
+      )
+    )
+      throw new ProjectProductionPlanningError(
+        'DECISION_ALREADY_RECORDED',
+        `${capacity} already decided this revision.`,
+        409
+      );
+    if (
+      existing.some(
+        (a) => a.actor_user_id === actor.userId && a.decision === 'APPROVED'
+      )
+    )
+      throw new ProjectProductionPlanningError(
+        'SEGREGATION_OF_DUTIES',
+        'One user cannot provide multiple functional approvals.',
+        403
+      );
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_approvals (workflow_step_instance_id,project_id,approval_type,decision,signature_meaning,reason,actor_employee_id,actor_user_id,actor_display_name,actor_role,step_revision_snapshot,evidence_snapshot) VALUES (${ctx.step.id},${projectId},${`PRODUCTION_PLANNING_${capacity}`},${decision},${signatureMeaning},${clean(reason) || null},${actor.employeeId ?? null},${actor.userId},${actor.displayName},${actor.role},${String(plan.revision_number)},${JSON.stringify({ planId, capacity, configurationBaselineId: plan.configuration_baseline_id })}::jsonb)`
+    );
+    if (decision !== 'APPROVED') {
+      await tx.execute(
+        sql`UPDATE project_production_plans SET status='REJECTED',updated_at=now() WHERE id=${planId}`
+      );
+      await tx.execute(
+        sql`UPDATE project_workflow_step_instances SET status='BLOCKED',blocked_reason=${`${capacity} ${decision.toLowerCase()}: ${clean(reason)}`},updated_at=now() WHERE id=${ctx.step.id}`
+      );
+    } else {
+      const all = await approvals(planId, ctx.step.id, tx);
+      if (
+        ['ENGINEERING', 'QUALITY', 'OPERATIONS'].every((role) =>
+          all.some(
+            (a) =>
+              a.approval_type === `PRODUCTION_PLANNING_${role}` &&
+              a.decision === 'APPROVED'
+          )
+        )
+      ) {
+        const model = await readModel(projectId, tx);
+        if (model.readiness.blockers.length)
+          throw new ProjectProductionPlanningError(
+            'PLAN_NOT_READY',
+            'Plan changed or has readiness blockers.',
+            409,
+            { blockers: model.readiness.blockers }
+          );
+        await releaseAuthoritativeLinks(model, actor, tx);
+        await tx.execute(
+          sql`UPDATE project_production_plans SET status='RELEASED',released_by=${actor.userId},released_by_display_name=${actor.displayName},released_at=now(),updated_at=now() WHERE id=${planId}`
+        );
+        await tx.execute(
+          sql`UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now(),completed_by=${actor.employeeId ?? null},completed_by_display_name=${actor.displayName},blocked_reason=NULL,revision_reference=${String(plan.revision_number)},effectivity_reference=${plan.effectivity_reference},updated_at=now() WHERE id=${ctx.step.id}`
+        );
+      }
+    }
+    await audit(
+      `P2_V2_PRODUCTION_PLAN_${capacity}_DECIDED`,
+      plan,
+      actor,
+      tx,
+      clean(reason) || undefined
+    );
+    return readModel(projectId, tx);
+  });
+}
+export const recordEngineeringDecision = (
+  projectId: string,
+  planId: string,
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: PlanningActor
+) =>
+  recordDecision(
+    projectId,
+    planId,
+    'ENGINEERING',
+    decision,
+    signatureMeaning,
+    reason,
+    actor
+  );
+export const recordQualityDecision = (
+  projectId: string,
+  planId: string,
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: PlanningActor
+) =>
+  recordDecision(
+    projectId,
+    planId,
+    'QUALITY',
+    decision,
+    signatureMeaning,
+    reason,
+    actor
+  );
+export const recordOperationsDecision = (
+  projectId: string,
+  planId: string,
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: PlanningActor
+) =>
+  recordDecision(
+    projectId,
+    planId,
+    'OPERATIONS',
+    decision,
+    signatureMeaning,
+    reason,
+    actor
+  );
+
+export async function revisePlan(
+  projectId: string,
+  planId: string,
+  input: PlanHeaderInput,
+  actor: PlanningActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const prior = await currentPlan(projectId, tx);
+    if (!prior || prior.id !== planId)
+      throw new ProjectProductionPlanningError(
+        'CURRENT_PLAN_NOT_FOUND',
+        'Current plan not found.',
+        404
+      );
+    if (!['RELEASED', 'REJECTED'].includes(prior.status))
+      throw new ProjectProductionPlanningError(
+        'REVISION_NOT_ALLOWED',
+        'Only released or rejected plans may be revised.',
+        409
+      );
+    await tx.execute(
+      sql`UPDATE project_production_plans SET status='SUPERSEDED',superseded_at=now(),updated_at=now() WHERE id=${planId}`
+    );
+    const next = await createRevision(
+      projectId,
+      input,
+      actor,
+      tx,
+      Number(prior.revision_number) + 1
+    );
+    await tx.execute(
+      sql`UPDATE project_production_plans SET superseded_by_plan_id=${next.id} WHERE id=${planId}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_approvals SET superseded_at=now() WHERE workflow_step_instance_id=${prior.workflow_step_instance_id} AND evidence_snapshot->>'planId'=${planId} AND superseded_at IS NULL`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='IN_PROGRESS',completed_at=NULL,completed_by=NULL,completed_by_display_name=NULL,blocked_reason=NULL,updated_at=now() WHERE id=${prior.workflow_step_instance_id}`
+    );
+    await audit('P2_V2_PRODUCTION_PLAN_REVISED', next, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function evaluateProductionPlanningReadiness(
+  projectId: string,
+  tx: Executor = db
+) {
+  return (await readModel(projectId, tx)).readiness;
+}
+export async function synchronizeProductionPlanningStage(
+  projectId: string,
+  tx: Executor = db
+) {
+  const model = await readModel(projectId, tx);
+  if (model.plan?.status === 'RELEASED' && model.readiness.stale) {
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='BLOCKED',blocked_reason=${model.readiness.differences.join(' ')},completed_at=NULL,completed_by=NULL,completed_by_display_name=NULL,updated_at=now() WHERE id=${model.stage.id}`
+    );
+  }
+  return readModel(projectId, tx);
+}

--- a/server/src/services/projectProductionPlanningValidation.ts
+++ b/server/src/services/projectProductionPlanningValidation.ts
@@ -1,0 +1,103 @@
+export class ProjectProductionPlanningError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly status = 400,
+    public readonly details: Record<string, unknown> = {}
+  ) {
+    super(message);
+    this.name = 'ProjectProductionPlanningError';
+  }
+}
+
+export type PlanningItem = Record<string, unknown>;
+const text = (value: unknown) => String(value ?? '').trim();
+const list = (value: unknown) => (Array.isArray(value) ? value : []);
+
+export function productionPlanItemBlockers(item: PlanningItem): string[] {
+  if (!item.is_manufactured) return [];
+  const part = text(item.part_number) || 'Unknown part';
+  const blockers: string[] = [];
+  if (
+    item.bom_release_status !== 'RELEASED' &&
+    item.bom_release_status !== 'NOT_REQUIRED_APPROVED'
+  )
+    blockers.push(
+      `${part}: released BOM or approved BOM N/A decision required.`
+    );
+  if (!item.routing_requirement)
+    blockers.push(`${part}: routing decision required.`);
+  if (
+    item.routing_requirement === 'REQUIRED' &&
+    item.routing_release_status !== 'RELEASED'
+  )
+    blockers.push(`${part}: approved/released routing required.`);
+  if (
+    item.routing_requirement === 'NOT_REQUIRED_APPROVED' &&
+    !text(item.routing_not_required_reason)
+  )
+    blockers.push(`${part}: routing N/A reason required.`);
+  if (!item.traveler_requirement)
+    blockers.push(`${part}: traveler decision required.`);
+  if (
+    item.traveler_requirement === 'REQUIRED' &&
+    !['INDIVIDUAL', 'BATCH', 'LOT'].includes(text(item.traveler_type))
+  )
+    blockers.push(`${part}: traveler type required.`);
+  if (
+    item.traveler_requirement === 'NOT_REQUIRED_APPROVED' &&
+    !text(item.traveler_not_required_reason)
+  )
+    blockers.push(`${part}: traveler N/A reason required.`);
+  if (!item.work_instruction_requirement)
+    blockers.push(`${part}: work-instruction decision required.`);
+  if (
+    ['DRAWING_SPEC_SUFFICIENT', 'NOT_REQUIRED_APPROVED'].includes(
+      text(item.work_instruction_requirement)
+    ) &&
+    !text(item.work_instruction_basis)
+  )
+    blockers.push(`${part}: work-instruction decision basis required.`);
+  if (!item.inspection_extent)
+    blockers.push(`${part}: inspection strategy required.`);
+  if (
+    item.inspection_extent === 'APPROVED_SAMPLING' &&
+    (!text(item.sampling_plan_id) ||
+      text(item.sampling_plan_status).toUpperCase() !== 'APPROVED')
+  )
+    blockers.push(`${part}: approved sampling plan required.`);
+  if (!item.fai_requirement) blockers.push(`${part}: FAI decision required.`);
+  if (item.fai_requirement === 'NOT_REQUIRED' && !text(item.fai_reason))
+    blockers.push(`${part}: FAI N/A reason required.`);
+  if (!item.traceability_level)
+    blockers.push(`${part}: traceability decision required.`);
+  if (!item.special_process_source)
+    blockers.push(`${part}: special-process decision required.`);
+  if (
+    item.special_process_source !== 'NONE' &&
+    list(item.special_process_requirements).length === 0
+  )
+    blockers.push(`${part}: special-process requirements required.`);
+  if (!Array.isArray(item.required_certifications))
+    blockers.push(`${part}: certification decision required.`);
+  if (!Array.isArray(item.required_test_records))
+    blockers.push(`${part}: test-record decision required.`);
+  if (
+    !Array.isArray(item.tooling_requirements) ||
+    !Array.isArray(item.cnc_program_requirements)
+  )
+    blockers.push(`${part}: tooling/program decisions required.`);
+  if (!item.packaging_instruction_requirement)
+    blockers.push(`${part}: packaging decision required.`);
+  if (
+    item.packaging_instruction_requirement === 'REQUIRED' &&
+    !text(item.packaging_instruction_reference)
+  )
+    blockers.push(`${part}: packaging instruction reference required.`);
+  if (
+    item.packaging_instruction_requirement === 'NOT_REQUIRED_APPROVED' &&
+    !text(item.notes)
+  )
+    blockers.push(`${part}: packaging N/A reason required.`);
+  return blockers;
+}


### PR DESCRIPTION
## Summary
- add revision-controlled P2 v2 production plans and manufactured assembly-tree item baselines
- enforce released BOM/routing evidence, structured planning decisions, independent Engineering/Quality/Operations approvals, readiness, staleness, and revision history
- expose the Production Planning stage UI/API without creating WAD, traveler, production-order, inventory, scheduling, or shipping records
- keep legacy workflows unchanged and keep p2_v2 inactive for new project creation

## Validation
- server workflow/BOM/WAD/closing/release-gate regression: 103/103 passed
- focused component suites: 5/5 passed
- focused ESLint on new Phase 6 files and workflow component changes: passed
- git diff --check and cached diff check: passed
- initial 6144 MB TypeScript run reported no diagnostics in touched files; two confirmation runs remained resident at about 4 GB combined and were terminated, so this PR does not claim repository-wide type cleanliness

## Safety boundaries
- additive migration only; no enum expansion and no legacy record conversion
- no generic status endpoint or physical deletion endpoint
- only Design Applicability and Production Planning are writable in the ten-stage summary
- release requires the current PO revision, current design release where applicable, released configuration evidence, readiness, and three distinct approvals