### PR TITLE
Fix production layup schedule save QueryResult handling

### DIFF
--- a/server/__tests__/layupSchedulePOUnitParsing.test.ts
+++ b/server/__tests__/layupSchedulePOUnitParsing.test.ts
@@ -88,4 +88,14 @@ describe('layup schedule PO progression scope', () => {
     expect(route).toContain('WHERE order_id = ANY($1::text[])');
     expect(route).toContain('INSERT INTO layup_schedule');
   });
+
+  it('maps eligible regular orders from the production pg QueryResult rows', () => {
+    const saveStart = route.indexOf("router.post('/save'");
+    const saveRoute = route.slice(saveStart, route.indexOf("router.get('/current-week'", saveStart));
+
+    expect(saveRoute).toContain('const eligibleResult = await client.query<{ order_id: string }>');
+    expect(saveRoute).toContain('eligibleResult.rows.map(row => row.order_id)');
+    expect(saveRoute).not.toContain('eligibleRows.map');
+    expect(saveRoute).not.toContain(') as any[]');
+  });
 });

--- a/server/src/routes/layupSchedule.ts
+++ b/server/src/routes/layupSchedule.ts
@@ -901,13 +901,13 @@ router.post('/save', async (req: Request, res: Response) => {
         const uniqueOrderIds = Array.from(new Set(orderIds));
         
         // Pre-filter to only orders in eligible source departments (preserving original WHERE guard)
-        const eligibleRows = await client.query(
+        const eligibleResult = await client.query<{ order_id: string }>(
           `SELECT order_id FROM all_orders
            WHERE order_id = ANY($1::text[])
            AND current_department IN ('P1 Production Queue', 'Production Queue')`,
           [uniqueOrderIds]
-        ) as any[];
-        const eligibleIds = eligibleRows.map((r: any) => r.order_id);
+        );
+        const eligibleIds = eligibleResult.rows.map(row => row.order_id);
 
         if (eligibleIds.length > 0) {
           const movedRows = await auditUpdateOrders({


### PR DESCRIPTION
## Summary

- fix `/api/layup-schedule/save` to read eligible regular-order rows from the PostgreSQL `QueryResult.rows` array
- remove the invalid `as any[]` cast that hid the production return shape
- add regression coverage for the exact `eligibleRows.map is not a function` failure

## Root cause

The save transaction called `client.query(...)` and cast the returned PostgreSQL `QueryResult` to `any[]`. Type assertions do not transform runtime values, so production returned `{ rows, rowCount, ... }` and `eligibleRows.map(...)` threw before the transaction could commit.

Generation was unaffected and returned 200; the failure occurred only while saving and progressing selected regular orders.

## Validation

- bundled Node syntax checks passed for the touched route and regression test
- `git diff --cached --check` passed
- focused Vitest execution was attempted, but the shared dependency tree currently cannot resolve `rollup` from Vite; no dependency or lockfile changes were made for this hotfix

## Data impact

No migration and no database or production-data changes. Failed save attempts were rolled back by the existing transaction handler.