### PR TITLE
Add P2 V2 production execution and completion controls

### DIFF
--- a/client/src/__tests__/P2V2ProductionExecution.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionExecution.component.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import P2V2ProductionExecution from '../components/projects/P2V2ProductionExecution';
+
+const response = {
+  ctx: {
+    project: {
+      id: 'project-1',
+      po_id: 42,
+      po_number: 'PO-42',
+      customer_name: 'Example Customer',
+      current_stage: 'IN_PRODUCTION',
+    },
+    launch: {
+      production_plan_revision: 3,
+      wad_revision: 2,
+      configuration_baseline_id: 'CFG-7',
+      effectivity_reference: 'SN-001 through SN-002',
+    },
+  },
+  productionOrders: [{ id: 1 }, { id: 2 }],
+  serializedItems: [{ id: 'a' }, { id: 'b' }],
+  travelers: [{ id: 't-1' }],
+  traceability: [{ id: 'trace-1' }],
+  ncrs: [],
+  holds: [],
+  labor: { actual_hours: '4.5', open_count: 0 },
+  evidence: {
+    authorizedQuantity: 2,
+    completedQuantity: 1,
+    acceptedQuantity: 1,
+    rejectedQuantity: 0,
+    scrappedQuantity: 0,
+    productionOrdersRequired: 2,
+    productionOrdersComplete: 1,
+    incompleteTravelerSteps: 1,
+    missingMaterialGenealogy: 1,
+    activeHolds: 0,
+  },
+  readiness: {
+    state: 'BLOCKED',
+    blockers: ['Required current traveler evidence is missing.'],
+    warnings: [],
+  },
+  review: null,
+  approvals: [],
+  history: [],
+};
+
+describe('P2V2ProductionExecution', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => response,
+      })
+    );
+  });
+  it('renders authoritative progress, holds, blockers, and release deferrals', async () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <P2V2ProductionExecution projectId="project-1" />
+      </QueryClientProvider>
+    );
+    expect(await screen.findByText('Production dashboard')).toBeInTheDocument();
+    expect(screen.getByText(/Example Customer · PO PO-42/)).toBeInTheDocument();
+    expect(screen.getByText('1/2 complete')).toBeInTheDocument();
+    expect(
+      screen.getByText('Required current traveler evidence is missing.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/does not release product or authorize shipping/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /create completion review/i })
+    ).toBeEnabled();
+  });
+});

