### PR TITLE
Harden P2 V2 production launch and keep it disabled pending validation

### DIFF
--- a/client/src/__tests__/P2V2PreproductionReadiness.component.test.tsx
+++ b/client/src/__tests__/P2V2PreproductionReadiness.component.test.tsx
@@ -1,65 +1,78 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import P2V2PreproductionReadiness from '../components/projects/P2V2PreproductionReadiness';
 
-function renderReadiness() {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        review: {
-          id: 'review-1',
-          revision_number: 2,
-          lock_version: 7,
-          status: 'COMPLETE',
-          checklist_snapshot: [
-            {
-              key: 'routing',
-              category: 'Manufacturing planning',
-              label: 'Approved routing',
-              applicability: 'REQUIRED',
-              satisfied: true,
-              evidence: [{ recordType: 'ROUTING', recordId: 'route-1' }],
-            },
-          ],
-          source_stage_revisions: {
-            commercial: 1,
-            technical: 2,
-            productionPlanning: 3,
-            wadAuthorization: 4,
-          },
-          exceptions: [],
-          risks_and_controls: [
-            { risk: 'Capacity', owner: 'Ops', control: 'Plan' },
-          ],
-          effectivity_reference: 'PO line 10',
+function renderReadiness(
+  overrides: Record<string, unknown> = {},
+  actionFailure?: string
+) {
+  const model = {
+    review: {
+      id: 'review-1',
+      revision_number: 2,
+      lock_version: 7,
+      status: 'COMPLETE',
+      checklist_snapshot: [
+        {
+          key: 'routing',
+          category: 'Manufacturing planning',
+          label: 'Approved routing',
+          applicability: 'REQUIRED',
+          satisfied: true,
+          evidence: [{ recordType: 'ROUTING', recordId: 'route-1' }],
         },
-        history: [],
-        approvals: [
-          {
-            id: 'a1',
-            approval_type: 'PREPRODUCTION_PROJECT_MANAGEMENT',
-            decision: 'APPROVED',
-            actor_display_name: 'Project Manager',
-            decided_at: '2026-07-23T12:00:00Z',
-          },
-        ],
-        requiredApprovals: [
-          'PROJECT_MANAGEMENT',
-          'ENGINEERING',
-          'QUALITY',
-          'OPERATIONS',
-        ],
-        readiness: { state: 'READY', blockers: [], stale: false },
-        release: null,
-        launch: null,
-        projectStatus: 'PREPRODUCTION_READINESS',
-      }),
-    })
-  );
+      ],
+      source_stage_revisions: {
+        commercial: 1,
+        technical: 2,
+        productionPlanning: 3,
+        wadAuthorization: 4,
+      },
+      exceptions: [],
+      risks_and_controls: [{ risk: 'Capacity', owner: 'Ops', control: 'Plan' }],
+      effectivity_reference: 'PO line 10',
+    },
+    history: [],
+    approvals: [
+      {
+        id: 'a1',
+        approval_type: 'PREPRODUCTION_PROJECT_MANAGEMENT',
+        decision: 'APPROVED',
+        actor_display_name: 'Project Manager',
+        decided_at: '2026-07-23T12:00:00Z',
+      },
+    ],
+    requiredApprovals: [
+      'PROJECT_MANAGEMENT',
+      'ENGINEERING',
+      'QUALITY',
+      'OPERATIONS',
+    ],
+    readiness: { state: 'READY', blockers: [], stale: false },
+    release: null,
+    launch: null,
+    projectStatus: 'PREPRODUCTION_READINESS',
+    productionLaunchEnabled: true,
+    ...overrides,
+  };
+  const fetchImplementation = actionFailure
+    ? vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => model,
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({ message: actionFailure }),
+        })
+    : vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => model,
+      });
+  vi.stubGlobal('fetch', fetchImplementation);
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -84,5 +97,83 @@ describe('P2V2PreproductionReadiness', () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId('approve-production-release')).toBeEnabled();
     expect(screen.getByTestId('launch-production')).toBeDisabled();
