### PR TITLE
Phase 2A: establish Design Control project authority

### DIFF
--- a/client/src/__tests__/designControlAuthority.client.test.ts
+++ b/client/src/__tests__/designControlAuthority.client.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { describe, expect, it } from 'vitest';
+import { DESIGN_CONTROL_WORKFLOW } from '@shared/designControlWorkflow';
+
+describe('Design Control client authority foundation', () => {
+  it('uses the shared twelve-step workflow definition', () => {
+    expect(DESIGN_CONTROL_WORKFLOW.map((step) => step.key)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+      '11',
+      '12',
+    ]);
+
+    const source = readFileSync(
+      join(process.cwd(), 'client/src/pages/QMSDesignControlPage.tsx'),
+      'utf8'
+    );
+    expect(source).toContain("from '@shared/designControlWorkflow'");
+    expect(source).not.toContain('legacyDesignWorkflowSteps');
+  });
+
+  it('keeps server projects authoritative and local-only data visible for review', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'client/src/pages/RDProjectsPage.tsx'),
+      'utf8'
+    );
+    expect(source).toContain('const projects = sharedProjects');
+    expect(source).toContain('Browser-local project data needs review');
+    expect(source).toContain('Review and import');
+    expect(source).toContain('No record was selected automatically');
+  });
+});

--- a/client/src/pages/QMSDesignControlPage.tsx
+++ b/client/src/pages/QMSDesignControlPage.tsx
@@ -20,6 +20,7 @@ import {
   Route,
   ShieldCheck,
 } from 'lucide-react';
+import { DESIGN_CONTROL_WORKFLOW } from '@shared/designControlWorkflow';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -538,275 +539,16 @@ const lifecycleStages = [
   { stage: 'Release', owner: 'Manufacturing', state: 'Engineering baseline ready for manufactured-item creation' },
 ];
 
