### PR TITLE
Integrate P2 V2 commercial review stages

### DIFF
--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -7,13 +7,19 @@ import P2V2ProjectWorkflow from '../components/projects/P2V2ProjectWorkflow';
 const stages = Array.from({ length: 10 }, (_, index) => ({
   id: `step-${index + 1}`,
   stepType:
-    index === 3
-      ? 'design_applicability'
-      : index === 4
-        ? 'production_planning'
-        : index === 5
-          ? 'wad_authorization'
-          : `stage_${index + 1}`,
+    index === 0
+      ? 'rfq_risk_assessment'
+      : index === 1
+        ? 'estimate_quote'
+        : index === 2
+          ? 'contract_review'
+          : index === 3
+            ? 'design_applicability'
+            : index === 4
+              ? 'production_planning'
+              : index === 5
+                ? 'wad_authorization'
+                : `stage_${index + 1}`,
   stepOrder: index + 1,
   label: `Stage ${index + 1}`,
   description: `Description ${index + 1}`,
@@ -137,11 +143,18 @@ describe('P2V2ProjectWorkflow', () => {
     expect(screen.getByTestId('v2-approval')).toHaveTextContent('REJECTED');
   });
 
-  it('makes only Design Applicability, Production Planning and WAD Authorization writable from the ten-stage summary', async () => {
+  it('makes only the first six stages writable from the ten-stage summary', async () => {
     renderWorkflow(initialized);
     expect(
-      await screen.findByTestId('open-design-applicability')
+      await screen.findByTestId('open-commercial-review-rfq_risk_assessment')
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('open-commercial-review-estimate_quote')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('open-commercial-review-contract_review')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('open-design-applicability')).toBeInTheDocument();
     expect(
       screen.getAllByRole('button', { name: 'Open Design Applicability' })
     ).toHaveLength(1);

--- a/client/src/components/projects/P2V2CommercialReview.tsx
+++ b/client/src/components/projects/P2V2CommercialReview.tsx
@@ -1,0 +1,478 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type Stage = 'rfq_risk_assessment' | 'estimate_quote' | 'contract_review';
+// The raw additive API mirrors JSONB and SQL aliases without expanding shared schema types.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+type Model = {
+  review: Row | null;
+  history: Row[];
+  approvals: Row[];
+  requiredApprovals: string[];
+  readiness: {
+    ready: boolean;
+    stale: boolean;
+    blockers: string[];
+    differences: string[];
+  };
+};
+const labels: Record<Stage, string> = {
+  rfq_risk_assessment: 'RFQ Review',
+  estimate_quote: 'Estimate & Quote Review',
+  contract_review: 'Contract Review',
+};
+const sourceDefaults: Record<Stage, string> = {
+  rfq_risk_assessment: 'estimating_rfq',
+  estimate_quote: 'quote',
+  contract_review: 'contract_review_instance',
+};
+const endpoint = (projectId: string, stage: Stage) =>
+  `/api/projects/${projectId}/workflow-v2/commercial-reviews/${stage}`;
+async function request(url: string, method = 'GET', body?: unknown) {
+  const response = await fetch(url, {
+    method,
+    credentials: 'include',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok)
+    throw new Error(data.message || data.error || 'Request failed');
+  return data;
+}
+const json = (value: unknown) => JSON.stringify(value ?? [], null, 2);
+const parseArray = (value: string) => {
+  const parsed = JSON.parse(value || '[]');
+  if (!Array.isArray(parsed))
+    throw new Error('This field must be a JSON array.');
+  return parsed;
+};
+
+export default function P2V2CommercialReview({
+  projectId,
+  stage,
+}: {
+  projectId: string;
+  stage: Stage;
+}) {
+  const [open, setOpen] = useState(false);
+  const [sourceRecordType, setSourceRecordType] = useState(
+    sourceDefaults[stage]
+  );
+  const [sourceRecordId, setSourceRecordId] = useState('');
+  const [secondarySourceId, setSecondarySourceId] = useState('');
+  const [effectivityReference, setEffectivityReference] = useState('');
+  const [sufficientlyDefined, setSufficientlyDefined] = useState(false);
+  const [differencesResolved, setDifferencesResolved] = useState(false);
+  const [financeRequired, setFinanceRequired] = useState(false);
+  const [differences, setDifferences] = useState('[]');
+  const [risks, setRisks] = useState('[]');
+  const [informationRequests, setInformationRequests] = useState('[]');
+  const [error, setError] = useState('');
+  const client = useQueryClient();
+  const key = [
+    '/api/projects',
+    projectId,
+    'workflow-v2',
+    'commercial-reviews',
+    stage,
+  ];
+  const { data, isLoading } = useQuery<Model>({
+    queryKey: key,
+    queryFn: () => request(endpoint(projectId, stage)),
+    enabled: open,
+  });
+  const { data: permissions } = useQuery<{ permissions: string[] }>({
+    queryKey: ['/api/permissions/me'],
+    queryFn: () => request('/api/permissions/me'),
+  });
+  const allowed = useMemo(
+    () => new Set(permissions?.permissions ?? []),
+    [permissions]
+  );
+  const mutation = useMutation({
+    mutationFn: (input: { url: string; method?: string; body?: unknown }) =>
+      request(input.url, input.method, input.body),
+    onSuccess: async () => {
+      setError('');
+      await client.invalidateQueries({ queryKey: key });
+      await client.invalidateQueries({
+        queryKey: ['/api/projects', projectId, 'workflow-v2'],
+      });
+    },
+    onError: (cause: Error) => setError(cause.message),
+  });
+  const review = data?.review;
+  const reviewId = String(review?.id ?? '');
+  const revision = Number(review?.revision_number ?? 0);
+  const concurrencyToken = Number(review?.lock_version ?? revision);
+  const status = String(review?.status ?? '');
+  useEffect(() => {
+    if (!review) return;
+    setSourceRecordType(
+      String(review.source_record_type ?? sourceDefaults[stage])
+    );
+    setSourceRecordId(String(review.source_record_id ?? ''));
+    setSecondarySourceId(
+      String(review.source_snapshot?.secondarySourceId ?? '')
+    );
+    setEffectivityReference(String(review.effectivity_reference ?? ''));
+    setSufficientlyDefined(Boolean(review.sufficiently_defined));
+    setDifferencesResolved(Boolean(review.differences_resolved));
+    setFinanceRequired(Boolean(review.requirements_snapshot?.financeRequired));
+    setDifferences(json(review.differences));
+    setRisks(json(review.risks));
+    setInformationRequests(json(review.unresolved_information_requests));
+  }, [review, stage]);
+  const draftBody = () => ({
+    sourceRecordType,
+    sourceRecordId: sourceRecordId || String(review?.source_record_id ?? ''),
+    secondarySourceId: secondarySourceId || null,
+    sufficientlyDefined,
+    differencesResolved,
+    financeRequired,
+    effectivityReference: effectivityReference || null,
+    differences: parseArray(differences),
+    risks: parseArray(risks),
+    unresolvedInformationRequests: parseArray(informationRequests),
+  });
+  const run = (suffix: string, body: unknown, method = 'POST') =>
+    mutation.mutate({
+      url: `${endpoint(projectId, stage)}${suffix}`,
+      method,
+      body,
+    });
+  const save = () => {
+    try {
+      const body = draftBody();
+      if (reviewId)
+        run(
+          `/${reviewId}`,
+          { ...body, expectedRevision: concurrencyToken },
+          'PATCH'
+        );
+      else run('', body);
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : 'Invalid review input.'
+      );
+    }
+  };
+  const decide = (capacity: string, decision: 'APPROVED' | 'REJECTED') => {
+    const signatureMeaning = window.prompt(
+      'Signature meaning (required):',
+      `I ${decision === 'APPROVED' ? 'approve' : 'reject'} this commercial-review revision.`
+    );
+    if (!signatureMeaning) return;
+    const reason =
+      window.prompt(
+        decision === 'REJECTED' ? 'Reason (required):' : 'Comment:',
+        ''
+      ) ?? '';
+    if (decision === 'REJECTED' && !reason.trim()) return;
+    run(`/${reviewId}/${capacity}-decision`, {
+      expectedRevision: concurrencyToken,
+      decision,
+      signatureMeaning,
+      reason,
+    });
+  };
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        data-testid={`open-commercial-review-${stage}`}
+      >
+        Open {labels[stage]}
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] max-w-5xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{labels[stage]}</DialogTitle>
+            <DialogDescription>
+              Revision-controlled review of authoritative commercial records.
+              This action does not alter the source record.
+            </DialogDescription>
+          </DialogHeader>
+          {isLoading ? (
+            <p>Loading review…</p>
+          ) : (
+            <div className="space-y-5 text-sm">
+              <div className="flex flex-wrap gap-2">
+                <Badge>{status || 'NOT STARTED'}</Badge>
+                {review && (
+                  <Badge variant="outline">Review revision {revision}</Badge>
+                )}
+                {data?.readiness.stale && (
+                  <Badge variant="destructive">SOURCE CHANGED</Badge>
+                )}
+              </div>
+              {error && (
+                <p className="rounded bg-red-50 p-2 text-red-700">{error}</p>
+              )}
+              <section className="grid gap-3 md:grid-cols-2">
+                <div>
+                  <Label>Authoritative record type</Label>
+                  <Input
+                    value={sourceRecordType}
+                    onChange={(e) => setSourceRecordType(e.target.value)}
+                    disabled={status !== '' && status !== 'DRAFT'}
+                  />
+                </div>
+                <div>
+                  <Label>Authoritative record identifier</Label>
+                  <Input
+                    value={
+                      sourceRecordId || String(review?.source_record_id ?? '')
+                    }
+                    onChange={(e) => setSourceRecordId(e.target.value)}
+                    disabled={status !== '' && status !== 'DRAFT'}
+                  />
+                </div>
+                {stage === 'estimate_quote' && (
+                  <div>
+                    <Label>Estimate/version identifier</Label>
+                    <Input
+                      value={secondarySourceId}
+                      onChange={(e) => setSecondarySourceId(e.target.value)}
+                    />
+                  </div>
+                )}
+                <div>
+                  <Label>Effectivity / contract basis</Label>
+                  <Input
+                    value={effectivityReference}
+                    onChange={(e) => setEffectivityReference(e.target.value)}
+                  />
+                </div>
+              </section>
+              <section className="grid gap-3 md:grid-cols-3">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={sufficientlyDefined}
+                    onChange={(e) => setSufficientlyDefined(e.target.checked)}
+                  />{' '}
+                  Requirements sufficiently defined
+                </label>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={differencesResolved}
+                    onChange={(e) => setDifferencesResolved(e.target.checked)}
+                  />{' '}
+                  Differences resolved
+                </label>
+                {stage === 'contract_review' && (
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={financeRequired}
+                      onChange={(e) => setFinanceRequired(e.target.checked)}
+                    />{' '}
+                    Finance approval required
+                  </label>
+                )}
+              </section>
+              <section className="grid gap-3 md:grid-cols-3">
+                <div>
+                  <Label>Differences and resolutions (JSON)</Label>
+                  <Textarea
+                    rows={7}
+                    value={differences}
+                    onChange={(e) => setDifferences(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label>Risks, owners and controls (JSON)</Label>
+                  <Textarea
+                    rows={7}
+                    value={risks}
+                    onChange={(e) => setRisks(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label>Open information requests (JSON)</Label>
+                  <Textarea
+                    rows={7}
+                    value={informationRequests}
+                    onChange={(e) => setInformationRequests(e.target.value)}
+                  />
+                </div>
+              </section>
+              <section>
+                <h4 className="font-medium">Readiness and downstream impact</h4>
+                {data?.readiness.blockers.length ? (
+                  <ul className="list-disc pl-5 text-red-700">
+                    {data.readiness.blockers.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-green-700">
+                    Current review basis is ready.
+                  </p>
+                )}
+                <p className="text-muted-foreground">
+                  An invalid or stale approved commercial basis blocks Design
+                  Applicability, Production Planning and WAD Authorization
+                  without rewriting released history.
+                </p>
+              </section>
+              {review && (
+                <section className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <h4 className="font-medium">Requirements baseline</h4>
+                    <pre className="max-h-52 overflow-auto rounded bg-muted p-2 text-xs">
+                      {json(review.requirements_snapshot)}
+                    </pre>
+                  </div>
+                  <div>
+                    <h4 className="font-medium">
+                      Authoritative source snapshot
+                    </h4>
+                    <pre className="max-h-52 overflow-auto rounded bg-muted p-2 text-xs">
+                      {json(review.source_snapshot)}
+                    </pre>
+                  </div>
+                  <div>
+                    <h4 className="font-medium">Assumptions</h4>
+                    <pre className="rounded bg-muted p-2 text-xs">
+                      {json(review.assumptions)}
+                    </pre>
+                  </div>
+                  <div>
+                    <h4 className="font-medium">Exclusions</h4>
+                    <pre className="rounded bg-muted p-2 text-xs">
+                      {json(review.exclusions)}
+                    </pre>
+                  </div>
+                </section>
+              )}
+              <section>
+                <h4 className="font-medium">Required functional approvals</h4>
+                <p>
+                  {data?.requiredApprovals.join(', ') ||
+                    'Determined when the draft is created.'}
+                </p>
+                <ul>
+                  {data?.approvals.map((approval) => (
+                    <li key={approval.id}>
+                      {approval.approval_type}: {approval.decision} —{' '}
+                      {approval.actor_display_name}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+              <section>
+                <h4 className="font-medium">Immutable revision history</h4>
+                <ul>
+                  {data?.history.map((item) => (
+                    <li key={item.id}>
+                      Revision {item.revision_number}: {item.status} —{' '}
+                      {item.source_record_type} {item.source_record_id}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+              <div className="flex flex-wrap gap-2">
+                {allowed.has('projects.commercial_review.manage') &&
+                  (!status || status === 'DRAFT') && (
+                    <Button onClick={save} disabled={mutation.isPending}>
+                      {review ? 'Save Draft' : 'Create Draft'}
+                    </Button>
+                  )}
+                {status === 'DRAFT' && (
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      run(`/${reviewId}/submit`, {
+                        expectedRevision: concurrencyToken,
+                      })
+                    }
+                  >
+                    Submit
+                  </Button>
+                )}
+                {status === 'PENDING_APPROVAL' &&
+                  data?.requiredApprovals.map((role) => {
+                    const capacity =
+                      role === 'PROJECT_MANAGEMENT' ? 'pm' : role.toLowerCase();
+                    const capability = `projects.commercial_review.${capacity}_decide`;
+                    return allowed.has(capability) ? (
+                      <span key={role} className="flex gap-1">
+                        <Button
+                          size="sm"
+                          onClick={() => decide(capacity, 'APPROVED')}
+                        >
+                          Approve {role}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => decide(capacity, 'REJECTED')}
+                        >
+                          Reject
+                        </Button>
+                      </span>
+                    ) : null;
+                  })}
+                {status === 'PENDING_APPROVAL' &&
+                  allowed.has('projects.commercial_review.manage') && (
+                    <Button
+                      onClick={() =>
+                        run(`/${reviewId}/complete`, {
+                          expectedRevision: concurrencyToken,
+                        })
+                      }
+                    >
+                      Complete Stage
+                    </Button>
+                  )}
+                {reviewId &&
+                  status !== 'DRAFT' &&
+                  allowed.has('projects.commercial_review.manage') && (
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        try {
+                          run(`/${reviewId}/revise`, {
+                            ...draftBody(),
+                            expectedRevision: concurrencyToken,
+                          });
+                        } catch (cause) {
+                          setError(
+                            cause instanceof Error
+                              ? cause.message
+                              : 'Invalid review input.'
+                          );
+                        }
+                      }}
+                    >
+                      Create New Revision
+                    </Button>
+                  )}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -13,6 +13,7 @@ import {
 import P2V2DesignApplicability from './P2V2DesignApplicability';
 import P2V2ProductionPlanning from './P2V2ProductionPlanning';
 import P2V2WadAuthorization from './P2V2WadAuthorization';
+import P2V2CommercialReview from './P2V2CommercialReview';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -369,6 +370,30 @@ export default function P2V2ProjectWorkflow({
                 <Eye className="mr-1 h-4 w-4" />
                 Details
               </Button>
+              {(
+                [
+                  'rfq_risk_assessment',
+                  'estimate_quote',
+                  'contract_review',
+                ] as const
+              ).includes(
+                stage.stepType as
+                  | 'rfq_risk_assessment'
+                  | 'estimate_quote'
+                  | 'contract_review'
+              ) && (
+                <div className="mt-3">
+                  <P2V2CommercialReview
+                    projectId={projectId}
+                    stage={
+                      stage.stepType as
+                        | 'rfq_risk_assessment'
+                        | 'estimate_quote'
+                        | 'contract_review'
+                    }
+                  />
+                </div>
+              )}
               {stage.stepType === 'design_applicability' && (
                 <div className="mt-3">
                   <P2V2DesignApplicability projectId={projectId} />

--- a/migrations/0206_project_commercial_stage_reviews.sql
+++ b/migrations/0206_project_commercial_stage_reviews.sql
@@ -1,0 +1,88 @@
+-- Phase 8A: additive p2_v2 commercial-stage review revisions.
+-- Authoritative RFQ, estimate, quote, PO and contract-review records remain unchanged.
+CREATE TABLE IF NOT EXISTS project_commercial_stage_reviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  workflow_instance_id UUID NOT NULL,
+  workflow_step_instance_id UUID NOT NULL,
+  stage_type TEXT NOT NULL CHECK (stage_type IN ('rfq_risk_assessment','estimate_quote','contract_review')),
+  revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+  lock_version INTEGER NOT NULL DEFAULT 1 CHECK (lock_version > 0),
+  status TEXT NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT','PENDING_APPROVAL','APPROVED','COMPLETE','REJECTED','STALE','INVALIDATED','SUPERSEDED')),
+  source_record_type TEXT NOT NULL,
+  source_record_id TEXT NOT NULL,
+  source_revision TEXT,
+  source_updated_at TIMESTAMP,
+  source_snapshot JSONB NOT NULL,
+  requirements_snapshot JSONB NOT NULL,
+  assumptions JSONB NOT NULL DEFAULT '[]'::jsonb,
+  exclusions JSONB NOT NULL DEFAULT '[]'::jsonb,
+  differences JSONB NOT NULL DEFAULT '[]'::jsonb,
+  blockers JSONB NOT NULL DEFAULT '[]'::jsonb,
+  risks JSONB NOT NULL DEFAULT '[]'::jsonb,
+  unresolved_information_requests JSONB NOT NULL DEFAULT '[]'::jsonb,
+  sufficiently_defined BOOLEAN,
+  differences_resolved BOOLEAN NOT NULL DEFAULT false,
+  effectivity_reference TEXT,
+  owner_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  owner_display_name TEXT,
+  submitted_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  invalidated_at TIMESTAMP,
+  invalidation_reason TEXT,
+  superseded_at TIMESTAMP,
+  superseded_by_review_id UUID REFERENCES project_commercial_stage_reviews(id) ON DELETE RESTRICT,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT commercial_review_instance_project_fk FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT commercial_review_step_project_fk FOREIGN KEY (workflow_step_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT commercial_review_revision_unique UNIQUE (project_id, workflow_instance_id, stage_type, revision_number)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_commercial_reviews_current_unique
+  ON project_commercial_stage_reviews(project_id, workflow_instance_id,stage_type)
+  WHERE status IN ('DRAFT','PENDING_APPROVAL','APPROVED','COMPLETE');
+CREATE INDEX IF NOT EXISTS project_commercial_reviews_project_idx
+  ON project_commercial_stage_reviews(project_id,stage_type,revision_number DESC);
+
+INSERT INTO perm_capabilities (key,description,category) VALUES
+ ('projects.commercial_review.manage','Link, draft, submit and revise P2 V2 commercial reviews','projects'),
+ ('projects.commercial_review.pm_decide','Record PM/Sales/Contracts commercial decisions','projects'),
+ ('projects.commercial_review.engineering_decide','Record Engineering contract-review decisions','engineering'),
+ ('projects.commercial_review.quality_decide','Record Quality contract-review decisions','quality'),
+ ('projects.commercial_review.operations_decide','Record Operations contract-review decisions','operations'),
+ ('projects.commercial_review.finance_decide','Record conditional Finance contract-review decisions','finance')
+ON CONFLICT (key) DO UPDATE SET description=EXCLUDED.description,category=EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id,capability_id)
+SELECT pr.id,pc.id FROM perm_roles pr JOIN perm_capabilities pc ON (
+ (pr.name IN ('ADMIN','OWNER') AND pc.key LIKE 'projects.commercial_review.%') OR
+ (pr.name IN ('PROJECT_MANAGER','PROGRAM_MANAGER','SALES','CONTRACTS') AND pc.key IN ('projects.commercial_review.manage','projects.commercial_review.pm_decide')) OR
+ (pr.name IN ('ENGINEERING','ENGINEER','ENGINEERING_MANAGER') AND pc.key='projects.commercial_review.engineering_decide') OR
+ (pr.name IN ('QUALITY','QC','QUALITY_MANAGER') AND pc.key='projects.commercial_review.quality_decide') OR
+ (pr.name IN ('OPERATIONS','OPERATIONS_MANAGER','PRODUCTION_MANAGER') AND pc.key='projects.commercial_review.operations_decide') OR
+ (pr.name IN ('FINANCE','CONTROLLER') AND pc.key='projects.commercial_review.finance_decide')
+) ON CONFLICT (role_id,capability_id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION protect_commercial_review_snapshots()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.status <> 'DRAFT' AND (
+    NEW.source_record_type IS DISTINCT FROM OLD.source_record_type OR
+    NEW.source_record_id IS DISTINCT FROM OLD.source_record_id OR
+    NEW.source_revision IS DISTINCT FROM OLD.source_revision OR
+    NEW.source_updated_at IS DISTINCT FROM OLD.source_updated_at OR
+    NEW.source_snapshot IS DISTINCT FROM OLD.source_snapshot OR
+    NEW.requirements_snapshot IS DISTINCT FROM OLD.requirements_snapshot
+  ) THEN
+    RAISE EXCEPTION 'Submitted commercial-review snapshots are immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS protect_commercial_review_snapshots_trigger ON project_commercial_stage_reviews;
+CREATE TRIGGER protect_commercial_review_snapshots_trigger
+BEFORE UPDATE ON project_commercial_stage_reviews
+FOR EACH ROW EXECUTE FUNCTION protect_commercial_review_snapshots();

--- a/server/__tests__/projectCommercialReview.test.ts
+++ b/server/__tests__/projectCommercialReview.test.ts
@@ -1,0 +1,141 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  commercialQuoteEligibility,
+  requiredCommercialApprovalRoles,
+} from '../src/services/projectCommercialReviewRules';
+
+const root = path.resolve(__dirname, '../..');
+const service = fs.readFileSync(
+  path.join(root, 'server/src/services/projectCommercialReviewService.ts'),
+  'utf8'
+);
+const routes = fs.readFileSync(
+  path.join(root, 'server/src/routes/projectCommercialReviews.ts'),
+  'utf8'
+);
+const migration = fs.readFileSync(
+  path.join(root, 'migrations/0206_project_commercial_stage_reviews.sql'),
+  'utf8'
+);
+
+describe('P2 V2 commercial review safety', () => {
+  it('rejects ineligible quote evidence and accepts a current released basis', () => {
+    expect(
+      commercialQuoteEligibility({
+        quoteStatus: 'DRAFT',
+        validUntil: '2026-01-01',
+        hasReleasedSnapshot: false,
+        estimateStatus: 'REJECTED',
+        estimateApprovalStatuses: ['APPROVED', 'PENDING'],
+        now: new Date('2026-07-01').getTime(),
+      })
+    ).toHaveLength(5);
+    expect(
+      commercialQuoteEligibility({
+        quoteStatus: 'SENT',
+        validUntil: '2027-01-01',
+        hasReleasedSnapshot: true,
+        estimateStatus: 'APPROVED',
+        estimateApprovalStatuses: ['APPROVED'],
+        now: new Date('2026-07-01').getTime(),
+      })
+    ).toEqual([]);
+  });
+
+  it('applies conditional Finance approval only to Contract Review', () => {
+    expect(requiredCommercialApprovalRoles('estimate_quote', true)).toEqual([
+      'PROJECT_MANAGEMENT',
+    ]);
+    expect(requiredCommercialApprovalRoles('contract_review', true)).toEqual([
+      'PROJECT_MANAGEMENT',
+      'ENGINEERING',
+      'QUALITY',
+      'OPERATIONS',
+      'FINANCE',
+    ]);
+  });
+
+  it('fails closed for NULL, legacy and unknown workflow versions', () => {
+    expect(service).toContain("version !== 'p2_v2'");
+    expect(service).toContain('resolveProjectWorkflowVersion');
+    expect(service).toContain('P2_V2_REQUIRED');
+  });
+
+  it('uses authoritative RFQ, quote, estimate, PO and contract-review sources read-only', () => {
+    for (const source of [
+      'estimating_rfqs',
+      'rfq_risk_assessments',
+      'quotes',
+      'quote_snapshots',
+      'estimate_versions',
+      'p2_purchase_orders',
+      'contract_review_checklist_instances',
+      'quote_po_reconciliations',
+    ])
+      expect(service).toContain(source);
+    expect(service).not.toMatch(
+      /UPDATE\s+(estimating_rfqs|rfq_risk_assessments|quotes|p2_purchase_orders|contract_review_checklist_instances)/i
+    );
+  });
+
+  it('enforces predecessor, source eligibility and exact revision gates', () => {
+    expect(service).toContain('PREDECESSOR_REQUIRED');
+    expect(service).toContain('Authoritative source revision changed.');
+    expect(service).toContain('Current RFQ review is not complete.');
+    expect(service).toContain('Contract differences must be resolved.');
+  });
+
+  it('requires functional approvals and segregation of duties', () => {
+    for (const role of [
+      'PROJECT_MANAGEMENT',
+      'ENGINEERING',
+      'QUALITY',
+      'OPERATIONS',
+      'FINANCE',
+    ])
+      expect(service).toContain(role);
+    expect(service).toContain('SEGREGATION_OF_DUTIES');
+    expect(service).toContain("evidence_snapshot->>'commercialReviewId'");
+  });
+
+  it('uses optimistic concurrency, immutable revision history and a single current revision', () => {
+    expect(service).toContain('expectedRevision');
+    expect(service).toContain('FOR UPDATE');
+    expect(service).toContain('STALE_REVISION');
+    expect(service).toContain("status='SUPERSEDED'");
+    expect(migration).toContain('commercial_review_revision_unique');
+    expect(migration).toContain('project_commercial_reviews_current_unique');
+    expect(migration).toContain('protect_commercial_review_snapshots');
+    expect(migration).not.toMatch(/\b(UPDATE|DELETE)\s+projects\b/i);
+  });
+
+  it('exposes only bounded commercial-review mutations and no production creation', () => {
+    for (const action of ['/submit', '-decision', '/complete', '/revise'])
+      expect(routes).toContain(action);
+    expect(routes).not.toContain('router.delete');
+    expect(service).not.toMatch(
+      /INSERT INTO\s+(production_orders|production_work_orders|inventory|shipping)/i
+    );
+  });
+});
+
+describe('commercial baseline propagation', () => {
+  it('is consumed by Design, Production Planning and WAD readiness', () => {
+    for (const file of [
+      'projectDesignApplicabilityService.ts',
+      'projectProductionPlanningService.ts',
+      'projectWadAuthorizationService.ts',
+    ]) {
+      const contents = fs.readFileSync(
+        path.join(root, 'server/src/services', file),
+        'utf8'
+      );
+      expect(contents).toContain('evaluateCommercialBaseline');
+      expect(contents).toContain('commercial.blockers');
+    }
+  });
+});

--- a/server/src/routes/projectCommercialReviews.ts
+++ b/server/src/routes/projectCommercialReviews.ts
@@ -1,0 +1,270 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { getUserPermissions } from '../services/permissionService';
+import {
+  completeCommercialReview,
+  createCommercialReview,
+  decideCommercialReview,
+  getCommercialReview,
+  ProjectCommercialReviewError,
+  reviseCommercialReview,
+  submitCommercialReview,
+  updateCommercialDraft,
+  type CommercialActor,
+} from '../services/projectCommercialReviewService';
+
+const router = Router({ mergeParams: true });
+const stages = z.enum([
+  'rfq_risk_assessment',
+  'estimate_quote',
+  'contract_review',
+]);
+const differenceSchema = z.object({
+  description: z.string().min(1),
+  resolution: z.string().optional(),
+  resolved: z.boolean().optional(),
+});
+const draftSchema = z.object({
+  sourceRecordType: z.string().min(1),
+  sourceRecordId: z.string().min(1),
+  secondarySourceId: z.string().nullable().optional(),
+  requirements: z.record(z.unknown()).optional(),
+  assumptions: z.array(z.unknown()).optional(),
+  exclusions: z.array(z.unknown()).optional(),
+  differences: z.array(differenceSchema).optional(),
+  risks: z
+    .array(
+      z.object({
+        description: z.string().min(1),
+        owner: z.string().min(1),
+        control: z.string().min(1),
+      })
+    )
+    .optional(),
+  unresolvedInformationRequests: z.array(z.unknown()).optional(),
+  sufficientlyDefined: z.boolean().optional(),
+  differencesResolved: z.boolean().optional(),
+  effectivityReference: z.string().nullable().optional(),
+  financeRequired: z.boolean().optional(),
+});
+const revisionSchema = z.object({
+  expectedRevision: z.number().int().positive(),
+});
+const decisionSchema = revisionSchema.extend({
+  decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+  signatureMeaning: z.string().min(1),
+  reason: z.string().optional().default(''),
+});
+
+function actor(req: Request): CommercialActor {
+  if (!req.user?.id || !req.user?.username || !req.user?.role)
+    throw new ProjectCommercialReviewError(
+      'ACTOR_REQUIRED',
+      'Authenticated actor identity is required.',
+      401
+    );
+  return {
+    userId: req.user.id,
+    employeeId: req.user.employeeId ?? null,
+    username: req.user.username,
+    displayName: req.user.username,
+    role: req.user.role,
+  };
+}
+async function requireCapability(req: Request, capability: string) {
+  const value = actor(req);
+  const { permissionSet } = await getUserPermissions(value.userId, value.role);
+  if (!permissionSet.has(capability))
+    throw new ProjectCommercialReviewError(
+      'FORBIDDEN',
+      `The ${capability} capability is required.`,
+      403
+    );
+  return value;
+}
+function fail(res: Response, error: unknown) {
+  if (error instanceof z.ZodError)
+    return res
+      .status(400)
+      .json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error instanceof ProjectCommercialReviewError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
+  console.error('P2 V2 commercial review error:', error);
+  return res.status(500).json({
+    error: 'COMMERCIAL_REVIEW_FAILED',
+    message: 'Commercial review action failed.',
+  });
+}
+const projectId = (req: Request) => String(req.params.id);
+const stage = (req: Request) => stages.parse(req.params.stage);
+
+router.get('/:stage', async (req, res) => {
+  try {
+    res.json(await getCommercialReview(projectId(req), stage(req)));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/:stage/history', async (req, res) => {
+  try {
+    const model = await getCommercialReview(projectId(req), stage(req));
+    res.json({
+      history: model.history,
+      approvals: model.approvals,
+      readiness: model.readiness,
+    });
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:stage', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.commercial_review.manage'
+    );
+    res
+      .status(201)
+      .json(
+        await createCommercialReview(
+          projectId(req),
+          stage(req),
+          draftSchema.parse(req.body),
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.patch('/:stage/:reviewId', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.commercial_review.manage'
+    );
+    const body = draftSchema.and(revisionSchema).parse(req.body) as z.infer<
+      typeof draftSchema
+    > & {
+      expectedRevision: number;
+    };
+    res.json(
+      await updateCommercialDraft(
+        projectId(req),
+        stage(req),
+        req.params.reviewId,
+        body.expectedRevision,
+        body,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:stage/:reviewId/submit', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.commercial_review.manage'
+    );
+    const body = revisionSchema.parse(req.body);
+    res.json(
+      await submitCommercialReview(
+        projectId(req),
+        stage(req),
+        req.params.reviewId,
+        body.expectedRevision,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+const decisions = [
+  ['pm', 'PROJECT_MANAGEMENT', 'projects.commercial_review.pm_decide'],
+  [
+    'engineering',
+    'ENGINEERING',
+    'projects.commercial_review.engineering_decide',
+  ],
+  ['quality', 'QUALITY', 'projects.commercial_review.quality_decide'],
+  ['operations', 'OPERATIONS', 'projects.commercial_review.operations_decide'],
+  ['finance', 'FINANCE', 'projects.commercial_review.finance_decide'],
+] as const;
+for (const [path, capacity, capability] of decisions) {
+  router.post(`/:stage/:reviewId/${path}-decision`, async (req, res) => {
+    try {
+      const user = await requireCapability(req, capability);
+      const body = decisionSchema.parse(req.body);
+      res.json(
+        await decideCommercialReview(
+          projectId(req),
+          stage(req),
+          req.params.reviewId,
+          body.expectedRevision,
+          capacity,
+          body.decision,
+          body.signatureMeaning,
+          body.reason,
+          user
+        )
+      );
+    } catch (error) {
+      fail(res, error);
+    }
+  });
+}
+router.post('/:stage/:reviewId/complete', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.commercial_review.manage'
+    );
+    const body = revisionSchema.parse(req.body);
+    res.json(
+      await completeCommercialReview(
+        projectId(req),
+        stage(req),
+        req.params.reviewId,
+        body.expectedRevision,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:stage/:reviewId/revise', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.commercial_review.manage'
+    );
+    const body = draftSchema.and(revisionSchema).parse(req.body) as z.infer<
+      typeof draftSchema
+    > & {
+      expectedRevision: number;
+    };
+    res
+      .status(201)
+      .json(
+        await reviseCommercialReview(
+          projectId(req),
+          stage(req),
+          req.params.reviewId,
+          body.expectedRevision,
+          body,
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+
+export default router;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -39,6 +39,7 @@ import { buildP2V2WorkflowResponse, buildUninitializedP2V2Response } from '../se
 import projectProductionPlanningRoutes from './projectProductionPlanning';
 import { getCurrentProductionPlan } from '../services/projectProductionPlanningService';
 import projectWadAuthorizationRoutes from './projectWadAuthorization';
+import projectCommercialReviewRoutes from './projectCommercialReviews';
 import { getCurrentWadAuthorization } from '../services/projectWadAuthorizationService';
 import { getUserPermissions } from '../services/permissionService';
 import {
@@ -1582,6 +1583,7 @@ function sendDesignError(res: Response, error: unknown) {
 
 router.use('/:id/workflow-v2/production-planning', projectProductionPlanningRoutes);
 router.use('/:id/workflow-v2/wad-authorization', projectWadAuthorizationRoutes);
+router.use('/:id/workflow-v2/commercial-reviews', projectCommercialReviewRoutes);
 
 router.get('/:id/workflow-v2/design-applicability', async (req, res) => {
   try {

--- a/server/src/services/projectCommercialReviewRules.ts
+++ b/server/src/services/projectCommercialReviewRules.ts
@@ -1,0 +1,53 @@
+export type CommercialStageRule =
+  | 'rfq_risk_assessment'
+  | 'estimate_quote'
+  | 'contract_review';
+
+export function commercialQuoteEligibility(input: {
+  quoteStatus: string;
+  validUntil?: string | Date | null;
+  hasReleasedSnapshot: boolean;
+  estimateStatus?: string | null;
+  estimateApprovalStatuses: string[];
+  now?: number;
+}) {
+  const values: string[] = [];
+  if (!['SENT', 'ACCEPTED'].includes(input.quoteStatus.toUpperCase()))
+    values.push(
+      `Quote status ${input.quoteStatus} is not eligible for V2 completion.`
+    );
+  if (
+    input.validUntil &&
+    new Date(input.validUntil).getTime() < (input.now ?? Date.now())
+  )
+    values.push('Quote validity has expired.');
+  if (!input.hasReleasedSnapshot)
+    values.push('Released quote snapshot is required.');
+  if (!input.estimateStatus)
+    values.push('An authoritative estimate version is required.');
+  else if (
+    !['APPROVED', 'RELEASED'].includes(input.estimateStatus.toUpperCase())
+  )
+    values.push('Estimate version is not approved/released.');
+  if (
+    input.estimateApprovalStatuses.some(
+      (status) => status.toUpperCase() !== 'APPROVED'
+    )
+  )
+    values.push('Estimate has incomplete or rejected authorization evidence.');
+  return values;
+}
+
+export const requiredCommercialApprovalRoles = (
+  stage: CommercialStageRule,
+  financeRequired = false
+) =>
+  stage === 'contract_review'
+    ? [
+        'PROJECT_MANAGEMENT',
+        'ENGINEERING',
+        'QUALITY',
+        'OPERATIONS',
+        ...(financeRequired ? ['FINANCE'] : []),
+      ]
+    : ['PROJECT_MANAGEMENT'];

--- a/server/src/services/projectCommercialReviewService.ts
+++ b/server/src/services/projectCommercialReviewService.ts
@@ -1,0 +1,1049 @@
+import { createHash } from 'crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+import {
+  commercialQuoteEligibility,
+  requiredCommercialApprovalRoles,
+} from './projectCommercialReviewRules';
+
+export type CommercialStage =
+  | 'rfq_risk_assessment'
+  | 'estimate_quote'
+  | 'contract_review';
+type Executor = AuditLedgerTx;
+// Additive raw-query rows avoid expanding the central schema surface.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+export type CommercialActor = {
+  userId: number;
+  employeeId?: number | null;
+  username: string;
+  displayName: string;
+  role: string;
+};
+export type CommercialDraftInput = {
+  sourceRecordType: string;
+  sourceRecordId: string;
+  secondarySourceId?: string | null;
+  requirements?: Record<string, unknown>;
+  assumptions?: unknown[];
+  exclusions?: unknown[];
+  differences?: Array<{
+    description?: string;
+    resolution?: string;
+    resolved?: boolean;
+  }>;
+  risks?: Array<{ description?: string; owner?: string; control?: string }>;
+  unresolvedInformationRequests?: unknown[];
+  sufficientlyDefined?: boolean;
+  differencesResolved?: boolean;
+  effectivityReference?: string | null;
+  financeRequired?: boolean;
+};
+export class ProjectCommercialReviewError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 400,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+const resultRows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+const clean = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : '';
+const hash = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+async function context(
+  projectId: string,
+  stage: CommercialStage,
+  tx: Executor,
+  lock = false,
+  requirePredecessors = true
+) {
+  const project = resultRows(
+    await tx.execute(
+      sql`SELECT id,workflow_version,po_id FROM projects WHERE id=${projectId} ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  )[0];
+  if (!project)
+    throw new ProjectCommercialReviewError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.',
+      404
+    );
+  let version: ReturnType<typeof resolveProjectWorkflowVersion>;
+  try {
+    version = resolveProjectWorkflowVersion(project.workflow_version);
+  } catch {
+    throw new ProjectCommercialReviewError(
+      'UNKNOWN_WORKFLOW_VERSION',
+      'The project workflow version is not recognized.',
+      409
+    );
+  }
+  if (version !== 'p2_v2')
+    throw new ProjectCommercialReviewError(
+      'P2_V2_REQUIRED',
+      'Commercial review requires an explicit p2_v2 project.',
+      409,
+      { effectiveWorkflowVersion: version }
+    );
+  const instances = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_instances WHERE project_id=${projectId} AND workflow_version='p2_v2' AND status NOT IN ('SUPERSEDED','CANCELLED') ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  );
+  if (instances.length !== 1)
+    throw new ProjectCommercialReviewError(
+      instances.length
+        ? 'DUPLICATE_ACTIVE_INSTANCES'
+        : 'WORKFLOW_INSTANCE_REQUIRED',
+      instances.length
+        ? 'Multiple active V2 workflow instances exist.'
+        : 'An active V2 workflow instance is required.',
+      409
+    );
+  const steps = resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_instances WHERE workflow_instance_id=${instances[0].id} ORDER BY step_order`
+    )
+  );
+  const integrity = validateWorkflowInstanceIntegrity(instances[0], steps);
+  if (integrity.length)
+    throw new ProjectCommercialReviewError(
+      'WORKFLOW_INTEGRITY_FAILED',
+      'The V2 workflow failed integrity validation.',
+      409,
+      { issues: integrity }
+    );
+  const step = steps.find((entry) => entry.step_type === stage);
+  if (!step)
+    throw new ProjectCommercialReviewError(
+      'COMMERCIAL_STAGE_REQUIRED',
+      `The ${stage} workflow stage is missing.`,
+      409
+    );
+  const predecessorTypes =
+    stage === 'rfq_risk_assessment'
+      ? []
+      : stage === 'estimate_quote'
+        ? ['rfq_risk_assessment']
+        : ['rfq_risk_assessment', 'estimate_quote'];
+  const incomplete = predecessorTypes.filter(
+    (type) =>
+      steps.find((entry) => entry.step_type === type)?.status !== 'COMPLETE'
+  );
+  if (requirePredecessors && incomplete.length)
+    throw new ProjectCommercialReviewError(
+      'PREDECESSOR_REQUIRED',
+      'Required commercial predecessor stages are not complete.',
+      409,
+      { incompleteStages: incomplete }
+    );
+  return { project, instance: instances[0], step, steps };
+}
+
+async function sourceSnapshot(
+  projectId: string,
+  stage: CommercialStage,
+  input: Pick<
+    CommercialDraftInput,
+    'sourceRecordType' | 'sourceRecordId' | 'secondarySourceId'
+  >,
+  tx: Executor
+) {
+  if (stage === 'rfq_risk_assessment') {
+    if (input.sourceRecordType === 'estimating_rfq') {
+      const rfq = resultRows(
+        await tx.execute(
+          sql`SELECT * FROM estimating_rfqs WHERE id=${input.sourceRecordId}::uuid`
+        )
+      )[0];
+      if (!rfq)
+        throw new ProjectCommercialReviewError(
+          'RFQ_NOT_FOUND',
+          'Authoritative estimating RFQ not found.',
+          404
+        );
+      const parts = resultRows(
+        await tx.execute(
+          sql`SELECT * FROM estimating_rfq_parts WHERE rfq_id=${rfq.id} ORDER BY line_number`
+        )
+      );
+      const assumptions = resultRows(
+        await tx.execute(
+          sql`SELECT * FROM estimate_assumptions WHERE rfq_id=${rfq.id} ORDER BY created_at`
+        )
+      );
+      const snapshot = { rfq, parts, assumptions };
+      return {
+        snapshot,
+        requirements: { parts, requestedDueDate: rfq.requested_due_date },
+        sourceRevision: clean(rfq.revision) || hash(snapshot),
+        sourceUpdatedAt: rfq.updated_at,
+        eligibilityBlockers: parts.length
+          ? []
+          : ['Authoritative RFQ has no requested parts/services.'],
+      };
+    }
+    if (input.sourceRecordType === 'rfq_risk_assessment') {
+      const rfq = resultRows(
+        await tx.execute(
+          sql`SELECT * FROM rfq_risk_assessments WHERE id=${Number(input.sourceRecordId)}`
+        )
+      )[0];
+      if (!rfq)
+        throw new ProjectCommercialReviewError(
+          'RFQ_NOT_FOUND',
+          'Authoritative RFQ risk assessment not found.',
+          404
+        );
+      const snapshot = { rfq };
+      const blockers = [];
+      if (String(rfq.status).toLowerCase() !== 'submitted')
+        blockers.push('RFQ risk assessment is not submitted.');
+      if (String(rfq.bid_decision).toLowerCase() !== 'bid')
+        blockers.push('RFQ does not have an approved Bid decision.');
+      return {
+        snapshot,
+        requirements: rfq.form_data ?? {},
+        sourceRevision: hash(snapshot),
+        sourceUpdatedAt: rfq.updated_at,
+        eligibilityBlockers: blockers,
+      };
+    }
+    throw new ProjectCommercialReviewError(
+      'INVALID_RFQ_SOURCE',
+      'RFQ source must be estimating_rfq or rfq_risk_assessment.'
+    );
+  }
+  if (stage === 'estimate_quote') {
+    if (input.sourceRecordType !== 'quote')
+      throw new ProjectCommercialReviewError(
+        'INVALID_QUOTE_SOURCE',
+        'Estimate & Quote source must be quote.'
+      );
+    const quote = resultRows(
+      await tx.execute(
+        sql`SELECT * FROM quotes WHERE id=${input.sourceRecordId}::uuid`
+      )
+    )[0];
+    if (!quote)
+      throw new ProjectCommercialReviewError(
+        'QUOTE_NOT_FOUND',
+        'Authoritative quote not found.',
+        404
+      );
+    const quoteSnapshot = resultRows(
+      await tx.execute(
+        sql`SELECT * FROM quote_snapshots WHERE quote_id=${quote.id} ORDER BY revision_number DESC LIMIT 1`
+      )
+    )[0];
+    const lines = quoteSnapshot
+      ? resultRows(
+          await tx.execute(
+            sql`SELECT * FROM quote_line_snapshots WHERE quote_snapshot_id=${quoteSnapshot.id} ORDER BY line_number`
+          )
+        )
+      : [];
+    const estimate = input.secondarySourceId
+      ? resultRows(
+          await tx.execute(
+            sql`SELECT ev.*,er.rfq_number,er.id AS rfq_id FROM estimate_versions ev JOIN estimating_rfqs er ON er.id=ev.rfq_id WHERE ev.id=${input.secondarySourceId}::uuid`
+          )
+        )[0]
+      : null;
+    const estimateApprovals = estimate
+      ? resultRows(
+          await tx.execute(
+            sql`SELECT * FROM estimating_approvals WHERE estimate_version_id=${estimate.id} ORDER BY approval_role`
+          )
+        )
+      : [];
+    const estimateLines = estimate
+      ? resultRows(
+          await tx.execute(
+            sql`SELECT * FROM estimate_line_versions WHERE estimate_version_id=${estimate.id} ORDER BY line_number NULLS LAST,created_at`
+          )
+        )
+      : [];
+    const estimateAssumptions = estimate
+      ? resultRows(
+          await tx.execute(
+            sql`SELECT * FROM estimate_assumptions WHERE rfq_id=${estimate.rfq_id} ORDER BY created_at`
+          )
+        )
+      : [];
+    const tooling = estimate
+      ? resultRows(
+          await tx.execute(
+            sql`SELECT * FROM estimating_tooling WHERE rfq_id=${estimate.rfq_id} ORDER BY created_at`
+          )
+        )
+      : [];
+    const processRows = estimate
+      ? resultRows(
+          await tx.execute(
+            sql`SELECT * FROM estimating_process_rows WHERE rfq_id=${estimate.rfq_id} ORDER BY created_at`
+          )
+        )
+      : [];
+    const shipping = estimate
+      ? resultRows(
+          await tx.execute(
+            sql`SELECT * FROM estimating_shipping WHERE rfq_id=${estimate.rfq_id} ORDER BY created_at`
+          )
+        )
+      : [];
+    const snapshot = {
+      quote,
+      quoteSnapshot,
+      lines,
+      estimate,
+      estimateLines,
+      estimateAssumptions,
+      tooling,
+      processRows,
+      shipping,
+      estimateApprovals,
+    };
+    const blockers = commercialQuoteEligibility({
+      quoteStatus: String(quote.status),
+      validUntil: quote.valid_until,
+      hasReleasedSnapshot: Boolean(quoteSnapshot),
+      estimateStatus: estimate?.status ? String(estimate.status) : null,
+      estimateApprovalStatuses: estimateApprovals.map((entry) =>
+        String(entry.approval_status)
+      ),
+    });
+    return {
+      snapshot,
+      requirements: {
+        lines,
+        pricing: quoteSnapshot?.total_amount,
+        validity: quoteSnapshot?.valid_until,
+        assumptions: {
+          bom: quoteSnapshot?.bom_assumptions,
+          labor: quoteSnapshot?.labor_assumptions,
+          leadTimes: quoteSnapshot?.lead_times,
+          estimate: estimateAssumptions,
+        },
+        estimateLines,
+        tooling,
+        processRows,
+        shipping,
+        exclusions: quoteSnapshot?.exclusions,
+      },
+      sourceRevision: quoteSnapshot
+        ? String(quoteSnapshot.revision_number)
+        : hash(snapshot),
+      sourceUpdatedAt: quote.updated_at,
+      eligibilityBlockers: blockers,
+    };
+  }
+  if (input.sourceRecordType !== 'contract_review_instance')
+    throw new ProjectCommercialReviewError(
+      'INVALID_CONTRACT_SOURCE',
+      'Contract Review source must be contract_review_instance.'
+    );
+  const contract = resultRows(
+    await tx.execute(
+      sql`SELECT cri.*,prc.status AS purchase_review_status,prc.form_data AS purchase_review_data,po.po_number,po.revision_number AS po_revision_number,po.is_current_revision,po.source_quote_id,po.updated_at AS po_updated_at
+          FROM contract_review_checklist_instances cri
+          LEFT JOIN purchase_review_checklists prc ON prc.id=cri.purchase_review_checklist_id
+          LEFT JOIN p2_purchase_orders po ON po.id=cri.p2_purchase_order_id
+          WHERE cri.id=${input.sourceRecordId}::uuid AND cri.project_id=${projectId}`
+    )
+  )[0];
+  if (!contract)
+    throw new ProjectCommercialReviewError(
+      'CONTRACT_REVIEW_NOT_FOUND',
+      'Authoritative contract review not found for this project.',
+      404
+    );
+  const poItems = contract.p2_purchase_order_id
+    ? resultRows(
+        await tx.execute(
+          sql`SELECT * FROM p2_purchase_order_items WHERE po_id=${contract.p2_purchase_order_id} ORDER BY id`
+        )
+      )
+    : [];
+  const reconciliation = contract.p2_purchase_order_id
+    ? resultRows(
+        await tx.execute(
+          sql`SELECT * FROM quote_po_reconciliations WHERE p2_purchase_order_id=${contract.p2_purchase_order_id} ORDER BY checked_at DESC LIMIT 1`
+        )
+      )[0]
+    : null;
+  const snapshot = { contract, poItems, reconciliation };
+  const blockers: string[] = [];
+  if (String(contract.status).toLowerCase() !== 'approved')
+    blockers.push('Authoritative contract review is not approved.');
+  if (
+    contract.purchase_review_checklist_id &&
+    contract.purchase_review_status !== 'APPROVED'
+  )
+    blockers.push('Purchase review checklist is not approved.');
+  if (!contract.p2_purchase_order_id || !contract.is_current_revision)
+    blockers.push('Current accepted customer PO revision is required.');
+  if (!poItems.length) blockers.push('Accepted customer PO has no line items.');
+  if (!reconciliation || reconciliation.status !== 'MATCH')
+    blockers.push('Accepted PO does not have a matching quote reconciliation.');
+  return {
+    snapshot,
+    requirements: {
+      acceptedPo: {
+        id: contract.p2_purchase_order_id,
+        number: contract.po_number,
+        revision: contract.po_revision_number,
+      },
+      poItems,
+      contractResponses: contract.responses,
+      reviewAreas: contract.review_area_status,
+      purchaseReview: contract.purchase_review_data,
+      reconciliation,
+    },
+    sourceRevision: `${contract.po_revision_number}:${hash(snapshot)}`,
+    sourceUpdatedAt: contract.po_updated_at ?? contract.updated_at,
+    eligibilityBlockers: blockers,
+  };
+}
+
+async function current(
+  projectId: string,
+  stage: CommercialStage,
+  tx: Executor
+) {
+  return (
+    resultRows(
+      await tx.execute(
+        sql`SELECT * FROM project_commercial_stage_reviews WHERE project_id=${projectId} AND stage_type=${stage} AND status IN ('DRAFT','PENDING_APPROVAL','APPROVED','COMPLETE','REJECTED','STALE','INVALIDATED') ORDER BY revision_number DESC LIMIT 1`
+      )
+    )[0] ?? null
+  );
+}
+async function reviewHistory(
+  projectId: string,
+  stage: CommercialStage,
+  tx: Executor
+) {
+  return resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_commercial_stage_reviews WHERE project_id=${projectId} AND stage_type=${stage} ORDER BY revision_number DESC`
+    )
+  );
+}
+async function approvals(review: Row, tx: Executor) {
+  return resultRows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_approvals WHERE workflow_step_instance_id=${review.workflow_step_instance_id} AND evidence_snapshot->>'commercialReviewId'=${review.id} ORDER BY decided_at`
+    )
+  );
+}
+const requiredRoles = (review: Row) =>
+  requiredCommercialApprovalRoles(
+    review.stage_type,
+    Boolean(review.requirements_snapshot?.financeRequired)
+  );
+
+async function blockers(
+  projectId: string,
+  stage: CommercialStage,
+  review: Row | null,
+  tx: Executor
+) {
+  if (!review)
+    return {
+      ready: false,
+      stale: false,
+      blockers: ['A commercial review draft is required.'],
+      differences: [],
+    };
+  const source = await sourceSnapshot(
+    projectId,
+    stage,
+    {
+      sourceRecordType: review.source_record_type,
+      sourceRecordId: review.source_record_id,
+      secondarySourceId: review.source_snapshot?.secondarySourceId,
+    },
+    tx
+  );
+  const values = [...source.eligibilityBlockers];
+  const differences: string[] = [];
+  if (source.sourceRevision !== review.source_revision) {
+    differences.push('Authoritative source revision changed.');
+    values.push('Review source is stale and requires a new revision.');
+  }
+  if (stage === 'rfq_risk_assessment') {
+    if (!review.sufficiently_defined)
+      values.push('RFQ must be marked sufficiently defined.');
+    if (!(review.requirements_snapshot?.parts ?? []).length)
+      values.push('Part/service and quantity requirements are required.');
+    if (
+      !review.requirements_snapshot?.requestedDueDate &&
+      !review.requirements_snapshot?.deliveryException
+    )
+      values.push(
+        'Requested delivery or approved delivery exception is required.'
+      );
+    if (review.unresolved_information_requests?.length)
+      values.push('Blocking RFQ information requests remain unresolved.');
+  }
+  if (stage === 'estimate_quote') {
+    const rfq = await current(projectId, 'rfq_risk_assessment', tx);
+    if (!rfq || rfq.status !== 'COMPLETE')
+      values.push('Current RFQ review is not complete.');
+    if (
+      review.requirements_snapshot?.rfqReviewId !== rfq?.id ||
+      Number(review.requirements_snapshot?.rfqReviewRevision) !==
+        Number(rfq?.revision_number)
+    )
+      values.push(
+        'Estimate & Quote basis does not match the current RFQ review.'
+      );
+    if (
+      rfq?.source_record_type === 'estimating_rfq' &&
+      review.source_snapshot?.estimate?.rfq_id !== rfq.source_record_id
+    )
+      values.push(
+        'Authoritative estimate does not originate from the reviewed RFQ.'
+      );
+  }
+  if (stage === 'contract_review') {
+    for (const predecessor of [
+      'rfq_risk_assessment',
+      'estimate_quote',
+    ] as const) {
+      const item = await current(projectId, predecessor, tx);
+      if (!item || item.status !== 'COMPLETE')
+        values.push(`${predecessor} review is not complete and current.`);
+    }
+    const rfq = await current(projectId, 'rfq_risk_assessment', tx);
+    const estimateQuote = await current(projectId, 'estimate_quote', tx);
+    if (
+      review.requirements_snapshot?.rfqReviewId !== rfq?.id ||
+      Number(review.requirements_snapshot?.rfqReviewRevision) !==
+        Number(rfq?.revision_number)
+    )
+      values.push('Contract basis does not match the current RFQ review.');
+    if (
+      review.requirements_snapshot?.estimateQuoteReviewId !==
+        estimateQuote?.id ||
+      Number(review.requirements_snapshot?.estimateQuoteReviewRevision) !==
+        Number(estimateQuote?.revision_number)
+    )
+      values.push(
+        'Contract basis does not match the current Estimate & Quote review.'
+      );
+    if (
+      review.source_snapshot?.reconciliation?.quote_id &&
+      review.source_snapshot.reconciliation.quote_id !==
+        estimateQuote?.source_record_id
+    )
+      values.push(
+        'Accepted PO reconciliation does not match the reviewed quote.'
+      );
+    if (!review.differences_resolved)
+      values.push('Contract differences must be resolved.');
+    if (
+      review.differences?.some(
+        (entry: Row) => !entry.resolved || !clean(entry.resolution)
+      )
+    )
+      values.push(
+        'Every contract difference requires a documented resolution.'
+      );
+    if (
+      review.risks?.some(
+        (entry: Row) =>
+          !clean(entry.description) ||
+          !clean(entry.owner) ||
+          !clean(entry.control)
+      )
+    )
+      values.push('Every contract risk requires an owner and control.');
+  }
+  return {
+    ready: values.length === 0,
+    stale: differences.length > 0,
+    blockers: Array.from(new Set(values)),
+    differences,
+  };
+}
+
+async function readModel(
+  projectId: string,
+  stage: CommercialStage,
+  tx: Executor
+) {
+  await context(projectId, stage, tx, false, false);
+  const review = await current(projectId, stage, tx);
+  const readiness = await blockers(projectId, stage, review, tx);
+  const reviewApprovals = review ? await approvals(review, tx) : [];
+  return {
+    review:
+      review && readiness.stale && review.status === 'COMPLETE'
+        ? { ...review, status: 'STALE', detected_status: 'STALE' }
+        : review,
+    history: await reviewHistory(projectId, stage, tx),
+    approvals: readiness.stale
+      ? reviewApprovals.map((entry) => ({
+          ...entry,
+          invalidated: true,
+          invalidation_reason: 'Authoritative source revision changed.',
+        }))
+      : reviewApprovals,
+    requiredApprovals: review ? requiredRoles(review) : [],
+    readiness,
+  };
+}
+export const getCommercialReview = (
+  projectId: string,
+  stage: CommercialStage,
+  tx: Executor = db
+) => readModel(projectId, stage, tx);
+
+async function audit(
+  eventType: string,
+  review: Row,
+  actor: CommercialActor,
+  tx: Executor,
+  reason?: string
+) {
+  await recordAuditEvent(
+    {
+      eventType,
+      subjectType: 'project_commercial_stage_review',
+      subjectId: review.id,
+      sourceService: 'projectCommercialReviewService',
+      actor: {
+        id: actor.userId,
+        username: actor.displayName,
+        role: actor.role,
+      },
+      reason,
+      payload: {
+        projectId: review.project_id,
+        stage: review.stage_type,
+        revision: review.revision_number,
+        sourceRecordType: review.source_record_type,
+        sourceRecordId: review.source_record_id,
+      },
+    },
+    tx
+  );
+}
+
+async function insertRevision(
+  projectId: string,
+  stage: CommercialStage,
+  input: CommercialDraftInput,
+  actor: CommercialActor,
+  tx: Executor,
+  revision: number
+) {
+  const ctx = await context(projectId, stage, tx, true);
+  const source = await sourceSnapshot(projectId, stage, input, tx);
+  const rfqBasis =
+    stage === 'rfq_risk_assessment'
+      ? null
+      : await current(projectId, 'rfq_risk_assessment', tx);
+  const estimateQuoteBasis =
+    stage === 'contract_review'
+      ? await current(projectId, 'estimate_quote', tx)
+      : null;
+  const requirements = {
+    ...source.requirements,
+    ...(input.requirements ?? {}),
+    ...(stage === 'estimate_quote'
+      ? {
+          rfqReviewId: rfqBasis?.id,
+          rfqReviewRevision: rfqBasis?.revision_number,
+        }
+      : {}),
+    ...(stage === 'contract_review'
+      ? {
+          rfqReviewId: rfqBasis?.id,
+          rfqReviewRevision: rfqBasis?.revision_number,
+          estimateQuoteReviewId: estimateQuoteBasis?.id,
+          estimateQuoteReviewRevision: estimateQuoteBasis?.revision_number,
+          financeRequired: Boolean(input.financeRequired),
+        }
+      : {}),
+  };
+  const review = resultRows(
+    await tx.execute(
+      sql`INSERT INTO project_commercial_stage_reviews (project_id,workflow_instance_id,workflow_step_instance_id,stage_type,revision_number,status,source_record_type,source_record_id,source_revision,source_updated_at,source_snapshot,requirements_snapshot,assumptions,exclusions,differences,blockers,risks,unresolved_information_requests,sufficiently_defined,differences_resolved,effectivity_reference,owner_user_id,owner_display_name,created_by,created_by_display_name)
+          VALUES (${projectId},${ctx.instance.id},${ctx.step.id},${stage},${revision},'DRAFT',${input.sourceRecordType},${input.sourceRecordId},${source.sourceRevision},${source.sourceUpdatedAt},${JSON.stringify({ ...source.snapshot, secondarySourceId: input.secondarySourceId ?? null })}::jsonb,${JSON.stringify(requirements)}::jsonb,${JSON.stringify(input.assumptions ?? [])}::jsonb,${JSON.stringify(input.exclusions ?? [])}::jsonb,${JSON.stringify(input.differences ?? [])}::jsonb,${JSON.stringify(source.eligibilityBlockers)}::jsonb,${JSON.stringify(input.risks ?? [])}::jsonb,${JSON.stringify(input.unresolvedInformationRequests ?? [])}::jsonb,${input.sufficientlyDefined ?? null},${Boolean(input.differencesResolved)},${clean(input.effectivityReference) || null},${actor.userId},${actor.displayName},${actor.userId},${actor.displayName}) RETURNING *`
+    )
+  )[0];
+  await tx.execute(
+    sql`UPDATE project_workflow_step_instances SET status='IN_PROGRESS',started_at=COALESCE(started_at,now()),blocked_reason=NULL,updated_at=now() WHERE id=${ctx.step.id}`
+  );
+  await audit('P2_V2_COMMERCIAL_REVIEW_DRAFT_CREATED', review, actor, tx);
+  return review;
+}
+
+export async function createCommercialReview(
+  projectId: string,
+  stage: CommercialStage,
+  input: CommercialDraftInput,
+  actor: CommercialActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, stage, tx, true);
+    if (await current(projectId, stage, tx))
+      throw new ProjectCommercialReviewError(
+        'CURRENT_REVIEW_EXISTS',
+        'A current review revision already exists.',
+        409
+      );
+    await insertRevision(projectId, stage, input, actor, tx, 1);
+    return readModel(projectId, stage, tx);
+  });
+}
+
+export async function updateCommercialDraft(
+  projectId: string,
+  stage: CommercialStage,
+  reviewId: string,
+  expectedRevision: number,
+  input: CommercialDraftInput,
+  actor: CommercialActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, stage, tx, true);
+    const review = await current(projectId, stage, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedRevision
+    )
+      throw new ProjectCommercialReviewError(
+        'STALE_REVISION',
+        'The review revision changed; reload before saving.',
+        409
+      );
+    if (review.status !== 'DRAFT')
+      throw new ProjectCommercialReviewError(
+        'DRAFT_REQUIRED',
+        'Submitted/released review snapshots are immutable.',
+        409
+      );
+    const source = await sourceSnapshot(projectId, stage, input, tx);
+    await tx.execute(
+      sql`UPDATE project_commercial_stage_reviews SET source_record_type=${input.sourceRecordType},source_record_id=${input.sourceRecordId},source_revision=${source.sourceRevision},source_updated_at=${source.sourceUpdatedAt},source_snapshot=${JSON.stringify({ ...source.snapshot, secondarySourceId: input.secondarySourceId ?? null })}::jsonb,requirements_snapshot=${JSON.stringify({ ...source.requirements, ...(input.requirements ?? {}), ...(review.requirements_snapshot?.rfqReviewId ? { rfqReviewId: review.requirements_snapshot.rfqReviewId, rfqReviewRevision: review.requirements_snapshot.rfqReviewRevision } : {}), ...(review.requirements_snapshot?.estimateQuoteReviewId ? { estimateQuoteReviewId: review.requirements_snapshot.estimateQuoteReviewId, estimateQuoteReviewRevision: review.requirements_snapshot.estimateQuoteReviewRevision } : {}), ...(stage === 'contract_review' ? { financeRequired: Boolean(input.financeRequired) } : {}) })}::jsonb,assumptions=${JSON.stringify(input.assumptions ?? [])}::jsonb,exclusions=${JSON.stringify(input.exclusions ?? [])}::jsonb,differences=${JSON.stringify(input.differences ?? [])}::jsonb,risks=${JSON.stringify(input.risks ?? [])}::jsonb,unresolved_information_requests=${JSON.stringify(input.unresolvedInformationRequests ?? [])}::jsonb,sufficiently_defined=${input.sufficientlyDefined ?? null},differences_resolved=${Boolean(input.differencesResolved)},effectivity_reference=${clean(input.effectivityReference) || null},lock_version=lock_version+1,updated_at=now() WHERE id=${reviewId} AND lock_version=${expectedRevision} AND status='DRAFT'`
+    );
+    await audit('P2_V2_COMMERCIAL_REVIEW_DRAFT_UPDATED', review, actor, tx);
+    return readModel(projectId, stage, tx);
+  });
+}
+
+export async function submitCommercialReview(
+  projectId: string,
+  stage: CommercialStage,
+  reviewId: string,
+  expectedRevision: number,
+  actor: CommercialActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, stage, tx, true);
+    const review = await current(projectId, stage, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedRevision
+    )
+      throw new ProjectCommercialReviewError(
+        'STALE_REVISION',
+        'The active review revision changed.',
+        409
+      );
+    if (review.status !== 'DRAFT')
+      throw new ProjectCommercialReviewError(
+        'DRAFT_REQUIRED',
+        'Only a draft may be submitted.',
+        409
+      );
+    const readiness = await blockers(projectId, stage, review, tx);
+    if (!readiness.ready)
+      throw new ProjectCommercialReviewError(
+        'REVIEW_NOT_READY',
+        'Commercial review has blockers.',
+        409,
+        { blockers: readiness.blockers }
+      );
+    await tx.execute(
+      sql`UPDATE project_commercial_stage_reviews SET status='PENDING_APPROVAL',submitted_at=now(),lock_version=lock_version+1,updated_at=now() WHERE id=${reviewId}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='PENDING_APPROVAL',updated_at=now() WHERE id=${ctx.step.id}`
+    );
+    await audit('P2_V2_COMMERCIAL_REVIEW_SUBMITTED', review, actor, tx);
+    return readModel(projectId, stage, tx);
+  });
+}
+
+export async function decideCommercialReview(
+  projectId: string,
+  stage: CommercialStage,
+  reviewId: string,
+  expectedRevision: number,
+  capacity:
+    | 'PROJECT_MANAGEMENT'
+    | 'ENGINEERING'
+    | 'QUALITY'
+    | 'OPERATIONS'
+    | 'FINANCE',
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: CommercialActor
+) {
+  if (!clean(signatureMeaning))
+    throw new ProjectCommercialReviewError(
+      'SIGNATURE_REQUIRED',
+      'Signature meaning is required.'
+    );
+  if (decision !== 'APPROVED' && !clean(reason))
+    throw new ProjectCommercialReviewError(
+      'REASON_REQUIRED',
+      'Rejection/return reason is required.'
+    );
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, stage, tx, true);
+    const review = await current(projectId, stage, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedRevision
+    )
+      throw new ProjectCommercialReviewError(
+        'STALE_REVISION',
+        'The active review revision changed.',
+        409
+      );
+    if (review.status !== 'PENDING_APPROVAL')
+      throw new ProjectCommercialReviewError(
+        'PENDING_APPROVAL_REQUIRED',
+        'Review is not pending approval.',
+        409
+      );
+    if (!requiredRoles(review).includes(capacity))
+      throw new ProjectCommercialReviewError(
+        'APPROVAL_NOT_REQUIRED',
+        `${capacity} approval is not required.`,
+        409
+      );
+    const existing = await approvals(review, tx);
+    if (
+      existing.some((entry) => entry.approval_type === `COMMERCIAL_${capacity}`)
+    )
+      throw new ProjectCommercialReviewError(
+        'DECISION_ALREADY_RECORDED',
+        `${capacity} already decided this revision.`,
+        409
+      );
+    if (
+      existing.some(
+        (entry) =>
+          entry.actor_user_id === actor.userId && entry.decision === 'APPROVED'
+      )
+    )
+      throw new ProjectCommercialReviewError(
+        'SEGREGATION_OF_DUTIES',
+        'One user cannot represent multiple required commercial functions.',
+        403
+      );
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_approvals (workflow_step_instance_id,project_id,approval_type,decision,signature_meaning,reason,actor_employee_id,actor_user_id,actor_display_name,actor_role,step_revision_snapshot,evidence_snapshot)
+          VALUES (${ctx.step.id},${projectId},${`COMMERCIAL_${capacity}`},${decision},${signatureMeaning},${clean(reason) || null},${actor.employeeId ?? null},${actor.userId},${actor.displayName},${actor.role},${String(review.revision_number)},${JSON.stringify({ commercialReviewId: review.id, stage, revision: review.revision_number, sourceRecordType: review.source_record_type, sourceRecordId: review.source_record_id, sourceRevision: review.source_revision, invalidated: false })}::jsonb)`
+    );
+    if (decision !== 'APPROVED') {
+      await tx.execute(
+        sql`UPDATE project_commercial_stage_reviews SET status='REJECTED',lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`
+      );
+    } else {
+      await tx.execute(
+        sql`UPDATE project_commercial_stage_reviews SET lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`
+      );
+      await tx.execute(
+        sql`UPDATE project_workflow_step_instances SET status='BLOCKED',blocked_reason=${`${capacity} ${decision.toLowerCase()}: ${clean(reason)}`},updated_at=now() WHERE id=${ctx.step.id}`
+      );
+    }
+    await audit(
+      `P2_V2_COMMERCIAL_${capacity}_DECIDED`,
+      review,
+      actor,
+      tx,
+      clean(reason) || undefined
+    );
+    return readModel(projectId, stage, tx);
+  });
+}
+
+export async function completeCommercialReview(
+  projectId: string,
+  stage: CommercialStage,
+  reviewId: string,
+  expectedRevision: number,
+  actor: CommercialActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, stage, tx, true);
+    const review = await current(projectId, stage, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedRevision
+    )
+      throw new ProjectCommercialReviewError(
+        'STALE_REVISION',
+        'The active review revision changed.',
+        409
+      );
+    if (review.status !== 'PENDING_APPROVAL')
+      throw new ProjectCommercialReviewError(
+        'PENDING_APPROVAL_REQUIRED',
+        'Review must be submitted before completion.',
+        409
+      );
+    const readiness = await blockers(projectId, stage, review, tx);
+    if (!readiness.ready)
+      throw new ProjectCommercialReviewError(
+        'REVIEW_NOT_READY',
+        'Commercial review changed or has blockers.',
+        409,
+        { blockers: readiness.blockers }
+      );
+    const evidence = await approvals(review, tx);
+    const missing = requiredRoles(review).filter(
+      (role) =>
+        !evidence.some(
+          (entry) =>
+            entry.approval_type === `COMMERCIAL_${role}` &&
+            entry.decision === 'APPROVED'
+        )
+    );
+    if (missing.length)
+      throw new ProjectCommercialReviewError(
+        'APPROVALS_REQUIRED',
+        'Required functional approvals are missing.',
+        409,
+        { missingApprovals: missing }
+      );
+    await tx.execute(
+      sql`UPDATE project_commercial_stage_reviews SET status='COMPLETE',completed_at=now(),lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now(),completed_by=${actor.employeeId ?? null},completed_by_display_name=${actor.displayName},blocked_reason=NULL,revision_reference=${String(review.revision_number)},effectivity_reference=${review.effectivity_reference},updated_at=now() WHERE id=${ctx.step.id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_links SET unlinked_at=now(),unlink_reason='Superseded commercial review evidence' WHERE workflow_step_instance_id=${ctx.step.id} AND is_authoritative=true AND unlinked_at IS NULL`
+    );
+    await tx.execute(
+      sql`INSERT INTO project_workflow_step_links (workflow_step_instance_id,project_id,record_type,record_id,relationship_type,is_authoritative,record_revision,effectivity_reference,linked_by,linked_by_display_name)
+          VALUES (${ctx.step.id},${projectId},${review.source_record_type},${review.source_record_id},'PRIMARY',true,${review.source_revision},${review.effectivity_reference},${actor.employeeId ?? null},${actor.displayName})`
+    );
+    await audit('P2_V2_COMMERCIAL_REVIEW_COMPLETED', review, actor, tx);
+    return readModel(projectId, stage, tx);
+  });
+}
+
+export async function reviseCommercialReview(
+  projectId: string,
+  stage: CommercialStage,
+  reviewId: string,
+  expectedRevision: number,
+  input: CommercialDraftInput,
+  actor: CommercialActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, stage, tx, true);
+    const prior = await current(projectId, stage, tx);
+    if (
+      !prior ||
+      prior.id !== reviewId ||
+      Number(prior.lock_version) !== expectedRevision
+    )
+      throw new ProjectCommercialReviewError(
+        'STALE_REVISION',
+        'The active review revision changed.',
+        409
+      );
+    if (
+      !['COMPLETE', 'REJECTED', 'STALE', 'INVALIDATED'].includes(prior.status)
+    )
+      throw new ProjectCommercialReviewError(
+        'REVISION_NOT_ALLOWED',
+        'Only complete or rejected reviews may be revised.',
+        409
+      );
+    await tx.execute(
+      sql`UPDATE project_commercial_stage_reviews SET status='SUPERSEDED',superseded_at=now(),updated_at=now() WHERE id=${prior.id}`
+    );
+    const next = await insertRevision(
+      projectId,
+      stage,
+      input,
+      actor,
+      tx,
+      Number(prior.revision_number) + 1
+    );
+    await tx.execute(
+      sql`UPDATE project_commercial_stage_reviews SET superseded_by_review_id=${next.id} WHERE id=${prior.id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_approvals SET superseded_at=now(),evidence_snapshot=jsonb_set(COALESCE(evidence_snapshot,'{}'::jsonb),'{invalidated}','true'::jsonb) WHERE workflow_step_instance_id=${prior.workflow_step_instance_id} AND evidence_snapshot->>'commercialReviewId'=${prior.id} AND superseded_at IS NULL`
+    );
+    await audit('P2_V2_COMMERCIAL_REVIEW_REVISED', next, actor, tx);
+    return readModel(projectId, stage, tx);
+  });
+}
+
+export async function evaluateCommercialBaseline(
+  projectId: string,
+  tx: Executor = db
+) {
+  const values: string[] = [];
+  const differences: string[] = [];
+  for (const stage of [
+    'rfq_risk_assessment',
+    'estimate_quote',
+    'contract_review',
+  ] as const) {
+    const review = await current(projectId, stage, tx);
+    if (!review || review.status !== 'COMPLETE') {
+      values.push(`${stage} commercial review is not complete.`);
+      continue;
+    }
+    try {
+      const state = await blockers(projectId, stage, review, tx);
+      if (state.stale) differences.push(...state.differences);
+      if (state.stale || state.blockers.length)
+        values.push(...state.blockers.map((item) => `${stage}: ${item}`));
+    } catch (error) {
+      if (!(error instanceof ProjectCommercialReviewError)) throw error;
+      const difference = `${stage}: authoritative source is unavailable or ineligible (${error.message})`;
+      values.push(difference);
+      differences.push(difference);
+    }
+  }
+  return {
+    valid: values.length === 0,
+    blockers: Array.from(new Set(values)),
+    differences: Array.from(new Set(differences)),
+  };
+}

--- a/server/src/services/projectDesignApplicabilityService.ts
+++ b/server/src/services/projectDesignApplicabilityService.ts
@@ -4,6 +4,7 @@ import { db } from '../../db';
 import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
 import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
 import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+import { evaluateCommercialBaseline } from './projectCommercialReviewService';
 import {
   ProjectDesignApplicabilityError,
   validateDesignApplicabilityInput,
@@ -223,6 +224,8 @@ async function readModel(projectId: string, tx: Executor) {
     tx
   );
   const blockers: string[] = [];
+  const commercial = await evaluateCommercialBaseline(projectId, tx);
+  blockers.push(...commercial.blockers);
   if (!decision) blockers.push('Create a Design Applicability decision.');
   else {
     if (decision.status !== 'APPROVED')

--- a/server/src/services/projectProductionPlanningService.ts
+++ b/server/src/services/projectProductionPlanningService.ts
@@ -6,6 +6,7 @@ import { db } from '../../db';
 import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
 import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
 import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+import { evaluateCommercialBaseline } from './projectCommercialReviewService';
 import {
   ProjectProductionPlanningError,
   productionPlanItemBlockers,
@@ -435,6 +436,8 @@ async function readModel(projectId: string, tx: Executor) {
   const blockers = plan
     ? items.flatMap(productionPlanItemBlockers)
     : ['Create a Production Planning draft.'];
+  const commercial = await evaluateCommercialBaseline(projectId, tx);
+  blockers.push(...commercial.blockers);
   for (const item of items.filter((row) => row.is_manufactured)) {
     if (
       item.inspection_extent === 'APPROVED_SAMPLING' &&

--- a/server/src/services/projectWadAuthorizationService.ts
+++ b/server/src/services/projectWadAuthorizationService.ts
@@ -5,6 +5,7 @@ import { sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
 import { getCurrentProductionPlan } from './projectProductionPlanningService';
+import { evaluateCommercialBaseline } from './projectCommercialReviewService';
 import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
 import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
 import {
@@ -234,6 +235,9 @@ async function readiness(
 ) {
   const blockers: string[] = [];
   const differences: string[] = [];
+  const commercial = await evaluateCommercialBaseline(projectId, tx);
+  blockers.push(...commercial.blockers);
+  differences.push(...commercial.differences);
   if (!authorization)
     return {
       ready: false,


### PR DESCRIPTION
## Summary

- add an additive, revision-controlled `project_commercial_stage_reviews` foundation for p2_v2 RFQ, Estimate & Quote, and Contract Review stages
- reuse authoritative RFQ, estimating, quote snapshot, customer PO, reconciliation, purchase-review, and contract-review records through read-only source adapters
- add authenticated V2-only draft, update, submit, functional decision, completion, history, blocker, and revision APIs
- add separate RFQ Review, Estimate & Quote Review, and Contract Review panels to the ten-stage workflow so stages 1-6 are writable and stages 7-10 remain read-only
- propagate stale or invalid commercial-baseline blockers into Design Applicability, Production Planning, and WAD Authorization readiness without rewriting released history

## Controls

- p2_v2 is required and unknown workflow versions fail closed
- immutable source and requirements snapshots after submission
- optimistic `lock_version` concurrency plus transaction locks and uniqueness constraints
- exact upstream-review revision capture and authoritative source-change detection
- required Project Management, Engineering, Quality, Operations, and conditional Finance approvals
- one actor cannot approve multiple required functions on the same revision
- no backfill, no legacy route changes, no p2_v2 activation, and no production/release record creation

## Validation

- Phase 8A plus Phase 1-7 focused server regressions: 73 passed
- P2 V2 workflow component tests: 4 passed
- legacy quote/WAD/release/closing regressions: 137 passed
- focused ESLint on new/updated Phase 8A registry/API/UI/test files: passed
- `git diff --cached --check`: passed
- memory-safe repository TypeScript: repository remains non-clean from pre-existing diagnostics; no diagnostic originated in the new Phase 8A files

## Existing unrelated failures

- 5 `estimatingLimitClamping` tests fail on current main because their `../schema` mock does not export `insertEstimatingRfqSchema`; Phase 8A does not modify that test or route.

The migration was not applied to any shared or production database.