### PR TITLE
Harden client behavior during production startup

### DIFF
--- a/client/src/__tests__/serverReadiness.test.ts
+++ b/client/src/__tests__/serverReadiness.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchWhenServerReady,
+  parseResponse,
+  waitForServerReady,
+} from '@/lib/serverReadiness';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('server readiness handling', () => {
+  it('waits until boot status reports ready', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ status: 'not_ready' }, 503))
+      .mockResolvedValueOnce(jsonResponse({ status: 'not_ready' }, 503))
+      .mockResolvedValueOnce(jsonResponse({ status: 'ready' }));
+
+    await waitForServerReady({ fetchImpl, timeoutMs: 1_000, pollIntervalMs: 0 });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('replays the original request only after routes report ready', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ error: 'Server starting, please retry' }, 503))
+      .mockResolvedValueOnce(jsonResponse({ status: 'ready' }))
+      .mockResolvedValueOnce(jsonResponse({ user: { id: 1 } }));
+
+    const response = await fetchWhenServerReady(
+      '/api/auth/login',
+      { method: 'POST' },
+      { fetchImpl, pollIntervalMs: 0 },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchImpl.mock.calls.map(([url]) => url)).toEqual([
+      '/api/auth/login',
+      '/api/boot-status',
+      '/api/auth/login',
+    ]);
+  });
+
+  it('returns non-JSON upstream errors without a syntax error', async () => {
+    const response = new Response('Internal Server Error', {
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+    await expect(parseResponse(response)).resolves.toEqual({
+      data: null,
+      error: 'Internal Server Error',
+    });
+  });
+
+  it('does not retry genuine authentication failures', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ error: 'Invalid username or password' }, 401));
+
+    const response = await fetchWhenServerReady(
+      '/api/auth/login',
+      { method: 'POST' },
+      { fetchImpl },
+    );
+
+    expect(response.status).toBe(401);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/__tests__/startupReadinessIntegration.test.ts
+++ b/client/src/__tests__/startupReadinessIntegration.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function source(relativePath: string): string {
+  return fs.readFileSync(path.resolve(process.cwd(), relativePath), 'utf8');
+}
+
+describe('startup readiness client integration', () => {
+  it('routes login and badge login through readiness-aware fetching', () => {
+    const login = source('client/src/pages/LoginPage.tsx');
+    expect(login).toContain("fetchWhenServerReady('/api/auth/login'");
+    expect(login).toContain("fetchWhenServerReady('/api/auth/badge-login'");
+    expect(login).toContain('parseResponse<any>(response)');
+    expect(login).not.toContain('const data = await response.json()');
+  });
+
+  it('uses readiness-aware fetching for shared API and query requests', () => {
+    const queryClient = source('client/src/lib/queryClient.ts');
+    expect(queryClient).toContain('fetchWhenServerReady(fullUrl, config)');
+    expect(queryClient).toContain('fetchWhenServerReady(url, {');
+    expect(queryClient).toContain('isDeployment ? 135000 : 120000');
+  });
+
+  it('waits for route readiness before opening the notification socket', () => {
+    const websocket = source('client/src/hooks/useWebSocketNotifications.ts');
+    const readinessIndex = websocket.indexOf('await waitForServerReady()');
+    const socketIndex = websocket.indexOf('new WebSocket(wsUrl)');
+    expect(readinessIndex).toBeGreaterThan(-1);
+    expect(socketIndex).toBeGreaterThan(readinessIndex);
+  });
+});

