### PR TITLE
Repair production launch status constraint

### DIFF
--- a/migrations/0223_project_production_launch_status_repair.sql
+++ b/migrations/0223_project_production_launch_status_repair.sql
@@ -1,0 +1,10 @@
+-- Preserve both terminal launch outcomes declared by the Phase 8C base schema.
+--
+-- Migration 0212 added a COMPLETE-only check as NOT VALID. Existing FAILED
+-- audit rows remained readable, but schema promotion tools still reject the
+-- contradictory final schema because the base status check permits FAILED.
+-- The partial unique index continues to enforce at most one COMPLETE launch
+-- per project.
+
+ALTER TABLE IF EXISTS project_production_launches
+  DROP CONSTRAINT IF EXISTS project_production_launches_complete_only_check;

--- a/server/__tests__/migrationSafety.test.ts
+++ b/server/__tests__/migrationSafety.test.ts
@@ -281,6 +281,22 @@ describe('Migration file structure', () => {
     expect(empty, `Empty migration files: ${empty.join(', ')}`).toHaveLength(0);
   });
 
+  it('repairs the contradictory P2 V2 production-launch status constraint', () => {
+    const base = fs.readFileSync(
+      path.join(MIGRATIONS_DIR, '0210_project_preproduction_readiness.sql'),
+      'utf8',
+    );
+    const repair = fs.readFileSync(
+      path.join(MIGRATIONS_DIR, '0223_project_production_launch_status_repair.sql'),
+      'utf8',
+    );
+
+    expect(base).toMatch(/status\s+TEXT\s+NOT NULL\s+CHECK\s*\(status IN \('COMPLETE','FAILED'\)\)/);
+    expect(repair).toMatch(
+      /DROP CONSTRAINT IF EXISTS project_production_launches_complete_only_check/,
+    );
+  });
+
   it('no NEW migration files share an undocumented numeric prefix with an existing file', () => {
     const seen = new Map<string, string[]>();
     for (const f of files) {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -248,6 +248,7 @@ export const safeMigrationFiles = [
   '0220_p2_v2_production_execution.sql',
   '0221_design_history_files.sql',
   '0222_vendor_scope_approved_for.sql',
+  '0223_project_production_launch_status_repair.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -283,6 +284,7 @@ export const criticalMigrationFiles = new Set([
   '0220_p2_v2_production_execution.sql',
   '0221_design_history_files.sql',
   '0222_vendor_scope_approved_for.sql',
+  '0223_project_production_launch_status_repair.sql',
 ]);
 
 export async function runSafeBootMigrations() {


### PR DESCRIPTION
## Summary

- add a forward-only migration that removes the contradictory `COMPLETE`-only constraint from `project_production_launches`
- preserve the original `COMPLETE | FAILED` status contract and the partial unique index that limits each project to one completed launch
- register the repair in safe-boot and critical migration execution
- add a regression assertion covering the base status contract and repair migration

## Root cause

Migration `0212_project_preproduction_launch_safety.sql` added `project_production_launches_complete_only_check`, while the Phase 8C base schema explicitly permits both `COMPLETE` and `FAILED`. Existing failed launch audit records therefore caused production schema validation to reject the deployment.

## Impact

The repair drops only the contradictory check constraint. It does not delete or rewrite production rows, and it preserves failed launch audit history.

## Validation

- `git diff --cached --check` passed
- static launch-status migration contract check passed
- focused Vitest execution was attempted but unavailable in the clean worktree because dependencies were not installed
- no real PostgreSQL migration was run locally