### PR TITLE
Add P2 V2 WAD authorization controls

### DIFF
--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -11,7 +11,9 @@ const stages = Array.from({ length: 10 }, (_, index) => ({
       ? 'design_applicability'
       : index === 4
         ? 'production_planning'
-        : `stage_${index + 1}`,
+        : index === 5
+          ? 'wad_authorization'
+          : `stage_${index + 1}`,
   stepOrder: index + 1,
   label: `Stage ${index + 1}`,
   description: `Description ${index + 1}`,
@@ -135,7 +137,7 @@ describe('P2V2ProjectWorkflow', () => {
     expect(screen.getByTestId('v2-approval')).toHaveTextContent('REJECTED');
   });
 
-  it('makes only Design Applicability and Production Planning writable from the ten-stage summary', async () => {
+  it('makes only Design Applicability, Production Planning and WAD Authorization writable from the ten-stage summary', async () => {
     renderWorkflow(initialized);
     expect(
       await screen.findByTestId('open-design-applicability')
@@ -145,6 +147,9 @@ describe('P2V2ProjectWorkflow', () => {
     ).toHaveLength(1);
     expect(
       screen.getAllByRole('button', { name: 'Open Production Planning' })
+    ).toHaveLength(1);
+    expect(
+      screen.getAllByRole('button', { name: 'Open WAD Authorization' })
     ).toHaveLength(1);
     expect(screen.getAllByRole('button', { name: 'Details' })).toHaveLength(10);
   });

--- a/client/src/__tests__/P2V2WadAuthorization.component.test.tsx
+++ b/client/src/__tests__/P2V2WadAuthorization.component.test.tsx
@@ -1,0 +1,122 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import P2V2WadAuthorization from '../components/projects/P2V2WadAuthorization';
+
+const model = {
+  authorization: {
+    id: 'auth-1',
+    status: 'RELEASED',
+    wad_number: 'WAD-P2-1',
+    wad_revision: 2,
+    production_plan_revision: 4,
+    configuration_revision: 'PO-10 Rev 3',
+    effectivity_reference: 'PO-10 Rev 3',
+    wad_work_order_id: 'wad-1',
+    inherited_requirements_snapshot: {
+      manufacturedItems: [
+        {
+          id: 'part-1',
+          part_number: 'MAKE-100',
+          extended_project_quantity: 4,
+          routing_requirement: 'REQUIRED',
+          traveler_requirement: 'REQUIRED',
+          traveler_type: 'BATCH',
+          work_instruction_requirement: 'DRAWING_SPEC_SUFFICIENT',
+          inspection_extent: 'APPROVED_SAMPLING',
+          sampling_plan_id: 'SP-1',
+          fai_requirement: 'PARTIAL',
+          traceability_level: 'LOT',
+          special_process_source: 'NONE',
+          required_certifications: ['C of C'],
+          required_test_records: ['Final test'],
+          packaging_instruction_requirement: 'REQUIRED',
+        },
+      ],
+    },
+    budget_snapshot: {
+      departments: [{ department: 'Assembly', hours: 20, chargeCodeId: 7 }],
+      materialBudget: 1000,
+      outsideProcessingBudget: 250,
+      startDate: '2026-07-23',
+      dueDate: '2026-08-01',
+      risks: [
+        { description: 'Capacity', owner: 'Pat', control: 'Weekly review' },
+      ],
+    },
+  },
+  wad: { id: 'wad-1' },
+  readiness: {
+    ready: false,
+    stale: true,
+    blockers: ['WAD source Production Plan is no longer current.'],
+    differences: ['Production Plan revision changed.'],
+  },
+  approvals: [
+    {
+      approval_type: 'WAD_PROJECT_MANAGEMENT',
+      decision: 'APPROVED',
+      actor_display_name: 'PM',
+    },
+  ],
+  requiredApprovals: [
+    'PROJECT_MANAGEMENT',
+    'ENGINEERING',
+    'QUALITY',
+    'OPERATIONS',
+    'FINANCE',
+    'EXECUTIVE',
+  ],
+  history: [
+    {
+      id: 'auth-1',
+      wad_revision: 2,
+      status: 'RELEASED',
+      production_plan_revision: 4,
+    },
+    {
+      id: 'auth-0',
+      wad_revision: 1,
+      status: 'SUPERSEDED',
+      production_plan_revision: 3,
+    },
+  ],
+};
+
+describe('P2V2WadAuthorization', () => {
+  beforeEach(() => vi.restoreAllMocks());
+  it('renders inherited requirements, budgets, approvals, blockers and history without Launch Production', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: unknown) => ({
+        ok: true,
+        json: async () =>
+          String(input).includes('/api/permissions/me')
+            ? { permissions: [] }
+            : model,
+      }))
+    );
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={client}>
+        <P2V2WadAuthorization projectId="p1" />
+      </QueryClientProvider>
+    );
+    fireEvent.click(screen.getByTestId('open-wad-authorization'));
+    expect(await screen.findByText('MAKE-100')).toBeInTheDocument();
+    expect(screen.getByText(/Assembly: 20 hours/)).toBeInTheDocument();
+    expect(screen.getByText(/PROJECT_MANAGEMENT approval/)).toBeInTheDocument();
+    expect(screen.getByText(/EXECUTIVE approval/)).toBeInTheDocument();
+    expect(screen.getByTestId('wad-authorization-stale')).toHaveTextContent(
+      'Production Plan revision changed'
+    );
+    expect(screen.getByText(/WAD source Production Plan/)).toBeInTheDocument();
+    expect(screen.getByText(/WAD Rev 1/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /launch production/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -12,6 +12,7 @@ import {
 
 import P2V2DesignApplicability from './P2V2DesignApplicability';
 import P2V2ProductionPlanning from './P2V2ProductionPlanning';
+import P2V2WadAuthorization from './P2V2WadAuthorization';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -376,6 +377,11 @@ export default function P2V2ProjectWorkflow({
               {stage.stepType === 'production_planning' && (
                 <div className="mt-3">
                   <P2V2ProductionPlanning projectId={projectId} />
+                </div>
+              )}
+              {stage.stepType === 'wad_authorization' && (
+                <div className="mt-3">
+                  <P2V2WadAuthorization projectId={projectId} />
                 </div>
               )}
             </CardContent>

--- a/client/src/components/projects/P2V2WadAuthorization.tsx
+++ b/client/src/components/projects/P2V2WadAuthorization.tsx
@@ -1,0 +1,509 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useLocation } from 'wouter';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+
+// Dynamic API rows mirror additive snapshot JSON without a generated schema.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+const value = (row: Row | null | undefined, key: string) =>
+  String(row?.[key] ?? '—');
+const endpoint = (projectId: string) =>
+  `/api/projects/${projectId}/workflow-v2/wad-authorization`;
+async function request(url: string, init?: { method?: string; body?: string }) {
+  const response = await fetch(url, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+  const body = await response.json();
+  if (!response.ok)
+    throw new Error(body.message || body.error || 'WAD Authorization failed.');
+  return body;
+}
+
+export default function P2V2WadAuthorization({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const [, navigate] = useLocation();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState('');
+  const [department, setDepartment] = useState('');
+  const [hours, setHours] = useState('');
+  const [chargeCodeId, setChargeCodeId] = useState('');
+  const [materialBudget, setMaterialBudget] = useState('');
+  const [outsideBudget, setOutsideBudget] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [risk, setRisk] = useState('');
+  const [riskOwner, setRiskOwner] = useState('');
+  const [riskControl, setRiskControl] = useState('');
+  const [financeRequired, setFinanceRequired] = useState(false);
+  const [executiveRequired, setExecutiveRequired] = useState(false);
+  const [existingWadId, setExistingWadId] = useState('');
+  const { data, refetch, isLoading } = useQuery<Row>({
+    queryKey: [endpoint(projectId)],
+    queryFn: () => request(endpoint(projectId)),
+    enabled: open,
+  });
+  const { data: permissions } = useQuery<Row>({
+    queryKey: ['/api/permissions/me'],
+    queryFn: () => request('/api/permissions/me'),
+  });
+  const allowed = new Set<string>(permissions?.permissions ?? []);
+  const authorization = data?.authorization;
+  const status = value(authorization, 'status');
+  const canManage = allowed.has('projects.wad_authorization.manage');
+
+  const draftPayload = {
+    budget: {
+      departments: [
+        {
+          department,
+          hours: Number(hours),
+          chargeCodeId: Number(chargeCodeId),
+        },
+      ],
+      materialBudget: Number(materialBudget),
+      outsideProcessingBudget: Number(outsideBudget),
+      startDate,
+      dueDate,
+      risks: [{ description: risk, owner: riskOwner, control: riskControl }],
+      responsibleOwners: [riskOwner],
+    },
+    financeRequired,
+    executiveRequired,
+  };
+  async function act(suffix: string, body: Row = {}, method = 'POST') {
+    try {
+      setError('');
+      await request(`${endpoint(projectId)}${suffix}`, {
+        method,
+        body: JSON.stringify(body),
+      });
+      await refetch();
+    } catch (failure) {
+      setError(failure instanceof Error ? failure.message : String(failure));
+    }
+  }
+  const decisions = [
+    ['PROJECT_MANAGEMENT', 'pm', 'projects.wad_authorization.pm_decide'],
+    [
+      'ENGINEERING',
+      'engineering',
+      'projects.wad_authorization.engineering_decide',
+    ],
+    ['QUALITY', 'quality', 'projects.wad_authorization.quality_decide'],
+    [
+      'OPERATIONS',
+      'operations',
+      'projects.wad_authorization.operations_decide',
+    ],
+    ['FINANCE', 'finance', 'projects.wad_authorization.finance_decide'],
+    ['EXECUTIVE', 'executive', 'projects.wad_authorization.executive_decide'],
+  ];
+  const inherited =
+    authorization?.inherited_requirements_snapshot?.manufacturedItems ?? [];
+  const budget = authorization?.budget_snapshot ?? {};
+
+  return (
+    <>
+      <Button
+        data-testid="open-wad-authorization"
+        onClick={() => setOpen(true)}
+        size="sm"
+        variant="outline"
+      >
+        Open WAD Authorization
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="max-h-[92vh] max-w-6xl overflow-y-auto"
+          data-testid="wad-authorization-dialog"
+        >
+          <DialogHeader>
+            <DialogTitle>Work Authorization Document (WAD)</DialogTitle>
+            <DialogDescription>
+              Authorizes the released P2 V2 Production Plan. This action does
+              not launch production, generate travelers, or release queues.
+            </DialogDescription>
+          </DialogHeader>
+          {isLoading ? (
+            <p>Loading WAD authorization…</p>
+          ) : (
+            <div className="space-y-5">
+              {authorization ? (
+                <>
+                  <section className="grid gap-3 rounded border p-4 md:grid-cols-5">
+                    <div>
+                      <span className="text-xs text-muted-foreground">
+                        Status
+                      </span>
+                      <div>
+                        <Badge>{status}</Badge>
+                      </div>
+                    </div>
+                    <div>
+                      <span className="text-xs text-muted-foreground">WAD</span>
+                      <p>
+                        {value(authorization, 'wad_number')} Rev{' '}
+                        {value(authorization, 'wad_revision')}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-muted-foreground">
+                        Production Plan
+                      </span>
+                      <p>
+                        Rev {value(authorization, 'production_plan_revision')}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-muted-foreground">
+                        Configuration
+                      </span>
+                      <p>{value(authorization, 'configuration_revision')}</p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-muted-foreground">
+                        Effectivity
+                      </span>
+                      <p>{value(authorization, 'effectivity_reference')}</p>
+                    </div>
+                  </section>
+                  {data.readiness?.stale && (
+                    <section
+                      className="rounded border border-red-300 bg-red-50 p-3"
+                      data-testid="wad-authorization-stale"
+                    >
+                      <h3 className="font-semibold">Source baseline changed</h3>
+                      <ul className="list-disc pl-5 text-sm">
+                        {data.readiness.differences.map((item: string) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                    </section>
+                  )}
+                  {!!data.readiness?.blockers?.length && (
+                    <section className="rounded border border-amber-300 bg-amber-50 p-3">
+                      <h3 className="font-semibold">Readiness blockers</h3>
+                      <ul className="list-disc pl-5 text-sm">
+                        {data.readiness.blockers.map((item: string) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                    </section>
+                  )}
+                  <section>
+                    <h3 className="font-semibold">
+                      Inherited scope and requirements
+                    </h3>
+                    <div className="mt-2 space-y-2">
+                      {inherited.map((item: Row) => (
+                        <div
+                          className="rounded border p-3 text-sm"
+                          key={item.id}
+                        >
+                          <strong>{item.part_number}</strong> · Qty{' '}
+                          {item.extended_project_quantity} · Source: released
+                          Production Plan Rev{' '}
+                          {authorization.production_plan_revision}
+                          <p>
+                            Routing {item.routing_requirement}; Traveler{' '}
+                            {item.traveler_requirement} {item.traveler_type}; WI{' '}
+                            {item.work_instruction_requirement}; Inspection{' '}
+                            {item.inspection_extent}; Sampling{' '}
+                            {item.sampling_plan_id || 'N/A'}; FAI{' '}
+                            {item.fai_requirement}; Traceability{' '}
+                            {item.traceability_level}
+                          </p>
+                          <p>
+                            Special process {item.special_process_source};
+                            Certifications{' '}
+                            {JSON.stringify(item.required_certifications ?? [])}
+                            ; Tests{' '}
+                            {JSON.stringify(item.required_test_records ?? [])};
+                            Packaging {item.packaging_instruction_requirement}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                  <section>
+                    <h3 className="font-semibold">Budgets and charge codes</h3>
+                    {(budget.departments ?? []).map((entry: Row) => (
+                      <div className="text-sm" key={entry.department}>
+                        {entry.department}: {entry.hours} hours · Charge code{' '}
+                        {entry.chargeCodeId}
+                      </div>
+                    ))}
+                    <p className="text-sm">
+                      Material ${budget.materialBudget}; Outside processing $
+                      {budget.outsideProcessingBudget}; Tooling/NRE $
+                      {budget.toolingNreBudget ?? 0}
+                    </p>
+                  </section>
+                  <section>
+                    <h3 className="font-semibold">
+                      Schedule and risk controls
+                    </h3>
+                    <p className="text-sm">
+                      {budget.startDate} through {budget.dueDate}
+                    </p>
+                    {(budget.risks ?? []).map((item: Row, index: number) => (
+                      <p
+                        className="text-sm"
+                        key={`${item.description}-${index}`}
+                      >
+                        {item.description} · Owner {item.owner} · Control{' '}
+                        {item.control}
+                      </p>
+                    ))}
+                  </section>
+                  <section className="grid gap-3 md:grid-cols-3">
+                    {decisions
+                      .filter(([role]) =>
+                        (data.requiredApprovals ?? []).includes(role)
+                      )
+                      .map(([role, path, capability]) => {
+                        const approval = (data.approvals ?? []).find(
+                          (item: Row) => item.approval_type === `WAD_${role}`
+                        );
+                        return (
+                          <div className="rounded border p-3" key={role}>
+                            <h3 className="font-semibold">{role} approval</h3>
+                            {approval ? (
+                              <p className="text-sm">
+                                {approval.decision} by{' '}
+                                {approval.actor_display_name}
+                              </p>
+                            ) : (
+                              <p className="text-sm">Pending</p>
+                            )}
+                            {status === 'PENDING_APPROVAL' &&
+                              allowed.has(capability) &&
+                              !approval && (
+                                <div className="mt-2 flex gap-2">
+                                  <Button
+                                    size="sm"
+                                    onClick={() =>
+                                      act(
+                                        `/${authorization.id}/${path}-decision`,
+                                        {
+                                          decision: 'APPROVED',
+                                          signatureMeaning: `${role} WAD authorization approval`,
+                                        }
+                                      )
+                                    }
+                                  >
+                                    Approve
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="destructive"
+                                    onClick={() =>
+                                      act(
+                                        `/${authorization.id}/${path}-decision`,
+                                        {
+                                          decision: 'REJECTED',
+                                          signatureMeaning: `${role} WAD authorization rejection`,
+                                          reason: 'Returned for correction',
+                                        }
+                                      )
+                                    }
+                                  >
+                                    Reject
+                                  </Button>
+                                </div>
+                              )}
+                          </div>
+                        );
+                      })}
+                  </section>
+                  <section>
+                    <h3 className="font-semibold">Revision history</h3>
+                    {(data.history ?? []).map((entry: Row) => (
+                      <p className="text-sm" key={entry.id}>
+                        WAD Rev {entry.wad_revision} · {entry.status} ·
+                        Production Plan Rev {entry.production_plan_revision}
+                      </p>
+                    ))}
+                  </section>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      onClick={() =>
+                        navigate(
+                          `/work-orders/${authorization.wad_work_order_id}`
+                        )
+                      }
+                    >
+                      Open WAD
+                    </Button>
+                    {status === 'DRAFT' && canManage && (
+                      <Button
+                        onClick={() => act(`/${authorization.id}/submit`)}
+                      >
+                        Submit
+                      </Button>
+                    )}
+                    {status === 'PENDING_APPROVAL' &&
+                      allowed.has('projects.wad_authorization.release') && (
+                        <Button
+                          onClick={() =>
+                            act(`/${authorization.id}/release`, {
+                              signatureMeaning:
+                                'Release the approved WAD authorization',
+                            })
+                          }
+                        >
+                          Release WAD
+                        </Button>
+                      )}
+                    {['RELEASED', 'REJECTED', 'BLOCKED'].includes(status) &&
+                      canManage && (
+                        <Button
+                          onClick={() =>
+                            act(`/${authorization.id}/revise`, draftPayload)
+                          }
+                        >
+                          Create Revision
+                        </Button>
+                      )}
+                  </div>
+                </>
+              ) : (
+                <section className="space-y-3 rounded border p-4">
+                  <h3 className="font-semibold">Create WAD Draft</h3>
+                  <div className="grid gap-2 md:grid-cols-3">
+                    <Input
+                      placeholder="Department"
+                      value={department}
+                      onChange={(event) => setDepartment(event.target.value)}
+                    />
+                    <Input
+                      placeholder="Labor hours"
+                      type="number"
+                      value={hours}
+                      onChange={(event) => setHours(event.target.value)}
+                    />
+                    <Input
+                      placeholder="Active charge-code ID"
+                      type="number"
+                      value={chargeCodeId}
+                      onChange={(event) => setChargeCodeId(event.target.value)}
+                    />
+                    <Input
+                      placeholder="Material budget"
+                      type="number"
+                      value={materialBudget}
+                      onChange={(event) =>
+                        setMaterialBudget(event.target.value)
+                      }
+                    />
+                    <Input
+                      placeholder="Outside-processing budget"
+                      type="number"
+                      value={outsideBudget}
+                      onChange={(event) => setOutsideBudget(event.target.value)}
+                    />
+                    <Input
+                      aria-label="WAD start date"
+                      type="date"
+                      value={startDate}
+                      onChange={(event) => setStartDate(event.target.value)}
+                    />
+                    <Input
+                      aria-label="WAD due date"
+                      type="date"
+                      value={dueDate}
+                      onChange={(event) => setDueDate(event.target.value)}
+                    />
+                    <Input
+                      placeholder="Risk"
+                      value={risk}
+                      onChange={(event) => setRisk(event.target.value)}
+                    />
+                    <Input
+                      placeholder="Risk owner"
+                      value={riskOwner}
+                      onChange={(event) => setRiskOwner(event.target.value)}
+                    />
+                    <Input
+                      placeholder="Risk control"
+                      value={riskControl}
+                      onChange={(event) => setRiskControl(event.target.value)}
+                    />
+                  </div>
+                  <label className="mr-4 text-sm">
+                    <input
+                      checked={financeRequired}
+                      onChange={(event) =>
+                        setFinanceRequired(event.target.checked)
+                      }
+                      type="checkbox"
+                    />{' '}
+                    Finance approval required
+                  </label>
+                  <label className="text-sm">
+                    <input
+                      checked={executiveRequired}
+                      onChange={(event) =>
+                        setExecutiveRequired(event.target.checked)
+                      }
+                      type="checkbox"
+                    />{' '}
+                    Executive approval required
+                  </label>
+                  {canManage && (
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        onClick={() => act('/create-draft', draftPayload)}
+                      >
+                        Create WAD Draft
+                      </Button>
+                      <Input
+                        className="max-w-sm"
+                        placeholder="Existing WAD ID"
+                        value={existingWadId}
+                        onChange={(event) =>
+                          setExistingWadId(event.target.value)
+                        }
+                      />
+                      <Button
+                        disabled={!existingWadId}
+                        variant="outline"
+                        onClick={() =>
+                          act('/link-existing', {
+                            ...draftPayload,
+                            wadId: existingWadId,
+                            confirmation: 'LINK_MATCHING_BASELINE',
+                          })
+                        }
+                      >
+                        Link Existing WAD
+                      </Button>
+                    </div>
+                  )}
+                </section>
+              )}
+              {error && <p className="text-sm text-red-700">{error}</p>}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/migrations/0205_project_wad_authorizations.sql
+++ b/migrations/0205_project_wad_authorizations.sql
@@ -1,0 +1,64 @@
+-- Phase 7: additive p2_v2 WAD authorization bridge.
+-- The authoritative WAD remains production_work_orders. No legacy backfill.
+CREATE TABLE IF NOT EXISTS project_wad_authorizations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  workflow_instance_id UUID NOT NULL,
+  workflow_step_instance_id UUID NOT NULL,
+  workflow_step_type TEXT NOT NULL DEFAULT 'wad_authorization' CHECK (workflow_step_type = 'wad_authorization'),
+  production_plan_id UUID NOT NULL REFERENCES project_production_plans(id) ON DELETE RESTRICT,
+  production_plan_revision INTEGER NOT NULL CHECK (production_plan_revision > 0),
+  wad_work_order_id UUID NOT NULL REFERENCES production_work_orders(id) ON DELETE RESTRICT,
+  wad_number TEXT NOT NULL,
+  wad_revision INTEGER NOT NULL CHECK (wad_revision > 0),
+  status TEXT NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT','PENDING_APPROVAL','APPROVED','RELEASED','REJECTED','BLOCKED','SUPERSEDED')),
+  po_id INTEGER REFERENCES p2_purchase_orders(id) ON DELETE RESTRICT,
+  po_revision_number INTEGER,
+  configuration_revision TEXT NOT NULL,
+  effectivity_reference TEXT NOT NULL,
+  inherited_requirements_snapshot JSONB NOT NULL,
+  budget_snapshot JSONB NOT NULL,
+  approval_snapshot JSONB,
+  finance_required BOOLEAN NOT NULL DEFAULT false,
+  executive_required BOOLEAN NOT NULL DEFAULT false,
+  authorized_at TIMESTAMP,
+  authorized_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  authorized_by_display_name TEXT,
+  superseded_at TIMESTAMP,
+  superseded_by_authorization_id UUID REFERENCES project_wad_authorizations(id) ON DELETE RESTRICT,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_wad_authorizations_instance_project_fk FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_wad_authorizations_step_identity_fk FOREIGN KEY (workflow_step_instance_id, workflow_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, workflow_instance_id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_wad_authorizations_revision_unique UNIQUE (project_id, workflow_instance_id, wad_revision)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_wad_authorizations_current_unique
+  ON project_wad_authorizations(project_id, workflow_instance_id) WHERE status <> 'SUPERSEDED';
+CREATE INDEX IF NOT EXISTS project_wad_authorizations_project_idx
+  ON project_wad_authorizations(project_id, wad_revision DESC);
+
+INSERT INTO perm_capabilities (key, description, category) VALUES
+ ('projects.wad_authorization.manage','Create, submit and revise P2 V2 WAD authorizations','projects'),
+ ('projects.wad_authorization.pm_decide','Record Project Management V2 WAD decisions','projects'),
+ ('projects.wad_authorization.engineering_decide','Record Engineering V2 WAD decisions','engineering'),
+ ('projects.wad_authorization.quality_decide','Record Quality V2 WAD decisions','quality'),
+ ('projects.wad_authorization.operations_decide','Record Operations V2 WAD decisions','operations'),
+ ('projects.wad_authorization.finance_decide','Record conditional Finance V2 WAD decisions','finance'),
+ ('projects.wad_authorization.executive_decide','Record conditional Executive V2 WAD decisions','executive'),
+ ('projects.wad_authorization.release','Release an approved P2 V2 WAD authorization','projects')
+ON CONFLICT (key) DO UPDATE SET description=EXCLUDED.description, category=EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT pr.id, pc.id FROM perm_roles pr JOIN perm_capabilities pc ON (
+ (pr.name IN ('ADMIN','OWNER') AND pc.key IN ('projects.wad_authorization.manage','projects.wad_authorization.release')) OR
+ (pr.name IN ('PROJECT_MANAGER','PROGRAM_MANAGER') AND pc.key IN ('projects.wad_authorization.manage','projects.wad_authorization.pm_decide','projects.wad_authorization.release')) OR
+ (pr.name IN ('ENGINEERING','ENGINEER','ENGINEERING_MANAGER') AND pc.key='projects.wad_authorization.engineering_decide') OR
+ (pr.name IN ('QUALITY','QC','QUALITY_MANAGER') AND pc.key='projects.wad_authorization.quality_decide') OR
+ (pr.name IN ('OPERATIONS','OPERATIONS_MANAGER','PRODUCTION_MANAGER') AND pc.key='projects.wad_authorization.operations_decide') OR
+ (pr.name IN ('FINANCE','CONTROLLER') AND pc.key='projects.wad_authorization.finance_decide') OR
+ (pr.name IN ('EXECUTIVE') AND pc.key='projects.wad_authorization.executive_decide')
+) ON CONFLICT (role_id, capability_id) DO NOTHING;

--- a/server/__tests__/projectWadAuthorization.test.ts
+++ b/server/__tests__/projectWadAuthorization.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  inheritedRequirementBlockers,
+  wadBudgetBlockers,
+} from '../src/services/projectWadAuthorizationValidation';
+
+const root = resolve(__dirname, '../..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+const migration = read('migrations/0205_project_wad_authorizations.sql');
+const service = read('server/src/services/projectWadAuthorizationService.ts');
+const routes = read('server/src/routes/projectWadAuthorization.ts');
+
+describe('Phase 7 additive WAD bridge', () => {
+  it('adds a controlled bridge without legacy backfill or project_steps mutation', () => {
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS project_wad_authorizations'
+    );
+    expect(migration).toContain("workflow_step_type = 'wad_authorization'");
+    expect(migration).toContain('project_wad_authorizations_current_unique');
+    expect(migration).not.toMatch(/UPDATE\s+(?:projects|project_steps)\b/i);
+    expect(migration).not.toMatch(/ON DELETE CASCADE/i);
+  });
+  it('has scoped routes with no delete or arbitrary status input', () => {
+    expect(routes).toContain("router.post('/create-draft'");
+    expect(routes).toContain("router.post('/link-existing'");
+    expect(routes).toContain("router.post('/:authorizationId/release'");
+    expect(routes).not.toMatch(/router\.delete/i);
+    expect(routes).not.toMatch(/stage-status|mark-complete|skip/i);
+    expect(service).toContain('EXISTING_WAD_REQUIRES_LINK');
+    expect(service).toContain('LINK_MATCHING_BASELINE');
+  });
+});
+
+describe('WAD inheritance and budget readiness', () => {
+  const manufactured = {
+    is_manufactured: true,
+    part_number: 'MAKE-1',
+    routing_requirement: 'REQUIRED',
+    traveler_requirement: 'REQUIRED',
+    work_instruction_requirement: 'DRAWING_SPEC_SUFFICIENT',
+    inspection_requirement: 'REQUIRED',
+    inspection_extent: 'ONE_HUNDRED_PERCENT',
+    fai_requirement: 'NOT_REQUIRED',
+    traceability_level: 'LOT',
+    special_process_source: 'NONE',
+    packaging_instruction_requirement: 'NOT_REQUIRED_APPROVED',
+  };
+  it('accepts a complete manufactured requirement snapshot', () => {
+    expect(inheritedRequirementBlockers([manufactured])).toEqual([]);
+  });
+  it('blocks missing sampling and manufacturing decisions exactly', () => {
+    expect(
+      inheritedRequirementBlockers([
+        {
+          ...manufactured,
+          routing_requirement: null,
+          inspection_extent: 'APPROVED_SAMPLING',
+          sampling_plan_id: null,
+        },
+      ])
+    ).toEqual(
+      expect.arrayContaining([
+        'MAKE-1: inherited routing decision is missing.',
+        'MAKE-1: approved sampling requires a sampling-plan ID.',
+      ])
+    );
+  });
+  it('requires charge codes, budgets, schedule, risks and owners', () => {
+    expect(
+      wadBudgetBlockers({
+        departments: [{ department: 'Assembly', hours: 0, chargeCodeId: null }],
+        materialBudget: null,
+        outsideProcessingBudget: null,
+      })
+    ).toEqual(
+      expect.arrayContaining([
+        'Assembly: an active charge code is required.',
+        'Assembly: zero-budget work requires justification.',
+        'A non-negative material budget is required.',
+        'Outside-processing budget must be addressed with a non-negative value.',
+        'WAD start and due dates are required.',
+        'At least one project risk and control is required.',
+        'At least one responsible owner is required.',
+      ])
+    );
+  });
+});
+
+describe('controlled approval, release and revision behavior', () => {
+  it('requires separate capabilities and exact-revision evidence', () => {
+    for (const role of [
+      'PROJECT_MANAGEMENT',
+      'ENGINEERING',
+      'QUALITY',
+      'OPERATIONS',
+      'FINANCE',
+      'EXECUTIVE',
+    ])
+      expect(service).toContain(role);
+    expect(service).toContain('SEGREGATION_OF_DUTIES');
+    expect(service).toContain('step_revision_snapshot');
+    expect(service).toContain('APPROVALS_REQUIRED');
+  });
+  it('releases authoritative WAD without calling production launch paths', () => {
+    expect(service).toContain("wad_status='APPROVED',status='RELEASED'");
+    expect(service).not.toMatch(
+      /release-to-p2|manufacturing_queue|travelers|production_orders/i
+    );
+    expect(service).toContain("status='SUPERSEDED'");
+    expect(service).toContain('superseded_by_authorization_id');
+  });
+});

--- a/server/src/routes/projectWadAuthorization.ts
+++ b/server/src/routes/projectWadAuthorization.ts
@@ -1,0 +1,235 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { getUserPermissions } from '../services/permissionService';
+import {
+  createWadDraft,
+  getCurrentWadAuthorization,
+  linkExistingWad,
+  ProjectWadAuthorizationError,
+  recordWadDecision,
+  releaseWadAuthorization,
+  reviseWadAuthorization,
+  submitWadAuthorization,
+  type WadAuthorizationActor,
+} from '../services/projectWadAuthorizationService';
+
+const router = Router({ mergeParams: true });
+const budgetSchema = z.object({
+  departments: z.array(
+    z.object({
+      department: z.string().min(1),
+      hours: z.number().nonnegative(),
+      chargeCodeId: z.number().int().positive().nullable(),
+      zeroBudgetJustification: z.string().nullable().optional(),
+    })
+  ),
+  materialBudget: z.number().nonnegative(),
+  outsideProcessingBudget: z.number().nonnegative(),
+  toolingNreBudget: z.number().nonnegative().nullable().optional(),
+  warningThreshold: z.number().nonnegative().nullable().optional(),
+  blockingThreshold: z.number().positive().nullable().optional(),
+  startDate: z.string().min(1),
+  dueDate: z.string().min(1),
+  risks: z.array(
+    z.object({
+      description: z.string().min(1),
+      owner: z.string().min(1),
+      control: z.string().min(1),
+    })
+  ),
+  responsibleOwners: z.array(z.string().min(1)),
+});
+const draftSchema = z.object({
+  budget: budgetSchema,
+  financeRequired: z.boolean().optional(),
+  executiveRequired: z.boolean().optional(),
+  confirmation: z.string().optional(),
+});
+const decisionSchema = z.object({
+  decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+  signatureMeaning: z.string().min(1),
+  reason: z.string().optional().default(''),
+});
+const releaseSchema = z.object({ signatureMeaning: z.string().min(1) });
+
+function actor(req: Request): WadAuthorizationActor {
+  if (!req.user?.id || !req.user?.username || !req.user?.role)
+    throw new ProjectWadAuthorizationError(
+      'ACTOR_REQUIRED',
+      'Authenticated actor identity is required.',
+      401
+    );
+  return {
+    userId: req.user.id,
+    employeeId: req.user.employeeId ?? null,
+    username: req.user.username,
+    displayName: req.user.username,
+    role: req.user.role,
+  };
+}
+async function requireCapability(req: Request, capability: string) {
+  const value = actor(req);
+  const { permissionSet } = await getUserPermissions(value.userId, value.role);
+  if (!permissionSet.has(capability))
+    throw new ProjectWadAuthorizationError(
+      'FORBIDDEN',
+      `The ${capability} capability is required.`,
+      403
+    );
+  return value;
+}
+function fail(res: Response, error: unknown) {
+  if (error instanceof z.ZodError)
+    return res
+      .status(400)
+      .json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error instanceof ProjectWadAuthorizationError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
+  console.error('P2 V2 WAD Authorization error:', error);
+  return res.status(500).json({
+    error: 'WAD_AUTHORIZATION_FAILED',
+    message: 'WAD Authorization action failed.',
+  });
+}
+const projectId = (req: Request) => String(req.params.id);
+
+router.get('/', async (req, res) => {
+  try {
+    res.json(await getCurrentWadAuthorization(projectId(req)));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/create-draft', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.wad_authorization.manage'
+    );
+    res
+      .status(201)
+      .json(
+        await createWadDraft(projectId(req), draftSchema.parse(req.body), user)
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/link-existing', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.wad_authorization.manage'
+    );
+    const body = draftSchema
+      .extend({ wadId: z.string().uuid() })
+      .parse(req.body);
+    res
+      .status(201)
+      .json(await linkExistingWad(projectId(req), body.wadId, body, user));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:authorizationId/submit', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.wad_authorization.manage'
+    );
+    res.json(
+      await submitWadAuthorization(
+        projectId(req),
+        req.params.authorizationId,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+const decisionRoutes = [
+  ['pm-decision', 'PROJECT_MANAGEMENT', 'projects.wad_authorization.pm_decide'],
+  [
+    'engineering-decision',
+    'ENGINEERING',
+    'projects.wad_authorization.engineering_decide',
+  ],
+  ['quality-decision', 'QUALITY', 'projects.wad_authorization.quality_decide'],
+  [
+    'operations-decision',
+    'OPERATIONS',
+    'projects.wad_authorization.operations_decide',
+  ],
+  ['finance-decision', 'FINANCE', 'projects.wad_authorization.finance_decide'],
+  [
+    'executive-decision',
+    'EXECUTIVE',
+    'projects.wad_authorization.executive_decide',
+  ],
+] as const;
+for (const [path, capacity, capability] of decisionRoutes) {
+  router.post(`/:authorizationId/${path}`, async (req, res) => {
+    try {
+      const user = await requireCapability(req, capability);
+      const body = decisionSchema.parse(req.body);
+      res.json(
+        await recordWadDecision(
+          projectId(req),
+          req.params.authorizationId,
+          capacity,
+          body.decision,
+          body.signatureMeaning,
+          body.reason,
+          user
+        )
+      );
+    } catch (error) {
+      fail(res, error);
+    }
+  });
+}
+router.post('/:authorizationId/release', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.wad_authorization.release'
+    );
+    const body = releaseSchema.parse(req.body);
+    res.json(
+      await releaseWadAuthorization(
+        projectId(req),
+        req.params.authorizationId,
+        body.signatureMeaning,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:authorizationId/revise', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.wad_authorization.manage'
+    );
+    res
+      .status(201)
+      .json(
+        await reviseWadAuthorization(
+          projectId(req),
+          req.params.authorizationId,
+          draftSchema.parse(req.body),
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+
+export default router;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -38,6 +38,8 @@ import { getActiveWorkflowInstanceForProject, getWorkflowReadModel } from '../se
 import { buildP2V2WorkflowResponse, buildUninitializedP2V2Response } from '../services/projectWorkflowV2ReadModel';
 import projectProductionPlanningRoutes from './projectProductionPlanning';
 import { getCurrentProductionPlan } from '../services/projectProductionPlanningService';
+import projectWadAuthorizationRoutes from './projectWadAuthorization';
+import { getCurrentWadAuthorization } from '../services/projectWadAuthorizationService';
 import { getUserPermissions } from '../services/permissionService';
 import {
   createDraft as createDesignApplicabilityDraft,
@@ -1579,6 +1581,7 @@ function sendDesignError(res: Response, error: unknown) {
 }
 
 router.use('/:id/workflow-v2/production-planning', projectProductionPlanningRoutes);
+router.use('/:id/workflow-v2/wad-authorization', projectWadAuthorizationRoutes);
 
 router.get('/:id/workflow-v2/design-applicability', async (req, res) => {
   try {
@@ -1680,6 +1683,51 @@ router.get('/:id/workflow-v2', async (req, res) => {
                 ...stage,
                 status: 'BLOCKED',
                 blockedReason: productionPlan.readiness.differences.join(' '),
+              }
+            : stage
+        );
+        response.blockedStages = response.stages.filter(
+          (stage) => stage.status === 'BLOCKED'
+        ).length;
+      }
+    }
+    const planningStage = response.stages.find(
+      (stage) => stage.stepType === 'production_planning'
+    );
+    const wadStage = response.stages.find(
+      (stage) => stage.stepType === 'wad_authorization'
+    );
+    if (wadStage?.status === 'COMPLETE' && planningStage?.status !== 'COMPLETE') {
+      response.stages = response.stages.map((stage) =>
+        stage.stepType === 'wad_authorization'
+          ? {
+              ...stage,
+              status: 'BLOCKED',
+              blockedReason:
+                'The released Production Planning baseline is no longer current.',
+            }
+          : stage
+      );
+      response.blockedStages = response.stages.filter(
+        (stage) => stage.status === 'BLOCKED'
+      ).length;
+    }
+    if (
+      planningStage?.status === 'COMPLETE' &&
+      ['COMPLETE', 'NOT_APPLICABLE'].includes(designStage?.status ?? '')
+    ) {
+      const wadAuthorization = await getCurrentWadAuthorization(project.id);
+      if (
+        wadAuthorization.authorization?.status === 'RELEASED' &&
+        wadAuthorization.readiness.stale
+      ) {
+        response.stages = response.stages.map((stage) =>
+          stage.stepType === 'wad_authorization'
+            ? {
+                ...stage,
+                status: 'BLOCKED',
+                blockedReason:
+                  wadAuthorization.readiness.differences.join(' '),
               }
             : stage
         );

--- a/server/src/services/projectWadAuthorizationService.ts
+++ b/server/src/services/projectWadAuthorizationService.ts
@@ -1,0 +1,827 @@
+import { randomUUID } from 'crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
+import { getCurrentProductionPlan } from './projectProductionPlanningService';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+import {
+  inheritedRequirementBlockers,
+  wadBudgetBlockers,
+  type WadBudgetInput,
+} from './projectWadAuthorizationValidation';
+
+type Executor = AuditLedgerTx;
+// Raw-query rows keep the additive bridge isolated from the central schema.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+export type WadAuthorizationActor = {
+  userId: number;
+  employeeId?: number | null;
+  username: string;
+  displayName: string;
+  role: string;
+};
+export type WadDraftInput = {
+  budget: WadBudgetInput;
+  financeRequired?: boolean;
+  executiveRequired?: boolean;
+  confirmation?: string;
+};
+export class ProjectWadAuthorizationError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 400,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+const rows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+const clean = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : '';
+
+async function context(
+  projectId: string,
+  tx: Executor,
+  lock = false,
+  requirePrerequisites = true
+) {
+  const project = rows(
+    await tx.execute(
+      sql`SELECT id,project_code AS project_number,project_name,customer_name_snapshot AS customer_name,workflow_version,po_id FROM projects WHERE id=${projectId} ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  )[0];
+  if (!project)
+    throw new ProjectWadAuthorizationError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.',
+      404
+    );
+  const version = resolveProjectWorkflowVersion(project.workflow_version);
+  if (version !== 'p2_v2')
+    throw new ProjectWadAuthorizationError(
+      'P2_V2_REQUIRED',
+      'WAD Authorization requires an explicit p2_v2 project.',
+      409,
+      { effectiveWorkflowVersion: version }
+    );
+  const instances = rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_instances WHERE project_id=${projectId} AND workflow_version='p2_v2' AND status NOT IN ('SUPERSEDED','CANCELLED') ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  );
+  if (instances.length !== 1)
+    throw new ProjectWadAuthorizationError(
+      instances.length
+        ? 'DUPLICATE_ACTIVE_INSTANCES'
+        : 'WORKFLOW_INSTANCE_REQUIRED',
+      instances.length
+        ? 'Multiple active V2 instances exist.'
+        : 'An active V2 workflow instance is required.',
+      409
+    );
+  const steps = rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_instances WHERE workflow_instance_id=${instances[0].id} ORDER BY step_order`
+    )
+  );
+  const issues = validateWorkflowInstanceIntegrity(instances[0], steps);
+  if (issues.length)
+    throw new ProjectWadAuthorizationError(
+      'WORKFLOW_INTEGRITY_FAILED',
+      'The V2 workflow failed integrity validation.',
+      409,
+      { issues }
+    );
+  const step = steps.find((entry) => entry.step_type === 'wad_authorization');
+  const design = steps.find(
+    (entry) => entry.step_type === 'design_applicability'
+  );
+  const planning = steps.find(
+    (entry) => entry.step_type === 'production_planning'
+  );
+  if (!step)
+    throw new ProjectWadAuthorizationError(
+      'WAD_AUTHORIZATION_STAGE_REQUIRED',
+      'WAD Authorization stage is missing.',
+      409
+    );
+  if (
+    requirePrerequisites &&
+    (!design || !['COMPLETE', 'NOT_APPLICABLE'].includes(design.status))
+  )
+    throw new ProjectWadAuthorizationError(
+      'DESIGN_APPLICABILITY_REQUIRED',
+      'Design Applicability must remain complete or approved not applicable.',
+      409
+    );
+  if (requirePrerequisites && (!planning || planning.status !== 'COMPLETE'))
+    throw new ProjectWadAuthorizationError(
+      'PRODUCTION_PLANNING_REQUIRED',
+      'Production Planning must be complete.',
+      409
+    );
+  return { project, instance: instances[0], step, design, planning };
+}
+
+async function currentAuthorization(projectId: string, tx: Executor) {
+  return (
+    rows(
+      await tx.execute(
+        sql`SELECT * FROM project_wad_authorizations WHERE project_id=${projectId} AND status<>'SUPERSEDED' ORDER BY wad_revision DESC LIMIT 1`
+      )
+    )[0] ?? null
+  );
+}
+async function history(projectId: string, tx: Executor) {
+  return rows(
+    await tx.execute(
+      sql`SELECT * FROM project_wad_authorizations WHERE project_id=${projectId} ORDER BY wad_revision DESC`
+    )
+  );
+}
+async function approvals(authorization: Row, tx: Executor) {
+  return rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_approvals WHERE workflow_step_instance_id=${authorization.workflow_step_instance_id} AND evidence_snapshot->>'authorizationId'=${authorization.id} ORDER BY decided_at`
+    )
+  );
+}
+const requiredRoles = (authorization: Row) => [
+  'PROJECT_MANAGEMENT',
+  'ENGINEERING',
+  'QUALITY',
+  'OPERATIONS',
+  ...(authorization.finance_required ? ['FINANCE'] : []),
+  ...(authorization.executive_required ? ['EXECUTIVE'] : []),
+];
+
+async function audit(
+  eventType: string,
+  authorization: Row,
+  actor: WadAuthorizationActor,
+  tx: Executor,
+  reason?: string
+) {
+  await recordAuditEvent(
+    {
+      eventType,
+      subjectType: 'project_wad_authorization',
+      subjectId: authorization.id,
+      sourceService: 'projectWadAuthorizationService',
+      actor: {
+        id: actor.userId,
+        username: actor.displayName,
+        role: actor.role,
+      },
+      reason,
+      payload: {
+        projectId: authorization.project_id,
+        wadId: authorization.wad_work_order_id,
+        wadRevision: authorization.wad_revision,
+        productionPlanId: authorization.production_plan_id,
+        productionPlanRevision: authorization.production_plan_revision,
+      },
+    },
+    tx
+  );
+}
+
+function inheritedSnapshot(ctx: Row, planModel: Row) {
+  const manufactured = planModel.items.filter(
+    (item: Row) => item.is_manufactured
+  );
+  return {
+    source: 'RELEASED_P2_V2_PRODUCTION_PLAN',
+    project: {
+      id: ctx.project.id,
+      code: ctx.project.project_number,
+      name: ctx.project.project_name,
+      customer: ctx.project.customer_name,
+    },
+    po: {
+      id: planModel.plan.po_id,
+      number: planModel.plan.po_number,
+      revision: planModel.plan.po_revision_number,
+    },
+    productionPlan: {
+      id: planModel.plan.id,
+      revision: planModel.plan.revision_number,
+      configurationBaselineId: planModel.plan.configuration_baseline_id,
+      configurationRevision: planModel.plan.configuration_revision,
+      designReleaseId: planModel.plan.design_release_id,
+      designReleaseRevision: planModel.plan.design_release_revision,
+      effectivityReference: planModel.plan.effectivity_reference,
+      requirementSource: planModel.plan.requirement_source,
+    },
+    manufacturedItems: manufactured,
+    sourceAttribution:
+      'Each manufacturing requirement is inherited from the released P2 V2 Production Plan item snapshot.',
+  };
+}
+
+async function readiness(
+  projectId: string,
+  authorization: Row | null,
+  tx: Executor
+) {
+  const blockers: string[] = [];
+  const differences: string[] = [];
+  if (!authorization)
+    return {
+      ready: false,
+      stale: false,
+      blockers: ['A WAD draft is required.'],
+      differences,
+    };
+  const ctx = await context(projectId, tx, false, false);
+  if (!['COMPLETE', 'NOT_APPLICABLE'].includes(ctx.design?.status ?? '')) {
+    blockers.push('Design Applicability is no longer valid.');
+    differences.push('Design Applicability decision or release changed.');
+  }
+  if (ctx.planning?.status !== 'COMPLETE') {
+    blockers.push('Production Planning is no longer complete.');
+    differences.push('Production Planning stage is no longer complete.');
+  }
+  const planModel = await getCurrentProductionPlan(projectId, tx);
+  if (!planModel.plan || planModel.plan.status !== 'RELEASED')
+    blockers.push('The current Production Plan must be RELEASED.');
+  if (planModel.readiness.stale) {
+    blockers.push(...planModel.readiness.differences);
+    differences.push(...planModel.readiness.differences);
+  }
+  if (planModel.plan?.id !== authorization.production_plan_id) {
+    differences.push('Production Plan revision changed.');
+    blockers.push('WAD source Production Plan is no longer current.');
+  }
+  if (
+    Number(planModel.plan?.po_revision_number) !==
+    Number(authorization.po_revision_number)
+  ) {
+    differences.push('Customer PO revision changed.');
+    blockers.push(
+      'WAD PO revision does not match the current Production Plan.'
+    );
+  }
+  if (
+    planModel.plan?.configuration_revision !==
+    authorization.configuration_revision
+  ) {
+    differences.push('Configuration baseline changed.');
+    blockers.push('WAD configuration baseline is stale.');
+  }
+  const snapshot = authorization.inherited_requirements_snapshot ?? {};
+  blockers.push(
+    ...inheritedRequirementBlockers(snapshot.manufacturedItems ?? [])
+  );
+  blockers.push(...wadBudgetBlockers(authorization.budget_snapshot ?? {}));
+  const departments = authorization.budget_snapshot?.departments ?? [];
+  for (const department of departments) {
+    if (!department.chargeCodeId) continue;
+    const active = rows(
+      await tx.execute(
+        sql`SELECT id FROM charge_codes WHERE id=${department.chargeCodeId} AND active=true LIMIT 1`
+      )
+    );
+    if (!active.length)
+      blockers.push(
+        `${department.department || 'Department'}: charge code is missing or inactive.`
+      );
+  }
+  const wad = rows(
+    await tx.execute(
+      sql`SELECT * FROM production_work_orders WHERE id=${authorization.wad_work_order_id} AND project_id=${projectId}`
+    )
+  )[0];
+  if (!wad)
+    blockers.push(
+      'The authoritative Work Authorization Document (WAD) is missing.'
+    );
+  const wadMeta = wad?.wizard_data?.__p2V2Authorization;
+  if (wadMeta?.authorizationId !== authorization.id)
+    blockers.push(
+      'The authoritative WAD does not contain the matching V2 authorization source snapshot.'
+    );
+  if (authorization.status === 'RELEASED' && wad?.wad_status !== 'APPROVED')
+    blockers.push('The authoritative WAD is no longer approved.');
+  return {
+    ready: blockers.length === 0,
+    stale: differences.length > 0,
+    blockers: Array.from(new Set(blockers)),
+    differences: Array.from(new Set(differences)),
+    currentPlanId: planModel.plan?.id ?? null,
+    stage: ctx.step,
+  };
+}
+
+async function readModel(projectId: string, tx: Executor) {
+  const ctx = await context(projectId, tx, false, false);
+  const authorization = await currentAuthorization(projectId, tx);
+  const wad = authorization
+    ? (rows(
+        await tx.execute(
+          sql`SELECT id,work_order_number,project_id,part_number,description,quantity,status,wad_status,department_budgets,total_budget_hours,material_budget_amount,start_date,due_date,warning_threshold,blocked_threshold,wizard_data,created_at,updated_at FROM production_work_orders WHERE id=${authorization.wad_work_order_id}`
+        )
+      )[0] ?? null)
+    : null;
+  return {
+    authorization,
+    wad,
+    history: await history(projectId, tx),
+    approvals: authorization ? await approvals(authorization, tx) : [],
+    requiredApprovals: authorization ? requiredRoles(authorization) : [],
+    readiness: await readiness(projectId, authorization, tx),
+    stage: ctx.step,
+  };
+}
+export const getCurrentWadAuthorization = (
+  projectId: string,
+  tx: Executor = db
+) => readModel(projectId, tx);
+
+function departmentBudgetObject(budget: WadBudgetInput) {
+  return Object.fromEntries(
+    (budget.departments ?? []).map((entry) => [
+      clean(entry.department),
+      {
+        hours: entry.hours,
+        chargeCodeId: entry.chargeCodeId,
+        zeroBudgetJustification: clean(entry.zeroBudgetJustification) || null,
+      },
+    ])
+  );
+}
+
+async function createRevision(
+  projectId: string,
+  input: WadDraftInput,
+  actor: WadAuthorizationActor,
+  tx: Executor,
+  revision: number,
+  existingWadId?: string
+) {
+  const ctx = await context(projectId, tx, true);
+  const planModel = await getCurrentProductionPlan(projectId, tx);
+  if (
+    !planModel.plan ||
+    planModel.plan.status !== 'RELEASED' ||
+    planModel.readiness.stale
+  )
+    throw new ProjectWadAuthorizationError(
+      'RELEASED_PLAN_REQUIRED',
+      'A current, non-stale RELEASED Production Plan is required.',
+      409,
+      { blockers: planModel.readiness.blockers }
+    );
+  const inherited = inheritedSnapshot(ctx, planModel);
+  const inheritedBlockers = inheritedRequirementBlockers(
+    inherited.manufacturedItems
+  );
+  if (inheritedBlockers.length)
+    throw new ProjectWadAuthorizationError(
+      'INHERITANCE_INCOMPLETE',
+      'Released plan inheritance is incomplete.',
+      409,
+      { blockers: inheritedBlockers }
+    );
+  const root = inherited.manufacturedItems[0];
+  const totalHours = (input.budget.departments ?? []).reduce(
+    (sum, entry) => sum + Number(entry.hours ?? 0),
+    0
+  );
+  let wad: Row;
+  if (existingWadId) {
+    wad = rows(
+      await tx.execute(
+        sql`SELECT * FROM production_work_orders WHERE id=${existingWadId} AND project_id=${projectId} FOR UPDATE`
+      )
+    )[0];
+    if (!wad)
+      throw new ProjectWadAuthorizationError(
+        'WAD_OWNERSHIP_MISMATCH',
+        'Existing WAD does not belong to this project.',
+        409
+      );
+    const meta = wad.wizard_data?.__p2V2Authorization;
+    if (
+      meta &&
+      (meta.productionPlanId !== planModel.plan.id ||
+        Number(meta.productionPlanRevision) !==
+          Number(planModel.plan.revision_number))
+    )
+      throw new ProjectWadAuthorizationError(
+        'WAD_BASELINE_MISMATCH',
+        'Existing WAD does not match the current released Production Plan.',
+        409,
+        {
+          differences: [
+            'Production Plan ID or revision differs from the current baseline.',
+          ],
+        }
+      );
+  } else {
+    const wadNumber = `WAD-${clean(ctx.project.project_number) || 'P2V2'}-${revision}-${randomUUID().slice(0, 8).toUpperCase()}`;
+    wad = rows(
+      await tx.execute(
+        sql`INSERT INTO production_work_orders (work_order_number,project_id,part_number,description,quantity,status,wad_status,department_budgets,total_budget_hours,material_budget_amount,start_date,due_date,warning_threshold,blocked_threshold,wizard_data,created_at,updated_at)
+            VALUES (${wadNumber},${projectId},${root.part_number},${`P2 V2 WAD authorization for ${ctx.project.project_name ?? ctx.project.project_number}`},${Math.ceil(Number(root.extended_project_quantity ?? 1))},'PLANNED','DRAFT',${JSON.stringify(departmentBudgetObject(input.budget))}::jsonb,${String(totalHours)},${String(input.budget.materialBudget ?? 0)},${input.budget.startDate ?? null},${input.budget.dueDate ?? null},${input.budget.warningThreshold == null ? null : String(input.budget.warningThreshold)},${input.budget.blockingThreshold == null ? null : String(input.budget.blockingThreshold)},${JSON.stringify({})}::jsonb,now(),now()) RETURNING *`
+      )
+    )[0];
+  }
+  const authorization = rows(
+    await tx.execute(
+      sql`INSERT INTO project_wad_authorizations (project_id,workflow_instance_id,workflow_step_instance_id,production_plan_id,production_plan_revision,wad_work_order_id,wad_number,wad_revision,status,po_id,po_revision_number,configuration_revision,effectivity_reference,inherited_requirements_snapshot,budget_snapshot,finance_required,executive_required,created_by,created_by_display_name)
+          VALUES (${projectId},${ctx.instance.id},${ctx.step.id},${planModel.plan.id},${planModel.plan.revision_number},${wad.id},${wad.work_order_number},${revision},'DRAFT',${planModel.plan.po_id},${planModel.plan.po_revision_number},${planModel.plan.configuration_revision},${planModel.plan.effectivity_reference},${JSON.stringify(inherited)}::jsonb,${JSON.stringify(input.budget)}::jsonb,${Boolean(input.financeRequired)},${Boolean(input.executiveRequired)},${actor.userId},${actor.displayName}) RETURNING *`
+    )
+  )[0];
+  const wizardData = {
+    ...(wad.wizard_data ?? {}),
+    currentRevision: revision,
+    revisionStatus: 'DRAFT',
+    approvals: [],
+    __p2V2Authorization: {
+      authorizationId: authorization.id,
+      productionPlanId: planModel.plan.id,
+      productionPlanRevision: planModel.plan.revision_number,
+      poId: planModel.plan.po_id,
+      poRevision: planModel.plan.po_revision_number,
+      configurationRevision: planModel.plan.configuration_revision,
+      effectivityReference: planModel.plan.effectivity_reference,
+      inheritedRequirements: inherited,
+      budget: input.budget,
+      source: 'P2 V2 WAD Authorization',
+    },
+  };
+  await tx.execute(
+    sql`UPDATE production_work_orders SET wizard_data=${JSON.stringify(wizardData)}::jsonb,updated_at=now() WHERE id=${wad.id}`
+  );
+  await tx.execute(
+    sql`UPDATE project_workflow_step_instances SET status='IN_PROGRESS',blocked_reason=NULL,started_at=COALESCE(started_at,now()),updated_at=now() WHERE id=${ctx.step.id}`
+  );
+  await audit('P2_V2_WAD_DRAFT_CREATED', authorization, actor, tx);
+  return authorization;
+}
+
+export async function createWadDraft(
+  projectId: string,
+  input: WadDraftInput,
+  actor: WadAuthorizationActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    if (await currentAuthorization(projectId, tx))
+      throw new ProjectWadAuthorizationError(
+        'CURRENT_AUTHORIZATION_EXISTS',
+        'A current WAD authorization already exists.',
+        409
+      );
+    const existingWad = rows(
+      await tx.execute(
+        sql`SELECT id,work_order_number,wad_status,status FROM production_work_orders WHERE project_id=${projectId} AND status NOT IN ('COMPLETE','CLOSED','CANCELLED','CANCELED') ORDER BY created_at DESC LIMIT 1`
+      )
+    )[0];
+    if (existingWad)
+      throw new ProjectWadAuthorizationError(
+        'EXISTING_WAD_REQUIRES_LINK',
+        'An existing WAD must be reviewed and linked; a duplicate was not created.',
+        409,
+        {
+          wadId: existingWad.id,
+          wadNumber: existingWad.work_order_number,
+          wadStatus: existingWad.wad_status,
+          workOrderStatus: existingWad.status,
+        }
+      );
+    await createRevision(projectId, input, actor, tx, 1);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function linkExistingWad(
+  projectId: string,
+  wadId: string,
+  input: WadDraftInput,
+  actor: WadAuthorizationActor
+) {
+  if (input.confirmation !== 'LINK_MATCHING_BASELINE')
+    throw new ProjectWadAuthorizationError(
+      'CONFIRMATION_REQUIRED',
+      'Controlled baseline-match confirmation is required.'
+    );
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    if (await currentAuthorization(projectId, tx))
+      throw new ProjectWadAuthorizationError(
+        'CURRENT_AUTHORIZATION_EXISTS',
+        'A current WAD authorization already exists.',
+        409
+      );
+    await createRevision(projectId, input, actor, tx, 1, wadId);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function submitWadAuthorization(
+  projectId: string,
+  authorizationId: string,
+  actor: WadAuthorizationActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const authorization = await currentAuthorization(projectId, tx);
+    if (!authorization || authorization.id !== authorizationId)
+      throw new ProjectWadAuthorizationError(
+        'CURRENT_AUTHORIZATION_NOT_FOUND',
+        'Current WAD authorization not found.',
+        404
+      );
+    if (authorization.status !== 'DRAFT')
+      throw new ProjectWadAuthorizationError(
+        'DRAFT_REQUIRED',
+        'Only a draft WAD authorization may be submitted.',
+        409
+      );
+    const state = await readiness(projectId, authorization, tx);
+    if (!state.ready)
+      throw new ProjectWadAuthorizationError(
+        'WAD_NOT_READY',
+        'WAD authorization has readiness blockers.',
+        409,
+        { blockers: state.blockers }
+      );
+    await tx.execute(
+      sql`UPDATE project_wad_authorizations SET status='PENDING_APPROVAL',updated_at=now() WHERE id=${authorizationId}`
+    );
+    await tx.execute(
+      sql`UPDATE production_work_orders SET wad_status='PENDING_APPROVAL',wizard_data=jsonb_set(COALESCE(wizard_data,'{}'::jsonb),'{revisionStatus}','"IN_REVIEW"'::jsonb),updated_at=now() WHERE id=${authorization.wad_work_order_id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='PENDING_APPROVAL',updated_at=now() WHERE id=${ctx.step.id}`
+    );
+    await audit('P2_V2_WAD_SUBMITTED', authorization, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function recordWadDecision(
+  projectId: string,
+  authorizationId: string,
+  capacity:
+    | 'PROJECT_MANAGEMENT'
+    | 'ENGINEERING'
+    | 'QUALITY'
+    | 'OPERATIONS'
+    | 'FINANCE'
+    | 'EXECUTIVE',
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: WadAuthorizationActor
+) {
+  if (!clean(signatureMeaning))
+    throw new ProjectWadAuthorizationError(
+      'SIGNATURE_MEANING_REQUIRED',
+      'Signature meaning is required.'
+    );
+  if (decision !== 'APPROVED' && !clean(reason))
+    throw new ProjectWadAuthorizationError(
+      'REASON_REQUIRED',
+      'Rejection/return reason is required.'
+    );
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const authorization = await currentAuthorization(projectId, tx);
+    if (!authorization || authorization.id !== authorizationId)
+      throw new ProjectWadAuthorizationError(
+        'CURRENT_AUTHORIZATION_NOT_FOUND',
+        'Current WAD authorization not found.',
+        404
+      );
+    if (authorization.status !== 'PENDING_APPROVAL')
+      throw new ProjectWadAuthorizationError(
+        'PENDING_APPROVAL_REQUIRED',
+        'WAD authorization is not pending approval.',
+        409
+      );
+    if (!requiredRoles(authorization).includes(capacity))
+      throw new ProjectWadAuthorizationError(
+        'APPROVAL_NOT_REQUIRED',
+        `${capacity} approval is not required for this revision.`,
+        409
+      );
+    const existing = await approvals(authorization, tx);
+    if (existing.some((entry) => entry.approval_type === `WAD_${capacity}`))
+      throw new ProjectWadAuthorizationError(
+        'DECISION_ALREADY_RECORDED',
+        `${capacity} already decided this WAD revision.`,
+        409
+      );
+    if (
+      existing.some(
+        (entry) =>
+          entry.actor_user_id === actor.userId && entry.decision === 'APPROVED'
+      )
+    )
+      throw new ProjectWadAuthorizationError(
+        'SEGREGATION_OF_DUTIES',
+        'One user cannot provide multiple functional WAD approvals.',
+        403
+      );
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_approvals (workflow_step_instance_id,project_id,approval_type,decision,signature_meaning,reason,actor_employee_id,actor_user_id,actor_display_name,actor_role,step_revision_snapshot,evidence_snapshot)
+          VALUES (${ctx.step.id},${projectId},${`WAD_${capacity}`},${decision},${signatureMeaning},${clean(reason) || null},${actor.employeeId ?? null},${actor.userId},${actor.displayName},${actor.role},${String(authorization.wad_revision)},${JSON.stringify({ authorizationId, wadId: authorization.wad_work_order_id, wadRevision: authorization.wad_revision, productionPlanId: authorization.production_plan_id, productionPlanRevision: authorization.production_plan_revision, poId: authorization.po_id, poRevision: authorization.po_revision_number, configurationRevision: authorization.configuration_revision, capacity })}::jsonb)`
+    );
+    if (decision !== 'APPROVED') {
+      await tx.execute(
+        sql`UPDATE project_wad_authorizations SET status='REJECTED',updated_at=now() WHERE id=${authorizationId}`
+      );
+      await tx.execute(
+        sql`UPDATE production_work_orders SET wad_status='DRAFT',updated_at=now() WHERE id=${authorization.wad_work_order_id}`
+      );
+      await tx.execute(
+        sql`UPDATE project_workflow_step_instances SET status='BLOCKED',blocked_reason=${`${capacity} ${decision.toLowerCase()}: ${clean(reason)}`},updated_at=now() WHERE id=${ctx.step.id}`
+      );
+    }
+    await audit(
+      `P2_V2_WAD_${capacity}_DECIDED`,
+      authorization,
+      actor,
+      tx,
+      clean(reason) || undefined
+    );
+    return readModel(projectId, tx);
+  });
+}
+
+async function releaseLinks(
+  authorization: Row,
+  actor: WadAuthorizationActor,
+  tx: Executor
+) {
+  await tx.execute(
+    sql`UPDATE project_workflow_step_links SET unlinked_at=now(),unlink_reason='Superseded by released WAD authorization revision' WHERE workflow_step_instance_id=${authorization.workflow_step_instance_id} AND is_authoritative=true AND unlinked_at IS NULL`
+  );
+  for (const link of [
+    [
+      'production_work_order',
+      authorization.wad_work_order_id,
+      String(authorization.wad_revision),
+      'PRIMARY',
+    ],
+    [
+      'project_production_plan',
+      authorization.production_plan_id,
+      String(authorization.production_plan_revision),
+      'EVIDENCE',
+    ],
+    [
+      'p2_purchase_order',
+      String(authorization.po_id),
+      String(authorization.po_revision_number),
+      'EVIDENCE',
+    ],
+    [
+      'configuration_baseline',
+      authorization.configuration_revision,
+      authorization.configuration_revision,
+      'EVIDENCE',
+    ],
+  ]) {
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_links (workflow_step_instance_id,project_id,record_type,record_id,relationship_type,is_authoritative,record_revision,effectivity_reference,linked_by,linked_by_display_name)
+          VALUES (${authorization.workflow_step_instance_id},${authorization.project_id},${link[0]},${link[1]},${link[3]},true,${link[2]},${authorization.effectivity_reference},${actor.employeeId ?? null},${actor.displayName})`
+    );
+  }
+}
+
+export async function releaseWadAuthorization(
+  projectId: string,
+  authorizationId: string,
+  signatureMeaning: string,
+  actor: WadAuthorizationActor
+) {
+  if (!clean(signatureMeaning))
+    throw new ProjectWadAuthorizationError(
+      'SIGNATURE_MEANING_REQUIRED',
+      'Release signature meaning is required.'
+    );
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const authorization = await currentAuthorization(projectId, tx);
+    if (!authorization || authorization.id !== authorizationId)
+      throw new ProjectWadAuthorizationError(
+        'CURRENT_AUTHORIZATION_NOT_FOUND',
+        'Current WAD authorization not found.',
+        404
+      );
+    if (authorization.status !== 'PENDING_APPROVAL')
+      throw new ProjectWadAuthorizationError(
+        'PENDING_APPROVAL_REQUIRED',
+        'WAD authorization is not pending approval.',
+        409
+      );
+    const state = await readiness(projectId, authorization, tx);
+    if (!state.ready)
+      throw new ProjectWadAuthorizationError(
+        'WAD_NOT_READY',
+        'WAD authorization has readiness blockers.',
+        409,
+        { blockers: state.blockers }
+      );
+    const evidence = await approvals(authorization, tx);
+    const missing = requiredRoles(authorization).filter(
+      (role) =>
+        !evidence.some(
+          (entry) =>
+            entry.approval_type === `WAD_${role}` &&
+            entry.decision === 'APPROVED'
+        )
+    );
+    if (missing.length)
+      throw new ProjectWadAuthorizationError(
+        'APPROVALS_REQUIRED',
+        'All required WAD approvals must be recorded.',
+        409,
+        { missingApprovals: missing }
+      );
+    const wizardApprovals = evidence.map((entry) => ({
+      role: String(entry.approval_type).replace(/^WAD_/, '').toLowerCase(),
+      userId: entry.actor_user_id,
+      displayName: entry.actor_display_name,
+      decision: entry.decision,
+      comments: entry.reason,
+      signature: entry.actor_display_name,
+      signatureMeaning: entry.signature_meaning,
+      signedAt: entry.decided_at,
+      source: 'P2 V2 WAD Authorization',
+    }));
+    await tx.execute(
+      sql`UPDATE production_work_orders SET wad_status='APPROVED',status='RELEASED',wizard_data=jsonb_set(jsonb_set(COALESCE(wizard_data,'{}'::jsonb),'{approvals}',${JSON.stringify(wizardApprovals)}::jsonb),'{revisionStatus}','"APPROVED"'::jsonb),updated_at=now() WHERE id=${authorization.wad_work_order_id} AND project_id=${projectId}`
+    );
+    await tx.execute(
+      sql`UPDATE project_wad_authorizations SET status='RELEASED',approval_snapshot=${JSON.stringify(wizardApprovals)}::jsonb,authorized_at=now(),authorized_by=${actor.userId},authorized_by_display_name=${actor.displayName},updated_at=now() WHERE id=${authorizationId}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now(),completed_by=${actor.employeeId ?? null},completed_by_display_name=${actor.displayName},blocked_reason=NULL,revision_reference=${String(authorization.wad_revision)},effectivity_reference=${authorization.effectivity_reference},updated_at=now() WHERE id=${ctx.step.id}`
+    );
+    await releaseLinks(authorization, actor, tx);
+    await audit(
+      'P2_V2_WAD_RELEASED',
+      authorization,
+      actor,
+      tx,
+      signatureMeaning
+    );
+    return readModel(projectId, tx);
+  });
+}
+
+export async function reviseWadAuthorization(
+  projectId: string,
+  authorizationId: string,
+  input: WadDraftInput,
+  actor: WadAuthorizationActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const prior = await currentAuthorization(projectId, tx);
+    if (!prior || prior.id !== authorizationId)
+      throw new ProjectWadAuthorizationError(
+        'CURRENT_AUTHORIZATION_NOT_FOUND',
+        'Current WAD authorization not found.',
+        404
+      );
+    if (!['RELEASED', 'REJECTED', 'BLOCKED'].includes(prior.status))
+      throw new ProjectWadAuthorizationError(
+        'REVISION_NOT_ALLOWED',
+        'Only released, rejected or blocked WAD authorizations may be revised.',
+        409
+      );
+    const nextRevision = Number(prior.wad_revision) + 1;
+    await tx.execute(
+      sql`UPDATE project_wad_authorizations SET status='SUPERSEDED',superseded_at=now(),updated_at=now() WHERE id=${prior.id}`
+    );
+    const next = await createRevision(
+      projectId,
+      input,
+      actor,
+      tx,
+      nextRevision
+    );
+    await tx.execute(
+      sql`UPDATE project_wad_authorizations SET superseded_by_authorization_id=${next.id} WHERE id=${prior.id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_approvals SET superseded_at=now() WHERE workflow_step_instance_id=${ctx.step.id} AND evidence_snapshot->>'authorizationId'=${prior.id} AND superseded_at IS NULL`
+    );
+    await audit('P2_V2_WAD_REVISED', next, actor, tx);
+    return readModel(projectId, tx);
+  });
+}

--- a/server/src/services/projectWadAuthorizationValidation.ts
+++ b/server/src/services/projectWadAuthorizationValidation.ts
@@ -1,0 +1,105 @@
+export type WadBudgetInput = {
+  departments?: Array<{
+    department?: string;
+    hours?: number;
+    chargeCodeId?: number | null;
+    zeroBudgetJustification?: string | null;
+  }>;
+  materialBudget?: number | null;
+  outsideProcessingBudget?: number | null;
+  toolingNreBudget?: number | null;
+  warningThreshold?: number | null;
+  blockingThreshold?: number | null;
+  startDate?: string | null;
+  dueDate?: string | null;
+  risks?: Array<{
+    description?: string;
+    owner?: string;
+    control?: string;
+  }>;
+  responsibleOwners?: string[];
+};
+
+const text = (value: unknown) => String(value ?? '').trim();
+
+export function wadBudgetBlockers(input: WadBudgetInput): string[] {
+  const blockers: string[] = [];
+  const departments = input.departments ?? [];
+  if (!departments.length)
+    blockers.push('At least one responsible department is required.');
+  for (const entry of departments) {
+    const department = text(entry.department) || 'Unnamed department';
+    if (!text(entry.department))
+      blockers.push('Every department requires a name.');
+    if (!entry.chargeCodeId)
+      blockers.push(`${department}: an active charge code is required.`);
+    if (entry.hours == null || entry.hours < 0)
+      blockers.push(
+        `${department}: labor budget hours must be zero or greater.`
+      );
+    if (entry.hours === 0 && !text(entry.zeroBudgetJustification))
+      blockers.push(`${department}: zero-budget work requires justification.`);
+  }
+  if (input.materialBudget == null || input.materialBudget < 0)
+    blockers.push('A non-negative material budget is required.');
+  if (
+    input.outsideProcessingBudget == null ||
+    input.outsideProcessingBudget < 0
+  )
+    blockers.push(
+      'Outside-processing budget must be addressed with a non-negative value.'
+    );
+  if (input.toolingNreBudget != null && input.toolingNreBudget < 0)
+    blockers.push('Tooling/NRE budget cannot be negative.');
+  if (!text(input.startDate) || !text(input.dueDate))
+    blockers.push('WAD start and due dates are required.');
+  if (!input.risks?.length)
+    blockers.push('At least one project risk and control is required.');
+  for (const risk of input.risks ?? []) {
+    if (!text(risk.description) || !text(risk.owner) || !text(risk.control))
+      blockers.push('Every risk requires a description, owner and control.');
+  }
+  if (!input.responsibleOwners?.some(text))
+    blockers.push('At least one responsible owner is required.');
+  if (
+    input.warningThreshold != null &&
+    input.blockingThreshold != null &&
+    (input.warningThreshold < 0 ||
+      input.warningThreshold >= input.blockingThreshold)
+  )
+    blockers.push(
+      'Warning threshold must be non-negative and less than the blocking threshold.'
+    );
+  return Array.from(new Set(blockers));
+}
+
+export function inheritedRequirementBlockers(
+  items: Array<Record<string, unknown>>
+): string[] {
+  const blockers: string[] = [];
+  const manufactured = items.filter((item) => item.is_manufactured === true);
+  if (!manufactured.length)
+    blockers.push('Released Production Plan has no manufactured items.');
+  for (const item of manufactured) {
+    const part = text(item.part_number) || 'Manufactured item';
+    for (const [field, label] of [
+      ['routing_requirement', 'routing decision'],
+      ['traveler_requirement', 'traveler decision'],
+      ['work_instruction_requirement', 'work-instruction decision'],
+      ['inspection_requirement', 'inspection strategy'],
+      ['fai_requirement', 'FAI decision'],
+      ['traceability_level', 'traceability requirement'],
+      ['special_process_source', 'special-process decision'],
+      ['packaging_instruction_requirement', 'packaging decision'],
+    ] as const) {
+      if (!text(item[field]))
+        blockers.push(`${part}: inherited ${label} is missing.`);
+    }
+    if (
+      item.inspection_extent === 'APPROVED_SAMPLING' &&
+      !text(item.sampling_plan_id)
+    )
+      blockers.push(`${part}: approved sampling requires a sampling-plan ID.`);
+  }
+  return blockers;
+}


### PR DESCRIPTION
## Summary
- add migration 0205 with a revision-controlled P2 V2 WAD authorization bridge linked to the authoritative `production_work_orders` WAD
- create or explicitly link a WAD draft from the current released Production Plan, preserving PO, configuration, effectivity, manufactured assembly requirements, budgets, charge codes, schedule, risks, and requirement sources
- enforce exact readiness blockers, distinct PM/Engineering/Quality/Operations approvals plus conditional Finance/Executive approvals, controlled release, staleness, immutable released revisions, audit evidence, and authoritative workflow links
- make only Stage 6 additionally writable and keep the existing WAD Wizard/Summary as the full editor

## Safety boundaries
- no legacy backfill or `project_steps` mutation
- no public V2 initializer and V2 project creation remains inactive
- no production-order, traveler, queue, inventory, material-release, or P2-release calls
- WAD authorization release does not call the legacy floor-release endpoint or launch production
- duplicate current WADs are prevented; existing WAD linkage requires explicit confirmation and project/baseline validation
- released WADs are never edited in place; revisions retain prior authorization and approval evidence
- Preproduction and later stages remain read-only

## Validation
- focused Phase 5-7 server tests: 19/19 passed
- Phase 1-7 workflow/WAD/BOM/closing/release regressions: 110/110 assertions passed; two setup timeouts in the parallel combined run passed when rerun serially (28/28)
- focused component tests: 5/5 passed
- focused ESLint: passed
- `git diff --check` and cached diff check: passed
- TypeScript with 6144 MB: no Phase 7-file diagnostics; four pre-existing diagnostics remain in `server/src/routes/projects.ts` (TS2802, TS2339, and two TS2344 diagnostics), so repository-wide type cleanliness is not claimed

## Existing WAD objects reused
- `production_work_orders` and its `wad_status`, operational status, budgets, dates, thresholds, and `wizard_data`
- existing WAD Wizard and Summary routes/pages
- `project_workflow_step_approvals`, `project_workflow_step_links`, audit ledger, charge-code registry, and existing WAD approval role semantics
- existing WAD revision history remains untouched and visible alongside the V2 authorization revision history