### PR TITLE
Fix P1 layup stock-model identity resolution

### DIFF
--- a/client/src/components/LayupSchedulePreview.tsx
+++ b/client/src/components/LayupSchedulePreview.tsx
@@ -12,6 +12,10 @@ interface ScheduledItem {
   orderId: string;
   fbOrderNumber: string;
   stockModel: string;
+  stockModelId?: string | null;
+  stockModelName?: string | null;
+  stockModelDisplayName?: string | null;
+  originalRef?: string | null;
   customerName: string;
   scheduledDate: string;
   moldId: string;
@@ -31,8 +35,19 @@ interface OverflowItem {
   orderId: string;
   fbOrderNumber: string;
   stockModel: string;
+  stockModelDisplayName?: string | null;
+  originalRef?: string | null;
+  errorCode?: 'STOCK_MODEL_UNRESOLVED' | 'NO_COMPATIBLE_MOLD' | 'NO_AVAILABLE_CAPACITY';
   customerName: string;
   reason: string;
+}
+
+function stockModelLabel(item: {
+  stockModel: string;
+  stockModelDisplayName?: string | null;
+  originalRef?: string | null;
+}): string {
+  return item.stockModelDisplayName || item.stockModel || item.originalRef || 'Unresolved stock model';
 }
 
 interface LayupSchedulePreviewProps {
@@ -463,7 +478,7 @@ export function LayupSchedulePreview({
               </div>
               <div>
                 <div class="field-label">Stock Model</div>
-                <div class="field-value">${item.stockModel}</div>
+                <div class="field-value">${stockModelLabel(item)}</div>
               </div>
               <div>
                 <div class="field-label">Mold</div>
@@ -607,7 +622,7 @@ export function LayupSchedulePreview({
                       <TableRow key={idx}>
                         <TableCell className="font-mono text-sm">{item.orderId}</TableCell>
                         <TableCell>
-                          <Badge variant="outline">{item.stockModel}</Badge>
+                          <Badge variant="outline">{stockModelLabel(item)}</Badge>
                         </TableCell>
                         <TableCell className="font-medium">{item.moldId}</TableCell>
                         <TableCell className="text-sm">
@@ -686,7 +701,7 @@ export function LayupSchedulePreview({
                       </div>
                       <div>
                         <div className="layup-field-label">Stock Model</div>
-                        <div className="layup-field-value">{item.stockModel}</div>
+                        <div className="layup-field-value">{stockModelLabel(item)}</div>
                       </div>
                       <div>
                         <div className="layup-field-label">Mold</div>
@@ -770,7 +785,7 @@ export function LayupSchedulePreview({
                   <TableRow key={idx}>
                     <TableCell className="font-mono text-sm">{item.orderId}</TableCell>
                     <TableCell>
-                      <Badge variant="outline">{item.stockModel}</Badge>
+                      <Badge variant="outline">{stockModelLabel(item)}</Badge>
                     </TableCell>
                     <TableCell className="text-sm">{item.customerName}</TableCell>
                     <TableCell className="text-sm text-yellow-700">{item.reason}</TableCell>

--- a/server/__tests__/layupSchedulePOUnitParsing.test.ts
+++ b/server/__tests__/layupSchedulePOUnitParsing.test.ts
@@ -56,6 +56,33 @@ describe('layup schedule PO progression scope', () => {
     expect(route).toContain('eligible existing production unit(s) could be resolved');
   });
 
+  it('never treats production or PO line IDs as stock-model identity', () => {
+    expect(route).not.toContain('row.stock_model_id || row.item_id');
+    expect(route).not.toContain('{ source: \'production_orders.item_id\'');
+    expect(route).not.toContain('{ source: \'purchase_order_items.item_id\'');
+  });
+
+  it('uses one resolver for demand and mold entries and returns traceable preview fields', () => {
+    expect(route).toContain('new StockModelResolver(stockModelsList)');
+    expect(route).toContain('stockModelResolver.resolve(m.model_name)');
+    expect(route).toContain('stockModelResolver.resolve(originalRef?.value)');
+    expect(route).toContain('stockModelDisplayName: item.stockModelDisplayName');
+    expect(route).toContain('originalRef: item.originalRef');
+  });
+
+  it('distinguishes unresolved identity, incompatible molds, and exhausted capacity', () => {
+    expect(route).toContain("errorCode: 'STOCK_MODEL_UNRESOLVED'");
+    expect(route).toContain("errorCode: 'NO_COMPATIBLE_MOLD'");
+    expect(route).toContain("errorCode: 'NO_AVAILABLE_CAPACITY'");
+  });
+
+  it('preserves snake-case and camel-case action length and inlet fields', () => {
+    expect(route).toContain('features.action_length || features.actionLength');
+    expect(route).toContain('features.action_inlet || features.actionInlet');
+    expect(route).toContain('specifications.action_length || specifications.actionLength');
+    expect(route).toContain('specifications.action_inlet || specifications.actionInlet');
+  });
+
   it('replaces only matching schedule rows so a repeated save is idempotent', () => {
     expect(route).toContain('DELETE FROM layup_schedule');
     expect(route).toContain('WHERE order_id = ANY($1::text[])');

--- a/server/__tests__/p1PODemandUiBoundary.test.ts
+++ b/server/__tests__/p1PODemandUiBoundary.test.ts
@@ -31,8 +31,8 @@ describe('P1 PO demand and production progression boundary', () => {
   it('shows Generate Schedule for regular, PO-only, and mixed selections', () => {
     const source = readFileSync(componentPath, 'utf8');
 
-    expect(source).toContain(
-      "selectedQueueOrders.size > 0 ||\n                  Array.from(selectedPOItems.values()).some"
+    expect(source).toMatch(
+      /selectedQueueOrders\.size > 0\s*\|\|\s*Array\.from\(selectedPOItems\.values\(\)\)\.some/,
     );
     expect(source).toContain('Generate Schedule');
   });

--- a/server/__tests__/p1POQueueHelper.test.ts
+++ b/server/__tests__/p1POQueueHelper.test.ts
@@ -358,4 +358,22 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     const result = computeP1Queue([], new Map(), []);
     expect(result).toHaveLength(0);
   });
+
+  it('prefers purchase_order_items.stock_model_id over specification labels', () => {
+    const po = makePO();
+    const item = makeItem({
+      stockModelId: '84',
+      specifications: { stockModel: 'stale-label' },
+    });
+    const result = computeP1Queue(
+      [po],
+      new Map([[po.id, [item]]]),
+      [makeProdRow({ production_status: 'PENDING', current_department: 'P1 Production Queue' })],
+    );
+
+    expect(result[0].purchaseOrders[0].items[0]).toMatchObject({
+      stockModel: '84',
+      stockModelId: '84',
+    });
+  });
 });

--- a/server/__tests__/stockModelResolver.test.ts
+++ b/server/__tests__/stockModelResolver.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  firstStockModelReference,
+  StockModelResolver,
+} from '../src/helpers/stockModelResolver';
+
+const records = [
+  { id: '71', name: 'fixture_model_alpha', displayName: 'Fixture Model Alpha' },
+  { id: '84', name: 'fixture_model_beta', displayName: 'Fixture Model Beta' },
+  { id: '85', name: 'mesa_universal', displayName: 'Mesa Universal' },
+  { id: '86', name: 'adj_gladius', displayName: 'Adjustable Gladius' },
+];
+
+describe('StockModelResolver', () => {
+  const resolver = new StockModelResolver(records);
+
+  it.each(records)('resolves numeric fixture ID $id to its verified fixture record', record => {
+    expect(resolver.resolve(record.id)).toEqual({
+      ...record,
+      canonicalKey: record.name,
+    });
+  });
+
+  it('resolves canonical internal names and normalized display names', () => {
+    expect(resolver.resolve('mesa_universal')?.id).toBe('85');
+    expect(resolver.resolve('Mesa-Universal')?.id).toBe('85');
+  });
+
+  it('uses approved aliases only when they identify one model', () => {
+    expect(resolver.resolve('cf_adj_gladius')?.id).toBe('86');
+  });
+
+  it('does not use broad substring matching', () => {
+    expect(resolver.resolve('mesa')).toBeNull();
+    expect(resolver.resolve('universal')).toBeNull();
+  });
+
+  it('refuses an ambiguous normalized display name', () => {
+    const ambiguous = new StockModelResolver([
+      ...records,
+      { id: '87', name: 'fixture_duplicate_one', displayName: 'Fixture Duplicate' },
+      { id: '88', name: 'fixture_duplicate_two', displayName: 'Fixture Duplicate' },
+    ]);
+    expect(ambiguous.resolve('Fixture Duplicate')).toBeNull();
+  });
+
+  it('matches demand and mold entries through the same resolved identity', () => {
+    const demand = resolver.resolve('85')!;
+    const mold = resolver.resolve('Mesa Universal')!;
+    expect(resolver.areCompatible(demand, mold)).toBe(true);
+  });
+});
+
+describe('firstStockModelReference', () => {
+  it('honors authoritative field priority and never substitutes a PO item ID', () => {
+    expect(firstStockModelReference([
+      { source: 'purchase_order_items.stock_model_id', value: '84' },
+      { source: 'production_orders.specifications.stockModel', value: 'fixture_model_alpha' },
+    ])).toEqual({
+      source: 'purchase_order_items.stock_model_id',
+      value: '84',
+    });
+  });
+
+  it('returns null when authoritative model fields are empty', () => {
+    expect(firstStockModelReference([
+      { source: 'purchase_order_items.stock_model_id', value: null },
+      { source: 'specifications.stockModel', value: '' },
+    ])).toBeNull();
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -7990,6 +7990,7 @@ export interface P1POQueueItem {
   poNumber: string;
   productName: string;
   stockModel: string | null;
+  stockModelId?: string | null;
   specifications: Record<string, any> | null;
   actionLength: string | null;
   material: string | null;

--- a/server/src/helpers/p1POQueueHelper.ts
+++ b/server/src/helpers/p1POQueueHelper.ts
@@ -118,6 +118,8 @@ export interface RawPurchaseOrderItem {
   notes: string | null;
   productionNotes: string | null;
   dueDate?: Date | string | null;
+  stockModelId?: string | null;
+  stockModelName?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -159,8 +161,10 @@ export function computeP1Queue(
       .map((item) => {
         const specs = (item.specifications as Record<string, unknown>) || {};
         const stockModel =
+          item.stockModelId ??
           (specs.stockModel as string | null) ??
           (specs.stock_model as string | null) ??
+          item.stockModelName ??
           null;
         const fulfillmentStats = itemFulfillmentMap.get(item.id);
         // This is the operational P1 queue, so selectable quantity means exact
@@ -174,6 +178,7 @@ export function computeP1Queue(
           poNumber: po.poNumber,
           productName: item.itemName ?? '',
           stockModel,
+          stockModelId: item.stockModelId ?? null,
           specifications:
             specs && Object.keys(specs).length > 0 ? specs : null,
           itemType: item.itemType ?? null,

--- a/server/src/helpers/stockModelResolver.ts
+++ b/server/src/helpers/stockModelResolver.ts
@@ -1,0 +1,129 @@
+export interface StockModelRecord {
+  id: string;
+  name: string;
+  displayName: string;
+}
+
+export interface ResolvedStockModel {
+  id: string;
+  name: string;
+  displayName: string;
+  canonicalKey: string;
+}
+
+const APPROVED_ALIASES: Record<string, string[]> = {
+  adjustable_gladius: [
+    'adj_amor',
+    'adj_gladius',
+    'adjustable_amor',
+    'cf_adj_armor',
+    'cf_adj_gladius',
+    'fg_adj_armor',
+    'fg_adj_gladius',
+  ],
+  adjustable_alpine_hunter: [
+    'adj_alpine_hunter',
+    'adj_alpine',
+    'cf_adj_alp_hunter',
+    'cf_adj_alpine_hunter',
+    'cf_adj_alpine',
+    'fg_adj_alp_hunter',
+    'fg_adj_alpine_hunter',
+    'fg_adj_alpine',
+  ],
+  alpine_hunter: ['cf_alpine_hunter', 'fg_alpine_hunter'],
+};
+
+export function normalizeStockModelReference(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function approvedAliasKey(value: string): string | null {
+  const normalized = normalizeStockModelReference(value);
+  for (const [canonical, aliases] of Object.entries(APPROVED_ALIASES)) {
+    if (canonical === normalized || aliases.includes(normalized)) return canonical;
+  }
+  return null;
+}
+
+export class StockModelResolver {
+  private readonly models: ResolvedStockModel[];
+  private readonly byId = new Map<string, ResolvedStockModel>();
+  private readonly byName = new Map<string, ResolvedStockModel[]>();
+  private readonly byDisplayName = new Map<string, ResolvedStockModel[]>();
+  private readonly byAlias = new Map<string, ResolvedStockModel[]>();
+
+  constructor(records: StockModelRecord[]) {
+    this.models = records.map(record => ({
+      id: String(record.id),
+      name: record.name,
+      displayName: record.displayName,
+      canonicalKey: normalizeStockModelReference(record.name),
+    }));
+
+    for (const model of this.models) {
+      this.byId.set(model.id.trim().toLowerCase(), model);
+      this.add(this.byName, model.canonicalKey, model);
+      this.add(this.byDisplayName, normalizeStockModelReference(model.displayName), model);
+      const alias = approvedAliasKey(model.name);
+      if (alias) this.add(this.byAlias, alias, model);
+    }
+  }
+
+  resolve(reference: unknown): ResolvedStockModel | null {
+    const original = String(reference ?? '').trim();
+    if (!original) return null;
+
+    const idMatch = this.byId.get(original.toLowerCase());
+    if (idMatch) return idMatch;
+
+    const normalized = normalizeStockModelReference(original);
+    return (
+      this.unique(this.byName.get(normalized)) ??
+      this.unique(this.byAlias.get(approvedAliasKey(normalized) ?? '')) ??
+      this.unique(this.byDisplayName.get(normalized))
+    );
+  }
+
+  areCompatible(left: ResolvedStockModel, right: ResolvedStockModel): boolean {
+    if (left.id === right.id) return true;
+    if (left.canonicalKey === right.canonicalKey) return true;
+
+    const leftAlias = approvedAliasKey(left.name);
+    const rightAlias = approvedAliasKey(right.name);
+    if (leftAlias && leftAlias === rightAlias) return true;
+
+    return (
+      normalizeStockModelReference(left.displayName) ===
+      normalizeStockModelReference(right.displayName)
+    );
+  }
+
+  private add(
+    map: Map<string, ResolvedStockModel[]>,
+    key: string,
+    model: ResolvedStockModel,
+  ): void {
+    const matches = map.get(key) ?? [];
+    if (!matches.some(match => match.id === model.id)) matches.push(model);
+    map.set(key, matches);
+  }
+
+  private unique(matches: ResolvedStockModel[] | undefined): ResolvedStockModel | null {
+    return matches?.length === 1 ? matches[0] : null;
+  }
+}
+
+export function firstStockModelReference(
+  candidates: Array<{ source: string; value: unknown }>,
+): { source: string; value: string } | null {
+  for (const candidate of candidates) {
+    const value = String(candidate.value ?? '').trim();
+    if (value) return { source: candidate.source, value };
+  }
+  return null;
+}

--- a/server/src/routes/layupSchedule.ts
+++ b/server/src/routes/layupSchedule.ts
@@ -10,6 +10,10 @@ import { parseP1POUnitOrderId } from '../utils/parseP1POUnitOrderId';
 import { isP1FlatTop } from '../utils/p1FlatTop';
 import { authorizeApiRoute } from '../../middleware/routeAuthorization';
 import { createUpdateMoldSettingsHandler } from './moldSettingsUpdate';
+import {
+  firstStockModelReference,
+  StockModelResolver,
+} from '../helpers/stockModelResolver';
 
 function normalizeMaterial(raw: string): string {
   const lower = raw.toLowerCase().trim();
@@ -309,16 +313,14 @@ router.post('/generate', async (req: Request, res: Response) => {
     
     // Fetch stock models with display names for material detection
     const stockModelsList = await db.select({
+      id: stockModels.id,
       name: stockModels.name,
       displayName: stockModels.displayName,
     }).from(stockModels);
     
-    // Create a map of model name -> display name for quick lookup
-    const stockModelDisplayMap = new Map(
-      stockModelsList.map(m => [m.name, m.displayName || ''])
-    );
+    const stockModelResolver = new StockModelResolver(stockModelsList);
     
-    console.log(`📦 Loaded ${stockModelDisplayMap.size} stock models for material detection`);
+    console.log(`📦 Loaded ${stockModelsList.length} stock models for identity resolution`);
     
     // Fetch ALL molds (don't filter by enabled status since database has them disabled)
     // Use pool.query for proper PostgreSQL array handling (rawSql/Neon driver returns empty arrays)
@@ -338,18 +340,29 @@ router.post('/generate', async (req: Request, res: Response) => {
     }
     
     // Parse stock_models from PostgreSQL array format "{a,b,c}" to JavaScript array
-    const activeMolds = rawMolds.map((m: any) => ({
-      id: m.id,
-      moldId: m.mold_id,
-      modelName: m.model_name,
-      stockModels: typeof m.stock_models === 'string' 
+    const activeMolds = rawMolds.map((m: any) => {
+      const moldStockModelRefs = typeof m.stock_models === 'string'
         ? m.stock_models.replace(/^\{|\}$/g, '').split(',').filter((s: string) => s.length > 0)
-        : (Array.isArray(m.stock_models) ? m.stock_models : []),
-      instanceNumber: m.instance_number,
-      enabled: m.enabled,
-      multiplier: m.multiplier || 1,
-      isActive: m.is_active,
-    }));
+        : (Array.isArray(m.stock_models) ? m.stock_models : []);
+      const fallbackMoldModel = stockModelResolver.resolve(m.model_name);
+
+      return {
+        id: m.id,
+        moldId: m.mold_id,
+        modelName: m.model_name,
+        stockModels: moldStockModelRefs,
+        resolvedStockModels: [
+          ...moldStockModelRefs
+            .map((reference: string) => stockModelResolver.resolve(reference))
+            .filter(Boolean),
+          ...(moldStockModelRefs.length === 0 && fallbackMoldModel ? [fallbackMoldModel] : []),
+        ],
+        instanceNumber: m.instance_number,
+        enabled: m.enabled,
+        multiplier: m.multiplier || 1,
+        isActive: m.is_active,
+      };
+    });
     
     console.log(`🏭 Found ${activeMolds.length} active molds`);
     if (activeMolds.length > 0) {
@@ -394,10 +407,10 @@ router.post('/generate', async (req: Request, res: Response) => {
         const otherOptions = Array.isArray(features.other_options) ? features.other_options : [];
         
         // Extract action length
-        let actionLength = features.action_length;
+        let actionLength = features.action_length || features.actionLength;
         if (!actionLength || actionLength === 'none') {
           // Try to derive from action_inlet
-          const actionInlet = features.action_inlet;
+          const actionInlet = features.action_inlet || features.actionInlet;
           if (actionInlet) {
             if (actionInlet.includes('short')) {
               actionLength = 'SA';
@@ -407,8 +420,9 @@ router.post('/generate', async (req: Request, res: Response) => {
           }
         }
         
-        // Use material_canonical as single source of truth for P1 material
-        let material: string | null = order.materialCanonical || null;
+        let material: string | null = features.material
+          ? normalizeMaterial(features.material)
+          : null;
         if (!material) {
           material = deriveCanonicalMaterial(order.stockModel || '') || null;
         }
@@ -430,10 +444,22 @@ router.post('/generate', async (req: Request, res: Response) => {
         
         const hasHeavyFill = otherOptions.includes('heavy_fill');
         
+        const originalRef = firstStockModelReference([
+          { source: 'all_orders.model_id', value: order.stockModel },
+        ]);
+        const resolvedStockModel = stockModelResolver.resolve(originalRef?.value);
+
         return {
           ...order,
+          stockModel: resolvedStockModel?.name || originalRef?.value || '',
+          resolvedStockModel,
+          stockModelId: resolvedStockModel?.id ?? null,
+          stockModelName: resolvedStockModel?.name ?? null,
+          stockModelDisplayName: resolvedStockModel?.displayName ?? null,
+          originalRef: originalRef?.value ?? null,
+          stockModelSource: originalRef?.source ?? null,
           actionLength,
-          actionInlet: features.action_inlet || null,
+          actionInlet: features.action_inlet || features.actionInlet || null,
           material,
           hasLOP,
           lopValue,
@@ -473,10 +499,15 @@ router.post('/generate', async (req: Request, res: Response) => {
             prod.due_date,
             prod.specifications,
             poi.stock_model_id,
-            poi.specifications AS po_specifications
+            poi.stock_model_name,
+            poi.specifications AS po_specifications,
+            pp.stock_model AS po_product_stock_model
           FROM production_orders prod
           JOIN purchase_order_items poi ON poi.id = prod.po_item_id
           JOIN purchase_orders po ON po.id = prod.po_id
+          LEFT JOIN po_products pp
+            ON poi.item_type = 'custom_model'
+            AND poi.item_id = pp.id::text
           WHERE prod.po_item_id = $1
             AND po.po_number = $2
             AND COALESCE(prod.is_fulfilled, false) = false
@@ -504,7 +535,9 @@ router.post('/generate', async (req: Request, res: Response) => {
         }
 
         for (const row of rows) {
-          const specifications = row.specifications || row.po_specifications || {};
+          const productionSpecifications = row.specifications || {};
+          const poSpecifications = row.po_specifications || {};
+          const specifications = { ...poSpecifications, ...productionSpecifications };
           let actionLength = specifications.action_length || specifications.actionLength || null;
           const actionInlet = specifications.action_inlet || specifications.actionInlet || null;
           if ((!actionLength || actionLength === 'none') && actionInlet) {
@@ -512,8 +545,17 @@ router.post('/generate', async (req: Request, res: Response) => {
             if (actionInlet.includes('long')) actionLength = 'LA';
           }
 
-          const stockModel =
-            row.stock_model_id || row.item_id || item.stockModel || row.item_name || '';
+          const originalRef = firstStockModelReference([
+            { source: 'purchase_order_items.stock_model_id', value: row.stock_model_id },
+            { source: 'production_orders.specifications.stockModel', value: productionSpecifications.stockModel },
+            { source: 'production_orders.specifications.stock_model', value: productionSpecifications.stock_model },
+            { source: 'purchase_order_items.specifications.stockModel', value: poSpecifications.stockModel },
+            { source: 'purchase_order_items.specifications.stock_model', value: poSpecifications.stock_model },
+            { source: 'po_products.stock_model', value: row.po_product_stock_model },
+            { source: 'purchase_order_items.stock_model_name', value: row.stock_model_name },
+          ]);
+          const resolvedStockModel = stockModelResolver.resolve(originalRef?.value);
+          const stockModel = resolvedStockModel?.name || originalRef?.value || '';
           const material = specifications.material
             ? normalizeMaterial(specifications.material)
             : deriveCanonicalMaterial(stockModel) || null;
@@ -525,6 +567,12 @@ router.post('/generate', async (req: Request, res: Response) => {
             poItemId: row.po_item_id,
             productionOrderId: row.order_id,
             stockModel,
+            resolvedStockModel,
+            stockModelId: resolvedStockModel?.id ?? null,
+            stockModelName: resolvedStockModel?.name ?? null,
+            stockModelDisplayName: resolvedStockModel?.displayName ?? null,
+            originalRef: originalRef?.value ?? null,
+            stockModelSource: originalRef?.source ?? null,
             customerId: row.customer_id,
             customerName: row.customer_name,
             dueDate: row.due_date,
@@ -576,75 +624,29 @@ router.post('/generate', async (req: Request, res: Response) => {
     for (const item of allItems) {
       let scheduled = false;
       
-      // Find compatible molds for this stock model
-      // Handle both array and string formats for mold.stockModels (in case Drizzle returns different formats)
-      // Also fallback to model_name matching if stockModels is empty (database driver workaround)
-      const compatibleMolds = activeMolds.filter(mold => {
-        if (!item.stockModel) return false;
-        
-        // Model name alias mappings for stock models with non-standard naming
-        // Includes carbon fiber (cf_) and fiberglass (fg_) variants
-        const modelAliases: Record<string, string[]> = {
-          'adjustable_gladius': ['adj_amor', 'adj_gladius', 'adjustable_amor', 'cf_adj_armor', 'cf_adj_gladius', 'fg_adj_armor', 'fg_adj_gladius'],
-          'adjustable_alpine_hunter': ['adj_alpine_hunter', 'adj_alpine', 'cf_adj_alp_hunter', 'cf_adj_alpine_hunter', 'cf_adj_alpine', 'fg_adj_alp_hunter', 'fg_adj_alpine_hunter', 'fg_adj_alpine'],
-          'alpine_hunter': ['cf_alpine_hunter', 'fg_alpine_hunter'],
-        };
-        
-        // Normalize function: "Mesa Universal" -> "mesa_universal"
-        const normalizeModelName = (name: string) => 
-          name.toLowerCase().replace(/\s+/g, '_').replace(/-/g, '_');
-        
-        // Check if stock model matches any alias
-        const getCanonicalName = (stockModel: string): string => {
-          const normalized = stockModel.toLowerCase();
-          for (const [canonical, aliases] of Object.entries(modelAliases)) {
-            if (aliases.includes(normalized) || normalized === canonical) {
-              return canonical;
-            }
-          }
-          return normalized;
-        };
-        
-        const canonicalStockModel = getCanonicalName(item.stockModel);
-        
-        // First try stockModels array matching
-        if (mold.stockModels && mold.stockModels.length > 0) {
-          // If it's an array, use includes
-          if (Array.isArray(mold.stockModels)) {
-            // Check both original and canonical names
-            return mold.stockModels.includes(item.stockModel) || 
-                   mold.stockModels.some(m => getCanonicalName(m) === canonicalStockModel);
-          }
-          
-          // If it's a string (postgres array format like "{a,b,c}"), parse and check
-          if (typeof mold.stockModels === 'string') {
-            const modelsStr = mold.stockModels as string;
-            // Handle postgres array format: {model1,model2,model3}
-            const cleanedModels = modelsStr.replace(/^\{|\}$/g, '').split(',');
-            return cleanedModels.includes(item.stockModel) ||
-                   cleanedModels.some(m => getCanonicalName(m) === canonicalStockModel);
-          }
-        }
-        
-        // Fallback: match by normalized model_name when stockModels is empty
-        // e.g., mold "Mesa Universal" matches stock_model "mesa_universal"
-        const normalizedMoldModel = normalizeModelName(mold.modelName);
-        const normalizedStockModel = item.stockModel.toLowerCase();
-        
-        // Check if normalized names match, including aliases
-        return normalizedMoldModel === normalizedStockModel ||
-               normalizedMoldModel === canonicalStockModel ||
-               normalizedMoldModel.includes(normalizedStockModel) ||
-               normalizedStockModel.includes(normalizedMoldModel) ||
-               normalizedMoldModel.includes(canonicalStockModel) ||
-               canonicalStockModel.includes(normalizedMoldModel);
-      });
+      if (!item.resolvedStockModel) {
+        overflowItems.push({
+          ...item,
+          errorCode: 'STOCK_MODEL_UNRESOLVED',
+          reason:
+            `Stock model "${item.originalRef || 'missing'}" could not be resolved. ` +
+            'Correct the stock model on the order or purchase-order line before scheduling.',
+        });
+        continue;
+      }
+
+      const compatibleMolds = activeMolds.filter(mold =>
+        mold.resolvedStockModels.some((moldModel: any) =>
+          stockModelResolver.areCompatible(item.resolvedStockModel, moldModel),
+        ),
+      );
       
       if (compatibleMolds.length === 0) {
         console.log(`⚠️ No compatible molds for ${item.orderId} (stockModel: ${item.stockModel}, type: ${typeof item.stockModel})`);
         overflowItems.push({
           ...item,
-          reason: `No compatible molds for stock model: ${item.stockModel}`,
+          errorCode: 'NO_COMPATIBLE_MOLD',
+          reason: `No compatible mold is configured for ${item.stockModelDisplayName}`,
         });
         continue;
       }
@@ -671,6 +673,10 @@ router.post('/generate', async (req: Request, res: Response) => {
               orderId: item.orderId,
               fbOrderNumber: item.fbOrderNumber,
               stockModel: item.stockModel,
+              stockModelId: item.stockModelId,
+              stockModelName: item.stockModelName,
+              stockModelDisplayName: item.stockModelDisplayName,
+              originalRef: item.originalRef,
               customerName: item.customerName,
               scheduledDate: format(scheduledDate, 'yyyy-MM-dd'),
               moldId: mold.moldId,
@@ -704,6 +710,7 @@ router.post('/generate', async (req: Request, res: Response) => {
         console.log(`❌ Cannot schedule ${item.orderId} - no capacity available`);
         overflowItems.push({
           ...item,
+          errorCode: 'NO_AVAILABLE_CAPACITY',
           reason: 'No available mold capacity in the scheduling window',
         });
       }


### PR DESCRIPTION
## Summary

- add one authoritative stock-model resolver for database IDs, internal names, approved aliases, and normalized display names
- use the same resolved identity for regular demand, P1 PO units, and mold compatibility
- remove the unsafe `production_orders.item_id` fallback and broad substring mold matching
- return stable preview identity fields and distinct unresolved, incompatible-mold, and capacity error codes
- preserve snake_case/camelCase action-length fields and keep existing demand/progression boundaries intact

## Root cause

The P1 PO scheduling path fell back from `purchase_order_items.stock_model_id` to `production_orders.item_id`. Numeric PO/item identifiers such as 71, 84, 85, and 86 were therefore treated as stock-model descriptions. Mold matching then mixed exact/alias checks with broad substring comparisons instead of resolving both sides through `stock_models`.

## Authoritative sources

- `stock_models.id`, `stock_models.name`, `stock_models.display_name`
- regular orders: `all_orders.model_id` (the current schema has no separate `all_orders.stock_model_id`)
- PO units: `purchase_order_items.stock_model_id`, production/PO `specifications.stockModel` and `specifications.stock_model`, `po_products.stock_model`, then `purchase_order_items.stock_model_name`
- molds: every `molds.stock_models` entry, with exact `molds.model_name` fallback only when the association array is empty

## Verification

- focused resolver/route/P1 queue suite: 49 passed
- mixed-demand/history/progression guards: 30 passed
- production Vite build: passed (existing duplicate-case and chunk-size warnings only)
- `git diff --check`: passed
- repository-wide `tsc --noEmit`: baseline remains red with approximately 2,350 unrelated diagnostics; the changed-route diagnostic introduced during implementation was corrected, and remaining filtered diagnostics predate this change

## Data impact

No migration. No database or production-data changes. No P2 scheduling changes.