### PR TITLE
Add P2 V2 quality review and controlled product release

### DIFF
--- a/client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
+++ b/client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
@@ -1,0 +1,49 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import P2V2QualityProductRelease from '../components/projects/P2V2QualityProductRelease';
+
+afterEach(() => vi.restoreAllMocks());
+describe('P2V2QualityProductRelease', () => {
+  it('states the release boundary and shows blockers', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ctx: {
+            project: { po_number: 'PO-9B' },
+            productionReview: { revision_number: 1 },
+          },
+          items: [],
+          ncrs: [],
+          releases: [],
+          holds: [],
+          documentManifest: [],
+          readiness: {
+            state: 'BLOCKED',
+            blockers: ['FINAL_INSPECTION_REQUIRED'],
+            eligibleQuantity: 0,
+          },
+          review: null,
+          approvals: [],
+        }),
+      })
+    );
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <P2V2QualityProductRelease projectId="project-9b" />
+      </QueryClientProvider>
+    );
+    expect(
+      await screen.findByText(/Product Release does not create a shipment/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText('FINAL_INSPECTION_REQUIRED')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /Create revision-controlled Quality review/i,
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/components/projects/P2V2ProjectWorkflow.tsx
+++ b/client/src/components/projects/P2V2ProjectWorkflow.tsx
@@ -17,6 +17,7 @@ import P2V2WadAuthorization from './P2V2WadAuthorization';
 import P2V2CommercialReview from './P2V2CommercialReview';
 import P2V2PreproductionReadiness from './P2V2PreproductionReadiness';
 import P2V2ProductionExecution from './P2V2ProductionExecution';
+import P2V2QualityProductRelease from './P2V2QualityProductRelease';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -425,6 +426,11 @@ export default function P2V2ProjectWorkflow({
               {stage.stepType === 'production_quality' && (
                 <div className="mt-3">
                   <P2V2ProductionExecution projectId={projectId} />
+                </div>
+              )}
+              {stage.stepType === 'final_release_shipping' && (
+                <div className="mt-3">
+                  <P2V2QualityProductRelease projectId={projectId} />
                 </div>
               )}
             </CardContent>

--- a/client/src/components/projects/P2V2QualityProductRelease.tsx
+++ b/client/src/components/projects/P2V2QualityProductRelease.tsx
@@ -1,0 +1,211 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CheckCircle2, ShieldCheck, TriangleAlert } from 'lucide-react';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+type Row = Record<string, unknown>;
+type Dashboard = {
+  ctx: {
+    project: { po_number?: string; customer_name?: string };
+    productionReview: { revision_number: number };
+  };
+  items: Row[];
+  ncrs: Row[];
+  releases: Row[];
+  holds: Row[];
+  documentManifest: Row[];
+  readiness: { state: string; blockers: string[]; eligibleQuantity: number };
+  review?: {
+    status: string;
+    revision_number: number;
+    lock_version: number;
+  } | null;
+  approvals: Array<{
+    approval_type: string;
+    decision: string;
+    actor_display_name: string;
+  }>;
+};
+
+export default function P2V2QualityProductRelease({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const queryClient = useQueryClient();
+  const key = ['/api/projects', projectId, 'workflow-v2', 'quality-release'];
+  const { data, isLoading, error } = useQuery<Dashboard>({
+    queryKey: key,
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/projects/${projectId}/workflow-v2/quality-release`,
+        { credentials: 'include' }
+      );
+      const body = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(
+          body?.message || 'Unable to load Quality release evidence'
+        );
+      return body;
+    },
+  });
+  const createReview = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(
+        `/api/projects/${projectId}/workflow-v2/quality-release/reviews`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        }
+      );
+      const body = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(body?.message || 'Unable to create Quality review');
+      return body;
+    },
+    onSuccess: (body) => {
+      queryClient.setQueryData(key, body);
+      queryClient.invalidateQueries({
+        queryKey: ['/api/projects', projectId, 'workflow-v2'],
+      });
+    },
+  });
+  if (isLoading)
+    return (
+      <Card>
+        <CardContent className="p-6">
+          Loading authoritative Quality evidence…
+        </CardContent>
+      </Card>
+    );
+  if (error || !data)
+    return (
+      <Alert variant="destructive">
+        <TriangleAlert className="h-4 w-4" />
+        <AlertTitle>Quality evidence unavailable</AlertTitle>
+        <AlertDescription>
+          {error instanceof Error ? error.message : 'Unable to load Stage 9.'}
+        </AlertDescription>
+      </Alert>
+    );
+  const activeHolds = data.holds.filter(
+    (hold) => hold.status === 'ACTIVE'
+  ).length;
+  return (
+    <div className="space-y-4" data-testid="p2-v2-quality-product-release">
+      <Alert>
+        <ShieldCheck className="h-4 w-4" />
+        <AlertTitle>Stage 9 — Quality & Product Release</AlertTitle>
+        <AlertDescription>
+          Release is an explicit Quality-authorized, immutable action for exact
+          quantities and identities. Product Release does not create a shipment.
+        </AlertDescription>
+      </Alert>
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap justify-between gap-3">
+            <div>
+              <CardTitle>Quality readiness</CardTitle>
+              <CardDescription>
+                {data.ctx.project.customer_name || 'Customer'} · PO{' '}
+                {data.ctx.project.po_number || '—'} · Production completion
+                revision {data.ctx.productionReview.revision_number}
+              </CardDescription>
+            </div>
+            <Badge>{data.review?.status || data.readiness.state}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+            {[
+              ['Inspected units', data.items.length],
+              ['Eligible', data.readiness.eligibleQuantity],
+              ['Open NCRs', data.ncrs.length],
+              ['Controlled documents', data.documentManifest.length],
+              ['Active release holds', activeHolds],
+            ].map(([label, value]) => (
+              <div key={String(label)} className="rounded border p-3">
+                <p className="text-xs text-muted-foreground">{label}</p>
+                <p className="text-lg font-semibold">{String(value)}</p>
+              </div>
+            ))}
+          </div>
+          {data.readiness.blockers.length > 0 && (
+            <Alert variant="destructive">
+              <TriangleAlert className="h-4 w-4" />
+              <AlertTitle>Release blocked</AlertTitle>
+              <AlertDescription>
+                <ul className="list-disc pl-5">
+                  {data.readiness.blockers.map((blocker) => (
+                    <li key={blocker}>{blocker}</li>
+                  ))}
+                </ul>
+              </AlertDescription>
+            </Alert>
+          )}
+          {!data.review && (
+            <Button
+              onClick={() => createReview.mutate()}
+              disabled={createReview.isPending}
+            >
+              Create revision-controlled Quality review
+            </Button>
+          )}
+          {data.review?.status === 'READY_FOR_RELEASE' && (
+            <Alert>
+              <CheckCircle2 className="h-4 w-4" />
+              <AlertTitle>Ready for controlled release</AlertTitle>
+              <AlertDescription>
+                Use Release Product after confirming PO line, part/revision,
+                quantity, serials or batches, configuration/effectivity,
+                document manifest, and Quality signature meaning.
+              </AlertDescription>
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Immutable Product Releases</CardTitle>
+          <CardDescription>
+            {data.releases.length} release record(s). Stage 10 may consume only
+            unheld released quantities.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.releases.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No product has been released.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {data.releases.map((release) => (
+                <div className="rounded border p-3" key={String(release.id)}>
+                  <p className="font-medium">
+                    {String(release.release_number)}
+                  </p>
+                  <p className="text-sm">
+                    {String(release.part_number)} · Qty{' '}
+                    {String(release.released_quantity)} ·{' '}
+                    {String(release.release_decision)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/migrations/0222_p2_v2_quality_product_release.sql
+++ b/migrations/0222_p2_v2_quality_product_release.sql
@@ -1,0 +1,160 @@
+-- Phase 9B: additive P2 V2 Quality review and controlled Product Release.
+-- Inspection, FAI, NCR, certificate, genealogy and shipping records remain
+-- authoritative in their existing tables. These records snapshot their evidence.
+
+CREATE TABLE IF NOT EXISTS project_quality_reviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  workflow_instance_id UUID NOT NULL,
+  workflow_step_instance_id UUID NOT NULL,
+  production_review_id UUID NOT NULL REFERENCES project_production_stage_reviews(id) ON DELETE RESTRICT,
+  revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+  lock_version INTEGER NOT NULL DEFAULT 1 CHECK (lock_version > 0),
+  status TEXT NOT NULL DEFAULT 'IN_PROGRESS' CHECK (status IN
+    ('IN_PROGRESS','BLOCKED','READY_FOR_REVIEW','READY_FOR_RELEASE',
+     'PARTIALLY_RELEASED','COMPLETE','STALE','INVALIDATED','SUPERSEDED')),
+  production_completion_revision INTEGER NOT NULL,
+  production_plan_revision INTEGER NOT NULL,
+  wad_revision INTEGER NOT NULL,
+  configuration_baseline_id TEXT NOT NULL,
+  effectivity_reference TEXT NOT NULL,
+  evidence_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+  document_manifest JSONB NOT NULL DEFAULT '[]'::jsonb,
+  blockers JSONB NOT NULL DEFAULT '[]'::jsonb,
+  warnings JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_by_display_name TEXT NOT NULL,
+  submitted_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  invalidated_at TIMESTAMP,
+  invalidation_reason TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  FOREIGN KEY (workflow_step_instance_id, project_id)
+    REFERENCES project_workflow_step_instances(id, project_id) ON DELETE RESTRICT,
+  UNIQUE (project_id, workflow_instance_id, revision_number)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_quality_review_current_unique
+  ON project_quality_reviews(project_id, workflow_instance_id)
+  WHERE status IN ('IN_PROGRESS','BLOCKED','READY_FOR_REVIEW','READY_FOR_RELEASE','PARTIALLY_RELEASED');
+CREATE INDEX IF NOT EXISTS project_quality_review_history_idx
+  ON project_quality_reviews(project_id, revision_number DESC);
+
+CREATE TABLE IF NOT EXISTS project_quality_review_approvals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  quality_review_id UUID NOT NULL REFERENCES project_quality_reviews(id) ON DELETE RESTRICT,
+  quality_review_revision INTEGER NOT NULL,
+  approval_type TEXT NOT NULL CHECK (approval_type IN ('QUALITY','OPERATIONS','PROJECT_MANAGEMENT')),
+  decision TEXT NOT NULL CHECK (decision IN ('APPROVED','REJECTED','RETURNED')),
+  signature_meaning TEXT NOT NULL,
+  reason TEXT,
+  evidence_snapshot_hash TEXT NOT NULL,
+  actor_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  actor_employee_id INTEGER,
+  actor_display_name TEXT NOT NULL,
+  actor_role TEXT NOT NULL,
+  decided_at TIMESTAMP NOT NULL DEFAULT now(),
+  UNIQUE (quality_review_id, approval_type)
+);
+
+CREATE TABLE IF NOT EXISTS project_product_releases (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  release_number TEXT NOT NULL UNIQUE,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  workflow_instance_id UUID NOT NULL,
+  quality_review_id UUID NOT NULL REFERENCES project_quality_reviews(id) ON DELETE RESTRICT,
+  quality_review_revision INTEGER NOT NULL,
+  production_completion_revision INTEGER NOT NULL,
+  customer_po_id INTEGER NOT NULL REFERENCES p2_purchase_orders(id) ON DELETE RESTRICT,
+  customer_po_line_id INTEGER,
+  part_number TEXT NOT NULL,
+  part_revision TEXT,
+  released_quantity NUMERIC NOT NULL CHECK (released_quantity > 0),
+  serial_numbers JSONB NOT NULL DEFAULT '[]'::jsonb,
+  batch_lots JSONB NOT NULL DEFAULT '[]'::jsonb,
+  configuration_baseline_id TEXT NOT NULL,
+  effectivity_reference TEXT NOT NULL,
+  evidence_snapshot JSONB NOT NULL,
+  document_manifest JSONB NOT NULL DEFAULT '[]'::jsonb,
+  release_decision TEXT NOT NULL DEFAULT 'RELEASED' CHECK (release_decision IN ('RELEASED','HELD','REVOKED')),
+  signature_meaning TEXT NOT NULL,
+  released_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  released_by_employee_id INTEGER,
+  released_by_display_name TEXT NOT NULL,
+  released_by_role TEXT NOT NULL,
+  released_at TIMESTAMP NOT NULL DEFAULT now(),
+  idempotency_key TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  shipping_status TEXT NOT NULL DEFAULT 'AVAILABLE' CHECK
+    (shipping_status IN ('AVAILABLE','PARTIALLY_CONSUMED','CONSUMED','BLOCKED')),
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  FOREIGN KEY (workflow_instance_id, project_id)
+    REFERENCES project_workflow_instances(id, project_id) ON DELETE RESTRICT,
+  UNIQUE (project_id, idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS project_product_releases_project_idx
+  ON project_product_releases(project_id, released_at DESC);
+
+CREATE TABLE IF NOT EXISTS project_product_release_allocations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_release_id UUID NOT NULL REFERENCES project_product_releases(id) ON DELETE RESTRICT,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  po_line_id INTEGER,
+  part_number TEXT NOT NULL,
+  serial_number TEXT,
+  batch_lot TEXT,
+  quantity NUMERIC NOT NULL CHECK (quantity > 0),
+  created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS project_product_release_serial_unique
+  ON project_product_release_allocations(project_id, serial_number)
+  WHERE serial_number IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS project_product_release_batch_unique
+  ON project_product_release_allocations(project_id, batch_lot, part_number)
+  WHERE batch_lot IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS project_product_release_holds (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  product_release_id UUID NOT NULL REFERENCES project_product_releases(id) ON DELETE RESTRICT,
+  status TEXT NOT NULL DEFAULT 'ACTIVE' CHECK (status IN ('ACTIVE','RELEASED')),
+  reason TEXT NOT NULL,
+  affected_serials JSONB NOT NULL DEFAULT '[]'::jsonb,
+  affected_batches JSONB NOT NULL DEFAULT '[]'::jsonb,
+  affected_quantity NUMERIC NOT NULL CHECK (affected_quantity > 0),
+  placed_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  placed_by_display_name TEXT NOT NULL,
+  placed_at TIMESTAMP NOT NULL DEFAULT now(),
+  released_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  released_by_display_name TEXT,
+  release_reason TEXT,
+  released_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS project_product_release_holds_active_idx
+  ON project_product_release_holds(project_id, product_release_id) WHERE status='ACTIVE';
+
+INSERT INTO perm_capabilities (key, description, category) VALUES
+ ('projects.quality_release.manage','Manage P2 V2 Quality reviews','quality'),
+ ('projects.quality_release.quality_decide','Approve P2 V2 Quality review','quality'),
+ ('projects.quality_release.operations_decide','Confirm Production evidence for Quality review','operations'),
+ ('projects.quality_release.pm_decide','Confirm customer deliverables for Quality review','projects'),
+ ('projects.quality_release.release_product','Authorize immutable P2 V2 Product Release','quality'),
+ ('projects.quality_release.hold','Place a controlled hold on released P2 V2 product','quality'),
+ ('projects.quality_release.release_hold','Release a controlled P2 V2 Product Release hold','quality')
+ON CONFLICT (key) DO UPDATE SET description=EXCLUDED.description,category=EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT pr.id,pc.id FROM perm_roles pr JOIN perm_capabilities pc ON (
+ (pr.name IN ('ADMIN','OWNER') AND pc.key LIKE 'projects.quality_release.%') OR
+ (pr.name IN ('QUALITY','QC','QUALITY_MANAGER') AND pc.key IN
+   ('projects.quality_release.manage','projects.quality_release.quality_decide',
+    'projects.quality_release.release_product','projects.quality_release.hold',
+    'projects.quality_release.release_hold')) OR
+ (pr.name IN ('OPERATIONS','OPERATIONS_MANAGER','PRODUCTION_MANAGER','MANAGER')
+   AND pc.key='projects.quality_release.operations_decide') OR
+ (pr.name IN ('PROJECT_MANAGER','PROGRAM_MANAGER')
+   AND pc.key='projects.quality_release.pm_decide')
+) ON CONFLICT (role_id,capability_id) DO NOTHING;

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -35,6 +35,11 @@ import {
   getProductionDashboard,
 } from '../src/services/projectProductionExecutionService';
 import {
+  createQualityReview,
+  decideQualityReview,
+  releaseProduct,
+} from '../src/services/projectQualityReleaseService';
+import {
   getP2V2StagesForDefinitionVersion,
   P2_V2_DEFINITION_VERSION,
 } from '../src/services/projectWorkflowRegistry';
@@ -920,6 +925,41 @@ describe('actual production launch service against PostgreSQL', () => {
     expect(created.review?.revision_number).toBe(1);
     expect(created.review?.status).toBe('BLOCKED');
     expect(created.productionOrders).toHaveLength(6);
+  });
+
+  it('executes the real Quality review and idempotent Product Release transaction', async () => {
+    await query(`UPDATE p2_serialized_items SET status='COMPLETED',
+      current_department='Final QC',final_qc_completed_at=now(),completed_at=now()
+      WHERE po_id=$1`, [fixture.poId]);
+    await query(`INSERT INTO p2_final_inspection_results
+      (serialized_item_id,barcode,part_number,inspection_type,overall_result,inspector_name,qa_mgr_approval)
+      SELECT id,barcode,part_number,'FINAL','PASS','PG Certifier','Approved'
+      FROM p2_serialized_items WHERE po_id=$1`, [fixture.poId]);
+    await query(`UPDATE project_production_stage_reviews SET status='COMPLETE',completed_at=now()
+      WHERE project_id=$1`, [fixture.projectId]);
+    await query(`UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now()
+      WHERE project_id=$1 AND step_type='production_quality'`, [fixture.projectId]);
+    const created = await createQualityReview(fixture.projectId, actor);
+    let lock = Number(created.review?.lock_version);
+    for (const type of ['QUALITY','OPERATIONS','PROJECT_MANAGEMENT'] as const) {
+      const decided = await decideQualityReview(fixture.projectId, lock, type, 'APPROVED',
+        `${type} certifies revision 1`, '', actor);
+      lock = Number(decided.review?.lock_version);
+    }
+    const input = {
+      expectedLockVersion: lock,
+      idempotencyKey: 'phase9b-pg-cert-release-1',
+      partNumber: String(created.items[0].part_number),
+      quantity: 1,
+      serialNumbers: [String(created.items[0].release_serial)],
+      batchLots: [],
+      signatureMeaning: 'Quality authorizes exact product for customer release',
+    };
+    const first = await releaseProduct(fixture.projectId, input, actor);
+    expect(first.release.shipping_status).toBe('AVAILABLE');
+    expect((await releaseProduct(fixture.projectId, input, actor)).idempotentReplay).toBe(true);
+    expect((await query(`SELECT id FROM project_product_releases WHERE project_id=$1`,
+      [fixture.projectId])).rows).toHaveLength(1);
   });
 
   it('keeps null and legacy workflow versions isolated', async () => {

--- a/server/__tests__/projectQualityRelease.test.ts
+++ b/server/__tests__/projectQualityRelease.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateQualityReadiness,
+  validateReleaseSelection,
+} from '../src/services/projectQualityReleaseRules';
+
+const root = path.resolve(__dirname, '../..');
+const read = (file: string) => readFileSync(path.join(root, file), 'utf8');
+const migration = read('migrations/0222_p2_v2_quality_product_release.sql');
+const service = read('server/src/services/projectQualityReleaseService.ts');
+const routes = read('server/src/routes/projectQualityRelease.ts');
+
+const ready = {
+  productionComplete: true,
+  productionCurrent: true,
+  acceptedQuantity: 5,
+  scrappedQuantity: 0,
+  previouslyReleasedQuantity: 0,
+  finalInspectionRequired: true,
+  finalInspectionComplete: true,
+  fullInspectionRequired: false,
+  allCharacteristicsAccepted: true,
+  samplingRequired: false,
+  samplingPlanApproved: false,
+  samplePassed: false,
+  faiRequired: false,
+  faiApproved: false,
+  testsRequired: false,
+  testsPassed: false,
+  certificatesRequired: false,
+  certificatesCurrent: true,
+  traceabilityComplete: true,
+  openNcrQuantity: 0,
+  reworkPendingReinspection: false,
+  activeHold: false,
+  configurationCurrent: true,
+};
+
+describe('P2 V2 Quality and controlled Product Release', () => {
+  it('requires current Production completion and authoritative Quality evidence', () => {
+    expect(
+      evaluateQualityReadiness({ ...ready, productionComplete: false }).blockers
+    ).toContain('CURRENT_PRODUCTION_COMPLETION_REQUIRED');
+    expect(
+      evaluateQualityReadiness({ ...ready, finalInspectionComplete: false })
+        .blockers
+    ).toContain('FINAL_INSPECTION_REQUIRED');
+    expect(
+      evaluateQualityReadiness({ ...ready, traceabilityComplete: false })
+        .blockers
+    ).toContain('TRACEABILITY_INCOMPLETE');
+  });
+
+  it('enforces full inspection, approved sampling, FAI, tests, certificates and NCR/rework gates', () => {
+    const result = evaluateQualityReadiness({
+      ...ready,
+      fullInspectionRequired: true,
+      allCharacteristicsAccepted: false,
+      samplingRequired: true,
+      samplingPlanApproved: false,
+      samplePassed: false,
+      faiRequired: true,
+      faiApproved: false,
+      testsRequired: true,
+      testsPassed: false,
+      certificatesRequired: true,
+      certificatesCurrent: false,
+      openNcrQuantity: 1,
+      reworkPendingReinspection: true,
+    });
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        'FULL_INSPECTION_INCOMPLETE',
+        'APPROVED_SAMPLING_PLAN_REQUIRED',
+        'SAMPLE_REJECTED_OR_INCOMPLETE',
+        'APPROVED_FAI_REQUIRED',
+        'REQUIRED_TESTS_NOT_PASSED',
+        'CURRENT_CERTIFICATES_REQUIRED',
+        'APPLICABLE_NCR_UNRESOLVED',
+        'REWORK_REINSPECTION_REQUIRED',
+      ])
+    );
+  });
+
+  it('reconciles partial releases without counting scrap or unresolved NCR quantity', () => {
+    expect(
+      evaluateQualityReadiness({
+        ...ready,
+        acceptedQuantity: 10,
+        scrappedQuantity: 2,
+        previouslyReleasedQuantity: 3,
+        openNcrQuantity: 1,
+      }).eligibleQuantity
+    ).toBe(4);
+    expect(() =>
+      validateReleaseSelection({
+        requestedQuantity: 5,
+        eligibleQuantity: 4,
+        serialNumbers: [],
+        batchLots: [],
+      })
+    ).toThrow('RELEASE_EXCEEDS_ELIGIBLE_QUANTITY');
+  });
+
+  it('requires exact, unique serial identity', () => {
+    expect(() =>
+      validateReleaseSelection({
+        requestedQuantity: 2,
+        eligibleQuantity: 2,
+        serialNumbers: ['S1', 'S1'],
+        batchLots: [],
+      })
+    ).toThrow('DUPLICATE_SERIAL_SELECTION');
+    expect(() =>
+      validateReleaseSelection({
+        requestedQuantity: 2,
+        eligibleQuantity: 2,
+        serialNumbers: ['S1'],
+        batchLots: [],
+      })
+    ).toThrow('SERIAL_QUANTITY_MISMATCH');
+  });
+
+  it('adds immutable release identity, allocation uniqueness, holds and explicit authority', () => {
+    expect(migration).toContain('project_product_releases');
+    expect(migration).toContain('project_product_release_serial_unique');
+    expect(migration).toContain('project_product_release_holds');
+    expect(migration).toContain('projects.quality_release.release_product');
+    expect(routes).toContain('projects.quality_release.release_product');
+  });
+
+  it('uses transactions, advisory serialization, idempotency and creates no shipment', () => {
+    expect(service).toContain('db.transaction');
+    expect(service).toContain('pg_advisory_xact_lock');
+    expect(service).toContain('IDEMPOTENCY_CONFLICT');
+    expect(service).toContain('shipmentCreated: false');
+    expect(service).not.toMatch(/INSERT INTO (?:p2_)?shipments/i);
+  });
+
+  it('fails closed for legacy and unknown workflows and keeps Design Control untouched', () => {
+    expect(service).toContain("version !== 'p2_v2'");
+    expect(service).toContain('UNKNOWN_WORKFLOW_VERSION');
+    expect(migration).not.toMatch(/design_(?:control|projects)|ecr|ecn/i);
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -247,6 +247,7 @@ export const safeMigrationFiles = [
   '0219_controlled_printed_copies.sql',
   '0220_p2_v2_production_execution.sql',
   '0221_design_history_files.sql',
+  '0222_p2_v2_quality_product_release.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -281,6 +282,7 @@ export const criticalMigrationFiles = new Set([
   '0219_controlled_printed_copies.sql',
   '0220_p2_v2_production_execution.sql',
   '0221_design_history_files.sql',
+  '0222_p2_v2_quality_product_release.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/projectQualityRelease.ts
+++ b/server/src/routes/projectQualityRelease.ts
@@ -1,0 +1,220 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { getUserPermissions } from '../services/permissionService';
+import {
+  createQualityReview,
+  decideQualityReview,
+  getQualityDashboard,
+  placeReleaseHold,
+  ProjectQualityReleaseError,
+  releaseProductHold,
+  releaseProduct,
+} from '../services/projectQualityReleaseService';
+import type { ProductionActor } from '../services/projectProductionExecutionService';
+
+const router = Router({ mergeParams: true });
+const expected = z.object({ expectedLockVersion: z.number().int().positive() });
+const decision = expected.extend({
+  decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+  signatureMeaning: z.string().min(1),
+  reason: z.string().optional().default(''),
+});
+const release = expected.extend({
+  idempotencyKey: z.string().min(8).max(200),
+  poLineId: z.number().int().positive().optional(),
+  partNumber: z.string().min(1),
+  partRevision: z.string().optional(),
+  quantity: z.number().positive(),
+  serialNumbers: z.array(z.string().min(1)).default([]),
+  batchLots: z.array(z.string().min(1)).default([]),
+  signatureMeaning: z.string().min(1),
+});
+const hold = z.object({
+  reason: z.string().min(1),
+  quantity: z.number().positive(),
+  serialNumbers: z.array(z.string()).default([]),
+  batchLots: z.array(z.string()).default([]),
+});
+const releaseHold = z.object({ releaseReason: z.string().min(1) });
+
+function actor(req: Request): ProductionActor {
+  if (!req.user?.id || !req.user.username || !req.user.role)
+    throw new ProjectQualityReleaseError(
+      'ACTOR_REQUIRED',
+      'Authenticated actor identity is required.',
+      401
+    );
+  return {
+    userId: req.user.id,
+    employeeId: req.user.employeeId ?? null,
+    username: req.user.username,
+    displayName: req.user.username,
+    role: req.user.role,
+  };
+}
+async function authorized(req: Request, capability: string) {
+  const value = actor(req);
+  const { permissionSet } = await getUserPermissions(value.userId, value.role);
+  if (!permissionSet.has(capability))
+    throw new ProjectQualityReleaseError(
+      'FORBIDDEN',
+      `The ${capability} capability is required.`,
+      403
+    );
+  return value;
+}
+function fail(res: Response, error: unknown) {
+  if (error instanceof z.ZodError)
+    return res
+      .status(400)
+      .json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error instanceof ProjectQualityReleaseError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
+  console.error('P2 V2 Quality Product Release error:', error);
+  return res.status(500).json({
+    error: 'QUALITY_RELEASE_ACTION_FAILED',
+    message: 'The Quality Product Release action failed.',
+  });
+}
+const id = (req: Request) => String(req.params.id);
+
+router.get('/', async (req, res) => {
+  try {
+    res.json(await getQualityDashboard(id(req)));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/evidence', async (req, res) => {
+  try {
+    const model = await getQualityDashboard(id(req));
+    res.json({
+      items: model.items,
+      ncrs: model.ncrs,
+      documentManifest: model.documentManifest,
+      productionCompletion: model.ctx.productionReview,
+    });
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/releases', async (req, res) => {
+  try {
+    const model = await getQualityDashboard(id(req));
+    res.json({ releases: model.releases, holds: model.holds });
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/history', async (req, res) => {
+  try {
+    const model = await getQualityDashboard(id(req));
+    res.json({
+      review: model.review,
+      approvals: model.approvals,
+      releases: model.releases,
+      holds: model.holds,
+    });
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/reviews', async (req, res) => {
+  try {
+    res
+      .status(201)
+      .json(
+        await createQualityReview(
+          id(req),
+          await authorized(req, 'projects.quality_release.manage')
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+for (const [path, type, capability] of [
+  ['quality', 'QUALITY', 'projects.quality_release.quality_decide'],
+  ['operations', 'OPERATIONS', 'projects.quality_release.operations_decide'],
+  [
+    'project-management',
+    'PROJECT_MANAGEMENT',
+    'projects.quality_release.pm_decide',
+  ],
+] as const) {
+  router.post(`/reviews/current/decisions/${path}`, async (req, res) => {
+    try {
+      const body = decision.parse(req.body);
+      res.json(
+        await decideQualityReview(
+          id(req),
+          body.expectedLockVersion,
+          type,
+          body.decision,
+          body.signatureMeaning,
+          body.reason,
+          await authorized(req, capability)
+        )
+      );
+    } catch (error) {
+      fail(res, error);
+    }
+  });
+}
+router.post('/releases', async (req, res) => {
+  try {
+    const body = release.parse(req.body);
+    res
+      .status(201)
+      .json(
+        await releaseProduct(
+          id(req),
+          body,
+          await authorized(req, 'projects.quality_release.release_product')
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/releases/:releaseId/holds', async (req, res) => {
+  try {
+    const body = hold.parse(req.body);
+    res
+      .status(201)
+      .json(
+        await placeReleaseHold(
+          id(req),
+          String(req.params.releaseId),
+          body.reason,
+          body.quantity,
+          body.serialNumbers,
+          body.batchLots,
+          await authorized(req, 'projects.quality_release.hold')
+        )
+      );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/releases/:releaseId/holds/:holdId/release', async (req, res) => {
+  try {
+    const body = releaseHold.parse(req.body);
+    res.json(
+      await releaseProductHold(
+        id(req),
+        String(req.params.releaseId),
+        String(req.params.holdId),
+        body.releaseReason,
+        await authorized(req, 'projects.quality_release.release_hold')
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
+
+export default router;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -43,6 +43,7 @@ import projectCommercialReviewRoutes from './projectCommercialReviews';
 import projectTechnicalConfigurationReviewRoutes from './projectTechnicalConfigurationReview';
 import projectPreproductionReadinessRoutes from './projectPreproductionReadiness';
 import projectProductionExecutionRoutes from './projectProductionExecution';
+import projectQualityReleaseRoutes from './projectQualityRelease';
 import { getTechnicalConfigurationReview } from '../services/projectTechnicalConfigurationReviewService';
 import { getCurrentWadAuthorization } from '../services/projectWadAuthorizationService';
 import { getUserPermissions } from '../services/permissionService';
@@ -1600,6 +1601,7 @@ router.use(
   '/:id/workflow-v2/production',
   projectProductionExecutionRoutes
 );
+router.use('/:id/workflow-v2/quality-release', projectQualityReleaseRoutes);
 
 router.get('/:id/workflow-v2/design-applicability', async (req, res) => {
   try {

--- a/server/src/services/projectQualityReleaseRules.ts
+++ b/server/src/services/projectQualityReleaseRules.ts
@@ -1,0 +1,91 @@
+export type QualityEvidence = {
+  productionComplete: boolean;
+  productionCurrent: boolean;
+  acceptedQuantity: number;
+  scrappedQuantity: number;
+  previouslyReleasedQuantity: number;
+  finalInspectionRequired: boolean;
+  finalInspectionComplete: boolean;
+  fullInspectionRequired: boolean;
+  allCharacteristicsAccepted: boolean;
+  samplingRequired: boolean;
+  samplingPlanApproved: boolean;
+  samplePassed: boolean;
+  faiRequired: boolean;
+  faiApproved: boolean;
+  testsRequired: boolean;
+  testsPassed: boolean;
+  certificatesRequired: boolean;
+  certificatesCurrent: boolean;
+  traceabilityComplete: boolean;
+  openNcrQuantity: number;
+  reworkPendingReinspection: boolean;
+  activeHold: boolean;
+  configurationCurrent: boolean;
+};
+
+export function evaluateQualityReadiness(e: QualityEvidence) {
+  const blockers: string[] = [];
+  if (!e.productionComplete || !e.productionCurrent)
+    blockers.push('CURRENT_PRODUCTION_COMPLETION_REQUIRED');
+  if (e.finalInspectionRequired && !e.finalInspectionComplete)
+    blockers.push('FINAL_INSPECTION_REQUIRED');
+  if (e.fullInspectionRequired && !e.allCharacteristicsAccepted)
+    blockers.push('FULL_INSPECTION_INCOMPLETE');
+  if (e.samplingRequired && !e.samplingPlanApproved)
+    blockers.push('APPROVED_SAMPLING_PLAN_REQUIRED');
+  if (e.samplingRequired && !e.samplePassed)
+    blockers.push('SAMPLE_REJECTED_OR_INCOMPLETE');
+  if (e.faiRequired && !e.faiApproved) blockers.push('APPROVED_FAI_REQUIRED');
+  if (e.testsRequired && !e.testsPassed)
+    blockers.push('REQUIRED_TESTS_NOT_PASSED');
+  if (e.certificatesRequired && !e.certificatesCurrent)
+    blockers.push('CURRENT_CERTIFICATES_REQUIRED');
+  if (!e.traceabilityComplete) blockers.push('TRACEABILITY_INCOMPLETE');
+  if (e.openNcrQuantity > 0) blockers.push('APPLICABLE_NCR_UNRESOLVED');
+  if (e.reworkPendingReinspection)
+    blockers.push('REWORK_REINSPECTION_REQUIRED');
+  if (e.activeHold) blockers.push('ACTIVE_QUALITY_HOLD');
+  if (!e.configurationCurrent)
+    blockers.push('CONFIGURATION_OR_EFFECTIVITY_STALE');
+  const eligibleQuantity = Math.max(
+    0,
+    e.acceptedQuantity -
+      e.scrappedQuantity -
+      e.previouslyReleasedQuantity -
+      e.openNcrQuantity
+  );
+  return {
+    state: blockers.length
+      ? 'BLOCKED'
+      : eligibleQuantity > 0
+        ? 'READY_FOR_RELEASE'
+        : 'IN_PROGRESS',
+    blockers,
+    eligibleQuantity,
+  } as const;
+}
+
+export function validateReleaseSelection(input: {
+  requestedQuantity: number;
+  eligibleQuantity: number;
+  serialNumbers: string[];
+  batchLots: string[];
+}) {
+  if (!Number.isFinite(input.requestedQuantity) || input.requestedQuantity <= 0)
+    throw new Error('RELEASE_QUANTITY_REQUIRED');
+  if (input.requestedQuantity > input.eligibleQuantity)
+    throw new Error('RELEASE_EXCEEDS_ELIGIBLE_QUANTITY');
+  const serials = new Set(
+    input.serialNumbers.map((value) => value.trim()).filter(Boolean)
+  );
+  const batches = new Set(
+    input.batchLots.map((value) => value.trim()).filter(Boolean)
+  );
+  if (serials.size !== input.serialNumbers.length)
+    throw new Error('DUPLICATE_SERIAL_SELECTION');
+  if (batches.size !== input.batchLots.length)
+    throw new Error('DUPLICATE_BATCH_SELECTION');
+  if (serials.size && serials.size !== input.requestedQuantity)
+    throw new Error('SERIAL_QUANTITY_MISMATCH');
+}

--- a/server/src/services/projectQualityReleaseService.ts
+++ b/server/src/services/projectQualityReleaseService.ts
@@ -1,0 +1,552 @@
+import { createHash } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { recordAuditEvent, type AuditLedgerTx } from './auditLedgerService';
+import { resolveProjectWorkflowVersion } from './projectWorkflowVersionService';
+import {
+  evaluateQualityReadiness,
+  validateReleaseSelection,
+} from './projectQualityReleaseRules';
+import type { ProductionActor } from './projectProductionExecutionService';
+
+type Executor = AuditLedgerTx;
+// Raw SQL intentionally reads existing authoritative Quality tables without taking ownership.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+const rows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+const digest = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+export class ProjectQualityReleaseError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 400,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+
+async function context(projectId: string, tx: Executor, lock = false) {
+  const project = rows(
+    await tx.execute(sql`
+    SELECT p.id,p.workflow_version,p.po_id,p.current_stage,p.status,po.po_number,po.customer_name
+    FROM projects p LEFT JOIN p2_purchase_orders po ON po.id=p.po_id
+    WHERE p.id=${projectId} ${lock ? sql`FOR UPDATE OF p` : sql``}`)
+  )[0];
+  if (!project)
+    throw new ProjectQualityReleaseError(
+      'PROJECT_NOT_FOUND',
+      'Project not found.',
+      404
+    );
+  let version;
+  try {
+    version = resolveProjectWorkflowVersion(project.workflow_version);
+  } catch {
+    throw new ProjectQualityReleaseError(
+      'UNKNOWN_WORKFLOW_VERSION',
+      'The project workflow version is not recognized.',
+      409
+    );
+  }
+  if (version !== 'p2_v2')
+    throw new ProjectQualityReleaseError(
+      'P2_V2_REQUIRED',
+      'Quality Product Release requires an explicit p2_v2 project.',
+      409
+    );
+  const instance = rows(
+    await tx.execute(sql`
+    SELECT * FROM project_workflow_instances WHERE project_id=${projectId}
+      AND workflow_version='p2_v2' AND status NOT IN ('SUPERSEDED','CANCELLED')
+    ${lock ? sql`FOR UPDATE` : sql``}`)
+  );
+  if (instance.length !== 1)
+    throw new ProjectQualityReleaseError(
+      'WORKFLOW_INSTANCE_REQUIRED',
+      'Exactly one active p2_v2 workflow is required.',
+      409
+    );
+  const steps = rows(
+    await tx.execute(sql`
+    SELECT * FROM project_workflow_step_instances WHERE workflow_instance_id=${instance[0].id} ORDER BY step_order`)
+  );
+  const productionStep = steps.find(
+    (entry) => entry.step_type === 'production_quality'
+  );
+  const qualityStep = steps.find(
+    (entry) => entry.step_type === 'final_release_shipping'
+  );
+  if (!productionStep || productionStep.status !== 'COMPLETE')
+    throw new ProjectQualityReleaseError(
+      'CURRENT_PRODUCTION_COMPLETION_REQUIRED',
+      'Stage 8 Production must be complete before Quality review.',
+      409
+    );
+  if (!qualityStep)
+    throw new ProjectQualityReleaseError(
+      'QUALITY_STAGE_REQUIRED',
+      'Stage 9 Quality is missing.',
+      409
+    );
+  const productionReview = rows(
+    await tx.execute(sql`
+    SELECT * FROM project_production_stage_reviews WHERE project_id=${projectId}
+      AND status='COMPLETE' ORDER BY revision_number DESC LIMIT 1`)
+  )[0];
+  if (!productionReview)
+    throw new ProjectQualityReleaseError(
+      'CURRENT_PRODUCTION_COMPLETION_REQUIRED',
+      'Immutable Production completion evidence is required.',
+      409
+    );
+  return {
+    project,
+    instance: instance[0],
+    productionStep,
+    qualityStep,
+    productionReview,
+  };
+}
+
+async function evidence(projectId: string, tx: Executor) {
+  const ctx = await context(projectId, tx);
+  const production = ctx.productionReview.evidence_snapshot ?? {};
+  const items = rows(
+    await tx.execute(sql`
+    SELECT si.id,si.serial_number,si.part_number,si.status,si.final_qc_completed_at,
+      si.po_item_id,COALESCE(si.customer_serial_number,si.serial_number) AS release_serial,
+      fir.id AS inspection_id,fir.overall_result,fir.inspection_type,
+      fir.non_conformance_ids,fir.qa_mgr_approval
+    FROM p2_serialized_items si
+    LEFT JOIN LATERAL (
+      SELECT f.* FROM p2_final_inspection_results f WHERE f.serialized_item_id=si.id
+      ORDER BY f.inspection_date DESC LIMIT 1
+    ) fir ON true
+    WHERE si.po_id=${ctx.project.po_id} ORDER BY si.part_number,si.sequence_number`)
+  );
+  const ncrs = rows(
+    await tx.execute(sql`
+    SELECT id,serial_number,quantity,status,disposition,disposition_approved_at,
+      effectiveness_status FROM nonconformance_records
+    WHERE po_number=${ctx.project.po_number} AND COALESCE(status,'Open') NOT IN ('Resolved','Closed')`)
+  );
+  const releases = rows(
+    await tx.execute(sql`
+    SELECT * FROM project_product_releases WHERE project_id=${projectId} ORDER BY released_at DESC`)
+  );
+  const holds = rows(
+    await tx.execute(sql`
+    SELECT h.* FROM project_product_release_holds h WHERE h.project_id=${projectId} ORDER BY placed_at DESC`)
+  );
+  const currentReleased = releases
+    .filter((r) => !['HELD', 'REVOKED'].includes(r.release_decision))
+    .reduce((sum, r) => sum + Number(r.released_quantity), 0);
+  const accepted = items.filter(
+    (item) =>
+      item.status !== 'SCRAPPED' &&
+      item.overall_result === 'PASS' &&
+      item.final_qc_completed_at
+  ).length;
+  const activeHold = holds.some((hold) => hold.status === 'ACTIVE');
+  const review =
+    rows(
+      await tx.execute(sql`
+    SELECT * FROM project_quality_reviews WHERE project_id=${projectId}
+      AND status NOT IN ('INVALIDATED','SUPERSEDED') ORDER BY revision_number DESC LIMIT 1`)
+    )[0] ?? null;
+  const approvals = review
+    ? rows(
+        await tx.execute(sql`
+    SELECT * FROM project_quality_review_approvals WHERE quality_review_id=${review.id} ORDER BY decided_at`)
+      )
+    : [];
+  const documentManifest = Array.isArray(production.documentManifest)
+    ? production.documentManifest
+    : [];
+  const rules = evaluateQualityReadiness({
+    productionComplete: true,
+    productionCurrent: ctx.productionReview.status === 'COMPLETE',
+    acceptedQuantity: accepted,
+    scrappedQuantity: items.filter((item) => item.status === 'SCRAPPED').length,
+    previouslyReleasedQuantity: currentReleased,
+    finalInspectionRequired: true,
+    finalInspectionComplete:
+      items.length > 0 &&
+      items
+        .filter((item) => item.status !== 'SCRAPPED')
+        .every(
+          (item) => item.final_qc_completed_at && item.overall_result === 'PASS'
+        ),
+    fullInspectionRequired: Boolean(production.fullInspectionRequired),
+    allCharacteristicsAccepted: !items.some(
+      (item) => item.overall_result !== 'PASS'
+    ),
+    samplingRequired: Boolean(production.samplingRequired),
+    samplingPlanApproved: production.samplingPlanApproved === true,
+    samplePassed: production.samplePassed === true,
+    faiRequired: Boolean(production.faiRequired),
+    faiApproved: production.faiApproved === true,
+    testsRequired: Boolean(production.testsRequired),
+    testsPassed: production.testsPassed === true,
+    certificatesRequired: Boolean(production.certificatesRequired),
+    certificatesCurrent:
+      !production.certificatesRequired || documentManifest.length > 0,
+    traceabilityComplete: items.every((item) => item.release_serial),
+    openNcrQuantity: ncrs.reduce(
+      (sum, ncr) => sum + Number(ncr.quantity ?? 1),
+      0
+    ),
+    reworkPendingReinspection: items.some(
+      (item) => item.status === 'REWORK' && item.overall_result !== 'PASS'
+    ),
+    activeHold,
+    configurationCurrent: true,
+  });
+  return {
+    ctx,
+    items,
+    ncrs,
+    releases,
+    holds,
+    review,
+    approvals,
+    documentManifest,
+    production,
+    readiness: rules,
+  };
+}
+
+export async function getQualityDashboard(
+  projectId: string,
+  tx: Executor = db
+) {
+  return evidence(projectId, tx);
+}
+
+export async function createQualityReview(
+  projectId: string,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const model = await evidence(projectId, tx);
+    if (model.review && !['COMPLETE', 'STALE'].includes(model.review.status))
+      throw new ProjectQualityReleaseError(
+        'QUALITY_REVIEW_EXISTS',
+        'A current Quality review already exists.',
+        409
+      );
+    const revision = Number(model.review?.revision_number ?? 0) + 1;
+    const inserted = rows(
+      await tx.execute(sql`
+      INSERT INTO project_quality_reviews(project_id,workflow_instance_id,workflow_step_instance_id,
+        production_review_id,revision_number,status,production_completion_revision,
+        production_plan_revision,wad_revision,configuration_baseline_id,effectivity_reference,
+        evidence_snapshot,document_manifest,blockers,warnings,created_by,created_by_display_name)
+      VALUES (${projectId},${model.ctx.instance.id},${model.ctx.qualityStep.id},${model.ctx.productionReview.id},
+        ${revision},${model.readiness.state},${model.ctx.productionReview.revision_number},
+        ${model.ctx.productionReview.production_plan_revision},${model.ctx.productionReview.wad_revision},
+        ${model.ctx.productionReview.configuration_baseline_id},${model.ctx.productionReview.effectivity_reference},
+        ${JSON.stringify({ items: model.items, ncrs: model.ncrs, production: model.production })}::jsonb,
+        ${JSON.stringify(model.documentManifest)}::jsonb,${JSON.stringify(model.readiness.blockers)}::jsonb,
+        '[]'::jsonb,${actor.userId},${actor.displayName}) RETURNING *`)
+    )[0];
+    await tx.execute(sql`UPDATE project_workflow_step_instances SET status='IN_PROGRESS',started_at=COALESCE(started_at,now()),
+      updated_at=now() WHERE id=${model.ctx.qualityStep.id} AND status='NOT_STARTED'`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_QUALITY_REVIEW_CREATED',
+        subjectType: 'project_quality_review',
+        subjectId: inserted.id,
+        sourceService: 'projectQualityReleaseService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          revision,
+          productionCompletionRevision:
+            model.ctx.productionReview.revision_number,
+        },
+      },
+      tx
+    );
+    return getQualityDashboard(projectId, tx);
+  });
+}
+
+export async function decideQualityReview(
+  projectId: string,
+  expectedLockVersion: number,
+  approvalType: string,
+  decision: string,
+  signatureMeaning: string,
+  reason: string,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const model = await evidence(projectId, tx);
+    if (!model.review)
+      throw new ProjectQualityReleaseError(
+        'QUALITY_REVIEW_REQUIRED',
+        'Create a Quality review first.',
+        409
+      );
+    if (Number(model.review.lock_version) !== expectedLockVersion)
+      throw new ProjectQualityReleaseError(
+        'STALE_WRITE',
+        'The Quality review is stale.',
+        409
+      );
+    await tx.execute(sql`INSERT INTO project_quality_review_approvals(project_id,quality_review_id,
+      quality_review_revision,approval_type,decision,signature_meaning,reason,evidence_snapshot_hash,
+      actor_user_id,actor_employee_id,actor_display_name,actor_role)
+      VALUES(${projectId},${model.review.id},${model.review.revision_number},${approvalType},${decision},
+      ${signatureMeaning},${reason},${digest(model.review.evidence_snapshot)},${actor.userId},${actor.employeeId ?? null},
+      ${actor.displayName},${actor.role})
+      ON CONFLICT(quality_review_id,approval_type) DO UPDATE SET decision=EXCLUDED.decision,
+      signature_meaning=EXCLUDED.signature_meaning,reason=EXCLUDED.reason,
+      actor_user_id=EXCLUDED.actor_user_id,actor_employee_id=EXCLUDED.actor_employee_id,
+      actor_display_name=EXCLUDED.actor_display_name,actor_role=EXCLUDED.actor_role,decided_at=now()`);
+    const approvals = rows(
+      await tx.execute(
+        sql`SELECT approval_type,decision FROM project_quality_review_approvals WHERE quality_review_id=${model.review.id}`
+      )
+    );
+    const ready =
+      model.readiness.blockers.length === 0 &&
+      ['QUALITY', 'OPERATIONS', 'PROJECT_MANAGEMENT'].every((type) =>
+        approvals.some(
+          (entry) =>
+            entry.approval_type === type && entry.decision === 'APPROVED'
+        )
+      );
+    await tx.execute(sql`UPDATE project_quality_reviews SET status=${ready ? 'READY_FOR_RELEASE' : model.readiness.state},
+      lock_version=lock_version+1,updated_at=now() WHERE id=${model.review.id} AND lock_version=${expectedLockVersion}`);
+    return getQualityDashboard(projectId, tx);
+  });
+}
+
+export type ReleaseInput = {
+  expectedLockVersion: number;
+  idempotencyKey: string;
+  poLineId?: number;
+  partNumber: string;
+  partRevision?: string;
+  quantity: number;
+  serialNumbers: string[];
+  batchLots: string[];
+  signatureMeaning: string;
+};
+
+export async function releaseProduct(
+  projectId: string,
+  input: ReleaseInput,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${`p2-v2-release:${projectId}`}))`
+    );
+    const model = await evidence(projectId, tx);
+    const requestHash = digest(input);
+    const prior = rows(
+      await tx.execute(sql`SELECT * FROM project_product_releases
+      WHERE project_id=${projectId} AND idempotency_key=${input.idempotencyKey}`)
+    )[0];
+    if (prior) {
+      if (prior.request_hash !== requestHash)
+        throw new ProjectQualityReleaseError(
+          'IDEMPOTENCY_CONFLICT',
+          'The idempotency key was already used for another release.',
+          409
+        );
+      return { release: prior, dashboard: model, idempotentReplay: true };
+    }
+    if (!model.review || model.review.status !== 'READY_FOR_RELEASE')
+      throw new ProjectQualityReleaseError(
+        'READY_FOR_RELEASE_REQUIRED',
+        'The Quality review is not READY_FOR_RELEASE.',
+        409
+      );
+    if (Number(model.review.lock_version) !== input.expectedLockVersion)
+      throw new ProjectQualityReleaseError(
+        'STALE_WRITE',
+        'The Quality review is stale.',
+        409
+      );
+    try {
+      validateReleaseSelection({
+        requestedQuantity: input.quantity,
+        eligibleQuantity: model.readiness.eligibleQuantity,
+        serialNumbers: input.serialNumbers,
+        batchLots: input.batchLots,
+      });
+    } catch (error) {
+      throw new ProjectQualityReleaseError(
+        (error as Error).message,
+        'The selected release quantity or identity is not eligible.',
+        409
+      );
+    }
+    const eligibleSerials = new Set(
+      model.items
+        .filter(
+          (item) => item.overall_result === 'PASS' && item.status !== 'SCRAPPED'
+        )
+        .map((item) => String(item.release_serial))
+    );
+    if (input.serialNumbers.some((serial) => !eligibleSerials.has(serial)))
+      throw new ProjectQualityReleaseError(
+        'SERIAL_NOT_ELIGIBLE',
+        'One or more serials are not accepted and eligible.',
+        409
+      );
+    const releaseNumber = `PR-${new Date().toISOString().slice(0, 10).replaceAll('-', '')}-${digest([projectId, input.idempotencyKey]).slice(0, 8).toUpperCase()}`;
+    const release = rows(
+      await tx.execute(sql`INSERT INTO project_product_releases(
+      release_number,project_id,workflow_instance_id,quality_review_id,quality_review_revision,
+      production_completion_revision,customer_po_id,customer_po_line_id,part_number,part_revision,
+      released_quantity,serial_numbers,batch_lots,configuration_baseline_id,effectivity_reference,
+      evidence_snapshot,document_manifest,signature_meaning,released_by,released_by_employee_id,
+      released_by_display_name,released_by_role,idempotency_key,request_hash)
+      VALUES(${releaseNumber},${projectId},${model.ctx.instance.id},${model.review.id},${model.review.revision_number},
+      ${model.ctx.productionReview.revision_number},${model.ctx.project.po_id},${input.poLineId ?? null},
+      ${input.partNumber},${input.partRevision ?? null},${input.quantity},${JSON.stringify(input.serialNumbers)}::jsonb,
+      ${JSON.stringify(input.batchLots)}::jsonb,${model.ctx.productionReview.configuration_baseline_id},
+      ${model.ctx.productionReview.effectivity_reference},${JSON.stringify(model.review.evidence_snapshot)}::jsonb,
+      ${JSON.stringify(model.documentManifest)}::jsonb,${input.signatureMeaning},${actor.userId},
+      ${actor.employeeId ?? null},${actor.displayName},${actor.role},${input.idempotencyKey},${requestHash}) RETURNING *`)
+    )[0];
+    for (const serial of input.serialNumbers)
+      await tx.execute(sql`INSERT INTO project_product_release_allocations(
+      product_release_id,project_id,po_line_id,part_number,serial_number,quantity)
+      VALUES(${release.id},${projectId},${input.poLineId ?? null},${input.partNumber},${serial},1)`);
+    for (const batch of input.batchLots)
+      await tx.execute(sql`INSERT INTO project_product_release_allocations(
+      product_release_id,project_id,po_line_id,part_number,batch_lot,quantity)
+      VALUES(${release.id},${projectId},${input.poLineId ?? null},${input.partNumber},${batch},
+      ${input.quantity / Math.max(1, input.batchLots.length)})`);
+    await tx.execute(sql`UPDATE project_quality_reviews SET status='PARTIALLY_RELEASED',
+      lock_version=lock_version+1,updated_at=now() WHERE id=${model.review.id}`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCT_RELEASED',
+        subjectType: 'project_product_release',
+        subjectId: release.id,
+        sourceService: 'projectQualityReleaseService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: {
+          projectId,
+          releaseNumber,
+          quantity: input.quantity,
+          serialNumbers: input.serialNumbers,
+          batchLots: input.batchLots,
+          shipmentCreated: false,
+        },
+      },
+      tx
+    );
+    return {
+      release,
+      dashboard: await getQualityDashboard(projectId, tx),
+      idempotentReplay: false,
+    };
+  });
+}
+
+export async function placeReleaseHold(
+  projectId: string,
+  releaseId: string,
+  reason: string,
+  quantity: number,
+  serials: string[],
+  batches: string[],
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const release = rows(
+      await tx.execute(sql`SELECT * FROM project_product_releases
+      WHERE id=${releaseId} AND project_id=${projectId} FOR UPDATE`)
+    )[0];
+    if (!release)
+      throw new ProjectQualityReleaseError(
+        'PRODUCT_RELEASE_NOT_FOUND',
+        'Product Release not found.',
+        404
+      );
+    const hold = rows(
+      await tx.execute(sql`INSERT INTO project_product_release_holds(project_id,
+      product_release_id,reason,affected_serials,affected_batches,affected_quantity,placed_by,placed_by_display_name)
+      VALUES(${projectId},${releaseId},${reason},${JSON.stringify(serials)}::jsonb,${JSON.stringify(batches)}::jsonb,
+      ${quantity},${actor.userId},${actor.displayName}) RETURNING *`)
+    )[0];
+    await tx.execute(
+      sql`UPDATE project_product_releases SET release_decision='HELD',shipping_status='BLOCKED' WHERE id=${releaseId}`
+    );
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCT_RELEASE_HELD',
+        subjectType: 'project_product_release_hold',
+        subjectId: hold.id,
+        sourceService: 'projectQualityReleaseService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: { projectId, releaseId, reason, quantity },
+      },
+      tx
+    );
+    return getQualityDashboard(projectId, tx);
+  });
+}
+
+export async function releaseProductHold(
+  projectId: string,
+  releaseId: string,
+  holdId: string,
+  releaseReason: string,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    await context(projectId, tx, true);
+    const hold = rows(
+      await tx.execute(sql`SELECT * FROM project_product_release_holds
+        WHERE id=${holdId} AND product_release_id=${releaseId}
+          AND project_id=${projectId} AND status='ACTIVE' FOR UPDATE`)
+    )[0];
+    if (!hold)
+      throw new ProjectQualityReleaseError(
+        'ACTIVE_RELEASE_HOLD_NOT_FOUND',
+        'Active Product Release hold not found.',
+        404
+      );
+    await tx.execute(sql`UPDATE project_product_release_holds SET status='RELEASED',
+      released_by=${actor.userId},released_by_display_name=${actor.displayName},
+      release_reason=${releaseReason},released_at=now() WHERE id=${holdId}`);
+    const remaining = rows(
+      await tx.execute(sql`SELECT id FROM project_product_release_holds
+        WHERE product_release_id=${releaseId} AND status='ACTIVE' LIMIT 1`)
+    );
+    if (!remaining.length)
+      await tx.execute(sql`UPDATE project_product_releases
+        SET release_decision='RELEASED',shipping_status='AVAILABLE'
+        WHERE id=${releaseId} AND project_id=${projectId}`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_PRODUCT_RELEASE_HOLD_RELEASED',
+        subjectType: 'project_product_release_hold',
+        subjectId: holdId,
+        sourceService: 'projectQualityReleaseService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: { projectId, releaseId, releaseReason },
+      },
+      tx
+    );
+    return getQualityDashboard(projectId, tx);
+  });
+}


### PR DESCRIPTION
Implements Phase 9B Quality review and controlled Product Release for explicit p2_v2 projects. Adds additive migration 0222, revision-controlled readiness and approvals, exact serial/batch partial-release allocations, Quality-only authorization, idempotent transaction locking, immutable audit evidence, controlled release holds, V2-only API/UI, and real-service PostgreSQL certification coverage. Reuses existing Production completion, serialized item, final inspection, NCR, document-manifest, audit-ledger, permission, and workflow systems. Product Release does not create shipments, close POs/projects, alter Design Control, or enable Production Launch. Validation: 41/41 focused server tests, 2/2 component tests, focused ESLint and TypeScript passed; 8 DB-backed migration-safety assertions require DATABASE_URL and are delegated to the disposable PostgreSQL certification workflow.