### PR TITLE
Repair production launch composite-key migration ordering

### DIFF
--- a/migrations/0226_project_production_launch_composite_key.sql
+++ b/migrations/0226_project_production_launch_composite_key.sql
@@ -1,0 +1,26 @@
+-- Make the composite project/launch identity an explicit table constraint.
+-- PostgreSQL accepts the pre-existing unique index as an FK target, but schema
+-- diff publishers may not order a standalone index ahead of the dependent FK.
+-- The named constraint exposes that dependency without changing any data.
+
+DO $$
+BEGIN
+  IF to_regclass('public.project_production_launches') IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'project_production_launches'::regclass
+      AND conname = 'project_production_launches_id_project_key'
+      AND contype = 'u'
+  ) THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS project_production_launches_id_project_key
+      ON project_production_launches(id, project_id);
+
+    ALTER TABLE project_production_launches
+      ADD CONSTRAINT project_production_launches_id_project_key
+      UNIQUE USING INDEX project_production_launches_id_project_key;
+  END IF;
+END $$;

--- a/server/__tests__/projectProductionLaunchCompositeKey.test.ts
+++ b/server/__tests__/projectProductionLaunchCompositeKey.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const migrationName = '0226_project_production_launch_composite_key.sql';
+const migration = fs.readFileSync(
+  path.join(root, 'migrations', migrationName),
+  'utf8',
+);
+const safeBoot = fs.readFileSync(
+  path.join(root, 'server/scripts/migrations/runSafeBootMigrations.ts'),
+  'utf8',
+);
+
+describe('project production launch composite key repair', () => {
+  it('creates the unique index before attaching the named constraint', () => {
+    const createIndexAt = migration.indexOf(
+      'CREATE UNIQUE INDEX IF NOT EXISTS project_production_launches_id_project_key',
+    );
+    const addConstraintAt = migration.indexOf(
+      'ADD CONSTRAINT project_production_launches_id_project_key',
+    );
+
+    expect(createIndexAt).toBeGreaterThan(-1);
+    expect(addConstraintAt).toBeGreaterThan(createIndexAt);
+    expect(migration).toContain(
+      'UNIQUE USING INDEX project_production_launches_id_project_key',
+    );
+  });
+
+  it('is idempotent and registered as a critical safe-boot migration', () => {
+    expect(migration).toContain(
+      "to_regclass('public.project_production_launches') IS NULL",
+    );
+    expect(migration).toContain('IF NOT EXISTS (');
+    expect(safeBoot.match(new RegExp(migrationName.replace('.', '\\.'), 'g'))).toHaveLength(2);
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -252,6 +252,7 @@ export const safeMigrationFiles = [
   '0223_project_production_launch_status_repair.sql',
   '0224_p2_v2_quality_release_hardening.sql',
   '0225_p2_v2_shipping_project_closeout.sql',
+  '0226_project_production_launch_composite_key.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -291,6 +292,7 @@ export const criticalMigrationFiles = new Set([
   '0223_project_production_launch_status_repair.sql',
   '0224_p2_v2_quality_release_hardening.sql',
   '0225_p2_v2_shipping_project_closeout.sql',
+  '0226_project_production_launch_composite_key.sql',
 ]);
 
 export async function runSafeBootMigrations() {


### PR DESCRIPTION
## Summary
- add an idempotent `0226` migration that exposes `(id, project_id)` on `project_production_launches` as a named `UNIQUE` constraint
- create the supporting unique index before attaching the constraint
- register the repair in both safe-boot and critical migration lists
- add focused static coverage for ordering, idempotency guards, and registration

## Root cause
The publishing schema-diff attempted to add the composite foreign key from `project_production_stage_reviews(production_launch_id, project_id)` before production had a recognized unique constraint on `project_production_launches(id, project_id)`. The original `0220` migration creates a valid standalone unique index first, but the external schema publisher did not preserve that file-level dependency order.

## Safety and impact
This migration is additive and does not copy, delete, or rewrite production data. `project_production_launches.id` is already a primary key, so the composite pair is inherently unique. The named constraint makes that prerequisite explicit to schema-diff tooling while preserving the same-project foreign-key integrity.

This is a schema deployment repair only; it does not add or change Phase 9 workflow behavior.

## Validation
- focused composite-key repair tests: 2/2 passed
- `git diff --cached --check` and compare-range diff check passed
- broader static suite: 7 unrelated static checks passed; one existing duplicate-`0222` prefix baseline failure
- database-backed migration tests were not run because no isolated `DATABASE_URL` is available in this worktree