### PR TITLE
Complete P2 V2 production launch certification fixes

### DIFF
--- a/server/__tests__/p2V2ProductionLaunchFeatureGate.test.ts
+++ b/server/__tests__/p2V2ProductionLaunchFeatureGate.test.ts
@@ -38,6 +38,9 @@ describe('P2 V2 Production Launch feature gate', () => {
     ['explicit false', 'false'],
     ['malformed', 'enabled'],
     ['unknown', '1'],
+    ['whitespace-wrapped true', ' true '],
+    ['uppercase true', 'TRUE'],
+    ['mixed-case true', 'True'],
   ])('fails closed when configuration is %s', async (_label, value) => {
     if (value === undefined) {
       delete process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED;
@@ -68,7 +71,7 @@ describe('P2 V2 Production Launch feature gate', () => {
   });
 
   it('enables only the exact true configuration', () => {
-    process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED = ' true ';
+    process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED = 'true';
     expect(isP2V2ProductionLaunchEnabled()).toBe(true);
   });
 });

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -41,7 +41,7 @@ export const salariedDraftEntryEnabled: boolean = envBool('SALARIED_DRAFT_ENTRY_
  * launch validation are complete.
  */
 export function isP2V2ProductionLaunchEnabled(): boolean {
-  return envBool('P2_V2_PRODUCTION_LAUNCH_ENABLED', false);
+  return process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED === 'true';
 }
 
 /**


### PR DESCRIPTION
## What changed

- Require the consequential `P2_V2_PRODUCTION_LAUNCH_ENABLED` flag to equal the literal string `true`.
- Add regression coverage proving missing, false, malformed, unknown, whitespace-wrapped, uppercase, and mixed-case values all fail closed.

## Why

The Phase 8 deployment-certification gate requires Production Launch to remain disabled unless the exact supported value is supplied. The shared boolean parser normalized whitespace and case, so values such as ` true ` and `TRUE` could enable launch.

## Impact

Production Launch remains disabled by default. No shared or deployment configuration is changed. Production Release and legacy release paths are unaffected.

## Validation

- Focused Phase 7/8C server tests: 39 passed
- Focused client component tests: 52 passed
- Static migration safety checks: 7 passed, 8 database-backed tests skipped
- Focused ESLint: passed
- TypeScript `tsc --noEmit --pretty false` with 4 GB heap: passed
- `git diff --check`: passed

## Certification limitation

Real PostgreSQL migration replay, rollback, concurrency, idempotency, routing-fixture reconciliation, and legacy-isolation database certification could not be performed because this environment has no Docker engine, local PostgreSQL service, or repository-supported isolated database URL. Phase 9 remains blocked and this PR must not be merged as a claim of full database certification.