### PR TITLE
Show Flat Top badges across the P1 workflow

### DIFF
--- a/client/src/__tests__/p1FlatTop.test.ts
+++ b/client/src/__tests__/p1FlatTop.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { isP1FlatTopOrder } from '../utils/p1FlatTop';
+
+describe('isP1FlatTopOrder', () => {
+  it.each([
+    { isFlattop: true },
+    { is_flattop: true },
+    { features: { isFlattop: true } },
+    { features: { flat_top: 'yes' } },
+    { specifications: { flatTop: true } },
+    { features: { specifications: { features: { flattop: 'flat top' } } } },
+  ])('recognizes persisted flat-top aliases', (order) => {
+    expect(isP1FlatTopOrder(order)).toBe(true);
+  });
+
+  it('does not classify an ordinary stock as flat top', () => {
+    expect(
+      isP1FlatTopOrder({
+        orderId: 'FB354',
+        stockModelId: 'cf_privateer',
+        features: {},
+      })
+    ).toBe(false);
+  });
+});

--- a/client/src/components/LayupSchedulePreview.tsx
+++ b/client/src/components/LayupSchedulePreview.tsx
@@ -24,6 +24,7 @@ interface ScheduledItem {
   lopValue?: string | null;
   hasADL?: boolean;
   hasHeavyFill?: boolean;
+  isFlatTop?: boolean;
 }
 
 interface OverflowItem {
@@ -371,6 +372,11 @@ export function LayupSchedulePreview({
       border-color: #ea580c; 
       color: #9a3412;
     }
+    .badge-flattop {
+      background: linear-gradient(to bottom, #fef9c3, #fef08a);
+      border-color: #ca8a04;
+      color: #713f12;
+    }
     .badge-stiller { 
       background: linear-gradient(to bottom, #fef3c7, #fde68a);
       border-color: #d97706; 
@@ -476,12 +482,13 @@ export function LayupSchedulePreview({
               const hasStillerInlet = stillerInlets.some(pattern => actionInlet.includes(pattern));
               const showStiller = isMA && hasStillerInlet;
               const showSMR = isMA && !hasStillerInlet;
-              const hasBadges = item.hasLOP || item.hasADL || item.hasHeavyFill || showStiller || showSMR;
+              const hasBadges = item.hasLOP || item.hasADL || item.hasHeavyFill || item.isFlatTop || showStiller || showSMR;
               return hasBadges ? `
               <div class="badges">
                 ${item.hasLOP ? `<div class="badge badge-lop">LOP ${item.lopValue || ''}</div>` : ''}
                 ${item.hasADL ? '<div class="badge badge-adl">ADL</div>' : ''}
                 ${item.hasHeavyFill ? '<div class="badge badge-heavy">HEAVY</div>' : ''}
+                ${item.isFlatTop ? '<div class="badge badge-flattop">FLAT TOP</div>' : ''}
                 ${showStiller ? '<div class="badge badge-stiller">Stiller</div>' : ''}
                 ${showSMR ? '<div class="badge badge-smr">SMR</div>' : ''}
               </div>
@@ -626,6 +633,11 @@ export function LayupSchedulePreview({
                                 Heavy Fill
                               </Badge>
                             )}
+                            {item.isFlatTop && (
+                              <Badge className="bg-yellow-100 text-yellow-900 border-yellow-300 text-xs">
+                                Flat Top
+                              </Badge>
+                            )}
                             {(() => {
                               const actionLength = (item.actionLength || '').toLowerCase().trim();
                               const actionInlet = (item.actionInlet || '').toLowerCase().trim();
@@ -648,7 +660,7 @@ export function LayupSchedulePreview({
                               }
                               return null;
                             })()}
-                            {!item.hasLOP && !item.hasADL && !item.hasHeavyFill && !(
+                            {!item.hasLOP && !item.hasADL && !item.hasHeavyFill && !item.isFlatTop && !(
                               (item.actionLength || '').toLowerCase() === 'ma' || (item.actionLength || '').toLowerCase() === 'medium'
                             ) && (
                               <span className="text-gray-400 text-xs">-</span>
@@ -696,12 +708,13 @@ export function LayupSchedulePreview({
                       const hasStillerInlet = stillerInlets.some(pattern => actionInlet.includes(pattern));
                       const showStiller = isMA && hasStillerInlet;
                       const showSMR = isMA && !hasStillerInlet;
-                      const hasBadges = item.hasLOP || item.hasADL || item.hasHeavyFill || showStiller || showSMR;
+                      const hasBadges = item.hasLOP || item.hasADL || item.hasHeavyFill || item.isFlatTop || showStiller || showSMR;
                       return hasBadges ? (
                         <div className="layup-badges">
                           {item.hasLOP && <span className="layup-badge layup-badge-lop">LOP {item.lopValue || ''}</span>}
                           {item.hasADL && <span className="layup-badge layup-badge-adl">ADL</span>}
                           {item.hasHeavyFill && <span className="layup-badge layup-badge-heavy">HEAVY</span>}
+                          {item.isFlatTop && <span className="layup-badge layup-badge-flattop">FLAT TOP</span>}
                           {showStiller && <span className="layup-badge layup-badge-stiller">Stiller</span>}
                           {showSMR && <span className="layup-badge layup-badge-smr">SMR</span>}
                         </div>

--- a/client/src/components/ProductionQueueManager.tsx
+++ b/client/src/components/ProductionQueueManager.tsx
@@ -72,6 +72,7 @@ import { LayupSchedulePreview } from './LayupSchedulePreview';
 import { ScheduleHistoryDialog } from './ScheduleHistoryDialog';
 import { MoldSettings } from './MoldSettings';
 import { deriveOrderLabels } from '@/utils/deriveOrderLabels';
+import { isP1FlatTopOrder } from '@/utils/p1FlatTop';
 
 interface ProductionQueueOrder {
   orderId: string;
@@ -1151,7 +1152,7 @@ export default function ProductionQueueManager() {
           <TableHead>Stock Model</TableHead>
           <TableHead>Action Length</TableHead>
           <TableHead>Bottom Metal</TableHead>
-          <TableHead>LOP / Fill</TableHead>
+          <TableHead>Other</TableHead>
           <TableHead>Due Date</TableHead>
           <TableHead>Days to Due</TableHead>
           <TableHead>Urgency</TableHead>
@@ -1186,6 +1187,7 @@ export default function ProductionQueueManager() {
             : '';
           const otherOptions = order.features?.other_options || [];
           const hasHeavyFill = Array.isArray(otherOptions) && otherOptions.includes('heavy_fill');
+          const isFlatTop = isP1FlatTopOrder(order);
           const queueIndex = productionQueue.findIndex((queueOrder) => queueOrder.orderId === order.orderId);
 
           return (
@@ -1253,13 +1255,6 @@ export default function ProductionQueueManager() {
                   <Badge variant="secondary" className="font-medium">
                     {actionLength}
                   </Badge>
-                ) : order.isFlattop ? (
-                  <Badge
-                    className="bg-yellow-100 text-yellow-900 border-yellow-300 font-semibold"
-                    title="Flattop stock: action length is not machined"
-                  >
-                    FLATTOP
-                  </Badge>
                 ) : isTikkaModel ? (
                   <Badge
                     variant="secondary"
@@ -1289,6 +1284,11 @@ export default function ProductionQueueManager() {
                   {hasHeavyFill && (
                     <Badge className="bg-purple-100 text-purple-800 border-purple-200 font-semibold text-xs">
                       HEAVY FILL
+                    </Badge>
+                  )}
+                  {isFlatTop && (
+                    <Badge className="bg-yellow-100 text-yellow-900 border-yellow-300 font-semibold text-xs">
+                      FLAT TOP
                     </Badge>
                   )}
                 </div>
@@ -2219,7 +2219,7 @@ export default function ProductionQueueManager() {
                         <TableHead>Stock Model</TableHead>
                         <TableHead>Action Length</TableHead>
                         <TableHead>Bottom Metal</TableHead>
-                        <TableHead>LOP / Fill</TableHead>
+                        <TableHead>Other</TableHead>
                         <TableHead>Due Date</TableHead>
                         <TableHead>Days to Due</TableHead>
                         <TableHead>Urgency</TableHead>
@@ -2255,6 +2255,7 @@ export default function ProductionQueueManager() {
                         // Check for heavy fill option
                         const otherOptions = order.features?.other_options || [];
                         const hasHeavyFill = Array.isArray(otherOptions) && otherOptions.includes('heavy_fill');
+                        const isFlatTop = isP1FlatTopOrder(order);
 
                         return (
                           <TableRow
@@ -2327,13 +2328,6 @@ export default function ProductionQueueManager() {
                                 >
                                   {actionLengthDisplay}
                                 </Badge>
-                              ) : order.isFlattop ? (
-                                <Badge
-                                  className="bg-yellow-100 text-yellow-900 border-yellow-300 font-semibold"
-                                  title="Flattop stock: action length is not machined"
-                                >
-                                  FLATTOP
-                                </Badge>
                               ) : isTikkaModel ? (
                                 <Badge
                                   variant="secondary"
@@ -2363,6 +2357,11 @@ export default function ProductionQueueManager() {
                                 {hasHeavyFill && (
                                   <Badge className="bg-purple-100 text-purple-800 border-purple-200 font-semibold text-xs">
                                     HEAVY FILL
+                                  </Badge>
+                                )}
+                                {isFlatTop && (
+                                  <Badge className="bg-yellow-100 text-yellow-900 border-yellow-300 font-semibold text-xs">
+                                    FLAT TOP
                                   </Badge>
                                 )}
                               </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1115,6 +1115,12 @@
     border-color: #9a3412;
     color: #9a3412;
   }
+
+  .layup-badge-flattop {
+    background: #fef9c3;
+    border-color: #ca8a04;
+    color: #713f12;
+  }
   
   .layup-badge-stiller {
     background: #fef3c7;

--- a/client/src/pages/BarcodeQueuePage.tsx
+++ b/client/src/pages/BarcodeQueuePage.tsx
@@ -73,6 +73,7 @@ import TicketBadge, { useOrderTicketCounts } from '@/components/TicketBadge';
 import OrderActionButtons from '@/components/OrderActionButtons';
 import DepartmentOrderNotes from '@/components/DepartmentOrderNotes';
 import { deriveOrderLabels, logBarcodeDebug } from '@/utils/deriveOrderLabels';
+import { isP1FlatTopOrder } from '@/utils/p1FlatTop';
 
 // Kickback form validation schema
 const kickbackFormSchema = z.object({
@@ -103,34 +104,8 @@ type KickbackFormData = z.infer<typeof kickbackFormSchema>;
 
 type ViewMode = 'grouped' | 'flat' | 'list';
 
-const isFlatTopValue = (value: unknown) =>
-  value === true ||
-  (typeof value === 'string' && ['true', 'yes', 'flat top', 'flattop'].includes(value.trim().toLowerCase()));
-
-const isFlatTopOrder = (order: any) => {
-  if (!order) return false;
-  const specifications = order.specifications ?? order.features?.specifications ?? {};
-  const nestedFeatures = specifications?.features ?? {};
-  return (
-    isFlatTopValue(order.isFlattop) ||
-    isFlatTopValue(order.isFlatTop) ||
-    isFlatTopValue(order.flatTop) ||
-    isFlatTopValue(order.flat_top) ||
-    isFlatTopValue(order.features?.flattop) ||
-    isFlatTopValue(order.features?.flatTop) ||
-    isFlatTopValue(order.features?.flat_top) ||
-    isFlatTopValue(specifications?.isFlattop) ||
-    isFlatTopValue(specifications?.flatTop) ||
-    isFlatTopValue(specifications?.flat_top) ||
-    isFlatTopValue(nestedFeatures?.isFlattop) ||
-    isFlatTopValue(nestedFeatures?.flatTop) ||
-    isFlatTopValue(nestedFeatures?.flat_top) ||
-    isFlatTopValue(nestedFeatures?.flattop)
-  );
-};
-
 const isRegularFlatTopOrder = (order: any) =>
-  !String(order?.orderId || '').startsWith('PO-') && isFlatTopOrder(order);
+  !String(order?.orderId || '').startsWith('PO-') && isP1FlatTopOrder(order);
 
 export default function BarcodeQueuePage() {
   const [selectedOrders, setSelectedOrders] = useState<Set<string>>(new Set());
@@ -533,7 +508,7 @@ export default function BarcodeQueuePage() {
           
           if (isPOItem) {
             // Check if PO item has flattop option
-            const isFlattop = isFlatTopOrder(order);
+            const isFlattop = isP1FlatTopOrder(order);
             if (isFlattop) {
               poFlatTopOrderIds.push(orderId);
             } else {
@@ -977,7 +952,7 @@ export default function BarcodeQueuePage() {
               const lopVal = (() => { const l = order.features?.length_of_pull; return l?.includes('lop_adj_') ? (l.match(/lop_adj_([\d.]+)/)?.[1] ?? null) : null; })();
               const hasHeavyFill = (() => { const f = order.features; if (!f) return false; const opts = f.other_options; if (Array.isArray(opts) && opts.includes('heavy_fill')) return true; const v = f.heavy_fill || f.heavyFill || f.heavy_fill_option; return v === 'true' || v === true || v === 'yes' || v === 'heavy_fill'; })();
               const hasADL = typeof order.features?.bottom_metal === 'string' && order.features.bottom_metal.toLowerCase().includes('adl');
-              const isRegularFlatTop = isFlatTopOrder(order);
+              const isRegularFlatTop = isP1FlatTopOrder(order);
 
               return (
                 <Card
@@ -1098,7 +1073,7 @@ export default function BarcodeQueuePage() {
                     const lopVal = (() => { const l = order.features?.length_of_pull; return l?.includes('lop_adj_') ? (l.match(/lop_adj_([\d.]+)/)?.[1] ?? null) : null; })();
                     const hasHeavyFill = (() => { const f = order.features; if (!f) return false; const opts = f.other_options; if (Array.isArray(opts) && opts.includes('heavy_fill')) return true; const v = f.heavy_fill || f.heavyFill || f.heavy_fill_option; return v === 'true' || v === true || v === 'yes' || v === 'heavy_fill'; })();
                     const hasADL = typeof order.features?.bottom_metal === 'string' && order.features.bottom_metal.toLowerCase().includes('adl');
-                    const isRegularFlatTop = isFlatTopOrder(order);
+                    const isRegularFlatTop = isP1FlatTopOrder(order);
 
                     return (
                       <tr
@@ -1269,7 +1244,7 @@ export default function BarcodeQueuePage() {
                       const lopVal = (() => { const l = order.features?.length_of_pull; return l?.includes('lop_adj_') ? (l.match(/lop_adj_([\d.]+)/)?.[1] ?? null) : null; })();
                       const hasHeavyFill = (() => { const f = order.features; if (!f) return false; const opts = f.other_options; if (Array.isArray(opts) && opts.includes('heavy_fill')) return true; const v = f.heavy_fill || f.heavyFill || f.heavy_fill_option; return v === 'true' || v === true || v === 'yes' || v === 'heavy_fill'; })();
                       const hasADL = typeof order.features?.bottom_metal === 'string' && order.features.bottom_metal.toLowerCase().includes('adl');
-                      const isRegularFlatTop = isFlatTopOrder(order);
+                      const isRegularFlatTop = isP1FlatTopOrder(order);
 
                       return (
                         <Card
@@ -1595,7 +1570,7 @@ export default function BarcodeQueuePage() {
                             const actionLength = orderLabels2.actionLengthRaw;
                             const isTikka = orderLabels2.isTikka;
                             const materialType = orderLabels2.materialLabel;
-                            const isRegularFlatTop = isFlatTopOrder(order);
+                            const isRegularFlatTop = isP1FlatTopOrder(order);
 
                             // Check if this is a PO order (no label printing needed)
                             const isPOOrder = order.orderId.startsWith('PO-');
@@ -1711,7 +1686,7 @@ export default function BarcodeQueuePage() {
                                           {getActionBadgeLabel(orderLabels2)} Action
                                         </Badge>
                                         {/* Flattop badge for P1 PO orders */}
-                                        {isPOOrder && isFlatTopOrder(order) && (
+                                        {isPOOrder && isP1FlatTopOrder(order) && (
                                           <Badge
                                             variant="outline"
                                             className="text-xs border-purple-500 text-purple-700 bg-purple-50 font-semibold"

--- a/client/src/utils/p1FlatTop.ts
+++ b/client/src/utils/p1FlatTop.ts
@@ -1,0 +1,52 @@
+const isTrueFlatTopValue = (value: unknown) =>
+  value === true ||
+  (typeof value === 'string' &&
+    ['true', 'yes', 'flat top', 'flattop'].includes(
+      value.trim().toLowerCase()
+    ));
+
+export function isP1FlatTopOrder(order: unknown): boolean {
+  if (!order || typeof order !== 'object') return false;
+
+  const candidate = order as Record<string, any>;
+  const features =
+    candidate.features && typeof candidate.features === 'object'
+      ? candidate.features
+      : {};
+  const specifications =
+    candidate.specifications && typeof candidate.specifications === 'object'
+      ? candidate.specifications
+      : features.specifications && typeof features.specifications === 'object'
+        ? features.specifications
+        : {};
+  const nestedFeatures =
+    specifications.features && typeof specifications.features === 'object'
+      ? specifications.features
+      : {};
+
+  return [
+    candidate.isFlattop,
+    candidate.isFlatTop,
+    candidate.is_flattop,
+    candidate.flatTop,
+    candidate.flat_top,
+    features.isFlattop,
+    features.isFlatTop,
+    features.is_flattop,
+    features.flatTop,
+    features.flat_top,
+    features.flattop,
+    specifications.isFlattop,
+    specifications.isFlatTop,
+    specifications.is_flattop,
+    specifications.flatTop,
+    specifications.flat_top,
+    specifications.flattop,
+    nestedFeatures.isFlattop,
+    nestedFeatures.isFlatTop,
+    nestedFeatures.is_flattop,
+    nestedFeatures.flatTop,
+    nestedFeatures.flat_top,
+    nestedFeatures.flattop,
+  ].some(isTrueFlatTopValue);
+}

--- a/server/src/routes/layupSchedule.ts
+++ b/server/src/routes/layupSchedule.ts
@@ -7,6 +7,7 @@ import { eq, and, inArray, sql } from 'drizzle-orm';
 import { format, addDays, startOfWeek, getDay } from 'date-fns';
 import { deriveCanonicalMaterial } from '../utils/deriveCanonicalMaterial';
 import { parseP1POUnitOrderId } from '../utils/parseP1POUnitOrderId';
+import { isP1FlatTop } from '../utils/p1FlatTop';
 
 function normalizeMaterial(raw: string): string {
   const lower = raw.toLowerCase().trim();
@@ -422,6 +423,7 @@ router.post('/generate', async (req: Request, res: Response) => {
           customerName: allOrders.customerId, // Using customerId as customerName for now
           dueDate: allOrders.dueDate,
           features: allOrders.features,
+          isFlattop: allOrders.isFlattop,
         })
         .from(allOrders)
         .where(inArray(allOrders.orderId, selectedOrderIds));
@@ -483,6 +485,10 @@ router.post('/generate', async (req: Request, res: Response) => {
           lopValue,
           hasADL,
           hasHeavyFill,
+          isFlatTop: isP1FlatTop({
+            ...features,
+            isFlattop: order.isFlattop,
+          }),
         };
       });
     }
@@ -501,6 +507,7 @@ router.post('/generate', async (req: Request, res: Response) => {
           actionLength: poProducts.actionLength,
           actionInlet: poProducts.actionInlet,
           stockModel: poProducts.stockModel,
+          flatTop: poProducts.flatTop,
         })
         .from(poProducts)
         .where(inArray(poProducts.id, itemIds));
@@ -569,6 +576,9 @@ router.post('/generate', async (req: Request, res: Response) => {
             hasLOP: false,
             hasADL: false,
             hasHeavyFill: false,
+            isFlatTop:
+              poProductData?.flatTop === true ||
+              isP1FlatTop((item as any).specifications),
           });
         }
       }
@@ -718,6 +728,7 @@ router.post('/generate', async (req: Request, res: Response) => {
               lopValue: item.lopValue || null,
               hasADL: item.hasADL || false,
               hasHeavyFill: item.hasHeavyFill || false,
+              isFlatTop: item.isFlatTop || false,
             });
             
             moldDayCapacity[mold.moldId][day] = currentUsage + 1;
@@ -1578,7 +1589,8 @@ router.get('/week/:weekStart', async (req: Request, res: Response) => {
           ao.fb_order_number,
           ao.model_id AS stock_model,
           ao.customer_id AS customer_name,
-          ao.features
+          ao.features,
+          ao.is_flattop
         FROM all_orders ao
         WHERE ao.order_id = ANY($1::text[])
       `,
@@ -1655,6 +1667,7 @@ router.get('/week/:weekStart', async (req: Request, res: Response) => {
           hasLOP: checkHasLOP(features),
           hasADL: checkHasADL(features),
           hasHeavyFill: checkHasHeavyFill(features),
+          isFlatTop: isP1FlatTop(features),
         };
       } else {
         // Regular order
@@ -1688,6 +1701,10 @@ router.get('/week/:weekStart', async (req: Request, res: Response) => {
           hasLOP: checkHasLOP(features),
           hasADL: checkHasADL(features),
           hasHeavyFill: checkHasHeavyFill(features),
+          isFlatTop: isP1FlatTop({
+            ...features,
+            isFlattop: order.is_flattop,
+          }),
         };
       }
     });


### PR DESCRIPTION
## What changed

- Rename the P1 production queue `LOP / Fill` column to `Other` and show Flat Top alongside the existing LOP and Fill badges.
- Use one client-side Flat Top detector across production queue and Barcode views, including persisted camelCase and snake_case aliases.
- Carry Flat Top classification through generated and historical layup schedules.
- Show Flat Top on schedule previews, printed schedules, and Barcode cards.
- Add focused coverage for the supported persisted Flat Top aliases.

## Why

Flat Top orders such as FB354 could be correctly configured while appearing blank in the production queue because the queue and Barcode pages inspected different field aliases. The schedule payload also omitted the Flat Top classification. Operators therefore could not reliably distinguish Flat Top work as it moved through scheduling and Barcode.

## Impact

Operators can now see a clear `FLAT TOP` badge in the production queue's `Other` column, on the layup schedule and printed checklist, and in Barcode. Existing LOP, Fill, and Bottom Metal indicators remain intact.

## Validation

- Focused Flat Top alias assertions: passed.
- `git diff --cached --check`: passed.
- Full Vitest run was unavailable locally because the isolated worktree had no installed dependencies and package downloads were blocked.