### PR TITLE
Correct P2 V2 technical and configuration review scope

### DIFF
--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -14,7 +14,7 @@ const stages = Array.from({ length: 10 }, (_, index) => ({
         : index === 2
           ? 'contract_review'
           : index === 3
-            ? 'design_applicability'
+            ? 'technical_configuration_review'
             : index === 4
               ? 'production_planning'
               : index === 5
@@ -154,10 +154,17 @@ describe('P2V2ProjectWorkflow', () => {
     expect(
       screen.getByTestId('open-commercial-review-contract_review')
     ).toBeInTheDocument();
-    expect(screen.getByTestId('open-design-applicability')).toBeInTheDocument();
     expect(
-      screen.getAllByRole('button', { name: 'Open Design Applicability' })
+      screen.getByTestId('open-technical-configuration-review')
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', {
+        name: 'Open Technical & Configuration Review',
+      })
     ).toHaveLength(1);
+    expect(
+      screen.queryByRole('button', { name: 'Open Design Applicability' })
+    ).not.toBeInTheDocument();
     expect(
       screen.getAllByRole('button', { name: 'Open Production Planning' })
     ).toHaveLength(1);

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -12,6 +12,7 @@ import {
 
 import P2V2DesignApplicability from './P2V2DesignApplicability';
 import P2V2ProductionPlanning from './P2V2ProductionPlanning';
+import P2V2TechnicalConfigurationReview from './P2V2TechnicalConfigurationReview';
 import P2V2WadAuthorization from './P2V2WadAuthorization';
 import P2V2CommercialReview from './P2V2CommercialReview';
 
@@ -397,6 +398,11 @@ export default function P2V2ProjectWorkflow({
               {stage.stepType === 'design_applicability' && (
                 <div className="mt-3">
                   <P2V2DesignApplicability projectId={projectId} />
+                </div>
+              )}
+              {stage.stepType === 'technical_configuration_review' && (
+                <div className="mt-3">
+                  <P2V2TechnicalConfigurationReview projectId={projectId} />
                 </div>
               )}
               {stage.stepType === 'production_planning' && (

--- a/client/src/components/projects/P2V2TechnicalConfigurationReview.tsx
+++ b/client/src/components/projects/P2V2TechnicalConfigurationReview.tsx
@@ -1,0 +1,493 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+// The additive API deliberately carries revision snapshots as JSON.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+type Model = {
+  review: Row | null;
+  history: Row[];
+  approvals: Row[];
+  requiredApprovals: string[];
+  readiness: {
+    ready: boolean;
+    stale: boolean;
+    blockers: string[];
+    differences: string[];
+  };
+};
+const endpoint = (projectId: string) =>
+  `/api/projects/${projectId}/workflow-v2/technical-configuration-review`;
+async function request(url: string, method = 'GET', body?: unknown) {
+  const response = await fetch(url, {
+    method,
+    credentials: 'include',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok)
+    throw new Error(data.message || data.error || 'Request failed');
+  return data;
+}
+const pretty = (value: unknown) => JSON.stringify(value ?? [], null, 2);
+const parseArray = (value: string, label: string) => {
+  const parsed = JSON.parse(value || '[]');
+  if (!Array.isArray(parsed)) throw new Error(`${label} must be a JSON array.`);
+  return parsed;
+};
+
+const baselineFields = [
+  [
+    'partRequirements',
+    'Part, quantity, drawing and specification requirements',
+  ],
+  ['configurationReferences', 'Configuration and BOM references'],
+  ['qualityClauses', 'Customer-specific quality clauses'],
+  ['specialRequirements', 'Special requirements'],
+  ['keyCharacteristics', 'Key characteristics'],
+  ['criticalItems', 'Critical items and product-safety controls'],
+  ['materialRequirements', 'Material requirements'],
+  ['certificationRequirements', 'Certification requirements'],
+  ['testReportRequirements', 'Test-report requirements'],
+  ['faiRequirements', 'FAI requirements'],
+  ['sourceInspectionRequirements', 'Source-inspection requirements'],
+  ['specialProcesses', 'Special processes and approved sources'],
+  ['traceabilityRequirements', 'Traceability requirements'],
+  ['preservationPackagingRequirements', 'Preservation and packaging'],
+  ['acceptanceCriteria', 'Acceptance criteria'],
+  ['counterfeitPreventionRequirements', 'Counterfeit-part prevention'],
+  ['customerProperty', 'Customer-furnished property'],
+  ['regulatoryRequirements', 'Regulatory and statutory requirements'],
+  ['deviationsWaivers', 'Approved deviations, waivers and concessions'],
+] as const;
+
+export default function P2V2TechnicalConfigurationReview({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [effectivityReference, setEffectivityReference] = useState('');
+  const [sufficientlyDefined, setSufficientlyDefined] = useState(false);
+  const [supplyChainRequired, setSupplyChainRequired] = useState(false);
+  const [baseline, setBaseline] = useState<Record<string, string>>(
+    Object.fromEntries(baselineFields.map(([key]) => [key, '[]']))
+  );
+  const [releasedEvidence, setReleasedEvidence] = useState('[]');
+  const [conflicts, setConflicts] = useState('[]');
+  const [missingInformation, setMissingInformation] = useState('[]');
+  const [risks, setRisks] = useState('[]');
+  const [error, setError] = useState('');
+  const client = useQueryClient();
+  const key = [
+    '/api/projects',
+    projectId,
+    'workflow-v2',
+    'technical-configuration-review',
+  ];
+  const { data, isLoading } = useQuery<Model>({
+    queryKey: key,
+    queryFn: () => request(endpoint(projectId)),
+    enabled: open,
+  });
+  const { data: permissions } = useQuery<{ permissions: string[] }>({
+    queryKey: ['/api/permissions/me'],
+    queryFn: () => request('/api/permissions/me'),
+  });
+  const allowed = useMemo(
+    () => new Set(permissions?.permissions ?? []),
+    [permissions]
+  );
+  const mutation = useMutation({
+    mutationFn: (input: { url: string; method?: string; body?: unknown }) =>
+      request(input.url, input.method, input.body),
+    onSuccess: async () => {
+      setError('');
+      await client.invalidateQueries({ queryKey: key });
+      await client.invalidateQueries({
+        queryKey: ['/api/projects', projectId, 'workflow-v2'],
+      });
+    },
+    onError: (cause: Error) => setError(cause.message),
+  });
+  const review = data?.review;
+  const reviewId = String(review?.id ?? '');
+  const revision = Number(review?.revision_number ?? 0);
+  const token = Number(review?.lock_version ?? revision);
+  const status = String(review?.status ?? '');
+
+  useEffect(() => {
+    if (!review) return;
+    setEffectivityReference(String(review.effectivity_reference ?? ''));
+    setSufficientlyDefined(Boolean(review.sufficiently_defined));
+    setSupplyChainRequired(Boolean(review.supply_chain_required));
+    setBaseline(
+      Object.fromEntries(
+        baselineFields.map(([field]) => [
+          field,
+          pretty(review.technical_baseline?.[field]),
+        ])
+      )
+    );
+    setReleasedEvidence(pretty(review.released_evidence));
+    setConflicts(pretty(review.conflicts));
+    setMissingInformation(pretty(review.missing_information));
+    setRisks(pretty(review.risks));
+  }, [review]);
+
+  const body = () => ({
+    technicalBaseline: Object.fromEntries(
+      baselineFields.map(([field, label]) => [
+        field,
+        parseArray(baseline[field], label),
+      ])
+    ),
+    releasedEvidence: parseArray(releasedEvidence, 'Released evidence'),
+    conflicts: parseArray(conflicts, 'Conflicts'),
+    missingInformation: parseArray(missingInformation, 'Missing information'),
+    risks: parseArray(risks, 'Risks'),
+    sufficientlyDefined,
+    supplyChainRequired,
+    effectivityReference,
+  });
+  const run = (suffix: string, payload: unknown, method = 'POST') =>
+    mutation.mutate({
+      url: `${endpoint(projectId)}${suffix}`,
+      method,
+      body: payload,
+    });
+  const save = () => {
+    try {
+      const payload = body();
+      if (reviewId)
+        run(`/${reviewId}`, { ...payload, expectedRevision: token }, 'PATCH');
+      else run('', payload);
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : 'Invalid review input.'
+      );
+    }
+  };
+  const decide = (capacity: string, decision: 'APPROVED' | 'REJECTED') => {
+    const signatureMeaning = window.prompt(
+      'Signature meaning (required):',
+      `I ${decision === 'APPROVED' ? 'confirm' : 'reject'} this manufacturing technical/configuration review revision.`
+    );
+    if (!signatureMeaning) return;
+    const reason =
+      window.prompt(
+        decision === 'REJECTED' ? 'Reason (required):' : 'Comment:',
+        ''
+      ) ?? '';
+    if (decision === 'REJECTED' && !reason.trim()) return;
+    run(`/${reviewId}/${capacity}-decision`, {
+      expectedRevision: token,
+      decision,
+      signatureMeaning,
+      reason,
+    });
+  };
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        data-testid="open-technical-configuration-review"
+      >
+        Open Technical &amp; Configuration Review
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[92vh] max-w-6xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Technical &amp; Configuration Review</DialogTitle>
+            <DialogDescription>
+              Confirm that the customer PO has a complete, current, approved and
+              unambiguous manufacturing and inspection baseline. Referenced
+              released engineering evidence is read-only.
+            </DialogDescription>
+          </DialogHeader>
+          {isLoading ? (
+            <p>Loading Technical &amp; Configuration Review…</p>
+          ) : (
+            <div className="space-y-5 text-sm">
+              <div className="flex flex-wrap gap-2">
+                <Badge>{status || 'NOT STARTED'}</Badge>
+                {review && (
+                  <Badge variant="outline">Review revision {revision}</Badge>
+                )}
+                {data?.readiness.stale && (
+                  <Badge variant="destructive">TECHNICAL SOURCE CHANGED</Badge>
+                )}
+              </div>
+              {error && (
+                <p className="rounded bg-red-50 p-2 text-red-700">{error}</p>
+              )}
+              {review && (
+                <section className="grid gap-3 md:grid-cols-3">
+                  <div>
+                    <p className="text-xs text-muted-foreground">Customer PO</p>
+                    <p className="font-medium">
+                      {review.source_snapshot?.po?.po_number ?? review.po_id}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">PO revision</p>
+                    <p className="font-medium">{review.po_revision_number}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground">
+                      Source revision
+                    </p>
+                    <p className="break-all font-mono text-xs">
+                      {review.source_revision}
+                    </p>
+                  </div>
+                </section>
+              )}
+              <div className="grid gap-3 md:grid-cols-3">
+                <div>
+                  <Label>Delivery and configuration effectivity</Label>
+                  <Input
+                    value={effectivityReference}
+                    onChange={(event) =>
+                      setEffectivityReference(event.target.value)
+                    }
+                  />
+                </div>
+                <label className="self-end">
+                  <input
+                    type="checkbox"
+                    checked={sufficientlyDefined}
+                    onChange={(event) =>
+                      setSufficientlyDefined(event.target.checked)
+                    }
+                  />{' '}
+                  Baseline is complete, approved and unambiguous
+                </label>
+                <label className="self-end">
+                  <input
+                    type="checkbox"
+                    checked={supplyChainRequired}
+                    onChange={(event) =>
+                      setSupplyChainRequired(event.target.checked)
+                    }
+                  />{' '}
+                  Supply Chain confirmation required
+                </label>
+              </div>
+              <section className="grid gap-3 md:grid-cols-2">
+                {baselineFields.map(([field, label]) => (
+                  <div key={field}>
+                    <Label>{label} (JSON)</Label>
+                    <Textarea
+                      rows={field === 'partRequirements' ? 8 : 4}
+                      value={baseline[field]}
+                      onChange={(event) =>
+                        setBaseline((current) => ({
+                          ...current,
+                          [field]: event.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+                ))}
+              </section>
+              <section className="grid gap-3 md:grid-cols-2">
+                <div>
+                  <Label>Released technical evidence (JSON)</Label>
+                  <Textarea
+                    rows={7}
+                    value={releasedEvidence}
+                    onChange={(event) =>
+                      setReleasedEvidence(event.target.value)
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Controlled documents, released BOM revisions, and released
+                    engineering outputs may be referenced read-only.
+                  </p>
+                </div>
+                <div>
+                  <Label>
+                    Technical/configuration conflicts and resolutions
+                  </Label>
+                  <Textarea
+                    rows={7}
+                    value={conflicts}
+                    onChange={(event) => setConflicts(event.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label>Missing or obsolete technical information</Label>
+                  <Textarea
+                    rows={6}
+                    value={missingInformation}
+                    onChange={(event) =>
+                      setMissingInformation(event.target.value)
+                    }
+                  />
+                </div>
+                <div>
+                  <Label>Manufacturing risks, owners and controls</Label>
+                  <Textarea
+                    rows={6}
+                    value={risks}
+                    onChange={(event) => setRisks(event.target.value)}
+                  />
+                </div>
+              </section>
+              <section>
+                <h4 className="font-medium">Readiness and downstream impact</h4>
+                {data?.readiness.blockers.length ? (
+                  <ul className="list-disc pl-5 text-red-700">
+                    {data.readiness.blockers.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-green-700">
+                    The technical/configuration baseline is current and ready.
+                  </p>
+                )}
+                <p className="text-muted-foreground">
+                  A stale baseline blocks Production Planning and WAD
+                  Authorization. Existing released plans and authorizations are
+                  preserved and must be revised through their controlled
+                  workflows.
+                </p>
+              </section>
+              <section>
+                <h4 className="font-medium">
+                  Required functional confirmations
+                </h4>
+                <p>{data?.requiredApprovals.join(', ')}</p>
+                <ul>
+                  {data?.approvals.map((approval) => (
+                    <li key={approval.id}>
+                      {approval.approval_type}: {approval.decision} —{' '}
+                      {approval.actor_display_name}
+                      {approval.invalidated ? ' (invalidated)' : ''}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+              <section>
+                <h4 className="font-medium">Immutable revision history</h4>
+                <ul>
+                  {data?.history.map((item) => (
+                    <li key={item.id}>
+                      Revision {item.revision_number}: {item.status} — PO
+                      revision {item.po_revision_number}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+              <div className="flex flex-wrap gap-2">
+                {allowed.has('projects.technical_configuration.manage') &&
+                  (!status || status === 'DRAFT') && (
+                    <Button onClick={save} disabled={mutation.isPending}>
+                      {review ? 'Save Draft' : 'Create Draft'}
+                    </Button>
+                  )}
+                {status === 'DRAFT' && (
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      run(`/${reviewId}/submit`, { expectedRevision: token })
+                    }
+                  >
+                    Submit for Functional Review
+                  </Button>
+                )}
+                {status === 'PENDING_APPROVAL' &&
+                  data?.requiredApprovals.map((role) => {
+                    const capacity =
+                      role === 'PROJECT_MANAGEMENT'
+                        ? 'pm'
+                        : role === 'SUPPLY_CHAIN'
+                          ? 'supply-chain'
+                          : role.toLowerCase();
+                    const capability = `projects.technical_configuration.${role === 'PROJECT_MANAGEMENT' ? 'pm' : role.toLowerCase()}_decide`;
+                    return allowed.has(capability) ? (
+                      <span key={role} className="flex gap-1">
+                        <Button
+                          size="sm"
+                          onClick={() => decide(capacity, 'APPROVED')}
+                        >
+                          Confirm {role}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => decide(capacity, 'REJECTED')}
+                        >
+                          Reject
+                        </Button>
+                      </span>
+                    ) : null;
+                  })}
+                {status === 'PENDING_APPROVAL' &&
+                  allowed.has('projects.technical_configuration.manage') && (
+                    <Button
+                      onClick={() =>
+                        run(`/${reviewId}/complete`, {
+                          expectedRevision: token,
+                        })
+                      }
+                    >
+                      Complete Stage
+                    </Button>
+                  )}
+                {reviewId &&
+                  status !== 'DRAFT' &&
+                  allowed.has('projects.technical_configuration.manage') && (
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        try {
+                          run(`/${reviewId}/revise`, {
+                            ...body(),
+                            expectedRevision: token,
+                          });
+                        } catch (cause) {
+                          setError(
+                            cause instanceof Error
+                              ? cause.message
+                              : 'Invalid review input.'
+                          );
+                        }
+                      }}
+                    >
+                      Create New Revision
+                    </Button>
+                  )}
+              </div>
+              <p className="rounded bg-slate-50 p-3 text-xs text-muted-foreground">
+                Operational scope: AS9100 8.1, 8.1.2, applicable 8.1.3 and
+                8.1.4, 8.2, applicable 8.4, 8.5, and 8.6. Product design and
+                development remain exclusively in the separate Design Control
+                module.
+              </p>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/migrations/0209_project_technical_configuration_reviews.sql
+++ b/migrations/0209_project_technical_configuration_reviews.sql
@@ -1,0 +1,98 @@
+-- Phase 8B: manufacturing Technical & Configuration Review for p2_v2 definition v2.
+-- Migration 0203 and its Design Applicability records remain intact for definition-v1 compatibility.
+-- No legacy rows are backfilled and no Design Control, PO, production, or release records are changed.
+CREATE TABLE IF NOT EXISTS project_technical_configuration_reviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  workflow_instance_id UUID NOT NULL,
+  workflow_step_instance_id UUID NOT NULL,
+  workflow_step_type TEXT NOT NULL DEFAULT 'technical_configuration_review'
+    CHECK (workflow_step_type = 'technical_configuration_review'),
+  revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+  lock_version INTEGER NOT NULL DEFAULT 1 CHECK (lock_version > 0),
+  status TEXT NOT NULL DEFAULT 'DRAFT'
+    CHECK (status IN ('DRAFT','PENDING_APPROVAL','COMPLETE','REJECTED','STALE','INVALIDATED','SUPERSEDED')),
+  po_id INTEGER REFERENCES p2_purchase_orders(id) ON DELETE RESTRICT,
+  po_revision_number INTEGER NOT NULL,
+  source_revision TEXT NOT NULL,
+  source_snapshot JSONB NOT NULL,
+  technical_baseline JSONB NOT NULL,
+  released_evidence JSONB NOT NULL DEFAULT '[]'::jsonb,
+  conflicts JSONB NOT NULL DEFAULT '[]'::jsonb,
+  missing_information JSONB NOT NULL DEFAULT '[]'::jsonb,
+  risks JSONB NOT NULL DEFAULT '[]'::jsonb,
+  sufficiently_defined BOOLEAN NOT NULL DEFAULT false,
+  supply_chain_required BOOLEAN NOT NULL DEFAULT false,
+  effectivity_reference TEXT NOT NULL,
+  owner_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  owner_display_name TEXT,
+  submitted_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  invalidated_at TIMESTAMP,
+  invalidation_reason TEXT,
+  superseded_at TIMESTAMP,
+  superseded_by_review_id UUID REFERENCES project_technical_configuration_reviews(id) ON DELETE RESTRICT,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_technical_review_instance_project_fk
+    FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_technical_review_step_project_fk
+    FOREIGN KEY (workflow_step_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, project_id) ON DELETE RESTRICT,
+  CONSTRAINT project_technical_review_revision_unique
+    UNIQUE (project_id, workflow_instance_id, revision_number)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS project_technical_reviews_current_unique
+  ON project_technical_configuration_reviews(project_id, workflow_instance_id)
+  WHERE status IN ('DRAFT','PENDING_APPROVAL','COMPLETE');
+CREATE INDEX IF NOT EXISTS project_technical_reviews_project_idx
+  ON project_technical_configuration_reviews(project_id, revision_number DESC);
+
+INSERT INTO perm_capabilities (key, description, category) VALUES
+ ('projects.technical_configuration.manage','Draft, submit and revise P2 V2 technical and configuration reviews','projects'),
+ ('projects.technical_configuration.pm_decide','Confirm customer-order and scope alignment','projects'),
+ ('projects.technical_configuration.engineering_decide','Confirm technical package and manufacturability','engineering'),
+ ('projects.technical_configuration.quality_decide','Confirm inspection, acceptance and quality-clause requirements','quality'),
+ ('projects.technical_configuration.operations_decide','Confirm production capability, capacity and execution readiness','operations'),
+ ('projects.technical_configuration.supply_chain_decide','Confirm conditional external-source and material readiness','procurement')
+ON CONFLICT (key) DO UPDATE
+SET description=EXCLUDED.description, category=EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT pr.id, pc.id
+FROM perm_roles pr
+JOIN perm_capabilities pc ON (
+ (pr.name IN ('ADMIN','OWNER') AND pc.key LIKE 'projects.technical_configuration.%') OR
+ (pr.name IN ('PROJECT_MANAGER','PROGRAM_MANAGER','SALES','CONTRACTS') AND pc.key IN ('projects.technical_configuration.manage','projects.technical_configuration.pm_decide')) OR
+ (pr.name IN ('ENGINEERING','ENGINEER','ENGINEERING_MANAGER','MANUFACTURING_ENGINEERING') AND pc.key IN ('projects.technical_configuration.manage','projects.technical_configuration.engineering_decide')) OR
+ (pr.name IN ('QUALITY','QC','QUALITY_MANAGER') AND pc.key='projects.technical_configuration.quality_decide') OR
+ (pr.name IN ('OPERATIONS','OPERATIONS_MANAGER','PRODUCTION_MANAGER','MANAGER') AND pc.key='projects.technical_configuration.operations_decide') OR
+ (pr.name IN ('PROCUREMENT','PURCHASING','SUPPLY_CHAIN','SUPPLY_CHAIN_MANAGER') AND pc.key='projects.technical_configuration.supply_chain_decide')
+)
+ON CONFLICT (role_id, capability_id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION protect_technical_configuration_review_snapshots()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.status <> 'DRAFT' AND (
+    NEW.po_id IS DISTINCT FROM OLD.po_id OR
+    NEW.po_revision_number IS DISTINCT FROM OLD.po_revision_number OR
+    NEW.source_revision IS DISTINCT FROM OLD.source_revision OR
+    NEW.source_snapshot IS DISTINCT FROM OLD.source_snapshot OR
+    NEW.technical_baseline IS DISTINCT FROM OLD.technical_baseline OR
+    NEW.released_evidence IS DISTINCT FROM OLD.released_evidence
+  ) THEN
+    RAISE EXCEPTION 'Submitted technical/configuration review snapshots are immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS protect_technical_configuration_review_snapshots_trigger
+  ON project_technical_configuration_reviews;
+CREATE TRIGGER protect_technical_configuration_review_snapshots_trigger
+BEFORE UPDATE ON project_technical_configuration_reviews
+FOR EACH ROW EXECUTE FUNCTION protect_technical_configuration_review_snapshots();

--- a/server/__tests__/projectTechnicalConfigurationReview.test.ts
+++ b/server/__tests__/projectTechnicalConfigurationReview.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(__dirname, '../..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+const service = read(
+  'server/src/services/projectTechnicalConfigurationReviewService.ts'
+);
+const route = read('server/src/routes/projectTechnicalConfigurationReview.ts');
+const migration = read(
+  'migrations/0209_project_technical_configuration_reviews.sql'
+);
+const productionPlanning = read(
+  'server/src/services/projectProductionPlanningService.ts'
+);
+const wadAuthorization = read(
+  'server/src/services/projectWadAuthorizationService.ts'
+);
+const designMigration = read(
+  'migrations/0203_project_design_applicability_decisions.sql'
+);
+
+describe('Phase 8B technical and configuration review boundaries', () => {
+  it('adds revision-controlled technical review storage without rewriting Phase 5 or legacy data', () => {
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS project_technical_configuration_reviews'
+    );
+    expect(migration).toContain('lock_version INTEGER NOT NULL DEFAULT 1');
+    expect(migration).toContain('source_snapshot JSONB NOT NULL');
+    expect(migration).toContain('technical_baseline JSONB NOT NULL');
+    expect(migration).not.toMatch(/UPDATE\s+(projects|project_steps)\b/i);
+    expect(migration).not.toMatch(/\bDROP\s+TABLE\b|\bDELETE\s+FROM\b/i);
+    expect(designMigration).toContain(
+      'CREATE TABLE IF NOT EXISTS project_design_applicability_decisions'
+    );
+  });
+
+  it('requires the three commercial predecessors and a current authoritative baseline', () => {
+    expect(service).toContain(
+      "const required = ['rfq_risk_assessment', 'estimate_quote', 'contract_review']"
+    );
+    expect(service).toContain('evaluateCommercialBaseline(projectId, tx)');
+    expect(service).toContain(
+      'sourceSnapshot(projectId, ctx.project.po_id, tx)'
+    );
+    expect(service).toContain(
+      'released drawing/specification revision or approved exception is required'
+    );
+    expect(service).toContain(
+      'Every technical/configuration conflict requires a resolution.'
+    );
+    expect(service).toContain(
+      'Required technical information remains missing.'
+    );
+  });
+
+  it('uses manufacturing functions, conditional Supply Chain, and segregation of duties', () => {
+    for (const role of [
+      'PROJECT_MANAGEMENT',
+      'ENGINEERING',
+      'QUALITY',
+      'OPERATIONS',
+      'SUPPLY_CHAIN',
+    ])
+      expect(service).toContain(`'${role}'`);
+    expect(service).toContain(
+      "...(supplyChainRequired ? ['SUPPLY_CHAIN'] : [])"
+    );
+    expect(service).toContain(
+      'One actor cannot represent multiple required manufacturing functions.'
+    );
+    expect(service).toContain('step_revision_snapshot');
+    expect(service).toContain('revision: review.revision_number');
+  });
+
+  it('preserves submitted history, invalidates superseded approvals, and rejects concurrent writes', () => {
+    expect(migration).toContain("OLD.status <> 'DRAFT'");
+    expect(service).toContain(
+      'WHERE id=${reviewId} AND lock_version=${expectedRevision}'
+    );
+    expect(service).toContain("'STALE_REVISION'");
+    expect(service).toContain("status='SUPERSEDED'");
+    expect(service).toContain("'{invalidated}'");
+    expect(route).not.toMatch(/router\.delete/i);
+  });
+
+  it('references only released technical evidence and exposes no Design Control mutation', () => {
+    expect(service).toContain("'CONTROLLED_DOCUMENT'");
+    expect(service).toContain("'BOM_REVISION'");
+    expect(service).toContain("'ENGINEERING_RELEASE'");
+    expect(service).toContain(
+      'SELECT id,release_revision revision,release_status status,released_at updated_at FROM engineering_releases'
+    );
+    expect(service).not.toMatch(
+      /(?:INSERT\s+INTO|UPDATE)\s+(?:rd_projects|design_projects|engineering_changes|ecrs|ecns)\b/i
+    );
+    expect(route).not.toMatch(
+      /design-(?:input|output|verification|validation|release)|\becr\b|\becn\b/i
+    );
+  });
+
+  it('propagates stale technical-baseline blockers without changing released production records', () => {
+    expect(productionPlanning).toContain(
+      'evaluateTechnicalConfigurationBaseline(projectId, tx)'
+    );
+    expect(wadAuthorization).toContain(
+      'evaluateTechnicalConfigurationBaseline'
+    );
+    expect(productionPlanning).toContain(
+      "'TECHNICAL_CONFIGURATION_BASELINE_INVALID'"
+    );
+    for (const source of [service, productionPlanning, wadAuthorization]) {
+      expect(source).not.toMatch(
+        /(?:INSERT\s+INTO|DELETE\s+FROM)\s+(?:production_orders|travelers|inventory_transactions|shipments|project_closings)\b/i
+      );
+    }
+  });
+
+  it('fails closed outside definition-version 2 and keeps build-to-print independent of Design Projects', () => {
+    expect(service).toContain("workflowVersion !== 'p2_v2'");
+    expect(service).toContain('Number(instances[0].definition_version) !== 2');
+    expect(service).not.toContain('CUSTOMER_BUILD_TO_PRINT');
+    expect(service).not.toContain('Design Project');
+    expect(service).not.toContain('createDesign');
+  });
+});

--- a/server/__tests__/projectWorkflowInstance.test.ts
+++ b/server/__tests__/projectWorkflowInstance.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getInternalP2V2InitializationStages,
+  getP2V2StagesForDefinitionVersion,
   P2_V2_DEFINITION_VERSION,
 } from '../src/services/projectWorkflowRegistry';
 import { validateWorkflowInstanceIntegrity } from '../src/services/projectWorkflowInstanceIntegrity';
@@ -67,7 +68,7 @@ describe('p2_v2 workflow instance snapshots and integrity', () => {
       'rfq_risk_assessment',
       'estimate_quote',
       'contract_review',
-      'design_applicability',
+      'technical_configuration_review',
       'production_planning',
       'wad_authorization',
       'preproduction_release',
@@ -82,6 +83,22 @@ describe('p2_v2 workflow instance snapshots and integrity', () => {
 
   it('accepts a complete registry-matching instance', () => {
     expect(validateWorkflowInstanceIntegrity(instance, validSteps)).toEqual([]);
+  });
+
+  it('continues to validate stored definition-version-1 snapshots unchanged', () => {
+    const legacySnapshot = getP2V2StagesForDefinitionVersion(1);
+    expect(
+      validateWorkflowInstanceIntegrity(
+        { ...instance, definition_version: 1 },
+        legacySnapshot.map((stage) => ({
+          project_id: instance.project_id,
+          step_type: stage.type,
+          step_order: stage.order,
+          label_snapshot: stage.label,
+          description_snapshot: stage.description,
+        }))
+      )
+    ).toEqual([]);
   });
 
   it('reports missing, duplicate, order, project, unknown, definition, and version corruption', () => {

--- a/server/__tests__/projectWorkflowRegistry.test.ts
+++ b/server/__tests__/projectWorkflowRegistry.test.ts
@@ -9,6 +9,7 @@ import {
   getOrderedProjectWorkflowSteps,
   getProjectWorkflowDefinition,
   getProjectWorkflowStepDefinition,
+  getP2V2StagesForDefinitionVersion,
   isLegacyProjectWorkflow,
   LEGACY_STARTUP_REPAIR_STEPS,
   validateProjectWorkflowDefinition,
@@ -51,7 +52,7 @@ describe('project workflow registry', () => {
     expect(isLegacyProjectWorkflow('legacy_v1')).toBe(true);
   });
 
-  it('defines p2_v2 as ten inactive metadata stages with no database steps', () => {
+  it('defines p2_v2 as ten inactive customer-PO workflow stages with no database steps', () => {
     const definition = getProjectWorkflowDefinition('p2_v2');
     expect(definition).toMatchObject({
       version: 'p2_v2',
@@ -62,16 +63,22 @@ describe('project workflow registry', () => {
     expect(
       definition.stages.map(({ type, label }) => ({ type, label }))
     ).toEqual([
-      { type: 'rfq_risk_assessment', label: 'RFQ & Risk' },
+      { type: 'rfq_risk_assessment', label: 'RFQ Review' },
       { type: 'estimate_quote', label: 'Estimate & Quote' },
-      { type: 'contract_review', label: 'PO & Contract Review' },
-      { type: 'design_applicability', label: 'Design Applicability' },
+      { type: 'contract_review', label: 'Contract Review' },
+      {
+        type: 'technical_configuration_review',
+        label: 'Technical & Configuration Review',
+      },
       { type: 'production_planning', label: 'Production Planning' },
       { type: 'wad_authorization', label: 'WAD Authorization' },
-      { type: 'preproduction_release', label: 'Preproduction & Release' },
-      { type: 'production_quality', label: 'Production & Quality' },
-      { type: 'final_release_shipping', label: 'Final Release & Shipping' },
-      { type: 'project_closing', label: 'Project Closing' },
+      { type: 'preproduction_release', label: 'Preproduction Readiness' },
+      { type: 'production_quality', label: 'Production' },
+      {
+        type: 'final_release_shipping',
+        label: 'Quality & Product Release',
+      },
+      { type: 'project_closing', label: 'Shipping & Project Closing' },
     ]);
     expect(definition.stages.map((stage) => stage.order)).toEqual([
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
@@ -79,6 +86,26 @@ describe('project workflow registry', () => {
     expect(isLegacyProjectWorkflow('p2_v2')).toBe(false);
     expect(() => getInitializableProjectWorkflowSteps('p2_v2')).toThrow(
       'p2_v2 workflow initialization is not available'
+    );
+  });
+
+  it('retains the definition-version-1 snapshot without converting existing instances', () => {
+    expect(
+      getP2V2StagesForDefinitionVersion(1).map(({ type, label }) => ({
+        type,
+        label,
+      }))
+    ).toContainEqual({
+      type: 'design_applicability',
+      label: 'Design Applicability',
+    });
+    expect(
+      getP2V2StagesForDefinitionVersion(1).some(
+        (stage) => stage.type === 'technical_configuration_review'
+      )
+    ).toBe(false);
+    expect(() => getP2V2StagesForDefinitionVersion(999)).toThrow(
+      'Unknown p2_v2 definition version 999'
     );
   });
 

--- a/server/src/routes/projectTechnicalConfigurationReview.ts
+++ b/server/src/routes/projectTechnicalConfigurationReview.ts
@@ -1,0 +1,297 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { getUserPermissions } from '../services/permissionService';
+import {
+  completeTechnicalConfigurationReview,
+  createTechnicalConfigurationReview,
+  decideTechnicalConfigurationReview,
+  getTechnicalConfigurationReview,
+  ProjectTechnicalConfigurationReviewError,
+  reviseTechnicalConfigurationReview,
+  submitTechnicalConfigurationReview,
+  updateTechnicalConfigurationDraft,
+  type TechnicalReviewActor,
+} from '../services/projectTechnicalConfigurationReviewService';
+
+const router = Router({ mergeParams: true });
+const evidenceSchema = z.object({
+  recordType: z.enum([
+    'CONTROLLED_DOCUMENT',
+    'BOM_REVISION',
+    'ENGINEERING_RELEASE',
+  ]),
+  recordId: z.string().min(1),
+  revision: z.string().nullable().optional(),
+  effectivity: z.string().nullable().optional(),
+});
+const partRequirementSchema = z.object({
+  partNumber: z.string().min(1),
+  quantity: z.number().positive(),
+  drawingNumber: z.string().optional(),
+  drawingRevision: z.string().optional(),
+  specifications: z.array(z.unknown()).optional(),
+  technicalDataException: z.string().optional(),
+});
+const baselineSchema = z
+  .object({
+    partRequirements: z.array(partRequirementSchema).optional(),
+    configurationReferences: z.array(z.unknown()).optional(),
+    qualityClauses: z.array(z.unknown()).optional(),
+    specialRequirements: z.array(z.unknown()).optional(),
+    keyCharacteristics: z.array(z.unknown()).optional(),
+    criticalItems: z.array(z.unknown()).optional(),
+    materialRequirements: z.array(z.unknown()).optional(),
+    certificationRequirements: z.array(z.unknown()).optional(),
+    testReportRequirements: z.array(z.unknown()).optional(),
+    faiRequirements: z.array(z.unknown()).optional(),
+    sourceInspectionRequirements: z.array(z.unknown()).optional(),
+    specialProcesses: z.array(z.unknown()).optional(),
+    traceabilityRequirements: z.array(z.unknown()).optional(),
+    preservationPackagingRequirements: z.array(z.unknown()).optional(),
+    acceptanceCriteria: z.array(z.unknown()).optional(),
+    counterfeitPreventionRequirements: z.array(z.unknown()).optional(),
+    customerProperty: z.array(z.unknown()).optional(),
+    regulatoryRequirements: z.array(z.unknown()).optional(),
+    deviationsWaivers: z.array(z.unknown()).optional(),
+  })
+  .passthrough();
+const reviewSchema = z.object({
+  technicalBaseline: baselineSchema,
+  releasedEvidence: z.array(evidenceSchema).optional(),
+  conflicts: z
+    .array(
+      z.object({
+        description: z.string().min(1),
+        resolution: z.string().optional(),
+        resolved: z.boolean().optional(),
+      })
+    )
+    .optional(),
+  missingInformation: z.array(z.unknown()).optional(),
+  risks: z
+    .array(
+      z.object({
+        description: z.string().min(1),
+        owner: z.string().min(1),
+        control: z.string().min(1),
+      })
+    )
+    .optional(),
+  sufficientlyDefined: z.boolean().optional(),
+  supplyChainRequired: z.boolean().optional(),
+  effectivityReference: z.string().min(1),
+});
+const revisionSchema = z.object({
+  expectedRevision: z.number().int().positive(),
+});
+const decisionSchema = revisionSchema.extend({
+  decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+  signatureMeaning: z.string().min(1),
+  reason: z.string().optional().default(''),
+});
+
+function actor(req: Request): TechnicalReviewActor {
+  if (!req.user?.id || !req.user.username || !req.user.role)
+    throw new ProjectTechnicalConfigurationReviewError(
+      'ACTOR_REQUIRED',
+      'Authenticated actor identity is required.',
+      401
+    );
+  return {
+    userId: req.user.id,
+    employeeId: req.user.employeeId ?? null,
+    username: req.user.username,
+    displayName: req.user.username,
+    role: req.user.role,
+  };
+}
+async function requireCapability(req: Request, capability: string) {
+  const value = actor(req);
+  const { permissionSet } = await getUserPermissions(value.userId, value.role);
+  if (!permissionSet.has(capability))
+    throw new ProjectTechnicalConfigurationReviewError(
+      'FORBIDDEN',
+      `The ${capability} capability is required.`,
+      403
+    );
+  return value;
+}
+function fail(res: Response, error: unknown) {
+  if (error instanceof z.ZodError)
+    return res
+      .status(400)
+      .json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error instanceof ProjectTechnicalConfigurationReviewError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
+  console.error('P2 V2 Technical & Configuration Review error:', error);
+  return res.status(500).json({
+    error: 'TECHNICAL_CONFIGURATION_REVIEW_FAILED',
+    message: 'Technical & Configuration Review action failed.',
+  });
+}
+const projectId = (req: Request) => String(req.params.id);
+
+router.get('/', async (req, res) => {
+  try {
+    res.json(await getTechnicalConfigurationReview(projectId(req)));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/history', async (req, res) => {
+  try {
+    const model = await getTechnicalConfigurationReview(projectId(req));
+    res.json({
+      history: model.history,
+      approvals: model.approvals,
+      readiness: model.readiness,
+    });
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.technical_configuration.manage'
+    );
+    res
+      .status(201)
+      .json(
+        await createTechnicalConfigurationReview(
+          projectId(req),
+          reviewSchema.parse(req.body),
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.patch('/:reviewId', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.technical_configuration.manage'
+    );
+    const body = reviewSchema.and(revisionSchema).parse(req.body);
+    res.json(
+      await updateTechnicalConfigurationDraft(
+        projectId(req),
+        req.params.reviewId,
+        body.expectedRevision,
+        body,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:reviewId/submit', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.technical_configuration.manage'
+    );
+    const body = revisionSchema.parse(req.body);
+    res.json(
+      await submitTechnicalConfigurationReview(
+        projectId(req),
+        req.params.reviewId,
+        body.expectedRevision,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+const decisions = [
+  ['pm', 'PROJECT_MANAGEMENT', 'projects.technical_configuration.pm_decide'],
+  [
+    'engineering',
+    'ENGINEERING',
+    'projects.technical_configuration.engineering_decide',
+  ],
+  ['quality', 'QUALITY', 'projects.technical_configuration.quality_decide'],
+  [
+    'operations',
+    'OPERATIONS',
+    'projects.technical_configuration.operations_decide',
+  ],
+  [
+    'supply-chain',
+    'SUPPLY_CHAIN',
+    'projects.technical_configuration.supply_chain_decide',
+  ],
+] as const;
+for (const [path, capacity, capability] of decisions) {
+  router.post(`/:reviewId/${path}-decision`, async (req, res) => {
+    try {
+      const user = await requireCapability(req, capability);
+      const body = decisionSchema.parse(req.body);
+      res.json(
+        await decideTechnicalConfigurationReview(
+          projectId(req),
+          req.params.reviewId,
+          body.expectedRevision,
+          capacity,
+          body.decision,
+          body.signatureMeaning,
+          body.reason,
+          user
+        )
+      );
+    } catch (error) {
+      fail(res, error);
+    }
+  });
+}
+router.post('/:reviewId/complete', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.technical_configuration.manage'
+    );
+    const body = revisionSchema.parse(req.body);
+    res.json(
+      await completeTechnicalConfigurationReview(
+        projectId(req),
+        req.params.reviewId,
+        body.expectedRevision,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:reviewId/revise', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.technical_configuration.manage'
+    );
+    const body = reviewSchema.and(revisionSchema).parse(req.body);
+    res
+      .status(201)
+      .json(
+        await reviseTechnicalConfigurationReview(
+          projectId(req),
+          req.params.reviewId,
+          body.expectedRevision,
+          body,
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+
+export default router;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -40,6 +40,8 @@ import projectProductionPlanningRoutes from './projectProductionPlanning';
 import { getCurrentProductionPlan } from '../services/projectProductionPlanningService';
 import projectWadAuthorizationRoutes from './projectWadAuthorization';
 import projectCommercialReviewRoutes from './projectCommercialReviews';
+import projectTechnicalConfigurationReviewRoutes from './projectTechnicalConfigurationReview';
+import { getTechnicalConfigurationReview } from '../services/projectTechnicalConfigurationReviewService';
 import { getCurrentWadAuthorization } from '../services/projectWadAuthorizationService';
 import { getUserPermissions } from '../services/permissionService';
 import {
@@ -1584,6 +1586,10 @@ function sendDesignError(res: Response, error: unknown) {
 router.use('/:id/workflow-v2/production-planning', projectProductionPlanningRoutes);
 router.use('/:id/workflow-v2/wad-authorization', projectWadAuthorizationRoutes);
 router.use('/:id/workflow-v2/commercial-reviews', projectCommercialReviewRoutes);
+router.use(
+  '/:id/workflow-v2/technical-configuration-review',
+  projectTechnicalConfigurationReviewRoutes
+);
 
 router.get('/:id/workflow-v2/design-applicability', async (req, res) => {
   try {
@@ -1651,29 +1657,51 @@ router.get('/:id/workflow-v2', async (req, res) => {
     if (!instance) return res.json(buildUninitializedP2V2Response(project.id));
     const model = await getWorkflowReadModel(String(instance.id));
     const response = buildP2V2WorkflowResponse(project.id, model);
-    const design = await getCurrentDesignApplicability(project.id);
-    if (
-      design.decision?.status === 'APPROVED' &&
-      design.decision.responsibility_type !== 'CUSTOMER_BUILD_TO_PRINT' &&
-      !design.release.released
-    ) {
-      response.stages = response.stages.map((stage) =>
-        stage.stepType === 'design_applicability'
-          ? {
-              ...stage,
-              status: 'BLOCKED',
-              blockedReason: design.release.blockers.join(' '),
-            }
-          : stage
-      );
-      response.blockedStages = response.stages.filter(
-        (stage) => stage.status === 'BLOCKED'
-      ).length;
+    const compatibilityDefinition = Number(instance.definition_version) === 1;
+    if (compatibilityDefinition) {
+      const design = await getCurrentDesignApplicability(project.id);
+      if (
+        design.decision?.status === 'APPROVED' &&
+        design.decision.responsibility_type !== 'CUSTOMER_BUILD_TO_PRINT' &&
+        !design.release.released
+      ) {
+        response.stages = response.stages.map((stage) =>
+          stage.stepType === 'design_applicability'
+            ? {
+                ...stage,
+                status: 'BLOCKED',
+                blockedReason: design.release.blockers.join(' '),
+              }
+            : stage
+        );
+      }
+    } else {
+      const technical = await getTechnicalConfigurationReview(project.id);
+      if (technical.review && !technical.readiness.ready) {
+        response.stages = response.stages.map((stage) =>
+          stage.stepType === 'technical_configuration_review'
+            ? {
+                ...stage,
+                status: 'BLOCKED',
+                blockedReason: technical.readiness.blockers.join(' '),
+              }
+            : stage
+        );
+      }
     }
-    const designStage = response.stages.find(
-      (stage) => stage.stepType === 'design_applicability'
+    response.blockedStages = response.stages.filter(
+      (stage) => stage.status === 'BLOCKED'
+    ).length;
+    const prerequisiteStage = response.stages.find((stage) =>
+      compatibilityDefinition
+        ? stage.stepType === 'design_applicability'
+        : stage.stepType === 'technical_configuration_review'
     );
-    if (['COMPLETE', 'NOT_APPLICABLE'].includes(designStage?.status ?? '')) {
+    if (
+      ['COMPLETE', 'NOT_APPLICABLE'].includes(
+        prerequisiteStage?.status ?? ''
+      )
+    ) {
       const productionPlan = await getCurrentProductionPlan(project.id);
       if (
         productionPlan.plan?.status === 'RELEASED' &&
@@ -1716,7 +1744,9 @@ router.get('/:id/workflow-v2', async (req, res) => {
     }
     if (
       planningStage?.status === 'COMPLETE' &&
-      ['COMPLETE', 'NOT_APPLICABLE'].includes(designStage?.status ?? '')
+      ['COMPLETE', 'NOT_APPLICABLE'].includes(
+        prerequisiteStage?.status ?? ''
+      )
     ) {
       const wadAuthorization = await getCurrentWadAuthorization(project.id);
       if (

--- a/server/src/services/projectProductionPlanningService.ts
+++ b/server/src/services/projectProductionPlanningService.ts
@@ -7,6 +7,7 @@ import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
 import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
 import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
 import { evaluateCommercialBaseline } from './projectCommercialReviewService';
+import { evaluateTechnicalConfigurationBaseline } from './projectTechnicalConfigurationReviewService';
 import {
   ProjectProductionPlanningError,
   productionPlanItemBlockers,
@@ -38,7 +39,12 @@ const resultRows = <T extends Row>(value: unknown): T[] =>
 const clean = (value: unknown) =>
   typeof value === 'string' ? value.trim() : '';
 
-async function context(projectId: string, tx: Executor, lock = false) {
+async function context(
+  projectId: string,
+  tx: Executor,
+  lock = false,
+  requireTechnicalBaseline = true
+) {
   const project = resultRows(
     await tx.execute(
       sql`SELECT id, workflow_version, po_id FROM projects WHERE id=${projectId} ${lock ? sql`FOR UPDATE` : sql``}`
@@ -87,20 +93,52 @@ async function context(projectId: string, tx: Executor, lock = false) {
       { issues }
     );
   const step = steps.find((row) => row.step_type === 'production_planning');
-  const design = steps.find((row) => row.step_type === 'design_applicability');
+  const compatibilityDefinition = Number(instances[0].definition_version) === 1;
+  const technical = steps.find((row) =>
+    compatibilityDefinition
+      ? row.step_type === 'design_applicability'
+      : row.step_type === 'technical_configuration_review'
+  );
   if (!step)
     throw new ProjectProductionPlanningError(
       'PRODUCTION_PLANNING_STAGE_REQUIRED',
       'Production Planning stage is missing.',
       409
     );
-  if (!design || !['COMPLETE', 'NOT_APPLICABLE'].includes(design.status))
-    throw new ProjectProductionPlanningError(
-      'DESIGN_APPLICABILITY_REQUIRED',
-      'Design Applicability must be complete or approved not applicable.',
-      409
+  if (requireTechnicalBaseline) {
+    if (
+      !technical ||
+      !(compatibilityDefinition
+        ? ['COMPLETE', 'NOT_APPLICABLE'].includes(technical.status)
+        : technical.status === 'COMPLETE')
+    )
+      throw new ProjectProductionPlanningError(
+        'TECHNICAL_CONFIGURATION_REVIEW_REQUIRED',
+        'Technical & Configuration Review must be complete and current.',
+        409
+      );
+  }
+  if (requireTechnicalBaseline && !compatibilityDefinition) {
+    const baseline = await evaluateTechnicalConfigurationBaseline(
+      projectId,
+      tx
     );
-  return { project, instance: instances[0], step, steps };
+    if (!baseline.valid)
+      throw new ProjectProductionPlanningError(
+        'TECHNICAL_CONFIGURATION_BASELINE_INVALID',
+        'Technical & Configuration Review is incomplete or stale.',
+        409,
+        { blockers: baseline.blockers }
+      );
+  }
+  return {
+    project,
+    instance: instances[0],
+    step,
+    steps,
+    technical,
+    compatibilityDefinition,
+  };
 }
 
 async function currentPlan(projectId: string, tx: Executor) {
@@ -182,16 +220,16 @@ async function configurationRows(
   );
 }
 
-function baselineHash(po: Row, rows: Row[], designRelease?: Row | null) {
+function baselineHash(po: Row, rows: Row[], technicalBasis?: Row | null) {
   return createHash('sha256')
     .update(
       JSON.stringify({
         po: [po.id, po.revision_number, po.updated_at],
-        designRelease: designRelease
+        technicalBasis: technicalBasis
           ? [
-              designRelease.id,
-              designRelease.release_revision,
-              designRelease.release_status,
+              technicalBasis.id,
+              technicalBasis.source_revision ?? technicalBasis.release_revision,
+              technicalBasis.status ?? technicalBasis.release_status,
             ]
           : null,
         items: rows.map((row) => [
@@ -381,6 +419,19 @@ async function staleness(
         'The controlling Engineering Release was reopened or superseded.'
       );
   }
+  if (!ctx.compatibilityDefinition) {
+    const technical = await evaluateTechnicalConfigurationBaseline(
+      plan.project_id,
+      tx
+    );
+    const currentReference = technical.review
+      ? `Technical Review ${technical.review.revision_number}:${technical.review.source_revision}`
+      : null;
+    if (!technical.valid || plan.configuration_revision !== currentReference)
+      differences.push(
+        'Technical & Configuration Review is stale or differs from the released planning baseline.'
+      );
+  }
   for (const item of items.filter((row) => row.is_manufactured)) {
     const state = resultRows(
       await tx.execute(
@@ -411,7 +462,7 @@ async function staleness(
 }
 
 async function readModel(projectId: string, tx: Executor) {
-  const ctx = await context(projectId, tx);
+  const ctx = await context(projectId, tx, false, false);
   const plan = await currentPlan(projectId, tx);
   const history = resultRows(
     await tx.execute(
@@ -438,6 +489,13 @@ async function readModel(projectId: string, tx: Executor) {
     : ['Create a Production Planning draft.'];
   const commercial = await evaluateCommercialBaseline(projectId, tx);
   blockers.push(...commercial.blockers);
+  if (!ctx.compatibilityDefinition) {
+    const technical = await evaluateTechnicalConfigurationBaseline(
+      projectId,
+      tx
+    );
+    blockers.push(...technical.blockers);
+  }
   for (const item of items.filter((row) => row.is_manufactured)) {
     if (
       item.inspection_extent === 'APPROVED_SAMPLING' &&
@@ -563,11 +621,20 @@ async function createRevision(
       'The current P2 PO has no configuration items.',
       409
     );
-  const designRelease = await currentDesignRelease(projectId, tx);
-  const baseline = baselineHash(po, rows, designRelease);
+  const designRelease = ctx.compatibilityDefinition
+    ? await currentDesignRelease(projectId, tx)
+    : null;
+  const technical = ctx.compatibilityDefinition
+    ? null
+    : await evaluateTechnicalConfigurationBaseline(projectId, tx);
+  const technicalBasis = technical?.review ?? designRelease;
+  const baseline = baselineHash(po, rows, technicalBasis);
+  const configurationRevision = technical?.review
+    ? `Technical Review ${technical.review.revision_number}:${technical.review.source_revision}`
+    : `PO ${po.po_number} Rev ${po.revision_number}`;
   const plan = resultRows(
     await tx.execute(
-      sql`INSERT INTO project_production_plans (project_id,workflow_instance_id,workflow_step_instance_id,revision_number,status,po_id,po_revision_number,po_number,configuration_baseline_id,configuration_revision,design_release_id,design_release_revision,effectivity_type,effectivity_reference,requirement_source,planning_basis,notes,created_by,created_by_display_name) VALUES (${projectId},${ctx.instance.id},${ctx.step.id},${revision},'DRAFT',${po.id},${po.revision_number},${po.po_number},${baseline},${`PO ${po.po_number} Rev ${po.revision_number}`},${designRelease?.id ?? null},${designRelease?.release_revision ?? null},${input.effectivityType ?? 'PO_REVISION'},${clean(input.effectivityReference) || `PO ${po.po_number} Rev ${po.revision_number}`},${clean(input.requirementSource)},${clean(input.planningBasis)},${clean(input.notes) || null},${actor.userId},${actor.displayName}) RETURNING *`
+      sql`INSERT INTO project_production_plans (project_id,workflow_instance_id,workflow_step_instance_id,revision_number,status,po_id,po_revision_number,po_number,configuration_baseline_id,configuration_revision,design_release_id,design_release_revision,effectivity_type,effectivity_reference,requirement_source,planning_basis,notes,created_by,created_by_display_name) VALUES (${projectId},${ctx.instance.id},${ctx.step.id},${revision},'DRAFT',${po.id},${po.revision_number},${po.po_number},${baseline},${configurationRevision},${designRelease?.id ?? null},${designRelease?.release_revision ?? null},${input.effectivityType ?? 'PO_REVISION'},${clean(input.effectivityReference) || `PO ${po.po_number} Rev ${po.revision_number}`},${clean(input.requirementSource)},${clean(input.planningBasis)},${clean(input.notes) || null},${actor.userId},${actor.displayName}) RETURNING *`
     )
   )[0];
   await insertConfigurationItems(plan, rows, tx);
@@ -626,12 +693,21 @@ export async function refreshDraft(
         409
       );
     const rows = await configurationRows(projectId, po.id, tx);
-    const designRelease = await currentDesignRelease(projectId, tx);
+    const designRelease = ctx.compatibilityDefinition
+      ? await currentDesignRelease(projectId, tx)
+      : null;
+    const technical = ctx.compatibilityDefinition
+      ? null
+      : await evaluateTechnicalConfigurationBaseline(projectId, tx);
+    const technicalBasis = technical?.review ?? designRelease;
+    const configurationRevision = technical?.review
+      ? `Technical Review ${technical.review.revision_number}:${technical.review.source_revision}`
+      : `PO ${po.po_number} Rev ${po.revision_number}`;
     await tx.execute(
       sql`DELETE FROM project_production_plan_items WHERE production_plan_id=${planId}`
     );
     await tx.execute(
-      sql`UPDATE project_production_plans SET po_id=${po.id},po_revision_number=${po.revision_number},po_number=${po.po_number},configuration_baseline_id=${baselineHash(po, rows, designRelease)},configuration_revision=${`PO ${po.po_number} Rev ${po.revision_number}`},design_release_id=${designRelease?.id ?? null},design_release_revision=${designRelease?.release_revision ?? null},effectivity_reference=${`PO ${po.po_number} Rev ${po.revision_number}`},updated_at=now() WHERE id=${planId}`
+      sql`UPDATE project_production_plans SET po_id=${po.id},po_revision_number=${po.revision_number},po_number=${po.po_number},configuration_baseline_id=${baselineHash(po, rows, technicalBasis)},configuration_revision=${configurationRevision},design_release_id=${designRelease?.id ?? null},design_release_revision=${designRelease?.release_revision ?? null},effectivity_reference=${`PO ${po.po_number} Rev ${po.revision_number}`},updated_at=now() WHERE id=${planId}`
     );
     const refreshed = {
       ...plan,

--- a/server/src/services/projectTechnicalConfigurationReviewService.ts
+++ b/server/src/services/projectTechnicalConfigurationReviewService.ts
@@ -1,0 +1,882 @@
+import { createHash } from 'crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
+import { evaluateCommercialBaseline } from './projectCommercialReviewService';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+
+type Executor = AuditLedgerTx;
+// Additive raw-query rows avoid expanding the central schema surface.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+export type TechnicalReviewActor = {
+  userId: number;
+  employeeId?: number | null;
+  username: string;
+  displayName: string;
+  role: string;
+};
+export type TechnicalEvidence = {
+  recordType: 'CONTROLLED_DOCUMENT' | 'BOM_REVISION' | 'ENGINEERING_RELEASE';
+  recordId: string;
+  revision?: string | null;
+  effectivity?: string | null;
+};
+export type TechnicalReviewInput = {
+  technicalBaseline: {
+    partRequirements?: Array<{
+      partNumber?: string;
+      quantity?: number;
+      drawingNumber?: string;
+      drawingRevision?: string;
+      specifications?: unknown[];
+      technicalDataException?: string;
+    }>;
+    configurationReferences?: unknown[];
+    qualityClauses?: unknown[];
+    specialRequirements?: unknown[];
+    keyCharacteristics?: unknown[];
+    criticalItems?: unknown[];
+    materialRequirements?: unknown[];
+    certificationRequirements?: unknown[];
+    testReportRequirements?: unknown[];
+    faiRequirements?: unknown[];
+    sourceInspectionRequirements?: unknown[];
+    specialProcesses?: unknown[];
+    traceabilityRequirements?: unknown[];
+    preservationPackagingRequirements?: unknown[];
+    acceptanceCriteria?: unknown[];
+    counterfeitPreventionRequirements?: unknown[];
+    customerProperty?: unknown[];
+    regulatoryRequirements?: unknown[];
+    deviationsWaivers?: unknown[];
+  };
+  releasedEvidence?: TechnicalEvidence[];
+  conflicts?: Array<{
+    description?: string;
+    resolution?: string;
+    resolved?: boolean;
+  }>;
+  missingInformation?: unknown[];
+  risks?: Array<{ description?: string; owner?: string; control?: string }>;
+  sufficientlyDefined?: boolean;
+  supplyChainRequired?: boolean;
+  effectivityReference: string;
+};
+export class ProjectTechnicalConfigurationReviewError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 400,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+const rows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+const clean = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : '';
+const hash = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+async function context(
+  projectId: string,
+  tx: Executor,
+  lock = false,
+  requirePredecessors = true
+) {
+  const project = rows(
+    await tx.execute(
+      sql`SELECT id,workflow_version,po_id FROM projects WHERE id=${projectId} ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  )[0];
+  if (!project)
+    throw new ProjectTechnicalConfigurationReviewError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.',
+      404
+    );
+  let workflowVersion: ReturnType<typeof resolveProjectWorkflowVersion>;
+  try {
+    workflowVersion = resolveProjectWorkflowVersion(project.workflow_version);
+  } catch {
+    throw new ProjectTechnicalConfigurationReviewError(
+      'UNKNOWN_WORKFLOW_VERSION',
+      'The project workflow version is not recognized.',
+      409
+    );
+  }
+  if (workflowVersion !== 'p2_v2')
+    throw new ProjectTechnicalConfigurationReviewError(
+      'P2_V2_REQUIRED',
+      'Technical & Configuration Review requires an explicit p2_v2 project.',
+      409,
+      { effectiveWorkflowVersion: workflowVersion }
+    );
+  const instances = rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_instances WHERE project_id=${projectId} AND workflow_version='p2_v2' AND status NOT IN ('SUPERSEDED','CANCELLED') ${lock ? sql`FOR UPDATE` : sql``}`
+    )
+  );
+  if (instances.length !== 1)
+    throw new ProjectTechnicalConfigurationReviewError(
+      instances.length
+        ? 'DUPLICATE_ACTIVE_INSTANCES'
+        : 'WORKFLOW_INSTANCE_REQUIRED',
+      instances.length
+        ? 'Multiple active V2 workflow instances exist.'
+        : 'An active V2 workflow instance is required.',
+      409
+    );
+  if (Number(instances[0].definition_version) !== 2)
+    throw new ProjectTechnicalConfigurationReviewError(
+      'TECHNICAL_REVIEW_DEFINITION_REQUIRED',
+      'Technical & Configuration Review is available only to p2_v2 definition version 2.',
+      409
+    );
+  const steps = rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_instances WHERE workflow_instance_id=${instances[0].id} ORDER BY step_order`
+    )
+  );
+  const issues = validateWorkflowInstanceIntegrity(instances[0], steps);
+  if (issues.length)
+    throw new ProjectTechnicalConfigurationReviewError(
+      'WORKFLOW_INTEGRITY_FAILED',
+      'The V2 workflow failed integrity validation.',
+      409,
+      { issues }
+    );
+  const step = steps.find(
+    (entry) => entry.step_type === 'technical_configuration_review'
+  );
+  if (!step)
+    throw new ProjectTechnicalConfigurationReviewError(
+      'TECHNICAL_REVIEW_STAGE_REQUIRED',
+      'Technical & Configuration Review stage is missing.',
+      409
+    );
+  const required = ['rfq_risk_assessment', 'estimate_quote', 'contract_review'];
+  const incomplete = required.filter(
+    (type) =>
+      steps.find((entry) => entry.step_type === type)?.status !== 'COMPLETE'
+  );
+  if (requirePredecessors && incomplete.length)
+    throw new ProjectTechnicalConfigurationReviewError(
+      'COMMERCIAL_PREDECESSORS_REQUIRED',
+      'RFQ Review, Estimate & Quote, and Contract Review must be complete.',
+      409,
+      { incompleteStages: incomplete }
+    );
+  if (requirePredecessors) {
+    const commercial = await evaluateCommercialBaseline(projectId, tx);
+    if (!commercial.valid)
+      throw new ProjectTechnicalConfigurationReviewError(
+        'COMMERCIAL_BASELINE_INVALID',
+        'The approved commercial baseline is incomplete or stale.',
+        409,
+        { blockers: commercial.blockers }
+      );
+  }
+  return { project, instance: instances[0], step, steps };
+}
+
+async function sourceSnapshot(
+  projectId: string,
+  projectPoId: number | null,
+  tx: Executor
+) {
+  const po = rows(
+    await tx.execute(sql`
+      WITH selected AS (
+        SELECT COALESCE(parent_po_id,id) root_id
+        FROM p2_purchase_orders WHERE id=${projectPoId}
+      )
+      SELECT po.* FROM p2_purchase_orders po
+      LEFT JOIN selected s ON true
+      WHERE (po.project_id=${projectId} OR po.id=s.root_id OR po.parent_po_id=s.root_id)
+        AND po.is_current_revision=true
+      ORDER BY po.revision_number DESC,po.updated_at DESC LIMIT 1`)
+  )[0];
+  if (!po)
+    throw new ProjectTechnicalConfigurationReviewError(
+      'CURRENT_PO_REQUIRED',
+      'A current customer PO revision is required.',
+      409
+    );
+  const items = rows(
+    await tx.execute(sql`
+      SELECT poi.*,ii.ag_part_number,ii.name inventory_name,ii.item_type,ii.type,
+             ii.manufacturing_level,ii.traceability_required,ii.requires_coc,
+             ii.requires_test_report,ii.has_tds,ii.tds_file_path
+      FROM p2_purchase_order_items poi
+      LEFT JOIN inventory_items ii ON ii.id=poi.inventory_item_id
+      WHERE poi.po_id=${po.id}
+      ORDER BY poi.id`)
+  );
+  const configurations = rows(
+    await tx.execute(sql`
+      SELECT poi.id po_item_id,COALESCE(ii.ag_part_number,poi.part_number) part_number,
+             b.id bom_id,br.id bom_revision_id,br.rev_code bom_revision,
+             br.is_released bom_is_released,br.updated_at bom_updated_at
+      FROM p2_purchase_order_items poi
+      LEFT JOIN inventory_items ii ON ii.id=poi.inventory_item_id
+      LEFT JOIN LATERAL (
+        SELECT value.* FROM boms value
+        WHERE value.parent_part_ag_number=COALESCE(ii.ag_part_number,poi.part_number)
+          AND value.is_active=true
+        ORDER BY value.updated_at DESC LIMIT 1
+      ) b ON true
+      LEFT JOIN LATERAL (
+        SELECT value.* FROM bom_revisions value WHERE value.bom_id=b.id
+        ORDER BY value.is_released DESC,value.effective_from DESC NULLS LAST,value.created_at DESC
+        LIMIT 1
+      ) br ON true
+      WHERE poi.po_id=${po.id}
+      ORDER BY poi.id`)
+  );
+  const snapshot = { po, items, configurations };
+  return {
+    po,
+    items,
+    configurations,
+    snapshot,
+    revision: `${po.revision_number}:${hash(snapshot)}`,
+  };
+}
+
+async function validateEvidence(evidence: TechnicalEvidence[], tx: Executor) {
+  const values: string[] = [];
+  const snapshots: Row[] = [];
+  for (const item of evidence) {
+    let record: Row | undefined;
+    if (item.recordType === 'CONTROLLED_DOCUMENT')
+      record = rows(
+        await tx.execute(
+          sql`SELECT id,document_number,revision,status,updated_at FROM controlled_documents WHERE id::text=${item.recordId} OR document_number=${item.recordId} ORDER BY updated_at DESC LIMIT 1`
+        )
+      )[0];
+    if (item.recordType === 'BOM_REVISION')
+      record = rows(
+        await tx.execute(
+          sql`SELECT id,rev_code revision,is_released status,updated_at FROM bom_revisions WHERE id::text=${item.recordId} LIMIT 1`
+        )
+      )[0];
+    if (item.recordType === 'ENGINEERING_RELEASE')
+      record = rows(
+        await tx.execute(
+          sql`SELECT id,release_revision revision,release_status status,released_at updated_at FROM engineering_releases WHERE id::text=${item.recordId} LIMIT 1`
+        )
+      )[0];
+    if (!record) {
+      values.push(`${item.recordType} ${item.recordId} was not found.`);
+      continue;
+    }
+    const approved =
+      item.recordType === 'BOM_REVISION'
+        ? Boolean(record.status)
+        : ['approved', 'released', 'complete', 'completed'].includes(
+            String(record.status).toLowerCase()
+          );
+    if (!approved)
+      values.push(
+        `${item.recordType} ${item.recordId} is not released/approved.`
+      );
+    if (
+      clean(item.revision) &&
+      clean(record.revision) &&
+      clean(item.revision) !== clean(record.revision)
+    )
+      values.push(`${item.recordType} ${item.recordId} revision changed.`);
+    snapshots.push({
+      ...item,
+      authoritativeRevision: record.revision ?? null,
+      authoritativeStatus: record.status,
+      authoritativeUpdatedAt: record.updated_at,
+    });
+  }
+  return { blockers: values, snapshots };
+}
+
+async function current(projectId: string, tx: Executor) {
+  return (
+    rows(
+      await tx.execute(
+        sql`SELECT * FROM project_technical_configuration_reviews WHERE project_id=${projectId} AND status IN ('DRAFT','PENDING_APPROVAL','COMPLETE','REJECTED','STALE','INVALIDATED') ORDER BY revision_number DESC LIMIT 1`
+      )
+    )[0] ?? null
+  );
+}
+async function history(projectId: string, tx: Executor) {
+  return rows(
+    await tx.execute(
+      sql`SELECT * FROM project_technical_configuration_reviews WHERE project_id=${projectId} ORDER BY revision_number DESC`
+    )
+  );
+}
+async function approvals(review: Row, tx: Executor) {
+  return rows(
+    await tx.execute(
+      sql`SELECT * FROM project_workflow_step_approvals WHERE workflow_step_instance_id=${review.workflow_step_instance_id} AND evidence_snapshot->>'technicalReviewId'=${review.id} ORDER BY decided_at`
+    )
+  );
+}
+export const requiredTechnicalReviewRoles = (supplyChainRequired = false) => [
+  'PROJECT_MANAGEMENT',
+  'ENGINEERING',
+  'QUALITY',
+  'OPERATIONS',
+  ...(supplyChainRequired ? ['SUPPLY_CHAIN'] : []),
+];
+
+async function readiness(projectId: string, review: Row | null, tx: Executor) {
+  if (!review)
+    return {
+      ready: false,
+      stale: false,
+      blockers: ['Create a Technical & Configuration Review draft.'],
+      differences: [],
+    };
+  const ctx = await context(projectId, tx, false, false);
+  const source = await sourceSnapshot(projectId, ctx.project.po_id, tx);
+  const evidence = await validateEvidence(review.released_evidence ?? [], tx);
+  const blockers = [...evidence.blockers];
+  const differences: string[] = [];
+  if (source.revision !== review.source_revision) {
+    differences.push(
+      'Customer PO, line-item, or BOM/configuration revision changed.'
+    );
+    blockers.push(
+      'The technical baseline source changed; create a new review revision.'
+    );
+  }
+  const commercial = await evaluateCommercialBaseline(projectId, tx);
+  blockers.push(...commercial.blockers);
+  differences.push(...commercial.differences);
+  if (!review.sufficiently_defined)
+    blockers.push(
+      'The technical baseline must be marked complete and unambiguous.'
+    );
+  if (!clean(review.effectivity_reference))
+    blockers.push('Delivery/configuration effectivity is required.');
+  const requirements = review.technical_baseline?.partRequirements ?? [];
+  for (const item of source.items) {
+    const partNumber = clean(item.ag_part_number) || clean(item.part_number);
+    const captured = requirements.find(
+      (entry: Row) => clean(entry.partNumber) === partNumber
+    );
+    if (!captured) {
+      blockers.push(`${partNumber}: technical part requirement is missing.`);
+      continue;
+    }
+    if (Number(captured.quantity) !== Number(item.quantity))
+      blockers.push(
+        `${partNumber}: reviewed quantity does not match the customer PO.`
+      );
+    if (
+      (!clean(captured.drawingNumber) || !clean(captured.drawingRevision)) &&
+      !clean(captured.technicalDataException)
+    )
+      blockers.push(
+        `${partNumber}: released drawing/specification revision or approved exception is required.`
+      );
+  }
+  if (
+    (review.conflicts ?? []).some(
+      (entry: Row) => !entry.resolved || !clean(entry.resolution)
+    )
+  )
+    blockers.push(
+      'Every technical/configuration conflict requires a resolution.'
+    );
+  if ((review.missing_information ?? []).length)
+    blockers.push('Required technical information remains missing.');
+  if (
+    (review.risks ?? []).some(
+      (entry: Row) =>
+        !clean(entry.description) ||
+        !clean(entry.owner) ||
+        !clean(entry.control)
+    )
+  )
+    blockers.push('Every technical risk requires an owner and control.');
+  return {
+    ready: blockers.length === 0,
+    stale: differences.length > 0,
+    blockers: Array.from(new Set(blockers)),
+    differences: Array.from(new Set(differences)),
+    currentSourceRevision: source.revision,
+    evidenceSnapshots: evidence.snapshots,
+  };
+}
+
+async function readModel(projectId: string, tx: Executor) {
+  await context(projectId, tx, false, false);
+  const review = await current(projectId, tx);
+  const state = await readiness(projectId, review, tx);
+  const reviewApprovals = review ? await approvals(review, tx) : [];
+  return {
+    review:
+      review && state.stale && review.status === 'COMPLETE'
+        ? { ...review, status: 'STALE', detected_status: 'STALE' }
+        : review,
+    history: await history(projectId, tx),
+    approvals: state.stale
+      ? reviewApprovals.map((entry) => ({
+          ...entry,
+          invalidated: true,
+          invalidation_reason: 'Technical source revision changed.',
+        }))
+      : reviewApprovals,
+    requiredApprovals: review
+      ? requiredTechnicalReviewRoles(Boolean(review.supply_chain_required))
+      : requiredTechnicalReviewRoles(false),
+    readiness: state,
+  };
+}
+export const getTechnicalConfigurationReview = (
+  projectId: string,
+  tx: Executor = db
+) => readModel(projectId, tx);
+
+async function audit(
+  eventType: string,
+  review: Row,
+  actor: TechnicalReviewActor,
+  tx: Executor,
+  reason?: string
+) {
+  await recordAuditEvent(
+    {
+      eventType,
+      subjectType: 'project_technical_configuration_review',
+      subjectId: review.id,
+      sourceService: 'projectTechnicalConfigurationReviewService',
+      actor: { id: actor.userId, username: actor.username, role: actor.role },
+      reason,
+      payload: {
+        projectId: review.project_id,
+        reviewRevision: review.revision_number,
+        poId: review.po_id,
+        poRevision: review.po_revision_number,
+      },
+    },
+    tx
+  );
+}
+
+async function insertRevision(
+  projectId: string,
+  input: TechnicalReviewInput,
+  actor: TechnicalReviewActor,
+  tx: Executor,
+  revisionNumber: number
+) {
+  const ctx = await context(projectId, tx, true);
+  const source = await sourceSnapshot(projectId, ctx.project.po_id, tx);
+  const evidence = await validateEvidence(input.releasedEvidence ?? [], tx);
+  const review = rows(
+    await tx.execute(sql`
+      INSERT INTO project_technical_configuration_reviews
+        (project_id,workflow_instance_id,workflow_step_instance_id,revision_number,status,
+         po_id,po_revision_number,source_revision,source_snapshot,technical_baseline,
+         released_evidence,conflicts,missing_information,risks,sufficiently_defined,
+         supply_chain_required,effectivity_reference,owner_user_id,owner_display_name,
+         created_by,created_by_display_name)
+      VALUES
+        (${projectId},${ctx.instance.id},${ctx.step.id},${revisionNumber},'DRAFT',
+         ${source.po.id},${source.po.revision_number},${source.revision},${JSON.stringify(source.snapshot)}::jsonb,
+         ${JSON.stringify(input.technicalBaseline)}::jsonb,${JSON.stringify(evidence.snapshots)}::jsonb,
+         ${JSON.stringify(input.conflicts ?? [])}::jsonb,${JSON.stringify(input.missingInformation ?? [])}::jsonb,
+         ${JSON.stringify(input.risks ?? [])}::jsonb,${Boolean(input.sufficientlyDefined)},
+         ${Boolean(input.supplyChainRequired)},${clean(input.effectivityReference)},${actor.userId},
+         ${actor.displayName},${actor.userId},${actor.displayName})
+      RETURNING *`)
+  )[0];
+  await tx.execute(
+    sql`UPDATE project_workflow_step_instances SET status='IN_PROGRESS',started_at=COALESCE(started_at,now()),blocked_reason=NULL,updated_at=now() WHERE id=${ctx.step.id}`
+  );
+  await audit('P2_V2_TECHNICAL_REVIEW_DRAFT_CREATED', review, actor, tx);
+  return review;
+}
+
+export async function createTechnicalConfigurationReview(
+  projectId: string,
+  input: TechnicalReviewInput,
+  actor: TechnicalReviewActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    if (await current(projectId, tx))
+      throw new ProjectTechnicalConfigurationReviewError(
+        'CURRENT_REVIEW_EXISTS',
+        'A current Technical & Configuration Review revision already exists.',
+        409
+      );
+    await insertRevision(projectId, input, actor, tx, 1);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function updateTechnicalConfigurationDraft(
+  projectId: string,
+  reviewId: string,
+  expectedRevision: number,
+  input: TechnicalReviewInput,
+  actor: TechnicalReviewActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedRevision
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'STALE_REVISION',
+        'The review changed; reload before saving.',
+        409
+      );
+    if (review.status !== 'DRAFT')
+      throw new ProjectTechnicalConfigurationReviewError(
+        'DRAFT_REQUIRED',
+        'Submitted and completed review revisions are immutable.',
+        409
+      );
+    const source = await sourceSnapshot(projectId, ctx.project.po_id, tx);
+    const evidence = await validateEvidence(input.releasedEvidence ?? [], tx);
+    await tx.execute(sql`
+      UPDATE project_technical_configuration_reviews SET
+        po_id=${source.po.id},po_revision_number=${source.po.revision_number},
+        source_revision=${source.revision},source_snapshot=${JSON.stringify(source.snapshot)}::jsonb,
+        technical_baseline=${JSON.stringify(input.technicalBaseline)}::jsonb,
+        released_evidence=${JSON.stringify(evidence.snapshots)}::jsonb,
+        conflicts=${JSON.stringify(input.conflicts ?? [])}::jsonb,
+        missing_information=${JSON.stringify(input.missingInformation ?? [])}::jsonb,
+        risks=${JSON.stringify(input.risks ?? [])}::jsonb,
+        sufficiently_defined=${Boolean(input.sufficientlyDefined)},
+        supply_chain_required=${Boolean(input.supplyChainRequired)},
+        effectivity_reference=${clean(input.effectivityReference)},
+        lock_version=lock_version+1,updated_at=now()
+      WHERE id=${reviewId} AND lock_version=${expectedRevision} AND status='DRAFT'`);
+    await audit('P2_V2_TECHNICAL_REVIEW_DRAFT_UPDATED', review, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function submitTechnicalConfigurationReview(
+  projectId: string,
+  reviewId: string,
+  expectedRevision: number,
+  actor: TechnicalReviewActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedRevision
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'STALE_REVISION',
+        'The review changed; reload before submitting.',
+        409
+      );
+    if (review.status !== 'DRAFT')
+      throw new ProjectTechnicalConfigurationReviewError(
+        'DRAFT_REQUIRED',
+        'Only a draft may be submitted.',
+        409
+      );
+    const state = await readiness(projectId, review, tx);
+    if (!state.ready)
+      throw new ProjectTechnicalConfigurationReviewError(
+        'TECHNICAL_REVIEW_NOT_READY',
+        'Technical & Configuration Review has blockers.',
+        409,
+        { blockers: state.blockers }
+      );
+    await tx.execute(
+      sql`UPDATE project_technical_configuration_reviews SET status='PENDING_APPROVAL',submitted_at=now(),lock_version=lock_version+1,updated_at=now() WHERE id=${reviewId}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='PENDING_APPROVAL',updated_at=now() WHERE id=${ctx.step.id}`
+    );
+    await audit('P2_V2_TECHNICAL_REVIEW_SUBMITTED', review, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function decideTechnicalConfigurationReview(
+  projectId: string,
+  reviewId: string,
+  expectedRevision: number,
+  capacity:
+    | 'PROJECT_MANAGEMENT'
+    | 'ENGINEERING'
+    | 'QUALITY'
+    | 'OPERATIONS'
+    | 'SUPPLY_CHAIN',
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: TechnicalReviewActor
+) {
+  if (!clean(signatureMeaning))
+    throw new ProjectTechnicalConfigurationReviewError(
+      'SIGNATURE_REQUIRED',
+      'Signature meaning is required.'
+    );
+  if (decision !== 'APPROVED' && !clean(reason))
+    throw new ProjectTechnicalConfigurationReviewError(
+      'REASON_REQUIRED',
+      'A rejection or return requires a comment.'
+    );
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedRevision
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'STALE_REVISION',
+        'The review changed; reload before deciding.',
+        409
+      );
+    if (review.status !== 'PENDING_APPROVAL')
+      throw new ProjectTechnicalConfigurationReviewError(
+        'PENDING_APPROVAL_REQUIRED',
+        'The review is not pending functional approval.',
+        409
+      );
+    if (
+      !requiredTechnicalReviewRoles(
+        Boolean(review.supply_chain_required)
+      ).includes(capacity)
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'APPROVAL_NOT_REQUIRED',
+        `${capacity} approval is not required.`,
+        409
+      );
+    const existing = await approvals(review, tx);
+    if (
+      existing.some(
+        (entry) => entry.approval_type === `TECHNICAL_CONFIGURATION_${capacity}`
+      )
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'DECISION_ALREADY_RECORDED',
+        `${capacity} already decided this revision.`,
+        409
+      );
+    if (
+      existing.some(
+        (entry) =>
+          Number(entry.actor_user_id) === actor.userId &&
+          entry.decision === 'APPROVED'
+      )
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'SEGREGATION_OF_DUTIES',
+        'One actor cannot represent multiple required manufacturing functions.',
+        403
+      );
+    await tx.execute(sql`
+      INSERT INTO project_workflow_step_approvals
+        (workflow_step_instance_id,project_id,approval_type,decision,signature_meaning,
+         reason,actor_employee_id,actor_user_id,actor_display_name,actor_role,
+         step_revision_snapshot,evidence_snapshot)
+      VALUES
+        (${ctx.step.id},${projectId},${`TECHNICAL_CONFIGURATION_${capacity}`},${decision},
+         ${signatureMeaning},${clean(reason) || null},${actor.employeeId ?? null},${actor.userId},
+         ${actor.displayName},${actor.role},${String(review.revision_number)},
+         ${JSON.stringify({
+           technicalReviewId: review.id,
+           revision: review.revision_number,
+           sourceRevision: review.source_revision,
+           invalidated: false,
+         })}::jsonb)`);
+    if (decision === 'APPROVED')
+      await tx.execute(
+        sql`UPDATE project_technical_configuration_reviews SET lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`
+      );
+    else {
+      await tx.execute(
+        sql`UPDATE project_technical_configuration_reviews SET status='REJECTED',lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`
+      );
+      await tx.execute(
+        sql`UPDATE project_workflow_step_instances SET status='BLOCKED',blocked_reason=${`${capacity} ${decision.toLowerCase()}: ${clean(reason)}`},updated_at=now() WHERE id=${ctx.step.id}`
+      );
+    }
+    await audit(
+      `P2_V2_TECHNICAL_${capacity}_DECIDED`,
+      review,
+      actor,
+      tx,
+      clean(reason) || undefined
+    );
+    return readModel(projectId, tx);
+  });
+}
+
+export async function completeTechnicalConfigurationReview(
+  projectId: string,
+  reviewId: string,
+  expectedRevision: number,
+  actor: TechnicalReviewActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedRevision
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'STALE_REVISION',
+        'The review changed; reload before completion.',
+        409
+      );
+    if (review.status !== 'PENDING_APPROVAL')
+      throw new ProjectTechnicalConfigurationReviewError(
+        'PENDING_APPROVAL_REQUIRED',
+        'Submit the review before completion.',
+        409
+      );
+    const state = await readiness(projectId, review, tx);
+    if (!state.ready)
+      throw new ProjectTechnicalConfigurationReviewError(
+        'TECHNICAL_REVIEW_NOT_READY',
+        'Technical & Configuration Review has blockers.',
+        409,
+        { blockers: state.blockers }
+      );
+    const evidence = await approvals(review, tx);
+    const missing = requiredTechnicalReviewRoles(
+      Boolean(review.supply_chain_required)
+    ).filter(
+      (role) =>
+        !evidence.some(
+          (entry) =>
+            entry.approval_type === `TECHNICAL_CONFIGURATION_${role}` &&
+            entry.decision === 'APPROVED'
+        )
+    );
+    if (missing.length)
+      throw new ProjectTechnicalConfigurationReviewError(
+        'APPROVALS_REQUIRED',
+        'Required independent functional approvals are missing.',
+        409,
+        { missingApprovals: missing }
+      );
+    await tx.execute(
+      sql`UPDATE project_technical_configuration_reviews SET status='COMPLETE',completed_at=now(),lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now(),completed_by=${actor.employeeId ?? null},completed_by_display_name=${actor.displayName},blocked_reason=NULL,revision_reference=${String(review.revision_number)},effectivity_reference=${review.effectivity_reference},updated_at=now() WHERE id=${ctx.step.id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_links SET unlinked_at=now(),unlink_reason='Superseded technical/configuration review evidence',updated_at=now() WHERE workflow_step_instance_id=${ctx.step.id} AND unlinked_at IS NULL`
+    );
+    await tx.execute(sql`
+      INSERT INTO project_workflow_step_links
+        (workflow_step_instance_id,project_id,record_type,record_id,relationship_type,
+         is_authoritative,record_revision,effectivity_reference,linked_by,linked_by_display_name)
+      VALUES
+        (${ctx.step.id},${projectId},'TECHNICAL_CONFIGURATION_REVIEW',${review.id},'PRIMARY',
+         true,${String(review.revision_number)},${review.effectivity_reference},
+         ${actor.employeeId ?? null},${actor.displayName})`);
+    await audit('P2_V2_TECHNICAL_REVIEW_COMPLETED', review, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function reviseTechnicalConfigurationReview(
+  projectId: string,
+  reviewId: string,
+  expectedRevision: number,
+  input: TechnicalReviewInput,
+  actor: TechnicalReviewActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const prior = await current(projectId, tx);
+    if (
+      !prior ||
+      prior.id !== reviewId ||
+      Number(prior.lock_version) !== expectedRevision
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'STALE_REVISION',
+        'The review changed; reload before revision.',
+        409
+      );
+    if (
+      !['COMPLETE', 'REJECTED', 'STALE', 'INVALIDATED'].includes(prior.status)
+    )
+      throw new ProjectTechnicalConfigurationReviewError(
+        'REVISION_NOT_ALLOWED',
+        'Only completed, rejected, stale, or invalidated reviews may be revised.',
+        409
+      );
+    await tx.execute(
+      sql`UPDATE project_technical_configuration_reviews SET status='SUPERSEDED',superseded_at=now(),updated_at=now() WHERE id=${prior.id}`
+    );
+    const next = await insertRevision(
+      projectId,
+      input,
+      actor,
+      tx,
+      Number(prior.revision_number) + 1
+    );
+    await tx.execute(
+      sql`UPDATE project_technical_configuration_reviews SET superseded_by_review_id=${next.id} WHERE id=${prior.id}`
+    );
+    await tx.execute(
+      sql`UPDATE project_workflow_step_approvals SET superseded_at=now(),evidence_snapshot=jsonb_set(COALESCE(evidence_snapshot,'{}'::jsonb),'{invalidated}','true'::jsonb) WHERE workflow_step_instance_id=${prior.workflow_step_instance_id} AND evidence_snapshot->>'technicalReviewId'=${prior.id} AND superseded_at IS NULL`
+    );
+    await audit('P2_V2_TECHNICAL_REVIEW_REVISED', next, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function evaluateTechnicalConfigurationBaseline(
+  projectId: string,
+  tx: Executor = db
+) {
+  const review = await current(projectId, tx);
+  if (!review || review.status !== 'COMPLETE')
+    return {
+      valid: false,
+      stale: false,
+      blockers: ['Technical & Configuration Review is not complete.'],
+      differences: [],
+      review: review ?? null,
+    };
+  try {
+    const state = await readiness(projectId, review, tx);
+    return { valid: state.ready, ...state, review };
+  } catch (error) {
+    if (!(error instanceof ProjectTechnicalConfigurationReviewError))
+      throw error;
+    return {
+      valid: false,
+      stale: true,
+      blockers: [error.message],
+      differences: [error.message],
+      review,
+    };
+  }
+}

--- a/server/src/services/projectWadAuthorizationService.ts
+++ b/server/src/services/projectWadAuthorizationService.ts
@@ -6,6 +6,7 @@ import { db } from '../../db';
 import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
 import { getCurrentProductionPlan } from './projectProductionPlanningService';
 import { evaluateCommercialBaseline } from './projectCommercialReviewService';
+import { evaluateTechnicalConfigurationBaseline } from './projectTechnicalConfigurationReviewService';
 import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
 import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
 import {
@@ -102,9 +103,13 @@ async function context(
       { issues }
     );
   const step = steps.find((entry) => entry.step_type === 'wad_authorization');
-  const design = steps.find(
-    (entry) => entry.step_type === 'design_applicability'
+  const compatibilityDefinition = Number(instances[0].definition_version) === 1;
+  const technical = steps.find((entry) =>
+    compatibilityDefinition
+      ? entry.step_type === 'design_applicability'
+      : entry.step_type === 'technical_configuration_review'
   );
+  const contract = steps.find((entry) => entry.step_type === 'contract_review');
   const planning = steps.find(
     (entry) => entry.step_type === 'production_planning'
   );
@@ -116,11 +121,20 @@ async function context(
     );
   if (
     requirePrerequisites &&
-    (!design || !['COMPLETE', 'NOT_APPLICABLE'].includes(design.status))
+    (!technical ||
+      !(compatibilityDefinition
+        ? ['COMPLETE', 'NOT_APPLICABLE'].includes(technical.status)
+        : technical.status === 'COMPLETE'))
   )
     throw new ProjectWadAuthorizationError(
-      'DESIGN_APPLICABILITY_REQUIRED',
-      'Design Applicability must remain complete or approved not applicable.',
+      'TECHNICAL_CONFIGURATION_REVIEW_REQUIRED',
+      'Technical & Configuration Review must remain complete and current.',
+      409
+    );
+  if (requirePrerequisites && (!contract || contract.status !== 'COMPLETE'))
+    throw new ProjectWadAuthorizationError(
+      'CONTRACT_REVIEW_REQUIRED',
+      'Contract Review must remain complete and current.',
       409
     );
   if (requirePrerequisites && (!planning || planning.status !== 'COMPLETE'))
@@ -129,7 +143,14 @@ async function context(
       'Production Planning must be complete.',
       409
     );
-  return { project, instance: instances[0], step, design, planning };
+  return {
+    project,
+    instance: instances[0],
+    step,
+    technical,
+    planning,
+    compatibilityDefinition,
+  };
 }
 
 async function currentAuthorization(projectId: string, tx: Executor) {
@@ -241,14 +262,26 @@ async function readiness(
   if (!authorization)
     return {
       ready: false,
-      stale: false,
-      blockers: ['A WAD draft is required.'],
+      stale: differences.length > 0,
+      blockers: Array.from(new Set([...blockers, 'A WAD draft is required.'])),
       differences,
     };
   const ctx = await context(projectId, tx, false, false);
-  if (!['COMPLETE', 'NOT_APPLICABLE'].includes(ctx.design?.status ?? '')) {
-    blockers.push('Design Applicability is no longer valid.');
-    differences.push('Design Applicability decision or release changed.');
+  if (
+    !(ctx.compatibilityDefinition
+      ? ['COMPLETE', 'NOT_APPLICABLE'].includes(ctx.technical?.status ?? '')
+      : ctx.technical?.status === 'COMPLETE')
+  ) {
+    blockers.push('Technical & Configuration Review is no longer valid.');
+    differences.push('Technical/configuration baseline changed.');
+  }
+  if (!ctx.compatibilityDefinition) {
+    const technical = await evaluateTechnicalConfigurationBaseline(
+      projectId,
+      tx
+    );
+    blockers.push(...technical.blockers);
+    differences.push(...technical.differences);
   }
   if (ctx.planning?.status !== 'COMPLETE') {
     blockers.push('Production Planning is no longer complete.');

--- a/server/src/services/projectWorkflowInstanceIntegrity.ts
+++ b/server/src/services/projectWorkflowInstanceIntegrity.ts
@@ -1,5 +1,5 @@
 import {
-  getInternalP2V2InitializationStages,
+  getP2V2StagesForDefinitionVersion,
   P2_V2_DEFINITION_VERSION,
 } from './projectWorkflowRegistry';
 
@@ -21,13 +21,24 @@ export function validateWorkflowInstanceIntegrity(
   instance: Row,
   steps: Row[]
 ): WorkflowIntegrityIssue[] {
-  const definition = getInternalP2V2InitializationStages();
   const issues: WorkflowIntegrityIssue[] = [];
   if (instance.workflow_version !== 'p2_v2')
     issues.push({
       code: 'WRONG_WORKFLOW_VERSION',
       message: 'Workflow instance is not p2_v2.',
     });
+  let definition: ReturnType<typeof getP2V2StagesForDefinitionVersion>;
+  try {
+    definition = getP2V2StagesForDefinitionVersion(
+      Number(instance.definition_version)
+    );
+  } catch {
+    issues.push({
+      code: 'REGISTRY_DEFINITION_MISMATCH',
+      message: `Unknown p2_v2 definition version ${String(instance.definition_version)}.`,
+    });
+    return issues;
+  }
   const byType = new Map<string, Row[]>();
   const byOrder = new Map<number, Row[]>();
   for (const step of steps) {
@@ -68,11 +79,11 @@ export function validateWorkflowInstanceIntegrity(
     ) {
       issues.push({
         code: 'REGISTRY_DEFINITION_MISMATCH',
-        message: `Stage ${stage.type} does not match definition version ${P2_V2_DEFINITION_VERSION}.`,
+        message: `Stage ${stage.type} does not match definition version ${String(instance.definition_version ?? P2_V2_DEFINITION_VERSION)}.`,
       });
     }
   }
-  for (const [order, matches] of byOrder)
+  for (const [order, matches] of Array.from(byOrder))
     if (matches.length > 1)
       issues.push({
         code: 'DUPLICATE_ORDER',

--- a/server/src/services/projectWorkflowRegistry.ts
+++ b/server/src/services/projectWorkflowRegistry.ts
@@ -139,7 +139,7 @@ const LEGACY_V1_STEPS = freezeItems<ProjectWorkflowStepDefinition>([
   },
 ]);
 
-const P2_V2_STAGES = freezeItems<ProjectWorkflowStageDefinition>([
+const P2_V2_DEFINITION_V1_STAGES = freezeItems<ProjectWorkflowStageDefinition>([
   {
     type: 'rfq_risk_assessment',
     order: 1,
@@ -202,7 +202,87 @@ const P2_V2_STAGES = freezeItems<ProjectWorkflowStageDefinition>([
   },
 ]);
 
-export const P2_V2_DEFINITION_VERSION = 1;
+const P2_V2_STAGES = freezeItems<ProjectWorkflowStageDefinition>([
+  {
+    type: 'rfq_risk_assessment',
+    order: 1,
+    label: 'RFQ Review',
+    description:
+      'Confirm customer inquiry scope, requirements, and risk evidence.',
+  },
+  {
+    type: 'estimate_quote',
+    order: 2,
+    label: 'Estimate & Quote',
+    description: 'Confirm the approved estimate and released commercial offer.',
+  },
+  {
+    type: 'contract_review',
+    order: 3,
+    label: 'Contract Review',
+    description:
+      'Approve the accepted customer order and contractual baseline.',
+  },
+  {
+    type: 'technical_configuration_review',
+    order: 4,
+    label: 'Technical & Configuration Review',
+    description:
+      'Confirm the released technical and configuration baseline required to manufacture and inspect the customer order.',
+  },
+  {
+    type: 'production_planning',
+    order: 5,
+    label: 'Production Planning',
+    description:
+      'Establish BOM, routing, material, quality, and execution plans.',
+  },
+  {
+    type: 'wad_authorization',
+    order: 6,
+    label: 'WAD Authorization',
+    description: 'Authorize work through controlled WAD evidence.',
+  },
+  {
+    type: 'preproduction_release',
+    order: 7,
+    label: 'Preproduction Readiness',
+    description:
+      'Confirm materials, tooling, documents, and readiness before release.',
+  },
+  {
+    type: 'production_quality',
+    order: 8,
+    label: 'Production',
+    description: 'Execute controlled manufacturing operations.',
+  },
+  {
+    type: 'final_release_shipping',
+    order: 9,
+    label: 'Quality & Product Release',
+    description:
+      'Complete inspection, acceptance, certification, and product release.',
+  },
+  {
+    type: 'project_closing',
+    order: 10,
+    label: 'Shipping & Project Closing',
+    description:
+      'Ship the accepted product and close the customer-order project.',
+  },
+]);
+
+export const P2_V2_DEFINITION_VERSION = 2;
+
+export function getP2V2StagesForDefinitionVersion(
+  definitionVersion: number
+): readonly ProjectWorkflowStageDefinition[] {
+  if (definitionVersion === 1) return P2_V2_DEFINITION_V1_STAGES;
+  if (definitionVersion === P2_V2_DEFINITION_VERSION) return P2_V2_STAGES;
+  throw new ProjectWorkflowDefinitionValidationError(
+    `Unknown p2_v2 definition version ${definitionVersion}`
+  );
+}
 
 // Internal-only snapshot source for Phase 3. This does not make p2_v2 active
 // or available to normal project creation.


### PR DESCRIPTION
## Summary

- replaces the new p2_v2 definition's Design Applicability stage with a manufacturing-focused Technical & Configuration Review while retaining definition-version-1 snapshots for compatibility
- adds a revision-controlled technical/configuration review service, API, UI, approvals, released-evidence validation, stale-source detection, audit events, and additive migration 0209
- propagates current technical-baseline requirements into Production Planning and WAD readiness without creating or modifying Design Projects, ECR/ECN, production, traveler, inventory, shipping, or closing records
- keeps p2_v2 inactive for normal project creation and leaves NULL/legacy_v1 behavior unchanged

## Why

P2 Projects represent customer purchase orders moving through manufacturing. Product design and AS9100 section 8.3 activities belong to the separate Design Control module. P2 may reference released technical evidence read-only, but must not initiate or approve design work.

## Compatibility and safety

- p2_v2 definition version 2 uses `technical_configuration_review`
- stored definition version 1 instances continue to validate and use their existing `design_applicability` records
- unknown definition versions fail closed
- migration 0203 is unchanged and retained for compatibility
- migration 0209 is additive; no database migration was applied by this work
- no automatic p2_v2 initialization or activation was added

## Validation

- combined Phase 1-8B, legacy workflow, WAD, release, and closing server suite: 131/134 passed after rebasing onto current main
  - all 131 relevant assertions passed
  - 3 Design Control release-gate assertions fail identically on a clean current-main worktree after PRs #1520/#1521; Phase 8B does not touch those files
- P2 V2 component suite: 6/6 passed after rebase
- separate Design Control component regression: 2/2 passed before rebase
- focused ESLint for Phase 8B-owned files: passed
- `git diff --check`: passed
- TypeScript with `NODE_OPTIONS=--max-old-space-size=6144`: no diagnostics in new Phase 8B files; four existing diagnostics remain in untouched portions of `server/src/routes/projects.ts` (TS2802 at the RFQ Set spread, missing storage method, and two generic QueryResultRow constraints)

## Notes

This PR is intentionally draft and must not be merged until the upstream Design Control release-gate regression is reviewed separately.