### PR TITLE
Fix Mold Settings save contract

### DIFF
--- a/client/src/components/MoldSettings.tsx
+++ b/client/src/components/MoldSettings.tsx
@@ -43,6 +43,11 @@ interface StockModel {
   isActive: boolean;
 }
 
+interface UpdateMoldResponse {
+  success: true;
+  mold: Mold;
+}
+
 interface MoldSettingsProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -90,20 +95,27 @@ export function MoldSettings({ open, onOpenChange }: MoldSettingsProps) {
     enabled: open || addMoldOpen,
   });
 
-  const updateMoldMutation = useMutation({
+  const updateMoldMutation = useMutation<UpdateMoldResponse, Error, { id: number; data: Partial<Mold> }>({
     mutationFn: async ({ id, data }: { id: number; data: Partial<Mold> }) => {
       return apiRequest(`/api/layup-schedule/molds/${id}`, {
         method: 'PATCH',
         body: JSON.stringify(data),
       });
     },
-    onSuccess: () => {
+    onSuccess: ({ mold }) => {
+      queryClient.setQueryData<Mold[]>(['/api/molds'], (current) =>
+        current?.map((item) => (item.id === mold.id ? mold : item)),
+      );
       queryClient.invalidateQueries({ queryKey: ['/api/molds'] });
       toast({ title: 'Mold updated', description: 'Mold settings have been saved.' });
       setEditingMold(null);
     },
-    onError: (error: any) => {
-      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    onError: (error) => {
+      const message =
+        error.message && !error.message.trim().startsWith('<')
+          ? error.message
+          : 'Unable to save mold settings.';
+      toast({ title: 'Unable to save mold', description: message, variant: 'destructive' });
     },
   });
 
@@ -485,12 +497,23 @@ export function MoldSettings({ open, onOpenChange }: MoldSettingsProps) {
                                     disabled={updateMoldMutation.isPending}
                                     className="h-8 px-2"
                                   >
-                                    <Save className="w-3 h-3" />
+                                    {updateMoldMutation.isPending ? (
+                                      <>
+                                        <RefreshCw className="w-3 h-3 animate-spin" />
+                                        <span className="sr-only">Saving</span>
+                                      </>
+                                    ) : (
+                                      <>
+                                        <Save className="w-3 h-3" />
+                                        <span className="sr-only">Save mold</span>
+                                      </>
+                                    )}
                                   </Button>
                                   <Button
                                     size="sm"
                                     variant="outline"
                                     onClick={cancelEditing}
+                                    disabled={updateMoldMutation.isPending}
                                     className="h-8 px-2"
                                   >
                                     <X className="w-3 h-3" />

--- a/server/__tests__/moldSettingsUpdate.test.ts
+++ b/server/__tests__/moldSettingsUpdate.test.ts
@@ -1,0 +1,220 @@
+import express, { type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  db: {},
+  pool: { query: vi.fn() },
+}));
+
+import { authorizeApiRoute } from '../middleware/routeAuthorization';
+import { createUpdateMoldSettingsHandler } from '../src/routes/moldSettingsUpdate';
+
+type MoldRow = Record<string, unknown>;
+
+const originalRow: MoldRow = {
+  id: 2,
+  mold_id: 'MOLD-002',
+  model_name: 'Alpine',
+  stock_models: ['cf_alpine'],
+  instance_number: 3,
+  enabled: true,
+  multiplier: 2,
+  is_active: true,
+  created_at: new Date('2026-01-01T00:00:00.000Z'),
+  updated_at: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+function createDatabase(initialRows: MoldRow[] = [originalRow], validStockModels = ['cf_alpine', 'cf_privateer']) {
+  const rows = initialRows.map((row) => ({ ...row, stock_models: [...(row.stock_models as string[])] }));
+
+  const database = {
+    query: vi.fn(async (text: string, params: unknown[] = []) => {
+      if (text.startsWith('SELECT id FROM stock_models')) {
+        const requested = params[0] as string[];
+        return { rows: requested.filter((id) => validStockModels.includes(id)).map((id) => ({ id })) };
+      }
+
+      const id = params.at(-1);
+      const row = rows.find((candidate) => candidate.id === id);
+      if (!row) return { rows: [] };
+
+      const assignments = text.match(/SET ([\s\S]+?)\s+WHERE/)?.[1].split(',') ?? [];
+      assignments.forEach((assignment, index) => {
+        const column = assignment.trim().split(/\s*=\s*/)[0];
+        if (column !== 'updated_at') row[column] = params[index - 1];
+      });
+      row.updated_at = new Date('2026-07-28T00:00:00.000Z');
+      return { rows: [{ ...row }] };
+    }),
+  };
+
+  return { database, rows };
+}
+
+function createApp(
+  database: ReturnType<typeof createDatabase>['database'],
+  user: { id: number; username: string; role: string } | null = {
+    id: 1,
+    username: 'admin',
+    role: 'ADMIN',
+  },
+) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    if (user) req.user = user as Request['user'];
+    next();
+  });
+  app.patch(
+    '/api/layup-schedule/molds/:id',
+    authorizeApiRoute(['/department-queue/production-queue']),
+    createUpdateMoldSettingsHandler(database),
+  );
+  return app;
+}
+
+describe('PATCH /api/layup-schedule/molds/:id', () => {
+  it('updates an existing mold with a valid stock model and returns the canonical API shape', async () => {
+    const { database } = createDatabase();
+    const response = await request(createApp(database))
+      .patch('/api/layup-schedule/molds/2')
+      .send({ stockModels: ['cf_privateer'] });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toMatch(/json/);
+    expect(response.body).toMatchObject({
+      success: true,
+      mold: {
+        id: 2,
+        moldId: 'MOLD-002',
+        stockModels: ['cf_privateer'],
+        instanceNumber: 3,
+      },
+    });
+  });
+
+  it('replaces an existing stock-model association', async () => {
+    const { database, rows } = createDatabase();
+    await request(createApp(database))
+      .patch('/api/layup-schedule/molds/2')
+      .send({ stockModels: ['cf_privateer'] })
+      .expect(200);
+
+    expect(rows[0].stock_models).toEqual(['cf_privateer']);
+  });
+
+  it('clears the association when stockModels is null', async () => {
+    const { database, rows } = createDatabase();
+    const response = await request(createApp(database))
+      .patch('/api/layup-schedule/molds/2')
+      .send({ stockModels: null })
+      .expect(200);
+
+    expect(rows[0].stock_models).toEqual([]);
+    expect(response.body.mold.stockModels).toEqual([]);
+  });
+
+  it('returns JSON 404 for a nonexistent mold', async () => {
+    const { database } = createDatabase([]);
+    const response = await request(createApp(database))
+      .patch('/api/layup-schedule/molds/999')
+      .send({ enabled: false });
+
+    expect(response.status).toBe(404);
+    expect(response.headers['content-type']).toMatch(/json/);
+    expect(response.body).toEqual({ success: false, error: 'Mold not found' });
+  });
+
+  it('rejects a nonexistent stock model without updating the mold', async () => {
+    const { database } = createDatabase();
+    const response = await request(createApp(database))
+      .patch('/api/layup-schedule/molds/2')
+      .send({ stockModels: ['missing_model'] });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ success: false, error: 'Stock model not found: missing_model' });
+    expect(database.query).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['abc', '2x', '0', '-1', '1.5'])('rejects malformed mold ID %s with JSON', async (id) => {
+    const { database } = createDatabase();
+    const response = await request(createApp(database))
+      .patch(`/api/layup-schedule/molds/${id}`)
+      .send({ enabled: false });
+
+    expect(response.status).toBe(400);
+    expect(response.headers['content-type']).toMatch(/json/);
+    expect(response.body.success).toBe(false);
+    expect(database.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthenticated user with JSON', async () => {
+    const { database } = createDatabase();
+    const response = await request(createApp(database, null))
+      .patch('/api/layup-schedule/molds/2')
+      .send({ enabled: false });
+
+    expect(response.status).toBe(401);
+    expect(response.headers['content-type']).toMatch(/json/);
+    expect(response.body).toEqual({ error: 'Authentication required' });
+    expect(database.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects an authenticated user without Mold Settings access with JSON', async () => {
+    const { database } = createDatabase();
+    const response = await request(
+      createApp(database, { id: 42, username: 'no_mold_access', role: 'EMPLOYEE' }),
+    )
+      .patch('/api/layup-schedule/molds/2')
+      .send({ enabled: false });
+
+    expect(response.status).toBe(403);
+    expect(response.headers['content-type']).toMatch(/json/);
+    expect(response.body).toMatchObject({ error: 'Access denied' });
+    expect(database.query).not.toHaveBeenCalled();
+  });
+
+  it('preserves unrelated mold fields omitted from the request', async () => {
+    const { database } = createDatabase();
+    const response = await request(createApp(database))
+      .patch('/api/layup-schedule/molds/2')
+      .send({ enabled: false })
+      .expect(200);
+
+    expect(response.body.mold).toMatchObject({
+      moldId: 'MOLD-002',
+      modelName: 'Alpine',
+      instanceNumber: 3,
+      multiplier: 2,
+      stockModels: ['cf_alpine'],
+      enabled: false,
+    });
+  });
+
+  it('rejects unsupported mold fields instead of silently accepting them', async () => {
+    const { database } = createDatabase();
+    const response = await request(createApp(database))
+      .patch('/api/layup-schedule/molds/2')
+      .send({ moldId: 'RENAMED' });
+
+    expect(response.status).toBe(400);
+    expect(response.headers['content-type']).toMatch(/json/);
+    expect(response.body.success).toBe(false);
+    expect(database.query).not.toHaveBeenCalled();
+  });
+
+  it('persists the updated association in the row used by mold reads', async () => {
+    const { database, rows } = createDatabase();
+    await request(createApp(database))
+      .patch('/api/layup-schedule/molds/2')
+      .send({ stockModels: ['cf_privateer'] })
+      .expect(200);
+
+    const readModel = {
+      ...rows[0],
+      stockModels: rows[0].stock_models,
+    };
+    expect(readModel.stockModels).toEqual(['cf_privateer']);
+  });
+});

--- a/server/src/routes/layupSchedule.ts
+++ b/server/src/routes/layupSchedule.ts
@@ -8,6 +8,8 @@ import { format, addDays, startOfWeek, getDay } from 'date-fns';
 import { deriveCanonicalMaterial } from '../utils/deriveCanonicalMaterial';
 import { parseP1POUnitOrderId } from '../utils/parseP1POUnitOrderId';
 import { isP1FlatTop } from '../utils/p1FlatTop';
+import { authorizeApiRoute } from '../../middleware/routeAuthorization';
+import { createUpdateMoldSettingsHandler } from './moldSettingsUpdate';
 
 function normalizeMaterial(raw: string): string {
   const lower = raw.toLowerCase().trim();
@@ -95,60 +97,12 @@ router.patch('/molds/bulk/by-model', async (req: Request, res: Response) => {
   }
 });
 
-// Update a mold's settings (enabled, multiplier, isActive)
-router.patch('/molds/:id', async (req: Request, res: Response) => {
-  try {
-    const { id } = req.params;
-    const { enabled, multiplier, isActive, stockModels: newStockModels } = req.body;
-    
-    console.log(`🔧 Updating mold id=${id} with:`, { enabled, multiplier, isActive, stockModels: newStockModels });
-    
-    // Build dynamic UPDATE query using raw SQL (Drizzle .returning() doesn't work with this DB)
-    const setClauses: string[] = ['updated_at = NOW()'];
-    const params: any[] = [];
-    let paramIndex = 1;
-    
-    if (typeof enabled === 'boolean') {
-      setClauses.push(`enabled = $${paramIndex++}`);
-      params.push(enabled);
-    }
-    if (typeof isActive === 'boolean') {
-      setClauses.push(`is_active = $${paramIndex++}`);
-      params.push(isActive);
-    }
-    if (typeof multiplier === 'number' && multiplier > 0) {
-      setClauses.push(`multiplier = $${paramIndex++}`);
-      params.push(multiplier);
-    }
-    if (Array.isArray(newStockModels)) {
-      setClauses.push(`stock_models = $${paramIndex++}`);
-      params.push(newStockModels);
-    }
-    
-    params.push(parseInt(id));
-    
-    const updateQuery = `
-      UPDATE molds 
-      SET ${setClauses.join(', ')} 
-      WHERE id = $${paramIndex}
-      RETURNING *
-    `;
-    
-    const result = await pool.query(updateQuery, params);
-    const rows = result?.rows || result || [];
-    
-    if (!Array.isArray(rows) || rows.length === 0) {
-      console.log(`❌ Mold id=${id} not found or update failed`);
-      return res.status(404).json({ success: false, error: 'Mold not found' });
-    }
-    
-    console.log(`✅ Updated mold ${id}:`, rows[0]);
-    res.json({ success: true, mold: rows[0] });
-  } catch (error: any) {
-    console.error('Error updating mold:', error);
-    res.status(500).json({ success: false, error: error.message });
-  }
-});
+// Update the editable Mold Settings fields by numeric database ID.
+router.patch(
+  '/molds/:id',
+  authorizeApiRoute(['/department-queue/production-queue']),
+  createUpdateMoldSettingsHandler(),
+);
 
 // Update a mold's stock_models
 router.patch('/molds/:moldId/stock-models', async (req: Request, res: Response) => {

--- a/server/src/routes/moldSettingsUpdate.ts
+++ b/server/src/routes/moldSettingsUpdate.ts
@@ -1,0 +1,117 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import { z } from 'zod';
+
+import { pool } from '../../db';
+
+type Queryable = {
+  query: (text: string, params?: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
+};
+
+const moldIdSchema = z.string().regex(/^[1-9]\d*$/, 'Mold ID must be a positive integer');
+
+const updateMoldSettingsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    isActive: z.boolean().optional(),
+    multiplier: z.number().int().positive('multiplier must be a positive integer').optional(),
+    stockModels: z.array(z.string().trim().min(1)).nullable().optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one supported mold field is required',
+  });
+
+function moldRowToApi(row: Record<string, unknown>) {
+  return {
+    id: row.id,
+    moldId: row.mold_id,
+    modelName: row.model_name,
+    stockModels: row.stock_models ?? [],
+    instanceNumber: row.instance_number,
+    enabled: row.enabled,
+    multiplier: row.multiplier,
+    isActive: row.is_active,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+export function createUpdateMoldSettingsHandler(database: Queryable = pool): RequestHandler {
+  return async (req: Request, res: Response, _next: NextFunction) => {
+    const idResult = moldIdSchema.safeParse(req.params.id);
+    if (!idResult.success) {
+      return res.status(400).json({ success: false, error: idResult.error.issues[0].message });
+    }
+
+    const bodyResult = updateMoldSettingsSchema.safeParse(req.body);
+    if (!bodyResult.success) {
+      const issue = bodyResult.error.issues[0];
+      const field = issue.path.length > 0 ? `${issue.path.join('.')}: ` : '';
+      return res.status(400).json({ success: false, error: `${field}${issue.message}` });
+    }
+
+    const update = bodyResult.data;
+    const requestedStockModels = update.stockModels === null ? [] : update.stockModels;
+
+    try {
+      if (requestedStockModels) {
+        const uniqueStockModels = [...new Set(requestedStockModels)];
+        if (uniqueStockModels.length !== requestedStockModels.length) {
+          return res.status(400).json({
+            success: false,
+            error: 'stockModels must not contain duplicate IDs',
+          });
+        }
+
+        if (uniqueStockModels.length > 0) {
+          const stockModelResult = await database.query(
+            'SELECT id FROM stock_models WHERE id = ANY($1::text[])',
+            [uniqueStockModels],
+          );
+          const existingIds = new Set(stockModelResult.rows.map((row) => String(row.id)));
+          const missingIds = uniqueStockModels.filter((stockModelId) => !existingIds.has(stockModelId));
+          if (missingIds.length > 0) {
+            return res.status(400).json({
+              success: false,
+              error: `Stock model not found: ${missingIds.join(', ')}`,
+            });
+          }
+        }
+      }
+
+      const setClauses: string[] = ['updated_at = NOW()'];
+      const params: unknown[] = [];
+      const addValue = (column: string, value: unknown, cast = '') => {
+        params.push(value);
+        setClauses.push(`${column} = $${params.length}${cast}`);
+      };
+
+      if (update.enabled !== undefined) addValue('enabled', update.enabled);
+      if (update.isActive !== undefined) addValue('is_active', update.isActive);
+      if (update.multiplier !== undefined) addValue('multiplier', update.multiplier);
+      if (requestedStockModels !== undefined) {
+        addValue('stock_models', requestedStockModels, '::text[]');
+      }
+
+      params.push(Number(idResult.data));
+      const result = await database.query(
+        `UPDATE molds
+         SET ${setClauses.join(', ')}
+         WHERE id = $${params.length}
+         RETURNING *`,
+        params,
+      );
+
+      if (result.rows.length === 0) {
+        return res.status(404).json({ success: false, error: 'Mold not found' });
+      }
+
+      return res.json({ success: true, mold: moldRowToApi(result.rows[0]) });
+    } catch (error) {
+      console.error('Error updating mold settings:', error);
+      return res.status(500).json({
+        success: false,
+        error: 'Failed to update mold settings',
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- harden the existing `PATCH /api/layup-schedule/molds/:id` endpoint instead of adding a duplicate route
- validate numeric mold IDs, supported fields, stock-model IDs, null clearing, and not-found cases
- enforce Mold Settings route authorization and return canonical JSON responses
- refresh the frontend mold cache after a successful save and show a non-repeatable pending state
- add regression coverage for update, replace, clear, malformed/missing IDs, authorization, JSON errors, field preservation, and persisted reads

## Root cause

Mold Settings previously called the unsupported `PATCH /api/molds/:id` path. The correct handler is mounted under `/api/layup-schedule`, and the existing handler also lacked strict validation and stock-model existence checks.

## Validation

- focused Mold Settings regression suite: 15/15 passed
- production Vite build: passed (6,331 modules transformed)
- `git diff --cached --check`: passed
- repository-wide TypeScript check remains red on the existing unrelated baseline; the focused suite and production build pass

## Migration

None required.