### PR TITLE
Add P2 V2 ten-stage integration certification

### DIFF
--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -16,6 +16,7 @@ on:
       - 'server/src/routes/projectShippingCloseout.ts'
       - 'server/storage.ts'
       - 'server/__tests__/p2V2PostgresCertification.test.ts'
+      - 'client/src/__tests__/P2V2*.component.test.tsx'
       - 'package.json'
       - 'package-lock.json'
 
@@ -97,4 +98,32 @@ jobs:
           npx vitest run
           --config vitest.config.server.ts
           server/__tests__/p2V2PostgresCertification.test.ts
+          --reporter=verbose
+
+      - name: Run Phase 1-9 focused server regressions
+        run: >-
+          npx vitest run
+          --config vitest.config.server.ts
+          server/__tests__/projectCommercialReview.test.ts
+          server/__tests__/projectTechnicalConfigurationReview.test.ts
+          server/__tests__/projectProductionPlanning.test.ts
+          server/__tests__/projectWadAuthorization.test.ts
+          server/__tests__/projectPreproductionReadiness.test.ts
+          server/__tests__/projectProductionExecution.test.ts
+          server/__tests__/projectQualityRelease.test.ts
+          server/__tests__/projectShippingCloseout.test.ts
+          server/__tests__/p2V2ProductionLaunchFeatureGate.test.ts
+          --reporter=verbose
+
+      - name: Run P2 V2 ten-stage component regressions
+        run: >-
+          npx vitest run
+          --config vitest.config.client.ts
+          client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+          client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+          client/src/__tests__/P2V2WadAuthorization.component.test.tsx
+          client/src/__tests__/P2V2PreproductionReadiness.component.test.tsx
+          client/src/__tests__/P2V2ProductionExecution.component.test.tsx
+          client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
+          client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
           --reporter=verbose

--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -4,24 +4,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import P2V2ProjectWorkflow from '../components/projects/P2V2ProjectWorkflow';
 
