### PR TITLE
Add P2 V2 preproduction and production release gates

### DIFF
--- a/client/src/__tests__/P2V2PreproductionReadiness.component.test.tsx
+++ b/client/src/__tests__/P2V2PreproductionReadiness.component.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import P2V2PreproductionReadiness from '../components/projects/P2V2PreproductionReadiness';
+
+function renderReadiness() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        review: {
+          id: 'review-1',
+          revision_number: 2,
+          lock_version: 7,
+          status: 'COMPLETE',
+          checklist_snapshot: [
+            {
+              key: 'routing',
+              category: 'Manufacturing planning',
+              label: 'Approved routing',
+              applicability: 'REQUIRED',
+              satisfied: true,
+              evidence: [{ recordType: 'ROUTING', recordId: 'route-1' }],
+            },
+          ],
+          source_stage_revisions: {
+            commercial: 1,
+            technical: 2,
+            productionPlanning: 3,
+            wadAuthorization: 4,
+          },
+          exceptions: [],
+          risks_and_controls: [
+            { risk: 'Capacity', owner: 'Ops', control: 'Plan' },
+          ],
+          effectivity_reference: 'PO line 10',
+        },
+        history: [],
+        approvals: [
+          {
+            id: 'a1',
+            approval_type: 'PREPRODUCTION_PROJECT_MANAGEMENT',
+            decision: 'APPROVED',
+            actor_display_name: 'Project Manager',
+            decided_at: '2026-07-23T12:00:00Z',
+          },
+        ],
+        requiredApprovals: [
+          'PROJECT_MANAGEMENT',
+          'ENGINEERING',
+          'QUALITY',
+          'OPERATIONS',
+        ],
+        readiness: { state: 'READY', blockers: [], stale: false },
+        release: null,
+        launch: null,
+        projectStatus: 'PREPRODUCTION_READINESS',
+      }),
+    })
+  );
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <P2V2PreproductionReadiness projectId="project-1" />
+    </QueryClientProvider>
+  );
+}
+
+describe('P2V2PreproductionReadiness', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('shows readiness evidence and keeps release and launch as separate controls', async () => {
+    renderReadiness();
+    expect(
+      await screen.findByText('Checklist and evidence')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Approved routing/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/does not create production records or launch work/i)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('approve-production-release')).toBeEnabled();
+    expect(screen.getByTestId('launch-production')).toBeDisabled();
+  });
+});

