### PR TITLE
Fix mold settings save routes

### DIFF
--- a/client/src/components/MoldSettings.tsx
+++ b/client/src/components/MoldSettings.tsx
@@ -92,7 +92,7 @@ export function MoldSettings({ open, onOpenChange }: MoldSettingsProps) {
 
   const updateMoldMutation = useMutation({
     mutationFn: async ({ id, data }: { id: number; data: Partial<Mold> }) => {
-      return apiRequest(`/api/molds/${id}`, {
+      return apiRequest(`/api/layup-schedule/molds/${id}`, {
         method: 'PATCH',
         body: JSON.stringify(data),
       });
@@ -109,7 +109,7 @@ export function MoldSettings({ open, onOpenChange }: MoldSettingsProps) {
 
   const bulkUpdateMutation = useMutation({
     mutationFn: async ({ modelName, data }: { modelName: string; data: Partial<Mold> }) => {
-      return apiRequest('/api/molds/bulk/by-model', {
+      return apiRequest('/api/layup-schedule/molds/bulk/by-model', {
         method: 'PATCH',
         body: JSON.stringify({ modelName, ...data }),
       });


### PR DESCRIPTION
## Summary
- send individual mold saves to the mounted layup-schedule mold update route
- send bulk enable/disable changes to the corresponding mounted bulk route

## Root cause
Mold Settings sent `PATCH /api/molds/:id`, but the numeric-ID PATCH handler is mounted at `/api/layup-schedule/molds/:id`. Express returned `Cannot PATCH /api/molds/8` before the selected stock models reached the database. The bulk mutation used the same incorrect base path.

## User impact
Saving a mold's selected stock models and using Enable All or Disable All now reaches the existing server handlers instead of returning 404.

## Validation
- TypeScript `tsc --noEmit` passed before publishing the correction
- verified both PATCH route declarations and the `/api/layup-schedule` mount
- `git diff --check origin/main...HEAD`
- compare-range audit: one commit, one file, two route replacements