-const stages = Array.from({ length: 10 }, (_, index) => ({
+const stageDefinitions = [
+  ['rfq_risk_assessment', 'RFQ & Risk Assessment'],
+  ['estimate_quote', 'Estimate & Quote'],
+  ['contract_review', 'Contract Review'],
+  ['technical_configuration_review', 'Technical & Configuration Review'],
+  ['production_planning', 'Production Planning'],
+  ['wad_authorization', 'WAD Authorization'],
+  ['preproduction_release', 'Preproduction & Production Release'],
+  ['production_quality', 'Production Execution'],
+  ['final_release_shipping', 'Quality & Product Release'],
+  ['project_closing', 'Shipping, Delivery & Project Closing'],
+] as const;
+
+const stages = stageDefinitions.map(([stepType, label], index) => ({
   id: `step-${index + 1}`,
-  stepType:
-    index === 0
-      ? 'rfq_risk_assessment'
-      : index === 1
-        ? 'estimate_quote'
-        : index === 2
-          ? 'contract_review'
-          : index === 3
-            ? 'technical_configuration_review'
-            : index === 4
-              ? 'production_planning'
-              : index === 5
-                ? 'wad_authorization'
-                : `stage_${index + 1}`,
+  stepType,
   stepOrder: index + 1,
-  label: `Stage ${index + 1}`,
+  label,
   description: `Description ${index + 1}`,
   status: index === 0 ? 'BLOCKED' : 'NOT_STARTED',
   applicability: 'REQUIRED',
@@ -113,6 +113,8 @@ describe('P2V2ProjectWorkflow', () => {
       await screen.findByText('P2 Project Workflow V2')
     ).toBeInTheDocument();
     expect(screen.getAllByTestId(/^v2-stage-\d+$/)).toHaveLength(10);
+    for (const [, label] of stageDefinitions)
+      expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.getByTestId('v2-integrity-warning')).toHaveTextContent(
       'Example integrity problem'
     );
@@ -121,6 +123,9 @@ describe('P2V2ProjectWorkflow', () => {
     );
     expect(screen.getByText('BLOCKED')).toBeInTheDocument();
     for (const forbidden of [
+      'Design Control',
+      'ECR',
+      'ECN',
       'Start',
       'Mark Complete',
       'Skip',

--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -94,7 +94,15 @@ const initialized = {
 function renderWorkflow(response: object) {
   vi.stubGlobal(
     'fetch',
-    vi.fn().mockResolvedValue({ ok: true, json: async () => response })
+    vi.fn().mockImplementation(async (input: RequestInfo | URL) =>
+      String(input).endsWith('/workflow-v2')
+        ? { ok: true, json: async () => response }
+        : {
+            ok: false,
+            status: 404,
+            json: async () => ({ message: 'Endpoint not mocked in summary test' }),
+          }
+    )
   );
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },

--- a/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+++ b/client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
@@ -86,6 +86,8 @@ const initialized = {
   blockedStages: 1,
   pendingApprovalStages: 0,
   percentComplete: 0,
+  requiredApprovals: [],
+  approvals: [],
   stages,
 };
 

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -760,6 +760,7 @@ async function createFixture(
       'ENGINEERING',
       'QUALITY',
       'OPERATIONS',
+      'SUPPLY_CHAIN',
     ].entries()) {
       await decidePreproduction(
         projectId,
@@ -780,7 +781,7 @@ async function createFixture(
     await completePreproduction(
       projectId,
       readinessId,
-      readinessLockVersion + 5,
+      readinessLockVersion + 6,
       actor
     );
     const release = await approveProductionRelease(projectId, actor);

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -615,9 +615,9 @@ async function createFixture(
             special_process_source,packaging_instruction_requirement,notes)
          VALUES ($1,$2,$3,$4,$5,$6,$7,$12,$13,$8,$9,
                  CASE WHEN $13 THEN 'A' ELSE NULL END,
-                 CASE WHEN $13 THEN 'RELEASED' ELSE 'NOT_APPLICABLE' END,
+                 CASE WHEN $13 THEN 'RELEASED' ELSE 'NOT_REQUIRED_APPROVED' END,
                  $10,CASE WHEN $13 THEN '1' ELSE NULL END,
-                 CASE WHEN $13 THEN 'RELEASED' ELSE 'NOT_APPLICABLE' END,
+                 CASE WHEN $13 THEN 'RELEASED' ELSE 'NOT_REQUIRED_APPROVED' END,
                  'CFG-A','DWG-CERT','A',
                  'REQUIRED','REQUIRED','INDIVIDUAL',
                  'DRAWING_SPEC_SUFFICIENT','Released drawing','REQUIRED',

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -362,6 +362,26 @@ async function createFixture(
        VALUES ($1,'A',true) RETURNING id`,
       [bomChild.rows[0].id]
     );
+    const bomLayup = await client.query<{ id: string }>(
+      `INSERT INTO boms(parent_part_ag_number,code,is_active)
+       VALUES ($1,$2,true) RETURNING id`,
+      [`LAYUP-${suffix}`, `BOM-LAYUP-${suffix}`]
+    );
+    const bomLayupRevision = await client.query<{ id: string }>(
+      `INSERT INTO bom_revisions(bom_id,rev_code,is_released)
+       VALUES ($1,'A',true) RETURNING id`,
+      [bomLayup.rows[0].id]
+    );
+    const bomCutting = await client.query<{ id: string }>(
+      `INSERT INTO boms(parent_part_ag_number,code,is_active)
+       VALUES ($1,$2,true) RETURNING id`,
+      [`CUT-${suffix}`, `BOM-CUT-${suffix}`]
+    );
+    const bomCuttingRevision = await client.query<{ id: string }>(
+      `INSERT INTO bom_revisions(bom_id,rev_code,is_released)
+       VALUES ($1,'A',true) RETURNING id`,
+      [bomCutting.rows[0].id]
+    );
     await client.query(
       `INSERT INTO bom_lines(revision_id,child_part_ag_number,qty_per)
        VALUES ($1,$2,2)`,
@@ -567,8 +587,8 @@ async function createFixture(
         path: 'layup',
         parent: null,
         qty: 1,
-        bom: bomChild.rows[0].id,
-        revision: bomChildRevision.rows[0].id,
+        bom: bomLayup.rows[0].id,
+        revision: bomLayupRevision.rows[0].id,
         routing: layupRouting.rows[0].id,
         serial: false,
         makeBuy: 'MAKE',
@@ -580,8 +600,8 @@ async function createFixture(
         path: 'cutting',
         parent: null,
         qty: 1,
-        bom: bomChild.rows[0].id,
-        revision: bomChildRevision.rows[0].id,
+        bom: bomCutting.rows[0].id,
+        revision: bomCuttingRevision.rows[0].id,
         routing: cuttingRouting.rows[0].id,
         serial: false,
         makeBuy: 'MAKE',

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -1156,8 +1156,9 @@ describe('actual production launch service against PostgreSQL', () => {
       certifiedStageOrder
     );
     expect(
-      lifecycle.rows.slice(0, 8).every((entry) => entry.status === 'COMPLETE')
+      lifecycle.rows.slice(0, 7).every((entry) => entry.status === 'COMPLETE')
     ).toBe(true);
+    expect(lifecycle.rows[7].status).toBe('IN_PROGRESS');
     const launch = await query<{
       production_evidence: Record<string, unknown>;
     }>(

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -217,10 +217,10 @@ async function createFixture(
     await client.query(
       `INSERT INTO p2_purchase_order_items
          (po_id,inventory_item_id,part_number,part_name,quantity,specifications)
-       SELECT $1,id,ag_part_number,name,1,$3
+       SELECT $1::integer,id,ag_part_number,name,1,$3
        FROM inventory_items WHERE ag_part_number=$2
        UNION ALL
-       SELECT $1,id,ag_part_number,name,1,$4
+       SELECT $1::integer,id,ag_part_number,name,1,$4
        FROM inventory_items WHERE ag_part_number=$2`,
       [
         poId,

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -193,7 +193,7 @@ async function createFixture(
          ($1,'Parent Assembly','Manufactured','MANUFACTURED','ASSEMBLY','FINAL','Assembly'),
          ($2,'Machined Child','Manufactured','MANUFACTURED','MACHINED_PART','COMPONENT','CNC'),
          ($3,'Layup Detail','Manufactured','MANUFACTURED','COMPOSITE','COMPONENT','Layup'),
-         ($4,'Cut Detail','Manufactured','MANUFACTURED','CUT_PART','COMPONENT','Cutting Table'),
+         ($4,'Cut Detail','Manufactured','MANUFACTURED','COMPONENT','COMPONENT','Cutting Table'),
          ($5,'Purchased Hardware','Purchased','PURCHASED',NULL,'COMPONENT',NULL)
        ON CONFLICT (ag_part_number) DO NOTHING`,
       [

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -11,12 +11,18 @@ import {
 } from '../scripts/migrations/runSafeBootMigrations';
 import { isP2V2ProductionLaunchEnabled } from '../src/lib/featureFlags';
 import {
+  completeCommercialReview,
   createCommercialReview,
+  decideCommercialReview,
+  submitCommercialReview,
   type CommercialActor,
   type CommercialStage,
 } from '../src/services/projectCommercialReviewService';
 import {
+  completeTechnicalConfigurationReview,
   createTechnicalConfigurationReview,
+  decideTechnicalConfigurationReview,
+  submitTechnicalConfigurationReview,
   type TechnicalReviewActor,
 } from '../src/services/projectTechnicalConfigurationReviewService';
 import {
@@ -83,6 +89,18 @@ const actor: CommercialActor & TechnicalReviewActor = {
   role: 'ADMIN',
 };
 const baseProjectId = '00000000-0000-4000-8000-000000000801';
+const certifiedStageOrder = [
+  'rfq_risk_assessment',
+  'estimate_quote',
+  'contract_review',
+  'technical_configuration_review',
+  'production_planning',
+  'wad_authorization',
+  'preproduction_release',
+  'production_quality',
+  'final_release_shipping',
+  'project_closing',
+];
 
 type Fixture = {
   projectId: string;
@@ -102,23 +120,53 @@ async function query<T extends Record<string, unknown>>(
   return pool.query<T>(text, values);
 }
 
-async function markStageComplete(
+const certificationActor = (
+  userId: number,
+  role: string
+): CommercialActor & TechnicalReviewActor => ({
+  ...actor,
+  userId,
+  employeeId: userId,
+  username: `phase10-certifier-${userId}`,
+  displayName: `Phase 10 Certifier ${userId}`,
+  role,
+});
+
+async function certifyCommercialStage(
   projectId: string,
   stage: CommercialStage,
-  reviewId: string
+  review: { id: string; lock_version: number | string }
 ) {
-  await query(
-    `UPDATE project_commercial_stage_reviews
-       SET status='COMPLETE', sufficiently_defined=true,
-           differences_resolved=true, completed_at=now()
-     WHERE id=$1`,
-    [reviewId]
+  let model = await submitCommercialReview(
+    projectId,
+    stage,
+    review.id,
+    Number(review.lock_version),
+    actor
   );
-  await query(
-    `UPDATE project_workflow_step_instances
-       SET status='COMPLETE', completed_at=now()
-     WHERE project_id=$1 AND step_type=$2`,
-    [projectId, stage]
+  const roles =
+    stage === 'contract_review'
+      ? ['PROJECT_MANAGEMENT', 'ENGINEERING', 'QUALITY', 'OPERATIONS']
+      : ['PROJECT_MANAGEMENT'];
+  for (const [index, role] of roles.entries()) {
+    model = await decideCommercialReview(
+      projectId,
+      stage,
+      review.id,
+      Number(model.review.lock_version),
+      role as 'PROJECT_MANAGEMENT' | 'ENGINEERING' | 'QUALITY' | 'OPERATIONS',
+      'APPROVED',
+      `${role} approves the controlled ${stage} baseline`,
+      '',
+      certificationActor(9101 + index, role)
+    );
+  }
+  return completeCommercialReview(
+    projectId,
+    stage,
+    review.id,
+    Number(model.review.lock_version),
+    actor
   );
 }
 
@@ -143,9 +191,18 @@ async function createFixture(
           manufacturing_level,manufacturing_department)
          VALUES
          ($1,'Parent Assembly','Manufactured','MANUFACTURED','ASSEMBLY','FINAL','Assembly'),
-         ($2,'Machined Child','Manufactured','MANUFACTURED','MACHINED_PART','COMPONENT','CNC')
+         ($2,'Machined Child','Manufactured','MANUFACTURED','MACHINED_PART','COMPONENT','CNC'),
+         ($3,'Layup Detail','Manufactured','MANUFACTURED','COMPOSITE','COMPONENT','Layup'),
+         ($4,'Cut Detail','Manufactured','MANUFACTURED','CUT_PART','COMPONENT','Cutting Table'),
+         ($5,'Purchased Hardware','Purchased','PURCHASED',NULL,'COMPONENT',NULL)
        ON CONFLICT (ag_part_number) DO NOTHING`,
-      [`PARENT-${suffix}`, `CHILD-${suffix}`]
+      [
+        `PARENT-${suffix}`,
+        `CHILD-${suffix}`,
+        `LAYUP-${suffix}`,
+        `CUT-${suffix}`,
+        `BUY-${suffix}`,
+      ]
     );
     const po = await client.query<{ id: number }>(
       `INSERT INTO p2_purchase_orders
@@ -160,9 +217,17 @@ async function createFixture(
     await client.query(
       `INSERT INTO p2_purchase_order_items
          (po_id,inventory_item_id,part_number,part_name,quantity,specifications)
-       SELECT $1,id,ag_part_number,name,2,'Released configuration'
+       SELECT $1,id,ag_part_number,name,1,$3
+       FROM inventory_items WHERE ag_part_number=$2
+       UNION ALL
+       SELECT $1,id,ag_part_number,name,1,$4
        FROM inventory_items WHERE ag_part_number=$2`,
-      [poId, `PARENT-${suffix}`]
+      [
+        poId,
+        `PARENT-${suffix}`,
+        'Customer PO line 1 - released configuration',
+        'Customer PO line 2 - released configuration',
+      ]
     );
     await client.query(
       `INSERT INTO projects
@@ -326,6 +391,24 @@ async function createFixture(
        RETURNING id`,
       [projectId, `CHILD-${suffix}`, routingTemplate.rows[0].id]
     );
+    const layupRouting = await client.query<{ id: string }>(
+      `INSERT INTO part_routings
+         (inventory_item_id,project_id,part_number,part_name,department_sequence,
+          traceability_config,created_from_template_id,created_by)
+       VALUES ((SELECT id::text FROM inventory_items WHERE ag_part_number=$2),
+               $1,$2,'Layup Detail','["Layup"]','{}',$3,'phase10')
+       RETURNING id`,
+      [projectId, `LAYUP-${suffix}`, routingTemplate.rows[0].id]
+    );
+    const cuttingRouting = await client.query<{ id: string }>(
+      `INSERT INTO part_routings
+         (inventory_item_id,project_id,part_number,part_name,department_sequence,
+          traceability_config,created_from_template_id,created_by)
+       VALUES ((SELECT id::text FROM inventory_items WHERE ag_part_number=$2),
+               $1,$2,'Cut Detail','["Cutting Table"]','{}',$3,'phase10')
+       RETURNING id`,
+      [projectId, `CUT-${suffix}`, routingTemplate.rows[0].id]
+    );
     await client.query('COMMIT');
 
     const rfqReview = await createCommercialReview(
@@ -344,10 +427,10 @@ async function createFixture(
       },
       actor
     );
-    await markStageComplete(
+    await certifyCommercialStage(
       projectId,
       'rfq_risk_assessment',
-      rfqReview.review.id
+      rfqReview.review
     );
     const quoteReview = await createCommercialReview(
       projectId,
@@ -362,7 +445,11 @@ async function createFixture(
       },
       actor
     );
-    await markStageComplete(projectId, 'estimate_quote', quoteReview.review.id);
+    await certifyCommercialStage(
+      projectId,
+      'estimate_quote',
+      quoteReview.review
+    );
     const contractReview = await createCommercialReview(
       projectId,
       'contract_review',
@@ -375,10 +462,10 @@ async function createFixture(
       },
       actor
     );
-    await markStageComplete(
+    await certifyCommercialStage(
       projectId,
       'contract_review',
-      contractReview.review.id
+      contractReview.review
     );
     const technical = await createTechnicalConfigurationReview(
       projectId,
@@ -398,15 +485,34 @@ async function createFixture(
       },
       actor
     );
-    await query(
-      `UPDATE project_technical_configuration_reviews
-         SET status='COMPLETE',completed_at=now() WHERE id=$1`,
-      [technical.review.id]
+    let technicalModel = await submitTechnicalConfigurationReview(
+      projectId,
+      technical.review.id,
+      Number(technical.review.lock_version),
+      actor
     );
-    await query(
-      `UPDATE project_workflow_step_instances SET status='COMPLETE'
-         WHERE id=$1`,
-      [steps.technical_configuration_review]
+    for (const [index, role] of [
+      'PROJECT_MANAGEMENT',
+      'ENGINEERING',
+      'QUALITY',
+      'OPERATIONS',
+    ].entries()) {
+      technicalModel = await decideTechnicalConfigurationReview(
+        projectId,
+        technical.review.id,
+        Number(technicalModel.review.lock_version),
+        role as 'PROJECT_MANAGEMENT' | 'ENGINEERING' | 'QUALITY' | 'OPERATIONS',
+        'APPROVED',
+        `${role} approves the controlled technical baseline`,
+        '',
+        certificationActor(9101 + index, role)
+      );
+    }
+    await completeTechnicalConfigurationReview(
+      projectId,
+      technical.review.id,
+      Number(technicalModel.review.lock_version),
+      actor
     );
     const configurationRevision = `Technical Review 1:${technical.review.source_revision}`;
     const plan = await query<{ id: string }>(
@@ -439,6 +545,8 @@ async function createFixture(
         revision: bomParentRevision.rows[0].id,
         routing: parentRouting.rows[0].id,
         serial: true,
+        makeBuy: 'MAKE',
+        manufactured: true,
       },
       {
         part: `CHILD-${suffix}`,
@@ -450,6 +558,47 @@ async function createFixture(
         revision: bomChildRevision.rows[0].id,
         routing: childRouting.rows[0].id,
         serial: false,
+        makeBuy: 'MAKE',
+        manufactured: true,
+      },
+      {
+        part: `LAYUP-${suffix}`,
+        name: 'Layup Detail',
+        path: 'layup',
+        parent: null,
+        qty: 1,
+        bom: bomChild.rows[0].id,
+        revision: bomChildRevision.rows[0].id,
+        routing: layupRouting.rows[0].id,
+        serial: false,
+        makeBuy: 'MAKE',
+        manufactured: true,
+      },
+      {
+        part: `CUT-${suffix}`,
+        name: 'Cut Detail',
+        path: 'cutting',
+        parent: null,
+        qty: 1,
+        bom: bomChild.rows[0].id,
+        revision: bomChildRevision.rows[0].id,
+        routing: cuttingRouting.rows[0].id,
+        serial: false,
+        makeBuy: 'MAKE',
+        manufactured: true,
+      },
+      {
+        part: `BUY-${suffix}`,
+        name: 'Purchased Hardware',
+        path: 'purchased',
+        parent: null,
+        qty: 1,
+        bom: null,
+        revision: null,
+        routing: null,
+        serial: false,
+        makeBuy: 'BUY',
+        manufactured: false,
       },
     ]) {
       await query(
@@ -464,8 +613,12 @@ async function createFixture(
             inspection_requirement,inspection_extent,fai_requirement,fai_reason,
             traceability_level,serialization_required,lot_traceability_required,
             special_process_source,packaging_instruction_requirement,notes)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,'MAKE',true,$8,$9,'A','RELEASED',
-                 $10,'1','RELEASED','CFG-A','DWG-CERT','A',
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$12,$13,$8,$9,
+                 CASE WHEN $13 THEN 'A' ELSE NULL END,
+                 CASE WHEN $13 THEN 'RELEASED' ELSE 'NOT_APPLICABLE' END,
+                 $10,CASE WHEN $13 THEN '1' ELSE NULL END,
+                 CASE WHEN $13 THEN 'RELEASED' ELSE 'NOT_APPLICABLE' END,
+                 'CFG-A','DWG-CERT','A',
                  'REQUIRED','REQUIRED','INDIVIDUAL',
                  'DRAWING_SPEC_SUFFICIENT','Released drawing','REQUIRED',
                  'IN_PROCESS_AND_FINAL','NOT_REQUIRED','Certification fixture',
@@ -483,6 +636,8 @@ async function createFixture(
           item.revision,
           item.routing,
           item.serial,
+          item.makeBuy,
+          item.manufactured,
         ]
       );
     }
@@ -668,7 +823,7 @@ afterAll(async () => {
   await pool.end();
 });
 
-describe('Phase 8 migration certification', () => {
+describe('Phase 10A ten-stage migration certification', () => {
   it('uses deterministic safe-boot order, checksum, and critical 0212 migration', () => {
     expect(new Set(safeMigrationFiles).size).toBe(safeMigrationFiles.length);
     expect(
@@ -692,6 +847,22 @@ describe('Phase 8 migration certification', () => {
     expect(
       criticalMigrationFiles.has('0225_p2_v2_shipping_project_closeout.sql')
     ).toBe(true);
+    for (const migration of [
+      '0199_project_workflow_version.sql',
+      '0202_project_workflow_instances.sql',
+      '0204_project_production_plans.sql',
+      '0205_project_wad_authorizations.sql',
+      '0206_project_commercial_stage_reviews.sql',
+      '0209_project_technical_configuration_reviews.sql',
+      '0210_project_preproduction_readiness.sql',
+      '0212_project_preproduction_launch_safety.sql',
+      '0220_p2_v2_production_execution.sql',
+      '0222_p2_v2_quality_product_release.sql',
+      '0224_p2_v2_quality_release_hardening.sql',
+      '0225_p2_v2_shipping_project_closeout.sql',
+      '0226_project_production_launch_composite_key.sql',
+    ])
+      expect(safeMigrationFiles).toContain(migration);
     const migration = readFileSync(
       path.resolve('migrations/0210_project_preproduction_readiness.sql')
     );
@@ -924,7 +1095,7 @@ describe('actual production launch service against PostgreSQL', () => {
       po_status: 'IN_PRODUCTION',
       production_status: 'IN_PROGRESS',
       serials: 2,
-      orders: 6,
+      orders: 8,
       launches: 1,
     });
     const orders = await query<{
@@ -939,8 +1110,27 @@ describe('actual production launch service against PostgreSQL', () => {
     );
     expect(orders.rows).toEqual([
       { sku: 'CHILD-A', department: 'CNC', count: 4 },
+      { sku: 'CUT-A', department: 'Cutting Table', count: 1 },
+      { sku: 'LAYUP-A', department: 'Layup', count: 1 },
       { sku: 'PARENT-A', department: 'Assembly', count: 2 },
     ]);
+    expect(orders.rows.some((entry) => entry.sku === 'BUY-A')).toBe(false);
+    const lifecycle = await query<{
+      step_type: string;
+      step_order: number;
+      status: string;
+    }>(
+      `SELECT step_type,step_order,status
+       FROM project_workflow_step_instances
+       WHERE project_id=$1 ORDER BY step_order`,
+      [fixture.projectId]
+    );
+    expect(lifecycle.rows.map((entry) => entry.step_type)).toEqual(
+      certifiedStageOrder
+    );
+    expect(
+      lifecycle.rows.slice(0, 8).every((entry) => entry.status === 'COMPLETE')
+    ).toBe(true);
     const launch = await query<{
       production_evidence: Record<string, unknown>;
     }>(
@@ -967,7 +1157,7 @@ describe('actual production launch service against PostgreSQL', () => {
 
   it('aggregates launched authoritative records without duplicating execution data', async () => {
     const dashboard = await getProductionDashboard(baseProjectId);
-    expect(dashboard.productionOrders).toHaveLength(6);
+    expect(dashboard.productionOrders).toHaveLength(8);
     expect(dashboard.serializedItems).toHaveLength(2);
     expect(dashboard.readiness.state).toBe('BLOCKED');
     expect(dashboard.deferrals).toEqual({
@@ -978,7 +1168,7 @@ describe('actual production launch service against PostgreSQL', () => {
     const created = await createCompletionReview(baseProjectId, actor);
     expect(created.review?.revision_number).toBe(1);
     expect(created.review?.status).toBe('BLOCKED');
-    expect(created.productionOrders).toHaveLength(6);
+    expect(created.productionOrders).toHaveLength(8);
   });
 
   it('executes the complete real Quality lifecycle, partial release, concurrency, rollback and hold controls', async () => {

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -384,8 +384,14 @@ async function createFixture(
     );
     await client.query(
       `INSERT INTO bom_lines(revision_id,child_part_ag_number,qty_per)
-       VALUES ($1,$2,2)`,
-      [bomParentRevision.rows[0].id, `CHILD-${suffix}`]
+       VALUES ($1,$2,2),($1,$3,1),($1,$4,1),($1,$5,1)`,
+      [
+        bomParentRevision.rows[0].id,
+        `CHILD-${suffix}`,
+        `LAYUP-${suffix}`,
+        `CUT-${suffix}`,
+        `BUY-${suffix}`,
+      ]
     );
     const routingTemplate = await client.query<{ id: string }>(
       `INSERT INTO production_control_templates
@@ -586,7 +592,7 @@ async function createFixture(
         name: 'Layup Detail',
         path: 'layup',
         parent: null,
-        qty: 1,
+        qty: 2,
         bom: bomLayup.rows[0].id,
         revision: bomLayupRevision.rows[0].id,
         routing: layupRouting.rows[0].id,
@@ -599,7 +605,7 @@ async function createFixture(
         name: 'Cut Detail',
         path: 'cutting',
         parent: null,
-        qty: 1,
+        qty: 2,
         bom: bomCutting.rows[0].id,
         revision: bomCuttingRevision.rows[0].id,
         routing: cuttingRouting.rows[0].id,
@@ -612,7 +618,7 @@ async function createFixture(
         name: 'Purchased Hardware',
         path: 'purchased',
         parent: null,
-        qty: 1,
+        qty: 2,
         bom: null,
         revision: null,
         routing: null,
@@ -1116,7 +1122,7 @@ describe('actual production launch service against PostgreSQL', () => {
       po_status: 'IN_PRODUCTION',
       production_status: 'IN_PROGRESS',
       serials: 2,
-      orders: 8,
+      orders: 10,
       launches: 1,
     });
     const orders = await query<{
@@ -1131,8 +1137,8 @@ describe('actual production launch service against PostgreSQL', () => {
     );
     expect(orders.rows).toEqual([
       { sku: 'CHILD-A', department: 'CNC', count: 4 },
-      { sku: 'CUT-A', department: 'Cutting Table', count: 1 },
-      { sku: 'LAYUP-A', department: 'Layup', count: 1 },
+      { sku: 'CUT-A', department: 'Cutting Table', count: 2 },
+      { sku: 'LAYUP-A', department: 'Layup', count: 2 },
       { sku: 'PARENT-A', department: 'Assembly', count: 2 },
     ]);
     expect(orders.rows.some((entry) => entry.sku === 'BUY-A')).toBe(false);
@@ -1178,7 +1184,7 @@ describe('actual production launch service against PostgreSQL', () => {
 
   it('aggregates launched authoritative records without duplicating execution data', async () => {
     const dashboard = await getProductionDashboard(baseProjectId);
-    expect(dashboard.productionOrders).toHaveLength(8);
+    expect(dashboard.productionOrders).toHaveLength(10);
     expect(dashboard.serializedItems).toHaveLength(2);
     expect(dashboard.readiness.state).toBe('BLOCKED');
     expect(dashboard.deferrals).toEqual({
@@ -1189,7 +1195,7 @@ describe('actual production launch service against PostgreSQL', () => {
     const created = await createCompletionReview(baseProjectId, actor);
     expect(created.review?.revision_number).toBe(1);
     expect(created.review?.status).toBe('BLOCKED');
-    expect(created.productionOrders).toHaveLength(8);
+    expect(created.productionOrders).toHaveLength(10);
   });
 
   it('executes the complete real Quality lifecycle, partial release, concurrency, rollback and hold controls', async () => {

--- a/server/__tests__/projectPreproductionReadiness.test.ts
+++ b/server/__tests__/projectPreproductionReadiness.test.ts
@@ -277,7 +277,7 @@ describe('Phase 8C integration safety contract', () => {
     expect(transaction).toContain('FOR SHARE OF ppi,pr,pct');
     expect(transaction).toContain('assertProductionCountsMatchPlan');
     expect(transaction).toMatch(
-      /generateP2ProductionOrders\(\s*poId,\s*undefined,\s*tx\s*\)/
+      /storage\.generateP2ProductionOrders\(\s*poId,\s*undefined,\s*tx\s*\)/
     );
     expect(transaction).toContain("step_type === 'production_quality'");
     expect(transaction).toContain("current_stage='IN_PRODUCTION'");

--- a/server/__tests__/projectPreproductionReadiness.test.ts
+++ b/server/__tests__/projectPreproductionReadiness.test.ts
@@ -276,8 +276,9 @@ describe('Phase 8C integration safety contract', () => {
     expect(transaction).toContain('RELEASED_ROUTING_STALE');
     expect(transaction).toContain('FOR SHARE OF ppi,pr,pct');
     expect(transaction).toContain('assertProductionCountsMatchPlan');
-    expect(transaction).toMatch(
-      /storage\.generateP2ProductionOrders\(\s*poId,\s*undefined,\s*tx\s*\)/
+    expect(transaction).toContain('storage.generateP2ProductionOrders(');
+    expect(transaction).toContain(
+      "() => dependencies.fault?.('AFTER_FIRST_PRODUCTION_ORDER')"
     );
     expect(transaction).toContain("step_type === 'production_quality'");
     expect(transaction).toContain("current_stage='IN_PRODUCTION'");

--- a/server/__tests__/projectPreproductionReadiness.test.ts
+++ b/server/__tests__/projectPreproductionReadiness.test.ts
@@ -255,7 +255,7 @@ describe('Phase 8C integration safety contract', () => {
 
   it('locks, revalidates, creates, activates Stage 8, and transitions inside one launch transaction', () => {
     const launch = service.slice(
-      service.indexOf('export async function launchProduction')
+      service.indexOf('async function launchProductionWithDependencies')
     );
     expect(launch.indexOf('isP2V2ProductionLaunchEnabled()')).toBeLessThan(
       launch.indexOf('db.transaction')
@@ -292,7 +292,7 @@ describe('Phase 8C integration safety contract', () => {
   it('keeps Production Release non-consequential and enforces launch through the gated service', () => {
     const release = service.slice(
       service.indexOf('export async function approveProductionRelease'),
-      service.indexOf('export async function launchProduction')
+      service.indexOf('async function launchProductionWithDependencies')
     );
     expect(release).not.toContain('addP2SerializedItemsForPoItem');
     expect(release).not.toContain('generateP2ProductionOrders');

--- a/server/__tests__/projectTechnicalConfigurationReview.test.ts
+++ b/server/__tests__/projectTechnicalConfigurationReview.test.ts
@@ -54,6 +54,13 @@ describe('Phase 8B technical and configuration review boundaries', () => {
     expect(service).toContain(
       'Required technical information remains missing.'
     );
+    expect(service).toContain('sourceRequirementsByPart');
+    expect(service).toContain(
+      '(sourceRequirementsByPart.get(partNumber) ?? 0) + Number(item.quantity)'
+    );
+    expect(service).toContain(
+      'Number(captured.quantity) !== sourceQuantity'
+    );
   });
 
   it('uses manufacturing functions, conditional Supply Chain, and segregation of duties', () => {

--- a/server/src/services/projectTechnicalConfigurationReviewService.ts
+++ b/server/src/services/projectTechnicalConfigurationReviewService.ts
@@ -380,8 +380,15 @@ async function readiness(projectId: string, review: Row | null, tx: Executor) {
   if (!clean(review.effectivity_reference))
     blockers.push('Delivery/configuration effectivity is required.');
   const requirements = review.technical_baseline?.partRequirements ?? [];
+  const sourceRequirementsByPart = new Map<string, number>();
   for (const item of source.items) {
     const partNumber = clean(item.ag_part_number) || clean(item.part_number);
+    sourceRequirementsByPart.set(
+      partNumber,
+      (sourceRequirementsByPart.get(partNumber) ?? 0) + Number(item.quantity)
+    );
+  }
+  for (const [partNumber, sourceQuantity] of sourceRequirementsByPart) {
     const captured = requirements.find(
       (entry: Row) => clean(entry.partNumber) === partNumber
     );
@@ -389,7 +396,7 @@ async function readiness(projectId: string, review: Row | null, tx: Executor) {
       blockers.push(`${partNumber}: technical part requirement is missing.`);
       continue;
     }
-    if (Number(captured.quantity) !== Number(item.quantity))
+    if (Number(captured.quantity) !== sourceQuantity)
       blockers.push(
         `${partNumber}: reviewed quantity does not match the customer PO.`
       );


### PR DESCRIPTION
## Summary

- upgrades the disposable PostgreSQL 16 certification from the Phase 8/9 seam to the complete ten-stage p2_v2 customer-PO lifecycle
- drives RFQ, quote, contract review, and technical/configuration completion through their production submission, approval, segregation-of-duties, audit, and completion services
- expands the fixture to multiple customer PO lines plus Assembly-first, CNC, Layup, canonical Cutting Table, and purchased requirements
- proves purchased requirements do not create manufactured production orders
- adds the focused Phase 1-9 server and p2_v2 component regression suites to the certification workflow
- verifies the ordered customer-PO stage names and continued Design Control/ECR/ECN isolation in the UI

## Safety

- disposable job-local PostgreSQL 16.4 only
- no shared database migrations or real project, production, shipment, delivery, or closeout records
- p2_v2 creation remains disabled
- Production Launch remains deployment-disabled and is enabled only inside the disposable certification step
- no Phase 10B work

## Validation

- `git diff --check`
- `git diff --cached --check`
- PostgreSQL migration replay, schema-idempotency comparison, full lifecycle certification, focused server regressions, and component regressions run in GitHub Actions
- local Node checks were unavailable in the isolated worktree because project dependencies and `npm` were not installed; they are not reported as passes
