### PR TITLE
Show generated P1 PO units in production queue

### DIFF
--- a/server/__tests__/p1ProductionOrdersQueueVisibility.test.ts
+++ b/server/__tests__/p1ProductionOrdersQueueVisibility.test.ts
@@ -12,11 +12,21 @@ describe('P1 production order workflow boundary', () => {
     'utf8',
   );
 
-  it('keeps Purchase Order Management demand out of the regular production queue', () => {
+  it('keeps PO writes separate while including production rows in the unified queue read model', () => {
     expect(productionQueueSource).toContain(
       "COALESCE(o.order_source, 'SALES') <> 'PO_RELEASE'",
     );
-    expect(productionQueueSource).not.toContain('FROM production_orders p');
+    expect(productionQueueSource).toContain('FROM production_orders p');
+    expect(productionQueueSource).toContain(
+      "p.current_department = 'P1 Production Queue'",
+    );
+    expect(productionQueueSource).toContain(
+      "UPPER(COALESCE(p.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')",
+    );
+    expect(productionQueueSource).toContain("'po_item_id', p.po_item_id");
+    expect(productionQueueSource).toContain(
+      'WHERE mirrored.order_id = p.order_id',
+    );
   });
 
   it('creates only production_orders while scheduling PO demand', () => {

--- a/server/src/routes/productionQueue.ts
+++ b/server/src/routes/productionQueue.ts
@@ -470,55 +470,101 @@ router.get('/prioritized', async (req: Request, res: Response) => {
     console.log('🧹 CLEANUP: Processing orders that need attention...');
     await autoMoveInvalidStockModelOrders(storage);
 
-    // This is the regular sales-order queue. Purchase Order Management demand
-    // remains in production_orders until it is explicitly progressed to Barcode.
-    // Exclude historical PO_RELEASE mirrors so they do not leak back into P1.
+    // Keep the write-model boundary intact: regular sales orders live in
+    // all_orders, while generated P1 PO units live only in production_orders
+    // until Barcode progression. The production queue is a unified read model,
+    // so both sources must be returned here. Historical PO_RELEASE mirrors are
+    // excluded from the sales-order half to prevent duplicate display.
     const queueQuery = `
-      SELECT
-        o.order_id as orderId,
-        o.fb_order_number as fbOrderNumber,
-        o.model_id as modelId,
-        o.model_id as stockModelId,
-        o.due_date as dueDate,
-        o.order_date as orderDate,
-        o.current_department as currentDepartment,
-        o.status,
-        o.customer_id as customerId,
-        o.features,
-        o.urgency,
-        o.is_manual_urgency as isManualUrgency,
-        NULL as manual_priority_override,
-        NULL as prioritySource,
-        'ready' as productionReadinessStatus,
-        0 as queuePosition,
-        o.created_at as createdAt,
-        COALESCE(c.name, 'Customer ' || o.customer_id) as customerName,
-        'SALES' as orderSource,
-        o.is_flattop as "isFlattop"
-      FROM all_orders o
-      LEFT JOIN customers c ON o.customer_id ~ '^[0-9]+$' AND CAST(o.customer_id AS INTEGER) = c.id
-      WHERE o.current_department = 'P1 Production Queue'
-        AND COALESCE(o.order_source, 'SALES') <> 'PO_RELEASE'
-        AND o.status IN ('FINALIZED', 'Active', 'IN_PROGRESS')
-        AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
-        AND o.model_id IS NOT NULL
-        AND o.model_id != ''
-        AND o.model_id != 'None'
-        AND LOWER(o.model_id) != 'no stock'
-        AND LOWER(o.model_id) != 'no_stock'
-        AND (
-          LOWER(COALESCE(
-            o.features->>'action_length',
-            o.features->>'actionLength',
-            o.features->'specifications'->>'action_length',
-            o.features->'specifications'->>'actionLength',
-            ''
-          )) NOT IN ('', 'null')
-          OR LOWER(o.model_id) LIKE '%m1a%'
-          OR LOWER(o.model_id) LIKE '%tikka%'
-          OR o.is_flattop = true
-        )
-      ORDER BY o.due_date ASC, o.created_at ASC
+      WITH queue_orders AS (
+        SELECT
+          o.order_id as orderId,
+          o.fb_order_number as fbOrderNumber,
+          o.model_id as modelId,
+          o.model_id as stockModelId,
+          o.due_date as dueDate,
+          o.order_date as orderDate,
+          o.current_department as currentDepartment,
+          o.status,
+          o.customer_id as customerId,
+          o.features,
+          o.urgency,
+          o.is_manual_urgency as isManualUrgency,
+          NULL as manual_priority_override,
+          NULL as prioritySource,
+          'ready' as productionReadinessStatus,
+          0 as queuePosition,
+          o.created_at as createdAt,
+          COALESCE(c.name, 'Customer ' || o.customer_id) as customerName,
+          'SALES' as orderSource,
+          o.is_flattop as "isFlattop"
+        FROM all_orders o
+        LEFT JOIN customers c ON o.customer_id ~ '^[0-9]+$' AND CAST(o.customer_id AS INTEGER) = c.id
+        WHERE o.current_department = 'P1 Production Queue'
+          AND COALESCE(o.order_source, 'SALES') <> 'PO_RELEASE'
+          AND o.status IN ('FINALIZED', 'Active', 'IN_PROGRESS')
+          AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
+          AND o.model_id IS NOT NULL
+          AND o.model_id != ''
+          AND o.model_id != 'None'
+          AND LOWER(o.model_id) != 'no stock'
+          AND LOWER(o.model_id) != 'no_stock'
+          AND (
+            LOWER(COALESCE(
+              o.features->>'action_length',
+              o.features->>'actionLength',
+              o.features->'specifications'->>'action_length',
+              o.features->'specifications'->>'actionLength',
+              ''
+            )) NOT IN ('', 'null')
+            OR LOWER(o.model_id) LIKE '%m1a%'
+            OR LOWER(o.model_id) LIKE '%tikka%'
+            OR o.is_flattop = true
+          )
+
+        UNION ALL
+
+        SELECT
+          p.order_id as orderId,
+          NULL::text as fbOrderNumber,
+          p.item_id as modelId,
+          p.item_id as stockModelId,
+          p.due_date as dueDate,
+          p.order_date as orderDate,
+          p.current_department as currentDepartment,
+          p.production_status as status,
+          p.customer_id as customerId,
+          COALESCE(p.specifications, '{}'::jsonb)
+            || jsonb_build_object(
+              'po_id', p.po_id,
+              'po_item_id', p.po_item_id,
+              'po_number', p.po_number
+            ) as features,
+          NULL::text as urgency,
+          false as isManualUrgency,
+          NULL as manual_priority_override,
+          NULL as prioritySource,
+          'ready' as productionReadinessStatus,
+          0 as queuePosition,
+          p.created_at as createdAt,
+          COALESCE(NULLIF(p.customer_name, ''), 'Customer ' || p.customer_id) as customerName,
+          'PO_RELEASE' as orderSource,
+          false as "isFlattop"
+        FROM production_orders p
+        WHERE p.current_department = 'P1 Production Queue'
+          AND UPPER(COALESCE(p.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')
+          AND p.item_id IS NOT NULL
+          AND p.item_id != ''
+          AND LOWER(p.item_id) NOT IN ('none', 'no stock', 'no_stock')
+          AND NOT EXISTS (
+            SELECT 1
+            FROM all_orders mirrored
+            WHERE mirrored.order_id = p.order_id
+          )
+      )
+      SELECT *
+      FROM queue_orders
+      ORDER BY dueDate ASC, createdAt ASC
     `;
 
     const queueResult = await pool.query(queueQuery);


### PR DESCRIPTION
## What changed
- restore active P1 `production_orders` to the prioritized production queue read model
- retain regular sales orders from `all_orders` while excluding historical `PO_RELEASE` mirrors
- include PO linkage fields in the queue feature payload and deduplicate mirrored order IDs
- update the workflow-boundary regression contract

## Why
Purchase Order Management could report generated units as pending while the P1 Production Queue omitted them. A workflow-boundary change correctly stopped creating premature `all_orders` mirrors, but also removed the authoritative `production_orders` rows from the queue read model.

This fix preserves the write boundary: generated PO units remain in `production_orders` until Barcode progression. Only the queue read model is unified.

## Impact
Pending and in-progress generated P1 PO units are visible and actionable in the P1 Production Queue without creating duplicate sales-order rows.

## Validation
- verified the reported mismatch against the live UI and queue response
- `git diff --check` passed
- static queue visibility contract passed
- focused Vitest execution was attempted but the shared local installation could not start because its Vite dependency could not resolve `rollup`; this is not reported as a test pass