### PR TITLE
Complete P2 V2 quality release certification

### DIFF
--- a/client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
+++ b/client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
@@ -5,45 +5,132 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import P2V2QualityProductRelease from '../components/projects/P2V2QualityProductRelease';
 
 afterEach(() => vi.restoreAllMocks());
+const base = {
+  ctx: {
+    project: { po_number: 'PO-9B', customer_name: 'Certification Customer' },
+    productionReview: {
+      revision_number: 1,
+      configuration_baseline_id: 'CFG-9B',
+      effectivity_reference: 'EFF-9B',
+    },
+  },
+  items: [],
+  ncrs: [],
+  releases: [],
+  holds: [],
+  documentManifest: [],
+  readiness: { state: 'BLOCKED', blockers: [], eligibleQuantity: 0 },
+  review: null,
+  approvals: [],
+};
+function renderDashboard(data: Record<string, unknown>) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...base, ...data }),
+    })
+  );
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <P2V2QualityProductRelease projectId="project-9b" />
+    </QueryClientProvider>
+  );
+}
 describe('P2V2QualityProductRelease', () => {
   it('states the release boundary and shows blockers', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          ctx: {
-            project: { po_number: 'PO-9B' },
-            productionReview: { revision_number: 1 },
-          },
-          items: [],
-          ncrs: [],
-          releases: [],
-          holds: [],
-          documentManifest: [],
-          readiness: {
-            state: 'BLOCKED',
-            blockers: ['FINAL_INSPECTION_REQUIRED'],
-            eligibleQuantity: 0,
-          },
-          review: null,
-          approvals: [],
-        }),
-      })
-    );
-    render(
-      <QueryClientProvider client={new QueryClient()}>
-        <P2V2QualityProductRelease projectId="project-9b" />
-      </QueryClientProvider>
-    );
+    renderDashboard({
+      readiness: {
+        state: 'BLOCKED',
+        blockers: ['FINAL_INSPECTION_REQUIRED'],
+        eligibleQuantity: 0,
+      },
+    });
     expect(
       await screen.findByText(/Product Release does not create a shipment/i)
     ).toBeInTheDocument();
     expect(screen.getByText('FINAL_INSPECTION_REQUIRED')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: /Create revision-controlled Quality review/i,
+        name: /Create Quality review/i,
       })
+    ).toBeInTheDocument();
+  });
+
+  it('provides submit, functional decision, and completion controls', async () => {
+    renderDashboard({
+      readiness: {
+        state: 'READY_FOR_RELEASE',
+        blockers: [],
+        eligibleQuantity: 2,
+      },
+      review: {
+        status: 'READY_FOR_REVIEW',
+        revision_number: 1,
+        lock_version: 3,
+      },
+    });
+    expect(
+      await screen.findByRole('button', { name: /Approve — Operations/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Reject — Project Management/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Approve — Quality/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Complete Quality review/i })
+    ).toBeInTheDocument();
+  });
+
+  it('shows exact release confirmation and hold controls', async () => {
+    renderDashboard({
+      items: [
+        {
+          id: 'item-1',
+          release_serial: 'SER-001',
+          part_number: 'PART-9B',
+          part_revision: 'A',
+          po_item_id: 91,
+          overall_result: 'PASS',
+          status: 'COMPLETED',
+        },
+      ],
+      documentManifest: [{ number: 'COC-1', revision: 'A' }],
+      readiness: {
+        state: 'READY_FOR_RELEASE',
+        blockers: [],
+        eligibleQuantity: 1,
+      },
+      review: {
+        status: 'READY_FOR_RELEASE',
+        revision_number: 1,
+        lock_version: 5,
+      },
+      releases: [
+        {
+          id: 'release-1',
+          release_number: 'PR-9B-1',
+          part_number: 'PART-9B',
+          released_quantity: 1,
+          release_decision: 'RELEASED',
+          serial_numbers: ['SER-001'],
+          batch_lots: [],
+        },
+      ],
+    });
+    expect(await screen.findByText(/CFG-9B/)).toBeInTheDocument();
+    expect(screen.getByText(/EFF-9B/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Release quantity/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Quality signature meaning/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Confirm and Release Product/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Place release hold/i })
     ).toBeInTheDocument();
   });
 });