+  });
+
+  it('disables both consequential actions when readiness is stale', async () => {
+    renderReadiness({
+      readiness: {
+        state: 'STALE',
+        stale: true,
+        blockers: ['Routing revision changed.'],
+      },
+      release: {
+        id: 'release-1',
+        status: 'APPROVED',
+        approved_at: '2026-07-23T12:00:00Z',
+      },
+      projectStatus: 'READY_FOR_P2_RELEASE',
+    });
+    expect(
+      await screen.findByText(/Routing revision changed/)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('approve-production-release')).toBeDisabled();
+    expect(screen.getByTestId('launch-production')).toBeDisabled();
+  });
+
+  it('disables Production Launch from server readiness while preserving Production Release', async () => {
+    renderReadiness({
+      productionLaunchEnabled: false,
+      release: {
+        id: 'release-1',
+        status: 'APPROVED',
+        approved_at: '2026-07-23T12:00:00Z',
+      },
+      projectStatus: 'READY_FOR_P2_RELEASE',
+    });
+
+    expect(
+      await screen.findByText(/Production Launch awaiting deployment validation/i)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('launch-production')).toBeDisabled();
+    expect(screen.getByText(/Release APPROVED/i)).toBeInTheDocument();
+  });
+
+  it('describes consequential launch actions and explicitly deferred records', async () => {
+    renderReadiness({
+      release: {
+        id: 'release-1',
+        status: 'APPROVED',
+        approved_at: '2026-07-23T12:00:00Z',
+      },
+      projectStatus: 'READY_FOR_P2_RELEASE',
+    });
+    const launch = await screen.findByTestId('launch-production');
+    fireEvent.click(launch);
+    expect(
+      await screen.findByText(/Travelers, inventory demands, reservations/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/changes the project to IN_PRODUCTION/i)
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the confirmation open and shows no false success when launch fails', async () => {
+    renderReadiness(
+      {
+        release: {
+          id: 'release-1',
+          status: 'APPROVED',
+          approved_at: '2026-07-23T12:00:00Z',
+        },
+        projectStatus: 'READY_FOR_P2_RELEASE',
+      },
+      'Routing revision changed.'
+    );
+    fireEvent.click(await screen.findByTestId('launch-production'));
+    fireEvent.click(screen.getByText('Confirm Launch Production'));
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2));
+    expect(
+      screen.getByTestId('launch-production-confirmation')
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/components/projects/P2V2PreproductionReadiness.tsx
+++ b/client/src/components/projects/P2V2PreproductionReadiness.tsx
@@ -56,6 +56,7 @@ type Model = {
   release: { id: string; status: string; approved_at: string } | null;
   launch: { id: string; status: string; launched_at: string } | null;
   projectStatus: string;
+  productionLaunchEnabled: boolean;
   recommendedChecklist: ChecklistItem[];
 };
 
@@ -380,7 +381,9 @@ export default function P2V2PreproductionReadiness({
               onClick={() => setLaunchOpen(true)}
               disabled={
                 action.isPending ||
+                !data.productionLaunchEnabled ||
                 data.projectStatus !== 'READY_FOR_P2_RELEASE' ||
+                data.readiness.state !== 'READY' ||
                 Boolean(data.launch?.status === 'COMPLETE')
               }
               data-testid="launch-production"
@@ -389,6 +392,16 @@ export default function P2V2PreproductionReadiness({
               Launch Production
             </Button>
           </div>
+          {!data.productionLaunchEnabled && (
+            <Alert data-testid="production-launch-disabled">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Production Launch awaiting deployment validation</AlertTitle>
+              <AlertDescription>
+                Production Release remains available, but V2 production records
+                cannot be generated until deployment validation is complete.
+              </AlertDescription>
+            </Alert>
+          )}
           {data.release && (
             <p className="text-sm">
               Release {data.release.status} ·{' '}
@@ -408,11 +421,14 @@ export default function P2V2PreproductionReadiness({
           <DialogHeader>
             <DialogTitle>Launch production?</DialogTitle>
             <DialogDescription>
-              This revalidates the approved release, creates only missing
-              serialized units and production orders through the existing P2
-              services, routes items to their first valid department, activates
-              Stage 8, and changes the project to IN_PRODUCTION. The operation
-              is atomic and protected against duplicate retries.
+              This revalidates the approved release, creates the serialized
+              units required by the released plan and its exact manufactured
+              production orders through the existing P2 services, routes each
+              item to its released first department, activates Stage 8, and
+              changes the project to IN_PRODUCTION. Travelers, inventory
+              demands, reservations, shipping, and closing records are not
+              created by this action. The operation is atomic and protected
+              against duplicate retries.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/migrations/0212_project_preproduction_launch_safety.sql
+++ b/migrations/0212_project_preproduction_launch_safety.sql
@@ -1,0 +1,72 @@
+-- This is the forward-only Phase 8C launch-safety correction.
+-- The merged 0210 migration is intentionally left byte-for-byte unchanged.
+-- Every operation is additive and safe when the original tables already exist.
+
+DO $$
+BEGIN
+  IF to_regclass('public.project_preproduction_readiness_reviews') IS NULL
+     OR to_regclass('public.project_production_releases') IS NULL
+     OR to_regclass('public.project_production_launches') IS NULL THEN
+    RAISE EXCEPTION
+      'Phase 8C base tables are missing; run 0210_project_preproduction_readiness.sql first';
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS project_preproduction_readiness_id_project_unique
+  ON project_preproduction_readiness_reviews(id, project_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS project_production_releases_id_project_unique
+  ON project_production_releases(id, project_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'project_production_releases'::regclass
+      AND contype = 'f'
+      AND pg_get_constraintdef(oid)
+        LIKE 'FOREIGN KEY (readiness_review_id, project_id)%'
+  ) THEN
+    ALTER TABLE project_production_releases
+      ADD CONSTRAINT project_production_releases_readiness_project_fkey
+      FOREIGN KEY (readiness_review_id, project_id)
+      REFERENCES project_preproduction_readiness_reviews(id, project_id)
+      ON DELETE RESTRICT NOT VALID;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'project_production_launches'::regclass
+      AND contype = 'f'
+      AND pg_get_constraintdef(oid)
+        LIKE 'FOREIGN KEY (production_release_id, project_id)%'
+  ) THEN
+    ALTER TABLE project_production_launches
+      ADD CONSTRAINT project_production_launches_release_project_fkey
+      FOREIGN KEY (production_release_id, project_id)
+      REFERENCES project_production_releases(id, project_id)
+      ON DELETE RESTRICT NOT VALID;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'project_production_launches'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%status%'
+      AND pg_get_constraintdef(oid) ILIKE '%COMPLETE%'
+      AND pg_get_constraintdef(oid) NOT ILIKE '%FAILED%'
+  ) THEN
+    ALTER TABLE project_production_launches
+      ADD CONSTRAINT project_production_launches_complete_only_check
+      CHECK (status = 'COMPLETE') NOT VALID;
+  END IF;
+END $$;

--- a/server/__tests__/migrationSafety.test.ts
+++ b/server/__tests__/migrationSafety.test.ts
@@ -262,6 +262,7 @@ const KNOWN_DUPLICATE_PREFIXES = new Set<string>([
   '0188', // 0188_rd_projects.sql vs 0188b_design_control_add_rd_project_id.sql — remediation migration to add rd_project_id columns to pre-existing design_control_* tables
   '0192', // 0192_backfill_routed_timer_oven_cure_logs.sql vs 0192_engineering_packages.sql — backfill oven/cure timer history landed in same window as engineering packages
   '0201', // 0201_close_fully_shipped_p1_purchase_orders.sql vs 0201_freezer_temperature_logs.sql — parallel P1 PO closure reconciliation + freezer temperature logging merged in the same window
+  '0210', // Three merged migrations already share 0210; preserve them and put Phase 8C corrections in 0212
 ]);
 
 describe('Migration file structure', () => {

--- a/server/__tests__/p2V2ProductionLaunchFeatureGate.test.ts
+++ b/server/__tests__/p2V2ProductionLaunchFeatureGate.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  transaction: vi.fn(),
+  recordAuditEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../db', () => ({
+  db: { transaction: mocks.transaction },
+  pool: {},
+}));
+vi.mock('../src/services/auditLedgerService', () => ({
+  recordAuditEvent: mocks.recordAuditEvent,
+}));
+
+import { isP2V2ProductionLaunchEnabled } from '../src/lib/featureFlags';
+import {
+  launchProduction,
+  ProjectPreproductionError,
+} from '../src/services/projectPreproductionReadinessService';
+
+const actor = {
+  userId: 7,
+  username: 'quality.manager',
+  displayName: 'Quality Manager',
+  role: 'QUALITY_MANAGER',
+};
+
+describe('P2 V2 Production Launch feature gate', () => {
+  afterEach(() => {
+    delete process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED;
+    mocks.transaction.mockReset();
+    mocks.recordAuditEvent.mockClear();
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['explicit false', 'false'],
+    ['malformed', 'enabled'],
+    ['unknown', '1'],
+  ])('fails closed when configuration is %s', async (_label, value) => {
+    if (value === undefined) {
+      delete process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED;
+    } else {
+      process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED = value;
+    }
+
+    expect(isP2V2ProductionLaunchEnabled()).toBe(false);
+    await expect(
+      launchProduction('project-1', 'request-key-123', actor)
+    ).rejects.toMatchObject<ProjectPreproductionError>({
+      code: 'P2_V2_PRODUCTION_LAUNCH_DISABLED',
+      status: 503,
+    });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+    expect(mocks.recordAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'P2_V2_PRODUCTION_LAUNCH_BLOCKED',
+        subjectId: 'project-1',
+      })
+    );
+    expect(mocks.recordAuditEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'P2_V2_PRODUCTION_LAUNCHED',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('enables only the exact true configuration', () => {
+    process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED = ' true ';
+    expect(isP2V2ProductionLaunchEnabled()).toBe(true);
+  });
+});

--- a/server/__tests__/projectPreproductionReadiness.test.ts
+++ b/server/__tests__/projectPreproductionReadiness.test.ts
@@ -1,7 +1,12 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
+  assertProductionCountsMatchPlan,
   checklistBlockers,
+  plannedProductionCounts,
   requiredPreproductionRoles,
   resolveFirstProductionDepartment,
 } from '../src/services/projectPreproductionRules';
@@ -62,6 +67,30 @@ describe('P2 V2 Preproduction Readiness rules', () => {
     ).toEqual([]);
   });
 
+  it.each([
+    ['risks-controlled', 'Applicable risks have owners and controls'],
+    [
+      'qualified-resources',
+      'Required employee qualifications and calibrated equipment are current',
+    ],
+    [
+      'safety-controls',
+      'Applicable safety, FOD, and environmental controls are identified',
+    ],
+  ])(
+    'keeps manually evidenced requirement %s fail-closed by default',
+    (key, label) => {
+      const item = {
+        key,
+        category: 'Safety gate',
+        label,
+        applicability: 'REQUIRED' as const,
+        satisfied: false,
+      };
+      expect(checklistBlockers([item])).toEqual([`Safety gate: ${label}`]);
+    }
+  );
+
   it('always requires four independent core functions', () => {
     expect(
       requiredPreproductionRoles({
@@ -93,8 +122,214 @@ describe('P2 V2 Preproduction Readiness rules', () => {
     ).toBe('Assembly');
   });
 
-  it('uses the legacy-safe Layup fallback only when routing is absent', () => {
-    expect(resolveFirstProductionDepartment([], false)).toBe('Layup');
+  it('fails closed when routing is absent or ambiguous', () => {
+    expect(resolveFirstProductionDepartment([], false)).toBeNull();
     expect(resolveFirstProductionDepartment([], true)).toBeNull();
+  });
+
+  it.each([
+    [['Layup', 'Quality'], 'Layup'],
+    [['CNC', 'Quality'], 'CNC'],
+    [['Cutting / Kitting', 'Layup'], 'Cutting Table'],
+    [['Kitting', 'Assembly'], 'Cutting Table'],
+  ])(
+    'resolves canonical first departments from released routing',
+    (sequence, expected) => {
+      expect(resolveFirstProductionDepartment(sequence, true)).toBe(expected);
+    }
+  );
+
+  it('aggregates multi-level manufactured quantities and excludes purchased items upstream', () => {
+    const counts = plannedProductionCounts([
+      {
+        part_number: 'ASM-1',
+        extended_project_quantity: '2',
+        routing_id: 'route-assembly',
+        routing_release_status: 'RELEASED',
+        department_sequence: ['Assembly', 'Quality'],
+      },
+      {
+        part_number: 'SUB-1',
+        extended_project_quantity: '4',
+        routing_id: 'route-cnc',
+        routing_release_status: 'RELEASED',
+        department_sequence: ['CNC', 'Quality'],
+      },
+      {
+        part_number: 'SUB-1',
+        extended_project_quantity: '2',
+        routing_id: 'route-cnc',
+        routing_release_status: 'RELEASED',
+        department_sequence: ['CNC', 'Quality'],
+      },
+    ]);
+    expect(Object.fromEntries(counts)).toEqual({ 'ASM-1': 2, 'SUB-1': 6 });
+  });
+
+  it.each([
+    [
+      {
+        routing_id: null,
+        routing_release_status: 'MISSING',
+        department_sequence: [],
+      },
+    ],
+    [
+      {
+        routing_id: 'r1',
+        routing_release_status: 'INACTIVE',
+        department_sequence: ['CNC'],
+      },
+    ],
+    [
+      {
+        routing_id: 'r1',
+        routing_release_status: 'RELEASED',
+        department_sequence: [],
+      },
+    ],
+  ])('blocks missing, obsolete, or ambiguous routing baselines', (routing) => {
+    expect(() =>
+      plannedProductionCounts([
+        {
+          part_number: 'MAKE-1',
+          extended_project_quantity: 1,
+          ...routing,
+        },
+      ])
+    ).toThrow(/released routing baseline/i);
+  });
+
+  it('rejects partial, duplicate, omitted, and unplanned generated records', () => {
+    const planned = new Map([
+      ['ASM-1', 2],
+      ['SUB-1', 1],
+    ]);
+    expect(() =>
+      assertProductionCountsMatchPlan(planned, ['ASM-1', 'SUB-1'])
+    ).toThrow(/ASM-1: planned 2, generated 1/);
+    expect(() =>
+      assertProductionCountsMatchPlan(planned, [
+        'ASM-1',
+        'ASM-1',
+        'SUB-1',
+        'EXTRA',
+      ])
+    ).toThrow(/EXTRA: planned 0, generated 1/);
+    expect(() =>
+      assertProductionCountsMatchPlan(planned, ['ASM-1', 'ASM-1', 'SUB-1'])
+    ).not.toThrow();
+  });
+});
+
+describe('Phase 8C integration safety contract', () => {
+  const root = process.cwd();
+  const service = fs.readFileSync(
+    path.join(
+      root,
+      'server/src/services/projectPreproductionReadinessService.ts'
+    ),
+    'utf8'
+  );
+  const migration = fs.readFileSync(
+    path.join(root, 'migrations/0212_project_preproduction_launch_safety.sql'),
+    'utf8'
+  );
+  const baseMigration = fs.readFileSync(
+    path.join(root, 'migrations/0210_project_preproduction_readiness.sql'),
+    'utf8'
+  );
+  const storage = fs.readFileSync(path.join(root, 'server/storage.ts'), 'utf8');
+  const route = fs.readFileSync(
+    path.join(root, 'server/src/routes/projectPreproductionReadiness.ts'),
+    'utf8'
+  );
+
+  it('keeps all V2 mutations fail-closed for legacy and unknown versions', () => {
+    expect(service).toContain('resolveProjectWorkflowVersion');
+    expect(service).toContain("if (version !== 'p2_v2')");
+    expect(service).toContain("'UNKNOWN_WORKFLOW_VERSION'");
+    expect(service).not.toContain('project_steps');
+    expect(service).not.toMatch(/designControl|ECR|ECN/);
+  });
+
+  it('locks, revalidates, creates, activates Stage 8, and transitions inside one launch transaction', () => {
+    const launch = service.slice(
+      service.indexOf('export async function launchProduction')
+    );
+    expect(launch.indexOf('isP2V2ProductionLaunchEnabled()')).toBeLessThan(
+      launch.indexOf('db.transaction')
+    );
+    expect(launch).toContain('P2_V2_PRODUCTION_LAUNCH_BLOCKED');
+    const transaction = launch.slice(
+      launch.indexOf('db.transaction'),
+      launch.indexOf("eventType: 'P2_V2_PRODUCTION_LAUNCH_FAILED'")
+    );
+    expect(transaction).toContain('pg_advisory_xact_lock');
+    expect(transaction).toContain(
+      "priorLaunch.idempotency_key === idempotencyKey"
+    );
+    expect(transaction).toContain("'PRODUCTION_ALREADY_LAUNCHED'");
+    expect(transaction).toContain('validateRelease(projectId, tx)');
+    expect(transaction).toContain('PREEXISTING_PRODUCTION_RECORDS');
+    expect(transaction).toContain('PREEXISTING_SERIALIZED_RECORDS');
+    expect(transaction).toContain('RELEASED_ROUTING_STALE');
+    expect(transaction).toContain('FOR SHARE OF ppi,pr,pct');
+    expect(transaction).toContain('assertProductionCountsMatchPlan');
+    expect(transaction).toMatch(
+      /generateP2ProductionOrders\(\s*poId,\s*undefined,\s*tx\s*\)/
+    );
+    expect(transaction).toContain("step_type === 'production_quality'");
+    expect(transaction).toContain("current_stage='IN_PRODUCTION'");
+    expect(transaction).toContain('P2_V2_PRODUCTION_LAUNCHED');
+    expect(launch).toMatch(
+      /\}\s*catch \(error\) \{\s*try \{\s*await recordAuditEvent\(\{\s*eventType: 'P2_V2_PRODUCTION_LAUNCH_FAILED'/
+    );
+    expect(launch).toContain('idempotencyKeyPresent');
+    expect(launch).not.toContain('idempotencyKey,\n          errorCode');
+  });
+
+  it('keeps Production Release non-consequential and enforces launch through the gated service', () => {
+    const release = service.slice(
+      service.indexOf('export async function approveProductionRelease'),
+      service.indexOf('export async function launchProduction')
+    );
+    expect(release).not.toContain('addP2SerializedItemsForPoItem');
+    expect(release).not.toContain('generateP2ProductionOrders');
+    expect(release).not.toContain("current_stage='IN_PRODUCTION'");
+    expect(route).toMatch(
+      /router\.post\('\/launch'[\s\S]*launchProduction\(projectId\(req\)/
+    );
+  });
+
+  it('keeps authoritative generator reads and sequence allocation on the supplied transaction', () => {
+    const generator = storage.slice(
+      storage.indexOf('async generateP2ProductionOrders('),
+      storage.indexOf('private normalizeP2SerialPrefix')
+    );
+    expect(generator).toContain('await dbClient');
+    expect(generator).not.toContain('this.getP2PurchaseOrder(');
+    expect(generator).not.toContain('this.getP2PurchaseOrderItems(');
+    expect(generator).toContain('generateNextP2OrderIdsWithClient');
+  });
+
+  it('uses compatible composite identities and additive partial uniqueness', () => {
+    expect(migration).toContain(
+      'project_preproduction_readiness_id_project_unique'
+    );
+    expect(migration).toContain(
+      'FOREIGN KEY (readiness_review_id, project_id)'
+    );
+    expect(migration).toContain(
+      'FOREIGN KEY (production_release_id, project_id)'
+    );
+    expect(baseMigration).toContain(
+      "WHERE status IN ('DRAFT','PENDING_APPROVAL','COMPLETE')"
+    );
+    expect(baseMigration).toContain("WHERE status='APPROVED'");
+    expect(baseMigration).toContain("WHERE status='COMPLETE'");
+    expect(migration).toContain('forward-only Phase 8C launch-safety correction');
+    expect(migration).not.toMatch(/\bUPDATE\s+projects\b/i);
+    expect(migration).not.toMatch(/\bINSERT\s+INTO\s+project_steps\b/i);
   });
 });

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -233,8 +233,10 @@ export const safeMigrationFiles = [
   '0207_design_control_authority_foundation.sql',
   '0208_design_control_authenticated_approvals.sql',
   '0210_master_document_control_hardening.sql',
+  '0210_project_preproduction_readiness.sql',
   '0211_design_control_form_templates.sql',
   '0210_repair_freezer_temperature_tracking.sql',
+  '0212_project_preproduction_launch_safety.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -256,8 +258,10 @@ export const criticalMigrationFiles = new Set([
   '0207_design_control_authority_foundation.sql',
   '0208_design_control_authenticated_approvals.sql',
   '0210_master_document_control_hardening.sql',
+  '0210_project_preproduction_readiness.sql',
   '0211_design_control_form_templates.sql',
   '0210_repair_freezer_temperature_tracking.sql',
+  '0212_project_preproduction_launch_safety.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -36,6 +36,15 @@ export const useAllocationCostingRead: boolean = envBool('USE_ALLOCATION_COSTING
 export const salariedDraftEntryEnabled: boolean = envBool('SALARIED_DRAFT_ENTRY_ENABLED', false);
 
 /**
+ * Gates only the consequential p2_v2 Production Launch mutation.
+ * This remains fail-closed until isolated-database, concurrency, and staging
+ * launch validation are complete.
+ */
+export function isP2V2ProductionLaunchEnabled(): boolean {
+  return envBool('P2_V2_PRODUCTION_LAUNCH_ENABLED', false);
+}
+
+/**
  * Cutover date for the punch_ledger migration.
  * For pay periods starting ON or AFTER this date, hour computations read
  * exclusively from public.punch_ledger.  For periods ending BEFORE this date,

--- a/server/src/services/projectPreproductionReadinessService.ts
+++ b/server/src/services/projectPreproductionReadinessService.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 
 import { db } from '../../db';
 import { storage } from '../../storage';
+import { isP2V2ProductionLaunchEnabled } from '../lib/featureFlags';
 import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
 import { evaluateCommercialBaseline } from './projectCommercialReviewService';
 import { getCurrentProductionPlan } from './projectProductionPlanningService';
@@ -10,7 +11,9 @@ import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
 import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
 import { getCurrentWadAuthorization } from './projectWadAuthorizationService';
 import {
+  assertProductionCountsMatchPlan,
   checklistBlockers,
+  plannedProductionCounts,
   requiredPreproductionRoles,
   resolveFirstProductionDepartment,
   type ChecklistDecision,
@@ -234,7 +237,7 @@ function recommendedChecklist(source: Awaited<ReturnType<typeof sourceState>>) {
       'risks-controlled',
       'Project and contract',
       'Applicable risks have owners and controls',
-      true,
+      false,
     ],
     [
       'technical-released',
@@ -322,7 +325,7 @@ function recommendedChecklist(source: Awaited<ReturnType<typeof sourceState>>) {
       'qualified-resources',
       'Resources',
       'Required employee qualifications and calibrated equipment are current',
-      true,
+      false,
     ],
     [
       'budgets-active',
@@ -334,7 +337,7 @@ function recommendedChecklist(source: Awaited<ReturnType<typeof sourceState>>) {
       'safety-controls',
       'Resources',
       'Applicable safety, FOD, and environmental controls are identified',
-      true,
+      false,
     ],
     [
       'wad-current',
@@ -447,6 +450,7 @@ async function readModel(projectId: string, tx: Executor = db) {
       : recommendedChecklist(await sourceState(projectId, tx)),
     stage: ctx.step,
     projectStatus: ctx.project.current_stage,
+    productionLaunchEnabled: isP2V2ProductionLaunchEnabled(),
   };
 }
 export const getPreproductionReadiness = (
@@ -941,12 +945,6 @@ export async function approveProductionRelease(
 ) {
   return db.transaction(async (tx) => {
     const { ctx, review, source } = await validateRelease(projectId, tx);
-    if (ctx.project.current_stage !== 'PREPRODUCTION_READINESS')
-      throw new ProjectPreproductionError(
-        'INVALID_PROJECT_STATUS',
-        'Project is not in the permitted preproduction status.',
-        409
-      );
     const existing = resultRows(
       await tx.execute(
         sql`SELECT * FROM project_production_releases WHERE project_id=${projectId} AND status='APPROVED'`
@@ -961,6 +959,12 @@ export async function approveProductionRelease(
         409
       );
     }
+    if (ctx.project.current_stage !== 'PREPRODUCTION_READINESS')
+      throw new ProjectPreproductionError(
+        'INVALID_PROJECT_STATUS',
+        'Project is not in the permitted preproduction status.',
+        409
+      );
     const plan = source.planning.plan;
     const wad = source.wad.authorization;
     const [release] = resultRows(
@@ -1013,17 +1017,51 @@ export async function launchProduction(
       'IDEMPOTENCY_KEY_REQUIRED',
       'An idempotency key is required.'
     );
+  if (!isP2V2ProductionLaunchEnabled()) {
+    try {
+      await recordAuditEvent({
+        eventType: 'P2_V2_PRODUCTION_LAUNCH_BLOCKED',
+        subjectType: 'project',
+        subjectId: projectId,
+        sourceService: 'projectPreproductionReadinessService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          reason: 'DEPLOYMENT_VALIDATION_PENDING',
+        },
+      });
+    } catch (auditError) {
+      console.error(
+        'Failed to record blocked P2 V2 production launch attempt:',
+        auditError
+      );
+    }
+    throw new ProjectPreproductionError(
+      'P2_V2_PRODUCTION_LAUNCH_DISABLED',
+      'V2 Production Launch is awaiting deployment validation.',
+      503
+    );
+  }
   try {
     return await db.transaction(async (tx) => {
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtext(${`p2-v2-launch:${projectId}`}))`
       );
-      const replay = resultRows(
+      const priorLaunch = resultRows(
         await tx.execute(sql`
           SELECT * FROM project_production_launches
-          WHERE project_id=${projectId} AND idempotency_key=${idempotencyKey} AND status='COMPLETE'`)
+          WHERE project_id=${projectId} AND status='COMPLETE'
+          ORDER BY launched_at DESC LIMIT 1 FOR UPDATE`)
       )[0];
-      if (replay) return readModel(projectId, tx);
+      if (priorLaunch) {
+        if (priorLaunch.idempotency_key === idempotencyKey)
+          return readModel(projectId, tx);
+        throw new ProjectPreproductionError(
+          'PRODUCTION_ALREADY_LAUNCHED',
+          'Production has already been launched for this project.',
+          409
+        );
+      }
       const { ctx, review, source } = await validateRelease(projectId, tx);
       if (ctx.project.current_stage !== 'READY_FOR_P2_RELEASE')
         throw new ProjectPreproductionError(
@@ -1051,7 +1089,7 @@ export async function launchProduction(
         );
       const items = resultRows(
         await tx.execute(
-          sql`SELECT id,quantity FROM p2_purchase_order_items WHERE po_id=${poId} ORDER BY id`
+          sql`SELECT id,quantity,part_number FROM p2_purchase_order_items WHERE po_id=${poId} ORDER BY id`
         )
       );
       if (!items.length)
@@ -1060,13 +1098,91 @@ export async function launchProduction(
           'The linked P2 PO has no line items.',
           409
         );
+      const planItems = resultRows(
+        await tx.execute(sql`
+          SELECT ppi.*,pr.department_sequence,
+                 pr.routing_revision live_routing_revision,
+                 pr.is_active live_routing_is_active,
+                 pct.approval_status live_routing_approval_status
+          FROM project_production_plan_items ppi
+          JOIN part_routings pr ON pr.id=ppi.routing_id
+          JOIN production_control_templates pct ON pct.id=pr.created_from_template_id
+          WHERE ppi.production_plan_id=${release.production_plan_id}
+            AND ppi.project_id=${projectId}
+            AND ppi.is_manufactured=true
+            AND ppi.make_buy='MAKE'
+          ORDER BY ppi.assembly_path
+          FOR SHARE OF ppi,pr,pct`)
+      );
+      if (!planItems.length)
+        throw new ProjectPreproductionError(
+          'MANUFACTURED_PLAN_REQUIRED',
+          'The released Production Plan has no manufactured items.',
+          409
+        );
+      const changedRouting = planItems.find(
+        (item) =>
+          !item.live_routing_is_active ||
+          item.live_routing_approval_status !== 'APPROVED' ||
+          String(item.live_routing_revision ?? '') !==
+            String(item.routing_revision ?? '')
+      );
+      if (changedRouting)
+        throw new ProjectPreproductionError(
+          'RELEASED_ROUTING_STALE',
+          `${changedRouting.part_number} routing changed after production release.`,
+          409
+        );
+      let plannedCounts: Map<string, number>;
+      try {
+        plannedCounts = plannedProductionCounts(
+          planItems.map((item) => ({
+            part_number: String(item.part_number ?? ''),
+            extended_project_quantity: item.extended_project_quantity,
+            routing_id: item.routing_id,
+            routing_release_status: item.routing_release_status,
+            department_sequence: item.department_sequence,
+          }))
+        );
+      } catch (error) {
+        throw new ProjectPreproductionError(
+          'RELEASED_ROUTING_INVALID',
+          error instanceof Error
+            ? error.message
+            : 'The released routing baseline is invalid.',
+          409
+        );
+      }
       const existingOrders = resultRows(
         await tx.execute(
           sql`SELECT id FROM p2_production_orders WHERE p2_po_id=${poId}`
         )
       );
+      if (existingOrders.length)
+        throw new ProjectPreproductionError(
+          'PREEXISTING_PRODUCTION_RECORDS',
+          'Production records already exist outside this V2 launch. Resolve them before retrying.',
+          409
+        );
+      const existingSerialized = resultRows(
+        await tx.execute(
+          sql`SELECT id FROM p2_serialized_items WHERE po_id=${poId} LIMIT 1`
+        )
+      );
+      if (existingSerialized.length)
+        throw new ProjectPreproductionError(
+          'PREEXISTING_SERIALIZED_RECORDS',
+          'Serialized records already exist outside this V2 launch. Resolve them before retrying.',
+          409
+        );
       const createdSerialIds: string[] = [];
       for (const item of items) {
+        const plannedTopLevel = planItems.find(
+          (entry) =>
+            entry.part_number === item.part_number &&
+            !clean(entry.parent_part_number)
+        );
+        if (!plannedTopLevel?.serialization_required) continue;
         const countRow = resultRows(
           await tx.execute(
             sql`SELECT count(*)::int count FROM p2_serialized_items WHERE po_item_id=${item.id}`
@@ -1087,10 +1203,65 @@ export async function launchProduction(
             ).map((entry) => entry.id)
           );
       }
-      const productionOrders =
-        existingOrders.length === 0
-          ? await storage.generateP2ProductionOrders(poId, undefined, tx)
-          : [];
+      const productionOrders = await storage.generateP2ProductionOrders(
+        poId,
+        undefined,
+        tx
+      );
+      try {
+        assertProductionCountsMatchPlan(
+          plannedCounts,
+          productionOrders.map((entry) => entry.sku)
+        );
+      } catch (error) {
+        throw new ProjectPreproductionError(
+          'GENERATED_RECORDS_MISMATCH',
+          error instanceof Error
+            ? error.message
+            : 'Generated production records do not match the released plan.',
+          409
+        );
+      }
+      const routeByPart = new Map<
+        string,
+        { department: string; routingId: string; routingRevision: unknown }
+      >();
+      for (const planItem of planItems) {
+        const department = resolveFirstProductionDepartment(
+          planItem.department_sequence,
+          true
+        );
+        const prior = routeByPart.get(planItem.part_number);
+        if (
+          !department ||
+          (prior &&
+            (prior.department !== department ||
+              prior.routingId !== planItem.routing_id))
+        )
+          throw new ProjectPreproductionError(
+            'AMBIGUOUS_RELEASED_ROUTING',
+            `${planItem.part_number} does not resolve to one released first department.`,
+            409
+          );
+        routeByPart.set(planItem.part_number, {
+          department,
+          routingId: planItem.routing_id,
+          routingRevision: planItem.routing_revision,
+        });
+      }
+      for (const order of productionOrders) {
+        const route = routeByPart.get(order.sku);
+        if (!route)
+          throw new ProjectPreproductionError(
+            'PRODUCTION_ORDER_NOT_PLANNED',
+            `Generated production order ${order.id} is not in the released plan.`,
+            409
+          );
+        await tx.execute(sql`
+          UPDATE p2_production_orders
+          SET department=${route.department},updated_at=now()
+          WHERE id=${order.id}`);
+      }
       const schedulable = resultRows(
         await tx.execute(sql`
           SELECT si.id,si.po_item_id,si.part_number,si.part_routing_id,
@@ -1160,6 +1331,14 @@ export async function launchProduction(
                 (entry) => entry.id
               ),
               routedItems: routed,
+              releasedRoutingBaselines: Array.from(routeByPart.entries()).map(
+                ([partNumber, value]) => ({ partNumber, ...value })
+              ),
+              travelersCreated: 0,
+              inventoryDemandsCreated: 0,
+              reservationsCreated: 0,
+              shippingRecordsCreated: 0,
+              closingRecordsCreated: 0,
             })}::jsonb,${actor.userId},${actor.displayName}) RETURNING *`)
       );
       await recordAuditEvent(
@@ -1186,21 +1365,26 @@ export async function launchProduction(
       return readModel(projectId, tx);
     });
   } catch (error) {
-    await recordAuditEvent({
-      eventType: 'P2_V2_PRODUCTION_LAUNCH_FAILED',
-      subjectType: 'project',
-      subjectId: projectId,
-      sourceService: 'projectPreproductionReadinessService',
-      actor: { id: actor.userId, username: actor.username, role: actor.role },
-      payload: {
-        projectId,
-        idempotencyKey,
-        errorCode:
-          error instanceof ProjectPreproductionError
-            ? error.code
-            : 'PRODUCTION_LAUNCH_FAILED',
-      },
-    });
+    try {
+      await recordAuditEvent({
+        eventType: 'P2_V2_PRODUCTION_LAUNCH_FAILED',
+        subjectType: 'project',
+        subjectId: projectId,
+        sourceService: 'projectPreproductionReadinessService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          // Do not persist the caller's potentially sensitive opaque key.
+          idempotencyKeyPresent: Boolean(clean(idempotencyKey)),
+          errorCode:
+            error instanceof ProjectPreproductionError
+              ? error.code
+              : 'PRODUCTION_LAUNCH_FAILED',
+        },
+      });
+    } catch (auditError) {
+      console.error('Failed to record P2 V2 launch failure audit:', auditError);
+    }
     throw error;
   }
 }

--- a/server/src/services/projectPreproductionRules.ts
+++ b/server/src/services/projectPreproductionRules.ts
@@ -57,7 +57,73 @@ export function resolveFirstProductionDepartment(
       (department): department is string =>
         typeof department === 'string' && clean(department).length > 0
     );
-    if (first) return clean(first);
+    if (first) {
+      const value = clean(first);
+      const normalized = value.toLowerCase().replace(/[\s/_-]+/g, ' ');
+      if (
+        normalized === 'cutting' ||
+        normalized === 'kitting' ||
+        normalized === 'cutting kitting' ||
+        normalized === 'cutting table'
+      )
+        return 'Cutting Table';
+      return value;
+    }
   }
-  return routingExists ? null : 'Layup';
+  // Phase 8C is fail-closed. Legacy scheduling may still use its historical
+  // Layup default, but a V2 production release must have an explicit baseline.
+  return routingExists ? null : null;
+}
+
+export type PlannedManufacturedItem = {
+  part_number: string;
+  extended_project_quantity: unknown;
+  routing_id?: string | null;
+  routing_release_status?: string | null;
+  department_sequence?: unknown;
+};
+
+export function plannedProductionCounts(items: PlannedManufacturedItem[]) {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const partNumber = clean(item.part_number);
+    const quantity = Number(item.extended_project_quantity);
+    if (!partNumber || !Number.isFinite(quantity) || quantity <= 0)
+      throw new Error(
+        'Every manufactured plan item requires a positive quantity.'
+      );
+    if (
+      item.routing_release_status !== 'RELEASED' ||
+      !item.routing_id ||
+      !resolveFirstProductionDepartment(item.department_sequence, true)
+    )
+      throw new Error(
+        `${partNumber} requires one unambiguous released routing baseline.`
+      );
+    counts.set(partNumber, (counts.get(partNumber) ?? 0) + Math.ceil(quantity));
+  }
+  return counts;
+}
+
+export function assertProductionCountsMatchPlan(
+  planned: Map<string, number>,
+  actualPartNumbers: string[]
+) {
+  const actual = new Map<string, number>();
+  for (const partNumber of actualPartNumbers)
+    actual.set(partNumber, (actual.get(partNumber) ?? 0) + 1);
+  const keys = new Set([
+    ...Array.from(planned.keys()),
+    ...Array.from(actual.keys()),
+  ]);
+  const mismatches = Array.from(keys)
+    .filter((key) => planned.get(key) !== actual.get(key))
+    .map(
+      (key) =>
+        `${key}: planned ${planned.get(key) ?? 0}, generated ${actual.get(key) ?? 0}`
+    );
+  if (mismatches.length)
+    throw new Error(
+      `Production records differ from the released plan: ${mismatches.join('; ')}`
+    );
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -3993,9 +3993,17 @@ export class DatabaseStorage implements IStorage {
   }
 
   async generateNextP2OrderIds(prefix: string, count: number): Promise<{ startSequence: number; endSequence: number }> {
+    return this.generateNextP2OrderIdsWithClient(prefix, count, db);
+  }
+
+  async generateNextP2OrderIdsWithClient(
+    prefix: string,
+    count: number,
+    dbClient: DbOrTx
+  ): Promise<{ startSequence: number; endSequence: number }> {
     const P2_ORDER_PREFIX = "";
 
-    const upsertResult = await db.execute(sql`
+    const upsertResult = await dbClient.execute(sql`
       INSERT INTO p2_order_id_sequences (year_month_prefix, current_sequence, updated_at)
       VALUES (${prefix}, ${count}, NOW())
       ON CONFLICT (year_month_prefix) DO UPDATE SET
@@ -4008,7 +4016,7 @@ export class DatabaseStorage implements IStorage {
     if (upsertResult && upsertResult.rows && upsertResult.rows.length > 0) {
       endSequence = Number(upsertResult.rows[0].current_sequence);
     } else {
-      const fallback = await db.execute(sql`
+      const fallback = await dbClient.execute(sql`
         SELECT current_sequence FROM p2_order_id_sequences WHERE year_month_prefix = ${prefix}
       `);
       endSequence = fallback?.rows?.[0] ? Number(fallback.rows[0].current_sequence) : count;
@@ -16238,12 +16246,20 @@ export class DatabaseStorage implements IStorage {
     opts?: { onlyPoItemId?: number; quantityOverride?: number },
     dbClient: DbOrTx = db
   ): Promise<P2ProductionOrder[]> {
-    const po = await this.getP2PurchaseOrder(poId);
+    const [po] = await dbClient
+      .select()
+      .from(p2PurchaseOrders)
+      .where(eq(p2PurchaseOrders.id, poId))
+      .limit(1);
     if (!po) {
       throw new Error(`P2 Purchase Order ${poId} not found`);
     }
 
-    const allPoItems = await this.getP2PurchaseOrderItems(poId);
+    const allPoItems = await dbClient
+      .select()
+      .from(p2PurchaseOrderItems)
+      .where(eq(p2PurchaseOrderItems.poId, poId))
+      .orderBy(p2PurchaseOrderItems.createdAt);
     if (allPoItems.length === 0) {
       throw new Error(`No items found for P2 Purchase Order ${poId}`);
     }
@@ -16565,7 +16581,12 @@ export class DatabaseStorage implements IStorage {
     const now = new Date();
     const currentPrefix = getCurrentYearMonthPrefix(now);
 
-    const { startSequence, endSequence } = await this.generateNextP2OrderIds(currentPrefix, pendingOrders.length);
+    const { startSequence, endSequence } =
+      await this.generateNextP2OrderIdsWithClient(
+        currentPrefix,
+        pendingOrders.length,
+        dbClient
+      );
 
     const BATCH_SIZE = 500;
     const productionOrders: P2ProductionOrder[] = [];


### PR DESCRIPTION
## Required corrective follow-up

PR #1526 was already merged at `a14b4ed73c519369883196a2721204fa653fa6be` before its production-launch safety gate completed. This draft PR is the required Phase 8C safety follow-up. It reconciles the two verified post-merge corrections (`a5761f415` and `475a4d540`) onto latest main without starting Phase 9.

## Production Launch remains disabled

P2 V2 Production Launch is server-gated by `P2_V2_PRODUCTION_LAUNCH_ENABLED`.

- missing, false, malformed, or unknown values are disabled
- only the trimmed, case-insensitive value `true` enables launch
- the gate runs before the launch transaction or any production-record generation
- disabled direct API calls return `503` with `P2_V2_PRODUCTION_LAUNCH_DISABLED`
- the server records `P2_V2_PRODUCTION_LAUNCH_BLOCKED`, not a success event
- the readiness read model exposes `productionLaunchEnabled`, and the V2 UI disables launch and shows that deployment validation is pending
- Production Release remains available and creates no production records

The flag must remain unset/false until the isolated-database migration, concurrency, and staging-launch validation below is complete.

## Migration-history decision

Latest main already contains three distinct `0210_*` migrations, including `0210_project_preproduction_readiness.sql`, and also contains `0211_design_control_form_templates.sql`. The safe-boot runner uses an explicit filename list, executes idempotent SQL on each boot, and has no filename/checksum migration ledger. Duplicate numeric prefixes are therefore tolerated but must be documented.

This PR:

- leaves the merged `0210_project_preproduction_readiness.sql` byte-for-byte unchanged
- documents the already-merged `0210` prefix collision in migration safety tests
- adds the existing 0210 Phase 8C base migration to the explicit safe-boot list
- adds forward-only `0212_project_preproduction_launch_safety.sql`
- uses guarded unique indexes and catalog-aware composite foreign keys/checks
- adds the new foreign keys and COMPLETE-only check as `NOT VALID`, enforcing new writes without deleting or rewriting historical rows
- adds both Phase 8C migrations to the critical safe-boot list

No migration was applied to a shared or production database.

## Transaction and safety corrections

- generator reads, sequence allocation, serialized-item creation, and production-order creation use the launch transaction
- project advisory locking and row locks cover the released Production Plan, routing, template, and release records
- preexisting serialized items and production orders are rejected
- generated counts are reconciled to the released manufactured plan
- routing revision, activation, approval, and release status are revalidated fail-closed
- risks, qualifications/calibration, and safety controls no longer receive unsafe default satisfaction
- failures roll back launch mutations; failure auditing occurs outside the rolled-back transaction
- opaque idempotency keys are not written to audit output
- same-key retries return the established completed result
- different-key repeated launches return `PRODUCTION_ALREADY_LAUNCHED`
- each manufactured part receives its released first department
- cutting-first routes canonicalize to `Cutting Table`; assembly-first routes to `Assembly`
- purchased components are excluded from manufactured production-order generation

## Launch records and deferred records

When eventually enabled and all gates pass, launch atomically creates required serialized items and manufactured production orders, assigns released first departments, activates the production-quality Stage 8 step, and transitions the project and linked PO to `IN_PRODUCTION`.

Travelers, inventory demands, reservations, shipping records, and closing records are explicitly reported as deferred and are not created by Production Launch.

## Validation

Passing:

- focused Phase 8C server contracts and feature gate: **29/29**
- complete available P2 V2 client component suite: **11/11**
- Design Control client authority test: **2/2**
- static migration structure selection: **4/4**, with **11** non-selected tests skipped
- focused ESLint across every changed TypeScript file: passed
- memory-safe TypeScript (`--max-old-space-size=4096`, `tsc --noEmit`): passed
- `git diff --check`: passed

Broad server selection (26 files): **239 passed, 22 failed**, plus one suite collection failure. All 22 failures and the collection failure were reproduced on untouched latest main:

- 14 baseline traveler/material/Design Control assertion or mock failures
- 8 database-backed migration tests blocked because `DATABASE_URL` is unavailable
- `routingStepService.test.ts` cannot collect without `DATABASE_URL`

The follow-up-specific undocumented `0210` migration-prefix failure present on main is fixed here. No real-database certification is claimed.

## Required staging validation before enabling

1. Replay `0210_project_preproduction_readiness.sql` and `0212_project_preproduction_launch_safety.sql` against an isolated production-shaped PostgreSQL baseline.
2. Inspect existing rows, then validate the two composite foreign keys and COMPLETE-only check.
3. Exercise concurrent same-key and different-key launch requests.
4. Force failures after serialized-item creation and after production-order generation to prove rollback leaves no partial records.
5. Verify changed/unreleased routing blocks launch.
6. Verify assembly-first, Cutting Table-first, multi-level manufactured, and purchased-component behavior.
7. Validate the complete staging launch/readback/audit path.
8. Only after certification, set `P2_V2_PRODUCTION_LAUNCH_ENABLED=true` in the validated deployment.

## Scope protections

- legacy endpoints and legacy workflow behavior are unchanged
- NULL and `legacy_v1` projects remain isolated; unknown workflow versions fail closed
- Design Control source is unchanged
- p2_v2 project creation remains disabled
- Production Launch remains protected on main by default after this PR
- this PR must not be merged until the required review and staging plan are accepted
- Phase 9 is not started