### PR TITLE
Add P1 flat top order workflow

### DIFF
--- a/client/src/components/OrderEntry.tsx
+++ b/client/src/components/OrderEntry.tsx
@@ -4180,6 +4180,7 @@ export default function OrderEntry() {
                         // Clear features that are not available for flattop
                         setFeatures((prev) => ({
                           ...prev,
+                          handedness: undefined,
                           action_length: undefined,
                           action_inlet: undefined,
                           bottom_metal: undefined,
@@ -4501,9 +4502,16 @@ export default function OrderEntry() {
                                 handedness: value === '__NONE__' ? undefined : value,
                               }))
                             }
+                            disabled={isFlattop}
                           >
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select handedness..." />
+                            <SelectTrigger className={isFlattop ? 'opacity-50 cursor-not-allowed' : ''}>
+                              <SelectValue
+                                placeholder={
+                                  isFlattop
+                                    ? 'Not Available (Flattop)'
+                                    : 'Select handedness...'
+                                }
+                              />
                             </SelectTrigger>
                             <SelectContent>
                               <SelectItem value="__NONE__">None</SelectItem>

--- a/client/src/components/POOrderEntry.tsx
+++ b/client/src/components/POOrderEntry.tsx
@@ -399,13 +399,21 @@ export default function POOrderEntry({
       unitPrice: basePrice + featuresPrice,
       totalPrice: totalPrice,
       specifications: {
-        features: features,
+        features: {
+          ...features,
+          isFlattop,
+          flatTop: isFlattop,
+          flat_top: isFlattop,
+          flattop: isFlattop,
+        },
         basePrice: basePrice,
         featuresPrice: featuresPrice,
         priceOverride: priceOverride,
         discountCode: discountCode,
         discountAmount: discountAmount,
         isFlattop: isFlattop,
+        flatTop: isFlattop,
+        flat_top: isFlattop,
       },
       notes: notes,
     };
@@ -423,6 +431,7 @@ export default function POOrderEntry({
         const isRestrictedForFlattop =
           isFlattop &&
           [
+            'handedness',
             'action_length',
             'action_inlet',
             'bottom_metal',
@@ -614,6 +623,7 @@ export default function POOrderEntry({
                   // Clear features that are not available for flattop
                   setFeatures((prev) => ({
                     ...prev,
+                    handedness: undefined,
                     action_length: undefined,
                     action_inlet: undefined,
                     bottom_metal: undefined,

--- a/client/src/pages/BarcodeQueuePage.tsx
+++ b/client/src/pages/BarcodeQueuePage.tsx
@@ -107,18 +107,30 @@ const isFlatTopValue = (value: unknown) =>
   value === true ||
   (typeof value === 'string' && ['true', 'yes', 'flat top', 'flattop'].includes(value.trim().toLowerCase()));
 
-const isRegularFlatTopOrder = (order: any) => {
-  if (!order || String(order.orderId || '').startsWith('PO-')) return false;
-
+const isFlatTopOrder = (order: any) => {
+  if (!order) return false;
+  const specifications = order.specifications ?? order.features?.specifications ?? {};
+  const nestedFeatures = specifications?.features ?? {};
   return (
     isFlatTopValue(order.isFlattop) ||
     isFlatTopValue(order.isFlatTop) ||
     isFlatTopValue(order.flatTop) ||
+    isFlatTopValue(order.flat_top) ||
     isFlatTopValue(order.features?.flattop) ||
     isFlatTopValue(order.features?.flatTop) ||
-    isFlatTopValue(order.features?.flat_top)
+    isFlatTopValue(order.features?.flat_top) ||
+    isFlatTopValue(specifications?.isFlattop) ||
+    isFlatTopValue(specifications?.flatTop) ||
+    isFlatTopValue(specifications?.flat_top) ||
+    isFlatTopValue(nestedFeatures?.isFlattop) ||
+    isFlatTopValue(nestedFeatures?.flatTop) ||
+    isFlatTopValue(nestedFeatures?.flat_top) ||
+    isFlatTopValue(nestedFeatures?.flattop)
   );
 };
+
+const isRegularFlatTopOrder = (order: any) =>
+  !String(order?.orderId || '').startsWith('PO-') && isFlatTopOrder(order);
 
 export default function BarcodeQueuePage() {
   const [selectedOrders, setSelectedOrders] = useState<Set<string>>(new Set());
@@ -521,7 +533,7 @@ export default function BarcodeQueuePage() {
           
           if (isPOItem) {
             // Check if PO item has flattop option
-            const isFlattop = order.features?.flattop === true || order.features?.flattop === 'true';
+            const isFlattop = isFlatTopOrder(order);
             if (isFlattop) {
               poFlatTopOrderIds.push(orderId);
             } else {
@@ -965,7 +977,7 @@ export default function BarcodeQueuePage() {
               const lopVal = (() => { const l = order.features?.length_of_pull; return l?.includes('lop_adj_') ? (l.match(/lop_adj_([\d.]+)/)?.[1] ?? null) : null; })();
               const hasHeavyFill = (() => { const f = order.features; if (!f) return false; const opts = f.other_options; if (Array.isArray(opts) && opts.includes('heavy_fill')) return true; const v = f.heavy_fill || f.heavyFill || f.heavy_fill_option; return v === 'true' || v === true || v === 'yes' || v === 'heavy_fill'; })();
               const hasADL = typeof order.features?.bottom_metal === 'string' && order.features.bottom_metal.toLowerCase().includes('adl');
-              const isRegularFlatTop = isRegularFlatTopOrder(order);
+              const isRegularFlatTop = isFlatTopOrder(order);
 
               return (
                 <Card
@@ -1086,7 +1098,7 @@ export default function BarcodeQueuePage() {
                     const lopVal = (() => { const l = order.features?.length_of_pull; return l?.includes('lop_adj_') ? (l.match(/lop_adj_([\d.]+)/)?.[1] ?? null) : null; })();
                     const hasHeavyFill = (() => { const f = order.features; if (!f) return false; const opts = f.other_options; if (Array.isArray(opts) && opts.includes('heavy_fill')) return true; const v = f.heavy_fill || f.heavyFill || f.heavy_fill_option; return v === 'true' || v === true || v === 'yes' || v === 'heavy_fill'; })();
                     const hasADL = typeof order.features?.bottom_metal === 'string' && order.features.bottom_metal.toLowerCase().includes('adl');
-                    const isRegularFlatTop = isRegularFlatTopOrder(order);
+                    const isRegularFlatTop = isFlatTopOrder(order);
 
                     return (
                       <tr
@@ -1257,7 +1269,7 @@ export default function BarcodeQueuePage() {
                       const lopVal = (() => { const l = order.features?.length_of_pull; return l?.includes('lop_adj_') ? (l.match(/lop_adj_([\d.]+)/)?.[1] ?? null) : null; })();
                       const hasHeavyFill = (() => { const f = order.features; if (!f) return false; const opts = f.other_options; if (Array.isArray(opts) && opts.includes('heavy_fill')) return true; const v = f.heavy_fill || f.heavyFill || f.heavy_fill_option; return v === 'true' || v === true || v === 'yes' || v === 'heavy_fill'; })();
                       const hasADL = typeof order.features?.bottom_metal === 'string' && order.features.bottom_metal.toLowerCase().includes('adl');
-                      const isRegularFlatTop = isRegularFlatTopOrder(order);
+                      const isRegularFlatTop = isFlatTopOrder(order);
 
                       return (
                         <Card
@@ -1583,7 +1595,7 @@ export default function BarcodeQueuePage() {
                             const actionLength = orderLabels2.actionLengthRaw;
                             const isTikka = orderLabels2.isTikka;
                             const materialType = orderLabels2.materialLabel;
-                            const isRegularFlatTop = isRegularFlatTopOrder(order);
+                            const isRegularFlatTop = isFlatTopOrder(order);
 
                             // Check if this is a PO order (no label printing needed)
                             const isPOOrder = order.orderId.startsWith('PO-');
@@ -1699,12 +1711,12 @@ export default function BarcodeQueuePage() {
                                           {getActionBadgeLabel(orderLabels2)} Action
                                         </Badge>
                                         {/* Flattop badge for P1 PO orders */}
-                                        {isPOOrder && (order.features?.flattop === true || order.features?.flattop === 'true') && (
+                                        {isPOOrder && isFlatTopOrder(order) && (
                                           <Badge
                                             variant="outline"
-                                            className="text-xs border-teal-600 text-teal-700 bg-teal-50"
+                                            className="text-xs border-purple-500 text-purple-700 bg-purple-50 font-semibold"
                                           >
-                                            FLATTOP
+                                            Flat Top
                                           </Badge>
                                         )}
                                         <Link

--- a/server/__tests__/p1FlatTopContract.test.ts
+++ b/server/__tests__/p1FlatTopContract.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isP1FlatTop,
+  normalizeP1FlatTopSpecifications,
+} from '../src/utils/p1FlatTop';
+
+describe('P1 Flat Top contract', () => {
+  it('recognizes legacy and current Flat Top shapes', () => {
+    expect(isP1FlatTop({ isFlattop: true })).toBe(true);
+    expect(isP1FlatTop({ flatTop: 'true' })).toBe(true);
+    expect(isP1FlatTop({ features: { flattop: true } })).toBe(true);
+    expect(isP1FlatTop({ features: { flat_top: 'yes' } })).toBe(true);
+    expect(isP1FlatTop({ flatTop: false })).toBe(false);
+  });
+
+  it('writes canonical aliases without discarding other specifications', () => {
+    const normalized = normalizeP1FlatTopSpecifications({
+      isFlattop: true,
+      action_length: 'short',
+      features: { paint: 'black' },
+    });
+
+    expect(normalized).toEqual(
+      expect.objectContaining({
+        action_length: 'short',
+        isFlattop: true,
+        flatTop: true,
+        flat_top: true,
+        features: expect.objectContaining({
+          paint: 'black',
+          isFlattop: true,
+          flatTop: true,
+          flat_top: true,
+          flattop: true,
+        }),
+      }),
+    );
+  });
+});

--- a/server/src/helpers/p1POQueueHelper.ts
+++ b/server/src/helpers/p1POQueueHelper.ts
@@ -1,4 +1,5 @@
 import type { P1POQueueCustomer, P1POQueueItem } from '../../schema';
+import { isP1FlatTop } from '../utils/p1FlatTop';
 
 // ---------------------------------------------------------------------------
 // Low-level fulfillment helpers
@@ -204,10 +205,7 @@ export function computeP1Queue(
             (specs.paint_options as string | null) ??
             null,
           texture: (specs.texture as string | null) ?? null,
-          flatTop:
-            (specs.flatTop as boolean | null) ??
-            (specs.flat_top as boolean | null) ??
-            null,
+          flatTop: isP1FlatTop(specs),
           orderedQuantity: Number(item.quantity || 0),
           availableQuantity,
           departmentStatuses: fulfillmentStats?.departmentStatuses ?? {},

--- a/server/src/routes/p1POQueue.ts
+++ b/server/src/routes/p1POQueue.ts
@@ -7,6 +7,10 @@ import { authorizeApiRoute } from '../../middleware/routeAuthorization';
 import { idempotencyMiddleware, logIdempotencyEvent } from '../../middleware/idempotency';
 import { resolveItemDisplayName } from '../utils/resolveItemDisplayName';
 import { deriveCanonicalMaterial } from '../utils/deriveCanonicalMaterial';
+import {
+  isP1FlatTop,
+  normalizeP1FlatTopSpecifications,
+} from '../utils/p1FlatTop';
 
 const router = Router();
 
@@ -398,7 +402,7 @@ router.post('/schedule', idempotencyMiddleware(), async (req: Request, res: Resp
 
         const specs = item.specifications || {};
         const normalizedSpecs = {
-          ...specs,
+          ...normalizeP1FlatTopSpecifications(specs),
           action_length: specs.action_length || specs.actionLength || '',
         };
         const dueDate = item.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
@@ -723,6 +727,7 @@ router.post('/progress', async (req: Request, res: Response) => {
 
         const item = poItem.rows[0];
         const specs = item.specifications || {};
+        const isFlatTop = isP1FlatTop(specs);
         const dueDate = item.due_date || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
 
         // Lock and progress the exact existing PENDING units. Creating rows here
@@ -752,20 +757,29 @@ router.post('/progress', async (req: Request, res: Response) => {
             po_id: item.po_id,
             specifications: specs,
             action_length: specs.action_length || '',
+            isFlattop: isFlatTop,
+            flatTop: isFlatTop,
+            flat_top: isFlatTop,
+            flattop: isFlatTop,
           });
 
           await client.query(`
             INSERT INTO all_orders (
               order_id, order_date, due_date, customer_id, model_id,
               current_department, status, notes, features, order_source,
-              source_po_id, source_po_item_id, department_history, created_at, updated_at
+              source_po_id, source_po_item_id, department_history, is_flattop,
+              created_at, updated_at
             ) VALUES (
               $1, NOW(), $2, $3, $4, 'Barcode', 'IN_PROGRESS', $5, $6::jsonb,
-              'PO_RELEASE', $7, $8, '[]'::jsonb, NOW(), NOW()
+              'PO_RELEASE', $7, $8, '[]'::jsonb, $9, NOW(), NOW()
             )
             ON CONFLICT (order_id) DO UPDATE
-            SET current_department = 'Barcode', status = 'IN_PROGRESS', updated_at = NOW()
-          `, [orderId, dueDate, item.customer_id || item.customer_name, item.item_id || '', notes, features, item.po_id, poItemId]);
+            SET current_department = 'Barcode',
+                status = 'IN_PROGRESS',
+                features = EXCLUDED.features,
+                is_flattop = EXCLUDED.is_flattop,
+                updated_at = NOW()
+          `, [orderId, dueDate, item.customer_id || item.customer_name, item.item_id || '', notes, features, item.po_id, poItemId, isFlatTop]);
 
           await client.query(`
             UPDATE production_orders

--- a/server/src/routes/poShippingQC.ts
+++ b/server/src/routes/poShippingQC.ts
@@ -17,6 +17,7 @@ import {
 } from '../services/p1ShipmentRevenueService';
 import { buildRevenueDimensionTags } from '../services/productionLineAccounting';
 import { deriveP1ProductionStatus } from '../utils/p1ProductionStatus';
+import { isP1FlatTop } from '../utils/p1FlatTop';
 
 const router = Router();
 
@@ -1159,6 +1160,7 @@ router.post('/smart-progress', async (req, res) => {
 
     const results = {
       toShippingQC: [] as string[],
+      toFinish: [] as string[],
       toCNC: [] as string[],
       failed: [] as { orderId: string; reason: string }[],
     };
@@ -1183,6 +1185,14 @@ router.post('/smart-progress', async (req, res) => {
           console.warn(
             `⚠️ ${orderId}: Wrong department (${order.currentDepartment})`
           );
+          continue;
+        }
+
+        if (isP1FlatTop(order.specifications)) {
+          await storage.updateProductionOrder(order.id, {
+            currentDepartment: 'Finish',
+          });
+          results.toFinish.push(orderId);
           continue;
         }
 
@@ -1229,9 +1239,10 @@ router.post('/smart-progress', async (req, res) => {
     // Always return 200 with success/failed arrays
     res.json({
       toShippingQC: results.toShippingQC,
+      toFinish: results.toFinish,
       toCNC: results.toCNC,
       failed: results.failed,
-      message: `Progressed ${results.toShippingQC.length + results.toCNC.length}/${orderIds.length} items`,
+      message: `Progressed ${results.toShippingQC.length + results.toFinish.length + results.toCNC.length}/${orderIds.length} items`,
     });
   } catch (error: any) {
     console.error('❌ Error in smart progression:', error);

--- a/server/src/utils/p1FlatTop.ts
+++ b/server/src/utils/p1FlatTop.ts
@@ -1,0 +1,54 @@
+const isTrueFlatTopValue = (value: unknown) =>
+  value === true ||
+  (typeof value === 'string' &&
+    ['true', 'yes', 'flat top', 'flattop'].includes(value.trim().toLowerCase()));
+
+export function isP1FlatTop(specifications: unknown): boolean {
+  const specs =
+    specifications && typeof specifications === 'object'
+      ? (specifications as Record<string, any>)
+      : {};
+  const features =
+    specs.features && typeof specs.features === 'object'
+      ? (specs.features as Record<string, any>)
+      : {};
+
+  return [
+    specs.isFlattop,
+    specs.isFlatTop,
+    specs.flatTop,
+    specs.flat_top,
+    specs.flattop,
+    features.isFlattop,
+    features.isFlatTop,
+    features.flatTop,
+    features.flat_top,
+    features.flattop,
+  ].some(isTrueFlatTopValue);
+}
+
+export function normalizeP1FlatTopSpecifications(specifications: unknown) {
+  const specs =
+    specifications && typeof specifications === 'object'
+      ? (specifications as Record<string, any>)
+      : {};
+  const features =
+    specs.features && typeof specs.features === 'object'
+      ? (specs.features as Record<string, any>)
+      : {};
+  const flatTop = isP1FlatTop(specs);
+
+  return {
+    ...specs,
+    isFlattop: flatTop,
+    flatTop,
+    flat_top: flatTop,
+    features: {
+      ...features,
+      isFlattop: flatTop,
+      flatTop,
+      flat_top: flatTop,
+      flattop: flatTop,
+    },
+  };
+}


### PR DESCRIPTION
## What changed

- lets users select Flat Top alongside the stock model in regular and P1 PO order entry
- clears and disables handedness, action length, action inlet, bottom metal, and barrel inlet for Flat Top items
- normalizes legacy and current Flat Top field names across P1 queue generation
- preserves the Flat Top flag when P1 production units move into the Barcode `all_orders` read model
- routes Flat Top PO items from Barcode directly to Finish, skipping CNC and Gunsmith
- displays a Flat Top badge across Barcode card and list layouts

## Why

Flat Top was stored under inconsistent field names at different workflow stages. That caused the P1 production and Barcode paths to lose the classification, show no badge, or route the item through normal CNC processing.

## Impact

Flat Top items now require no machining configuration for the five irrelevant fields and follow the intended production route consistently from order entry onward.

## Validation

- `vitest --config vitest.config.server.ts server/__tests__/p1FlatTopContract.test.ts` — 2 tests passed
- `tsc --noEmit --pretty false` — passed
- `git diff --check` — passed