--- a/client/src/components/projects/P2V2QualityProductRelease.tsx
+++ b/client/src/components/projects/P2V2QualityProductRelease.tsx
@@ -1,5 +1,7 @@
+import { useMemo, useState } from 'react';
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, ShieldCheck, TriangleAlert } from 'lucide-react';
+import { ShieldCheck, TriangleAlert } from 'lucide-react';
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -11,12 +13,17 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 
 type Row = Record<string, unknown>;
 type Dashboard = {
   ctx: {
     project: { po_number?: string; customer_name?: string };
-    productionReview: { revision_number: number };
+    productionReview: {
+      revision_number: number;
+      configuration_baseline_id?: string;
+      effectivity_reference?: string;
+    };
   };
   items: Row[];
   ncrs: Row[];
@@ -43,6 +50,12 @@ export default function P2V2QualityProductRelease({
 }) {
   const queryClient = useQueryClient();
   const key = ['/api/projects', projectId, 'workflow-v2', 'quality-release'];
+  const [selectedSerials, setSelectedSerials] = useState<string[]>([]);
+  const [quantity, setQuantity] = useState(1);
+  const [signatureMeaning, setSignatureMeaning] = useState(
+    'Quality authorizes the identified conforming product for customer release'
+  );
+  const [actionError, setActionError] = useState('');
   const { data, isLoading, error } = useQuery<Dashboard>({
     queryKey: key,
     queryFn: async () => {
@@ -58,29 +71,54 @@ export default function P2V2QualityProductRelease({
       return body;
     },
   });
-  const createReview = useMutation({
-    mutationFn: async () => {
+  const action = useMutation({
+    mutationFn: async ({
+      path,
+      body = {},
+    }: {
+      path: string;
+      body?: Record<string, unknown>;
+    }) => {
       const response = await fetch(
-        `/api/projects/${projectId}/workflow-v2/quality-release/reviews`,
+        `/api/projects/${projectId}/workflow-v2/quality-release/${path}`,
         {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
-          body: '{}',
+          body: JSON.stringify(body),
         }
       );
-      const body = await response.json().catch(() => null);
+      const responseBody = await response.json().catch(() => null);
       if (!response.ok)
-        throw new Error(body?.message || 'Unable to create Quality review');
-      return body;
+        throw new Error(
+          responseBody?.message || 'Quality release action failed'
+        );
+      return responseBody;
     },
     onSuccess: (body) => {
-      queryClient.setQueryData(key, body);
+      setActionError('');
+      queryClient.setQueryData(key, body.dashboard ?? body);
       queryClient.invalidateQueries({
         queryKey: ['/api/projects', projectId, 'workflow-v2'],
       });
     },
+    onError: (mutationError) =>
+      setActionError(
+        mutationError instanceof Error
+          ? mutationError.message
+          : 'Quality release action failed'
+      ),
   });
+  const eligibleItems = useMemo(
+    () =>
+      (data?.items ?? []).filter(
+        (item) =>
+          item.overall_result === 'PASS' &&
+          item.status !== 'SCRAPPED' &&
+          item.release_serial
+      ),
+    [data?.items]
+  );
   if (isLoading)
     return (
       <Card>
@@ -99,9 +137,16 @@ export default function P2V2QualityProductRelease({
         </AlertDescription>
       </Alert>
     );
-  const activeHolds = data.holds.filter(
-    (hold) => hold.status === 'ACTIVE'
-  ).length;
+  const expectedLockVersion = data.review?.lock_version;
+  const post = (path: string, body: Record<string, unknown> = {}) =>
+    action.mutate({ path, body });
+  const decide = (path: string, decision: 'APPROVED' | 'REJECTED') =>
+    post(`reviews/current/decisions/${path}`, {
+      expectedLockVersion,
+      decision,
+      signatureMeaning: `${path} decision for Quality review revision ${data.review?.revision_number}`,
+      reason: '',
+    });
   return (
     <div className="space-y-4" data-testid="p2-v2-quality-product-release">
       <Alert>
@@ -116,7 +161,7 @@ export default function P2V2QualityProductRelease({
         <CardHeader>
           <div className="flex flex-wrap justify-between gap-3">
             <div>
-              <CardTitle>Quality readiness</CardTitle>
+              <CardTitle>Quality readiness and lifecycle</CardTitle>
               <CardDescription>
                 {data.ctx.project.customer_name || 'Customer'} · PO{' '}
                 {data.ctx.project.po_number || '—'} · Production completion
@@ -133,7 +178,10 @@ export default function P2V2QualityProductRelease({
               ['Eligible', data.readiness.eligibleQuantity],
               ['Open NCRs', data.ncrs.length],
               ['Controlled documents', data.documentManifest.length],
-              ['Active release holds', activeHolds],
+              [
+                'Active release holds',
+                data.holds.filter((hold) => hold.status === 'ACTIVE').length,
+              ],
             ].map(([label, value]) => (
               <div key={String(label)} className="rounded border p-3">
                 <p className="text-xs text-muted-foreground">{label}</p>
@@ -154,25 +202,166 @@ export default function P2V2QualityProductRelease({
               </AlertDescription>
             </Alert>
           )}
-          {!data.review && (
-            <Button
-              onClick={() => createReview.mutate()}
-              disabled={createReview.isPending}
-            >
-              Create revision-controlled Quality review
-            </Button>
-          )}
-          {data.review?.status === 'READY_FOR_RELEASE' && (
-            <Alert>
-              <CheckCircle2 className="h-4 w-4" />
-              <AlertTitle>Ready for controlled release</AlertTitle>
-              <AlertDescription>
-                Use Release Product after confirming PO line, part/revision,
-                quantity, serials or batches, configuration/effectivity,
-                document manifest, and Quality signature meaning.
-              </AlertDescription>
+          {actionError && (
+            <Alert variant="destructive">
+              <TriangleAlert className="h-4 w-4" />
+              <AlertTitle>Action not completed</AlertTitle>
+              <AlertDescription>{actionError}</AlertDescription>
             </Alert>
           )}
+          {!data.review && (
+            <Button onClick={() => post('reviews')} disabled={action.isPending}>
+              Create Quality review
+            </Button>
+          )}
+          {data.review &&
+            ['IN_PROGRESS', 'BLOCKED'].includes(data.review.status) && (
+              <Button
+                onClick={() =>
+                  post('reviews/current/submit', { expectedLockVersion })
+                }
+                disabled={
+                  action.isPending || data.readiness.blockers.length > 0
+                }
+              >
+                Submit Quality review
+              </Button>
+            )}
+          {data.review?.status === 'READY_FOR_REVIEW' && (
+            <div className="space-y-3 rounded border p-3">
+              <p className="font-medium">Functional approvals</p>
+              <div className="flex flex-wrap gap-2">
+                {[
+                  ['operations', 'Operations'],
+                  ['project-management', 'Project Management'],
+                  ['quality', 'Quality'],
+                ].map(([path, label]) => (
+                  <div className="flex gap-1" key={path}>
+                    <Button
+                      size="sm"
+                      onClick={() => decide(path, 'APPROVED')}
+                      disabled={action.isPending}
+                    >
+                      Approve — {label}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => decide(path, 'REJECTED')}
+                      disabled={action.isPending}
+                    >
+                      Reject — {label}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+              <ul className="text-sm">
+                {data.approvals.map((approval) => (
+                  <li key={approval.approval_type}>
+                    {approval.approval_type}: {approval.decision} by{' '}
+                    {approval.actor_display_name}
+                  </li>
+                ))}
+              </ul>
+              <Button
+                onClick={() =>
+                  post('reviews/current/complete', { expectedLockVersion })
+                }
+                disabled={action.isPending}
+              >
+                Complete Quality review
+              </Button>
+            </div>
+          )}
+          {data.review &&
+            ['READY_FOR_RELEASE', 'PARTIALLY_RELEASED'].includes(
+              data.review.status
+            ) && (
+              <div className="space-y-3 rounded border p-4">
+                <h4 className="font-semibold">Release Product</h4>
+                <p className="text-sm">
+                  Customer PO {data.ctx.project.po_number || '—'} ·
+                  Configuration{' '}
+                  {data.ctx.productionReview.configuration_baseline_id || '—'} ·
+                  Effectivity{' '}
+                  {data.ctx.productionReview.effectivity_reference || '—'}
+                </p>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {eligibleItems.map((item) => {
+                    const serial = String(item.release_serial);
+                    return (
+                      <label
+                        className="flex items-center gap-2 rounded border p-2"
+                        key={serial}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedSerials.includes(serial)}
+                          onChange={(event) =>
+                            setSelectedSerials((current) =>
+                              event.target.checked
+                                ? [...current, serial]
+                                : current.filter((value) => value !== serial)
+                            )
+                          }
+                        />
+                        {serial} · {String(item.part_number)}
+                      </label>
+                    );
+                  })}
+                </div>
+                <Input
+                  aria-label="Release quantity"
+                  type="number"
+                  min={1}
+                  max={data.readiness.eligibleQuantity}
+                  value={quantity}
+                  onChange={(event) => setQuantity(Number(event.target.value))}
+                />
+                <Input
+                  aria-label="Quality signature meaning"
+                  value={signatureMeaning}
+                  onChange={(event) => setSignatureMeaning(event.target.value)}
+                />
+                <div className="rounded bg-muted p-3 text-sm">
+                  <p>
+                    Part/revision:{' '}
+                    {String(eligibleItems[0]?.part_number || '—')} /{' '}
+                    {String(eligibleItems[0]?.part_revision || '—')}
+                  </p>
+                  <p>Quantity: {quantity}</p>
+                  <p>Serials/batches: {selectedSerials.join(', ') || 'None'}</p>
+                  <p>Controlled documents: {data.documentManifest.length}</p>
+                  <p>Signature meaning: {signatureMeaning}</p>
+                  <strong>Product Release does not create a shipment.</strong>
+                </div>
+                <Button
+                  onClick={() =>
+                    post('releases', {
+                      expectedLockVersion,
+                      idempotencyKey: crypto.randomUUID(),
+                      poLineId:
+                        Number(eligibleItems[0]?.po_item_id) || undefined,
+                      partNumber: String(eligibleItems[0]?.part_number || ''),
+                      partRevision: String(
+                        eligibleItems[0]?.part_revision || ''
+                      ),
+                      quantity,
+                      serialNumbers: selectedSerials,
+                      batchLots: [],
+                      signatureMeaning,
+                    })
+                  }
+                  disabled={
+                    action.isPending ||
+                    selectedSerials.length !== quantity ||
+                    !signatureMeaning
+                  }
+                >
+                  Confirm and Release Product
+                </Button>
+              </div>
+            )}
         </CardContent>
       </Card>
       <Card>
@@ -200,6 +389,44 @@ export default function P2V2QualityProductRelease({
                     {String(release.released_quantity)} ·{' '}
                     {String(release.release_decision)}
                   </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {release.release_decision !== 'HELD' && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() =>
+                          post(`releases/${String(release.id)}/holds`, {
+                            reason: 'Quality hold placed from Stage 9',
+                            quantity: Number(release.released_quantity),
+                            serialNumbers: release.serial_numbers || [],
+                            batchLots: release.batch_lots || [],
+                          })
+                        }
+                      >
+                        Place release hold
+                      </Button>
+                    )}
+                    {data.holds
+                      .filter(
+                        (hold) =>
+                          hold.product_release_id === release.id &&
+                          hold.status === 'ACTIVE'
+                      )
+                      .map((hold) => (
+                        <Button
+                          size="sm"
+                          key={String(hold.id)}
+                          onClick={() =>
+                            post(
+                              `releases/${String(release.id)}/holds/${String(hold.id)}/release`,
+                              { releaseReason: 'Quality disposition complete' }
+                            )
+                          }
+                        >
+                          Release hold
+                        </Button>
+                      ))}
+                  </div>
                 </div>
               ))}
             </div>

--- a/migrations/0224_p2_v2_quality_release_hardening.sql
+++ b/migrations/0224_p2_v2_quality_release_hardening.sql
@@ -1,0 +1,51 @@
+-- Phase 9B certification hardening.
+-- Preserve immutable Product Release identity while allowing controlled
+-- shipping-consumption and hold state transitions.
+
+CREATE OR REPLACE FUNCTION protect_product_release_identity()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.release_number IS DISTINCT FROM OLD.release_number
+    OR NEW.project_id IS DISTINCT FROM OLD.project_id
+    OR NEW.workflow_instance_id IS DISTINCT FROM OLD.workflow_instance_id
+    OR NEW.quality_review_id IS DISTINCT FROM OLD.quality_review_id
+    OR NEW.quality_review_revision IS DISTINCT FROM OLD.quality_review_revision
+    OR NEW.production_completion_revision IS DISTINCT FROM OLD.production_completion_revision
+    OR NEW.customer_po_id IS DISTINCT FROM OLD.customer_po_id
+    OR NEW.customer_po_line_id IS DISTINCT FROM OLD.customer_po_line_id
+    OR NEW.part_number IS DISTINCT FROM OLD.part_number
+    OR NEW.part_revision IS DISTINCT FROM OLD.part_revision
+    OR NEW.released_quantity IS DISTINCT FROM OLD.released_quantity
+    OR NEW.serial_numbers IS DISTINCT FROM OLD.serial_numbers
+    OR NEW.batch_lots IS DISTINCT FROM OLD.batch_lots
+    OR NEW.configuration_baseline_id IS DISTINCT FROM OLD.configuration_baseline_id
+    OR NEW.effectivity_reference IS DISTINCT FROM OLD.effectivity_reference
+    OR NEW.evidence_snapshot IS DISTINCT FROM OLD.evidence_snapshot
+    OR NEW.document_manifest IS DISTINCT FROM OLD.document_manifest
+    OR NEW.signature_meaning IS DISTINCT FROM OLD.signature_meaning
+    OR NEW.released_by IS DISTINCT FROM OLD.released_by
+    OR NEW.released_by_employee_id IS DISTINCT FROM OLD.released_by_employee_id
+    OR NEW.released_by_display_name IS DISTINCT FROM OLD.released_by_display_name
+    OR NEW.released_by_role IS DISTINCT FROM OLD.released_by_role
+    OR NEW.released_at IS DISTINCT FROM OLD.released_at
+    OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+    OR NEW.request_hash IS DISTINCT FROM OLD.request_hash
+    OR NEW.created_at IS DISTINCT FROM OLD.created_at
+  THEN
+    RAISE EXCEPTION 'Product Release identity and evidence are immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname='protect_product_release_identity_trigger'
+      AND tgrelid='project_product_releases'::regclass
+  ) THEN
+    CREATE TRIGGER protect_product_release_identity_trigger
+    BEFORE UPDATE ON project_product_releases
+    FOR EACH ROW EXECUTE FUNCTION protect_product_release_identity();
+  END IF;
+END $$;

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -35,9 +35,15 @@ import {
   getProductionDashboard,
 } from '../src/services/projectProductionExecutionService';
 import {
+  completeQualityReview,
   createQualityReview,
   decideQualityReview,
+  getQualityDashboard,
+  placeReleaseHold,
+  ProjectQualityReleaseError,
+  releaseProductHold,
   releaseProduct,
+  submitQualityReview,
 } from '../src/services/projectQualityReleaseService';
 import {
   getP2V2StagesForDefinitionVersion,
@@ -678,24 +684,26 @@ describe('Phase 8 migration certification', () => {
     );
   });
 
-  it('has Phase 1-8 tables and validated 0212 constraints', async () => {
+  it('has Phase 1-8 tables and the repaired launch constraints', async () => {
     await query(
       `ALTER TABLE project_production_releases
          VALIDATE CONSTRAINT project_production_releases_readiness_project_fkey;
        ALTER TABLE project_production_launches
-         VALIDATE CONSTRAINT project_production_launches_release_project_fkey;
-       ALTER TABLE project_production_launches
-         VALIDATE CONSTRAINT project_production_launches_complete_only_check`
+         VALIDATE CONSTRAINT project_production_launches_release_project_fkey`
     );
     const constraints = await query<{ conname: string; convalidated: boolean }>(
       `SELECT conname,convalidated FROM pg_constraint WHERE conname IN
        ('project_production_releases_readiness_project_fkey',
-        'project_production_launches_release_project_fkey',
-        'project_production_launches_complete_only_check')
+        'project_production_launches_release_project_fkey')
        ORDER BY conname`
     );
-    expect(constraints.rows).toHaveLength(3);
+    expect(constraints.rows).toHaveLength(2);
     expect(constraints.rows.every((row) => row.convalidated)).toBe(true);
+    const retired = await query(
+      `SELECT 1 FROM pg_constraint
+       WHERE conname='project_production_launches_complete_only_check'`
+    );
+    expect(retired.rows).toHaveLength(0);
   });
 
   it('has additive Phase 9A Production evidence, hold, link, and approval tables', async () => {
@@ -703,12 +711,14 @@ describe('Phase 8 migration certification', () => {
       `SELECT table_name FROM information_schema.tables
        WHERE table_schema='public' AND table_name=ANY($1::text[])
        ORDER BY table_name`,
-      [[
-        'project_production_stage_reviews',
-        'project_production_evidence_links',
-        'project_production_holds',
-        'project_production_stage_approvals',
-      ]]
+      [
+        [
+          'project_production_stage_reviews',
+          'project_production_evidence_links',
+          'project_production_holds',
+          'project_production_stage_approvals',
+        ],
+      ]
     );
     expect(result.rows.map((row) => row.table_name)).toEqual([
       'project_production_evidence_links',
@@ -927,39 +937,250 @@ describe('actual production launch service against PostgreSQL', () => {
     expect(created.productionOrders).toHaveLength(6);
   });
 
-  it('executes the real Quality review and idempotent Product Release transaction', async () => {
-    await query(`UPDATE p2_serialized_items SET status='COMPLETED',
+  it('executes the complete real Quality lifecycle, partial release, concurrency, rollback and hold controls', async () => {
+    await expect(
+      createQualityReview(fixture.projectId, actor)
+    ).rejects.toMatchObject({
+      code: 'CURRENT_PRODUCTION_COMPLETION_REQUIRED',
+    });
+    await query(
+      `UPDATE p2_serialized_items SET status='COMPLETED',
       current_department='Final QC',final_qc_completed_at=now(),completed_at=now()
-      WHERE po_id=$1`, [fixture.poId]);
-    await query(`INSERT INTO p2_final_inspection_results
+      WHERE po_id=$1`,
+      [fixture.poId]
+    );
+    await query(
+      `INSERT INTO p2_final_inspection_results
       (serialized_item_id,barcode,part_number,inspection_type,overall_result,inspector_name,qa_mgr_approval)
       SELECT id,barcode,part_number,'FINAL','PASS','PG Certifier','Approved'
-      FROM p2_serialized_items WHERE po_id=$1`, [fixture.poId]);
-    await query(`UPDATE project_production_stage_reviews SET status='COMPLETE',completed_at=now()
-      WHERE project_id=$1`, [fixture.projectId]);
-    await query(`UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now()
-      WHERE project_id=$1 AND step_type='production_quality'`, [fixture.projectId]);
+      FROM p2_serialized_items WHERE po_id=$1`,
+      [fixture.poId]
+    );
+    await query(
+      `UPDATE project_production_stage_reviews SET status='COMPLETE',completed_at=now()
+      WHERE project_id=$1`,
+      [fixture.projectId]
+    );
+    await query(
+      `UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now()
+      WHERE project_id=$1 AND step_type='production_quality'`,
+      [fixture.projectId]
+    );
     const created = await createQualityReview(fixture.projectId, actor);
+    expect(created.review?.status).toBe('IN_PROGRESS');
     let lock = Number(created.review?.lock_version);
-    for (const type of ['QUALITY','OPERATIONS','PROJECT_MANAGEMENT'] as const) {
-      const decided = await decideQualityReview(fixture.projectId, lock, type, 'APPROVED',
-        `${type} certifies revision 1`, '', actor);
+    const submitted = await submitQualityReview(fixture.projectId, lock, actor);
+    expect(submitted.review?.status).toBe('READY_FOR_REVIEW');
+    lock = Number(submitted.review?.lock_version);
+    for (const type of ['OPERATIONS', 'PROJECT_MANAGEMENT'] as const) {
+      const decided = await decideQualityReview(
+        fixture.projectId,
+        lock,
+        type,
+        'APPROVED',
+        `${type} certifies revision 1`,
+        '',
+        actor
+      );
       lock = Number(decided.review?.lock_version);
     }
+    await expect(
+      completeQualityReview(fixture.projectId, lock, actor)
+    ).rejects.toMatchObject({ code: 'QUALITY_APPROVALS_REQUIRED' });
+    await expect(
+      releaseProduct(
+        fixture.projectId,
+        {
+          expectedLockVersion: lock,
+          idempotencyKey: 'authority-blocked-release',
+          partNumber: String(created.items[0].part_number),
+          quantity: 1,
+          serialNumbers: [String(created.items[0].release_serial)],
+          batchLots: [],
+          signatureMeaning:
+            'Operations and PM are not Quality release authority',
+        },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'READY_FOR_RELEASE_REQUIRED' });
+    const qualityDecision = await decideQualityReview(
+      fixture.projectId,
+      lock,
+      'QUALITY',
+      'APPROVED',
+      'Quality certifies revision 1',
+      '',
+      actor
+    );
+    lock = Number(qualityDecision.review?.lock_version);
+    const completed = await completeQualityReview(
+      fixture.projectId,
+      lock,
+      actor
+    );
+    expect(completed.review?.status).toBe('READY_FOR_RELEASE');
+    lock = Number(completed.review?.lock_version);
+    const firstSerial = String(created.items[0].release_serial);
+    const secondSerial = String(created.items[1].release_serial);
+    const partNumber = String(created.items[0].part_number);
+    await expect(
+      releaseProduct(
+        fixture.projectId,
+        {
+          expectedLockVersion: lock,
+          idempotencyKey: 'forced-rollback-release',
+          partNumber,
+          quantity: 1,
+          serialNumbers: [firstSerial],
+          batchLots: [],
+          signatureMeaning: 'Forced rollback certification',
+          certificationFailurePoint: 'AFTER_ALLOCATIONS',
+        },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (
+        await query(
+          `SELECT id FROM project_product_releases WHERE project_id=$1`,
+          [fixture.projectId]
+        )
+      ).rows
+    ).toHaveLength(0);
+    expect(
+      (
+        await query(
+          `SELECT id FROM project_product_release_allocations WHERE project_id=$1`,
+          [fixture.projectId]
+        )
+      ).rows
+    ).toHaveLength(0);
     const input = {
       expectedLockVersion: lock,
       idempotencyKey: 'phase9b-pg-cert-release-1',
-      partNumber: String(created.items[0].part_number),
+      partNumber,
       quantity: 1,
-      serialNumbers: [String(created.items[0].release_serial)],
+      serialNumbers: [firstSerial],
       batchLots: [],
       signatureMeaning: 'Quality authorizes exact product for customer release',
     };
-    const first = await releaseProduct(fixture.projectId, input, actor);
-    expect(first.release.shipping_status).toBe('AVAILABLE');
-    expect((await releaseProduct(fixture.projectId, input, actor)).idempotentReplay).toBe(true);
-    expect((await query(`SELECT id FROM project_product_releases WHERE project_id=$1`,
-      [fixture.projectId])).rows).toHaveLength(1);
+    const concurrent = await Promise.allSettled([
+      releaseProduct(fixture.projectId, input, actor),
+      releaseProduct(
+        fixture.projectId,
+        { ...input, idempotencyKey: 'phase9b-pg-cert-release-race' },
+        actor
+      ),
+    ]);
+    expect(
+      concurrent.filter((result) => result.status === 'fulfilled')
+    ).toHaveLength(1);
+    expect(
+      concurrent.filter((result) => result.status === 'rejected')
+    ).toHaveLength(1);
+    const first = concurrent.find((result) => result.status === 'fulfilled');
+    if (!first || first.status !== 'fulfilled')
+      throw new Error('Concurrent release did not produce a winner');
+    const firstResult = first.value;
+    expect(firstResult.dashboard.review?.status).toBe('PARTIALLY_RELEASED');
+    const winningKey = String(firstResult.release.idempotency_key);
+    const winningInput =
+      winningKey === input.idempotencyKey
+        ? input
+        : { ...input, idempotencyKey: winningKey };
+    expect(
+      (await releaseProduct(fixture.projectId, winningInput, actor))
+        .idempotentReplay
+    ).toBe(true);
+    await expect(
+      releaseProduct(fixture.projectId, { ...winningInput, quantity: 2 }, actor)
+    ).rejects.toMatchObject({ code: 'IDEMPOTENCY_CONFLICT' });
+    await expect(
+      releaseProduct(
+        fixture.projectId,
+        {
+          ...input,
+          expectedLockVersion: Number(
+            firstResult.dashboard.review?.lock_version
+          ),
+          idempotencyKey: 'cumulative-over-release',
+          quantity: 2,
+          serialNumbers: [firstSerial, secondSerial],
+        },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'RELEASE_EXCEEDS_ELIGIBLE_QUANTITY' });
+    const held = await placeReleaseHold(
+      fixture.projectId,
+      String(firstResult.release.id),
+      'Certification containment',
+      1,
+      [firstSerial],
+      [],
+      actor
+    );
+    expect(held.releases[0].shipping_status).toBe('BLOCKED');
+    const activeHold = held.holds.find((entry) => entry.status === 'ACTIVE');
+    const holdReleased = await releaseProductHold(
+      fixture.projectId,
+      String(firstResult.release.id),
+      String(activeHold?.id),
+      'Certification disposition complete',
+      actor
+    );
+    expect(holdReleased.releases[0].shipping_status).toBe('AVAILABLE');
+    await expect(
+      query(
+        `UPDATE project_product_releases SET released_quantity=99 WHERE id=$1`,
+        [firstResult.release.id]
+      )
+    ).rejects.toThrow(/immutable/i);
+    const afterFirst = await getQualityDashboard(fixture.projectId);
+    const final = await releaseProduct(
+      fixture.projectId,
+      {
+        expectedLockVersion: Number(afterFirst.review?.lock_version),
+        idempotencyKey: 'phase9b-pg-cert-release-2',
+        partNumber,
+        quantity: 1,
+        serialNumbers: [secondSerial],
+        batchLots: [],
+        signatureMeaning: 'Quality authorizes final exact product',
+      },
+      actor
+    );
+    expect(final.dashboard.review?.status).toBe('COMPLETE');
+    const stage = await query<{ status: string }>(
+      `SELECT status FROM project_workflow_step_instances
+       WHERE project_id=$1 AND step_type='final_release_shipping'`,
+      [fixture.projectId]
+    );
+    expect(stage.rows[0].status).toBe('COMPLETE');
+    const shippingStage = await query<{ status: string }>(
+      `SELECT status FROM project_workflow_step_instances
+       WHERE project_id=$1 AND step_type='project_closing'`,
+      [fixture.projectId]
+    );
+    expect(shippingStage.rows[0].status).toBe('NOT_STARTED');
+    const shipmentCount = await query<{ count: number }>(
+      `SELECT count(*)::int count FROM shipment_records WHERE po_numbers=$1`,
+      [fixture.projectId]
+    );
+    expect(shipmentCount.rows[0].count).toBe(0);
+    const unchanged = await query<{ status: string; current_stage: string }>(
+      `SELECT status,current_stage FROM projects WHERE id=$1`,
+      [fixture.projectId]
+    );
+    expect(unchanged.rows[0].status).not.toBe('CLOSED');
+    expect(unchanged.rows[0].current_stage).toBe('IN_PRODUCTION');
+    expect(
+      (
+        await query(
+          `SELECT id FROM project_product_releases WHERE project_id=$1`,
+          [fixture.projectId]
+        )
+      ).rows
+    ).toHaveLength(2);
   });
 
   it('keeps null and legacy workflow versions isolated', async () => {
@@ -987,5 +1208,21 @@ describe('actual production launch service against PostgreSQL', () => {
        AND current_stage<>'READY_FOR_P2_RELEASE'`
     );
     expect(changed.rows).toHaveLength(0);
+  });
+
+  it('fails closed for an unknown workflow version in the real Quality service', async () => {
+    const id = '00000000-0000-4000-8000-000000000804';
+    await query(
+      `INSERT INTO projects
+       (id,project_code,project_name,customer_id,workflow_version,current_stage)
+       VALUES ($1,'UNKNOWN-V2','Unknown isolation','CERT-A','future_v9','IN_PRODUCTION')`,
+      [id]
+    );
+    await expect(createQualityReview(id, actor)).rejects.toBeInstanceOf(
+      ProjectQualityReleaseError
+    );
+    await expect(createQualityReview(id, actor)).rejects.toMatchObject({
+      code: 'UNKNOWN_WORKFLOW_VERSION',
+    });
   });
 });

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -40,7 +40,6 @@ import {
   decideQualityReview,
   getQualityDashboard,
   placeReleaseHold,
-  ProjectQualityReleaseError,
   releaseProductHold,
   releaseProduct,
   submitQualityReview,
@@ -1210,19 +1209,23 @@ describe('actual production launch service against PostgreSQL', () => {
     expect(changed.rows).toHaveLength(0);
   });
 
-  it('fails closed for an unknown workflow version in the real Quality service', async () => {
+  it('fails closed for an unknown workflow version at the database boundary', async () => {
     const id = '00000000-0000-4000-8000-000000000804';
-    await query(
-      `INSERT INTO projects
-       (id,project_code,project_name,customer_id,workflow_version,current_stage)
-       VALUES ($1,'UNKNOWN-V2','Unknown isolation','CERT-A','future_v9','IN_PRODUCTION')`,
-      [id]
-    );
-    await expect(createQualityReview(id, actor)).rejects.toBeInstanceOf(
-      ProjectQualityReleaseError
-    );
+    await expect(
+      query(
+        `INSERT INTO projects
+         (id,project_code,project_name,customer_id,workflow_version,current_stage)
+         VALUES ($1,'UNKNOWN-V2','Unknown isolation','CERT-A','future_v9','IN_PRODUCTION')`,
+        [id]
+      )
+    ).rejects.toMatchObject({
+      constraint: 'projects_workflow_version_check',
+    });
+    expect(
+      (await query(`SELECT id FROM projects WHERE id=$1`, [id])).rows
+    ).toHaveLength(0);
     await expect(createQualityReview(id, actor)).rejects.toMatchObject({
-      code: 'UNKNOWN_WORKFLOW_VERSION',
+      code: 'PROJECT_NOT_FOUND',
     });
   });
 });

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -965,6 +965,11 @@ describe('actual production launch service against PostgreSQL', () => {
       WHERE project_id=$1 AND step_type='production_quality'`,
       [fixture.projectId]
     );
+    const stage10Before = await query<{ status: string; updated_at: Date }>(
+      `SELECT status,updated_at FROM project_workflow_step_instances
+       WHERE project_id=$1 AND step_type='project_closing'`,
+      [fixture.projectId]
+    );
     const created = await createQualityReview(fixture.projectId, actor);
     expect(created.review?.status).toBe('IN_PROGRESS');
     let lock = Number(created.review?.lock_version);
@@ -1155,12 +1160,12 @@ describe('actual production launch service against PostgreSQL', () => {
       [fixture.projectId]
     );
     expect(stage.rows[0].status).toBe('COMPLETE');
-    const shippingStage = await query<{ status: string }>(
-      `SELECT status FROM project_workflow_step_instances
+    const shippingStage = await query<{ status: string; updated_at: Date }>(
+      `SELECT status,updated_at FROM project_workflow_step_instances
        WHERE project_id=$1 AND step_type='project_closing'`,
       [fixture.projectId]
     );
-    expect(shippingStage.rows[0].status).toBe('NOT_STARTED');
+    expect(shippingStage.rows).toEqual(stage10Before.rows);
     const shipmentCount = await query<{ count: number }>(
       `SELECT count(*)::int count FROM shipment_records WHERE po_numbers=$1`,
       [fixture.projectId]

--- a/server/__tests__/projectQualityRelease.test.ts
+++ b/server/__tests__/projectQualityRelease.test.ts
@@ -11,6 +11,7 @@ import {
 const root = path.resolve(__dirname, '../..');
 const read = (file: string) => readFileSync(path.join(root, file), 'utf8');
 const migration = read('migrations/0222_p2_v2_quality_product_release.sql');
+const hardening = read('migrations/0224_p2_v2_quality_release_hardening.sql');
 const service = read('server/src/services/projectQualityReleaseService.ts');
 const routes = read('server/src/routes/projectQualityRelease.ts');
 
@@ -131,6 +132,10 @@ describe('P2 V2 Quality and controlled Product Release', () => {
     expect(migration).toContain('project_product_release_holds');
     expect(migration).toContain('projects.quality_release.release_product');
     expect(routes).toContain('projects.quality_release.release_product');
+    expect(hardening).toContain('protect_product_release_identity');
+    expect(hardening).toContain(
+      'Product Release identity and evidence are immutable'
+    );
   });
 
   it('uses transactions, advisory serialization, idempotency and creates no shipment', () => {
@@ -138,6 +143,9 @@ describe('P2 V2 Quality and controlled Product Release', () => {
     expect(service).toContain('pg_advisory_xact_lock');
     expect(service).toContain('IDEMPOTENCY_CONFLICT');
     expect(service).toContain('shipmentCreated: false');
+    expect(service).toContain('submitQualityReview');
+    expect(service).toContain('completeQualityReview');
+    expect(service).toContain('CERTIFICATION_FORCED_ROLLBACK');
     expect(service).not.toMatch(/INSERT INTO (?:p2_)?shipments/i);
   });
 

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -250,6 +250,7 @@ export const safeMigrationFiles = [
   '0222_p2_v2_quality_product_release.sql',
   '0222_vendor_scope_approved_for.sql',
   '0223_project_production_launch_status_repair.sql',
+  '0224_p2_v2_quality_release_hardening.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -287,6 +288,7 @@ export const criticalMigrationFiles = new Set([
   '0222_p2_v2_quality_product_release.sql',
   '0222_vendor_scope_approved_for.sql',
   '0223_project_production_launch_status_repair.sql',
+  '0224_p2_v2_quality_release_hardening.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/projectQualityRelease.ts
+++ b/server/src/routes/projectQualityRelease.ts
@@ -4,12 +4,14 @@ import { z } from 'zod';
 import { getUserPermissions } from '../services/permissionService';
 import {
   createQualityReview,
+  completeQualityReview,
   decideQualityReview,
   getQualityDashboard,
   placeReleaseHold,
   ProjectQualityReleaseError,
   releaseProductHold,
   releaseProduct,
+  submitQualityReview,
 } from '../services/projectQualityReleaseService';
 import type { ProductionActor } from '../services/projectProductionExecutionService';
 
@@ -136,6 +138,20 @@ router.post('/reviews', async (req, res) => {
     fail(res, error);
   }
 });
+router.post('/reviews/current/submit', async (req, res) => {
+  try {
+    const body = expected.parse(req.body);
+    res.json(
+      await submitQualityReview(
+        id(req),
+        body.expectedLockVersion,
+        await authorized(req, 'projects.quality_release.manage')
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
 for (const [path, type, capability] of [
   ['quality', 'QUALITY', 'projects.quality_release.quality_decide'],
   ['operations', 'OPERATIONS', 'projects.quality_release.operations_decide'],
@@ -164,6 +180,20 @@ for (const [path, type, capability] of [
     }
   });
 }
+router.post('/reviews/current/complete', async (req, res) => {
+  try {
+    const body = expected.parse(req.body);
+    res.json(
+      await completeQualityReview(
+        id(req),
+        body.expectedLockVersion,
+        await authorized(req, 'projects.quality_release.manage')
+      )
+    );
+  } catch (error) {
+    fail(res, error);
+  }
+});
 router.post('/releases', async (req, res) => {
   try {
     const body = release.parse(req.body);

--- a/server/src/services/projectQualityReleaseService.ts
+++ b/server/src/services/projectQualityReleaseService.ts
@@ -251,7 +251,7 @@ export async function createQualityReview(
         production_plan_revision,wad_revision,configuration_baseline_id,effectivity_reference,
         evidence_snapshot,document_manifest,blockers,warnings,created_by,created_by_display_name)
       VALUES (${projectId},${model.ctx.instance.id},${model.ctx.qualityStep.id},${model.ctx.productionReview.id},
-        ${revision},${model.readiness.state},${model.ctx.productionReview.revision_number},
+        ${revision},${model.readiness.blockers.length ? 'BLOCKED' : 'IN_PROGRESS'},${model.ctx.productionReview.revision_number},
         ${model.ctx.productionReview.production_plan_revision},${model.ctx.productionReview.wad_revision},
         ${model.ctx.productionReview.configuration_baseline_id},${model.ctx.productionReview.effectivity_reference},
         ${JSON.stringify({ items: model.items, ncrs: model.ncrs, production: model.production })}::jsonb,
@@ -280,6 +280,56 @@ export async function createQualityReview(
   });
 }
 
+export async function submitQualityReview(
+  projectId: string,
+  expectedLockVersion: number,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const model = await evidence(projectId, tx);
+    if (
+      !model.review ||
+      !['IN_PROGRESS', 'BLOCKED'].includes(model.review.status)
+    )
+      throw new ProjectQualityReleaseError(
+        'QUALITY_REVIEW_NOT_SUBMITTABLE',
+        'A current in-progress Quality review is required.',
+        409
+      );
+    if (Number(model.review.lock_version) !== expectedLockVersion)
+      throw new ProjectQualityReleaseError(
+        'STALE_WRITE',
+        'The Quality review is stale.',
+        409
+      );
+    if (model.readiness.blockers.length)
+      throw new ProjectQualityReleaseError(
+        'QUALITY_READINESS_BLOCKED',
+        'Quality evidence blockers must be resolved before submission.',
+        409,
+        { blockers: model.readiness.blockers }
+      );
+    await tx.execute(sql`UPDATE project_quality_reviews
+      SET status='READY_FOR_REVIEW',submitted_at=now(),lock_version=lock_version+1,
+        evidence_snapshot=${JSON.stringify({ items: model.items, ncrs: model.ncrs, production: model.production })}::jsonb,
+        document_manifest=${JSON.stringify(model.documentManifest)}::jsonb,
+        blockers='[]'::jsonb,updated_at=now()
+      WHERE id=${model.review.id} AND lock_version=${expectedLockVersion}`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_QUALITY_REVIEW_SUBMITTED',
+        subjectType: 'project_quality_review',
+        subjectId: model.review.id,
+        sourceService: 'projectQualityReleaseService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: { projectId, revision: model.review.revision_number },
+      },
+      tx
+    );
+    return getQualityDashboard(projectId, tx);
+  });
+}
+
 export async function decideQualityReview(
   projectId: string,
   expectedLockVersion: number,
@@ -295,6 +345,12 @@ export async function decideQualityReview(
       throw new ProjectQualityReleaseError(
         'QUALITY_REVIEW_REQUIRED',
         'Create a Quality review first.',
+        409
+      );
+    if (model.review.status !== 'READY_FOR_REVIEW')
+      throw new ProjectQualityReleaseError(
+        'QUALITY_REVIEW_NOT_PENDING_APPROVAL',
+        'Submit the Quality review before recording approvals.',
         409
       );
     if (Number(model.review.lock_version) !== expectedLockVersion)
@@ -313,21 +369,67 @@ export async function decideQualityReview(
       signature_meaning=EXCLUDED.signature_meaning,reason=EXCLUDED.reason,
       actor_user_id=EXCLUDED.actor_user_id,actor_employee_id=EXCLUDED.actor_employee_id,
       actor_display_name=EXCLUDED.actor_display_name,actor_role=EXCLUDED.actor_role,decided_at=now()`);
-    const approvals = rows(
-      await tx.execute(
-        sql`SELECT approval_type,decision FROM project_quality_review_approvals WHERE quality_review_id=${model.review.id}`
-      )
-    );
-    const ready =
-      model.readiness.blockers.length === 0 &&
-      ['QUALITY', 'OPERATIONS', 'PROJECT_MANAGEMENT'].every((type) =>
-        approvals.some(
+    await tx.execute(sql`UPDATE project_quality_reviews
+      SET lock_version=lock_version+1,updated_at=now()
+      WHERE id=${model.review.id} AND lock_version=${expectedLockVersion}`);
+    return getQualityDashboard(projectId, tx);
+  });
+}
+
+export async function completeQualityReview(
+  projectId: string,
+  expectedLockVersion: number,
+  actor: ProductionActor
+) {
+  return db.transaction(async (tx) => {
+    const model = await evidence(projectId, tx);
+    if (!model.review || model.review.status !== 'READY_FOR_REVIEW')
+      throw new ProjectQualityReleaseError(
+        'QUALITY_REVIEW_NOT_PENDING_APPROVAL',
+        'A submitted Quality review is required.',
+        409
+      );
+    if (Number(model.review.lock_version) !== expectedLockVersion)
+      throw new ProjectQualityReleaseError(
+        'STALE_WRITE',
+        'The Quality review is stale.',
+        409
+      );
+    if (model.readiness.blockers.length)
+      throw new ProjectQualityReleaseError(
+        'QUALITY_EVIDENCE_STALE',
+        'Authoritative Quality evidence no longer supports release.',
+        409,
+        { blockers: model.readiness.blockers }
+      );
+    const missing = ['QUALITY', 'OPERATIONS', 'PROJECT_MANAGEMENT'].filter(
+      (type) =>
+        !model.approvals.some(
           (entry) =>
             entry.approval_type === type && entry.decision === 'APPROVED'
         )
+    );
+    if (missing.length)
+      throw new ProjectQualityReleaseError(
+        'QUALITY_APPROVALS_REQUIRED',
+        'All required functional approvals must be recorded.',
+        409,
+        { missingApprovals: missing }
       );
-    await tx.execute(sql`UPDATE project_quality_reviews SET status=${ready ? 'READY_FOR_RELEASE' : model.readiness.state},
-      lock_version=lock_version+1,updated_at=now() WHERE id=${model.review.id} AND lock_version=${expectedLockVersion}`);
+    await tx.execute(sql`UPDATE project_quality_reviews
+      SET status='READY_FOR_RELEASE',completed_at=now(),lock_version=lock_version+1,updated_at=now()
+      WHERE id=${model.review.id} AND lock_version=${expectedLockVersion}`);
+    await recordAuditEvent(
+      {
+        eventType: 'P2_V2_QUALITY_REVIEW_COMPLETED',
+        subjectType: 'project_quality_review',
+        subjectId: model.review.id,
+        sourceService: 'projectQualityReleaseService',
+        actor: { id: actor.userId, username: actor.username, role: actor.role },
+        payload: { projectId, revision: model.review.revision_number },
+      },
+      tx
+    );
     return getQualityDashboard(projectId, tx);
   });
 }
@@ -342,6 +444,7 @@ export type ReleaseInput = {
   serialNumbers: string[];
   batchLots: string[];
   signatureMeaning: string;
+  certificationFailurePoint?: 'AFTER_RELEASE' | 'AFTER_ALLOCATIONS';
 };
 
 export async function releaseProduct(
@@ -368,7 +471,10 @@ export async function releaseProduct(
         );
       return { release: prior, dashboard: model, idempotentReplay: true };
     }
-    if (!model.review || model.review.status !== 'READY_FOR_RELEASE')
+    if (
+      !model.review ||
+      !['READY_FOR_RELEASE', 'PARTIALLY_RELEASED'].includes(model.review.status)
+    )
       throw new ProjectQualityReleaseError(
         'READY_FOR_RELEASE_REQUIRED',
         'The Quality review is not READY_FOR_RELEASE.',
@@ -423,6 +529,15 @@ export async function releaseProduct(
       ${JSON.stringify(model.documentManifest)}::jsonb,${input.signatureMeaning},${actor.userId},
       ${actor.employeeId ?? null},${actor.displayName},${actor.role},${input.idempotencyKey},${requestHash}) RETURNING *`)
     )[0];
+    if (
+      input.certificationFailurePoint === 'AFTER_RELEASE' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectQualityReleaseError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after release insert.',
+        409
+      );
     for (const serial of input.serialNumbers)
       await tx.execute(sql`INSERT INTO project_product_release_allocations(
       product_release_id,project_id,po_line_id,part_number,serial_number,quantity)
@@ -432,8 +547,28 @@ export async function releaseProduct(
       product_release_id,project_id,po_line_id,part_number,batch_lot,quantity)
       VALUES(${release.id},${projectId},${input.poLineId ?? null},${input.partNumber},${batch},
       ${input.quantity / Math.max(1, input.batchLots.length)})`);
-    await tx.execute(sql`UPDATE project_quality_reviews SET status='PARTIALLY_RELEASED',
+    if (
+      input.certificationFailurePoint === 'AFTER_ALLOCATIONS' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectQualityReleaseError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after allocation insert.',
+        409
+      );
+    const remainingQuantity = Math.max(
+      0,
+      model.readiness.eligibleQuantity - input.quantity
+    );
+    const reviewStatus =
+      remainingQuantity === 0 ? 'COMPLETE' : 'PARTIALLY_RELEASED';
+    await tx.execute(sql`UPDATE project_quality_reviews SET status=${reviewStatus},
       lock_version=lock_version+1,updated_at=now() WHERE id=${model.review.id}`);
+    if (reviewStatus === 'COMPLETE')
+      await tx.execute(sql`UPDATE project_workflow_step_instances
+        SET status='COMPLETE',completed_at=now(),completed_by=${actor.userId},
+          completed_by_display_name=${actor.displayName},updated_at=now()
+        WHERE id=${model.ctx.qualityStep.id} AND status='IN_PROGRESS'`);
     await recordAuditEvent(
       {
         eventType: 'P2_V2_PRODUCT_RELEASED',
@@ -448,6 +583,8 @@ export async function releaseProduct(
           serialNumbers: input.serialNumbers,
           batchLots: input.batchLots,
           shipmentCreated: false,
+          remainingQuantity,
+          stage9Complete: reviewStatus === 'COMPLETE',
         },
       },
       tx

--- a/server/src/services/projectQualityReleaseService.ts
+++ b/server/src/services/projectQualityReleaseService.ts
@@ -259,7 +259,8 @@ export async function createQualityReview(
         '[]'::jsonb,${actor.userId},${actor.displayName}) RETURNING *`)
     )[0];
     await tx.execute(sql`UPDATE project_workflow_step_instances SET status='IN_PROGRESS',started_at=COALESCE(started_at,now()),
-      updated_at=now() WHERE id=${model.ctx.qualityStep.id} AND status='NOT_STARTED'`);
+      updated_at=now() WHERE id=${model.ctx.qualityStep.id}
+        AND status IN ('NOT_STARTED','NOT_APPLICABLE')`);
     await recordAuditEvent(
       {
         eventType: 'P2_V2_QUALITY_REVIEW_CREATED',


### PR DESCRIPTION
Corrective follow-up for externally merged PR #1549. Repairs the stale launch-constraint certification assertion, adds additive migration 0224 to protect immutable Product Release identity, completes the real Quality review lifecycle (create, submit, functional decisions, complete), permits controlled partial releases through Stage 9 reconciliation, adds real-service rollback/concurrency/idempotency/hold certification, and supplies working Stage 9 UI controls for approvals, exact serial selection, release confirmation, and hold management. Product Release still creates no shipment, does not close the PO/project, does not modify Design Control, and does not enable Production Launch. Local validation: 41/41 focused server tests and 4/4 component tests passed; focused ESLint and diff checks passed. Repository-wide TypeScript exhausted both 2 GB and bounded 4 GB heaps and is reported as a validation limit.