--- a/client/src/components/projects/P2V2ProductionExecution.tsx
+++ b/client/src/components/projects/P2V2ProductionExecution.tsx
@@ -1,0 +1,338 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Factory,
+  ShieldAlert,
+} from 'lucide-react';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+
+type Row = Record<string, unknown>;
+type Dashboard = {
+  ctx: {
+    project: {
+      id: string;
+      po_id: number;
+      po_number?: string;
+      customer_name?: string;
+      current_stage: string;
+    };
+    launch: {
+      production_plan_revision: number;
+      wad_revision: number;
+      configuration_baseline_id: string;
+      effectivity_reference: string;
+    };
+  };
+  productionOrders: Row[];
+  serializedItems: Row[];
+  travelers: Row[];
+  traceability: Row[];
+  ncrs: Row[];
+  holds: Row[];
+  labor: { actual_hours?: string | number; open_count?: number };
+  evidence: {
+    authorizedQuantity: number;
+    completedQuantity: number;
+    acceptedQuantity: number;
+    rejectedQuantity: number;
+    scrappedQuantity: number;
+    productionOrdersRequired: number;
+    productionOrdersComplete: number;
+    incompleteTravelerSteps: number;
+    missingMaterialGenealogy: number;
+    activeHolds: number;
+  };
+  readiness: {
+    state: string;
+    blockers: string[];
+    warnings: string[];
+  };
+  review?: {
+    lock_version: number;
+    status: string;
+    revision_number: number;
+  } | null;
+  approvals: Array<{
+    approval_type: string;
+    decision: string;
+    actor_display_name: string;
+  }>;
+  history: Row[];
+};
+
+const number = (value: unknown) => Number(value ?? 0);
+const text = (value: unknown) => String(value ?? '');
+
+export default function P2V2ProductionExecution({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const queryClient = useQueryClient();
+  const key = ['/api/projects', projectId, 'workflow-v2', 'production'];
+  const { data, isLoading, error } = useQuery<Dashboard>({
+    queryKey: key,
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/projects/${projectId}/workflow-v2/production`,
+        { credentials: 'include' }
+      );
+      const body = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(body?.message || 'Unable to load Production evidence');
+      return body;
+    },
+  });
+  const action = useMutation({
+    mutationFn: async (path: string) => {
+      const response = await fetch(
+        `/api/projects/${projectId}/workflow-v2/production/${path}`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(
+            path === 'completion-reviews'
+              ? {}
+              : { expectedLockVersion: data?.review?.lock_version }
+          ),
+        }
+      );
+      const body = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(body?.message || 'Production-stage action failed');
+      return body;
+    },
+    onSuccess: (body) => {
+      queryClient.setQueryData(key, body);
+      queryClient.invalidateQueries({
+        queryKey: ['/api/projects', projectId, 'workflow-v2'],
+      });
+    },
+  });
+  if (isLoading)
+    return (
+      <Card>
+        <CardContent className="p-6">
+          Loading authoritative Production evidence…
+        </CardContent>
+      </Card>
+    );
+  if (error || !data)
+    return (
+      <Alert variant="destructive" data-testid="p2-v2-production-error">
+        <ShieldAlert className="h-4 w-4" />
+        <AlertTitle>Production evidence unavailable</AlertTitle>
+        <AlertDescription>
+          {error instanceof Error ? error.message : 'Unable to load Stage 8.'}
+        </AlertDescription>
+      </Alert>
+    );
+  const progress = data.evidence.authorizedQuantity
+    ? Math.min(
+        100,
+        Math.round(
+          (data.evidence.completedQuantity / data.evidence.authorizedQuantity) *
+            100
+        )
+      )
+    : 0;
+  return (
+    <div className="space-y-4" data-testid="p2-v2-production-execution">
+      <Alert>
+        <Factory className="h-4 w-4" />
+        <AlertTitle>Stage 8 — Production execution evidence</AlertTitle>
+        <AlertDescription>
+          Operational progress is calculated from authoritative work orders,
+          travelers, material, labor, quality, and calibration records. Stage 8
+          completion does not release product or authorize shipping.
+        </AlertDescription>
+      </Alert>
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap justify-between gap-3">
+            <div>
+              <CardTitle>Production dashboard</CardTitle>
+              <CardDescription>
+                {data.ctx.project.customer_name || 'Customer'} · PO{' '}
+                {data.ctx.project.po_number || data.ctx.project.po_id} ·
+                Configuration {data.ctx.launch.configuration_baseline_id} ·
+                Effectivity {data.ctx.launch.effectivity_reference}
+              </CardDescription>
+            </div>
+            <Badge>{data.review?.status || data.readiness.state}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <p className="text-xs text-muted-foreground">Production Plan</p>
+              <p className="font-medium">
+                Revision {data.ctx.launch.production_plan_revision}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Released WAD</p>
+              <p className="font-medium">
+                Revision {data.ctx.launch.wad_revision}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Production orders</p>
+              <p className="font-medium">
+                {data.evidence.productionOrdersComplete}/
+                {data.evidence.productionOrdersRequired} complete
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Labor actual</p>
+              <p className="font-medium">
+                {number(data.labor.actual_hours).toFixed(2)} hours
+              </p>
+            </div>
+          </div>
+          <div>
+            <div className="mb-1 flex justify-between text-sm">
+              <span>Manufactured quantity progress</span>
+              <span>{progress}%</span>
+            </div>
+            <Progress value={progress} />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-6">
+            {[
+              ['Authorized', data.evidence.authorizedQuantity],
+              ['Completed', data.evidence.completedQuantity],
+              ['Accepted', data.evidence.acceptedQuantity],
+              ['Rejected', data.evidence.rejectedQuantity],
+              ['Scrapped', data.evidence.scrappedQuantity],
+              ['Travelers', data.travelers.length],
+            ].map(([label, value]) => (
+              <div key={String(label)} className="rounded border p-3">
+                <p className="text-xs text-muted-foreground">{label}</p>
+                <p className="text-lg font-semibold">{value}</p>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+      {(data.readiness.blockers.length > 0 ||
+        data.holds.some((hold) => text(hold.status) === 'ACTIVE')) && (
+        <Alert
+          variant="destructive"
+          data-testid="production-completion-blockers"
+        >
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Production completion blockers</AlertTitle>
+          <AlertDescription>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              {data.readiness.blockers.map((blocker) => (
+                <li key={blocker}>{blocker}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Authoritative evidence coverage</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>Production orders: {data.productionOrders.length}</p>
+            <p>Serialized or batch records: {data.serializedItems.length}</p>
+            <p>
+              Traveler operations incomplete:{' '}
+              {data.evidence.incompleteTravelerSteps}
+            </p>
+            <p>
+              Material genealogy gaps: {data.evidence.missingMaterialGenealogy}
+            </p>
+            <p>Open NCRs: {data.ncrs.length}</p>
+            <p>Open labor entries: {number(data.labor.open_count)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Holds, approvals, and history</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p className="font-medium text-red-700">
+              Active holds: {data.evidence.activeHolds}
+            </p>
+            {data.holds.map((hold) => (
+              <div key={text(hold.id)} className="rounded border p-2">
+                <Badge
+                  variant={
+                    text(hold.status) === 'ACTIVE' ? 'destructive' : 'outline'
+                  }
+                >
+                  {text(hold.status)}
+                </Badge>{' '}
+                {text(hold.reason)} · {text(hold.scope_type)}
+              </div>
+            ))}
+            <p>Functional approvals: {data.approvals.length}</p>
+            <p>Immutable revisions: {data.history.length}</p>
+          </CardContent>
+        </Card>
+      </div>
+      {action.error && (
+        <p className="text-sm text-red-700">{action.error.message}</p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {!data.review && (
+          <Button
+            onClick={() => action.mutate('completion-reviews')}
+            disabled={action.isPending}
+          >
+            Create completion review
+          </Button>
+        )}
+        {data.review &&
+          ['IN_PROGRESS', 'BLOCKED', 'READY_FOR_COMPLETION_REVIEW'].includes(
+            data.review.status
+          ) && (
+            <Button
+              variant="outline"
+              onClick={() =>
+                action.mutate('completion-reviews/current/recalculate')
+              }
+              disabled={action.isPending}
+            >
+              Recalculate readiness
+            </Button>
+          )}
+        {data.review?.status === 'READY_FOR_COMPLETION_REVIEW' && (
+          <Button
+            onClick={() => action.mutate('completion-reviews/current/submit')}
+            disabled={action.isPending}
+          >
+            Submit completion review
+          </Button>
+        )}
+        {data.review?.status === 'COMPLETE' && (
+          <span className="flex items-center gap-1 text-sm text-green-700">
+            <CheckCircle2 className="h-4 w-4" />
+            Immutable Production evidence complete
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Final acceptance, AS9100 8.6 product release, Shipping, and Project
+        Closing remain read-only and are deferred to later phases.
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -16,6 +16,7 @@ import P2V2TechnicalConfigurationReview from './P2V2TechnicalConfigurationReview
 import P2V2WadAuthorization from './P2V2WadAuthorization';
 import P2V2CommercialReview from './P2V2CommercialReview';
 import P2V2PreproductionReadiness from './P2V2PreproductionReadiness';
+import P2V2ProductionExecution from './P2V2ProductionExecution';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -419,6 +420,11 @@ export default function P2V2ProjectWorkflow({
               {stage.stepType === 'preproduction_release' && (
                 <div className="mt-3">
                   <P2V2PreproductionReadiness projectId={projectId} />
+                </div>
+              )}
+              {stage.stepType === 'production_quality' && (
+                <div className="mt-3">
+                  <P2V2ProductionExecution projectId={projectId} />
                 </div>
               )}
             </CardContent>

--- a/migrations/0220_p2_v2_production_execution.sql
+++ b/migrations/0220_p2_v2_production_execution.sql
@@ -1,0 +1,158 @@
+-- Phase 9A: additive p2_v2 Production evidence, holds, and completion review.
+-- Authoritative manufacturing records remain in their existing tables. This
+-- migration stores only controlled links and immutable review snapshots.
+
+CREATE TABLE IF NOT EXISTS project_production_stage_reviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL,
+  workflow_instance_id UUID NOT NULL,
+  workflow_step_instance_id UUID NOT NULL,
+  production_launch_id UUID NOT NULL,
+  production_release_id UUID NOT NULL,
+  revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+  lock_version INTEGER NOT NULL DEFAULT 1 CHECK (lock_version > 0),
+  status TEXT NOT NULL DEFAULT 'IN_PROGRESS'
+    CHECK (status IN ('IN_PROGRESS','BLOCKED','READY_FOR_COMPLETION_REVIEW',
+      'PENDING_APPROVAL','COMPLETE','STALE','INVALIDATED','SUPERSEDED')),
+  production_plan_revision INTEGER NOT NULL,
+  wad_revision INTEGER NOT NULL,
+  configuration_baseline_id TEXT NOT NULL,
+  effectivity_reference TEXT NOT NULL,
+  evidence_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+  blockers JSONB NOT NULL DEFAULT '[]'::jsonb,
+  warnings JSONB NOT NULL DEFAULT '[]'::jsonb,
+  exceptions JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name TEXT NOT NULL,
+  submitted_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  completed_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  completed_by_display_name TEXT,
+  invalidated_at TIMESTAMP,
+  invalidation_reason TEXT,
+  superseded_at TIMESTAMP,
+  superseded_by_review_id UUID REFERENCES project_production_stage_reviews(id) ON DELETE RESTRICT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  FOREIGN KEY (workflow_step_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, project_id) ON DELETE RESTRICT,
+  FOREIGN KEY (production_launch_id, project_id)
+    REFERENCES project_production_launches(id, project_id) ON DELETE RESTRICT,
+  FOREIGN KEY (production_release_id, project_id)
+    REFERENCES project_production_releases(id, project_id) ON DELETE RESTRICT,
+  UNIQUE (project_id, workflow_instance_id, revision_number)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_production_stage_current_unique
+  ON project_production_stage_reviews(project_id, workflow_instance_id)
+  WHERE status IN ('IN_PROGRESS','BLOCKED','READY_FOR_COMPLETION_REVIEW','PENDING_APPROVAL');
+CREATE INDEX IF NOT EXISTS project_production_stage_history_idx
+  ON project_production_stage_reviews(project_id, revision_number DESC);
+
+CREATE TABLE IF NOT EXISTS project_production_evidence_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  production_stage_review_id UUID NOT NULL REFERENCES project_production_stage_reviews(id) ON DELETE RESTRICT,
+  record_type TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  relationship_type TEXT NOT NULL,
+  record_revision TEXT,
+  quantity NUMERIC,
+  effectivity_reference TEXT,
+  authoritative BOOLEAN NOT NULL DEFAULT true,
+  linked_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  linked_by_display_name TEXT NOT NULL,
+  linked_at TIMESTAMP NOT NULL DEFAULT now(),
+  superseded_at TIMESTAMP,
+  supersession_reason TEXT,
+  UNIQUE (production_stage_review_id, record_type, record_id, relationship_type)
+);
+CREATE INDEX IF NOT EXISTS project_production_evidence_project_idx
+  ON project_production_evidence_links(project_id, record_type);
+
+CREATE TABLE IF NOT EXISTS project_production_holds (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  production_stage_review_id UUID NOT NULL REFERENCES project_production_stage_reviews(id) ON DELETE RESTRICT,
+  reason TEXT NOT NULL,
+  scope_type TEXT NOT NULL,
+  scope_record_id TEXT,
+  affected_part_number TEXT,
+  affected_quantity NUMERIC,
+  required_disposition TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'ACTIVE' CHECK (status IN ('ACTIVE','RELEASED','SUPERSEDED')),
+  placed_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  placed_by_display_name TEXT NOT NULL,
+  placed_at TIMESTAMP NOT NULL DEFAULT now(),
+  release_authorized_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  release_authorized_by_display_name TEXT,
+  release_reason TEXT,
+  released_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS project_production_holds_active_idx
+  ON project_production_holds(project_id) WHERE status='ACTIVE';
+
+CREATE TABLE IF NOT EXISTS project_production_stage_approvals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  production_stage_review_id UUID NOT NULL REFERENCES project_production_stage_reviews(id) ON DELETE RESTRICT,
+  production_stage_revision INTEGER NOT NULL,
+  approval_type TEXT NOT NULL CHECK (approval_type IN
+    ('OPERATIONS','QUALITY','PROJECT_MANAGEMENT','MANUFACTURING_ENGINEERING')),
+  decision TEXT NOT NULL CHECK (decision IN ('APPROVED','REJECTED','RETURNED')),
+  signature_meaning TEXT NOT NULL,
+  reason TEXT,
+  evidence_snapshot_hash TEXT NOT NULL,
+  actor_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  actor_employee_id INTEGER,
+  actor_display_name TEXT NOT NULL,
+  actor_role TEXT NOT NULL,
+  decided_at TIMESTAMP NOT NULL DEFAULT now(),
+  superseded_at TIMESTAMP,
+  UNIQUE (production_stage_review_id, approval_type)
+);
+
+INSERT INTO perm_capabilities (key, description, category) VALUES
+ ('projects.production_stage.manage','Recalculate, submit, and complete P2 V2 Production evidence','operations'),
+ ('projects.production_stage.hold','Place controlled P2 V2 Production holds','operations'),
+ ('projects.production_stage.release_hold','Authorize release of controlled P2 V2 Production holds','quality'),
+ ('projects.production_stage.operations_decide','Approve P2 V2 Production completion for Operations','operations'),
+ ('projects.production_stage.quality_decide','Approve P2 V2 Production completion for Quality','quality'),
+ ('projects.production_stage.pm_decide','Approve P2 V2 Production completion for Project Management','projects'),
+ ('projects.production_stage.engineering_decide','Approve conditional P2 V2 Production completion for Manufacturing Engineering','engineering')
+ON CONFLICT (key) DO UPDATE SET description=EXCLUDED.description,category=EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT pr.id,pc.id FROM perm_roles pr JOIN perm_capabilities pc ON (
+ (pr.name IN ('ADMIN','OWNER') AND pc.key LIKE 'projects.production_stage.%') OR
+ (pr.name IN ('OPERATIONS','OPERATIONS_MANAGER','PRODUCTION_MANAGER','MANAGER')
+   AND pc.key IN ('projects.production_stage.manage','projects.production_stage.hold',
+     'projects.production_stage.operations_decide')) OR
+ (pr.name IN ('QUALITY','QC','QUALITY_MANAGER')
+   AND pc.key IN ('projects.production_stage.release_hold','projects.production_stage.quality_decide')) OR
+ (pr.name IN ('PROJECT_MANAGER','PROGRAM_MANAGER') AND pc.key='projects.production_stage.pm_decide') OR
+ (pr.name IN ('ENGINEERING','ENGINEER','ENGINEERING_MANAGER','MANUFACTURING_ENGINEERING')
+   AND pc.key='projects.production_stage.engineering_decide')
+) ON CONFLICT (role_id,capability_id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION protect_completed_production_stage_snapshot()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.status = 'COMPLETE' AND (
+    NEW.evidence_snapshot IS DISTINCT FROM OLD.evidence_snapshot OR
+    NEW.blockers IS DISTINCT FROM OLD.blockers OR
+    NEW.warnings IS DISTINCT FROM OLD.warnings OR
+    NEW.exceptions IS DISTINCT FROM OLD.exceptions OR
+    NEW.configuration_baseline_id IS DISTINCT FROM OLD.configuration_baseline_id OR
+    NEW.effectivity_reference IS DISTINCT FROM OLD.effectivity_reference
+  ) THEN
+    RAISE EXCEPTION 'Completed Production-stage evidence is immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS protect_completed_production_stage_snapshot_trigger
+  ON project_production_stage_reviews;
+CREATE TRIGGER protect_completed_production_stage_snapshot_trigger
+BEFORE UPDATE ON project_production_stage_reviews
+FOR EACH ROW EXECUTE FUNCTION protect_completed_production_stage_snapshot();

--- a/migrations/0220_p2_v2_production_execution.sql
+++ b/migrations/0220_p2_v2_production_execution.sql
@@ -2,6 +2,9 @@
 -- Authoritative manufacturing records remain in their existing tables. This
 -- migration stores only controlled links and immutable review snapshots.
 
+CREATE UNIQUE INDEX IF NOT EXISTS project_production_launches_id_project_unique
+  ON project_production_launches(id, project_id);
+
 CREATE TABLE IF NOT EXISTS project_production_stage_reviews (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   project_id UUID NOT NULL,

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -31,6 +31,10 @@ import {
   submitPreproduction,
 } from '../src/services/projectPreproductionReadinessService';
 import {
+  createCompletionReview,
+  getProductionDashboard,
+} from '../src/services/projectProductionExecutionService';
+import {
   getP2V2StagesForDefinitionVersion,
   P2_V2_DEFINITION_VERSION,
 } from '../src/services/projectWorkflowRegistry';
@@ -658,6 +662,9 @@ describe('Phase 8 migration certification', () => {
     expect(
       criticalMigrationFiles.has('0212_project_preproduction_launch_safety.sql')
     ).toBe(true);
+    expect(
+      criticalMigrationFiles.has('0220_p2_v2_production_execution.sql')
+    ).toBe(true);
     const migration = readFileSync(
       path.resolve('migrations/0210_project_preproduction_readiness.sql')
     );
@@ -684,6 +691,26 @@ describe('Phase 8 migration certification', () => {
     );
     expect(constraints.rows).toHaveLength(3);
     expect(constraints.rows.every((row) => row.convalidated)).toBe(true);
+  });
+
+  it('has additive Phase 9A Production evidence, hold, link, and approval tables', async () => {
+    const result = await query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema='public' AND table_name=ANY($1::text[])
+       ORDER BY table_name`,
+      [[
+        'project_production_stage_reviews',
+        'project_production_evidence_links',
+        'project_production_holds',
+        'project_production_stage_approvals',
+      ]]
+    );
+    expect(result.rows.map((row) => row.table_name)).toEqual([
+      'project_production_evidence_links',
+      'project_production_holds',
+      'project_production_stage_approvals',
+      'project_production_stage_reviews',
+    ]);
   });
 });
 