-const designWorkflowSteps: DesignWorkflowStep[] = [
-  {
-    id: '1',
-    title: 'Design Project Intake',
-    purpose: 'Capture what is being designed and why.',
-    fields: [
-      'Project / customer / order link',
-      'Design type',
-      'Product name',
-      'Intended use',
-      'Customer requirements summary',
-      'Target manufacturing date',
-      'Responsible engineer',
-      'Quality representative',
-      'Manufacturing representative',
-      'Required deliverables',
-    ],
-    approvals: ['Engineering intake approval', 'Quality intake approval'],
-  },
-  {
-    id: '2',
-    title: 'Design Planning',
-    purpose: 'AS9100 design planning.',
-    fields: [
-      'Design scope',
-      'Design milestones',
-      'Required reviews',
-      'Required verification activities',
-      'Required validation activities',
-      'Required resources',
-      'Required suppliers',
-      'Required software/tools',
-      'Responsibilities',
-      'Approval roles',
-    ],
-    approvals: ['Engineering planning approval', 'Quality planning approval', 'Manufacturing planning approval'],
-  },
-  {
-    id: '3',
-    title: 'Design Inputs / Requirements',
-    purpose: 'Capture controlled design inputs.',
-    fields: [
-      'Requirement ID',
-      'Requirement category',
-      'Source',
-      'Requirement statement',
-      'Acceptance criteria',
-      'Verification method',
-      'Priority',
-      'Owner',
-      'Status',
-    ],
-    checklist: [
-      'Customer requirements captured',
-      'Performance requirements captured',
-      'Regulatory requirements captured',
-      'Safety requirements captured',
-      'Material requirements captured',
-      'Manufacturing requirements captured',
-      'Inspection requirements captured',
-      'Test requirements captured',
-      'Packaging/shipping requirements captured',
-    ],
-    approvals: ['Requirements owner approval'],
-  },
-  {
-    id: '4',
-    title: 'Requirements Review Checklist',
-    purpose: 'Confirm requirements are complete before design work proceeds.',
-    fields: ['Review notes', 'Open requirement gaps', 'Disposition of conflicts'],
-    checklist: [
-      'Requirements are complete',
-      'Requirements are clear',
-      'Requirements are measurable',
-      'Conflicts resolved',
-      'Missing information documented',
-      'Manufacturability reviewed',
-      'Inspection requirements reviewed',
-      'Test requirements reviewed',
-      'Quality approval complete',
-      'Engineering approval complete',
-    ],
-    approvals: ['Engineering approval', 'Quality approval'],
-  },
-  {
-    id: '5',
-    title: 'Design Risk Assessment',
-    purpose: 'Assess design risk before committing to the selected design path.',
-    fields: [
-      'Risk item',
-      'Failure mode',
-      'Cause',
-      'Effect',
-      'Severity',
-      'Occurrence',
-      'Detection',
-      'Risk priority',
-      'Mitigation action',
-      'Owner',
-      'Due date',
-      'Residual risk',
-      'Approval status',
-    ],
-    examples: [
-      'Battery overheating',
-      'Composite delamination',
-      'Wing flex',
-      'CG out of tolerance',
-      'Servo mount failure',
-      'Material substitution',
-      'Supplier component change',
-      'Prototype test failure',
-    ],
-    approvals: ['Engineering risk approval', 'Quality risk approval'],
-  },
-  {
-    id: '6',
-    title: 'Concept Design Review',
-    purpose: 'Approve the concept before detailed design.',
-    fields: [
-      'Concept summary',
-      'Design alternatives considered',
-      'Selected concept',
-      'Reason selected',
-      'Major assumptions',
-      'Open questions',
-      'Manufacturability concerns',
-      'Quality concerns',
-      'Attachments',
-    ],
-    checklist: [
-      'Concept meets major requirements',
-      'Risks reviewed',
-      'Manufacturing reviewed',
-      'Quality reviewed',
-      'Customer needs considered',
-      'Approval to proceed',
-    ],
-    approvals: ['Engineering concept approval', 'Quality concept approval', 'Manufacturing concept approval'],
-  },
-  {
-    id: '7',
-    title: 'Detailed Design Outputs',
-    purpose: 'Control the actual design output package.',
-    fields: ['Output package notes', 'Linked drawings/BOM/revision package', 'Design output owner'],
-    checklist: [
-      'CAD model attached',
-      'Drawing attached',
-      'BOM created',
-      'Material specs defined',
-      'Critical characteristics defined',
-      'Tolerances defined',
-      'Special processes defined',
-      'Inspection points defined',
-      'Test requirements defined',
-      'Software/firmware version defined, if applicable',
-      'Supplier parts identified',
-      'Revision assigned',
-      'Design output approved',
-    ],
-    approvals: ['Engineering output approval', 'Document control approval'],
-  },
-  {
-    id: '8',
-    title: 'Prototype Build Record',
-    purpose: 'Document exactly what was built.',
-    fields: [
-      'Prototype serial number',
-      'Build revision',
-      'Build date',
-      'Builder',
-      'Linked BOM revision',
-      'Linked drawing revisions',
-      'Material lots',
-      'Purchased component lots/serials',
-      'Deviations used',
-      'Photos',
-      'Build notes',
-      'Issues found',
-      'Disposition',
-    ],
-    approvals: ['Engineering build approval', 'Quality build approval'],
-  },
-  {
-    id: '9',
-    title: 'Design Verification',
-    purpose: 'Confirm the design output meets the design inputs.',
-    fields: [
-      'Requirement ID',
-      'Verification method',
-      'Test/inspection performed',
-      'Result',
-      'Pass/fail',
-      'Evidence attachment',
-      'Nonconformance link',
-      'Engineering disposition',
-      'Verified by',
-      'Date',
-    ],
-    approvals: ['Verification approval'],
-  },
-  {
-    id: '10',
-    title: 'Design Validation',
-    purpose: 'Confirm the product works for the intended use/customer mission.',
-    fields: [
-      'Validation activity',
-      'Intended use tested',
-      'Mission/profile tested',
-      'Customer requirement linked',
-      'Result',
-      'Pass/fail',
-      'Evidence attachment',
-      'Customer witness/approval, if applicable',
-      'Validation approval',
-    ],
-    approvals: ['Engineering validation approval', 'Quality validation approval', 'Customer/program validation approval'],
-  },
-  {
-    id: '11',
-    title: 'Final Design Review',
-    purpose: 'Cross-functional approval before manufacturing release.',
-    fields: ['Final review notes', 'Open issue disposition', 'Configuration baseline'],
-    checklist: [
-      'All requirements reviewed',
-      'All high risks closed or accepted',
-      'Design outputs approved',
-      'Prototype build documented',
-      'Verification complete',
-      'Validation complete',
-      'Open issues dispositioned',
-      'Configuration baseline established',
-      'Manufacturing reviewed',
-      'Quality reviewed',
-      'Program management reviewed',
-    ],
-    approvals: ['Engineering', 'Quality', 'Manufacturing', 'Program Manager'],
-  },
-  {
-    id: '12',
-    title: 'Engineering Release Gate',
-    purpose: 'Freeze the controlled engineering baseline before manufactured inventory item creation.',
-    fields: ['Release package notes', 'Linked project_id / PO / WAD', 'Locked design revision baseline'],
-    checklist: [
-      'Released CAD',
-      'Released drawings',
-      'Released BOM',
-      'Approved routing',
-      'Approved traveler requirement',
-      'Approved work instructions',
-      'Approved inspection plan',
-      'Approved test procedure',
-      'Required certifications identified',
-      'Supplier requirements flowed down',
-      'Material requirements approved',
-      'Tooling/fixtures ready',
-      'CNC programs approved, if applicable',
-      'Training/certifications complete',
-      'Packaging/shipping requirements defined',
-      'Design revision baseline locked',
-    ],
-    approvals: [
-      'Engineering release approval',
-      'Quality release approval',
-      'Manufacturing release approval',
-      'Program Manager release approval',
-    ],
-  },
-];
+// Visible labels are projected from stable shared machine keys.
+const designWorkflowSteps: DesignWorkflowStep[] = DESIGN_CONTROL_WORKFLOW.map((step) => ({
+  id: step.key,
+  title: step.title,
+  purpose: step.purpose,
+  fields: step.fields.map((field) => field.label),
+  checklist: step.checklist.map((entry) => entry.label),
+  approvals: step.approvals.map((approval) => approval.label),
+  examples: step.examples ? [...step.examples] : undefined,
+}));
 
 function createInitialWorkflowData() {
   return designWorkflowSteps.reduce<Record<string, WorkflowStepData>>((acc, step) => {
@@ -1065,10 +807,16 @@ export default function QMSDesignControlPage() {
       try {
         const params = new URLSearchParams();
         if (rdProjectIdParam) params.set('rdProjectId', rdProjectIdParam);
-        const response = await apiRequest(`/api/qms/design-control${params.toString() ? `?${params.toString()}` : ''}`) as { records: DesignControlRecord[] };
+        const response = await apiRequest(`/api/qms/design-control${params.toString() ? `?${params.toString()}` : ''}`) as {
+          records: DesignControlRecord[];
+          authorityState?: string | null;
+          authoritativeRecordId?: string | null;
+        };
         if (cancelled) return;
         setDesignControlRecords(response.records ?? []);
-        setActiveDesignControlRecordId((current) => current ?? recordIdParam ?? response.records?.[0]?.id ?? null);
+        setActiveDesignControlRecordId((current) =>
+          current ?? recordIdParam ?? response.authoritativeRecordId ?? (rdProjectIdParam ? null : response.records?.[0]?.id) ?? null
+        );
       } catch (error: any) {
         if (!cancelled) setLoadError(error.message || 'Failed to load design control records.');
       } finally {

--- a/client/src/pages/RDProjectsPage.tsx
+++ b/client/src/pages/RDProjectsPage.tsx
@@ -170,6 +170,7 @@ interface DesignControlProjectRecord {
   id: string;
   title: string;
   status: string;
+  authorityStatus?: string;
   rdProjectId?: string | null;
   updatedAt?: string | null;
   releasedAt?: string | null;
@@ -495,17 +496,6 @@ function mergeDraftRecords(
   return [...byId.values()].sort((a, b) =>
     (b.updatedAt ?? '').localeCompare(a.updatedAt ?? '')
   );
-}
-
-function mergeProjects(
-  sharedProjects: RDProject[],
-  localProjects: RDProject[]
-) {
-  const byId = new Map<string, RDProject>();
-  for (const project of [...sharedProjects, ...localProjects]) {
-    if (project?.id) byId.set(project.id, project);
-  }
-  return [...byId.values()];
 }
 
 async function saveSharedProject(project: RDProject) {
@@ -900,6 +890,7 @@ export default function RDProjectsPage() {
   const [isGeneratingEngineeringPackage, setIsGeneratingEngineeringPackage] = useState(false);
   const [engineeringReleaseError, setEngineeringReleaseError] = useState<string | null>(null);
   const [engineeringPackageError, setEngineeringPackageError] = useState<string | null>(null);
+  const [localImportState, setLocalImportState] = useState<Record<string, string>>({});
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
     () => new URLSearchParams(window.location.search).get('projectId')
   );
@@ -918,10 +909,11 @@ export default function RDProjectsPage() {
     'overview';
   const [activeProjectTab, setActiveProjectTab] = useState(initialProjectTab);
 
-  const projects = useMemo(
-    () => mergeProjects(sharedProjects, localProjects),
-    [sharedProjects, localProjects]
-  );
+  const projects = sharedProjects;
+  const localOnlyProjects = useMemo(() => {
+    const serverIds = new Set(sharedProjects.map((project) => project.id));
+    return localProjects.filter((project) => project.id && !serverIds.has(project.id));
+  }, [localProjects, sharedProjects]);
   const draftRecords = useMemo(
     () => mergeDraftRecords(localDraftRecords, sharedDraftRecords),
     [localDraftRecords, sharedDraftRecords]
@@ -973,25 +965,30 @@ export default function RDProjectsPage() {
   const {
     data: selectedDesignControlPayload,
     isLoading: isLoadingDesignControlRecords,
-  } = useQuery<{ records: DesignControlProjectRecord[] }>({
-    queryKey: ['/api/qms/design-control', 'rd-project', selectedProject?.id],
+  } = useQuery<{
+    state: string;
+    authoritativeRecord: DesignControlProjectRecord | null;
+    records: DesignControlProjectRecord[];
+  }>({
+    queryKey: ['/api/rd-projects', selectedProject?.id, 'design-control'],
     enabled: Boolean(selectedProject?.id),
     retry: false,
     queryFn: async () => {
-      if (!selectedProject?.id) return { records: [] };
-      const params = new URLSearchParams({ rdProjectId: selectedProject.id });
-      const response = await fetch(`/api/qms/design-control?${params.toString()}`, {
+      if (!selectedProject?.id) return { state: 'NOT_INITIALIZED', authoritativeRecord: null, records: [] };
+      const response = await fetch(`/api/rd-projects/${encodeURIComponent(selectedProject.id)}/design-control`, {
         credentials: 'include',
       });
-      if (!response.ok) return { records: [] };
+      if (!response.ok) return { state: 'NOT_INITIALIZED', authoritativeRecord: null, records: [] };
       const payload = await response.json();
       return {
+        state: payload.state,
+        authoritativeRecord: payload.authoritativeRecord ?? null,
         records: Array.isArray(payload.records) ? payload.records : [],
       };
     },
   });
   const selectedDesignControlRecords = selectedDesignControlPayload?.records ?? [];
-  const activeDesignControlRecord = selectedDesignControlRecords[0] ?? null;
+  const activeDesignControlRecord = selectedDesignControlPayload?.authoritativeRecord ?? null;
   const {
     data: engineeringReleasePayload,
     isLoading: isLoadingEngineeringReleasePreview,
@@ -1297,18 +1294,12 @@ export default function RDProjectsPage() {
     if (!selectedProject) return;
     setIsCreatingDesignControlRecord(true);
     try {
-      const response = await fetch('/api/qms/design-control', {
+      const response = await fetch(`/api/rd-projects/${encodeURIComponent(selectedProject.id)}/design-control/initialize`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: `${selectedProject.projectName} Design Control`,
-          rdProjectId: selectedProject.id,
-          metadata: {
-            rdProjectName: selectedProject.projectName,
-            source: '/design/rd-projects',
-            downstreamIntent: 'released-design-to-manufactured-inventory-item',
-          },
         }),
       });
 
@@ -1317,14 +1308,45 @@ export default function RDProjectsPage() {
       }
 
       const payload = await response.json();
-      await queryClient.invalidateQueries({
-        queryKey: ['/api/qms/design-control', 'rd-project', selectedProject.id],
-      });
-      setLocation(designControlUrl(selectedProject, payload.record?.id));
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['/api/rd-projects', selectedProject.id, 'design-control'],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['/api/qms/design-control', 'rd-project', selectedProject.id],
+        }),
+      ]);
+      setLocation(designControlUrl(selectedProject, payload.resolution?.authoritativeRecord?.id));
     } catch (error) {
       console.error('Failed to create R&D design control record:', error);
     } finally {
       setIsCreatingDesignControlRecord(false);
+    }
+  };
+
+  const importLocalProject = async (project: RDProject) => {
+    if (!window.confirm(`Import the browser-local project "${project.projectName}" to the shared server project list? Existing server projects will not be overwritten.`)) return;
+    setLocalImportState((current) => ({ ...current, [project.id]: 'importing' }));
+    try {
+      const response = await fetch('/api/rd-projects/reconcile-local', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...project,
+          confirmed: true,
+          localStorageKey: R_AND_D_PROJECT_STORAGE_KEY,
+        }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setLocalImportState((current) => ({ ...current, [project.id]: payload.outcome ?? 'failed' }));
+        return;
+      }
+      setLocalImportState((current) => ({ ...current, [project.id]: 'imported' }));
+      await queryClient.invalidateQueries({ queryKey: ['/api/rd-projects'] });
+    } catch {
+      setLocalImportState((current) => ({ ...current, [project.id]: 'failed' }));
     }
   };
 
@@ -1404,6 +1426,46 @@ export default function RDProjectsPage() {
             New R &amp; D Project
           </Button>
         </div>
+
+        {localOnlyProjects.length > 0 && (
+          <Card className="border-amber-300 bg-amber-50">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base text-amber-900">
+                <AlertTriangle className="h-5 w-5" />
+                Browser-local project data needs review
+              </CardTitle>
+              <CardDescription className="text-amber-800">
+                These legacy records remain in this browser but are not shared server projects. They are excluded from normal project selection until reviewed and imported.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {localOnlyProjects.map((project) => (
+                <div key={project.id} className="flex flex-col gap-3 rounded-md border border-amber-200 bg-white p-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="font-medium">{project.projectName}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Owner: {project.owner || 'Unassigned'} · Status: {project.status} · Draft tabs: {project.draftTabIds.length}
+                    </p>
+                    {project.description && (
+                      <p className="mt-1 max-w-3xl text-sm text-muted-foreground">{project.description}</p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Local ID {project.id} · {localImportState[project.id] ?? 'local only'}
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={localImportState[project.id] === 'importing' || localImportState[project.id] === 'imported'}
+                    onClick={() => importLocalProject(project)}
+                  >
+                    {localImportState[project.id] === 'importing' ? 'Checking…' : localImportState[project.id] === 'imported' ? 'Imported' : 'Review and import'}
+                  </Button>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
 
         <div className="grid gap-4 md:grid-cols-3">
           <Card>
@@ -2061,7 +2123,7 @@ export default function RDProjectsPage() {
                           <Button
                             className="gap-2 self-start"
                             onClick={createDesignControlRecordForProject}
-                            disabled={isCreatingDesignControlRecord}
+                            disabled={isCreatingDesignControlRecord || selectedDesignControlRecords.length > 0}
                           >
                             <Plus className="h-4 w-4" />
                             {isCreatingDesignControlRecord ? 'Creating...' : 'Create Design Control'}
@@ -2071,6 +2133,11 @@ export default function RDProjectsPage() {
                           <div className="rounded-md border bg-white px-3 py-2 text-sm text-muted-foreground">
                             When this design is released, its R&amp;D data can become the source package for a manufactured inventory item. That released item can later be selected from P2 when a PO is received.
                           </div>
+                          {selectedDesignControlPayload?.state === 'RECONCILIATION_REQUIRED' && (
+                            <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+                              Multiple historical Design Control records require an administrator to designate authority. No record was selected automatically.
+                            </div>
+                          )}
                           {isLoadingDesignControlRecords ? (
                             <div className="rounded-md border bg-white px-3 py-4 text-sm text-muted-foreground">
                               Loading design-control records...
@@ -2099,9 +2166,11 @@ export default function RDProjectsPage() {
                                         {record.title}
                                       </p>
                                       <p className="mt-1 text-xs text-muted-foreground">
-                                        {record.releasedAt
+                                        {record.authorityStatus === 'authoritative'
+                                          ? 'Authoritative Design Control'
+                                          : record.releasedAt
                                           ? 'Released design control'
-                                          : `Status: ${record.status}`}
+                                          : `Status: ${record.status} · Authority: ${record.authorityStatus ?? 'legacy'}`}
                                       </p>
                                     </div>
                                     <Badge variant="outline">

--- a/migrations/0207_design_control_authority_foundation.sql
+++ b/migrations/0207_design_control_authority_foundation.sql
@@ -1,0 +1,89 @@
+-- Phase 2A: explicit, non-destructive Design Control authority.
+-- Single-record projects can be designated deterministically. Duplicate-record
+-- projects are intentionally left unresolved and flagged for reconciliation.
+
+ALTER TABLE IF EXISTS design_control_records
+  ADD COLUMN IF NOT EXISTS authority_status text NOT NULL DEFAULT 'legacy',
+  ADD COLUMN IF NOT EXISTS designated_authoritative_at timestamp,
+  ADD COLUMN IF NOT EXISTS designated_authoritative_by text,
+  ADD COLUMN IF NOT EXISTS superseded_at timestamp,
+  ADD COLUMN IF NOT EXISTS superseded_by text,
+  ADD COLUMN IF NOT EXISTS supersession_reason text,
+  ADD COLUMN IF NOT EXISTS superseded_by_record_id uuid,
+  ADD COLUMN IF NOT EXISTS record_version integer NOT NULL DEFAULT 1;
+
+DO $$ BEGIN
+  ALTER TABLE design_control_records
+    ADD CONSTRAINT design_control_records_authority_status_check
+    CHECK (authority_status IN ('legacy', 'authoritative', 'reconciliation_required', 'superseded'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE design_control_records
+    ADD CONSTRAINT design_control_records_superseded_by_record_fk
+    FOREIGN KEY (superseded_by_record_id)
+    REFERENCES design_control_records(id)
+    ON DELETE RESTRICT;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+WITH project_summary AS (
+  SELECT
+    rd_project_id,
+    count(*) AS record_count,
+    bool_or(authority_status IN ('legacy', 'reconciliation_required')) AS has_unresolved_records
+  FROM design_control_records
+  WHERE rd_project_id IS NOT NULL
+  GROUP BY rd_project_id
+)
+UPDATE design_control_records dcr
+SET authority_status = CASE
+      WHEN ps.record_count = 1 THEN 'authoritative'
+      ELSE 'reconciliation_required'
+    END,
+    designated_authoritative_at = CASE
+      WHEN ps.record_count = 1 THEN COALESCE(dcr.designated_authoritative_at, now())
+      ELSE dcr.designated_authoritative_at
+    END,
+    designated_authoritative_by = CASE
+      WHEN ps.record_count = 1 THEN COALESCE(dcr.designated_authoritative_by, 'migration:0207')
+      ELSE dcr.designated_authoritative_by
+    END
+FROM project_summary ps
+WHERE dcr.rd_project_id = ps.rd_project_id
+  AND (
+    (ps.record_count = 1 AND dcr.authority_status IN ('legacy', 'reconciliation_required'))
+    OR (
+      ps.record_count > 1
+      AND ps.has_unresolved_records
+      AND dcr.authority_status <> 'superseded'
+    )
+  );
+
+CREATE INDEX IF NOT EXISTS design_control_records_authority_status_idx
+  ON design_control_records(authority_status);
+
+CREATE UNIQUE INDEX IF NOT EXISTS design_control_records_authoritative_rd_project_unique
+  ON design_control_records(rd_project_id)
+  WHERE authority_status = 'authoritative' AND rd_project_id IS NOT NULL;
+
+INSERT INTO perm_capabilities (key, description, category)
+VALUES
+  ('design.control.create', 'Initialize the authoritative Design Control record for an R&D project', 'design'),
+  ('design.control.admin', 'Resolve duplicate Design Control authority and designate the current record', 'design')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT role.id, capability.id
+FROM perm_roles role
+JOIN perm_capabilities capability ON capability.key = 'design.control.create'
+WHERE role.name IN ('ADMIN', 'OWNER', 'PROJECT_MANAGER', 'ENGINEERING')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT role.id, capability.id
+FROM perm_roles role
+JOIN perm_capabilities capability ON capability.key = 'design.control.admin'
+WHERE role.name IN ('ADMIN', 'OWNER')
+ON CONFLICT DO NOTHING;

--- a/server/__tests__/designControlAuthorityFoundation.test.ts
+++ b/server/__tests__/designControlAuthorityFoundation.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({ db: {} }));
+
+import {
+  DESIGN_CONTROL_STEP_KEYS,
+  DESIGN_CONTROL_WORKFLOW,
+  workflowItemLookupKeys,
+} from '../../shared/designControlWorkflow';
+import { deriveDesignControlAuthorityState } from '../src/services/designControlAuthorityService';
+
+describe('Design Control authority foundation', () => {
+  it('defines one stable twelve-step workflow with the release gate last', () => {
+    expect(DESIGN_CONTROL_WORKFLOW).toHaveLength(12);
+    expect(DESIGN_CONTROL_STEP_KEYS).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+      '11',
+      '12',
+    ]);
+    expect(DESIGN_CONTROL_WORKFLOW.map((step) => step.order)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    ]);
+    expect(DESIGN_CONTROL_WORKFLOW.at(-1)).toMatchObject({
+      key: '12',
+      releaseGate: true,
+    });
+  });
+
+  it('retains legacy aliases while using stable canonical keys', () => {
+    const releaseApproval = DESIGN_CONTROL_WORKFLOW[11].approvals[0];
+    expect(workflowItemLookupKeys(releaseApproval)).toContain(
+      releaseApproval.key
+    );
+    expect(workflowItemLookupKeys(releaseApproval)).toContain(
+      'Engineering release approval'
+    );
+  });
+
+  it('derives authority only from explicit persisted states', () => {
+    expect(deriveDesignControlAuthorityState([])).toBe('NOT_INITIALIZED');
+    expect(
+      deriveDesignControlAuthorityState([{ authorityStatus: 'authoritative' }])
+    ).toBe('AUTHORITATIVE');
+    expect(
+      deriveDesignControlAuthorityState([
+        { authorityStatus: 'reconciliation_required' },
+        { authorityStatus: 'reconciliation_required' },
+      ])
+    ).toBe('RECONCILIATION_REQUIRED');
+    expect(
+      deriveDesignControlAuthorityState([
+        { authorityStatus: 'authoritative' },
+        { authorityStatus: 'authoritative' },
+      ])
+    ).toBe('INVALID_STATE');
+    expect(
+      deriveDesignControlAuthorityState([{ authorityStatus: 'superseded' }])
+    ).toBe('SUPERSEDED_ONLY');
+  });
+
+  it('enforces authority, permissions, and non-destructive reconciliation at integration seams', () => {
+    const root = process.cwd();
+    const migration = readFileSync(
+      join(root, 'migrations/0207_design_control_authority_foundation.sql'),
+      'utf8'
+    );
+    const projectRoutes = readFileSync(
+      join(root, 'server/src/routes/rdProjects.ts'),
+      'utf8'
+    );
+    const qmsRoutes = readFileSync(
+      join(root, 'server/src/routes/qmsDesignControl.ts'),
+      'utf8'
+    );
+    const releaseService = readFileSync(
+      join(root, 'server/src/services/engineeringReleaseService.ts'),
+      'utf8'
+    );
+    const rdProjectsPage = readFileSync(
+      join(root, 'client/src/pages/RDProjectsPage.tsx'),
+      'utf8'
+    );
+    const qmsPage = readFileSync(
+      join(root, 'client/src/pages/QMSDesignControlPage.tsx'),
+      'utf8'
+    );
+
+    expect(migration).toContain(
+      'design_control_records_authoritative_rd_project_unique'
+    );
+    expect(migration).toContain(
+      "WHERE authority_status = 'authoritative' AND rd_project_id IS NOT NULL"
+    );
+    expect(migration).not.toMatch(
+      /\bDELETE\s+FROM\s+design_control_records\b/i
+    );
+    expect(projectRoutes).toContain(
+      "requirePermission('design.control.create')"
+    );
+    expect(projectRoutes).toContain(
+      "requirePermission('design.control.admin')"
+    );
+    expect(projectRoutes).toContain('z.string().trim().min(1)');
+    expect(projectRoutes).toContain("outcome: 'possible_duplicate'");
+    expect(qmsRoutes).toContain("from '../../../shared/designControlWorkflow'");
+    expect(qmsPage).toContain("from '@shared/designControlWorkflow'");
+    expect(releaseService).toContain("authorityStatus !== 'authoritative'");
+    expect(rdProjectsPage).toContain('const projects = sharedProjects');
+    expect(rdProjectsPage).toContain('Browser-local project data needs review');
+  });
+});

--- a/server/__tests__/designControlSchemaHardening.test.ts
+++ b/server/__tests__/designControlSchemaHardening.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({
   db: {
@@ -27,6 +28,7 @@ const migrationFiles = [
   'migrations/0190_design_control_requirement_applicability.sql',
   'migrations/0191_engineering_releases.sql',
   'migrations/0192_engineering_packages.sql',
+  'migrations/0207_design_control_authority_foundation.sql',
 ];
 
 const originalDatabaseUrl = process.env.DATABASE_URL;
@@ -133,15 +135,36 @@ describe('Design Control schema hardening', () => {
 
   it('allows readiness when required schema SELECT checks succeed', async () => {
     const calls: string[] = [];
+    let callNumber = 0;
     const client = {
       execute: async (statement: unknown) => {
         calls.push(String(statement));
+        callNumber += 1;
+        if (callNumber === requiredDesignControlTables.length + 1) {
+          return [
+            { column_name: 'authority_status' },
+            { column_name: 'designated_authoritative_at' },
+            { column_name: 'designated_authoritative_by' },
+            { column_name: 'superseded_at' },
+            { column_name: 'superseded_by' },
+            { column_name: 'supersession_reason' },
+            { column_name: 'superseded_by_record_id' },
+            { column_name: 'record_version' },
+          ];
+        }
+        if (callNumber === requiredDesignControlTables.length + 2) return [{ present: 1 }];
+        if (callNumber === requiredDesignControlTables.length + 3) {
+          return [
+            { conname: 'design_control_records_authority_status_check' },
+            { conname: 'design_control_records_superseded_by_record_fk' },
+          ];
+        }
         return [];
       },
     };
 
     await expect(assertDesignControlSchemaReady(client)).resolves.toBeUndefined();
-    expect(calls).toHaveLength(requiredDesignControlTables.length);
+    expect(calls).toHaveLength(requiredDesignControlTables.length + 3);
   });
 
   it('surfaces safe-boot migration startup failures clearly', async () => {

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -17458,6 +17458,14 @@ export const designControlRecords = pgTable('design_control_records', {
   recordNumber: text('record_number'),
   title: text('title').notNull(),
   status: text('status').notNull().default('draft'),
+  authorityStatus: text('authority_status').notNull().default('legacy'),
+  designatedAuthoritativeAt: timestamp('designated_authoritative_at'),
+  designatedAuthoritativeBy: text('designated_authoritative_by'),
+  supersededAt: timestamp('superseded_at'),
+  supersededBy: text('superseded_by'),
+  supersessionReason: text('supersession_reason'),
+  supersededByRecordId: uuid('superseded_by_record_id'),
+  recordVersion: integer('record_version').notNull().default(1),
   rdProjectId: text('rd_project_id').references(() => rdProjects.id, { onDelete: 'set null' }),
   projectId: uuid('project_id').references(() => projects.id, { onDelete: 'set null' }),
   productionWorkOrderId: uuid('production_work_order_id').references(() => productionWorkOrders.id, { onDelete: 'set null' }),
@@ -17477,6 +17485,10 @@ export const designControlRecords = pgTable('design_control_records', {
   productionWorkOrderIdx: index('design_control_records_pwo_id_idx').on(table.productionWorkOrderId),
   p2PurchaseOrderIdx: index('design_control_records_p2_po_id_idx').on(table.p2PurchaseOrderId),
   statusIdx: index('design_control_records_status_idx').on(table.status),
+  authorityStatusIdx: index('design_control_records_authority_status_idx').on(table.authorityStatus),
+  authoritativeRdProjectUnique: uniqueIndex('design_control_records_authoritative_rd_project_unique')
+    .on(table.rdProjectId)
+    .where(sql`${table.authorityStatus} = 'authoritative' AND ${table.rdProjectId} IS NOT NULL`),
 }));
 
 const designControlTraceabilityColumns = () => ({

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -224,6 +224,7 @@ export const safeMigrationFiles = [
   '0199_project_workflow_version.sql',
   '0200_reconcile_oem_shipment_fulfillment.sql',
   '0201_close_fully_shipped_p1_purchase_orders.sql',
+  '0207_design_control_authority_foundation.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -242,6 +243,7 @@ export const criticalMigrationFiles = new Set([
   '0191_engineering_releases.sql',
   '0192_engineering_packages.sql',
   '0196_document_template_builder_tables.sql',
+  '0207_design_control_authority_foundation.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/qmsDesignControl.ts
+++ b/server/src/routes/qmsDesignControl.ts
@@ -2,6 +2,8 @@ import { Router, Request, Response } from 'express';
 import { and, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 
 import { db } from '../../db';
+import { authenticateToken } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/requirePermission';
 import {
   designControlChanges,
   designControlRecords,
@@ -28,6 +30,11 @@ import {
   designControlSchemaNotReadyPayload,
   isDesignControlSchemaNotReadyError,
 } from '../services/designControlSchemaReadiness';
+import { DESIGN_CONTROL_WORKFLOW, workflowItemLookupKeys } from '../../../shared/designControlWorkflow';
+import {
+  initializeDesignControlForProject,
+  resolveDesignControlAuthority,
+} from '../services/designControlAuthorityService';
 
 const router = Router();
 
@@ -53,259 +60,15 @@ type StepPayload = {
   status?: string;
 };
 
-const workflowSteps = [
-  {
-    key: '1',
-    title: 'Design Project Intake',
-    requiredFields: [
-      'Project / customer / order link',
-      'Design type',
-      'Product name',
-      'Intended use',
-      'Customer requirements summary',
-      'Target manufacturing date',
-      'Responsible engineer',
-      'Quality representative',
-      'Manufacturing representative',
-      'Required deliverables',
-    ],
-    requiredChecklist: [],
-    requiredApprovals: ['Engineering intake approval', 'Quality intake approval'],
-  },
-  {
-    key: '2',
-    title: 'Design Planning',
-    requiredFields: [
-      'Design scope',
-      'Design milestones',
-      'Required reviews',
-      'Required verification activities',
-      'Required validation activities',
-      'Required resources',
-      'Required suppliers',
-      'Required software/tools',
-      'Responsibilities',
-      'Approval roles',
-    ],
-    requiredChecklist: [],
-    requiredApprovals: ['Engineering planning approval', 'Quality planning approval', 'Manufacturing planning approval'],
-  },
-  {
-    key: '3',
-    title: 'Design Inputs / Requirements',
-    requiredFields: [
-      'Requirement ID',
-      'Requirement category',
-      'Source',
-      'Requirement statement',
-      'Acceptance criteria',
-      'Verification method',
-      'Priority',
-      'Owner',
-      'Status',
-    ],
-    requiredChecklist: [
-      'Customer requirements captured',
-      'Performance requirements captured',
-      'Regulatory requirements captured',
-      'Safety requirements captured',
-      'Material requirements captured',
-      'Manufacturing requirements captured',
-      'Inspection requirements captured',
-      'Test requirements captured',
-      'Packaging/shipping requirements captured',
-    ],
-    requiredApprovals: ['Requirements owner approval'],
-  },
-  {
-    key: '4',
-    title: 'Requirements Review Checklist',
-    requiredFields: ['Review notes', 'Open requirement gaps', 'Disposition of conflicts'],
-    requiredChecklist: [
-      'Requirements are complete',
-      'Requirements are clear',
-      'Requirements are measurable',
-      'Conflicts resolved',
-      'Missing information documented',
-      'Manufacturability reviewed',
-      'Inspection requirements reviewed',
-      'Test requirements reviewed',
-      'Quality approval complete',
-      'Engineering approval complete',
-    ],
-    requiredApprovals: ['Engineering approval', 'Quality approval'],
-  },
-  {
-    key: '5',
-    title: 'Design Risk Assessment',
-    requiredFields: [
-      'Risk item',
-      'Failure mode',
-      'Cause',
-      'Effect',
-      'Severity',
-      'Occurrence',
-      'Detection',
-      'Risk priority',
-      'Mitigation action',
-      'Owner',
-      'Due date',
-      'Residual risk',
-      'Approval status',
-    ],
-    requiredChecklist: [],
-    requiredApprovals: ['Engineering risk approval', 'Quality risk approval'],
-  },
-  {
-    key: '6',
-    title: 'Concept Design Review',
-    requiredFields: [
-      'Concept summary',
-      'Design alternatives considered',
-      'Selected concept',
-      'Reason selected',
-      'Major assumptions',
-      'Open questions',
-      'Manufacturability concerns',
-      'Quality concerns',
-      'Attachments',
-    ],
-    requiredChecklist: [
-      'Concept meets major requirements',
-      'Risks reviewed',
-      'Manufacturing reviewed',
-      'Quality reviewed',
-      'Customer needs considered',
-      'Approval to proceed',
-    ],
-    requiredApprovals: ['Engineering concept approval', 'Quality concept approval', 'Manufacturing concept approval'],
-  },
-  {
-    key: '7',
-    title: 'Detailed Design Outputs',
-    requiredFields: ['Output package notes', 'Linked drawings/BOM/revision package', 'Design output owner'],
-    requiredChecklist: [
-      'CAD model attached',
-      'Drawing attached',
-      'BOM created',
-      'Material specs defined',
-      'Critical characteristics defined',
-      'Tolerances defined',
-      'Special processes defined',
-      'Inspection points defined',
-      'Test requirements defined',
-      'Software/firmware version defined, if applicable',
-      'Supplier parts identified',
-      'Revision assigned',
-      'Design output approved',
-    ],
-    requiredApprovals: ['Engineering output approval', 'Document control approval'],
-  },
-  {
-    key: '8',
-    title: 'Prototype Build Record',
-    requiredFields: [
-      'Prototype serial number',
-      'Build revision',
-      'Build date',
-      'Builder',
-      'Linked BOM revision',
-      'Linked drawing revisions',
-      'Material lots',
-      'Purchased component lots/serials',
-      'Deviations used',
-      'Photos',
-      'Build notes',
-      'Issues found',
-      'Disposition',
-    ],
-    requiredChecklist: [],
-    requiredApprovals: ['Engineering build approval', 'Quality build approval'],
-  },
-  {
-    key: '9',
-    title: 'Design Verification',
-    requiredFields: [
-      'Requirement ID',
-      'Verification method',
-      'Test/inspection performed',
-      'Result',
-      'Pass/fail',
-      'Evidence attachment',
-      'Nonconformance link',
-      'Engineering disposition',
-      'Verified by',
-      'Date',
-    ],
-    requiredChecklist: [],
-    requiredApprovals: ['Verification approval'],
-  },
-  {
-    key: '10',
-    title: 'Design Validation',
-    requiredFields: [
-      'Validation activity',
-      'Intended use tested',
-      'Mission/profile tested',
-      'Customer requirement linked',
-      'Result',
-      'Pass/fail',
-      'Evidence attachment',
-      'Customer witness/approval, if applicable',
-      'Validation approval',
-    ],
-    requiredChecklist: [],
-    requiredApprovals: ['Engineering validation approval', 'Quality validation approval', 'Customer/program validation approval'],
-  },
-  {
-    key: '11',
-    title: 'Final Design Review',
-    requiredFields: ['Final review notes', 'Open issue disposition', 'Configuration baseline'],
-    requiredChecklist: [
-      'All requirements reviewed',
-      'All high risks closed or accepted',
-      'Design outputs approved',
-      'Prototype build documented',
-      'Verification complete',
-      'Validation complete',
-      'Open issues dispositioned',
-      'Configuration baseline established',
-      'Manufacturing reviewed',
-      'Quality reviewed',
-      'Program management reviewed',
-    ],
-    requiredApprovals: ['Engineering', 'Quality', 'Manufacturing', 'Program Manager'],
-  },
-  {
-    key: '12',
-    title: 'Engineering Release Gate',
-    requiredFields: ['Release package notes', 'Linked project_id / PO / WAD', 'Locked design revision baseline'],
-    requiredChecklist: [
-      'released CAD',
-      'released drawings',
-      'released BOM',
-      'approved routing',
-      'approved traveler requirement',
-      'approved work instructions',
-      'approved inspection plan',
-      'approved test procedure',
-      'required certifications identified',
-      'supplier requirements flowed down',
-      'material requirements approved',
-      'tooling and fixtures ready',
-      'CNC programs approved when applicable',
-      'training and certifications complete',
-      'packaging and shipping requirements defined',
-      'design revision baseline locked',
-    ],
-    requiredApprovals: [
-      'engineering release approval',
-      'quality release approval',
-      'manufacturing release approval',
-      'program manager release approval',
-    ],
-  },
-];
+// Route validation consumes the same canonical definition as initialization and the client.
+const workflowSteps = DESIGN_CONTROL_WORKFLOW.map((step) => ({
+  key: step.key,
+  title: step.title,
+  purpose: step.purpose,
+  requiredFields: step.fields.map((field) => field.key),
+  requiredChecklist: step.checklist.map((entry) => entry.key),
+  requiredApprovals: step.approvals.map((approval) => approval.key),
+}));
 
 const requiredStepKeys = workflowSteps.filter((step) => step.key !== '12').map((step) => step.key);
 const releaseGateSourceRequirements = canonicalManufacturingEvidenceRequirements.map((requirement) => ({
@@ -354,13 +117,15 @@ function valueForCanonicalKey(values: Record<string, unknown>, canonicalKey: str
   return found?.[1];
 }
 
-function isTruthyCanonical(values: Record<string, unknown>, canonicalKey: string) {
-  return valueForCanonicalKey(values, canonicalKey) === true;
-}
-
-function hasFilledCanonicalValue(values: Record<string, unknown>, canonicalKey: string) {
-  const value = valueForCanonicalKey(values, canonicalKey);
-  return String(value ?? '').trim().length > 0;
+function valuesForWorkflowItem(values: Record<string, unknown>, stepKey: string, kind: 'fields' | 'checklist' | 'approvals', canonicalKey: string) {
+  const step = DESIGN_CONTROL_WORKFLOW.find((candidate) => candidate.key === stepKey);
+  const workflowItem = step?.[kind].find((candidate) => candidate.key === canonicalKey);
+  const lookupKeys = workflowItem ? workflowItemLookupKeys(workflowItem) : [canonicalKey];
+  for (const lookupKey of lookupKeys) {
+    const value = valueForCanonicalKey(values, lookupKey);
+    if (value !== undefined) return value;
+  }
+  return undefined;
 }
 
 function missingForStep(step: WorkflowStepDefinition, payload: StepPayload, options: { includeChecklist?: boolean } = {}) {
@@ -370,9 +135,9 @@ function missingForStep(step: WorkflowStepDefinition, payload: StepPayload, opti
   const includeChecklist = options.includeChecklist ?? true;
 
   return {
-    fields: step.requiredFields.filter((field) => !hasFilledCanonicalValue(formData, field)),
-    checklist: includeChecklist ? step.requiredChecklist.filter((item) => !isTruthyCanonical(checklist, item)) : [],
-    approvals: step.requiredApprovals.filter((approval) => !isTruthyCanonical(approvals, approval)),
+    fields: step.requiredFields.filter((field) => String(valuesForWorkflowItem(formData, step.key, 'fields', field) ?? '').trim().length === 0),
+    checklist: includeChecklist ? step.requiredChecklist.filter((entry) => valuesForWorkflowItem(checklist, step.key, 'checklist', entry) !== true) : [],
+    approvals: step.requiredApprovals.filter((approval) => valuesForWorkflowItem(approvals, step.key, 'approvals', approval) !== true),
   };
 }
 
@@ -619,14 +384,20 @@ router.get('/', async (_req: Request, res: Response) => {
         .select()
         .from(designControlRecords)
         .orderBy(desc(designControlRecords.updatedAt), desc(designControlRecords.createdAt));
-    res.json({ records });
+    const rdProjectId = typeof _req.query.rdProjectId === 'string' ? _req.query.rdProjectId.trim() : '';
+    const authority = rdProjectId ? await resolveDesignControlAuthority(rdProjectId) : null;
+    res.json({
+      records,
+      authorityState: authority?.state ?? null,
+      authoritativeRecordId: authority?.authoritativeRecord?.id ?? null,
+    });
   } catch (error) {
     console.error('[qms-design-control] Failed to list records', error);
     res.status(500).json({ message: 'Failed to load design control records' });
   }
 });
 
-router.post('/', async (req: Request, res: Response) => {
+router.post('/', authenticateToken, requirePermission('design.control.create'), async (req: Request, res: Response) => {
   try {
     const parsed = insertDesignControlRecordSchema.safeParse({
       title: req.body?.title || 'New Design Control Record',
@@ -648,6 +419,28 @@ router.post('/', async (req: Request, res: Response) => {
       return;
     }
 
+    if (parsed.data.rdProjectId) {
+      const result = await initializeDesignControlForProject({
+        projectId: parsed.data.rdProjectId,
+        title: parsed.data.title,
+        actor: { username: actorFromRequest(req) },
+        requestMetadata: { ipAddress: req.ip, userAgent: req.get('user-agent') ?? null },
+      });
+      if (result.status === 'project_not_found') {
+        return res.status(404).json({ message: 'R&D project not found' });
+      }
+      if (result.status === 'conflict') {
+        return res.status(409).json({
+          message: 'This R&D project already has Design Control records. Use the project authority reconciliation workflow.',
+          authorityState: result.resolution.state,
+          authoritativeRecordId: result.resolution.authoritativeRecord?.id ?? null,
+        });
+      }
+      return res.status(result.status === 'created' ? 201 : 200).json({
+        record: result.resolution?.authoritativeRecord ?? null,
+        authorityState: result.resolution?.state ?? 'INVALID_STATE',
+      });
+    }
     const record = await createDesignControlRecordWithInitialWorkflow(parsed.data);
 
     res.status(201).json({ record });
@@ -664,7 +457,6 @@ router.get('/:id', async (req: Request, res: Response) => {
       res.status(404).json({ message: 'Design control record not found' });
       return;
     }
-
     await ensureWorkflowSteps(record);
     const [
       steps,
@@ -703,11 +495,18 @@ router.get('/:id', async (req: Request, res: Response) => {
   }
 });
 
-router.patch('/:id/steps/:stepKey', async (req: Request, res: Response) => {
+router.patch('/:id/steps/:stepKey', authenticateToken, async (req: Request, res: Response) => {
   try {
     const record = await getRecord(req.params.id);
     if (!record) {
       res.status(404).json({ message: 'Design control record not found' });
+      return;
+    }
+    if (record.rdProjectId && record.authorityStatus !== 'authoritative') {
+      res.status(409).json({
+        message: 'Historical Design Control records are read-only. Designate an authoritative record before editing.',
+        authorityStatus: record.authorityStatus,
+      });
       return;
     }
 
@@ -829,11 +628,18 @@ router.patch('/:id/steps/:stepKey', async (req: Request, res: Response) => {
   }
 });
 
-router.post('/:id/submit-release', async (req: Request, res: Response) => {
+router.post('/:id/submit-release', authenticateToken, async (req: Request, res: Response) => {
   try {
     const record = await getRecord(req.params.id);
     if (!record) {
       res.status(404).json({ message: 'Design control record not found' });
+      return;
+    }
+    if (record.rdProjectId && record.authorityStatus !== 'authoritative') {
+      res.status(409).json({
+        message: 'Historical Design Control records cannot be submitted for release.',
+        authorityStatus: record.authorityStatus,
+      });
       return;
     }
 
@@ -922,7 +728,7 @@ router.get('/:id/engineering-release-preview', async (req: Request, res: Respons
   }
 });
 
-router.post('/:id/engineering-release', async (req: Request, res: Response) => {
+router.post('/:id/engineering-release', authenticateToken, async (req: Request, res: Response) => {
   try {
     const result = await submitEngineeringRelease({
       recordId: req.params.id,

--- a/server/src/routes/rdProjects.ts
+++ b/server/src/routes/rdProjects.ts
@@ -1,9 +1,17 @@
 import { Router, type Request, type Response } from 'express';
-import { desc, eq } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 import { z } from 'zod';
+
 import { db } from '../../db';
 import { rdProjects } from '../../schema';
 import { resolveUserSnapshot } from '../../utils/userSnapshot';
+import { requirePermission } from '../../middleware/requirePermission';
+import {
+  designateAuthoritativeDesignControl,
+  initializeDesignControlForProject,
+  resolveDesignControlAuthority,
+} from '../services/designControlAuthorityService';
+import { recordAuditEvent } from '../services/auditLedgerService';
 
 const router = Router();
 
@@ -17,6 +25,20 @@ const rdProjectPayloadSchema = z.object({
   draftTabIds: z.array(z.string()).default([]),
   description: z.string().default(''),
 });
+
+const localReconciliationSchema = rdProjectPayloadSchema.extend({
+  confirmed: z.literal(true),
+  localStorageKey: z.string().trim().min(1),
+});
+
+function actorSnapshot(req: Request) {
+  const user = (req as any).user;
+  return {
+    id: typeof user?.id === 'number' ? user.id : null,
+    username: user?.username ?? user?.email ?? user?.displayName ?? 'unknown',
+    role: user?.role ?? null,
+  };
+}
 
 async function userSnapshot(req: Request) {
   const user = (req as any).user;
@@ -110,6 +132,148 @@ router.put('/:id', async (req: Request, res: Response) => {
       return res.status(400).json({ error: error.errors[0]?.message || 'Invalid R&D project payload' });
     }
     res.status(500).json({ error: 'Failed to save R&D project' });
+  }
+});
+
+router.get('/:projectId/design-control', async (req: Request, res: Response) => {
+  try {
+    const resolution = await resolveDesignControlAuthority(req.params.projectId);
+    if (!resolution) return res.status(404).json({ error: 'R&D project not found' });
+    res.json(resolution);
+  } catch (error) {
+    console.error('Resolve project Design Control authority error:', error);
+    res.status(500).json({ error: 'Failed to resolve project Design Control authority' });
+  }
+});
+
+router.post(
+  '/:projectId/design-control/initialize',
+  requirePermission('design.control.create'),
+  async (req: Request, res: Response) => {
+    try {
+      const result = await initializeDesignControlForProject({
+        projectId: req.params.projectId,
+        title: typeof req.body?.title === 'string' ? req.body.title : undefined,
+        actor: actorSnapshot(req),
+        requestMetadata: { ipAddress: req.ip, userAgent: req.get('user-agent') ?? null },
+      });
+      if (result.status === 'project_not_found') return res.status(404).json({ error: 'R&D project not found' });
+      if (result.status === 'conflict') {
+        return res.status(409).json({
+          error: 'DESIGN_CONTROL_RECONCILIATION_REQUIRED',
+          message: 'Existing Design Control records require explicit authority reconciliation.',
+          resolution: result.resolution,
+        });
+      }
+      res.status(result.status === 'created' ? 201 : 200).json(result);
+    } catch (error: any) {
+      if (error?.code === '23505') {
+        const resolution = await resolveDesignControlAuthority(req.params.projectId);
+        return res.status(200).json({ status: 'existing', resolution });
+      }
+      console.error('Initialize project Design Control error:', error);
+      res.status(500).json({ error: 'Failed to initialize project Design Control' });
+    }
+  },
+);
+
+router.post(
+  '/:projectId/design-control/designate',
+  requirePermission('design.control.admin'),
+  async (req: Request, res: Response) => {
+    try {
+      const parsed = z.object({
+        recordId: z.string().uuid(),
+        reason: z.string().trim().min(1),
+      }).parse(req.body);
+      const result = await designateAuthoritativeDesignControl({
+        projectId: req.params.projectId,
+        recordId: parsed.recordId,
+        reason: parsed.reason,
+        actor: actorSnapshot(req),
+        requestMetadata: { ipAddress: req.ip, userAgent: req.get('user-agent') ?? null },
+      });
+      if (result.status === 'project_not_found') return res.status(404).json({ error: 'R&D project not found' });
+      if (result.status === 'record_not_in_project') {
+        return res.status(409).json({ error: 'Selected Design Control record does not belong to this project' });
+      }
+      res.json(result);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: error.errors[0]?.message ?? 'Invalid designation request' });
+      }
+      console.error('Designate project Design Control authority error:', error);
+      res.status(500).json({ error: 'Failed to designate project Design Control authority' });
+    }
+  },
+);
+
+router.post('/reconcile-local', requirePermission('design.control.create'), async (req: Request, res: Response) => {
+  try {
+    const parsed = localReconciliationSchema.parse(req.body);
+    const [sameId] = await db.select().from(rdProjects).where(eq(rdProjects.id, parsed.id)).limit(1);
+    if (sameId) {
+      return res.status(409).json({ outcome: 'server_match', project: toClientProject(sameId) });
+    }
+
+    const possibleDuplicates = await db.execute(sql`
+      SELECT id, project_name, owner, status
+      FROM rd_projects
+      WHERE lower(trim(project_name)) = lower(trim(${parsed.projectName}))
+      ORDER BY updated_at DESC
+      LIMIT 10
+    `);
+    const duplicateRows = (possibleDuplicates as any)?.rows ?? possibleDuplicates;
+    if (Array.isArray(duplicateRows) && duplicateRows.length > 0) {
+      return res.status(409).json({
+        outcome: 'possible_duplicate',
+        message: 'A similarly named server project exists. No automatic merge or overwrite was performed.',
+        possibleDuplicates: duplicateRows,
+      });
+    }
+
+    const snapshot = await userSnapshot(req);
+    const created = await db.transaction(async (tx) => {
+      const [row] = await tx.insert(rdProjects).values({
+        id: parsed.id,
+        projectName: parsed.projectName,
+        owner: parsed.owner,
+        status: parsed.status,
+        signoffRequired: parsed.signoffRequired,
+        signoffUserId: parsed.signoffRequired ? parsed.signoffUserId : '',
+        draftTabIds: parsed.draftTabIds,
+        description: parsed.description,
+        createdByUserId: snapshot.userId,
+        createdByDisplayName: snapshot.displayName,
+        updatedByUserId: snapshot.userId,
+        updatedByDisplayName: snapshot.displayName,
+      }).returning();
+
+      await recordAuditEvent({
+        eventType: 'RD_PROJECT_IMPORTED_FROM_LOCAL_STORAGE',
+        subjectType: 'rd_project',
+        subjectId: row.id,
+        sourceService: 'rdProjects.route',
+        actor: actorSnapshot(req),
+        ipAddress: req.ip,
+        userAgent: req.get('user-agent') ?? null,
+        reason: 'Reviewed browser-local R&D project import',
+        fieldsChanged: { persistence: { before: 'browser_local', after: 'server_authoritative' } },
+        payload: {
+          projectId: row.id,
+          localStorageKey: parsed.localStorageKey,
+          importedFromLocalStorage: true,
+        },
+      }, tx);
+      return row;
+    });
+    res.status(201).json({ outcome: 'imported', project: toClientProject(created) });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ outcome: 'failed', error: error.errors[0]?.message ?? 'Invalid local project' });
+    }
+    console.error('Reconcile browser-local R&D project error:', error);
+    res.status(500).json({ outcome: 'failed', error: 'Failed to import local project; local data was not changed' });
   }
 });
 

--- a/server/src/services/designControlAuthorityService.ts
+++ b/server/src/services/designControlAuthorityService.ts
@@ -1,0 +1,326 @@
+import { and, asc, eq, ne, sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import {
+  designControlRecords,
+  designControlReleaseGate,
+  designControlSteps,
+  rdProjects,
+} from '../../schema';
+import { DESIGN_CONTROL_WORKFLOW } from '../../../shared/designControlWorkflow';
+import { recordAuditEvent } from './auditLedgerService';
+
+export type DesignControlActor = {
+  id?: number | null;
+  username: string;
+  role?: string | null;
+};
+
+type DesignControlRequestMetadata = {
+  ipAddress?: string | null;
+  userAgent?: string | null;
+};
+
+export type DesignControlAuthorityState =
+  | 'NOT_INITIALIZED'
+  | 'AUTHORITATIVE'
+  | 'RECONCILIATION_REQUIRED'
+  | 'SUPERSEDED_ONLY'
+  | 'INVALID_STATE';
+
+type Client = typeof db;
+
+export function deriveDesignControlAuthorityState(
+  records: Array<{ authorityStatus: string }>
+): DesignControlAuthorityState {
+  const authoritativeCount = records.filter(
+    (record) => record.authorityStatus === 'authoritative'
+  ).length;
+  const reconciliationCount = records.filter(
+    (record) => record.authorityStatus === 'reconciliation_required'
+  ).length;
+
+  if (records.length === 0) return 'NOT_INITIALIZED';
+  if (authoritativeCount === 1 && reconciliationCount === 0)
+    return 'AUTHORITATIVE';
+  if (
+    authoritativeCount === 0 &&
+    records.every((record) => record.authorityStatus === 'superseded')
+  ) {
+    return 'SUPERSEDED_ONLY';
+  }
+  if (
+    authoritativeCount === 0 &&
+    (records.length > 1 || reconciliationCount > 0)
+  ) {
+    return 'RECONCILIATION_REQUIRED';
+  }
+  return 'INVALID_STATE';
+}
+
+export async function resolveDesignControlAuthority(
+  projectId: string,
+  client: Client = db
+) {
+  const [project] = await client
+    .select()
+    .from(rdProjects)
+    .where(eq(rdProjects.id, projectId))
+    .limit(1);
+  if (!project) return null;
+
+  const records = await client
+    .select()
+    .from(designControlRecords)
+    .where(eq(designControlRecords.rdProjectId, projectId))
+    .orderBy(asc(designControlRecords.createdAt), asc(designControlRecords.id));
+
+  const authoritative = records.filter(
+    (record) => record.authorityStatus === 'authoritative'
+  );
+  const state = deriveDesignControlAuthorityState(records);
+
+  return {
+    project,
+    state,
+    authoritativeRecord: state === 'AUTHORITATIVE' ? authoritative[0] : null,
+    records,
+    historicalRecords: records.filter(
+      (record) => record.authorityStatus !== 'authoritative'
+    ),
+    allowedActions: {
+      initialize: state === 'NOT_INITIALIZED',
+      designate: records.length > 0 && (state !== 'AUTHORITATIVE' || records.length > 1),
+      viewHistory: records.length > 0,
+    },
+  };
+}
+
+export async function initializeDesignControlForProject(
+  input: {
+    projectId: string;
+    actor: DesignControlActor;
+    title?: string;
+    requestMetadata?: DesignControlRequestMetadata;
+  },
+  client: Client = db
+) {
+  return client.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${input.projectId}))`
+    );
+    const resolution = await resolveDesignControlAuthority(
+      input.projectId,
+      tx as Client
+    );
+    if (!resolution) return { status: 'project_not_found' as const };
+    if (resolution.state === 'AUTHORITATIVE') {
+      return { status: 'existing' as const, resolution };
+    }
+    if (resolution.records.length > 0) {
+      return { status: 'conflict' as const, resolution };
+    }
+
+    const now = new Date();
+    const [record] = await tx
+      .insert(designControlRecords)
+      .values({
+        title:
+          input.title?.trim() ||
+          `${resolution.project.projectName} Design Control`,
+        status: 'draft',
+        authorityStatus: 'authoritative',
+        designatedAuthoritativeAt: now,
+        designatedAuthoritativeBy: input.actor.username,
+        rdProjectId: input.projectId,
+        metadata: {
+          source: 'rd-project-design-control-initialize',
+          approvalEvidenceVersion: 1,
+          approvalMode: 'legacy_boolean_pending_phase_2b',
+        },
+      })
+      .returning();
+
+    for (const step of DESIGN_CONTROL_WORKFLOW) {
+      await tx.insert(designControlSteps).values({
+        recordId: record.id,
+        stepKey: step.key,
+        title: step.title,
+        status: 'incomplete',
+        rdProjectId: input.projectId,
+        formData: {},
+        checklist: {},
+        approvals: {},
+        attachments: [],
+        metadata: {
+          source: 'shared-design-control-workflow',
+          workflowOrder: step.order,
+          approvalMode: 'legacy_boolean_pending_phase_2b',
+        },
+      });
+    }
+
+    await tx.insert(designControlReleaseGate).values({
+      recordId: record.id,
+      rdProjectId: input.projectId,
+      gateStatus: 'not_ready',
+      formData: {},
+      checklist: {},
+      approvals: {},
+      attachments: [],
+      metadata: { source: 'rd-project-design-control-initialize' },
+    });
+
+    await recordAuditEvent(
+      {
+        eventType: 'DESIGN_CONTROL_INITIALIZED',
+        subjectType: 'rd_project',
+        subjectId: input.projectId,
+        sourceService: 'designControlAuthorityService',
+        actor: input.actor,
+        ipAddress: input.requestMetadata?.ipAddress,
+        userAgent: input.requestMetadata?.userAgent,
+        reason: 'Initialize authoritative Design Control',
+        fieldsChanged: {
+          authorityState: { before: 'NOT_INITIALIZED', after: 'AUTHORITATIVE' },
+          authoritativeRecordId: { before: null, after: record.id },
+        },
+        payload: {
+          projectId: input.projectId,
+          designControlRecordId: record.id,
+          priorAuthorityState: 'NOT_INITIALIZED',
+          resultingAuthorityState: 'AUTHORITATIVE',
+        },
+      },
+      tx
+    );
+
+    return {
+      status: 'created' as const,
+      resolution: await resolveDesignControlAuthority(
+        input.projectId,
+        tx as Client
+      ),
+    };
+  });
+}
+
+export async function designateAuthoritativeDesignControl(
+  input: {
+    projectId: string;
+    recordId: string;
+    reason: string;
+    actor: DesignControlActor;
+    requestMetadata?: DesignControlRequestMetadata;
+  },
+  client: Client = db
+) {
+  return client.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${input.projectId}))`
+    );
+    const before = await resolveDesignControlAuthority(
+      input.projectId,
+      tx as Client
+    );
+    if (!before) return { status: 'project_not_found' as const };
+    const selected = before.records.find(
+      (record) => record.id === input.recordId
+    );
+    if (!selected)
+      return { status: 'record_not_in_project' as const, resolution: before };
+    if (
+      before.state === 'AUTHORITATIVE' &&
+      before.authoritativeRecord?.id === input.recordId
+    ) {
+      return { status: 'existing' as const, resolution: before };
+    }
+
+    const now = new Date();
+    await tx
+      .update(designControlRecords)
+      .set({
+        authorityStatus: 'superseded',
+        supersededAt: now,
+        supersededBy: input.actor.username,
+        supersessionReason: input.reason,
+        supersededByRecordId: input.recordId,
+        recordVersion: sql`${designControlRecords.recordVersion} + 1`,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(designControlRecords.rdProjectId, input.projectId),
+          ne(designControlRecords.id, input.recordId),
+          ne(designControlRecords.authorityStatus, 'superseded')
+        )
+      );
+
+    await tx
+      .update(designControlRecords)
+      .set({
+        authorityStatus: 'authoritative',
+        designatedAuthoritativeAt: now,
+        designatedAuthoritativeBy: input.actor.username,
+        supersededAt: null,
+        supersededBy: null,
+        supersessionReason: null,
+        supersededByRecordId: null,
+        recordVersion: sql`${designControlRecords.recordVersion} + 1`,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(designControlRecords.id, input.recordId),
+          eq(designControlRecords.rdProjectId, input.projectId)
+        )
+      );
+
+    const after = await resolveDesignControlAuthority(
+      input.projectId,
+      tx as Client
+    );
+    await recordAuditEvent(
+      {
+        eventType: before.authoritativeRecord
+          ? 'DESIGN_CONTROL_AUTHORITY_REPLACED'
+          : 'DESIGN_CONTROL_AUTHORITY_DESIGNATED',
+        subjectType: 'rd_project',
+        subjectId: input.projectId,
+        sourceService: 'designControlAuthorityService',
+        actor: input.actor,
+        ipAddress: input.requestMetadata?.ipAddress,
+        userAgent: input.requestMetadata?.userAgent,
+        reason: input.reason,
+        fieldsChanged: {
+          authorityState: {
+            before: before.state,
+            after: after?.state ?? 'INVALID_STATE',
+          },
+          authoritativeRecordId: {
+            before: before.authoritativeRecord?.id ?? null,
+            after: input.recordId,
+          },
+        },
+        payload: {
+          projectId: input.projectId,
+          selectedRecordId: input.recordId,
+          priorRecordIds: before.records.map((record) => record.id),
+          priorAuthorityState: before.state,
+          resultingAuthorityState: after?.state ?? 'INVALID_STATE',
+        },
+      },
+      tx
+    );
+
+    return { status: 'designated' as const, resolution: after };
+  });
+}
+
+export function isAuthoritativeDesignControlRecord(
+  record: typeof designControlRecords.$inferSelect
+) {
+  return (
+    Boolean(record.rdProjectId) && record.authorityStatus === 'authoritative'
+  );
+}

--- a/server/src/services/designControlSchemaReadiness.ts
+++ b/server/src/services/designControlSchemaReadiness.ts
@@ -7,6 +7,7 @@ export const requiredDesignControlMigrations = [
   '0190_design_control_requirement_applicability.sql',
   '0191_engineering_releases.sql',
   '0192_engineering_packages.sql',
+  '0207_design_control_authority_foundation.sql',
 ] as const;
 
 export const requiredDesignControlTables = [
@@ -85,6 +86,61 @@ export async function assertDesignControlSchemaReady(client: ReadinessClient = d
         }
         throw error;
       }
+    }
+
+    const authorityColumns = await client.execute(sql`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'design_control_records'
+        AND column_name IN (
+          'authority_status', 'designated_authoritative_at', 'designated_authoritative_by',
+          'superseded_at', 'superseded_by', 'supersession_reason',
+          'superseded_by_record_id', 'record_version'
+        )
+    `);
+    const columnRows = ((authorityColumns as any)?.rows ?? authorityColumns) as Array<{ column_name?: string }>;
+    const presentColumns = new Set(Array.isArray(columnRows) ? columnRows.map((row) => row.column_name) : []);
+    const requiredColumns = [
+      'authority_status', 'designated_authoritative_at', 'designated_authoritative_by',
+      'superseded_at', 'superseded_by', 'supersession_reason',
+      'superseded_by_record_id', 'record_version',
+    ];
+    const missingColumns = requiredColumns.filter((column) => !presentColumns.has(column));
+    if (missingColumns.length > 0) {
+      throw new DesignControlSchemaNotReadyError(missingColumns.map((column) => `design_control_records.${column}`));
+    }
+
+    const authorityIndex = await client.execute(sql`
+      SELECT 1
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'design_control_records'
+        AND indexname = 'design_control_records_authoritative_rd_project_unique'
+      LIMIT 1
+    `);
+    const indexRows = (authorityIndex as any)?.rows ?? authorityIndex;
+    if (!Array.isArray(indexRows) || indexRows.length === 0) {
+      throw new DesignControlSchemaNotReadyError(['design_control_records_authoritative_rd_project_unique']);
+    }
+
+    const authorityConstraints = await client.execute(sql`
+      SELECT conname
+      FROM pg_constraint
+      WHERE conname IN (
+        'design_control_records_authority_status_check',
+        'design_control_records_superseded_by_record_fk'
+      )
+    `);
+    const constraintRows = ((authorityConstraints as any)?.rows ?? authorityConstraints) as Array<{ conname?: string }>;
+    const presentConstraints = new Set(Array.isArray(constraintRows) ? constraintRows.map((row) => row.conname) : []);
+    const requiredConstraints = [
+      'design_control_records_authority_status_check',
+      'design_control_records_superseded_by_record_fk',
+    ];
+    const missingConstraints = requiredConstraints.filter((name) => !presentConstraints.has(name));
+    if (missingConstraints.length > 0) {
+      throw new DesignControlSchemaNotReadyError(missingConstraints);
     }
 
     if (client === db) {

--- a/server/src/services/engineeringReleaseService.ts
+++ b/server/src/services/engineeringReleaseService.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto';
+
 import { and, desc, eq, sql } from 'drizzle-orm';
 
 import { db } from '../../db';
@@ -577,6 +578,16 @@ export async function submitEngineeringRelease(input: {
         status: 'existing' as const,
         release: existingRelease,
         preview: buildEngineeringReleasePreviewFromContext(context, existingRelease, [existingRelease]),
+      };
+    }
+
+    if (context.record.authorityStatus !== 'authoritative') {
+      return {
+        status: 'blocked' as const,
+        missingEvidence: [
+          `Design Control record is ${context.record.authorityStatus}; new Engineering Releases require the project's authoritative record`,
+        ],
+        preview,
       };
     }
 

--- a/shared/designControlWorkflow.ts
+++ b/shared/designControlWorkflow.ts
@@ -1,0 +1,408 @@
+export type DesignControlWorkflowItem = {
+  key: string;
+  label: string;
+  legacyLabels?: readonly string[];
+};
+
+export type DesignControlWorkflowStep = {
+  key: string;
+  order: number;
+  title: string;
+  purpose: string;
+  fields: readonly DesignControlWorkflowItem[];
+  checklist: readonly DesignControlWorkflowItem[];
+  approvals: readonly DesignControlWorkflowItem[];
+  examples?: readonly string[];
+  releaseGate: boolean;
+};
+
+const item = (
+  label: string,
+  key = label,
+  legacyLabels?: readonly string[]
+): DesignControlWorkflowItem => ({
+  key,
+  label,
+  legacyLabels,
+});
+const items = (labels: readonly string[]) => labels.map((label) => item(label));
+
+export const DESIGN_CONTROL_WORKFLOW = [
+  {
+    key: '1',
+    order: 1,
+    title: 'Design Project Intake',
+    purpose: 'Capture what is being designed and why.',
+    releaseGate: false,
+    fields: items([
+      'Project / customer / order link',
+      'Design type',
+      'Product name',
+      'Intended use',
+      'Customer requirements summary',
+      'Target manufacturing date',
+      'Responsible engineer',
+      'Quality representative',
+      'Manufacturing representative',
+      'Required deliverables',
+    ]),
+    checklist: [],
+    approvals: items([
+      'Engineering intake approval',
+      'Quality intake approval',
+    ]),
+  },
+  {
+    key: '2',
+    order: 2,
+    title: 'Design Planning',
+    purpose: 'AS9100 design planning.',
+    releaseGate: false,
+    fields: items([
+      'Design scope',
+      'Design milestones',
+      'Required reviews',
+      'Required verification activities',
+      'Required validation activities',
+      'Required resources',
+      'Required suppliers',
+      'Required software/tools',
+      'Responsibilities',
+      'Approval roles',
+    ]),
+    checklist: [],
+    approvals: items([
+      'Engineering planning approval',
+      'Quality planning approval',
+      'Manufacturing planning approval',
+    ]),
+  },
+  {
+    key: '3',
+    order: 3,
+    title: 'Design Inputs / Requirements',
+    purpose: 'Capture controlled design inputs.',
+    releaseGate: false,
+    fields: items([
+      'Requirement ID',
+      'Requirement category',
+      'Source',
+      'Requirement statement',
+      'Acceptance criteria',
+      'Verification method',
+      'Priority',
+      'Owner',
+      'Status',
+    ]),
+    checklist: items([
+      'Customer requirements captured',
+      'Performance requirements captured',
+      'Regulatory requirements captured',
+      'Safety requirements captured',
+      'Material requirements captured',
+      'Manufacturing requirements captured',
+      'Inspection requirements captured',
+      'Test requirements captured',
+      'Packaging/shipping requirements captured',
+    ]),
+    approvals: items(['Requirements owner approval']),
+  },
+  {
+    key: '4',
+    order: 4,
+    title: 'Requirements Review Checklist',
+    purpose: 'Confirm requirements are complete before design work proceeds.',
+    releaseGate: false,
+    fields: items([
+      'Review notes',
+      'Open requirement gaps',
+      'Disposition of conflicts',
+    ]),
+    checklist: items([
+      'Requirements are complete',
+      'Requirements are clear',
+      'Requirements are measurable',
+      'Conflicts resolved',
+      'Missing information documented',
+      'Manufacturability reviewed',
+      'Inspection requirements reviewed',
+      'Test requirements reviewed',
+      'Quality approval complete',
+      'Engineering approval complete',
+    ]),
+    approvals: items(['Engineering approval', 'Quality approval']),
+  },
+  {
+    key: '5',
+    order: 5,
+    title: 'Design Risk Assessment',
+    purpose:
+      'Assess design risk before committing to the selected design path.',
+    releaseGate: false,
+    fields: items([
+      'Risk item',
+      'Failure mode',
+      'Cause',
+      'Effect',
+      'Severity',
+      'Occurrence',
+      'Detection',
+      'Risk priority',
+      'Mitigation action',
+      'Owner',
+      'Due date',
+      'Residual risk',
+      'Approval status',
+    ]),
+    checklist: [],
+    approvals: items(['Engineering risk approval', 'Quality risk approval']),
+    examples: [
+      'Battery overheating',
+      'Composite delamination',
+      'Wing flex',
+      'CG out of tolerance',
+      'Servo mount failure',
+      'Material substitution',
+      'Supplier component change',
+      'Prototype test failure',
+    ],
+  },
+  {
+    key: '6',
+    order: 6,
+    title: 'Concept Design Review',
+    purpose: 'Approve the concept before detailed design.',
+    releaseGate: false,
+    fields: items([
+      'Concept summary',
+      'Design alternatives considered',
+      'Selected concept',
+      'Reason selected',
+      'Major assumptions',
+      'Open questions',
+      'Manufacturability concerns',
+      'Quality concerns',
+      'Attachments',
+    ]),
+    checklist: items([
+      'Concept meets major requirements',
+      'Risks reviewed',
+      'Manufacturing reviewed',
+      'Quality reviewed',
+      'Customer needs considered',
+      'Approval to proceed',
+    ]),
+    approvals: items([
+      'Engineering concept approval',
+      'Quality concept approval',
+      'Manufacturing concept approval',
+    ]),
+  },
+  {
+    key: '7',
+    order: 7,
+    title: 'Detailed Design Outputs',
+    purpose: 'Control the actual design output package.',
+    releaseGate: false,
+    fields: items([
+      'Output package notes',
+      'Linked drawings/BOM/revision package',
+      'Design output owner',
+    ]),
+    checklist: items([
+      'CAD model attached',
+      'Drawing attached',
+      'BOM created',
+      'Material specs defined',
+      'Critical characteristics defined',
+      'Tolerances defined',
+      'Special processes defined',
+      'Inspection points defined',
+      'Test requirements defined',
+      'Software/firmware version defined, if applicable',
+      'Supplier parts identified',
+      'Revision assigned',
+      'Design output approved',
+    ]),
+    approvals: items([
+      'Engineering output approval',
+      'Document control approval',
+    ]),
+  },
+  {
+    key: '8',
+    order: 8,
+    title: 'Prototype Build Record',
+    purpose: 'Document exactly what was built.',
+    releaseGate: false,
+    fields: items([
+      'Prototype serial number',
+      'Build revision',
+      'Build date',
+      'Builder',
+      'Linked BOM revision',
+      'Linked drawing revisions',
+      'Material lots',
+      'Purchased component lots/serials',
+      'Deviations used',
+      'Photos',
+      'Build notes',
+      'Issues found',
+      'Disposition',
+    ]),
+    checklist: [],
+    approvals: items(['Engineering build approval', 'Quality build approval']),
+  },
+  {
+    key: '9',
+    order: 9,
+    title: 'Design Verification',
+    purpose: 'Confirm the design output meets the design inputs.',
+    releaseGate: false,
+    fields: items([
+      'Requirement ID',
+      'Verification method',
+      'Test/inspection performed',
+      'Result',
+      'Pass/fail',
+      'Evidence attachment',
+      'Nonconformance link',
+      'Engineering disposition',
+      'Verified by',
+      'Date',
+    ]),
+    checklist: [],
+    approvals: items(['Verification approval']),
+  },
+  {
+    key: '10',
+    order: 10,
+    title: 'Design Validation',
+    purpose: 'Confirm the product works for the intended use/customer mission.',
+    releaseGate: false,
+    fields: items([
+      'Validation activity',
+      'Intended use tested',
+      'Mission/profile tested',
+      'Customer requirement linked',
+      'Result',
+      'Pass/fail',
+      'Evidence attachment',
+      'Customer witness/approval, if applicable',
+      'Validation approval',
+    ]),
+    checklist: [],
+    approvals: items([
+      'Engineering validation approval',
+      'Quality validation approval',
+      'Customer/program validation approval',
+    ]),
+  },
+  {
+    key: '11',
+    order: 11,
+    title: 'Final Design Review',
+    purpose: 'Cross-functional approval before manufacturing release.',
+    releaseGate: false,
+    fields: items([
+      'Final review notes',
+      'Open issue disposition',
+      'Configuration baseline',
+    ]),
+    checklist: items([
+      'All requirements reviewed',
+      'All high risks closed or accepted',
+      'Design outputs approved',
+      'Prototype build documented',
+      'Verification complete',
+      'Validation complete',
+      'Open issues dispositioned',
+      'Configuration baseline established',
+      'Manufacturing reviewed',
+      'Quality reviewed',
+      'Program management reviewed',
+    ]),
+    approvals: items([
+      'Engineering',
+      'Quality',
+      'Manufacturing',
+      'Program Manager',
+    ]),
+  },
+  {
+    key: '12',
+    order: 12,
+    title: 'Engineering Release Gate',
+    purpose:
+      'Freeze the controlled engineering baseline before manufactured inventory item creation.',
+    releaseGate: true,
+    fields: items([
+      'Release package notes',
+      'Linked project_id / PO / WAD',
+      'Locked design revision baseline',
+    ]),
+    checklist: [
+      item('Released CAD', 'released CAD'),
+      item('Released drawings', 'released drawings'),
+      item('Released BOM', 'released BOM'),
+      item('Approved routing', 'approved routing'),
+      item('Approved traveler requirement', 'approved traveler requirement'),
+      item('Approved work instructions', 'approved work instructions'),
+      item('Approved inspection plan', 'approved inspection plan'),
+      item('Approved test procedure', 'approved test procedure'),
+      item(
+        'Required certifications identified',
+        'required certifications identified'
+      ),
+      item(
+        'Supplier requirements flowed down',
+        'supplier requirements flowed down'
+      ),
+      item('Material requirements approved', 'material requirements approved'),
+      item('Tooling/fixtures ready', 'tooling and fixtures ready', [
+        'tooling/fixtures ready',
+      ]),
+      item(
+        'CNC programs approved, if applicable',
+        'CNC programs approved when applicable',
+        ['CNC programs approved, if applicable']
+      ),
+      item(
+        'Training/certifications complete',
+        'training and certifications complete',
+        ['training/certifications complete']
+      ),
+      item(
+        'Packaging/shipping requirements defined',
+        'packaging and shipping requirements defined',
+        ['packaging/shipping requirements defined']
+      ),
+      item(
+        'Design revision baseline locked',
+        'design revision baseline locked'
+      ),
+    ],
+    approvals: [
+      item('Engineering release approval', 'engineering release approval'),
+      item('Quality release approval', 'quality release approval'),
+      item('Manufacturing release approval', 'manufacturing release approval'),
+      item(
+        'Program Manager release approval',
+        'program manager release approval',
+        ['Program Manager release approval']
+      ),
+    ],
+  },
+] as const satisfies readonly DesignControlWorkflowStep[];
+
+export const DESIGN_CONTROL_STEP_KEYS = DESIGN_CONTROL_WORKFLOW.map(
+  (step) => step.key
+);
+
+export function workflowItemLookupKeys(
+  value: DesignControlWorkflowItem
+): string[] {
+  return Array.from(
+    new Set([value.key, value.label, ...(value.legacyLabels ?? [])])
+  );
+}


### PR DESCRIPTION
## Summary
- add an additive authority lifecycle and partial uniqueness guard for project-linked Design Control records
- centralize the 12-step workflow in one shared client/server definition
- add project-scoped initialization/designation APIs, audited local-project reconciliation, and historical read-only enforcement
- preserve Engineering Release history while blocking new releases from non-authoritative records

## Migration
- 0207_design_control_authority_foundation.sql
- single-record projects are backfilled authoritative
- unresolved duplicates are marked reconciliation_required without selecting or deleting a record
- adds design.control.create and design.control.admin capability grants

## Validation
- focused server: 31 passed
- focused client/component: 4 passed
- focused ESLint: 0 errors, 19 existing-style warnings with Prettier rule disabled
- shared workflow TypeScript check: passed
- git diff --check: passed

## Known unrelated validation
- repository-wide tsc exceeded 5.6 GB working set without producing diagnostics
- existing permissionEnforcement suite has 6 unrelated failures in work-order, traveler, and project-closing mocks/capability expectations

## Scope boundaries
No project or Design Control records are deleted. Historical Engineering Releases are not rewritten. ECR/ECN, controlled forms, Engineering Package changes, and Phase 2B authenticated approvals are not included.