### PR TITLE
Fix P2 oven/cure timer charge-code gates

### DIFF
--- a/server/__tests__/timerTraceability.test.ts
+++ b/server/__tests__/timerTraceability.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isOvenCureDepartmentName } from '../src/lib/timerTraceability';
+
+describe('isOvenCureDepartmentName', () => {
+  it.each(['Oven Cure', 'OVEN/CURE', 'Curing', 'Oven 1'])(
+    'identifies timer-managed traveler department %s',
+    (departmentName) => {
+      expect(isOvenCureDepartmentName(departmentName)).toBe(true);
+    },
+  );
+
+  it.each(['Layup', 'CNC', 'Final QC', null])(
+    'does not classify unrelated department %s as timer-managed',
+    (departmentName) => {
+      expect(isOvenCureDepartmentName(departmentName)).toBe(false);
+    },
+  );
+});

--- a/server/src/lib/timerTraceability.ts
+++ b/server/src/lib/timerTraceability.ts
@@ -1,3 +1,12 @@
+export function isOvenCureDepartmentName(departmentName?: string | null): boolean {
+  const department = (departmentName || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+  return /(^| )(oven|cure|curing)( |$)/.test(department);
+}
+
 export function isRoutingConnectedOvenCureRun(run: {
   departmentName?: string | null;
   travelerId?: string | null;
@@ -6,10 +15,5 @@ export function isRoutingConnectedOvenCureRun(run: {
 }): boolean {
   if (!run.travelerId && !run.travelerStepId && !run.travelerTaskId) return false;
 
-  const department = (run.departmentName || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
-    .trim();
-
-  return /(^| )(oven|cure|curing)( |$)/.test(department);
+  return isOvenCureDepartmentName(run.departmentName);
 }

--- a/server/src/routes/p2Traveler.ts
+++ b/server/src/routes/p2Traveler.ts
@@ -30,6 +30,7 @@ import { createEmployeeIdentitySnapshot } from '../../identity/userIdentity';
 import { buildChargeContextFromTraveler } from '../helpers/travelerBarcodeResolver';
 import { executeTravelerAutoPunch, type TravelerAutoPunchResult } from './timeClock';
 import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
+import { isOvenCureDepartmentName } from '../lib/timerTraceability';
 
 const router = Router();
 
@@ -2387,6 +2388,10 @@ router.post('/start-task', async (req: Request, res: Response) => {
 
     const departmentConfig = routing ? (routing.departmentConfig as any) : {};
     const config = departmentConfig?.[department] || {};
+    // Oven/Cure is a timer-managed routing operation. The linked production
+    // timer records its start/end timestamps and closes the traveler-visible
+    // cure log, so it is not a labor punch that requires a charge code.
+    const isTimerManagedOvenCure = isOvenCureDepartmentName(department);
 
     // BACKEND CERTIFICATION ENFORCEMENT - Critical for AS9100 compliance
     const certificationPartNumber =
@@ -2453,23 +2458,26 @@ router.post('/start-task', async (req: Request, res: Response) => {
     if (existingTask && existingTask.employeeId === parseInt(employeeId)) {
       // Task #188: also auto-switch the punch on resume so the operator's
       // active punch_ledger session is on the correct WAD/charge-code.
-      const resumedPunch = await runAutoPunchForP2Task({
-        travelerId: ensuredTravelerResult?.traveler?.id ?? null,
-        serialNumber: serializedItem.serialNumber,
-        partNumber: certificationPartNumber,
-        inventoryItemId: inventoryIdentity.inventoryItemId,
-        partRoutingId: routing?.id ?? serializedItem.partRoutingId ?? null,
-        internalPartNumber: inventoryIdentity.internalPartNumber,
-        serializedItemPartNumber: serializedItem.partNumber,
-        employeeId,
-        laborApprovalId: req.body?.laborApprovalId ? parseInt(req.body.laborApprovalId, 10) : null,
-        adminPtoOverride: req.body?.adminPtoOverride === true,
-        adminOverrideReason:
-          typeof req.body?.adminOverrideReason === 'string' ? req.body.adminOverrideReason.trim() : null,
-        user: req.user ?? null,
-        ip: req.ip ?? null,
-      });
-      if (!resumedPunch.ok) {
+      // Timer-managed Oven/Cure resumes do not create labor punches.
+      const resumedPunch = isTimerManagedOvenCure
+        ? null
+        : await runAutoPunchForP2Task({
+            travelerId: ensuredTravelerResult?.traveler?.id ?? null,
+            serialNumber: serializedItem.serialNumber,
+            partNumber: certificationPartNumber,
+            inventoryItemId: inventoryIdentity.inventoryItemId,
+            partRoutingId: routing?.id ?? serializedItem.partRoutingId ?? null,
+            internalPartNumber: inventoryIdentity.internalPartNumber,
+            serializedItemPartNumber: serializedItem.partNumber,
+            employeeId,
+            laborApprovalId: req.body?.laborApprovalId ? parseInt(req.body.laborApprovalId, 10) : null,
+            adminPtoOverride: req.body?.adminPtoOverride === true,
+            adminOverrideReason:
+              typeof req.body?.adminOverrideReason === 'string' ? req.body.adminOverrideReason.trim() : null,
+            user: req.user ?? null,
+            ip: req.ip ?? null,
+          });
+      if (resumedPunch && !resumedPunch.ok) {
         return res.status(resumedPunch.status).json(resumedPunch.body);
       }
 
@@ -2534,7 +2542,7 @@ router.post('/start-task', async (req: Request, res: Response) => {
         workTask: existingTask,
         resumed: true,
         message: 'Resumed existing task',
-        punch: resumedPunch.punch,
+        punch: resumedPunch?.punch ?? null,
       });
     }
 
@@ -2564,24 +2572,27 @@ router.post('/start-task', async (req: Request, res: Response) => {
     // charge-code activeness). Per Task #77, traveler punches default to
     // PENDING_APPROVAL. If a gate fails we return BEFORE inserting the
     // p2_work_tasks row so the operator is not "started" against an
-    // unauthorized charge code.
-    const startPunch = await runAutoPunchForP2Task({
-      travelerId: ensuredTravelerResult?.traveler?.id ?? null,
-      serialNumber: serializedItem.serialNumber,
-      partNumber: certificationPartNumber,
-      inventoryItemId: inventoryIdentity.inventoryItemId,
-      partRoutingId: routing?.id ?? serializedItem.partRoutingId ?? null,
-      internalPartNumber: inventoryIdentity.internalPartNumber,
-      serializedItemPartNumber: serializedItem.partNumber,
-      employeeId,
-      laborApprovalId: req.body?.laborApprovalId ? parseInt(req.body.laborApprovalId, 10) : null,
-      adminPtoOverride: req.body?.adminPtoOverride === true,
-      adminOverrideReason:
-        typeof req.body?.adminOverrideReason === 'string' ? req.body.adminOverrideReason.trim() : null,
-      user: req.user ?? null,
-      ip: req.ip ?? null,
-    });
-    if (!startPunch.ok) {
+    // unauthorized charge code. Timer-managed Oven/Cure steps intentionally
+    // skip the labor punch; their linked timer run owns elapsed-time evidence.
+    const startPunch = isTimerManagedOvenCure
+      ? null
+      : await runAutoPunchForP2Task({
+          travelerId: ensuredTravelerResult?.traveler?.id ?? null,
+          serialNumber: serializedItem.serialNumber,
+          partNumber: certificationPartNumber,
+          inventoryItemId: inventoryIdentity.inventoryItemId,
+          partRoutingId: routing?.id ?? serializedItem.partRoutingId ?? null,
+          internalPartNumber: inventoryIdentity.internalPartNumber,
+          serializedItemPartNumber: serializedItem.partNumber,
+          employeeId,
+          laborApprovalId: req.body?.laborApprovalId ? parseInt(req.body.laborApprovalId, 10) : null,
+          adminPtoOverride: req.body?.adminPtoOverride === true,
+          adminOverrideReason:
+            typeof req.body?.adminOverrideReason === 'string' ? req.body.adminOverrideReason.trim() : null,
+          user: req.user ?? null,
+          ip: req.ip ?? null,
+        });
+    if (startPunch && !startPunch.ok) {
       return res.status(startPunch.status).json(startPunch.body);
     }
 
@@ -2601,12 +2612,15 @@ router.post('/start-task', async (req: Request, res: Response) => {
       employeeCode,
       employeeName,
       certificationId: certification.id,
-      travelerId: startPunch.chargeContext.travelerId ?? null,
-      travelerStepId: startPunch.entry?.travelerStepId ?? null,
-      productionWorkOrderId: startPunch.entry?.productionWorkOrderId ?? null,
-      projectId: startPunch.entry?.projectId ?? null,
-      chargeCodeId: startPunch.entry?.chargeCodeId ?? null,
-      operationName: startPunch.chargeContext.operation ?? department,
+      travelerId: startPunch?.chargeContext.travelerId ?? ensuredTravelerResult?.traveler?.id ?? null,
+      travelerStepId: startPunch?.entry?.travelerStepId ?? null,
+      productionWorkOrderId:
+        startPunch?.entry?.productionWorkOrderId ??
+        ensuredTravelerResult?.traveler?.productionWorkOrderId ??
+        null,
+      projectId: startPunch?.entry?.projectId ?? null,
+      chargeCodeId: startPunch?.entry?.chargeCodeId ?? null,
+      operationName: startPunch?.chargeContext.operation ?? department,
       electronicSignoffRequired: true,
       electronicSignoffStatus: 'PENDING',
       status: 'IN_PROGRESS',
@@ -2718,7 +2732,7 @@ router.post('/start-task', async (req: Request, res: Response) => {
       success: true,
       workTask,
       message: 'Task started successfully',
-      punch: startPunch.punch,
+      punch: startPunch?.punch ?? null,
     });
   } catch (error: any) {
     console.error('Error starting task:', error);


### PR DESCRIPTION
## What changed

- classify Oven/Cure routing departments through the shared timer traceability helper
- skip labor auto-punch and charge-code resolution for timer-managed Oven/Cure in both P2 startup paths:
  - `POST /api/p2-traveler/start-task`
  - `POST /api/travelers/:travelerId/steps/:stepId/start`
- avoid mutating an operator's open punch or switching labor allocation when a routed Oven/Cure step starts
- preserve traveler and production work-order linkage without creating labor allocation
- add focused coverage for Oven/Cure department-name classification

## Why

P2 traveler startup automatically switched the operator to a WAD labor charge code before opening or starting the production timer. The production console capture confirmed the routed-step endpoint still returned `CHARGE_CODE_UNRESOLVED` for department `Oven/Cure` after the first path was corrected.

Oven/Cure is timer-managed: the linked Timer Station run records item start/end timestamps and creates/closes the traveler-visible cure log. It must not require or overwrite labor charge-code attribution.

## Impact

Operators can start or resume Oven/Cure from either P2 production traveler path without a charge code. Certification, routing, traveler linkage, and timer-to-cure-log traceability remain intact. Other production departments continue using the existing charge-code labor-punch gates.

## Validation

- focused server test: 8/8 passed
- both P2 traveler route files transpiled successfully
- `git diff --check` passed
- repository-wide TypeScript check was attempted at 2 GB and 4 GB heaps but exhausted memory before producing type diagnostics