### PR TITLE
Restore P1 PO queue boundary and schedule saves

### DIFF
--- a/server/__tests__/layupSchedulePOUnitParsing.test.ts
+++ b/server/__tests__/layupSchedulePOUnitParsing.test.ts
@@ -40,6 +40,17 @@ describe('layup schedule PO progression scope', () => {
     expect(route).not.toContain('WHERE po_number = ANY($1::text[])');
   });
 
+  it('resolves submitted production units by database identity instead of order-ID format', () => {
+    const saveStart = route.indexOf("router.post('/save'");
+    const saveRoute = route.slice(saveStart, route.indexOf("router.get('/current-week'", saveStart));
+
+    expect(saveRoute).toContain('FROM production_orders');
+    expect(saveRoute).toContain('WHERE order_id = ANY($1::text[])');
+    expect(saveRoute).toContain('const productionOrdersById = new Map(');
+    expect(saveRoute).toContain('productionOrdersById.get(orderId)');
+    expect(saveRoute).not.toContain('parseP1POUnitOrderId(orderId)');
+  });
+
   it('does not create demand or silently progress PO units to Barcode while saving', () => {
     const saveStart = route.indexOf("router.post('/save'");
     const saveRoute = route.slice(saveStart, route.indexOf("router.get('/current-week'", saveStart));

--- a/server/__tests__/p1ProductionOrdersQueueVisibility.test.ts
+++ b/server/__tests__/p1ProductionOrdersQueueVisibility.test.ts
@@ -12,21 +12,11 @@ describe('P1 production order workflow boundary', () => {
     'utf8',
   );
 
-  it('keeps PO writes separate while including production rows in the unified queue read model', () => {
+  it('keeps Purchase Order Management demand out of the regular production queue', () => {
     expect(productionQueueSource).toContain(
       "COALESCE(o.order_source, 'SALES') <> 'PO_RELEASE'",
     );
-    expect(productionQueueSource).toContain('FROM production_orders p');
-    expect(productionQueueSource).toContain(
-      "p.current_department = 'P1 Production Queue'",
-    );
-    expect(productionQueueSource).toContain(
-      "UPPER(COALESCE(p.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')",
-    );
-    expect(productionQueueSource).toContain("'po_item_id', p.po_item_id");
-    expect(productionQueueSource).toContain(
-      'WHERE mirrored.order_id = p.order_id',
-    );
+    expect(productionQueueSource).not.toContain('FROM production_orders p');
   });
 
   it('creates only production_orders while scheduling PO demand', () => {

--- a/server/src/routes/layupSchedule.ts
+++ b/server/src/routes/layupSchedule.ts
@@ -770,6 +770,32 @@ router.post('/save', async (req: Request, res: Response) => {
       const orderIdsToReplace = entries
         .map((e: any) => e.orderId)
         .filter(Boolean);
+      const submittedOrderIds = Array.from(new Set(orderIdsToReplace));
+
+      // Production-order IDs are not guaranteed to use the newer
+      // PO-<number>-<item>-<unit> format. Resolve record ownership from the
+      // authoritative table so legacy IDs (for example, department-generated
+      // IDs) are progressed as production orders instead of being mistaken for
+      // regular all_orders rows.
+      const productionOrderResult = submittedOrderIds.length > 0
+        ? await client.query<{
+            order_id: string;
+            po_item_id: number;
+            production_status: string | null;
+            is_fulfilled: boolean | null;
+          }>(
+            `
+            SELECT order_id, po_item_id, production_status, is_fulfilled
+            FROM production_orders
+            WHERE order_id = ANY($1::text[])
+            FOR UPDATE
+            `,
+            [submittedOrderIds],
+          )
+        : { rows: [] };
+      const productionOrdersById = new Map(
+        productionOrderResult.rows.map((row) => [row.order_id, row]),
+      );
 
       // Also derive layup days for logging purposes
       const layupDaysSet = new Set(entries.map((e: any) => {
@@ -855,23 +881,14 @@ router.post('/save', async (req: Request, res: Response) => {
         savedCount++;
         
         // Track PO items to update their order counts
-        const parsedPOUnit = parseP1POUnitOrderId(orderId);
-        if (parsedPOUnit) {
-            const existingUnit = await client.query(
-              `
-              SELECT order_id
-              FROM production_orders
-              WHERE order_id = $1
-                AND po_item_id = $2
-                AND COALESCE(is_fulfilled, false) = false
-                AND UPPER(COALESCE(production_status, 'PENDING')) != 'CANCELLED'
-              FOR UPDATE
-              `,
-              [orderId, parsedPOUnit.poItemId],
-            );
-            if (existingUnit.rows.length !== 1) {
+        const productionOrder = productionOrdersById.get(orderId);
+        if (productionOrder) {
+            if (
+              productionOrder.is_fulfilled
+              || String(productionOrder.production_status || 'PENDING').toUpperCase() === 'CANCELLED'
+            ) {
               throw new Error(
-                `Existing P1 production unit ${orderId} is missing or no longer eligible for scheduling`
+                `Existing P1 production unit ${orderId} is no longer eligible for scheduling`
               );
             }
 
@@ -881,11 +898,17 @@ router.post('/save', async (req: Request, res: Response) => {
               SET current_department = 'Layup/Plugging',
                   updated_at = NOW()
               WHERE order_id = $1
+                AND po_item_id = $2
               RETURNING order_id
               `,
-              [orderId],
+              [orderId, productionOrder.po_item_id],
             );
-            progressedCount += progressionResult.rowCount || 0;
+            if (progressionResult.rowCount !== 1) {
+              throw new Error(
+                `Existing P1 production unit ${orderId} could not be progressed`
+              );
+            }
+            progressedCount += 1;
         } else {
           // Track regular order IDs
           orderIds.push(orderId);

--- a/server/src/routes/productionQueue.ts
+++ b/server/src/routes/productionQueue.ts
@@ -470,101 +470,56 @@ router.get('/prioritized', async (req: Request, res: Response) => {
     console.log('🧹 CLEANUP: Processing orders that need attention...');
     await autoMoveInvalidStockModelOrders(storage);
 
-    // Keep the write-model boundary intact: regular sales orders live in
-    // all_orders, while generated P1 PO units live only in production_orders
-    // until Barcode progression. The production queue is a unified read model,
-    // so both sources must be returned here. Historical PO_RELEASE mirrors are
-    // excluded from the sales-order half to prevent duplicate display.
+    // This is the regular sales-order queue. Purchase Order Management demand
+    // remains in production_orders and is selected from the per-PO cards above
+    // this list. Exclude historical PO_RELEASE mirrors so P1 PO units do not
+    // leak into the all_orders queue.
     const queueQuery = `
-      WITH queue_orders AS (
-        SELECT
-          o.order_id as orderId,
-          o.fb_order_number as fbOrderNumber,
-          o.model_id as modelId,
-          o.model_id as stockModelId,
-          o.due_date as dueDate,
-          o.order_date as orderDate,
-          o.current_department as currentDepartment,
-          o.status,
-          o.customer_id as customerId,
-          o.features,
-          o.urgency,
-          o.is_manual_urgency as isManualUrgency,
-          NULL as manual_priority_override,
-          NULL as prioritySource,
-          'ready' as productionReadinessStatus,
-          0 as queuePosition,
-          o.created_at as createdAt,
-          COALESCE(c.name, 'Customer ' || o.customer_id) as customerName,
-          'SALES' as orderSource,
-          o.is_flattop as "isFlattop"
-        FROM all_orders o
-        LEFT JOIN customers c ON o.customer_id ~ '^[0-9]+$' AND CAST(o.customer_id AS INTEGER) = c.id
-        WHERE o.current_department = 'P1 Production Queue'
-          AND COALESCE(o.order_source, 'SALES') <> 'PO_RELEASE'
-          AND o.status IN ('FINALIZED', 'Active', 'IN_PROGRESS')
-          AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
-          AND o.model_id IS NOT NULL
-          AND o.model_id != ''
-          AND o.model_id != 'None'
-          AND LOWER(o.model_id) != 'no stock'
-          AND LOWER(o.model_id) != 'no_stock'
-          AND (
-            LOWER(COALESCE(
-              o.features->>'action_length',
-              o.features->>'actionLength',
-              o.features->'specifications'->>'action_length',
-              o.features->'specifications'->>'actionLength',
-              ''
-            )) NOT IN ('', 'null')
-            OR LOWER(o.model_id) LIKE '%m1a%'
-            OR LOWER(o.model_id) LIKE '%tikka%'
-            OR o.is_flattop = true
-          )
-
-        UNION ALL
-
-        SELECT
-          p.order_id as orderId,
-          NULL::text as fbOrderNumber,
-          p.item_id as modelId,
-          p.item_id as stockModelId,
-          p.due_date as dueDate,
-          p.order_date as orderDate,
-          p.current_department as currentDepartment,
-          p.production_status as status,
-          p.customer_id as customerId,
-          COALESCE(p.specifications, '{}'::jsonb)
-            || jsonb_build_object(
-              'po_id', p.po_id,
-              'po_item_id', p.po_item_id,
-              'po_number', p.po_number
-            ) as features,
-          NULL::text as urgency,
-          false as isManualUrgency,
-          NULL as manual_priority_override,
-          NULL as prioritySource,
-          'ready' as productionReadinessStatus,
-          0 as queuePosition,
-          p.created_at as createdAt,
-          COALESCE(NULLIF(p.customer_name, ''), 'Customer ' || p.customer_id) as customerName,
-          'PO_RELEASE' as orderSource,
-          false as "isFlattop"
-        FROM production_orders p
-        WHERE p.current_department = 'P1 Production Queue'
-          AND UPPER(COALESCE(p.production_status, '')) IN ('PENDING', 'IN_PROGRESS', 'ACTIVE')
-          AND p.item_id IS NOT NULL
-          AND p.item_id != ''
-          AND LOWER(p.item_id) NOT IN ('none', 'no stock', 'no_stock')
-          AND NOT EXISTS (
-            SELECT 1
-            FROM all_orders mirrored
-            WHERE mirrored.order_id = p.order_id
-          )
-      )
-      SELECT *
-      FROM queue_orders
-      ORDER BY dueDate ASC, createdAt ASC
+      SELECT
+        o.order_id as orderId,
+        o.fb_order_number as fbOrderNumber,
+        o.model_id as modelId,
+        o.model_id as stockModelId,
+        o.due_date as dueDate,
+        o.order_date as orderDate,
+        o.current_department as currentDepartment,
+        o.status,
+        o.customer_id as customerId,
+        o.features,
+        o.urgency,
+        o.is_manual_urgency as isManualUrgency,
+        NULL as manual_priority_override,
+        NULL as prioritySource,
+        'ready' as productionReadinessStatus,
+        0 as queuePosition,
+        o.created_at as createdAt,
+        COALESCE(c.name, 'Customer ' || o.customer_id) as customerName,
+        'SALES' as orderSource,
+        o.is_flattop as "isFlattop"
+      FROM all_orders o
+      LEFT JOIN customers c ON o.customer_id ~ '^[0-9]+$' AND CAST(o.customer_id AS INTEGER) = c.id
+      WHERE o.current_department = 'P1 Production Queue'
+        AND COALESCE(o.order_source, 'SALES') <> 'PO_RELEASE'
+        AND o.status IN ('FINALIZED', 'Active', 'IN_PROGRESS')
+        AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
+        AND o.model_id IS NOT NULL
+        AND o.model_id != ''
+        AND o.model_id != 'None'
+        AND LOWER(o.model_id) != 'no stock'
+        AND LOWER(o.model_id) != 'no_stock'
+        AND (
+          LOWER(COALESCE(
+            o.features->>'action_length',
+            o.features->>'actionLength',
+            o.features->'specifications'->>'action_length',
+            o.features->'specifications'->>'actionLength',
+            ''
+          )) NOT IN ('', 'null')
+          OR LOWER(o.model_id) LIKE '%m1a%'
+          OR LOWER(o.model_id) LIKE '%tikka%'
+          OR o.is_flattop = true
+        )
+      ORDER BY o.due_date ASC, o.created_at ASC
     `;
 
     const queueResult = await pool.query(queueQuery);


### PR DESCRIPTION
## What changed
- restore the regular P1 production queue to `all_orders` only
- keep P1 purchase-order demand in the per-PO cards and exclude `PO_RELEASE` mirrors from the regular queue
- resolve selected schedule entries against the authoritative `production_orders` table instead of inferring record ownership from the order-ID format
- lock and progress each exact eligible production unit transactionally
- add regression contracts for both the queue boundary and production-unit identity handling

## Why
A prior visibility change exposed P1 purchase-order production rows inside the regular production queue, even though purchase-order quantities belong in the per-PO cards above that list. Separately, schedules generated from those PO cards could contain valid production-unit IDs that do not follow the newer synthetic ID format; save then treated them as regular orders, failed to progress the production rows, and aborted printing.

## Impact
- regular P1 queue rows again represent `all_orders`
- P1 purchase-order items remain selectable by PO and line quantity from their cards
- approved PO schedules save and progress the exact production units before printing
- cancelled or fulfilled production units still fail closed and roll back the transaction

## Validation
- `git diff --check` passed
- Node syntax checks passed for both routes and both focused test files
- focused Vitest was attempted but the shared local Vite installation could not resolve `rollup`; this is documented as a runner limitation, not a passing test