### PR TITLE
Fix Draft Builder parts setup layout

### DIFF
--- a/client/src/pages/DraftBOMBuilderPage.tsx
+++ b/client/src/pages/DraftBOMBuilderPage.tsx
@@ -4916,8 +4916,8 @@ function PartsRequestWorkspace({
   return (
     <section className="space-y-4">
       <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-          <div className="min-w-0 flex-1 space-y-3">
+        <div className="space-y-4">
+          <div className="min-w-0 space-y-3">
             <div>
               <h2 className="font-semibold text-slate-950">Parts/request</h2>
               <p className="text-sm text-slate-600">
@@ -4987,7 +4987,7 @@ function PartsRequestWorkspace({
             </Accordion>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 border-t border-slate-200 pt-4">
             <label
               className="flex items-start gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm"
               title="During spreadsheet import, match exact AG, supplier, or manufacturer part numbers to existing Inventory items."


### PR DESCRIPTION
## What changed

- keeps the Parts/request heading, description, and part-search accordion at full card width
- moves import, request, Vendor PO, and finalization controls into a wrapping action bar below the search area
- adds a visual divider between setup and actions

## Why

At desktop `xl` widths, the setup card switched to a two-column flex layout. The action toolbar consumed most of the available row width and compressed the Parts/request content into a few-character-wide column.

## Impact

The Parts/request setup remains readable and usable across desktop and narrower viewport sizes without changing any Draft Builder workflow behavior.

## Validation

- `tsc --noEmit --pretty false` — passed
- `git diff --check` — passed