--- a/client/src/components/projects/P2V2PreproductionReadiness.tsx
+++ b/client/src/components/projects/P2V2PreproductionReadiness.tsx
@@ -1,0 +1,443 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, CheckCircle2, Rocket, ShieldCheck } from 'lucide-react';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useToast } from '@/hooks/use-toast';
+import { Input } from '@/components/ui/input';
+
+type ChecklistItem = {
+  key: string;
+  category: string;
+  label: string;
+  applicability: 'REQUIRED' | 'NOT_REQUIRED' | 'NOT_APPLICABLE';
+  satisfied: boolean;
+  justification?: string;
+  approvedJustification?: boolean;
+  evidence?: Array<{ recordType: string; recordId: string; revision?: string }>;
+};
+type Model = {
+  review: {
+    id: string;
+    revision_number: number;
+    lock_version: number;
+    status: string;
+    checklist_snapshot: ChecklistItem[];
+    source_stage_revisions: Record<string, string | number | null>;
+    exceptions: unknown[];
+    risks_and_controls: unknown[];
+    effectivity_reference: string;
+  } | null;
+  history: Array<{ id: string; revision_number: number; status: string }>;
+  approvals: Array<{
+    id: string;
+    approval_type: string;
+    decision: string;
+    actor_display_name: string;
+    decided_at: string;
+  }>;
+  requiredApprovals: string[];
+  readiness: {
+    state: 'READY' | 'NOT_READY' | 'BLOCKED' | 'STALE';
+    blockers: string[];
+    stale: boolean;
+  };
+  release: { id: string; status: string; approved_at: string } | null;
+  launch: { id: string; status: string; launched_at: string } | null;
+  projectStatus: string;
+  recommendedChecklist: ChecklistItem[];
+};
+
+const endpoint = (projectId: string) =>
+  `/api/projects/${projectId}/workflow-v2/preproduction-readiness`;
+
+export default function P2V2PreproductionReadiness({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const client = useQueryClient();
+  const { toast } = useToast();
+  const [launchOpen, setLaunchOpen] = useState(false);
+  const [effectivity, setEffectivity] = useState('');
+  const { data, isLoading, error } = useQuery<Model>({
+    queryKey: [
+      '/api/projects',
+      projectId,
+      'workflow-v2',
+      'preproduction-readiness',
+    ],
+    queryFn: async () => {
+      const response = await fetch(endpoint(projectId), {
+        credentials: 'include',
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(body?.message || 'Unable to load readiness');
+      return body;
+    },
+  });
+  const refresh = () =>
+    client.invalidateQueries({
+      queryKey: ['/api/projects', projectId],
+    });
+  const action = useMutation({
+    mutationFn: async ({
+      path,
+      body,
+    }: {
+      path: string;
+      body?: Record<string, unknown>;
+    }) => {
+      const response = await fetch(`${endpoint(projectId)}${path}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body ?? {}),
+      });
+      const result = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(
+          result?.message ||
+            (Array.isArray(result?.blockers)
+              ? result.blockers.join('; ')
+              : 'Action failed')
+        );
+      return result;
+    },
+    onSuccess: () => {
+      setLaunchOpen(false);
+      refresh();
+      toast({ title: 'Preproduction workflow updated' });
+    },
+    onError: (value) =>
+      toast({
+        title: 'Action blocked',
+        description: value instanceof Error ? value.message : 'Action failed',
+        variant: 'destructive',
+      }),
+  });
+  const approvalSummary = useMemo(
+    () =>
+      data?.requiredApprovals.map((role) => ({
+        role,
+        approval: data.approvals.find(
+          (item) =>
+            item.approval_type === `PREPRODUCTION_${role}` &&
+            item.decision === 'APPROVED'
+        ),
+      })) ?? [],
+    [data]
+  );
+  if (isLoading)
+    return <p className="text-sm">Loading Preproduction Readiness…</p>;
+  if (error || !data)
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Preproduction unavailable</AlertTitle>
+        <AlertDescription>
+          {error instanceof Error ? error.message : 'Unable to load readiness.'}
+        </AlertDescription>
+      </Alert>
+    );
+  if (!data.review)
+    return (
+      <Card data-testid="preproduction-no-revision">
+        <CardHeader>
+          <CardTitle>Start Preproduction Readiness</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            The draft is built dynamically from the current customer-order,
+            technical, Production Plan, and WAD baselines.
+          </p>
+          <Input
+            value={effectivity}
+            onChange={(event) => setEffectivity(event.target.value)}
+            placeholder="Configuration / PO-line effectivity"
+            aria-label="Readiness effectivity"
+          />
+          <Button
+            disabled={!effectivity.trim() || action.isPending}
+            onClick={() =>
+              action.mutate({
+                path: '',
+                body: {
+                  checklist: data.recommendedChecklist,
+                  effectivityReference: effectivity.trim(),
+                },
+              })
+            }
+          >
+            Create Readiness Draft
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  return (
+    <div className="space-y-3" data-testid="p2-v2-preproduction-readiness">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge>{data.readiness.state.replaceAll('_', ' ')}</Badge>
+        <Badge variant="outline">Revision {data.review.revision_number}</Badge>
+        <Badge variant="outline">
+          {data.review.status.replaceAll('_', ' ')}
+        </Badge>
+        <Badge variant="outline">Project: {data.projectStatus}</Badge>
+      </div>
+      {data.readiness.blockers.length > 0 && (
+        <Alert variant="destructive" data-testid="preproduction-blockers">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Release blockers</AlertTitle>
+          <AlertDescription>
+            <ul className="list-disc pl-5">
+              {data.readiness.blockers.map((blocker) => (
+                <li key={blocker}>{blocker}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+      <div className="grid gap-3 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Checklist and evidence</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {data.review.checklist_snapshot.map((item) => (
+              <div key={item.key} className="rounded border p-2">
+                <div className="flex justify-between gap-2">
+                  <span>
+                    <strong>{item.category}</strong> · {item.label}
+                  </span>
+                  <Badge variant="outline">
+                    {item.applicability.replaceAll('_', ' ')}
+                  </Badge>
+                </div>
+                <p
+                  className={
+                    item.satisfied ? 'text-green-700' : 'text-amber-700'
+                  }
+                >
+                  {item.satisfied ? 'Satisfied' : 'Open'}
+                </p>
+                {item.justification && (
+                  <p>Justification: {item.justification}</p>
+                )}
+                <p className="text-muted-foreground">
+                  Evidence: {item.evidence?.length ?? 0}
+                </p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Approvals and baseline</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {approvalSummary.map(({ role, approval }) => (
+              <div
+                key={role}
+                className="flex items-center justify-between rounded border p-2"
+              >
+                <span>{role.replaceAll('_', ' ')}</span>
+                {approval ? (
+                  <span className="text-green-700">
+                    <CheckCircle2 className="mr-1 inline h-4 w-4" />
+                    {approval.actor_display_name}
+                  </span>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">Required</Badge>
+                    {data.review?.status === 'PENDING_APPROVAL' && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={action.isPending}
+                        onClick={() =>
+                          action.mutate({
+                            path: `/${data.review!.id}/${
+                              role === 'PROJECT_MANAGEMENT'
+                                ? 'pm'
+                                : role.toLowerCase().replaceAll('_', '-')
+                            }-decision`,
+                            body: {
+                              expectedLockVersion: data.review!.lock_version,
+                              decision: 'APPROVED',
+                              signatureMeaning: `Approved as ${role.replaceAll('_', ' ')}`,
+                              reason: '',
+                            },
+                          })
+                        }
+                      >
+                        Approve
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+            <p>
+              <strong>Effectivity:</strong> {data.review.effectivity_reference}
+            </p>
+            <p>
+              <strong>Source revisions:</strong>{' '}
+              {Object.entries(data.review.source_stage_revisions)
+                .map(([key, value]) => `${key}: ${value ?? 'none'}`)
+                .join(' · ')}
+            </p>
+            <p>
+              <strong>Risks / controls:</strong>{' '}
+              {data.review.risks_and_controls.length}
+            </p>
+            <p>
+              <strong>Exceptions:</strong> {data.review.exceptions.length}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+      <Card className="border-blue-200">
+        <CardContent className="space-y-3 p-4">
+          <div>
+            <h4 className="font-semibold">Controlled production transition</h4>
+            <p className="text-sm text-muted-foreground">
+              Approving Production Release records authorization and changes the
+              project to READY_FOR_P2_RELEASE. It does not create production
+              records or launch work.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {data.review.status === 'DRAFT' && (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    action.mutate({
+                      path: `/${data.review!.id}/recalculate`,
+                      body: {
+                        expectedLockVersion: data.review!.lock_version,
+                      },
+                    })
+                  }
+                >
+                  Recalculate Evidence
+                </Button>
+                <Button
+                  variant="outline"
+                  disabled={data.readiness.state !== 'READY'}
+                  onClick={() =>
+                    action.mutate({
+                      path: `/${data.review!.id}/submit`,
+                      body: {
+                        expectedLockVersion: data.review!.lock_version,
+                      },
+                    })
+                  }
+                >
+                  Submit for Approval
+                </Button>
+              </>
+            )}
+            {data.review.status === 'PENDING_APPROVAL' && (
+              <Button
+                variant="outline"
+                onClick={() =>
+                  action.mutate({
+                    path: `/${data.review!.id}/complete`,
+                    body: { expectedLockVersion: data.review!.lock_version },
+                  })
+                }
+              >
+                Complete Readiness
+              </Button>
+            )}
+            <Button
+              onClick={() => action.mutate({ path: '/release/approve' })}
+              disabled={
+                action.isPending ||
+                data.review.status !== 'COMPLETE' ||
+                data.readiness.state !== 'READY' ||
+                Boolean(data.release)
+              }
+              data-testid="approve-production-release"
+            >
+              <ShieldCheck className="mr-2 h-4 w-4" />
+              Approve Production Release
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => setLaunchOpen(true)}
+              disabled={
+                action.isPending ||
+                data.projectStatus !== 'READY_FOR_P2_RELEASE' ||
+                Boolean(data.launch?.status === 'COMPLETE')
+              }
+              data-testid="launch-production"
+            >
+              <Rocket className="mr-2 h-4 w-4" />
+              Launch Production
+            </Button>
+          </div>
+          {data.release && (
+            <p className="text-sm">
+              Release {data.release.status} ·{' '}
+              {new Date(data.release.approved_at).toLocaleString()}
+            </p>
+          )}
+          {data.launch && (
+            <p className="text-sm">
+              Launch {data.launch.status} ·{' '}
+              {new Date(data.launch.launched_at).toLocaleString()}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+      <Dialog open={launchOpen} onOpenChange={setLaunchOpen}>
+        <DialogContent data-testid="launch-production-confirmation">
+          <DialogHeader>
+            <DialogTitle>Launch production?</DialogTitle>
+            <DialogDescription>
+              This revalidates the approved release, creates only missing
+              serialized units and production orders through the existing P2
+              services, routes items to their first valid department, activates
+              Stage 8, and changes the project to IN_PRODUCTION. The operation
+              is atomic and protected against duplicate retries.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setLaunchOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={action.isPending}
+              onClick={() =>
+                action.mutate({
+                  path: '/launch',
+                  body: {
+                    idempotencyKey:
+                      globalThis.crypto?.randomUUID?.() ??
+                      `${projectId}-${Date.now()}`,
+                  },
+                })
+              }
+            >
+              Confirm Launch Production
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -15,6 +15,7 @@ import P2V2ProductionPlanning from './P2V2ProductionPlanning';
 import P2V2TechnicalConfigurationReview from './P2V2TechnicalConfigurationReview';
 import P2V2WadAuthorization from './P2V2WadAuthorization';
 import P2V2CommercialReview from './P2V2CommercialReview';
+import P2V2PreproductionReadiness from './P2V2PreproductionReadiness';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -413,6 +414,11 @@ export default function P2V2ProjectWorkflow({
               {stage.stepType === 'wad_authorization' && (
                 <div className="mt-3">
                   <P2V2WadAuthorization projectId={projectId} />
+                </div>
+              )}
+              {stage.stepType === 'preproduction_release' && (
+                <div className="mt-3">
+                  <P2V2PreproductionReadiness projectId={projectId} />
                 </div>
               )}
             </CardContent>

--- a/migrations/0210_project_preproduction_readiness.sql
+++ b/migrations/0210_project_preproduction_readiness.sql
@@ -1,0 +1,128 @@
+-- Phase 8C: revision-controlled p2_v2 preproduction readiness and the
+-- separate Production Release / Production Launch evidence records.
+-- No existing project or production record is backfilled or changed.
+CREATE TABLE IF NOT EXISTS project_preproduction_readiness_reviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  workflow_instance_id UUID NOT NULL,
+  workflow_step_instance_id UUID NOT NULL,
+  revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+  lock_version INTEGER NOT NULL DEFAULT 1 CHECK (lock_version > 0),
+  status TEXT NOT NULL DEFAULT 'DRAFT'
+    CHECK (status IN ('DRAFT','PENDING_APPROVAL','COMPLETE','REJECTED','STALE','INVALIDATED','SUPERSEDED')),
+  readiness_state TEXT NOT NULL DEFAULT 'NOT_READY'
+    CHECK (readiness_state IN ('READY','NOT_READY','BLOCKED','STALE')),
+  source_stage_revisions JSONB NOT NULL DEFAULT '{}'::jsonb,
+  checklist_snapshot JSONB NOT NULL DEFAULT '[]'::jsonb,
+  blockers JSONB NOT NULL DEFAULT '[]'::jsonb,
+  exceptions JSONB NOT NULL DEFAULT '[]'::jsonb,
+  risks_and_controls JSONB NOT NULL DEFAULT '[]'::jsonb,
+  supply_chain_required BOOLEAN NOT NULL DEFAULT false,
+  finance_required BOOLEAN NOT NULL DEFAULT false,
+  effectivity_reference TEXT NOT NULL,
+  submitted_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  invalidated_at TIMESTAMP,
+  invalidation_reason TEXT,
+  superseded_at TIMESTAMP,
+  superseded_by_review_id UUID REFERENCES project_preproduction_readiness_reviews(id) ON DELETE RESTRICT,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  FOREIGN KEY (workflow_step_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, project_id) ON DELETE RESTRICT,
+  UNIQUE (project_id, workflow_instance_id, revision_number)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_preproduction_current_unique
+  ON project_preproduction_readiness_reviews(project_id, workflow_instance_id)
+  WHERE status IN ('DRAFT','PENDING_APPROVAL','COMPLETE');
+CREATE INDEX IF NOT EXISTS project_preproduction_history_idx
+  ON project_preproduction_readiness_reviews(project_id, revision_number DESC);
+
+CREATE TABLE IF NOT EXISTS project_production_releases (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  workflow_instance_id UUID NOT NULL,
+  readiness_review_id UUID NOT NULL REFERENCES project_preproduction_readiness_reviews(id) ON DELETE RESTRICT,
+  readiness_revision INTEGER NOT NULL,
+  wad_authorization_id UUID NOT NULL REFERENCES project_wad_authorizations(id) ON DELETE RESTRICT,
+  wad_revision INTEGER NOT NULL,
+  production_plan_id UUID NOT NULL REFERENCES project_production_plans(id) ON DELETE RESTRICT,
+  production_plan_revision INTEGER NOT NULL,
+  configuration_baseline_id TEXT NOT NULL,
+  effectivity_reference TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'APPROVED'
+    CHECK (status IN ('APPROVED','INVALIDATED','SUPERSEDED')),
+  approved_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  approved_by_display_name TEXT NOT NULL,
+  approved_at TIMESTAMP NOT NULL DEFAULT now(),
+  evidence_snapshot JSONB NOT NULL,
+  FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  UNIQUE (project_id, readiness_review_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_production_release_current_unique
+  ON project_production_releases(project_id)
+  WHERE status='APPROVED';
+
+CREATE TABLE IF NOT EXISTS project_production_launches (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  production_release_id UUID NOT NULL REFERENCES project_production_releases(id) ON DELETE RESTRICT,
+  idempotency_key TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('COMPLETE','FAILED')),
+  production_evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  error_code TEXT,
+  error_message TEXT,
+  launched_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  launched_by_display_name TEXT NOT NULL,
+  launched_at TIMESTAMP NOT NULL DEFAULT now(),
+  UNIQUE (project_id, idempotency_key)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_production_launch_complete_unique
+  ON project_production_launches(project_id) WHERE status='COMPLETE';
+
+INSERT INTO perm_capabilities (key, description, category) VALUES
+ ('projects.preproduction.manage','Draft, submit, complete and revise P2 V2 preproduction readiness','projects'),
+ ('projects.preproduction.pm_decide','Approve P2 V2 readiness for Project Management','projects'),
+ ('projects.preproduction.engineering_decide','Approve P2 V2 readiness for Engineering','engineering'),
+ ('projects.preproduction.quality_decide','Approve P2 V2 readiness for Quality','quality'),
+ ('projects.preproduction.operations_decide','Approve P2 V2 readiness for Operations','operations'),
+ ('projects.preproduction.supply_chain_decide','Approve conditional supply-chain readiness','procurement'),
+ ('projects.preproduction.finance_decide','Approve conditional commercial finance readiness','finance'),
+ ('projects.production_release.approve','Approve a P2 V2 project for production release','projects'),
+ ('projects.production_launch.launch','Launch an approved P2 V2 project into production','operations')
+ON CONFLICT (key) DO UPDATE SET description=EXCLUDED.description,category=EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT pr.id,pc.id FROM perm_roles pr JOIN perm_capabilities pc ON (
+ (pr.name IN ('ADMIN','OWNER') AND (pc.key LIKE 'projects.preproduction.%' OR pc.key LIKE 'projects.production_%')) OR
+ (pr.name IN ('PROJECT_MANAGER','PROGRAM_MANAGER') AND pc.key IN ('projects.preproduction.manage','projects.preproduction.pm_decide','projects.production_release.approve')) OR
+ (pr.name IN ('ENGINEERING','ENGINEER','ENGINEERING_MANAGER','MANUFACTURING_ENGINEERING') AND pc.key='projects.preproduction.engineering_decide') OR
+ (pr.name IN ('QUALITY','QC','QUALITY_MANAGER') AND pc.key='projects.preproduction.quality_decide') OR
+ (pr.name IN ('OPERATIONS','OPERATIONS_MANAGER','PRODUCTION_MANAGER','MANAGER') AND pc.key IN ('projects.preproduction.operations_decide','projects.production_launch.launch')) OR
+ (pr.name IN ('PROCUREMENT','PURCHASING','SUPPLY_CHAIN','SUPPLY_CHAIN_MANAGER') AND pc.key='projects.preproduction.supply_chain_decide') OR
+ (pr.name IN ('FINANCE','ACCOUNTING','CONTROLLER') AND pc.key='projects.preproduction.finance_decide')
+) ON CONFLICT (role_id,capability_id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION protect_preproduction_completed_snapshot()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.status NOT IN ('DRAFT','PENDING_APPROVAL') AND (
+    NEW.source_stage_revisions IS DISTINCT FROM OLD.source_stage_revisions OR
+    NEW.checklist_snapshot IS DISTINCT FROM OLD.checklist_snapshot OR
+    NEW.exceptions IS DISTINCT FROM OLD.exceptions OR
+    NEW.risks_and_controls IS DISTINCT FROM OLD.risks_and_controls OR
+    NEW.effectivity_reference IS DISTINCT FROM OLD.effectivity_reference
+  ) THEN RAISE EXCEPTION 'Completed preproduction readiness snapshots are immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS protect_preproduction_completed_snapshot_trigger
+  ON project_preproduction_readiness_reviews;
+CREATE TRIGGER protect_preproduction_completed_snapshot_trigger
+BEFORE UPDATE ON project_preproduction_readiness_reviews
+FOR EACH ROW EXECUTE FUNCTION protect_preproduction_completed_snapshot();

--- a/server/__tests__/projectPreproductionReadiness.test.ts
+++ b/server/__tests__/projectPreproductionReadiness.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  checklistBlockers,
+  requiredPreproductionRoles,
+  resolveFirstProductionDepartment,
+} from '../src/services/projectPreproductionRules';
+
+describe('P2 V2 Preproduction Readiness rules', () => {
+  it('accepts satisfied applicable items and does not require irrelevant items', () => {
+    expect(
+      checklistBlockers([
+        {
+          key: 'routing',
+          category: 'Manufacturing planning',
+          label: 'Approved routing',
+          applicability: 'REQUIRED',
+          satisfied: true,
+        },
+        {
+          key: 'cnc',
+          category: 'Manufacturing planning',
+          label: 'CNC program',
+          applicability: 'NOT_REQUIRED',
+          satisfied: false,
+        },
+      ])
+    ).toEqual([]);
+  });
+
+  it('blocks unsatisfied required items', () => {
+    expect(
+      checklistBlockers([
+        {
+          key: 'inspection',
+          category: 'Quality planning',
+          label: 'Inspection points defined',
+          applicability: 'REQUIRED',
+          satisfied: false,
+        },
+      ])
+    ).toEqual(['Quality planning: Inspection points defined']);
+  });
+
+  it('requires approved justification for not-applicable decisions', () => {
+    const item = {
+      key: 'fai',
+      category: 'Quality planning',
+      label: 'FAI',
+      applicability: 'NOT_APPLICABLE' as const,
+      satisfied: false,
+    };
+    expect(checklistBlockers([item])).toHaveLength(1);
+    expect(
+      checklistBlockers([
+        {
+          ...item,
+          justification: 'Repeat production; no FAI trigger applies.',
+          approvedJustification: true,
+        },
+      ])
+    ).toEqual([]);
+  });
+
+  it('always requires four independent core functions', () => {
+    expect(
+      requiredPreproductionRoles({
+        supply_chain_required: false,
+        finance_required: false,
+      })
+    ).toEqual(['PROJECT_MANAGEMENT', 'ENGINEERING', 'QUALITY', 'OPERATIONS']);
+  });
+
+  it('adds conditional Supply Chain and Finance approvals', () => {
+    expect(
+      requiredPreproductionRoles({
+        supply_chain_required: true,
+        finance_required: true,
+      })
+    ).toEqual([
+      'PROJECT_MANAGEMENT',
+      'ENGINEERING',
+      'QUALITY',
+      'OPERATIONS',
+      'SUPPLY_CHAIN',
+      'FINANCE',
+    ]);
+  });
+
+  it('routes assembly-first parts to Assembly', () => {
+    expect(
+      resolveFirstProductionDepartment(['Assembly', 'Quality'], true)
+    ).toBe('Assembly');
+  });
+
+  it('uses the legacy-safe Layup fallback only when routing is absent', () => {
+    expect(resolveFirstProductionDepartment([], false)).toBe('Layup');
+    expect(resolveFirstProductionDepartment([], true)).toBeNull();
+  });
+});

--- a/server/src/routes/projectPreproductionReadiness.ts
+++ b/server/src/routes/projectPreproductionReadiness.ts
@@ -1,0 +1,283 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { getUserPermissions } from '../services/permissionService';
+import {
+  approveProductionRelease,
+  completePreproduction,
+  createPreproductionReadiness,
+  decidePreproduction,
+  getPreproductionReadiness,
+  launchProduction,
+  ProjectPreproductionError,
+  recalculatePreproduction,
+  revisePreproduction,
+  submitPreproduction,
+  updatePreproductionDraft,
+  type PreproductionActor,
+} from '../services/projectPreproductionReadinessService';
+
+const router = Router({ mergeParams: true });
+const checklistItem = z.object({
+  key: z.string().min(1),
+  category: z.string().min(1),
+  label: z.string().min(1),
+  applicability: z.enum(['REQUIRED', 'NOT_REQUIRED', 'NOT_APPLICABLE']),
+  satisfied: z.boolean(),
+  evidence: z
+    .array(
+      z.object({
+        recordType: z.string().min(1),
+        recordId: z.string().min(1),
+        revision: z.string().optional(),
+      })
+    )
+    .optional(),
+  justification: z.string().optional(),
+  approvedJustification: z.boolean().optional(),
+});
+const readinessInput = z.object({
+  checklist: z.array(checklistItem),
+  exceptions: z.array(z.unknown()).optional(),
+  risksAndControls: z
+    .array(
+      z.object({
+        risk: z.string().min(1),
+        owner: z.string().min(1),
+        control: z.string().min(1),
+      })
+    )
+    .optional(),
+  effectivityReference: z.string().min(1),
+});
+const expected = z.object({ expectedLockVersion: z.number().int().positive() });
+const decision = expected.extend({
+  decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+  signatureMeaning: z.string().min(1),
+  reason: z.string().optional().default(''),
+});
+
+function actor(req: Request): PreproductionActor {
+  if (!req.user?.id || !req.user.username || !req.user.role)
+    throw new ProjectPreproductionError(
+      'ACTOR_REQUIRED',
+      'Authenticated actor identity is required.',
+      401
+    );
+  return {
+    userId: req.user.id,
+    employeeId: req.user.employeeId ?? null,
+    username: req.user.username,
+    displayName: req.user.username,
+    role: req.user.role,
+  };
+}
+async function requireCapability(req: Request, capability: string) {
+  const value = actor(req);
+  const { permissionSet } = await getUserPermissions(value.userId, value.role);
+  if (!permissionSet.has(capability))
+    throw new ProjectPreproductionError(
+      'FORBIDDEN',
+      `The ${capability} capability is required.`,
+      403
+    );
+  return value;
+}
+function fail(res: Response, error: unknown) {
+  if (error instanceof z.ZodError)
+    return res
+      .status(400)
+      .json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error instanceof ProjectPreproductionError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
+  console.error('P2 V2 Preproduction Readiness error:', error);
+  return res.status(500).json({
+    error: 'PREPRODUCTION_ACTION_FAILED',
+    message: 'The Preproduction Readiness action failed.',
+  });
+}
+const projectId = (req: Request) => String(req.params.id);
+
+router.get('/', async (req, res) => {
+  try {
+    res.json(await getPreproductionReadiness(projectId(req)));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/history', async (req, res) => {
+  try {
+    const model = await getPreproductionReadiness(projectId(req));
+    res.json({
+      history: model.history,
+      approvals: model.approvals,
+      release: model.release,
+      launch: model.launch,
+    });
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/', async (req, res) => {
+  try {
+    const user = await requireCapability(req, 'projects.preproduction.manage');
+    res
+      .status(201)
+      .json(
+        await createPreproductionReadiness(
+          projectId(req),
+          readinessInput.parse(req.body),
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.patch('/:reviewId', async (req, res) => {
+  try {
+    const user = await requireCapability(req, 'projects.preproduction.manage');
+    const body = readinessInput.and(expected).parse(req.body);
+    res.json(
+      await updatePreproductionDraft(
+        projectId(req),
+        req.params.reviewId,
+        body.expectedLockVersion,
+        body,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:reviewId/recalculate', async (req, res) => {
+  try {
+    const user = await requireCapability(req, 'projects.preproduction.manage');
+    const body = expected.parse(req.body);
+    res.json(
+      await recalculatePreproduction(
+        projectId(req),
+        req.params.reviewId,
+        body.expectedLockVersion,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:reviewId/submit', async (req, res) => {
+  try {
+    const user = await requireCapability(req, 'projects.preproduction.manage');
+    const body = expected.parse(req.body);
+    res.json(
+      await submitPreproduction(
+        projectId(req),
+        req.params.reviewId,
+        body.expectedLockVersion,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+const decisions = [
+  ['pm', 'PROJECT_MANAGEMENT', 'projects.preproduction.pm_decide'],
+  ['engineering', 'ENGINEERING', 'projects.preproduction.engineering_decide'],
+  ['quality', 'QUALITY', 'projects.preproduction.quality_decide'],
+  ['operations', 'OPERATIONS', 'projects.preproduction.operations_decide'],
+  [
+    'supply-chain',
+    'SUPPLY_CHAIN',
+    'projects.preproduction.supply_chain_decide',
+  ],
+  ['finance', 'FINANCE', 'projects.preproduction.finance_decide'],
+] as const;
+for (const [path, capacity, capability] of decisions) {
+  router.post(`/:reviewId/${path}-decision`, async (req, res) => {
+    try {
+      const user = await requireCapability(req, capability);
+      const body = decision.parse(req.body);
+      res.json(
+        await decidePreproduction(
+          projectId(req),
+          req.params.reviewId,
+          body.expectedLockVersion,
+          capacity,
+          body.decision,
+          body.signatureMeaning,
+          body.reason,
+          user
+        )
+      );
+    } catch (error) {
+      fail(res, error);
+    }
+  });
+}
+router.post('/:reviewId/complete', async (req, res) => {
+  try {
+    const user = await requireCapability(req, 'projects.preproduction.manage');
+    const body = expected.parse(req.body);
+    res.json(
+      await completePreproduction(
+        projectId(req),
+        req.params.reviewId,
+        body.expectedLockVersion,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/:reviewId/revise', async (req, res) => {
+  try {
+    const user = await requireCapability(req, 'projects.preproduction.manage');
+    const body = readinessInput.and(expected).parse(req.body);
+    res
+      .status(201)
+      .json(
+        await revisePreproduction(
+          projectId(req),
+          req.params.reviewId,
+          body.expectedLockVersion,
+          body,
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/release/approve', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_release.approve'
+    );
+    res.json(await approveProductionRelease(projectId(req), user));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/launch', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_launch.launch'
+    );
+    const body = z
+      .object({ idempotencyKey: z.string().min(8).max(200) })
+      .parse(req.body);
+    res.json(await launchProduction(projectId(req), body.idempotencyKey, user));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+
+export default router;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -41,6 +41,7 @@ import { getCurrentProductionPlan } from '../services/projectProductionPlanningS
 import projectWadAuthorizationRoutes from './projectWadAuthorization';
 import projectCommercialReviewRoutes from './projectCommercialReviews';
 import projectTechnicalConfigurationReviewRoutes from './projectTechnicalConfigurationReview';
+import projectPreproductionReadinessRoutes from './projectPreproductionReadiness';
 import { getTechnicalConfigurationReview } from '../services/projectTechnicalConfigurationReviewService';
 import { getCurrentWadAuthorization } from '../services/projectWadAuthorizationService';
 import { getUserPermissions } from '../services/permissionService';
@@ -1589,6 +1590,10 @@ router.use('/:id/workflow-v2/commercial-reviews', projectCommercialReviewRoutes)
 router.use(
   '/:id/workflow-v2/technical-configuration-review',
   projectTechnicalConfigurationReviewRoutes
+);
+router.use(
+  '/:id/workflow-v2/preproduction-readiness',
+  projectPreproductionReadinessRoutes
 );
 
 router.get('/:id/workflow-v2/design-applicability', async (req, res) => {

--- a/server/src/services/projectPreproductionReadinessService.ts
+++ b/server/src/services/projectPreproductionReadinessService.ts
@@ -1,0 +1,1206 @@
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { storage } from '../../storage';
+import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
+import { evaluateCommercialBaseline } from './projectCommercialReviewService';
+import { getCurrentProductionPlan } from './projectProductionPlanningService';
+import { evaluateTechnicalConfigurationBaseline } from './projectTechnicalConfigurationReviewService';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+import { getCurrentWadAuthorization } from './projectWadAuthorizationService';
+import {
+  checklistBlockers,
+  requiredPreproductionRoles,
+  resolveFirstProductionDepartment,
+  type ChecklistDecision,
+} from './projectPreproductionRules';
+
+type Executor = AuditLedgerTx;
+// Raw-query records keep this additive feature out of the central schema surface.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+export type PreproductionActor = {
+  userId: number;
+  employeeId?: number | null;
+  username: string;
+  displayName: string;
+  role: string;
+};
+export type PreproductionInput = {
+  checklist: ChecklistDecision[];
+  exceptions?: unknown[];
+  risksAndControls?: Array<{ risk: string; owner: string; control: string }>;
+  effectivityReference: string;
+};
+
+export class ProjectPreproductionError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 400,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+
+const resultRows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+const clean = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : '';
+
+async function context(
+  projectId: string,
+  tx: Executor,
+  lock = false,
+  requirePredecessors = true
+) {
+  const project = resultRows(
+    await tx.execute(sql`
+      SELECT id,workflow_version,po_id,current_stage,status
+      FROM projects WHERE id=${projectId} ${lock ? sql`FOR UPDATE` : sql``}`)
+  )[0];
+  if (!project)
+    throw new ProjectPreproductionError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.',
+      404
+    );
+  let version;
+  try {
+    version = resolveProjectWorkflowVersion(project.workflow_version);
+  } catch {
+    throw new ProjectPreproductionError(
+      'UNKNOWN_WORKFLOW_VERSION',
+      'The project workflow version is not recognized.',
+      409
+    );
+  }
+  if (version !== 'p2_v2')
+    throw new ProjectPreproductionError(
+      'P2_V2_REQUIRED',
+      'Preproduction Readiness requires an explicit p2_v2 project.',
+      409,
+      { effectiveWorkflowVersion: version }
+    );
+  const instances = resultRows(
+    await tx.execute(sql`
+      SELECT * FROM project_workflow_instances
+      WHERE project_id=${projectId} AND workflow_version='p2_v2'
+        AND status NOT IN ('SUPERSEDED','CANCELLED')
+      ${lock ? sql`FOR UPDATE` : sql``}`)
+  );
+  if (instances.length !== 1)
+    throw new ProjectPreproductionError(
+      instances.length
+        ? 'DUPLICATE_ACTIVE_INSTANCES'
+        : 'WORKFLOW_INSTANCE_REQUIRED',
+      instances.length
+        ? 'Multiple active V2 workflow instances exist.'
+        : 'An active V2 workflow instance is required.',
+      409
+    );
+  if (Number(instances[0].definition_version) !== 2)
+    throw new ProjectPreproductionError(
+      'PREPRODUCTION_DEFINITION_REQUIRED',
+      'Preproduction Readiness is available only to p2_v2 definition version 2.',
+      409
+    );
+  const steps = resultRows(
+    await tx.execute(sql`
+      SELECT * FROM project_workflow_step_instances
+      WHERE workflow_instance_id=${instances[0].id} ORDER BY step_order`)
+  );
+  const issues = validateWorkflowInstanceIntegrity(instances[0], steps);
+  if (issues.length)
+    throw new ProjectPreproductionError(
+      'WORKFLOW_INTEGRITY_FAILED',
+      'The V2 workflow failed integrity validation.',
+      409,
+      { issues }
+    );
+  const step = steps.find(
+    (entry) => entry.step_type === 'preproduction_release'
+  );
+  if (!step)
+    throw new ProjectPreproductionError(
+      'PREPRODUCTION_STAGE_REQUIRED',
+      'Preproduction Readiness stage is missing.',
+      409
+    );
+  const requiredTypes = [
+    'rfq_risk_assessment',
+    'estimate_quote',
+    'contract_review',
+    'technical_configuration_review',
+    'production_planning',
+    'wad_authorization',
+  ];
+  const incomplete = requiredTypes.filter(
+    (type) =>
+      steps.find((entry) => entry.step_type === type)?.status !== 'COMPLETE'
+  );
+  if (requirePredecessors && incomplete.length)
+    throw new ProjectPreproductionError(
+      'PREDECESSORS_REQUIRED',
+      'All commercial, technical, planning, and WAD predecessor stages must be complete.',
+      409,
+      { incompleteStages: incomplete }
+    );
+  return { project, instance: instances[0], step, steps };
+}
+
+async function sourceState(projectId: string, tx: Executor) {
+  const commercial = await evaluateCommercialBaseline(projectId, tx);
+  const technical = await evaluateTechnicalConfigurationBaseline(projectId, tx);
+  const planning = await getCurrentProductionPlan(projectId, tx);
+  const wad = await getCurrentWadAuthorization(projectId, tx);
+  const blockers: string[] = [];
+  const contractReview = resultRows(
+    await tx.execute(sql`
+      SELECT revision_number,requirements_snapshot FROM project_commercial_stage_reviews
+      WHERE project_id=${projectId} AND stage_type='contract_review'
+        AND status='COMPLETE'
+      ORDER BY revision_number DESC LIMIT 1`)
+  )[0];
+  if (!commercial.valid)
+    blockers.push(...commercial.blockers.map((b: string) => `Contract: ${b}`));
+  if (!technical.valid)
+    blockers.push(...technical.blockers.map((b: string) => `Technical: ${b}`));
+  if (
+    !planning.plan ||
+    planning.plan.status !== 'RELEASED' ||
+    !planning.readiness.ready
+  )
+    blockers.push(
+      ...(planning.readiness.blockers.length
+        ? planning.readiness.blockers.map((b: string) => `Planning: ${b}`)
+        : ['Planning: a current RELEASED Production Plan is required.'])
+    );
+  if (
+    !wad.authorization ||
+    wad.authorization.status !== 'RELEASED' ||
+    !wad.readiness.ready
+  )
+    blockers.push(
+      ...(wad.readiness.blockers.length
+        ? wad.readiness.blockers.map((b: string) => `WAD: ${b}`)
+        : ['WAD: a current RELEASED authorization is required.'])
+    );
+  return {
+    blockers: Array.from(new Set(blockers)),
+    revisions: {
+      commercial: contractReview?.revision_number ?? null,
+      technical: technical.review?.revision_number ?? null,
+      productionPlanning: planning.plan?.revision_number ?? null,
+      wadAuthorization: wad.authorization?.revision_number ?? null,
+    },
+    technical,
+    planning,
+    wad,
+    supplyChainRequired:
+      Boolean(technical.review?.supply_chain_required) ||
+      planning.items.some(
+        (item: Row) =>
+          item.make_buy === 'BUY' ||
+          (Array.isArray(item.special_process_requirements) &&
+            item.special_process_requirements.length > 0)
+      ),
+    financeRequired: Boolean(
+      contractReview?.requirements_snapshot?.financeRequired
+    ),
+  };
+}
+
+function recommendedChecklist(source: Awaited<ReturnType<typeof sourceState>>) {
+  const planningItems = source.planning.items as Row[];
+  const entries: Array<[string, string, string, boolean]> = [
+    [
+      'accepted-order',
+      'Project and contract',
+      'Accepted customer PO/order is current',
+      true,
+    ],
+    [
+      'contract-current',
+      'Project and contract',
+      'Contract Review is approved and current',
+      source.blockers.length === 0,
+    ],
+    [
+      'risks-controlled',
+      'Project and contract',
+      'Applicable risks have owners and controls',
+      true,
+    ],
+    [
+      'technical-released',
+      'Technical/configuration',
+      'Drawings and specifications are released/current',
+      source.technical.valid,
+    ],
+    [
+      'configuration-released',
+      'Technical/configuration',
+      'BOM/configuration baseline and effectivity are released',
+      source.technical.valid,
+    ],
+    [
+      'routing-complete',
+      'Manufacturing planning',
+      'Manufactured item tree and approved routings are complete',
+      source.planning.readiness.ready,
+    ],
+    [
+      'first-department',
+      'Manufacturing planning',
+      'First department and department sequence are resolved',
+      planningItems
+        .filter((item) => item.is_manufactured)
+        .every((item) => Boolean(item.routing_id)),
+    ],
+    [
+      'traveler-decision',
+      'Manufacturing planning',
+      'Traveler type or approved no-traveler exception is decided',
+      planningItems
+        .filter((item) => item.is_manufactured)
+        .every((item) => Boolean(item.traveler_requirement)),
+    ],
+    [
+      'instructions-released',
+      'Manufacturing planning',
+      'Required work instructions and specifications are released',
+      source.planning.readiness.ready,
+    ],
+    [
+      'tooling-programs',
+      'Manufacturing planning',
+      'Required tooling, fixtures, gauges, and CNC programs are available',
+      source.planning.readiness.ready,
+    ],
+    [
+      'inspection-defined',
+      'Quality planning',
+      'Inspection points and final acceptance criteria are defined',
+      source.planning.readiness.ready,
+    ],
+    [
+      'sampling-fai',
+      'Quality planning',
+      'Inspection extent, sampling, FAI, and test requirements are decided',
+      source.planning.readiness.ready,
+    ],
+    [
+      'traceability-certification',
+      'Quality planning',
+      'Traceability, certification, and C of C requirements are defined',
+      source.planning.readiness.ready,
+    ],
+    [
+      'material-availability',
+      'Materials and supply chain',
+      'Material availability, shortages, and planned supply are evaluated',
+      !source.supplyChainRequired || source.planning.readiness.ready,
+    ],
+    [
+      'supplier-approval',
+      'Materials and supply chain',
+      'Applicable suppliers and outside-process sources are approved',
+      !source.supplyChainRequired || source.planning.readiness.ready,
+    ],
+    [
+      'schedule-capacity',
+      'Resources',
+      'Department capacity and schedule are approved/current',
+      source.planning.readiness.ready,
+    ],
+    [
+      'qualified-resources',
+      'Resources',
+      'Required employee qualifications and calibrated equipment are current',
+      true,
+    ],
+    [
+      'budgets-active',
+      'Resources',
+      'Charge codes, labor, material, and outside-processing budgets are active',
+      source.wad.readiness.ready,
+    ],
+    [
+      'safety-controls',
+      'Resources',
+      'Applicable safety, FOD, and environmental controls are identified',
+      true,
+    ],
+    [
+      'wad-current',
+      'Project and contract',
+      'Released WAD authorization is current',
+      source.wad.readiness.ready,
+    ],
+  ];
+  return entries.map(([key, category, label, satisfied]) => ({
+    key,
+    category,
+    label,
+    applicability:
+      (key === 'supplier-approval' || key === 'material-availability') &&
+      !source.supplyChainRequired
+        ? ('NOT_REQUIRED' as const)
+        : ('REQUIRED' as const),
+    satisfied,
+    evidence: [],
+  }));
+}
+
+async function current(projectId: string, tx: Executor) {
+  return (
+    resultRows(
+      await tx.execute(sql`
+      SELECT * FROM project_preproduction_readiness_reviews
+      WHERE project_id=${projectId} AND status IN ('DRAFT','PENDING_APPROVAL','COMPLETE')
+      ORDER BY revision_number DESC LIMIT 1`)
+    )[0] ?? null
+  );
+}
+async function history(projectId: string, tx: Executor) {
+  return resultRows(
+    await tx.execute(sql`
+      SELECT * FROM project_preproduction_readiness_reviews
+      WHERE project_id=${projectId} ORDER BY revision_number DESC`)
+  );
+}
+async function approvals(review: Row, tx: Executor) {
+  return resultRows(
+    await tx.execute(sql`
+      SELECT * FROM project_workflow_step_approvals
+      WHERE workflow_step_instance_id=${review.workflow_step_instance_id}
+        AND evidence_snapshot->>'preproductionReadinessId'=${review.id}
+      ORDER BY decided_at`)
+  );
+}
+async function readiness(projectId: string, review: Row | null, tx: Executor) {
+  if (!review)
+    return {
+      state: 'NOT_READY',
+      ready: false,
+      blockers: ['Create a readiness revision.'],
+      stale: false,
+    };
+  const source = await sourceState(projectId, tx);
+  const stale =
+    JSON.stringify(review.source_stage_revisions) !==
+    JSON.stringify(source.revisions);
+  const blockers = [
+    ...source.blockers,
+    ...checklistBlockers(review.checklist_snapshot ?? []),
+  ];
+  if (stale)
+    blockers.unshift(
+      'Source stage revisions changed; create a new readiness revision.'
+    );
+  const state = stale
+    ? 'STALE'
+    : source.blockers.length
+      ? 'BLOCKED'
+      : blockers.length
+        ? 'NOT_READY'
+        : 'READY';
+  return {
+    state,
+    ready: state === 'READY',
+    blockers: Array.from(new Set(blockers)),
+    stale,
+    source,
+  };
+}
+
+async function readModel(projectId: string, tx: Executor = db) {
+  const ctx = await context(projectId, tx, false, false);
+  const review = await current(projectId, tx);
+  const release =
+    resultRows(
+      await tx.execute(sql`
+      SELECT * FROM project_production_releases WHERE project_id=${projectId}
+      ORDER BY approved_at DESC LIMIT 1`)
+    )[0] ?? null;
+  const launch =
+    resultRows(
+      await tx.execute(sql`
+      SELECT * FROM project_production_launches WHERE project_id=${projectId}
+      ORDER BY launched_at DESC LIMIT 1`)
+    )[0] ?? null;
+  return {
+    review,
+    history: await history(projectId, tx),
+    approvals: review ? await approvals(review, tx) : [],
+    requiredApprovals: review ? requiredPreproductionRoles(review) : [],
+    readiness: await readiness(projectId, review, tx),
+    release,
+    launch,
+    recommendedChecklist: review
+      ? recommendedChecklist((await readiness(projectId, review, tx)).source!)
+      : recommendedChecklist(await sourceState(projectId, tx)),
+    stage: ctx.step,
+    projectStatus: ctx.project.current_stage,
+  };
+}
+export const getPreproductionReadiness = (
+  projectId: string,
+  tx: Executor = db
+) => readModel(projectId, tx);
+
+async function insertRevision(
+  projectId: string,
+  input: PreproductionInput,
+  actor: PreproductionActor,
+  tx: Executor,
+  revision: number
+) {
+  const ctx = await context(projectId, tx, true);
+  const source = await sourceState(projectId, tx);
+  if (source.blockers.length)
+    throw new ProjectPreproductionError(
+      'PREDECESSOR_EVIDENCE_INVALID',
+      'Current predecessor evidence is required.',
+      409,
+      { blockers: source.blockers }
+    );
+  const checklist =
+    input.checklist.length > 0 ? input.checklist : recommendedChecklist(source);
+  const blockers = checklistBlockers(checklist);
+  const [row] = resultRows(
+    await tx.execute(sql`
+      INSERT INTO project_preproduction_readiness_reviews
+        (project_id,workflow_instance_id,workflow_step_instance_id,revision_number,
+         readiness_state,source_stage_revisions,checklist_snapshot,blockers,exceptions,
+         risks_and_controls,supply_chain_required,finance_required,effectivity_reference,
+         created_by,created_by_display_name)
+      VALUES (${projectId},${ctx.instance.id},${ctx.step.id},${revision},
+        ${blockers.length ? 'NOT_READY' : 'READY'},${JSON.stringify(source.revisions)}::jsonb,
+        ${JSON.stringify(checklist)}::jsonb,${JSON.stringify(blockers)}::jsonb,
+        ${JSON.stringify(input.exceptions ?? [])}::jsonb,
+        ${JSON.stringify(input.risksAndControls ?? [])}::jsonb,
+        ${source.supplyChainRequired},${source.financeRequired},
+        ${clean(input.effectivityReference)},${actor.userId},${actor.displayName})
+      RETURNING *`)
+  );
+  await tx.execute(sql`
+    UPDATE project_workflow_step_instances
+    SET status='IN_PROGRESS',started_at=COALESCE(started_at,now()),blocked_reason=NULL,updated_at=now()
+    WHERE id=${ctx.step.id}`);
+  await audit('P2_V2_PREPRODUCTION_REVISION_CREATED', row, actor, tx);
+  return row;
+}
+
+async function audit(
+  eventType: string,
+  review: Row,
+  actor: PreproductionActor,
+  tx: Executor
+) {
+  await recordAuditEvent(
+    {
+      eventType,
+      subjectType: 'project_preproduction_readiness',
+      subjectId: review.id,
+      sourceService: 'projectPreproductionReadinessService',
+      actor: { id: actor.userId, username: actor.username, role: actor.role },
+      payload: {
+        projectId: review.project_id,
+        revision: Number(review.revision_number),
+        status: review.status,
+      },
+    },
+    tx
+  );
+}
+
+export async function createPreproductionReadiness(
+  projectId: string,
+  input: PreproductionInput,
+  actor: PreproductionActor
+) {
+  return db.transaction(async (tx) => {
+    if (await current(projectId, tx))
+      throw new ProjectPreproductionError(
+        'ACTIVE_REVISION_EXISTS',
+        'An active readiness revision already exists.',
+        409
+      );
+    await insertRevision(projectId, input, actor, tx, 1);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function updatePreproductionDraft(
+  projectId: string,
+  reviewId: string,
+  expectedLockVersion: number,
+  input: PreproductionInput,
+  actor: PreproductionActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedLockVersion
+    )
+      throw new ProjectPreproductionError(
+        'STALE_REVISION',
+        'The readiness revision changed; reload before saving.',
+        409
+      );
+    if (review.status !== 'DRAFT')
+      throw new ProjectPreproductionError(
+        'DRAFT_REQUIRED',
+        'Only a draft may be edited.',
+        409
+      );
+    const source = await sourceState(projectId, tx);
+    const blockers = [
+      ...source.blockers,
+      ...checklistBlockers(input.checklist),
+    ];
+    await tx.execute(sql`
+      UPDATE project_preproduction_readiness_reviews SET
+        lock_version=lock_version+1,readiness_state=${source.blockers.length ? 'BLOCKED' : blockers.length ? 'NOT_READY' : 'READY'},
+        source_stage_revisions=${JSON.stringify(source.revisions)}::jsonb,
+        checklist_snapshot=${JSON.stringify(input.checklist)}::jsonb,
+        blockers=${JSON.stringify(blockers)}::jsonb,exceptions=${JSON.stringify(input.exceptions ?? [])}::jsonb,
+        risks_and_controls=${JSON.stringify(input.risksAndControls ?? [])}::jsonb,
+        supply_chain_required=${source.supplyChainRequired},
+        finance_required=${source.financeRequired},
+        effectivity_reference=${clean(input.effectivityReference)},updated_at=now()
+      WHERE id=${review.id}`);
+    await audit('P2_V2_PREPRODUCTION_DRAFT_UPDATED', review, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function recalculatePreproduction(
+  projectId: string,
+  reviewId: string,
+  expectedLockVersion: number,
+  actor: PreproductionActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedLockVersion
+    )
+      throw new ProjectPreproductionError(
+        'STALE_REVISION',
+        'The readiness revision changed; reload before recalculation.',
+        409
+      );
+    if (review.status !== 'DRAFT')
+      throw new ProjectPreproductionError(
+        'DRAFT_REQUIRED',
+        'Only a draft may be recalculated.',
+        409
+      );
+    const state = await readiness(projectId, review, tx);
+    if (!state.source)
+      throw new ProjectPreproductionError(
+        'READINESS_SOURCE_REQUIRED',
+        'Current predecessor evidence is required.',
+        409
+      );
+    await tx.execute(sql`
+      UPDATE project_preproduction_readiness_reviews SET lock_version=lock_version+1,
+        readiness_state=${state.state},blockers=${JSON.stringify(state.blockers)}::jsonb,
+        source_stage_revisions=${JSON.stringify(state.source.revisions)}::jsonb,updated_at=now()
+      WHERE id=${review.id}`);
+    await audit('P2_V2_PREPRODUCTION_RECALCULATED', review, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function submitPreproduction(
+  projectId: string,
+  reviewId: string,
+  expectedLockVersion: number,
+  actor: PreproductionActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedLockVersion
+    )
+      throw new ProjectPreproductionError(
+        'STALE_REVISION',
+        'The readiness revision changed; reload before submitting.',
+        409
+      );
+    if (review.status !== 'DRAFT')
+      throw new ProjectPreproductionError(
+        'DRAFT_REQUIRED',
+        'Only a draft may be submitted.',
+        409
+      );
+    const state = await readiness(projectId, review, tx);
+    if (!state.ready)
+      throw new ProjectPreproductionError(
+        'PREPRODUCTION_NOT_READY',
+        'Readiness has blockers.',
+        409,
+        { blockers: state.blockers }
+      );
+    await tx.execute(sql`
+      UPDATE project_preproduction_readiness_reviews
+      SET status='PENDING_APPROVAL',readiness_state='READY',submitted_at=now(),
+          lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`);
+    await tx.execute(sql`
+      UPDATE project_workflow_step_instances SET status='PENDING_APPROVAL',updated_at=now()
+      WHERE id=${review.workflow_step_instance_id}`);
+    await audit('P2_V2_PREPRODUCTION_SUBMITTED', review, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function decidePreproduction(
+  projectId: string,
+  reviewId: string,
+  expectedLockVersion: number,
+  capacity: string,
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: PreproductionActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedLockVersion
+    )
+      throw new ProjectPreproductionError(
+        'STALE_REVISION',
+        'The readiness revision changed; reload before deciding.',
+        409
+      );
+    if (review.status !== 'PENDING_APPROVAL')
+      throw new ProjectPreproductionError(
+        'PENDING_APPROVAL_REQUIRED',
+        'The revision is not pending approval.',
+        409
+      );
+    if (!requiredPreproductionRoles(review).includes(capacity))
+      throw new ProjectPreproductionError(
+        'APPROVAL_NOT_REQUIRED',
+        `${capacity} approval is not required.`,
+        409
+      );
+    const evidence = await approvals(review, tx);
+    if (
+      evidence.some(
+        (entry) => entry.approval_type === `PREPRODUCTION_${capacity}`
+      )
+    )
+      throw new ProjectPreproductionError(
+        'DECISION_ALREADY_RECORDED',
+        `${capacity} already decided this revision.`,
+        409
+      );
+    if (
+      evidence.some(
+        (entry) =>
+          Number(entry.actor_user_id) === actor.userId &&
+          entry.decision === 'APPROVED'
+      )
+    )
+      throw new ProjectPreproductionError(
+        'SEGREGATION_OF_DUTIES',
+        'One actor cannot approve multiple required functions.',
+        403
+      );
+    if (!clean(signatureMeaning) || (decision !== 'APPROVED' && !clean(reason)))
+      throw new ProjectPreproductionError(
+        'DECISION_EVIDENCE_REQUIRED',
+        'Signature meaning and rejection/return reason are required.'
+      );
+    await tx.execute(sql`
+      INSERT INTO project_workflow_step_approvals
+        (workflow_step_instance_id,project_id,approval_type,decision,signature_meaning,
+         reason,actor_employee_id,actor_user_id,actor_display_name,actor_role,
+         step_revision_snapshot,evidence_snapshot)
+      VALUES (${review.workflow_step_instance_id},${projectId},${`PREPRODUCTION_${capacity}`},
+        ${decision},${signatureMeaning},${clean(reason) || null},${actor.employeeId ?? null},
+        ${actor.userId},${actor.displayName},${actor.role},${String(review.revision_number)},
+        ${JSON.stringify({ preproductionReadinessId: review.id, revision: review.revision_number, invalidated: false })}::jsonb)`);
+    await tx.execute(sql`
+      UPDATE project_preproduction_readiness_reviews SET
+        status=${decision === 'APPROVED' ? 'PENDING_APPROVAL' : 'REJECTED'},
+        lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`);
+    if (decision !== 'APPROVED')
+      await tx.execute(sql`
+        UPDATE project_workflow_step_instances SET status='BLOCKED',
+          blocked_reason=${`${capacity} ${decision.toLowerCase()}: ${clean(reason)}`},updated_at=now()
+        WHERE id=${review.workflow_step_instance_id}`);
+    await audit(`P2_V2_PREPRODUCTION_${capacity}_DECIDED`, review, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function completePreproduction(
+  projectId: string,
+  reviewId: string,
+  expectedLockVersion: number,
+  actor: PreproductionActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedLockVersion
+    )
+      throw new ProjectPreproductionError(
+        'STALE_REVISION',
+        'The readiness revision changed; reload before completing.',
+        409
+      );
+    const state = await readiness(projectId, review, tx);
+    if (review.status !== 'PENDING_APPROVAL' || !state.ready)
+      throw new ProjectPreproductionError(
+        'PREPRODUCTION_NOT_READY',
+        'The submitted revision is not ready.',
+        409,
+        { blockers: state.blockers }
+      );
+    const evidence = await approvals(review, tx);
+    const missing = requiredPreproductionRoles(review).filter(
+      (role) =>
+        !evidence.some(
+          (entry) =>
+            entry.approval_type === `PREPRODUCTION_${role}` &&
+            entry.decision === 'APPROVED'
+        )
+    );
+    if (missing.length)
+      throw new ProjectPreproductionError(
+        'APPROVALS_REQUIRED',
+        'Required independent approvals are missing.',
+        409,
+        { missingApprovals: missing }
+      );
+    await tx.execute(sql`
+      UPDATE project_preproduction_readiness_reviews
+      SET status='COMPLETE',readiness_state='READY',completed_at=now(),
+          lock_version=lock_version+1,updated_at=now() WHERE id=${review.id}`);
+    await tx.execute(sql`
+      UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now(),
+        completed_by=${actor.employeeId ?? null},completed_by_display_name=${actor.displayName},
+        revision_reference=${String(review.revision_number)},
+        effectivity_reference=${review.effectivity_reference},blocked_reason=NULL,updated_at=now()
+      WHERE id=${review.workflow_step_instance_id}`);
+    await tx.execute(sql`
+      UPDATE projects SET current_stage='PREPRODUCTION_READINESS',
+        stage_updated_at=now(),updated_at=now() WHERE id=${projectId}`);
+    await audit('P2_V2_PREPRODUCTION_COMPLETED', review, actor, tx);
+    return readModel(projectId, tx);
+  });
+}
+
+export async function revisePreproduction(
+  projectId: string,
+  reviewId: string,
+  expectedLockVersion: number,
+  input: PreproductionInput,
+  actor: PreproductionActor
+) {
+  return db.transaction(async (tx) => {
+    const ctx = await context(projectId, tx, true);
+    const review = await current(projectId, tx);
+    if (
+      !review ||
+      review.id !== reviewId ||
+      Number(review.lock_version) !== expectedLockVersion
+    )
+      throw new ProjectPreproductionError(
+        'STALE_REVISION',
+        'The readiness revision changed; reload before revising.',
+        409
+      );
+    if (
+      !['COMPLETE', 'REJECTED', 'STALE', 'INVALIDATED'].includes(review.status)
+    )
+      throw new ProjectPreproductionError(
+        'REVISION_NOT_ALLOWED',
+        'This readiness revision cannot be superseded.',
+        409
+      );
+    const launched = resultRows(
+      await tx.execute(sql`
+        SELECT id FROM project_production_launches
+        WHERE project_id=${projectId} AND status='COMPLETE' LIMIT 1`)
+    )[0];
+    if (launched)
+      throw new ProjectPreproductionError(
+        'PRODUCTION_ALREADY_LAUNCHED',
+        'Readiness cannot be revised after production launch.',
+        409
+      );
+    await tx.execute(sql`
+      UPDATE project_preproduction_readiness_reviews SET status='SUPERSEDED',
+        superseded_at=now(),updated_at=now() WHERE id=${review.id}`);
+    const next = await insertRevision(
+      projectId,
+      input,
+      actor,
+      tx,
+      Number(review.revision_number) + 1
+    );
+    await tx.execute(sql`
+      UPDATE project_preproduction_readiness_reviews SET superseded_by_review_id=${next.id}
+      WHERE id=${review.id}`);
+    await tx.execute(sql`
+      UPDATE project_workflow_step_approvals SET superseded_at=now(),
+        evidence_snapshot=jsonb_set(COALESCE(evidence_snapshot,'{}'::jsonb),'{invalidated}','true'::jsonb)
+      WHERE evidence_snapshot->>'preproductionReadinessId'=${review.id} AND superseded_at IS NULL`);
+    await tx.execute(sql`
+      UPDATE project_production_releases SET status='INVALIDATED'
+      WHERE project_id=${projectId} AND readiness_review_id=${review.id}
+        AND status='APPROVED'`);
+    if (ctx.project.current_stage === 'READY_FOR_P2_RELEASE') {
+      await tx.execute(sql`
+        UPDATE projects SET current_stage='PREPRODUCTION_READINESS',
+          stage_updated_at=now(),updated_at=now() WHERE id=${projectId}`);
+      if (ctx.project.po_id)
+        await tx.execute(sql`
+          UPDATE p2_purchase_orders SET status='READY_FOR_PRODUCTION',updated_at=now()
+          WHERE id=${ctx.project.po_id}`);
+    }
+    return readModel(projectId, tx);
+  });
+}
+
+async function validateRelease(projectId: string, tx: Executor, lock = true) {
+  const ctx = await context(projectId, tx, lock);
+  const review = await current(projectId, tx);
+  const state = await readiness(projectId, review, tx);
+  if (!review || review.status !== 'COMPLETE' || !state.ready)
+    throw new ProjectPreproductionError(
+      'COMPLETED_READINESS_REQUIRED',
+      'A current completed Preproduction Readiness revision is required.',
+      409,
+      { blockers: state.blockers }
+    );
+  const evidence = await approvals(review, tx);
+  const missing = requiredPreproductionRoles(review).filter(
+    (role) =>
+      !evidence.some(
+        (entry) =>
+          entry.approval_type === `PREPRODUCTION_${role}` &&
+          entry.decision === 'APPROVED' &&
+          !entry.superseded_at
+      )
+  );
+  if (missing.length)
+    throw new ProjectPreproductionError(
+      'APPROVALS_REQUIRED',
+      'Required readiness approvals are missing.',
+      409,
+      { missingApprovals: missing }
+    );
+  const source = state.source;
+  if (!source)
+    throw new ProjectPreproductionError(
+      'RELEASE_BASELINE_REQUIRED',
+      'Current release baseline evidence is required.',
+      409
+    );
+  if (!source.planning.plan || !source.wad.authorization)
+    throw new ProjectPreproductionError(
+      'RELEASE_BASELINE_REQUIRED',
+      'Released Production Plan and WAD are required.',
+      409
+    );
+  return { ctx, review, source };
+}
+
+export async function approveProductionRelease(
+  projectId: string,
+  actor: PreproductionActor
+) {
+  return db.transaction(async (tx) => {
+    const { ctx, review, source } = await validateRelease(projectId, tx);
+    if (ctx.project.current_stage !== 'PREPRODUCTION_READINESS')
+      throw new ProjectPreproductionError(
+        'INVALID_PROJECT_STATUS',
+        'Project is not in the permitted preproduction status.',
+        409
+      );
+    const existing = resultRows(
+      await tx.execute(
+        sql`SELECT * FROM project_production_releases WHERE project_id=${projectId} AND status='APPROVED'`
+      )
+    )[0];
+    if (existing) {
+      if (existing.readiness_review_id === review.id)
+        return readModel(projectId, tx);
+      throw new ProjectPreproductionError(
+        'CONFLICTING_RELEASE',
+        'A different active production release exists.',
+        409
+      );
+    }
+    const plan = source.planning.plan;
+    const wad = source.wad.authorization;
+    const [release] = resultRows(
+      await tx.execute(sql`
+        INSERT INTO project_production_releases
+          (project_id,workflow_instance_id,readiness_review_id,readiness_revision,
+           wad_authorization_id,wad_revision,production_plan_id,production_plan_revision,
+           configuration_baseline_id,effectivity_reference,approved_by,
+           approved_by_display_name,evidence_snapshot)
+        VALUES (${projectId},${ctx.instance.id},${review.id},${Number(review.revision_number)},
+          ${wad.id},${Number(wad.revision_number)},${plan.id},${Number(plan.revision_number)},
+          ${String(plan.configuration_baseline_id)},${review.effectivity_reference},
+          ${actor.userId},${actor.displayName},
+          ${JSON.stringify({ sourceRevisions: review.source_stage_revisions, approvals: (await approvals(review, tx)).map((a) => ({ type: a.approval_type, actor: a.actor_display_name, decidedAt: a.decided_at })) })}::jsonb)
+        RETURNING *`)
+    );
+    await tx.execute(sql`
+      UPDATE projects SET current_stage='READY_FOR_P2_RELEASE',stage_updated_at=now(),updated_at=now()
+      WHERE id=${projectId}`);
+    if (ctx.project.po_id)
+      await tx.execute(sql`
+        UPDATE p2_purchase_orders SET status='READY_FOR_P2_RELEASE',updated_at=now()
+        WHERE id=${ctx.project.po_id}`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCTION_RELEASE_APPROVED',
+        subjectType: 'project_production_release',
+        subjectId: release.id,
+        sourceService: 'projectPreproductionReadinessService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          readinessRevision: Number(review.revision_number),
+          wadRevision: Number(wad.revision_number),
+        },
+      },
+      tx
+    );
+    return readModel(projectId, tx);
+  });
+}
+
+export async function launchProduction(
+  projectId: string,
+  idempotencyKey: string,
+  actor: PreproductionActor
+) {
+  if (!clean(idempotencyKey))
+    throw new ProjectPreproductionError(
+      'IDEMPOTENCY_KEY_REQUIRED',
+      'An idempotency key is required.'
+    );
+  try {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${`p2-v2-launch:${projectId}`}))`
+      );
+      const replay = resultRows(
+        await tx.execute(sql`
+          SELECT * FROM project_production_launches
+          WHERE project_id=${projectId} AND idempotency_key=${idempotencyKey} AND status='COMPLETE'`)
+      )[0];
+      if (replay) return readModel(projectId, tx);
+      const { ctx, review, source } = await validateRelease(projectId, tx);
+      if (ctx.project.current_stage !== 'READY_FOR_P2_RELEASE')
+        throw new ProjectPreproductionError(
+          'PRODUCTION_RELEASE_REQUIRED',
+          'Project must be READY_FOR_P2_RELEASE.',
+          409
+        );
+      const release = resultRows(
+        await tx.execute(sql`
+          SELECT * FROM project_production_releases
+          WHERE project_id=${projectId} AND status='APPROVED' FOR UPDATE`)
+      )[0];
+      if (!release || release.readiness_review_id !== review.id)
+        throw new ProjectPreproductionError(
+          'CURRENT_RELEASE_REQUIRED',
+          'The approved production release is missing or stale.',
+          409
+        );
+      const poId = Number(ctx.project.po_id);
+      if (!Number.isInteger(poId))
+        throw new ProjectPreproductionError(
+          'LINKED_PO_REQUIRED',
+          'A linked P2 customer PO is required.',
+          409
+        );
+      const items = resultRows(
+        await tx.execute(
+          sql`SELECT id,quantity FROM p2_purchase_order_items WHERE po_id=${poId} ORDER BY id`
+        )
+      );
+      if (!items.length)
+        throw new ProjectPreproductionError(
+          'PO_ITEMS_REQUIRED',
+          'The linked P2 PO has no line items.',
+          409
+        );
+      const existingOrders = resultRows(
+        await tx.execute(
+          sql`SELECT id FROM p2_production_orders WHERE p2_po_id=${poId}`
+        )
+      );
+      const createdSerialIds: string[] = [];
+      for (const item of items) {
+        const countRow = resultRows(
+          await tx.execute(
+            sql`SELECT count(*)::int count FROM p2_serialized_items WHERE po_item_id=${item.id}`
+          )
+        )[0];
+        const missing = Math.max(
+          0,
+          Number(item.quantity) - Number(countRow?.count ?? 0)
+        );
+        if (missing)
+          createdSerialIds.push(
+            ...(
+              await storage.addP2SerializedItemsForPoItem(
+                Number(item.id),
+                missing,
+                tx
+              )
+            ).map((entry) => entry.id)
+          );
+      }
+      const productionOrders =
+        existingOrders.length === 0
+          ? await storage.generateP2ProductionOrders(poId, undefined, tx)
+          : [];
+      const schedulable = resultRows(
+        await tx.execute(sql`
+          SELECT si.id,si.po_item_id,si.part_number,si.part_routing_id,
+                 pr.department_sequence
+          FROM p2_serialized_items si
+          LEFT JOIN part_routings pr ON pr.id=si.part_routing_id
+          WHERE si.po_id=${poId} AND si.status='ACTIVE'
+            AND si.current_department='Pending Layup'`)
+      );
+      const routed: Row[] = [];
+      const unresolved: Row[] = [];
+      for (const item of schedulable) {
+        const department = resolveFirstProductionDepartment(
+          item.department_sequence,
+          Boolean(item.part_routing_id)
+        );
+        if (!department) {
+          unresolved.push(item);
+          continue;
+        }
+        const updated = resultRows(
+          await tx.execute(sql`
+            UPDATE p2_serialized_items SET current_department=${department},
+              current_stage_index=0,updated_at=now()
+            WHERE id=${item.id} AND current_department='Pending Layup'
+            RETURNING id,po_item_id,part_routing_id,current_department`)
+        )[0];
+        if (updated) routed.push(updated);
+      }
+      if (unresolved.length)
+        throw new ProjectPreproductionError(
+          'FIRST_DEPARTMENT_UNRESOLVED',
+          'One or more routed items have no valid first production department.',
+          409,
+          { items: unresolved }
+        );
+      const productionStep = ctx.steps.find(
+        (entry) => entry.step_type === 'production_quality'
+      );
+      if (!productionStep)
+        throw new ProjectPreproductionError(
+          'PRODUCTION_STAGE_REQUIRED',
+          'Production stage is missing.',
+          409
+        );
+      await tx.execute(sql`
+        UPDATE project_workflow_step_instances SET status='IN_PROGRESS',
+          started_at=COALESCE(started_at,now()),blocked_reason=NULL,updated_at=now()
+        WHERE id=${productionStep.id}`);
+      await tx.execute(sql`
+        UPDATE projects SET current_stage='IN_PRODUCTION',stage_updated_at=now(),updated_at=now()
+        WHERE id=${projectId}`);
+      await tx.execute(sql`
+        UPDATE p2_purchase_orders SET status='IN_PRODUCTION',updated_at=now() WHERE id=${poId}`);
+      const [launch] = resultRows(
+        await tx.execute(sql`
+          INSERT INTO project_production_launches
+            (project_id,production_release_id,idempotency_key,status,production_evidence,
+             launched_by,launched_by_display_name)
+          VALUES (${projectId},${release.id},${idempotencyKey},'COMPLETE',
+            ${JSON.stringify({
+              poId,
+              productionPlanId: source.planning.plan!.id,
+              wadAuthorizationId: source.wad.authorization!.id,
+              createdSerializedItemIds: createdSerialIds,
+              createdProductionOrderIds: productionOrders.map(
+                (entry) => entry.id
+              ),
+              routedItems: routed,
+            })}::jsonb,${actor.userId},${actor.displayName}) RETURNING *`)
+      );
+      await recordAuditEvent(
+        {
+          eventType: 'P2_V2_PRODUCTION_LAUNCHED',
+          subjectType: 'project_production_launch',
+          subjectId: launch.id,
+          sourceService: 'projectPreproductionReadinessService',
+          actor: {
+            id: actor.userId,
+            username: actor.username,
+            role: actor.role,
+          },
+          payload: {
+            projectId,
+            poId,
+            serializedItemsCreated: createdSerialIds.length,
+            productionOrdersCreated: productionOrders.length,
+            itemsRouted: routed.length,
+          },
+        },
+        tx
+      );
+      return readModel(projectId, tx);
+    });
+  } catch (error) {
+    await recordAuditEvent({
+      eventType: 'P2_V2_PRODUCTION_LAUNCH_FAILED',
+      subjectType: 'project',
+      subjectId: projectId,
+      sourceService: 'projectPreproductionReadinessService',
+      actor: { id: actor.userId, username: actor.username, role: actor.role },
+      payload: {
+        projectId,
+        idempotencyKey,
+        errorCode:
+          error instanceof ProjectPreproductionError
+            ? error.code
+            : 'PRODUCTION_LAUNCH_FAILED',
+      },
+    });
+    throw error;
+  }
+}

--- a/server/src/services/projectPreproductionRules.ts
+++ b/server/src/services/projectPreproductionRules.ts
@@ -1,0 +1,63 @@
+export type ChecklistDecision = {
+  key: string;
+  category: string;
+  label: string;
+  applicability: 'REQUIRED' | 'NOT_REQUIRED' | 'NOT_APPLICABLE';
+  satisfied: boolean;
+  evidence?: Array<{ recordType: string; recordId: string; revision?: string }>;
+  justification?: string;
+  approvedJustification?: boolean;
+};
+
+const clean = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : '';
+
+export function checklistBlockers(checklist: ChecklistDecision[]) {
+  const blockers: string[] = [];
+  for (const item of checklist) {
+    if (!clean(item.key) || !clean(item.category) || !clean(item.label)) {
+      blockers.push(
+        'Every checklist item requires a key, category, and label.'
+      );
+      continue;
+    }
+    if (item.applicability === 'REQUIRED' && !item.satisfied)
+      blockers.push(`${item.category}: ${item.label}`);
+    if (
+      item.applicability === 'NOT_APPLICABLE' &&
+      (!clean(item.justification) || !item.approvedJustification)
+    )
+      blockers.push(
+        `${item.category}: ${item.label} requires an approved justification.`
+      );
+  }
+  return blockers;
+}
+
+export function requiredPreproductionRoles(review: {
+  supply_chain_required?: boolean;
+  finance_required?: boolean;
+}) {
+  return [
+    'PROJECT_MANAGEMENT',
+    'ENGINEERING',
+    'QUALITY',
+    'OPERATIONS',
+    ...(review.supply_chain_required ? ['SUPPLY_CHAIN'] : []),
+    ...(review.finance_required ? ['FINANCE'] : []),
+  ];
+}
+
+export function resolveFirstProductionDepartment(
+  departmentSequence: unknown,
+  routingExists: boolean
+) {
+  if (Array.isArray(departmentSequence)) {
+    const first = departmentSequence.find(
+      (department): department is string =>
+        typeof department === 'string' && clean(department).length > 0
+    );
+    if (first) return clean(first);
+  }
+  return routingExists ? null : 'Layup';
+}


### PR DESCRIPTION
## Summary

Implements Phase 8C for explicit `p2_v2` definition-v2 workflow instances:

- adds revision-controlled Stage 7 Preproduction Readiness records, immutable completed snapshots, history, optimistic concurrency, source-revision staleness detection, blockers, exceptions, risks/controls, effectivity, and approval evidence
- dynamically derives the readiness checklist from the current commercial, technical/configuration, released Production Plan, and released WAD baselines
- requires independent Project Management, Engineering, Quality, and Operations approvals; Supply Chain and Finance are added only when the authoritative upstream baselines require them
- adds a separate **Approve Production Release** action that records an immutable release snapshot and changes the project/PO to `READY_FOR_P2_RELEASE` without creating production records
- adds a separate confirmed **Launch Production** action that revalidates all gates in-transaction, activates Stage 8, changes the project/PO to `IN_PRODUCTION`, creates only missing serialized units, reuses existing P2 production-order generation, and routes every serialized item to the first department in its stamped routing (including Assembly-first routes)
- protects launches with a project advisory lock, a unique idempotency key, transaction rollback, and an append-only failure audit event
- adds the Stage 7 UI, blocker/evidence/approval/history views, and clearly separated release and launch controls

## Data model

Migration `0210_project_preproduction_readiness.sql` adds:

- `project_preproduction_readiness_reviews`
- `project_production_releases`
- `project_production_launches`
- narrowly scoped readiness/release/launch capabilities and role mappings
- immutable completed-readiness snapshot protection

The migration is additive only and was not applied to a shared or production database.

## Safety boundaries

- every service action verifies explicit `p2_v2`, definition version 2, workflow integrity, and project/instance/step associations
- NULL and `legacy_v1` projects continue through existing routes unchanged
- unknown workflow versions fail closed
- legacy `release-to-p2`, scheduling, production-order, traveler, shipping, and closing paths were not changed
- Design Control, Design Projects, ECR, and ECN paths were not changed or called
- normal `p2_v2` project creation remains disabled
- approving release does not create serialized items, production orders, travelers, reservations, schedules, queue entries, or labor charges

## Validation

- Phase 8C server rules: **7/7 passed**
- Phase 1-8B workflow/WAD/closing regression suite: **101/101 passed**
- P2 V2 component suite: **5/5 passed**
- focused ESLint on new/changed Phase 8C implementation and tests: **passed**
- `git diff --cached --check`: **passed**
- TypeScript with `NODE_OPTIONS=--max-old-space-size=6144`: repository remains non-clean due to the existing unrelated diagnostic backlog; complete output was searched and **no diagnostics reference any Phase 8C file**

## Remaining review focus

- exercise the migration and transactional launch against an isolated database fixture before production rollout
- confirm role names in each deployed tenant map to the new capabilities as expected
- validate any site-specific queue/cutting-table follow-on automation after the atomic launch transaction