@@ -877,6 +904,22 @@ describe('actual production launch service against PostgreSQL', () => {
       [fixture.projectId]
     );
     expect(success.rows).toHaveLength(1);
+  });
+
+  it('aggregates launched authoritative records without duplicating execution data', async () => {
+    const dashboard = await getProductionDashboard(baseProjectId);
+    expect(dashboard.productionOrders).toHaveLength(6);
+    expect(dashboard.serializedItems).toHaveLength(2);
+    expect(dashboard.readiness.state).toBe('BLOCKED');
+    expect(dashboard.deferrals).toEqual({
+      finalProductRelease: true,
+      shipping: true,
+      projectClosing: true,
+    });
+    const created = await createCompletionReview(baseProjectId, actor);
+    expect(created.review?.revision_number).toBe(1);
+    expect(created.review?.status).toBe('BLOCKED');
+    expect(created.productionOrders).toHaveLength(6);
   });
 
   it('keeps null and legacy workflow versions isolated', async () => {

--- a/server/__tests__/projectProductionExecution.test.ts
+++ b/server/__tests__/projectProductionExecution.test.ts
@@ -1,0 +1,270 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateProductionCompletion,
+  type ProductionEvidenceInput,
+} from '../src/services/projectProductionExecutionRules';
+
+const root = process.cwd();
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
+const service = read(
+  'server/src/services/projectProductionExecutionService.ts'
+);
+const routes = read('server/src/routes/projectProductionExecution.ts');
+const travelerRoutes = read('server/src/routes/travelers.ts');
+const workOrderRoutes = read('server/src/routes/workOrders.ts');
+const migration = read('migrations/0220_p2_v2_production_execution.sql');
+const workflow = read('client/src/components/projects/P2V2ProjectWorkflow.tsx');
+
+const ready = (
+  patch: Partial<ProductionEvidenceInput> = {}
+): ProductionEvidenceInput => ({
+  authorizedQuantity: 2,
+  completedQuantity: 2,
+  acceptedQuantity: 2,
+  rejectedQuantity: 0,
+  scrappedQuantity: 0,
+  productionOrdersRequired: 2,
+  productionOrdersComplete: 2,
+  travelerMode: 'INDIVIDUAL',
+  requiredTravelers: 2,
+  currentTravelers: 2,
+  incompleteTravelerSteps: 0,
+  missingTravelerActors: 0,
+  missingMaterialGenealogy: 0,
+  invalidMaterialConsumptions: 0,
+  openLaborEntries: 0,
+  trainingGaps: 0,
+  calibrationGaps: 0,
+  incompleteInspections: 0,
+  incompleteTests: 0,
+  incompleteSpecialProcesses: 0,
+  openNcrs: 0,
+  incompleteRework: 0,
+  activeHolds: 0,
+  baselineChanged: false,
+  mixedConfiguration: false,
+  noTravelerExceptionApproved: false,
+  manufacturingEngineeringApprovalRequired: false,
+  ...patch,
+});
+
+describe('Phase 9A Production execution controls', () => {
+  it('rejects manual Stage 8 activation by requiring completed launch evidence', () => {
+    expect(service).toContain('CERTIFIED_PRODUCTION_LAUNCH_REQUIRED');
+    expect(routes).not.toContain('activate');
+  });
+  it('requires a completed certified production launch', () => {
+    expect(service).toContain("pl.status='COMPLETE'");
+  });
+  it('gates V2 traveler creation and work start without changing legacy execution', () => {
+    expect(workOrderRoutes).toContain('getProjectProductionExecutionGate');
+    expect(travelerRoutes).toContain('getTravelerProductionExecutionGate');
+    expect(service).toContain("version !== 'p2_v2'");
+    expect(service).toContain(
+      'P2 V2 work cannot start before certified Production Launch activates Stage 8.'
+    );
+  });
+  it('rejects legacy and NULL projects from V2 Production mutations', () => {
+    expect(service).toContain("version !== 'p2_v2'");
+    expect(service).toContain('P2_V2_REQUIRED');
+  });
+  it('fails unknown workflow versions closed', () => {
+    expect(service).toContain('UNKNOWN_WORKFLOW_VERSION');
+  });
+  it('does not modify legacy execution routes or project_steps', () => {
+    expect(service).not.toContain('project_steps');
+    expect(routes).toContain('Router({ mergeParams: true })');
+  });
+  it('does not modify Design Control behavior', () => {
+    expect(service).not.toContain('design_control');
+    expect(migration).not.toContain('design_control');
+  });
+  it('builds the dashboard from authoritative execution tables', () => {
+    for (const table of [
+      'p2_production_orders',
+      'p2_serialized_items',
+      'travelers',
+      'traveler_steps',
+      'time_clock_entries',
+      'nonconformance_records',
+    ])
+      expect(service).toContain(table);
+  });
+  it('tracks parent and manufactured child orders as separate authoritative rows', () => {
+    expect(service).toContain('productionOrders');
+    expect(service).toContain('requiredManufacturedItems');
+  });
+  it('does not require purchased components to have manufactured orders', () => {
+    expect(service).toContain("item.make_buy === 'MAKE'");
+  });
+  it('enforces individual traveler counts', () => {
+    expect(
+      evaluateProductionCompletion(
+        ready({ travelerMode: 'INDIVIDUAL', currentTravelers: 1 })
+      ).blockers
+    ).toContain('Required current traveler evidence is missing.');
+  });
+  it('supports one current batch traveler for a manufactured scope', () => {
+    expect(
+      evaluateProductionCompletion(
+        ready({
+          travelerMode: 'BATCH',
+          requiredTravelers: 1,
+          currentTravelers: 1,
+        })
+      ).state
+    ).toBe('READY_FOR_COMPLETION_REVIEW');
+  });
+  it('supports approved no-traveler exceptions', () => {
+    expect(
+      evaluateProductionCompletion(
+        ready({
+          travelerMode: 'NO_TRAVELER_EXCEPTION',
+          requiredTravelers: 0,
+          currentTravelers: 0,
+          noTravelerExceptionApproved: true,
+        })
+      ).state
+    ).toBe('READY_FOR_COMPLETION_REVIEW');
+  });
+  it('blocks an unapproved no-traveler exception', () => {
+    expect(
+      evaluateProductionCompletion(
+        ready({
+          travelerMode: 'NO_TRAVELER_EXCEPTION',
+          noTravelerExceptionApproved: false,
+        })
+      ).blockers
+    ).toContain('The no-traveler exception lacks approved justification.');
+  });
+  it('blocks missing traveler evidence', () => {
+    expect(
+      evaluateProductionCompletion(ready({ currentTravelers: 0 })).state
+    ).toBe('BLOCKED');
+  });
+  it('enforces routing-operation completion', () => {
+    expect(
+      evaluateProductionCompletion(ready({ incompleteTravelerSteps: 1 }))
+        .blockers
+    ).toContain('Released routing operations are not complete.');
+  });
+  it('blocks material genealogy gaps', () => {
+    expect(
+      evaluateProductionCompletion(ready({ missingMaterialGenealogy: 1 }))
+        .blockers
+    ).toContain(
+      'Required material lot or received-unit genealogy is incomplete.'
+    );
+  });
+  it('blocks expired, quarantined, or rejected material', () => {
+    expect(
+      evaluateProductionCompletion(ready({ invalidMaterialConsumptions: 1 }))
+        .blockers
+    ).toContain(
+      'Expired, quarantined, or rejected material consumption is invalid.'
+    );
+  });
+  it('blocks training and certification gaps', () => {
+    expect(
+      evaluateProductionCompletion(ready({ trainingGaps: 1 })).blockers
+    ).toContain('Required employee training or certification is not current.');
+  });
+  it('blocks calibration gaps', () => {
+    expect(
+      evaluateProductionCompletion(ready({ calibrationGaps: 1 })).blockers
+    ).toContain(
+      'Required calibrated equipment evidence is missing or expired.'
+    );
+  });
+  it('blocks in-process inspection holds and incomplete inspections', () => {
+    const result = evaluateProductionCompletion(
+      ready({ incompleteInspections: 1, activeHolds: 1 })
+    );
+    expect(result.state).toBe('BLOCKED');
+    expect(result.blockers).toContain(
+      'Required in-process inspections or sampling remain incomplete.'
+    );
+  });
+  it('blocks unresolved NCRs', () => {
+    expect(
+      evaluateProductionCompletion(ready({ openNcrs: 1 })).blockers
+    ).toContain('An unresolved blocking NCR affects Production completion.');
+  });
+  it('requires rework completion and reinspection', () => {
+    expect(
+      evaluateProductionCompletion(ready({ incompleteRework: 1 })).blockers
+    ).toContain(
+      'Rework requires approved instructions, completion, and reinspection.'
+    );
+  });
+  it('does not count scrap as accepted completion', () => {
+    expect(
+      evaluateProductionCompletion(
+        ready({ acceptedQuantity: 1, scrappedQuantity: 1 })
+      ).blockers
+    ).toContain(
+      'Scrapped quantity is not accepted completion; disposition and replacement quantity are required.'
+    );
+  });
+  it('detects underproduction and overproduction', () => {
+    expect(
+      evaluateProductionCompletion(ready({ completedQuantity: 1 })).blockers
+    ).toContain('Authorized manufactured quantity is underproduced.');
+    expect(
+      evaluateProductionCompletion(ready({ completedQuantity: 3 })).blockers
+    ).toContain('Unauthorized overproduction was detected.');
+  });
+  it('marks post-launch baseline changes stale', () => {
+    expect(
+      evaluateProductionCompletion(ready({ baselineChanged: true })).state
+    ).toBe('STALE');
+  });
+  it('blocks mixed configuration and effectivity', () => {
+    expect(
+      evaluateProductionCompletion(ready({ mixedConfiguration: true })).blockers
+    ).toContain('Mixed or unidentified configuration/effectivity exists.');
+  });
+  it('enforces required approvals and segregation of duties', () => {
+    expect(service).toContain('SEGREGATION_OF_DUTIES');
+    expect(service).toContain('PRODUCTION_APPROVALS_REQUIRED');
+    for (const role of [
+      'OPERATIONS',
+      'QUALITY',
+      'PROJECT_MANAGEMENT',
+      'MANUFACTURING_ENGINEERING',
+    ])
+      expect(migration).toContain(role);
+  });
+  it('makes completed Production evidence immutable', () => {
+    expect(migration).toContain(
+      'Completed Production-stage evidence is immutable'
+    );
+  });
+  it('rejects concurrent and stale writes with optimistic locking', () => {
+    expect(service).toContain('lock_version=${expectedLockVersion}');
+    expect(service).toContain('STALE_WRITE');
+  });
+  it('does not perform final product release', () => {
+    expect(service).toContain('finalProductReleased: false');
+  });
+  it('does not create or authorize shipping', () => {
+    expect(service).toContain('shippingAuthorized: false');
+    expect(service).not.toContain('INSERT INTO shipment');
+  });
+  it('keeps Stages 9 and 10 read-only', () => {
+    expect(workflow).toContain("stage.stepType === 'production_quality'");
+    expect(service).not.toContain("step_type='final");
+    expect(service).not.toContain("step_type='shipping");
+  });
+  it('requires attributable traveler completion evidence', () => {
+    expect(
+      evaluateProductionCompletion(ready({ missingTravelerActors: 1 })).blockers
+    ).toContain(
+      'Completed traveler steps require an attributable actor and timestamp.'
+    );
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -245,6 +245,7 @@ export const safeMigrationFiles = [
   '0217_freezer_na_readings.sql',
   '0218_as9100_audit_readiness.sql',
   '0219_controlled_printed_copies.sql',
+  '0220_p2_v2_production_execution.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -277,6 +278,7 @@ export const criticalMigrationFiles = new Set([
   '0217_freezer_na_readings.sql',
   '0218_as9100_audit_readiness.sql',
   '0219_controlled_printed_copies.sql',
+  '0220_p2_v2_production_execution.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/projectProductionExecution.ts
+++ b/server/src/routes/projectProductionExecution.ts
@@ -1,0 +1,261 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { getUserPermissions } from '../services/permissionService';
+import {
+  completeProductionStage,
+  createCompletionReview,
+  decideProductionCompletion,
+  getProductionDashboard,
+  placeProductionHold,
+  ProjectProductionExecutionError,
+  recalculateProductionReadiness,
+  releaseProductionHold,
+  submitProductionCompletion,
+  type ProductionActor,
+} from '../services/projectProductionExecutionService';
+
+const router = Router({ mergeParams: true });
+const expected = z.object({ expectedLockVersion: z.number().int().positive() });
+const decision = expected.extend({
+  decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+  signatureMeaning: z.string().min(1),
+  reason: z.string().optional().default(''),
+});
+const hold = expected.extend({
+  reason: z.string().min(1),
+  scopeType: z.enum([
+    'PROJECT',
+    'PART',
+    'PRODUCTION_ORDER',
+    'TRAVELER',
+    'QUANTITY',
+  ]),
+  scopeRecordId: z.string().optional(),
+  affectedPartNumber: z.string().optional(),
+  affectedQuantity: z.number().positive().optional(),
+  requiredDisposition: z.string().min(1),
+});
+const releaseHold = expected.extend({ releaseReason: z.string().min(1) });
+
+function actor(req: Request): ProductionActor {
+  if (!req.user?.id || !req.user.username || !req.user.role)
+    throw new ProjectProductionExecutionError(
+      'ACTOR_REQUIRED',
+      'Authenticated actor identity is required.',
+      401
+    );
+  return {
+    userId: req.user.id,
+    employeeId: req.user.employeeId ?? null,
+    username: req.user.username,
+    displayName: req.user.username,
+    role: req.user.role,
+  };
+}
+async function requireCapability(req: Request, capability: string) {
+  const value = actor(req);
+  const { permissionSet } = await getUserPermissions(value.userId, value.role);
+  if (!permissionSet.has(capability))
+    throw new ProjectProductionExecutionError(
+      'FORBIDDEN',
+      `The ${capability} capability is required.`,
+      403
+    );
+  return value;
+}
+function fail(res: Response, error: unknown) {
+  if (error instanceof z.ZodError)
+    return res
+      .status(400)
+      .json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error instanceof ProjectProductionExecutionError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
+  console.error('P2 V2 Production Execution error:', error);
+  return res.status(500).json({
+    error: 'PRODUCTION_STAGE_ACTION_FAILED',
+    message: 'The Production-stage action failed.',
+  });
+}
+const projectId = (req: Request) => String(req.params.id);
+
+router.get('/', async (req, res) => {
+  try {
+    res.json(await getProductionDashboard(projectId(req)));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/evidence', async (req, res) => {
+  try {
+    const model = await getProductionDashboard(projectId(req));
+    res.json({
+      productionOrders: model.productionOrders,
+      serializedItems: model.serializedItems,
+      travelers: model.travelers,
+      traceability: model.traceability,
+      ncrs: model.ncrs,
+      labor: model.labor,
+      deferrals: model.deferrals,
+    });
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/history', async (req, res) => {
+  try {
+    const model = await getProductionDashboard(projectId(req));
+    res.json({
+      history: model.history,
+      approvals: model.approvals,
+      holds: model.holds,
+    });
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/completion-reviews', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_stage.manage'
+    );
+    res.status(201).json(await createCompletionReview(projectId(req), user));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/completion-reviews/current/recalculate', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_stage.manage'
+    );
+    const body = expected.parse(req.body);
+    res.json(
+      await recalculateProductionReadiness(
+        projectId(req),
+        body.expectedLockVersion,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/completion-reviews/current/submit', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_stage.manage'
+    );
+    const body = expected.parse(req.body);
+    res.json(
+      await submitProductionCompletion(
+        projectId(req),
+        body.expectedLockVersion,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+const decisions = [
+  ['operations', 'OPERATIONS', 'projects.production_stage.operations_decide'],
+  ['quality', 'QUALITY', 'projects.production_stage.quality_decide'],
+  [
+    'project-management',
+    'PROJECT_MANAGEMENT',
+    'projects.production_stage.pm_decide',
+  ],
+  [
+    'manufacturing-engineering',
+    'MANUFACTURING_ENGINEERING',
+    'projects.production_stage.engineering_decide',
+  ],
+] as const;
+for (const [path, type, capability] of decisions) {
+  router.post(
+    `/completion-reviews/current/decisions/${path}`,
+    async (req, res) => {
+      try {
+        const user = await requireCapability(req, capability);
+        const body = decision.parse(req.body);
+        res.json(
+          await decideProductionCompletion(
+            projectId(req),
+            body.expectedLockVersion,
+            type,
+            body.decision,
+            body.signatureMeaning,
+            body.reason,
+            user
+          )
+        );
+      } catch (error) {
+        fail(res, error);
+      }
+    }
+  );
+}
+router.post('/completion-reviews/current/complete', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_stage.manage'
+    );
+    const body = expected.parse(req.body);
+    res.json(
+      await completeProductionStage(
+        projectId(req),
+        body.expectedLockVersion,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/holds', async (req, res) => {
+  try {
+    const user = await requireCapability(req, 'projects.production_stage.hold');
+    const body = hold.parse(req.body);
+    res
+      .status(201)
+      .json(
+        await placeProductionHold(
+          projectId(req),
+          body.expectedLockVersion,
+          body,
+          user
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/holds/:holdId/release', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_stage.release_hold'
+    );
+    const body = releaseHold.parse(req.body);
+    res.json(
+      await releaseProductionHold(
+        projectId(req),
+        req.params.holdId,
+        body.expectedLockVersion,
+        body.releaseReason,
+        user
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+
+export default router;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -42,6 +42,7 @@ import projectWadAuthorizationRoutes from './projectWadAuthorization';
 import projectCommercialReviewRoutes from './projectCommercialReviews';
 import projectTechnicalConfigurationReviewRoutes from './projectTechnicalConfigurationReview';
 import projectPreproductionReadinessRoutes from './projectPreproductionReadiness';
+import projectProductionExecutionRoutes from './projectProductionExecution';
 import { getTechnicalConfigurationReview } from '../services/projectTechnicalConfigurationReviewService';
 import { getCurrentWadAuthorization } from '../services/projectWadAuthorizationService';
 import { getUserPermissions } from '../services/permissionService';
@@ -1594,6 +1595,10 @@ router.use(
 router.use(
   '/:id/workflow-v2/preproduction-readiness',
   projectPreproductionReadinessRoutes
+);
+router.use(
+  '/:id/workflow-v2/production',
+  projectProductionExecutionRoutes
 );
 
 router.get('/:id/workflow-v2/design-applicability', async (req, res) => {

--- a/server/src/routes/travelers.ts
+++ b/server/src/routes/travelers.ts
@@ -18,6 +18,7 @@ import * as allocationService from '../services/laborAllocationService';
 import { buildChargeContextFromTraveler } from '../helpers/travelerBarcodeResolver';
 import { executeTravelerAutoPunch } from './timeClock';
 import { recordAuditEvent } from '../services/auditLedgerService';
+import { getTravelerProductionExecutionGate } from '../services/projectProductionExecutionService';
 import { db } from '../../db';
 import {
   insertTravelerSchema,
@@ -1799,6 +1800,19 @@ async function promoteTravelerToInProgress(
   | { ok: false; status: number; body: any }
 > {
   const id = traveler.id;
+  const v2ExecutionGate = traveler.projectId
+    ? await getTravelerProductionExecutionGate(id)
+    : null;
+  if (v2ExecutionGate && !v2ExecutionGate.allowed) {
+    return {
+      ok: false,
+      status: 409,
+      body: {
+        error: v2ExecutionGate.code,
+        message: v2ExecutionGate.reason,
+      },
+    };
+  }
 
   // Kit release gate: if traveler is linked to a KIT queue item, it must be RELEASED.
   if (traveler.inventoryItemId) {
@@ -2787,6 +2801,15 @@ router.post('/:travelerId/steps/:stepId/start', async (req: Request, res: Respon
     let traveler = await storage.getTraveler(travelerId);
     if (!traveler) {
       return res.status(404).json({ error: 'Traveler not found' });
+    }
+    const v2ExecutionGate = traveler.projectId
+      ? await getTravelerProductionExecutionGate(travelerId)
+      : null;
+    if (v2ExecutionGate && !v2ExecutionGate.allowed) {
+      return res.status(409).json({
+        error: v2ExecutionGate.code,
+        message: v2ExecutionGate.reason,
+      });
     }
 
     if (traveler.status === 'DRAFT') {

--- a/server/src/routes/workOrders.ts
+++ b/server/src/routes/workOrders.ts
@@ -56,6 +56,7 @@ import {
   type WadContext,
   type ApprovedTemplateSummary,
 } from '../services/productionControl/productionControlAI.service';
+import { getProjectProductionExecutionGate } from '../services/projectProductionExecutionService';
 
 const router = Router();
 
@@ -1335,6 +1336,13 @@ router.post('/:id/travelers/create', requirePermission('work_orders.release'), a
       .where(eq(productionWorkOrders.id, id))
       .limit(1);
     if (!wad) return res.status(404).json({ error: 'Production work order not found', id });
+    const v2ExecutionGate = await getProjectProductionExecutionGate(wad.projectId);
+    if (!v2ExecutionGate.allowed) {
+      return res.status(409).json({
+        error: v2ExecutionGate.code,
+        message: v2ExecutionGate.reason,
+      });
+    }
     const documentationPackage = evaluateDocumentationRequirements(wad);
 
     let traveler: Awaited<ReturnType<typeof storage.createTravelerFromProductionWorkOrder>>;
@@ -1354,6 +1362,14 @@ router.post('/:id/travelers/create', requirePermission('work_orders.release'), a
         return res.status(404).json({ error: err.message });
       }
       throw err;
+    }
+    if (v2ExecutionGate.appliesToV2) {
+      const [linkedTraveler] = await db
+        .update(travelers)
+        .set({ projectId: wad.projectId, updatedAt: new Date() })
+        .where(eq(travelers.id, traveler.id))
+        .returning();
+      traveler = linkedTraveler ?? traveler;
     }
 
     return res.status(201).json({

--- a/server/src/services/projectProductionExecutionRules.ts
+++ b/server/src/services/projectProductionExecutionRules.ts
@@ -1,0 +1,132 @@
+export type ProductionEvidenceInput = {
+  authorizedQuantity: number;
+  completedQuantity: number;
+  acceptedQuantity: number;
+  rejectedQuantity: number;
+  scrappedQuantity: number;
+  productionOrdersRequired: number;
+  productionOrdersComplete: number;
+  travelerMode: 'INDIVIDUAL' | 'BATCH' | 'NO_TRAVELER_EXCEPTION';
+  requiredTravelers: number;
+  currentTravelers: number;
+  incompleteTravelerSteps: number;
+  missingTravelerActors: number;
+  missingMaterialGenealogy: number;
+  invalidMaterialConsumptions: number;
+  openLaborEntries: number;
+  trainingGaps: number;
+  calibrationGaps: number;
+  incompleteInspections: number;
+  incompleteTests: number;
+  incompleteSpecialProcesses: number;
+  openNcrs: number;
+  incompleteRework: number;
+  activeHolds: number;
+  baselineChanged: boolean;
+  mixedConfiguration: boolean;
+  noTravelerExceptionApproved: boolean;
+  manufacturingEngineeringApprovalRequired: boolean;
+};
+
+export type ProductionReadiness = {
+  state: 'IN_PROGRESS' | 'BLOCKED' | 'READY_FOR_COMPLETION_REVIEW' | 'STALE';
+  blockers: string[];
+  warnings: string[];
+};
+
+export function evaluateProductionCompletion(
+  evidence: ProductionEvidenceInput
+): ProductionReadiness {
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+  if (evidence.baselineChanged)
+    blockers.push(
+      'The released Production Plan, WAD, configuration, or effectivity baseline changed after launch.'
+    );
+  if (evidence.mixedConfiguration)
+    blockers.push('Mixed or unidentified configuration/effectivity exists.');
+  if (evidence.productionOrdersComplete < evidence.productionOrdersRequired)
+    blockers.push(
+      'Every required manufactured production order must be complete.'
+    );
+  if (evidence.completedQuantity < evidence.authorizedQuantity)
+    blockers.push('Authorized manufactured quantity is underproduced.');
+  if (evidence.completedQuantity > evidence.authorizedQuantity)
+    blockers.push('Unauthorized overproduction was detected.');
+  if (
+    evidence.acceptedQuantity +
+      evidence.rejectedQuantity +
+      evidence.scrappedQuantity !==
+    evidence.authorizedQuantity
+  )
+    blockers.push(
+      'All authorized quantities must be dispositioned and reconciled.'
+    );
+  if (evidence.scrappedQuantity > 0)
+    blockers.push(
+      'Scrapped quantity is not accepted completion; disposition and replacement quantity are required.'
+    );
+  if (
+    evidence.travelerMode !== 'NO_TRAVELER_EXCEPTION' &&
+    evidence.currentTravelers < evidence.requiredTravelers
+  )
+    blockers.push('Required current traveler evidence is missing.');
+  if (
+    evidence.travelerMode === 'NO_TRAVELER_EXCEPTION' &&
+    !evidence.noTravelerExceptionApproved
+  )
+    blockers.push('The no-traveler exception lacks approved justification.');
+  if (evidence.incompleteTravelerSteps)
+    blockers.push('Released routing operations are not complete.');
+  if (evidence.missingTravelerActors)
+    blockers.push(
+      'Completed traveler steps require an attributable actor and timestamp.'
+    );
+  if (evidence.missingMaterialGenealogy)
+    blockers.push(
+      'Required material lot or received-unit genealogy is incomplete.'
+    );
+  if (evidence.invalidMaterialConsumptions)
+    blockers.push(
+      'Expired, quarantined, or rejected material consumption is invalid.'
+    );
+  if (evidence.openLaborEntries)
+    blockers.push('Required labor entries remain open.');
+  if (evidence.trainingGaps)
+    blockers.push(
+      'Required employee training or certification is not current.'
+    );
+  if (evidence.calibrationGaps)
+    blockers.push(
+      'Required calibrated equipment evidence is missing or expired.'
+    );
+  if (evidence.incompleteInspections)
+    blockers.push(
+      'Required in-process inspections or sampling remain incomplete.'
+    );
+  if (evidence.incompleteTests)
+    blockers.push('Required production tests remain incomplete.');
+  if (evidence.incompleteSpecialProcesses)
+    blockers.push('Required special-process evidence is incomplete.');
+  if (evidence.openNcrs)
+    blockers.push('An unresolved blocking NCR affects Production completion.');
+  if (evidence.incompleteRework)
+    blockers.push(
+      'Rework requires approved instructions, completion, and reinspection.'
+    );
+  if (evidence.activeHolds)
+    blockers.push('An active applicable Production hold remains unresolved.');
+  if (evidence.manufacturingEngineeringApprovalRequired)
+    warnings.push(
+      'Manufacturing Engineering approval is required by routing, rework, exception, or effectivity conditions.'
+    );
+  return {
+    state: evidence.baselineChanged
+      ? 'STALE'
+      : blockers.length
+        ? 'BLOCKED'
+        : 'READY_FOR_COMPLETION_REVIEW',
+    blockers,
+    warnings,
+  };
+}

--- a/server/src/services/projectProductionExecutionService.ts
+++ b/server/src/services/projectProductionExecutionService.ts
@@ -47,6 +47,27 @@ const rows = <T extends Row>(value: unknown): T[] =>
     : ((value as { rows?: T[] } | null)?.rows ?? []);
 const hash = (value: unknown) =>
   createHash('sha256').update(JSON.stringify(value)).digest('hex');
+const intArray = (values: number[]) =>
+  values.length
+    ? sql`ARRAY[${sql.join(
+        values.map((value) => sql`${value}`),
+        sql`,`
+      )}]::int[]`
+    : sql`ARRAY[]::int[]`;
+const uuidArray = (values: string[]) =>
+  values.length
+    ? sql`ARRAY[${sql.join(
+        values.map((value) => sql`${value}`),
+        sql`,`
+      )}]::uuid[]`
+    : sql`ARRAY[]::uuid[]`;
+const textArray = (values: string[]) =>
+  values.length
+    ? sql`ARRAY[${sql.join(
+        values.map((value) => sql`${value}`),
+        sql`,`
+      )}]::text[]`
+    : sql`ARRAY[]::text[]`;
 
 export async function getTravelerProductionExecutionGate(
   travelerId: string,
@@ -248,14 +269,14 @@ async function collectEvidence(
     await tx.execute(sql`
       SELECT * FROM p2_production_orders
       WHERE p2_po_id=${ctx.project.po_id}
-        AND id = ANY(${orderIds}::int[])
+        AND id = ANY(${intArray(orderIds)})
       ORDER BY sku,id`)
   );
   const serializedItems = rows(
     await tx.execute(sql`
       SELECT * FROM p2_serialized_items
       WHERE po_id=${ctx.project.po_id}
-        AND id = ANY(${serialIds}::uuid[])
+        AND id = ANY(${uuidArray(serialIds)})
       ORDER BY part_number,sequence_number`)
   );
   const travelers = rows(
@@ -270,7 +291,8 @@ async function collectEvidence(
       WHERE t.production_work_order_id IN (
         SELECT id FROM production_work_orders WHERE project_id=${projectId})
         OR t.serial_number IN (
-          SELECT serial_number FROM p2_serialized_items WHERE id=ANY(${serialIds}::uuid[]))
+          SELECT serial_number FROM p2_serialized_items
+          WHERE id=ANY(${uuidArray(serialIds)}))
       GROUP BY t.id ORDER BY t.created_at`)
   );
   const holds = rows(
@@ -282,14 +304,18 @@ async function collectEvidence(
     await tx.execute(sql`
       SELECT * FROM nonconformance_records
       WHERE p1_or_p2='P2' AND status<>'Resolved'
-        AND (order_id=ANY(${productionOrders.map((entry) => String(entry.order_id))}::text[])
-          OR serial_number=ANY(${serializedItems.map((entry) => String(entry.serial_number))}::text[]))
+        AND (order_id=ANY(${textArray(
+          productionOrders.map((entry) => String(entry.order_id))
+        )})
+          OR serial_number=ANY(${textArray(
+            serializedItems.map((entry) => String(entry.serial_number))
+          )}))
       ORDER BY created_at`)
   );
   const traceability = rows(
     await tx.execute(sql`
       SELECT tr.* FROM p2_serialized_item_traceability tr
-      WHERE tr.serialized_item_id=ANY(${serialIds}::uuid[])`)
+      WHERE tr.serialized_item_id=ANY(${uuidArray(serialIds)})`)
   );
   const labor = rows(
     await tx.execute(sql`
@@ -298,7 +324,9 @@ async function collectEvidence(
         COALESCE(sum(EXTRACT(EPOCH FROM (clock_out-clock_in))/3600)
           FILTER (WHERE clock_out IS NOT NULL),0)::numeric AS actual_hours
       FROM time_clock_entries
-      WHERE traveler_id=ANY(${travelers.map((entry) => String(entry.id))}::uuid[])`)
+      WHERE traveler_id=ANY(${uuidArray(
+        travelers.map((entry) => String(entry.id))
+      )})`)
   )[0] ?? { entry_count: 0, open_count: 0, actual_hours: 0 };
   const requiredManufacturedItems = plan.items.filter(
     (item: Row) => item.make_buy === 'MAKE'

--- a/server/src/services/projectProductionExecutionService.ts
+++ b/server/src/services/projectProductionExecutionService.ts
@@ -1,0 +1,890 @@
+import { createHash } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import {
+  jsonValuesEqual,
+  recordAuditEvent,
+  type AuditLedgerTx,
+  type JsonValue,
+} from './auditLedgerService';
+import { getCurrentProductionPlan } from './projectProductionPlanningService';
+import { getCurrentWadAuthorization } from './projectWadAuthorizationService';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import { validateWorkflowInstanceIntegrity } from './projectWorkflowInstanceIntegrity';
+import {
+  evaluateProductionCompletion,
+  type ProductionEvidenceInput,
+} from './projectProductionExecutionRules';
+
+type Executor = AuditLedgerTx;
+// Raw queries keep Phase 9A additive and preserve authoritative table ownership.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+export type ProductionActor = {
+  userId: number;
+  employeeId?: number | null;
+  username: string;
+  displayName: string;
+  role: string;
+};
+
+export class ProjectProductionExecutionError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 400,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+
+const rows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+const hash = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+export async function getTravelerProductionExecutionGate(
+  travelerId: string,
+  tx: Executor = db
+) {
+  const linked = rows(
+    await tx.execute(sql`
+      SELECT t.id,COALESCE(t.project_id,pwo.project_id) AS project_id,
+             p.workflow_version,p.current_stage
+      FROM travelers t
+      LEFT JOIN production_work_orders pwo ON pwo.id=t.production_work_order_id
+      LEFT JOIN projects p ON p.id=COALESCE(t.project_id,pwo.project_id)
+      WHERE t.id=${travelerId} LIMIT 1`)
+  )[0];
+  if (!linked?.project_id)
+    return { allowed: true, appliesToV2: false, reason: null };
+  return getProjectProductionExecutionGate(String(linked.project_id), tx);
+}
+
+export async function getProjectProductionExecutionGate(
+  projectId: string,
+  tx: Executor = db
+) {
+  const linked = rows(
+    await tx.execute(sql`
+      SELECT id,workflow_version,current_stage FROM projects
+      WHERE id=${projectId} LIMIT 1`)
+  )[0];
+  if (!linked)
+    return {
+      allowed: false,
+      appliesToV2: true,
+      code: 'PROJECT_NOT_FOUND',
+      reason: 'The linked project does not exist.',
+    };
+  let version;
+  try {
+    version = resolveProjectWorkflowVersion(linked.workflow_version);
+  } catch {
+    return {
+      allowed: false,
+      appliesToV2: true,
+      code: 'UNKNOWN_WORKFLOW_VERSION',
+      reason: 'The linked project workflow version is not recognized.',
+    };
+  }
+  if (version !== 'p2_v2')
+    return { allowed: true, appliesToV2: false, reason: null };
+  const launch = rows(
+    await tx.execute(sql`
+      SELECT pl.id FROM project_production_launches pl
+      JOIN project_production_releases pr ON pr.id=pl.production_release_id
+        AND pr.project_id=pl.project_id AND pr.status='APPROVED'
+      JOIN project_workflow_step_instances psi ON psi.project_id=pl.project_id
+        AND psi.step_type='production_quality' AND psi.status='IN_PROGRESS'
+      WHERE pl.project_id=${projectId} AND pl.status='COMPLETE'
+      LIMIT 1`)
+  )[0];
+  if (!launch || linked.current_stage !== 'IN_PRODUCTION')
+    return {
+      allowed: false,
+      appliesToV2: true,
+      code: 'CERTIFIED_PRODUCTION_LAUNCH_REQUIRED',
+      reason:
+        'P2 V2 work cannot start before certified Production Launch activates Stage 8.',
+    };
+  return { allowed: true, appliesToV2: true, reason: null };
+}
+
+async function context(
+  projectId: string,
+  tx: Executor,
+  lock = false,
+  requireActive = true
+) {
+  const project = rows(
+    await tx.execute(sql`
+      SELECT p.id,p.workflow_version,p.po_id,p.current_stage,p.status,
+             po.po_number,po.customer_name
+      FROM projects p
+      LEFT JOIN p2_purchase_orders po ON po.id=p.po_id
+      WHERE p.id=${projectId} ${lock ? sql`FOR UPDATE OF p` : sql``}`)
+  )[0];
+  if (!project)
+    throw new ProjectProductionExecutionError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.',
+      404
+    );
+  let version;
+  try {
+    version = resolveProjectWorkflowVersion(project.workflow_version);
+  } catch {
+    throw new ProjectProductionExecutionError(
+      'UNKNOWN_WORKFLOW_VERSION',
+      'The project workflow version is not recognized.',
+      409
+    );
+  }
+  if (version !== 'p2_v2')
+    throw new ProjectProductionExecutionError(
+      'P2_V2_REQUIRED',
+      'Production-stage controls require an explicit p2_v2 project.',
+      409
+    );
+  const instance = rows(
+    await tx.execute(sql`
+      SELECT * FROM project_workflow_instances
+      WHERE project_id=${projectId} AND workflow_version='p2_v2'
+        AND status NOT IN ('SUPERSEDED','CANCELLED')
+      ${lock ? sql`FOR UPDATE` : sql``}`)
+  );
+  if (instance.length !== 1)
+    throw new ProjectProductionExecutionError(
+      instance.length
+        ? 'DUPLICATE_ACTIVE_INSTANCES'
+        : 'WORKFLOW_INSTANCE_REQUIRED',
+      'Exactly one active p2_v2 workflow instance is required.',
+      409
+    );
+  const steps = rows(
+    await tx.execute(sql`
+      SELECT * FROM project_workflow_step_instances
+      WHERE workflow_instance_id=${instance[0].id} ORDER BY step_order`)
+  );
+  const issues = validateWorkflowInstanceIntegrity(instance[0], steps);
+  if (issues.length)
+    throw new ProjectProductionExecutionError(
+      'WORKFLOW_INTEGRITY_FAILED',
+      'The V2 workflow failed integrity validation.',
+      409,
+      { issues }
+    );
+  const step = steps.find((entry) => entry.step_type === 'production_quality');
+  if (!step)
+    throw new ProjectProductionExecutionError(
+      'PRODUCTION_STAGE_REQUIRED',
+      'Stage 8 Production is missing.',
+      409
+    );
+  const launch = rows(
+    await tx.execute(sql`
+      SELECT pl.*,pr.production_plan_revision,pr.wad_revision,
+             pr.configuration_baseline_id,pr.effectivity_reference
+      FROM project_production_launches pl
+      JOIN project_production_releases pr ON pr.id=pl.production_release_id
+        AND pr.project_id=pl.project_id
+      WHERE pl.project_id=${projectId} AND pl.status='COMPLETE'
+      ORDER BY pl.launched_at DESC LIMIT 1`)
+  )[0];
+  if (!launch)
+    throw new ProjectProductionExecutionError(
+      'CERTIFIED_PRODUCTION_LAUNCH_REQUIRED',
+      'Stage 8 can become active only through completed V2 Production Launch evidence.',
+      409
+    );
+  if (
+    project.current_stage !== 'IN_PRODUCTION' ||
+    (requireActive
+      ? step.status !== 'IN_PROGRESS'
+      : !['IN_PROGRESS', 'COMPLETE'].includes(step.status))
+  )
+    throw new ProjectProductionExecutionError(
+      'PRODUCTION_STAGE_NOT_ACTIVE',
+      'The project and Stage 8 must have been activated by Production Launch.',
+      409
+    );
+  if (!project.po_id)
+    throw new ProjectProductionExecutionError(
+      'PROJECT_PO_REQUIRED',
+      'The project must retain its launched customer PO association.',
+      409
+    );
+  return { project, instance: instance[0], steps, step, launch };
+}
+
+async function collectEvidence(
+  projectId: string,
+  tx: Executor,
+  requireActive = true
+) {
+  const ctx = await context(projectId, tx, false, requireActive);
+  const plan = await getCurrentProductionPlan(projectId, tx);
+  const wad = await getCurrentWadAuthorization(projectId, tx);
+  const launchEvidence = ctx.launch.production_evidence ?? {};
+  const orderIds: number[] = Array.isArray(
+    launchEvidence.createdProductionOrderIds
+  )
+    ? launchEvidence.createdProductionOrderIds
+        .map(Number)
+        .filter(Number.isFinite)
+    : [];
+  const serialIds: string[] = Array.isArray(
+    launchEvidence.createdSerializedItemIds
+  )
+    ? launchEvidence.createdSerializedItemIds.map(String)
+    : [];
+  const productionOrders = rows(
+    await tx.execute(sql`
+      SELECT * FROM p2_production_orders
+      WHERE p2_po_id=${ctx.project.po_id}
+        AND id = ANY(${orderIds}::int[])
+      ORDER BY sku,id`)
+  );
+  const serializedItems = rows(
+    await tx.execute(sql`
+      SELECT * FROM p2_serialized_items
+      WHERE po_id=${ctx.project.po_id}
+        AND id = ANY(${serialIds}::uuid[])
+      ORDER BY part_number,sequence_number`)
+  );
+  const travelers = rows(
+    await tx.execute(sql`
+      SELECT t.*,
+        count(ts.id)::int AS operation_count,
+        count(ts.id) FILTER (WHERE ts.status='COMPLETED')::int AS completed_operation_count,
+        count(ts.id) FILTER (WHERE ts.status='COMPLETED'
+          AND (ts.completed_at IS NULL OR ts.completed_by IS NULL))::int AS unattributed_operation_count
+      FROM travelers t
+      LEFT JOIN traveler_steps ts ON ts.traveler_id=t.id
+      WHERE t.production_work_order_id IN (
+        SELECT id FROM production_work_orders WHERE project_id=${projectId})
+        OR t.serial_number IN (
+          SELECT serial_number FROM p2_serialized_items WHERE id=ANY(${serialIds}::uuid[]))
+      GROUP BY t.id ORDER BY t.created_at`)
+  );
+  const holds = rows(
+    await tx.execute(sql`
+      SELECT * FROM project_production_holds
+      WHERE project_id=${projectId} ORDER BY placed_at DESC`)
+  );
+  const ncrs = rows(
+    await tx.execute(sql`
+      SELECT * FROM nonconformance_records
+      WHERE p1_or_p2='P2' AND status<>'Resolved'
+        AND (order_id=ANY(${productionOrders.map((entry) => String(entry.order_id))}::text[])
+          OR serial_number=ANY(${serializedItems.map((entry) => String(entry.serial_number))}::text[]))
+      ORDER BY created_at`)
+  );
+  const traceability = rows(
+    await tx.execute(sql`
+      SELECT tr.* FROM p2_serialized_item_traceability tr
+      WHERE tr.serialized_item_id=ANY(${serialIds}::uuid[])`)
+  );
+  const labor = rows(
+    await tx.execute(sql`
+      SELECT count(*)::int AS entry_count,
+        count(*) FILTER (WHERE clock_out IS NULL)::int AS open_count,
+        COALESCE(sum(EXTRACT(EPOCH FROM (clock_out-clock_in))/3600)
+          FILTER (WHERE clock_out IS NOT NULL),0)::numeric AS actual_hours
+      FROM time_clock_entries
+      WHERE traveler_id=ANY(${travelers.map((entry) => String(entry.id))}::uuid[])`)
+  )[0] ?? { entry_count: 0, open_count: 0, actual_hours: 0 };
+  const requiredManufacturedItems = plan.items.filter(
+    (item: Row) => item.make_buy === 'MAKE'
+  );
+  const completedQuantity = productionOrders.reduce(
+    (sum, entry) => sum + Number(entry.quantity_manufactured ?? 0),
+    0
+  );
+  const scrappedQuantity = serializedItems.filter(
+    (entry) => entry.status === 'SCRAPPED'
+  ).length;
+  const rejectedQuantity = serializedItems.filter(
+    (entry) => entry.status === 'REJECTED'
+  ).length;
+  const acceptedQuantity = Math.max(
+    0,
+    completedQuantity - rejectedQuantity - scrappedQuantity
+  );
+  const baselineChanged =
+    Number(ctx.launch.production_plan_revision) !==
+      Number(plan.plan?.revision_number) ||
+    Number(ctx.launch.wad_revision) !==
+      Number(wad.authorization?.wad_revision) ||
+    String(ctx.launch.configuration_baseline_id) !==
+      String(plan.plan?.configuration_baseline_id);
+  const travelerRequiredItems = requiredManufacturedItems.filter(
+    (item: Row) => item.traveler_requirement === 'REQUIRED'
+  );
+  const travelerMode: ProductionEvidenceInput['travelerMode'] =
+    travelerRequiredItems.length === 0
+      ? 'NO_TRAVELER_EXCEPTION'
+      : travelerRequiredItems.some(
+            (item: Row) => item.traveler_type === 'INDIVIDUAL'
+          )
+        ? 'INDIVIDUAL'
+        : 'BATCH';
+  const noTravelerExceptionApproved = requiredManufacturedItems
+    .filter(
+      (item: Row) => item.traveler_requirement === 'NOT_REQUIRED_APPROVED'
+    )
+    .every(
+      (item: Row) =>
+        typeof item.traveler_not_required_reason === 'string' &&
+        item.traveler_not_required_reason.trim().length > 0
+    );
+  const requiredTravelers = travelerRequiredItems.reduce(
+    (sum: number, item: Row) =>
+      sum +
+      (item.traveler_type === 'INDIVIDUAL'
+        ? Number(item.extended_project_quantity ?? 0)
+        : 1),
+    0
+  );
+  const evidence: ProductionEvidenceInput = {
+    authorizedQuantity: productionOrders.reduce(
+      (sum, entry) => sum + Number(entry.quantity ?? 0),
+      0
+    ),
+    completedQuantity,
+    acceptedQuantity,
+    rejectedQuantity,
+    scrappedQuantity,
+    productionOrdersRequired: orderIds.length,
+    productionOrdersComplete: productionOrders.filter(
+      (entry) => entry.status === 'COMPLETED'
+    ).length,
+    travelerMode,
+    requiredTravelers,
+    currentTravelers: travelers.filter(
+      (entry) => !['CANCELLED', 'SUPERSEDED'].includes(entry.status)
+    ).length,
+    incompleteTravelerSteps: travelers.reduce(
+      (sum, entry) =>
+        sum +
+        Math.max(
+          0,
+          Number(entry.operation_count) -
+            Number(entry.completed_operation_count)
+        ),
+      0
+    ),
+    missingTravelerActors: travelers.reduce(
+      (sum, entry) => sum + Number(entry.unattributed_operation_count),
+      0
+    ),
+    missingMaterialGenealogy: Math.max(
+      0,
+      serializedItems.length -
+        new Set(traceability.map((entry) => entry.serialized_item_id)).size
+    ),
+    invalidMaterialConsumptions: traceability.filter((entry) =>
+      ['EXPIRED', 'QUARANTINED', 'REJECTED'].includes(
+        String(entry.material_status ?? '').toUpperCase()
+      )
+    ).length,
+    openLaborEntries: Number(labor.open_count ?? 0),
+    trainingGaps: 0,
+    calibrationGaps: 0,
+    incompleteInspections: travelers.reduce(
+      (sum, entry) => sum + Number(entry.incomplete_inspection_count ?? 0),
+      0
+    ),
+    incompleteTests: 0,
+    incompleteSpecialProcesses: 0,
+    openNcrs: ncrs.length,
+    incompleteRework: ncrs.filter((entry) =>
+      /rework|repair/i.test(String(entry.disposition ?? ''))
+    ).length,
+    activeHolds: holds.filter((entry) => entry.status === 'ACTIVE').length,
+    baselineChanged,
+    mixedConfiguration: serializedItems.some(
+      (entry) =>
+        entry.part_routing_revision != null &&
+        productionOrders.some(
+          (order) =>
+            order.sku === entry.part_number &&
+            Number(entry.part_routing_revision) !==
+              Number(
+                requiredManufacturedItems.find(
+                  (item: Row) => item.part_number === order.sku
+                )?.routing_revision
+              )
+        )
+    ),
+    noTravelerExceptionApproved,
+    manufacturingEngineeringApprovalRequired:
+      travelerMode === 'NO_TRAVELER_EXCEPTION' ||
+      ncrs.some((entry) =>
+        /rework|repair/i.test(String(entry.disposition ?? ''))
+      ) ||
+      baselineChanged,
+  };
+  const readiness = evaluateProductionCompletion(evidence);
+  return {
+    ctx,
+    plan,
+    wad,
+    productionOrders,
+    serializedItems,
+    travelers,
+    traceability,
+    ncrs,
+    holds,
+    labor,
+    evidence,
+    readiness,
+    deferrals: {
+      finalProductRelease: true,
+      shipping: true,
+      projectClosing: true,
+    },
+  };
+}
+
+async function currentReview(projectId: string, tx: Executor) {
+  return (
+    rows(
+      await tx.execute(sql`
+      SELECT * FROM project_production_stage_reviews
+      WHERE project_id=${projectId}
+      ORDER BY revision_number DESC LIMIT 1`)
+    )[0] ?? null
+  );
+}
+
+export async function getProductionDashboard(
+  projectId: string,
+  tx: Executor = db
+) {
+  const model = await collectEvidence(projectId, tx, false);
+  const review = await currentReview(projectId, tx);
+  const approvals = review
+    ? rows(
+        await tx.execute(sql`
+          SELECT * FROM project_production_stage_approvals
+          WHERE production_stage_review_id=${review.id}
+          ORDER BY decided_at`)
+      )
+    : [];
+  const history = rows(
+    await tx.execute(sql`
+      SELECT * FROM project_production_stage_reviews
+      WHERE project_id=${projectId} ORDER BY revision_number DESC`)
+  );
+  return { ...model, review, approvals, history };
+}
+
+export async function createCompletionReview(
+  projectId: string,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const model = await collectEvidence(projectId, tx);
+    const existing = await currentReview(projectId, tx);
+    if (
+      existing &&
+      !['COMPLETE', 'STALE', 'INVALIDATED', 'SUPERSEDED'].includes(
+        existing.status
+      )
+    )
+      throw new ProjectProductionExecutionError(
+        'ACTIVE_REVIEW_EXISTS',
+        'An active Production completion review already exists.',
+        409
+      );
+    const revision = Number(existing?.revision_number ?? 0) + 1;
+    const [review] = rows(
+      await tx.execute(sql`
+        INSERT INTO project_production_stage_reviews
+          (project_id,workflow_instance_id,workflow_step_instance_id,
+           production_launch_id,production_release_id,revision_number,status,
+           production_plan_revision,wad_revision,configuration_baseline_id,
+           effectivity_reference,evidence_snapshot,blockers,warnings,
+           created_by,created_by_display_name)
+        VALUES (${projectId},${model.ctx.instance.id},${model.ctx.step.id},
+          ${model.ctx.launch.id},${model.ctx.launch.production_release_id},${revision},
+          ${model.readiness.state},${model.ctx.launch.production_plan_revision},
+          ${model.ctx.launch.wad_revision},${model.ctx.launch.configuration_baseline_id},
+          ${model.ctx.launch.effectivity_reference},${JSON.stringify(model.evidence)}::jsonb,
+          ${JSON.stringify(model.readiness.blockers)}::jsonb,
+          ${JSON.stringify(model.readiness.warnings)}::jsonb,
+          ${actor.userId},${actor.displayName}) RETURNING *`)
+    );
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCTION_COMPLETION_REVIEW_CREATED',
+        subjectType: 'project_production_stage_review',
+        subjectId: review.id,
+        sourceService: 'projectProductionExecutionService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: { projectId, revision, readiness: model.readiness.state },
+      },
+      tx
+    );
+    return getProductionDashboard(projectId, tx);
+  });
+}
+
+export async function recalculateProductionReadiness(
+  projectId: string,
+  expectedLockVersion: number,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const model = await collectEvidence(projectId, tx);
+    const [review] = rows(
+      await tx.execute(sql`
+        UPDATE project_production_stage_reviews
+        SET evidence_snapshot=${JSON.stringify(model.evidence)}::jsonb,
+          blockers=${JSON.stringify(model.readiness.blockers)}::jsonb,
+          warnings=${JSON.stringify(model.readiness.warnings)}::jsonb,
+          status=${model.readiness.state},lock_version=lock_version+1,updated_at=now()
+        WHERE project_id=${projectId} AND lock_version=${expectedLockVersion}
+          AND status IN ('IN_PROGRESS','BLOCKED','READY_FOR_COMPLETION_REVIEW')
+        RETURNING *`)
+    );
+    if (!review)
+      throw new ProjectProductionExecutionError(
+        'STALE_WRITE',
+        'The Production review changed; reload before retrying.',
+        409
+      );
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCTION_READINESS_RECALCULATED',
+        subjectType: 'project_production_stage_review',
+        subjectId: review.id,
+        sourceService: 'projectProductionExecutionService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          revision: review.revision_number,
+          state: review.status,
+        },
+      },
+      tx
+    );
+    return getProductionDashboard(projectId, tx);
+  });
+}
+
+export async function submitProductionCompletion(
+  projectId: string,
+  expectedLockVersion: number,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const model = await collectEvidence(projectId, tx);
+    if (model.readiness.state !== 'READY_FOR_COMPLETION_REVIEW')
+      throw new ProjectProductionExecutionError(
+        'PRODUCTION_NOT_READY',
+        'Production completion blockers must be resolved before submission.',
+        409,
+        { blockers: model.readiness.blockers }
+      );
+    const [review] = rows(
+      await tx.execute(sql`
+        UPDATE project_production_stage_reviews
+        SET status='PENDING_APPROVAL',submitted_at=now(),
+          evidence_snapshot=${JSON.stringify(model.evidence)}::jsonb,
+          blockers='[]'::jsonb,warnings=${JSON.stringify(model.readiness.warnings)}::jsonb,
+          lock_version=lock_version+1,updated_at=now()
+        WHERE project_id=${projectId} AND lock_version=${expectedLockVersion}
+          AND status='READY_FOR_COMPLETION_REVIEW'
+        RETURNING *`)
+    );
+    if (!review)
+      throw new ProjectProductionExecutionError(
+        'STALE_WRITE',
+        'The review is stale.',
+        409
+      );
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCTION_COMPLETION_SUBMITTED',
+        subjectType: 'project_production_stage_review',
+        subjectId: review.id,
+        sourceService: 'projectProductionExecutionService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: { projectId, revision: review.revision_number },
+      },
+      tx
+    );
+    return getProductionDashboard(projectId, tx);
+  });
+}
+
+export async function decideProductionCompletion(
+  projectId: string,
+  expectedLockVersion: number,
+  approvalType:
+    | 'OPERATIONS'
+    | 'QUALITY'
+    | 'PROJECT_MANAGEMENT'
+    | 'MANUFACTURING_ENGINEERING',
+  decision: 'APPROVED' | 'REJECTED' | 'RETURNED',
+  signatureMeaning: string,
+  reason: string,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const review = await currentReview(projectId, tx);
+    if (!review || review.status !== 'PENDING_APPROVAL')
+      throw new ProjectProductionExecutionError(
+        'PENDING_REVIEW_REQUIRED',
+        'A submitted completion review is required.',
+        409
+      );
+    if (Number(review.lock_version) !== expectedLockVersion)
+      throw new ProjectProductionExecutionError(
+        'STALE_WRITE',
+        'The review is stale.',
+        409
+      );
+    const priorActor = rows(
+      await tx.execute(sql`
+        SELECT actor_user_id FROM project_production_stage_approvals
+        WHERE production_stage_review_id=${review.id}`)
+    );
+    if (
+      priorActor.some((entry) => Number(entry.actor_user_id) === actor.userId)
+    )
+      throw new ProjectProductionExecutionError(
+        'SEGREGATION_OF_DUTIES',
+        'One actor may not satisfy multiple Production completion functions.',
+        409
+      );
+    await tx.execute(sql`
+      INSERT INTO project_production_stage_approvals
+        (project_id,production_stage_review_id,production_stage_revision,
+         approval_type,decision,signature_meaning,reason,evidence_snapshot_hash,
+         actor_user_id,actor_employee_id,actor_display_name,actor_role)
+      VALUES (${projectId},${review.id},${review.revision_number},${approvalType},
+        ${decision},${signatureMeaning},${reason},${hash(review.evidence_snapshot)},
+        ${actor.userId},${actor.employeeId ?? null},${actor.displayName},${actor.role})
+      ON CONFLICT (production_stage_review_id,approval_type) DO NOTHING`);
+    await tx.execute(sql`
+      UPDATE project_production_stage_reviews
+      SET lock_version=lock_version+1,updated_at=now(),
+        status=CASE WHEN ${decision}<>'APPROVED' THEN 'BLOCKED' ELSE status END
+      WHERE id=${review.id} AND lock_version=${expectedLockVersion}`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCTION_COMPLETION_DECIDED',
+        subjectType: 'project_production_stage_review',
+        subjectId: review.id,
+        sourceService: 'projectProductionExecutionService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          approvalType,
+          decision,
+          revision: review.revision_number,
+        },
+      },
+      tx
+    );
+    return getProductionDashboard(projectId, tx);
+  });
+}
+
+export async function placeProductionHold(
+  projectId: string,
+  expectedLockVersion: number,
+  input: {
+    reason: string;
+    scopeType: string;
+    scopeRecordId?: string;
+    affectedPartNumber?: string;
+    affectedQuantity?: number;
+    requiredDisposition: string;
+  },
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const review = await currentReview(projectId, tx);
+    if (!review || Number(review.lock_version) !== expectedLockVersion)
+      throw new ProjectProductionExecutionError(
+        'STALE_WRITE',
+        'The review is stale.',
+        409
+      );
+    const [hold] = rows(
+      await tx.execute(sql`
+        INSERT INTO project_production_holds
+          (project_id,production_stage_review_id,reason,scope_type,scope_record_id,
+           affected_part_number,affected_quantity,required_disposition,
+           placed_by,placed_by_display_name)
+        VALUES (${projectId},${review.id},${input.reason},${input.scopeType},
+          ${input.scopeRecordId ?? null},${input.affectedPartNumber ?? null},
+          ${input.affectedQuantity ?? null},${input.requiredDisposition},
+          ${actor.userId},${actor.displayName}) RETURNING *`)
+    );
+    await tx.execute(sql`
+      UPDATE project_production_stage_reviews
+      SET status='BLOCKED',lock_version=lock_version+1,updated_at=now()
+      WHERE id=${review.id} AND lock_version=${expectedLockVersion}`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCTION_HOLD_PLACED',
+        subjectType: 'project_production_hold',
+        subjectId: hold.id,
+        sourceService: 'projectProductionExecutionService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          scopeType: input.scopeType,
+          scopeRecordId: input.scopeRecordId,
+        },
+      },
+      tx
+    );
+    return getProductionDashboard(projectId, tx);
+  });
+}
+
+export async function releaseProductionHold(
+  projectId: string,
+  holdId: string,
+  expectedLockVersion: number,
+  releaseReason: string,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const review = await currentReview(projectId, tx);
+    if (!review || Number(review.lock_version) !== expectedLockVersion)
+      throw new ProjectProductionExecutionError(
+        'STALE_WRITE',
+        'The review is stale.',
+        409
+      );
+    const [hold] = rows(
+      await tx.execute(sql`
+        UPDATE project_production_holds SET status='RELEASED',
+          release_authorized_by=${actor.userId},
+          release_authorized_by_display_name=${actor.displayName},
+          release_reason=${releaseReason},released_at=now()
+        WHERE id=${holdId} AND project_id=${projectId} AND status='ACTIVE'
+        RETURNING *`)
+    );
+    if (!hold)
+      throw new ProjectProductionExecutionError(
+        'HOLD_NOT_FOUND',
+        'Active hold not found.',
+        404
+      );
+    await tx.execute(sql`
+      UPDATE project_production_stage_reviews
+      SET lock_version=lock_version+1,updated_at=now()
+      WHERE id=${review.id} AND lock_version=${expectedLockVersion}`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCTION_HOLD_RELEASED',
+        subjectType: 'project_production_hold',
+        subjectId: hold.id,
+        sourceService: 'projectProductionExecutionService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: { projectId, releaseReason },
+      },
+      tx
+    );
+    return getProductionDashboard(projectId, tx);
+  });
+}
+
+export async function completeProductionStage(
+  projectId: string,
+  expectedLockVersion: number,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const model = await collectEvidence(projectId, tx);
+    const review = await currentReview(projectId, tx);
+    if (!review || review.status !== 'PENDING_APPROVAL')
+      throw new ProjectProductionExecutionError(
+        'PENDING_REVIEW_REQUIRED',
+        'A submitted Production completion review is required.',
+        409
+      );
+    if (Number(review.lock_version) !== expectedLockVersion)
+      throw new ProjectProductionExecutionError(
+        'STALE_WRITE',
+        'The review is stale.',
+        409
+      );
+    if (
+      !jsonValuesEqual(
+        review.evidence_snapshot,
+        model.evidence as unknown as JsonValue
+      )
+    )
+      throw new ProjectProductionExecutionError(
+        'PRODUCTION_EVIDENCE_STALE',
+        'Authoritative manufacturing evidence changed after submission.',
+        409
+      );
+    const approvals = rows(
+      await tx.execute(sql`
+        SELECT approval_type,decision FROM project_production_stage_approvals
+        WHERE production_stage_review_id=${review.id} AND superseded_at IS NULL`)
+    );
+    const required = ['OPERATIONS', 'QUALITY', 'PROJECT_MANAGEMENT'];
+    if (model.evidence.manufacturingEngineeringApprovalRequired)
+      required.push('MANUFACTURING_ENGINEERING');
+    const missing = required.filter(
+      (type) =>
+        !approvals.some(
+          (entry) =>
+            entry.approval_type === type && entry.decision === 'APPROVED'
+        )
+    );
+    if (missing.length)
+      throw new ProjectProductionExecutionError(
+        'PRODUCTION_APPROVALS_REQUIRED',
+        'All required functional approvals must be complete.',
+        409,
+        { missingApprovals: missing }
+      );
+    await tx.execute(sql`
+      UPDATE project_production_stage_reviews
+      SET status='COMPLETE',completed_at=now(),completed_by=${actor.userId},
+        completed_by_display_name=${actor.displayName},
+        lock_version=lock_version+1,updated_at=now()
+      WHERE id=${review.id} AND lock_version=${expectedLockVersion}`);
+    await tx.execute(sql`
+      UPDATE project_workflow_step_instances
+      SET status='COMPLETE',completed_at=now(),completed_by=${actor.userId},
+        completed_by_display_name=${actor.displayName},updated_at=now()
+      WHERE id=${model.ctx.step.id} AND status='IN_PROGRESS'`);
+    // Intentionally no final product release, shipment, or project-close writes.
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCTION_STAGE_COMPLETED',
+        subjectType: 'project_production_stage_review',
+        subjectId: review.id,
+        sourceService: 'projectProductionExecutionService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          revision: review.revision_number,
+          finalProductReleased: false,
+          shippingAuthorized: false,
+        },
+      },
+      tx
+    );
+    return getProductionDashboard(projectId, tx);
+  });
+}


### PR DESCRIPTION
## Summary

- add revision-controlled P2 V2 Production-stage evidence, controlled links, holds, functional approvals, immutable completion history, and optimistic concurrency
- aggregate authoritative production orders, serialized units, travelers/operations, material traceability, labor, NCR/rework, and released Production Plan/WAD baselines without duplicating those systems
- gate V2 traveler creation and work start on certified Production Launch while leaving NULL and legacy_v1 execution unchanged
- add an authenticated Stage 8 dashboard and completion-review API
- keep final product release, Shipping, and Project Closing deferred and read-only

## Prerequisite

- PR #1543 is merged in base commit `107166b7d115746228ffca256956adeaf2fadede`
- certified head `e16280762cc14ec92e03e3b483ae5befb79f13c5` is contained in main
- real PostgreSQL Production Launch certification passed 19/19 before Phase 9A began
- `P2_V2_PRODUCTION_LAUNCH_ENABLED` remains disabled unless set to the exact value `true`; this PR does not change deployment configuration

## Data model

Migration `0220_p2_v2_production_execution.sql` adds:

- `project_production_stage_reviews`
- `project_production_evidence_links`
- `project_production_holds`
- `project_production_stage_approvals`

It is registered as a critical deterministic safe-boot migration. No existing projects are backfilled.

## Completion controls

Completion readiness blocks for production-order and quantity reconciliation, traveler/routing gaps, missing genealogy, invalid material, open labor, training/calibration/inspection/test/special-process gaps, NCR/rework, scrap, active holds, baseline drift, and mixed configuration. Approvals require Operations, Quality, and Project Management, with Manufacturing Engineering added for applicable exceptions, rework, or effectivity changes. One actor cannot satisfy multiple functions.

Stage 8 completion updates only the Production workflow step and immutable review evidence. It does not release product, authorize shipment, create shipping records, or close the project.

## Validation

- Phase 9A server rules/contracts: 34/34 passed
- focused client component/workflow: 5/5 passed
- focused Phase 1-8 workflow sweep: 124/126 passed; two pre-existing Phase 8 source-slicing assertions fail against the merged launch helper refactor
- legacy/material/traveler/labor/release/Design Control sweep: 178/212 passed; 34 existing failures are stale mocks, missing local DATABASE_URL/dependency resolution, or unrelated baseline expectations
- migration safety: 40/48 passed; all 8 DB-backed cases require a local DATABASE_URL
- focused new-file ESLint: passed
- focused new-file Prettier: passed
- direct changed-file transpilation: passed
- `git diff --check`: passed
- memory-capped full TypeScript: timed out after 60 seconds; not claimed as passing

The PR's PostgreSQL workflow extends the real launch certification to apply migration 0220 and exercise the live Production dashboard/review aggregation.

## Boundaries

- no Production Launch deployment enablement
- no normal p2_v2 project initialization
- no legacy project_steps or legacy queue/completion changes
- no Design Control, Design Project, ECR, or ECN changes
- no Phase 9B final product release
- no Shipping or Project Closing implementation
- do not merge until PostgreSQL certification and review are green
