### PR TITLE
Fix P2 serialized unit status ledger

### DIFF
--- a/client/src/components/p2/P2StatusDashboard.tsx
+++ b/client/src/components/p2/P2StatusDashboard.tsx
@@ -35,8 +35,12 @@ interface POStatus {
   dueDate: string;
   totalItems: number;
   completedItems: number;
+  shippedItems?: number;
+  needsFinalizationItems?: number;
   scheduledItems: number;
   inProductionItems: number;
+  productionPipelineItems?: number;
+  missingItems?: number;
   scrappedItems?: number;
   pendingItems: number;
   hasBOMsNeeded: boolean;
@@ -328,7 +332,7 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                           <div className="flex items-center justify-between text-sm">
                             <span>Progress</span>
                             <span className="font-medium">
-                              {po.completedItems} / {po.totalItems} items
+                              {po.shippedItems ?? po.completedItems} / {po.totalItems} shipped
                             </span>
                           </div>
                           <Progress value={getProgressPercentage(po)} className="h-2" />
@@ -345,6 +349,12 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                               {po.inProductionItems} in production
                             </span>
                           )}
+                          {(po.needsFinalizationItems ?? 0) > 0 && (
+                            <span className="flex items-center gap-1 text-orange-600">
+                              <CheckCircle className="h-3 w-3" />
+                              {po.needsFinalizationItems} need finalization
+                            </span>
+                          )}
                           {po.scheduledItems > 0 && (
                             <span className="flex items-center gap-1 text-green-600">
                               <Clock className="h-3 w-3" />
@@ -357,10 +367,10 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                               {po.scrappedItems} scrapped
                             </span>
                           )}