--- a/client/src/__tests__/useWebSocketNotifications.component.test.tsx
+++ b/client/src/__tests__/useWebSocketNotifications.component.test.tsx
@@ -14,6 +14,10 @@ vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
+vi.mock('@/lib/serverReadiness', () => ({
+  waitForServerReady: vi.fn().mockResolvedValue(undefined),
+}));
+
 interface FakeWsInstance {
   onopen: ((event: Event) => void) | null;
   onmessage: ((event: MessageEvent) => void) | null;

--- a/client/src/hooks/useWebSocketNotifications.ts
+++ b/client/src/hooks/useWebSocketNotifications.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { handleWebSocketMessage } from '@/lib/punchNotificationHandlers';
+import { waitForServerReady } from '@/lib/serverReadiness';
 
 function getSessionToken(): string | null {
   const fromStorage = localStorage.getItem('sessionToken');
@@ -16,8 +17,15 @@ export function useWebSocketNotifications() {
   const reconnectAttemptsRef = useRef(0);
   const { toast } = useToast();
 
-  const connect = useCallback(() => {
+  const connect = useCallback(async () => {
     if (wsRef.current?.readyState === WebSocket.OPEN || wsRef.current?.readyState === WebSocket.CONNECTING) {
+      return;
+    }
+
+    try {
+      await waitForServerReady();
+    } catch {
+      reconnectTimeoutRef.current = setTimeout(connect, 10000);
       return;
     }
 

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from '@tanstack/react-query';
+import { fetchWhenServerReady } from './serverReadiness';
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -228,7 +229,9 @@ export async function apiRequest(url: string, options: ApiRequestOptions = {}) {
     window.location.hostname.includes('.repl.co') ||
     window.location.hostname.includes('agcompepoch.xyz');
 
-  const defaultTimeout = isDeployment ? 15000 : 120000;
+  // Production route registration can legitimately take close to a minute.
+  // Keep the request controller alive longer than the readiness poll window.
+  const defaultTimeout = isDeployment ? 135000 : 120000;
   const timeoutDuration = options.timeout ?? defaultTimeout;
 
   console.log(
@@ -284,7 +287,7 @@ export async function apiRequest(url: string, options: ApiRequestOptions = {}) {
   }
 
   try {
-    const response = await fetch(fullUrl, config);
+    const response = await fetchWhenServerReady(fullUrl, config);
     clearTimeout(timeoutId);
     console.log(`✅ API Response from ${url}: ${response.status}`);
 
@@ -396,7 +399,7 @@ export const getQueryFn: <T>(options: {
       (window.location.hostname.includes('.replit.app') ||
         window.location.hostname.includes('.repl.co') ||
         window.location.hostname.includes('agcompepoch.xyz'));
-    const timeoutDuration = isDeployment ? 45000 : 30000;
+    const timeoutDuration = isDeployment ? 135000 : 120000;
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
@@ -418,7 +421,7 @@ export const getQueryFn: <T>(options: {
         ? { Authorization: `Bearer ${storedToken}` }
         : {};
 
-      const res = await fetch(url, {
+      const res = await fetchWhenServerReady(url, {
         credentials: 'include',
         signal: controller.signal,
         headers,

--- a/client/src/lib/serverReadiness.ts
+++ b/client/src/lib/serverReadiness.ts
@@ -1,0 +1,120 @@
+const BOOT_STATUS_URL = '/api/boot-status';
+const DEFAULT_BOOT_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+
+type FetchLike = typeof fetch;
+
+export interface ParsedResponse<T = any> {
+  data: T | null;
+  error: string | null;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function responseBody(response: Response): Promise<any> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export async function parseResponse<T = any>(
+  response: Response,
+): Promise<ParsedResponse<T>> {
+  const body = await responseBody(response);
+  if (body && typeof body === 'object') {
+    return {
+      data: body as T,
+      error:
+        typeof body.error === 'string'
+          ? body.error
+          : typeof body.message === 'string'
+            ? body.message
+            : null,
+    };
+  }
+
+  return {
+    data: null,
+    error:
+      typeof body === 'string' && body.trim()
+        ? body.trim()
+        : response.statusText || `Request failed (${response.status})`,
+  };
+}
+
+async function isStartupResponse(response: Response): Promise<boolean> {
+  if (response.status !== 503) return false;
+  const parsed = await parseResponse(response.clone());
+  return (
+    parsed.error?.toLowerCase().includes('server starting') === true ||
+    parsed.error?.toLowerCase().includes('registering routes') === true
+  );
+}
+
+export async function waitForServerReady(options: {
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+} = {}): Promise<void> {
+  const {
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_BOOT_TIMEOUT_MS,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  } = options;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchImpl(BOOT_STATUS_URL, {
+        credentials: 'include',
+        cache: 'no-store',
+      });
+      const parsed = await parseResponse<{
+        status?: string;
+        routeRegistration?: { status?: string; error?: { message?: string } };
+      }>(response);
+
+      if (response.ok && parsed.data?.status === 'ready') return;
+      if (parsed.data?.routeRegistration?.status === 'failed') {
+        throw new Error(
+          parsed.data.routeRegistration.error?.message ||
+            'Server failed while registering routes',
+        );
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message !== 'Failed to fetch' &&
+        !error.message.includes('NetworkError')
+      ) {
+        throw error;
+      }
+    }
+    await delay(pollIntervalMs);
+  }
+
+  throw new Error('Server is still starting. Please try again in a moment.');
+}
+
+export async function fetchWhenServerReady(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  options: {
+    fetchImpl?: FetchLike;
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+  } = {},
+): Promise<Response> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const response = await fetchImpl(input, init);
+  if (!(await isStartupResponse(response))) return response;
+
+  await waitForServerReady({ ...options, fetchImpl });
+  return fetchImpl(input, init);
+}

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -15,6 +15,7 @@ import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { getDashboardRoute } from '@/config/dashboardMapping';
 import { queryClient } from '@/lib/queryClient';
+import { fetchWhenServerReady, parseResponse } from '@/lib/serverReadiness';
 
 type LoginMode = 'regular' | 'p2-traveler' | 'timer-station' | 'badge' | 'time-clock';
 
@@ -67,36 +68,6 @@ export default function LoginPage() {
     }
   }, [activeMode]);
 
-  // Retry POSTs that hit the boot-window 503 ("Server starting, please retry")
-  // or transient network errors. Up to ~6 attempts over ~10s. Auth failures
-  // (401/400) are returned immediately so genuine errors aren't masked.
-  const fetchWithBootRetry = async (
-    url: string,
-    init: RequestInit,
-    maxAttempts = 6,
-    delayMs = 1500,
-  ): Promise<Response> => {
-    let lastErr: unknown;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        const response = await fetch(url, init);
-        if (response.status !== 503) return response;
-        // Server is still booting — wait and retry.
-      } catch (err) {
-        lastErr = err;
-      }
-      if (attempt < maxAttempts) {
-        await new Promise((r) => setTimeout(r, delayMs));
-      }
-    }
-    if (lastErr) throw lastErr;
-    // Give up — return a synthetic 503 so the caller can show an error.
-    return new Response(
-      JSON.stringify({ error: 'Server is still starting. Please try again in a moment.' }),
-      { status: 503, headers: { 'Content-Type': 'application/json' } },
-    );
-  };
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -112,7 +83,7 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      const response = await fetchWithBootRetry('/api/auth/login', {
+      const response = await fetchWhenServerReady('/api/auth/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -121,9 +92,9 @@ export default function LoginPage() {
         body: JSON.stringify({ username, password }),
       });
 
-      const data = await response.json();
+      const { data, error } = await parseResponse<any>(response);
 
-      if (response.ok) {
+      if (response.ok && data) {
         if (data.sessionToken) {
           localStorage.setItem('sessionToken', data.sessionToken);
         }
@@ -142,7 +113,7 @@ export default function LoginPage() {
       } else {
         toast({
           title: 'Login Failed',
-          description: data.error || 'Invalid username or password',
+          description: error || 'Invalid username or password',
           variant: 'destructive',
         });
       }
@@ -173,7 +144,7 @@ export default function LoginPage() {
     setIsBadgeLoading(true);
 
     try {
-      const response = await fetchWithBootRetry('/api/auth/badge-login', {
+      const response = await fetchWhenServerReady('/api/auth/badge-login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -182,12 +153,12 @@ export default function LoginPage() {
         body: JSON.stringify({ employeeCode: badgeCode.trim() }),
       });
 
-      const data = await response.json();
+      const { data, error } = await parseResponse<any>(response);
 
-      if (!response.ok) {
+      if (!response.ok || !data) {
         toast({
           title: 'Badge Login Failed',
-          description: data.error || 'Invalid employee badge code',
+          description: error || 'Invalid employee badge code',
           variant: 'destructive',
         });
         return;


### PR DESCRIPTION
## Summary

- add a shared readiness client that polls `/api/boot-status` until the server reports `ready`, with a bounded two-minute timeout
- replay requests that receive the server's startup 503 only after route registration completes
- use readiness-aware fetching for login, badge login, shared API requests, and TanStack Query requests
- parse JSON and plain-text login responses safely so upstream `Internal Server Error` responses do not cause JSON syntax errors
- delay notification WebSocket creation until routes are ready
- align deployed request/query timeouts with the readiness window

## Root cause

Production route registration took about 58 seconds, while the existing fixed retry windows lasted roughly 8–16 seconds. The browser exhausted those retries, attempted login and WebSocket connections while routes were unavailable, and then tried to parse a plain-text upstream 500 response as JSON.

## User impact

During future deployments, the login page and background queries wait for authoritative server readiness instead of showing misleading authentication failures. Notification sockets connect only after route registration is complete, and unexpected non-JSON errors are shown as concise messages.

## Validation

- focused readiness, integration, and WebSocket tests: 9 passed
- production Vite build: passed
- `git diff --cached --check`: passed
- final focused rerun was blocked by the reused shared Vitest dependency tree losing its `rollup` package after the successful build; no dependencies or lockfiles were changed in this branch

## Data impact

No migration and no database or production-data changes. This PR is separate from the P1 layup stock-model PR.