-                          {po.pendingItems > 0 && (
+                          {(po.missingItems ?? po.pendingItems) > 0 && (
                             <span className="flex items-center gap-1 text-amber-600">
-                              <Clock className="h-3 w-3" />
-                              {po.pendingItems} pending
+                              <AlertCircle className="h-3 w-3" />
+                              {po.missingItems ?? po.pendingItems} missing
                             </span>
                           )}
                         </div>

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -70,6 +70,18 @@ interface P2Stats {
   activeTravelers?: number;
 }
 
+interface P2LedgerStatus {
+  id: number;
+  poNumber: string;
+  customerName: string;
+  status: string;
+  projectId: string | null;
+  projectCode?: string | null;
+  projectName?: string | null;
+  scheduledItems: number;
+  inProductionItems: number;
+}
+
 interface Traveler {
   id: string;
   travelerNumber: string;
@@ -175,7 +187,7 @@ export default function P2ControlCenter() {
     })
   );
 
-  const { data: allPOStatuses = [] } = useQuery<{ id: number; poNumber: string; customerName: string; status: string; projectId: string | null; projectCode?: string | null; projectName?: string | null }[]>({
+  const { data: allPOStatuses = [] } = useQuery<P2LedgerStatus[]>({
     queryKey: ['/api/p2/control-center/po-statuses'],
     refetchInterval: 30000,
   });
@@ -183,6 +195,16 @@ export default function P2ControlCenter() {
   const openPOs = useMemo(
     () => allPOStatuses.filter((po) => po.status !== 'completed'),
     [allPOStatuses]
+  );
+  const serializedLedgerStats = useMemo(
+    () => allPOStatuses.reduce(
+      (totals, po) => ({
+        scheduledItems: totals.scheduledItems + Number(po.scheduledItems || 0),
+        inProduction: totals.inProduction + Number(po.inProductionItems || 0),
+      }),
+      { scheduledItems: 0, inProduction: 0 },
+    ),
+    [allPOStatuses],
   );
   const poFilterOptions = useMemo(
     () => activeTab === 'shipping' ? allPOStatuses : openPOs,
@@ -422,12 +444,12 @@ export default function P2ControlCenter() {
               </div>
               <ArrowRight className="h-4 w-4 text-muted-foreground" />
               <div className="flex items-center gap-2">
-                <div className={`w-8 h-8 rounded-full flex items-center justify-center ${(stats?.scheduledItems || 0) > 0 ? 'bg-purple-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center ${serializedLedgerStats.scheduledItems > 0 ? 'bg-purple-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>
                   <Calendar className="h-4 w-4" />
                 </div>
                 <div className="text-sm">
                   <div className="font-medium">3. Schedule</div>
-                  <div className="text-xs text-muted-foreground">{stats?.scheduledItems || 0} scheduled</div>
+                  <div className="text-xs text-muted-foreground">{serializedLedgerStats.scheduledItems} scheduled</div>
                   {(gateBlockedCounts['step3'] ?? 0) > 0 && (
                     <div className="flex items-center gap-0.5 text-[10px] text-amber-600 dark:text-amber-400 mt-0.5">
                       <Lock className="h-2.5 w-2.5" />
@@ -438,12 +460,12 @@ export default function P2ControlCenter() {
               </div>
               <ArrowRight className="h-4 w-4 text-muted-foreground" />
               <div className="flex items-center gap-2">
-                <div className={`w-8 h-8 rounded-full flex items-center justify-center ${(stats?.inProduction || 0) > 0 ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center ${serializedLedgerStats.inProduction > 0 ? 'bg-green-600 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}>
                   <Factory className="h-4 w-4" />
                 </div>
                 <div className="text-sm">
                   <div className="font-medium">4. Production</div>
-                  <div className="text-xs text-muted-foreground">{stats?.inProduction || 0} in progress</div>
+                  <div className="text-xs text-muted-foreground">{serializedLedgerStats.inProduction} active</div>
                   {(gateBlockedCounts['step4'] ?? 0) > 0 && (
                     <div className="flex items-center gap-0.5 text-[10px] text-amber-600 dark:text-amber-400 mt-0.5">
                       <Lock className="h-2.5 w-2.5" />
@@ -540,7 +562,7 @@ export default function P2ControlCenter() {
               <Calendar className="h-4 w-4 text-purple-600" />
               <span className="text-sm text-muted-foreground">Scheduled</span>
             </div>
-            <div className="text-2xl font-bold mt-1">{stats?.scheduledItems || 0}</div>
+            <div className="text-2xl font-bold mt-1">{serializedLedgerStats.scheduledItems}</div>
           </CardContent>
         </Card>
 
@@ -550,7 +572,7 @@ export default function P2ControlCenter() {
               <Factory className="h-4 w-4 text-green-600" />
               <span className="text-sm text-muted-foreground">In Production</span>
             </div>
-            <div className="text-2xl font-bold mt-1">{stats?.inProduction || 0}</div>
+            <div className="text-2xl font-bold mt-1">{serializedLedgerStats.inProduction}</div>
           </CardContent>
         </Card>
 

--- a/server/__tests__/p2SerializedUnitLedger.test.ts
+++ b/server/__tests__/p2SerializedUnitLedger.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { buildP2SerializedUnitLedger } from '../src/lib/p2SerializedUnitLedger';
+
+describe('buildP2SerializedUnitLedger', () => {
+  it('uses mutually exclusive precedence and enforces the PO quantity invariant', () => {
+    const rows = [
+      ...Array.from({ length: 318 }, (_, index) => ({
+        id: `ship-${index}`,
+        serialNumber: `SERIAL-${index}`,
+        status: 'COMPLETED',
+        currentDepartment: 'Inventory',
+      })),
+      ...Array.from({ length: 2 }, (_, index) => ({
+        id: `final-${index}`,
+        serialNumber: `FINAL-${index}`,
+        status: 'ACTIVE',
+        currentDepartment: 'QC',
+        finalizedAt: new Date(),
+      })),
+      ...Array.from({ length: 27 }, (_, index) => ({
+        id: `oven-${index}`,
+        serialNumber: `OVEN-${index}`,
+        status: 'ACTIVE',
+        currentDepartment: 'Oven',
+      })),
+      ...Array.from({ length: 2 }, (_, index) => ({
+        id: `qc-${index}`,
+        serialNumber: `QC-${index}`,
+        status: 'ACTIVE',
+        currentDepartment: 'QC',
+      })),
+      ...Array.from({ length: 33 }, (_, index) => ({
+        id: `layup-${index}`,
+        serialNumber: `LAYUP-${index}`,
+        status: 'ACTIVE',
+        currentDepartment: 'Layup',
+      })),
+      // A lower-precedence historical duplicate must not double-count a unit.
+      {
+        id: 'old-duplicate',
+        serialNumber: 'SERIAL-0',
+        status: 'ACTIVE',
+        currentDepartment: 'Layup',
+      },
+      // These legacy/ghost records are not legitimate serialized workflow units.
+      ...Array.from({ length: 3 }, (_, index) => ({
+        id: `inventory-${index}`,
+        serialNumber: `INVENTORY-${index}`,
+        status: 'COMPLETED',
+        currentDepartment: 'Inventory',
+      })),
+      {
+        id: 'qc-ghost',
+        serialNumber: null,
+        status: 'ACTIVE',
+        currentDepartment: 'QC',
+      },
+    ];
+
+    const ledger = buildP2SerializedUnitLedger(
+      390,
+      rows,
+      Array.from({ length: 318 }, (_, index) => `ship-${index}`),
+    );
+
+    expect(ledger).toMatchObject({
+      shipped: 318,
+      finalization: 2,
+      activeProduction: 29,
+      scheduled: 33,
+      missing: 8,
+      productionPipeline: 62,
+      total: 390,
+      accounted: 382,
+    });
+    expect(
+      ledger.shipped
+        + ledger.finalization
+        + ledger.activeProduction
+        + ledger.scheduled
+        + ledger.missing,
+    ).toBe(ledger.total);
+  });
+
+  it('does not treat production completion as shipment evidence', () => {
+    const ledger = buildP2SerializedUnitLedger(1, [{
+      id: 'completed-only',
+      serialNumber: 'SERIAL-1',
+      status: 'COMPLETED',
+      currentDepartment: 'Inventory',
+    }], []);
+
+    expect(ledger.shipped).toBe(0);
+    expect(ledger.missing).toBe(1);
+  });
+});

--- a/server/src/lib/p2SerializedUnitLedger.ts
+++ b/server/src/lib/p2SerializedUnitLedger.ts
@@ -1,0 +1,136 @@
+export type P2SerializedUnitBucket =
+  | 'shipped'
+  | 'finalization'
+  | 'activeProduction'
+  | 'scheduled';
+
+export interface P2SerializedUnitLedgerRow {
+  id?: string | null;
+  serialNumber?: string | null;
+  serial_number?: string | null;
+  status?: string | null;
+  currentDepartment?: string | null;
+  current_department?: string | null;
+  finalizedAt?: string | Date | null;
+  finalized_at?: string | Date | null;
+}
+
+export interface P2SerializedUnitLedger {
+  shipped: number;
+  finalization: number;
+  activeProduction: number;
+  scheduled: number;
+  missing: number;
+  productionPipeline: number;
+  total: number;
+  accounted: number;
+  missingSerialSlots: string[];
+  bucketBySerial: Map<string, P2SerializedUnitBucket>;
+}
+
+const normalized = (value: unknown) => String(value ?? '').trim().toUpperCase();
+
+const serialKey = (row: P2SerializedUnitLedgerRow) =>
+  normalized(row.serialNumber ?? row.serial_number);
+
+const department = (row: P2SerializedUnitLedgerRow) =>
+  normalized(row.currentDepartment ?? row.current_department)
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ');
+
+const isScheduledDepartment = (value: string) =>
+  value === 'LAYUP' || value === 'PENDING LAYUP' || value === 'SCHEDULED';
+
+const isExcludedHistoricalRecord = (row: P2SerializedUnitLedgerRow) => {
+  const status = normalized(row.status);
+  const dept = department(row);
+  return dept === 'INVENTORY'
+    && ['COMPLETE', 'COMPLETED', 'CLOSED'].includes(status);
+};
+
+const classify = (
+  row: P2SerializedUnitLedgerRow,
+  shippedItemIds: ReadonlySet<string>,
+): P2SerializedUnitBucket | null => {
+  const id = String(row.id ?? '').trim().toLowerCase();
+  if (id && shippedItemIds.has(id)) return 'shipped';
+
+  if (row.finalizedAt ?? row.finalized_at) return 'finalization';
+  if (isExcludedHistoricalRecord(row)) return null;
+
+  const status = normalized(row.status);
+  const dept = department(row);
+  if (['SCRAP', 'SCRAPPED', 'CANCELED', 'CANCELLED', 'VOID'].includes(status)) {
+    return null;
+  }
+  if (isScheduledDepartment(dept)) return 'scheduled';
+  if (
+    dept
+    && !['INVENTORY', 'SHIPPED', 'SHIPPING', 'CLOSED'].includes(dept)
+    && !['PENDING', 'SCHEDULED', 'COMPLETE', 'COMPLETED', 'CLOSED', 'SHIPPED'].includes(status)
+  ) {
+    return 'activeProduction';
+  }
+  return null;
+};
+
+export function buildP2SerializedUnitLedger(
+  orderedQuantity: number,
+  rows: readonly P2SerializedUnitLedgerRow[],
+  shippedSerializedItemIds: Iterable<string>,
+): P2SerializedUnitLedger {
+  const total = Math.max(0, Math.trunc(Number(orderedQuantity) || 0));
+  const shippedIds = new Set(
+    Array.from(shippedSerializedItemIds, (id) => String(id).trim().toLowerCase())
+      .filter(Boolean),
+  );
+  const bucketBySerial = new Map<string, P2SerializedUnitBucket>();
+
+  // A serial can have historical duplicate rows. Evaluate every row and retain
+  // only the highest-precedence legitimate state for that physical unit.
+  const precedence: Record<P2SerializedUnitBucket, number> = {
+    shipped: 4,
+    finalization: 3,
+    activeProduction: 2,
+    scheduled: 1,
+  };
+  for (const row of rows) {
+    const serial = serialKey(row);
+    if (!serial) continue; // excludes nonserialized/quantity-only ghost rows
+    const bucket = classify(row, shippedIds);
+    if (!bucket) continue;
+    const existing = bucketBySerial.get(serial);
+    if (!existing || precedence[bucket] > precedence[existing]) {
+      bucketBySerial.set(serial, bucket);
+    }
+  }
+
+  const counts = {
+    shipped: 0,
+    finalization: 0,
+    activeProduction: 0,
+    scheduled: 0,
+  };
+  for (const bucket of bucketBySerial.values()) counts[bucket] += 1;
+
+  const accounted = Object.values(counts).reduce((sum, count) => sum + count, 0);
+  const missing = Math.max(0, total - accounted);
+  if (accounted > total) {
+    throw new Error(
+      `P2 serialized-unit ledger invariant failed: ${accounted} bucketed units exceed ordered quantity ${total}`,
+    );
+  }
+
+  return {
+    ...counts,
+    missing,
+    productionPipeline: counts.activeProduction + counts.scheduled,
+    total,
+    accounted,
+    missingSerialSlots: Array.from(
+      { length: missing },
+      (_, index) => `MISSING-${String(index + 1).padStart(3, '0')}`,
+    ),
+    bucketBySerial,
+  };
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -20,6 +20,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
+import { buildP2SerializedUnitLedger } from '../lib/p2SerializedUnitLedger';
 import { softAuth, authenticateToken, sessionAwareAuth, requireAdminOrOwner } from '../../middleware/auth';
 import { computeEffectivePriority, getEffectivePriorityScore } from '../../../shared/utils/computeEffectivePriority';
 import employeesRoutes from './employees';
@@ -4854,26 +4855,35 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const orderedQtyByPoId = new Map<number, number>(
         orderedQtyRows.map((r: any) => [Number(r.poId), Number(r.orderedQty) || 0])
       );
-      const shippedQtyRows = poIds.length > 0
+      const shippedSerializedItemRows = allPoIds.length > 0
         ? await optionalP2Rows(
-            'shipped lot quantity',
+            'shipped serialized-unit membership',
             dbPool.query(
-              `SELECT po_id AS "poId", COALESCE(SUM(quantity), 0)::int AS "shippedQty"
-               FROM p2_lot_numbers
-               WHERE po_id = ANY($1)
+              `SELECT
+                 lot.po_id AS "poId",
+                 shipped_item.id AS "serializedItemId"
+               FROM p2_lot_numbers lot
+               CROSS JOIN LATERAL jsonb_array_elements_text(
+                 COALESCE(lot.serialized_item_ids, '[]'::jsonb)
+               ) AS shipped_item(id)
+               WHERE lot.po_id = ANY($1)
                  AND (
-                   COALESCE(UPPER(status), '') IN ('SHIPPED', 'CLOSED', 'COMPLETE', 'COMPLETED')
-                   OR shipped_at IS NOT NULL
-                   OR packing_slip_id IS NOT NULL
-                 )
-               GROUP BY po_id`,
-              [poIds]
+                   COALESCE(UPPER(lot.status), '') = 'SHIPPED'
+                   OR lot.shipped_at IS NOT NULL
+                 )`,
+              [allPoIds]
             )
           )
         : [];
-      const shippedQtyByPoId = new Map<number, number>(
-        shippedQtyRows.map((r: any) => [Number(r.poId), Number(r.shippedQty) || 0])
-      );
+      const shippedSerializedItemIdsByPoId = new Map<number, Set<string>>();
+      for (const row of shippedSerializedItemRows) {
+        const poId = Number(row.poId);
+        const serializedItemId = String(row.serializedItemId ?? '').trim().toLowerCase();
+        if (!Number.isFinite(poId) || !serializedItemId) continue;
+        const ids = shippedSerializedItemIdsByPoId.get(poId) ?? new Set<string>();
+        ids.add(serializedItemId);
+        shippedSerializedItemIdsByPoId.set(poId, ids);
+      }
       
       p2StatusStage = 'building P2 status response';
       const poStatuses = pos.map((po: any) => {
@@ -4885,64 +4895,11 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const travelerProjectStats = linkedProject?.projectId
           ? travelerStatsByProject.get(String(linkedProject.projectId))
           : null;
-        const travelerCompletedItems = Number(travelerProjectStats?.completedQty ?? 0);
-        const travelerInProductionItems = Number(travelerProjectStats?.inProductionQty ?? 0);
         const travelerTotalItems = Number(travelerProjectStats?.totalQty ?? 0);
-        const sumStats = (rows: Array<any | undefined>) => rows.some(Boolean)
-          ? {
-              totalQty: rows.reduce((sum, row) => sum + Number(row?.totalQty ?? 0), 0),
-              completedQty: rows.reduce((sum, row) => sum + Number(row?.completedQty ?? 0), 0),
-              inProductionQty: rows.reduce((sum, row) => sum + Number(row?.inProductionQty ?? 0), 0),
-            }
-            : null;
-        const legacyP2Stats = sumStats(familyPoIds.map((id) => legacyStatsByPoId.get(id)));
-        const legacyProjectStats = sumStats(familyPoIds.map((id) => legacyProjectStatsByPoId.get(id)));
-        const legacyStats = sumStats([legacyP2Stats, legacyProjectStats]);
-        
-        // Use actual column names: status (ACTIVE/COMPLETED/SCRAPPED/HOLD) and currentDepartment
-        const serializedCompletedItems = poItems.filter((s: any) => {
-          const status = String(s.status || '').trim().toUpperCase();
-          const dept = String(s.currentDepartment || '').trim().toUpperCase();
-          return ['COMPLETED', 'COMPLETE', 'SHIPPED', 'CLOSED'].includes(status)
-            || ['SHIPPED', 'SHIPPING', 'CLOSED'].includes(dept)
-            || s.shippedAt
-            || s.packingSlipId;
-        }).length;
-        const legacyCompletedItems = Number(legacyStats?.completedQty ?? 0);
-        const shippedLotCompletedItems = familyPoIds.reduce(
-          (sum, familyPoId) => sum + (shippedQtyByPoId.get(familyPoId) ?? 0),
-          0
-        );
-        const completedItems = Math.max(
-          serializedCompletedItems,
-          legacyCompletedItems,
-          shippedLotCompletedItems,
-          travelerCompletedItems
-        );
-
-        const scheduledItems = poItems.filter((s: any) => {
-          if (s.status !== 'ACTIVE') return false;
-          const dept = normalizeP2ControlDepartment(s.currentDepartment || '');
-          return dept === 'Layup';
-        }).length;
-
         const scrappedItems = poItems.filter((s: any) => {
           const status = String(s.status || '').trim().toUpperCase();
           return status === 'SCRAPPED' || status === 'SCRAP';
         }).length;
-
-        const serializedInProductionItems = poItems.filter((s: any) => {
-          if (s.status !== 'ACTIVE') return false;
-          const dept = normalizeP2ControlDepartment(s.currentDepartment || '');
-          // Scheduled Layup work is not floor production yet.
-          return dept !== 'Pending Layup' && dept !== 'Layup' && dept !== '';
-        }).length;
-        const legacyInProductionItems = Number(legacyStats?.inProductionQty ?? 0);
-        const rawInProductionItems = Math.max(
-          serializedInProductionItems,
-          legacyInProductionItems,
-          travelerInProductionItems
-        );
 
         // totalItems is the sum of ordered quantities across all line items so that
         // lines without serialized items generated yet are still reflected on the card.
@@ -4954,14 +4911,21 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const totalItems = currentPoOrderedQty > 0
           ? currentPoOrderedQty
           : Math.max(familyOrderedQty, travelerTotalItems, poItems.length);
-        const inProductionItems = Math.min(
-          rawInProductionItems,
-          Math.max(0, totalItems - completedItems)
+        const shippedSerializedItemIds = new Set<string>();
+        for (const familyPoId of familyPoIds) {
+          for (const id of shippedSerializedItemIdsByPoId.get(familyPoId) ?? []) {
+            shippedSerializedItemIds.add(id);
+          }
+        }
+        const ledger = buildP2SerializedUnitLedger(
+          totalItems,
+          poItems,
+          shippedSerializedItemIds,
         );
-
-        // pendingItems = everything not yet completed or in-production (including
-        // line item quantities that haven't had serialized items generated yet).
-        const pendingItems = Math.max(0, totalItems - completedItems - scheduledItems - inProductionItems - scrappedItems);
+        const completedItems = ledger.shipped;
+        const scheduledItems = ledger.scheduled;
+        const inProductionItems = ledger.activeProduction;
+        const pendingItems = ledger.missing;
         
         const rawStatus = normalizeP2Status(po.status) || 'OPEN';
 
@@ -4977,8 +4941,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           dueDate: po.expectedDelivery,
           totalItems,
           completedItems,
+          shippedItems: ledger.shipped,
+          needsFinalizationItems: ledger.finalization,
           scheduledItems,
           inProductionItems,
+          productionPipelineItems: ledger.productionPipeline,
+          missingItems: ledger.missing,
           scrappedItems,
           pendingItems,
           hasBOMsNeeded: !po.bomConfigured,


### PR DESCRIPTION
## What changed

- adds one server-side serialized-unit ledger keyed and deduplicated by serial number across each P2 PO revision family
- applies mutually exclusive precedence: shipped, finalization, active production, scheduled, then missing
- counts shipment membership as the only shipped truth and stops promoting production-order completion into shipped/completed
- excludes historical completed Inventory records and nonserialized ghost rows from legitimate workflow buckets
- makes the Control Center summary and PO cards use the same ledger-derived Scheduled and In Production calculations
- exposes shipped, needs-finalization, production-pipeline, and missing quantities on the PO status response

## Why

The dashboard mixed serialized rows, travelers, legacy production orders, and shipped-lot quantities using independent maximum/additive calculations. That allowed 29 actively moving units plus 33 Layup units to appear as 62 “In Production” while Scheduled independently displayed 32.

For the PO014332 revision-family audit shape, the invariant is now encoded as:

- Shipped: 318
- Needs finalization: 2
- Active production: 29 (27 Oven + 2 QC)
- Scheduled/Layup: 33
- Missing: 8
- Total: 390

Production Pipeline remains derivable as 29 + 33 = 62, without mislabeling all 62 as active production.

## Validation

- `git diff --cached --check` passed
- bundled Node syntax check passed for `server/src/lib/p2SerializedUnitLedger.ts`
- focused regression test added for the 318 + 2 + 29 + 33 + 8 = 390 invariant and for excluding completed Inventory/nonserialized ghost records
- focused Vitest execution was attempted, but this clean worktree has no dependency tree; using a sibling installation reached Vitest but was blocked by unresolved local Tailwind/PostCSS dependencies

This is a separate corrective PR based on current `origin/main`; PR #1535 remains merged and unchanged.