### PR TITLE
Add persistent EPOCH software validation workflow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -87,6 +87,7 @@ const QMSPlaceholderPage = React.lazy(() => import('./pages/QMSPlaceholderPage')
 const QMSDesignControlPage = React.lazy(() => import('./pages/QMSDesignControlPage'));
 const QMSPartsEquipmentPage = React.lazy(() => import('./pages/QMSPartsEquipmentPage'));
 const AS9100AuditReadinessPage = React.lazy(() => import('./pages/AS9100AuditReadinessPage'));
+const EpochSoftwareValidationPage = React.lazy(() => import('./pages/EpochSoftwareValidationPage'));
 const EmployeePortalPage = React.lazy(() => import('./pages/EmployeePortalPage'));
 const KioskPage = React.lazy(() => import('./pages/timekeeping/KioskPage'));
 const TimeClockAdminPage = React.lazy(() => import('./pages/timekeeping/TimeClockAdminPage'));
@@ -904,6 +905,7 @@ function App() {
                   <Route path="/qms/parts-equipment" component={QMSPartsEquipmentPage} />
                   <Route path="/qms/design-control" component={QMSDesignControlPage} />
                   <Route path="/qms/as9100-audit-readiness" component={AS9100AuditReadinessPage} />
+                  <Route path="/qms/epoch-software-validation" component={EpochSoftwareValidationPage} />
                   <Route path="/qms" component={QMSPlaceholderPage} />
                   <Route path="/qms/:section">
                     {(params) => <QMSPlaceholderPage params={params} />}

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -994,6 +994,12 @@ export default function Navigation() {
       description: 'Evidence-based assessment cycles, approvals, auditor view, and controlled exports',
     },
     {
+      path: '/qms/epoch-software-validation',
+      label: 'EPOCH Software Validation',
+      icon: ShieldCheck,
+      description: 'Persistent intended-use validation packages, risk-based testing, evidence, and approvals',
+    },
+    {
       path: '/qms/parts-equipment',
       label: 'Parts and Equipment',
       icon: PackageCheck,

--- a/client/src/config/userPermissions.ts
+++ b/client/src/config/userPermissions.ts
@@ -36,6 +36,13 @@ export const CAPABILITY_GATED_ROUTES: Record<string, string | string[]> = {
     'qms.audit_readiness.approve',
     'qms.audit_readiness.admin',
   ],
+  '/qms/epoch-software-validation': [
+    'EPOCH_VALIDATION_VIEW',
+    'EPOCH_VALIDATION_CREATE',
+    'EPOCH_VALIDATION_EDIT',
+    'EPOCH_VALIDATION_TEST_EXECUTE',
+    'EPOCH_VALIDATION_EXPORT',
+  ],
   '/master-document-register': 'documents.view',
 };
 
@@ -170,6 +177,7 @@ export const VALID_NAVBAR_ROUTES = [
   '/qms/nsia-registrar',
   '/qms/design-control',
   '/qms/as9100-audit-readiness',
+  '/qms/epoch-software-validation',
   '/qms/parts-equipment',
   '/assets',
   '/asset-dashboard',

--- a/client/src/pages/AS9100AuditReadinessPage.tsx
+++ b/client/src/pages/AS9100AuditReadinessPage.tsx
@@ -30,6 +30,12 @@ type Detail = {
   assessment: Assessment & { assessment_version: number; product_design_in_scope: boolean };
   items: Item[];
   readiness: Record<string, number>;
+  epochSoftwareValidation?: {
+    state: string; message: string; complete: boolean; blockers: string[];
+    package?: { id: string; packageNumber: string; status: string; productionVersion: string } | null;
+    versionMatches?: boolean; periodicReviewCurrent?: boolean;
+    readiness?: Record<string, any>;
+  };
 };
 
 const statusTone = (status: string) => {
@@ -134,6 +140,40 @@ export default function AS9100AuditReadinessPage() {
         <div><span className="text-xs text-muted-foreground">Approval state</span><p><Badge className={statusTone(assessment.status)}>{label(assessment.status)}</Badge></p></div>
         <div className="md:col-span-4"><span className="text-xs text-muted-foreground">QMS scope</span><p>{assessment.qms_scope}</p></div>
       </CardContent></Card>
+      <Card className={detail.data.epochSoftwareValidation?.complete ? 'border-emerald-400' : 'border-amber-400'}>
+        <CardHeader><div className="flex flex-wrap items-center justify-between gap-3"><div>
+          <CardTitle className="text-base">Section 2 — EPOCH Intended-Use Validation</CardTitle>
+          <p className="mt-1 text-sm text-muted-foreground">{detail.data.epochSoftwareValidation?.message || 'Not validated — create or link an EPOCH Software Validation Package.'}</p>
+        </div><div className="flex flex-wrap gap-2">
+          <Button onClick={() => { window.location.href = '/qms/epoch-software-validation'; }}>Open EPOCH Software Validation</Button>
+          {detail.data.epochSoftwareValidation?.package && <Button variant="outline" onClick={() => { window.location.href = '/qms/epoch-software-validation'; }}>View Approved Validation</Button>}
+          <Button variant="outline" onClick={() => setSection('02')}>View Blockers</Button>
+          <Button variant="outline" onClick={() => setSection('02')}>View Evidence</Button>
+          <Button variant="outline" onClick={() => { window.location.href = '/qms/epoch-software-validation'; }}>View Validation History</Button>
+        </div></div></CardHeader>
+        <CardContent>
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              ['Intended Use approved', detail.data.epochSoftwareValidation?.readiness?.intendedUseApproved],
+              ['Software requirements approved', detail.data.epochSoftwareValidation?.readiness?.requirementsBaselineApproved],
+              ['Risk assessment approved', detail.data.epochSoftwareValidation?.readiness?.riskAssessmentApproved],
+              ['Validation Plan approved', detail.data.epochSoftwareValidation?.readiness?.validationPlanApproved],
+              ['Critical requirements tested', detail.data.epochSoftwareValidation?.readiness && detail.data.epochSoftwareValidation.readiness.criticalRequirementsTested >= detail.data.epochSoftwareValidation.readiness.criticalRequirements],
+              ['Critical tests passed', detail.data.epochSoftwareValidation?.readiness && detail.data.epochSoftwareValidation.readiness.criticalTestsPassed >= detail.data.epochSoftwareValidation.readiness.criticalTests],
+              ['No open critical defects', detail.data.epochSoftwareValidation?.readiness?.openCriticalDefects === 0],
+              ['No unaccepted high defects', detail.data.epochSoftwareValidation?.readiness && detail.data.epochSoftwareValidation.readiness.openHighDefects <= detail.data.epochSoftwareValidation.readiness.acceptedHighDefects],
+              ['Backup verification', detail.data.epochSoftwareValidation?.readiness?.backupPassed],
+              ['Restore test', detail.data.epochSoftwareValidation?.readiness?.restorePassed],
+              ['Outage drill', detail.data.epochSoftwareValidation?.readiness?.outageDrillPassed],
+              ['Production version approved', detail.data.epochSoftwareValidation?.versionMatches],
+              ['Periodic review current', detail.data.epochSoftwareValidation?.periodicReviewCurrent],
+            ].map(([name, ok]) => <div key={String(name)} className="flex items-center gap-2 rounded border p-2 text-sm">
+              {ok ? <CheckCircle2 className="h-4 w-4 text-emerald-600" /> : <AlertTriangle className="h-4 w-4 text-amber-600" />}
+              <span>{name}</span>
+            </div>)}
+          </div>
+        </CardContent>
+      </Card>
       <div className="grid gap-4 lg:grid-cols-[280px_1fr]">
         <Card><CardHeader><CardTitle className="text-base">12 checklist sections</CardTitle></CardHeader><CardContent className="space-y-3">
           {sectionStats.map(([key, value]) => <button key={key} className="w-full rounded-md border p-2 text-left hover:bg-muted" onClick={() => setSection(key)}>

--- a/client/src/pages/EpochSoftwareValidationPage.tsx
+++ b/client/src/pages/EpochSoftwareValidationPage.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, ArrowLeft, CheckCircle2, FileCheck2, History, Lock, Plus, ShieldCheck } from 'lucide-react';
+import { apiRequest } from '@/lib/queryClient';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+
+type Package = {
+  id:string;package_number:string;title:string;system_name:string;validation_type:string;status:string;
+  production_version:string;commit_or_release_identifier?:string;validation_environment:string;
+  planned_start_date:string;planned_completion_date:string;locked_at?:string;
+  requirement_count?:number;execution_count?:number;open_defect_count?:number;
+};
+type Detail = {
+  package:Package;intendedUse:any[];requirements:any[];risks:any[];plans:any[];protocols:any[];
+  executions:any[];defects:any[];approvals:any[];periodicReviews:any[];events:any[];
+  readiness:Record<string,any>&{ready:boolean;blockers:string[]};
+};
+const sections=[
+  ['01','Intended Use','Controlled scope and dual authenticated approval'],
+  ['02','Software Requirements','Normalized, revision-controlled requirements baseline'],
+  ['03','Software Risk Assessment','Requirement-linked risk and mitigation register'],
+  ['04','Validation Plan','Approved plan required before formal execution'],
+  ['05','Test Protocols','Revision-controlled protocols, steps, requirements and risks'],
+  ['06','Test Execution and Evidence','Server-derived results and independent review'],
+  ['07','Defects and Corrections','Controlled defects, containment, correction and retest'],
+  ['08','Validation Summary','Server-calculated authoritative readiness'],
+  ['09','Production Approval','Authenticated approval and immutable final snapshot'],
+  ['10','Periodic Review','Change review and revalidation decision'],
+] as const;
+const pretty=(v:string)=>v.replaceAll('_',' ').replace(/\b\w/g,c=>c.toUpperCase());
+const tone=(v:string)=>v.includes('APPROVED')||v==='PASSED'||v==='CLOSED'?'bg-emerald-100 text-emerald-800':
+  v.includes('BLOCK')||v.includes('REJECT')||v==='FAILED'?'bg-red-100 text-red-800':'bg-amber-100 text-amber-900';
+
+export default function EpochSoftwareValidationPage(){
+  const [selected,setSelected]=useState<string>();
+  const [createOpen,setCreateOpen]=useState(false);
+  const [auditor,setAuditor]=useState(false);
+  const [activeSection,setActiveSection]=useState('01');
+  const qc=useQueryClient(),{toast}=useToast();
+  const list=useQuery<Package[]>({queryKey:['/api/qms/epoch-software-validation'],
+    queryFn:async()=>(await apiRequest('/api/qms/epoch-software-validation')).json()});
+  const detail=useQuery<Detail>({queryKey:['/api/qms/epoch-software-validation',selected],enabled:Boolean(selected),
+    queryFn:async()=>(await apiRequest(`/api/qms/epoch-software-validation/${selected}`)).json()});
+  const create=useMutation({mutationFn:async(form:HTMLFormElement)=>{
+    const f=new FormData(form);const body=Object.fromEntries(f.entries());
+    return (await apiRequest('/api/qms/epoch-software-validation',{method:'POST',body})).json();
+  },onSuccess:(p:Package)=>{qc.invalidateQueries({queryKey:['/api/qms/epoch-software-validation']});
+    setCreateOpen(false);setSelected(p.id);toast({title:`${p.package_number} created`});},
+    onError:(e:Error)=>toast({title:'Package was not created',description:e.message,variant:'destructive'})});
+  const progress=useMemo(()=>{
+    const d=detail.data;if(!d)return 0;let complete=0;
+    if(d.readiness.intendedUseApproved)complete++;
+    if(d.readiness.requirementsBaselineApproved)complete++;
+    if(d.readiness.riskAssessmentApproved)complete++;
+    if(d.readiness.validationPlanApproved)complete++;
+    if(d.protocols.length&&d.protocols.every(x=>x.status==='APPROVED'))complete++;
+    if(d.executions.length&&d.executions.every(x=>['PASSED','PASSED_WITH_APPROVED_DEVIATION'].includes(x.overall_result)))complete++;
+    if(!d.readiness.openCriticalDefects&&!d.readiness.openHighDefects)complete++;
+    if(d.readiness.ready)complete+=2;
+    if(d.periodicReviews.length)complete++;
+    return complete*10;
+  },[detail.data]);
+
+  if(selected&&detail.data){
+    const d=detail.data,p=d.package,locked=Boolean(p.locked_at)||p.status.startsWith('APPROVED');
+    return <div className="container mx-auto space-y-5 p-4 lg:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3"><div>
+        <Button variant="ghost" className="px-0" onClick={()=>setSelected(undefined)}><ArrowLeft className="mr-2 h-4 w-4"/>Validation packages</Button>
+        <h1 className="text-2xl font-bold">{p.package_number} · {p.title}</h1>
+        <p className="text-sm text-muted-foreground">EPOCH {p.production_version} · {pretty(p.validation_type)} · {p.validation_environment}</p>
+      </div><div className="flex flex-wrap gap-2">
+        <Button variant={auditor?'default':'outline'} onClick={()=>setAuditor(v=>!v)}><ShieldCheck className="mr-2 h-4 w-4"/>Auditor View</Button>
+        <ExportMenu id={p.id}/>
+      </div></div>
+      <div className={`rounded-md border p-3 text-sm font-semibold ${locked?'border-emerald-500 bg-emerald-50 text-emerald-900':'border-amber-400 bg-amber-50 text-amber-900'}`}>
+        {locked?<><Lock className="mr-2 inline h-4 w-4"/>CONTROLLED EPOCH SOFTWARE VALIDATION RECORD</>:'DRAFT — NOT APPROVED FOR INTENDED USE'}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <Metric label="Workflow progress" value={`${progress}%`} ok={progress===100}/>
+        <Metric label="Requirements" value={String(d.requirements.length)} ok={d.readiness.requirementsBaselineApproved}/>
+        <Metric label="Tests passed" value={String(d.executions.filter(x=>x.overall_result==='PASSED').length)} ok={d.readiness.criticalTestsPassed===d.readiness.criticalTests}/>
+        <Metric label="Critical defects" value={String(d.readiness.openCriticalDefects||0)} danger={Boolean(d.readiness.openCriticalDefects)}/>
+        <Metric label="Overall readiness" value={d.readiness.ready?'Ready':'Blocked'} ok={d.readiness.ready} danger={!d.readiness.ready}/>
+      </div>
+      <Progress value={progress}/>
+      {!d.readiness.ready&&<Card className="border-red-300"><CardHeader><CardTitle className="flex items-center gap-2 text-base text-red-800"><AlertTriangle className="h-4 w-4"/>Readiness blockers</CardTitle></CardHeader>
+        <CardContent><ul className="list-disc space-y-1 pl-5 text-sm">{d.readiness.blockers.map(x=><li key={x}>{x}</li>)}</ul></CardContent></Card>}
+      <div className="grid gap-4 lg:grid-cols-[310px_1fr]">
+        <Card><CardHeader><CardTitle className="text-base">10 validation sections</CardTitle></CardHeader><CardContent className="space-y-2">
+          {sections.map(([key,title,description])=><button key={key} onClick={()=>setActiveSection(key)}
+            className={`w-full rounded-md border p-3 text-left ${activeSection===key?'border-primary bg-primary/5':'hover:bg-muted'}`}>
+            <div className="font-medium">{key}. {title}</div><div className="text-xs text-muted-foreground">{description}</div>
+          </button>)}
+        </CardContent></Card>
+        <SectionWorkspace section={activeSection} detail={d} auditor={auditor}/>
+      </div>
+      {auditor&&<Card><CardHeader><CardTitle className="flex items-center gap-2"><History className="h-5 w-5"/>Immutable audit history</CardTitle></CardHeader>
+        <CardContent><Table><TableHeader><TableRow><TableHead>Date</TableHead><TableHead>Action</TableHead><TableHead>Actor</TableHead><TableHead>Reason</TableHead></TableRow></TableHeader>
+          <TableBody>{d.events.map(e=><TableRow key={e.id}><TableCell>{new Date(e.created_at).toLocaleString()}</TableCell><TableCell>{pretty(e.action)}</TableCell><TableCell>{e.actor_display_name} · {e.actor_role}</TableCell><TableCell>{e.reason||'—'}</TableCell></TableRow>)}</TableBody></Table></CardContent></Card>}
+    </div>;
+  }
+
+  return <div className="container mx-auto space-y-5 p-4 lg:p-6">
+    <div className="flex flex-wrap items-start justify-between gap-3"><div><h1 className="text-2xl font-bold">EPOCH Software Validation</h1>
+      <p className="text-muted-foreground">Objective evidence that EPOCH is suitable for its approved, documented QMS intended use.</p></div>
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}><DialogTrigger asChild><Button><Plus className="mr-2 h-4 w-4"/>New validation package</Button></DialogTrigger>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto"><DialogHeader><DialogTitle>Create EPOCH Software Validation Package</DialogTitle></DialogHeader>
+        <form className="grid gap-4 md:grid-cols-2" onSubmit={e=>{e.preventDefault();create.mutate(e.currentTarget)}}>
+          <Field name="title" label="Package title" required/><Field name="systemName" label="System name" defaultValue="EPOCH" required/>
+          <Pick name="validationType" label="Validation type" values={['INITIAL_INTENDED_USE','MAJOR_RELEASE','CRITICAL_CHANGE','DATABASE_MIGRATION','SECURITY_ACCESS_CONTROL','BACKUP_RECOVERY','PERIODIC_REVIEW','PRE_AUDIT_REVALIDATION','CORRECTIVE_REVALIDATION']}/>
+          <Field name="productionVersion" label="Production version being validated" required/>
+          <Field name="commitOrReleaseIdentifier" label="Commit SHA or release identifier"/>
+          <Field name="productionDeploymentDate" label="Production deployment date" type="date"/>
+          <Field name="validationEnvironment" label="Validation environment" required/>
+          <Field name="productionEnvironmentReference" label="Production environment reference" required/>
+          <Field name="databaseProvider" label="Database type/provider" required/><Field name="hostingProvider" label="Hosting provider" required/>
+          <Field name="plannedStartDate" label="Planned start" type="date" required/><Field name="plannedCompletionDate" label="Planned completion" type="date" required/>
+          <div className="md:col-span-2"><Label>Reason for validation</Label><Textarea name="reasonForValidation" required/></div>
+          <div className="md:col-span-2"><Label>Notes</Label><Textarea name="notes"/></div>
+          <DialogFooter className="md:col-span-2"><Button type="submit" disabled={create.isPending}>Create controlled draft</Button></DialogFooter>
+        </form></DialogContent></Dialog>
+    </div>
+    <Card><CardContent className="pt-6 text-sm text-muted-foreground">This workflow does not assert that AS9100 requires a commercial ERP or a named validation format. It preserves objective evidence for EPOCH's defined QMS intended use.</CardContent></Card>
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">{list.data?.map(p=><Card key={p.id} className="cursor-pointer hover:border-primary" onClick={()=>setSelected(p.id)}>
+      <CardHeader><div className="flex justify-between gap-2"><CardTitle className="text-lg">{p.package_number}</CardTitle><Badge className={tone(p.status)}>{pretty(p.status)}</Badge></div></CardHeader>
+      <CardContent><p className="font-semibold">{p.title}</p><p className="mt-2 text-sm text-muted-foreground">EPOCH {p.production_version} · {pretty(p.validation_type)}</p>
+        <div className="mt-4 grid grid-cols-3 text-center text-xs"><div>{p.requirement_count||0}<br/>requirements</div><div>{p.execution_count||0}<br/>executions</div><div>{p.open_defect_count||0}<br/>open defects</div></div></CardContent>
+    </Card>)}</div>
+    {!list.isLoading&&!list.data?.length&&<Card><CardContent className="py-12 text-center text-muted-foreground">No validation package exists. Create the first controlled draft package.</CardContent></Card>}
+  </div>;
+}
+
+function SectionWorkspace({section,detail:d,auditor}:{section:string;detail:Detail;auditor:boolean}){
+  const title=sections.find(x=>x[0]===section)?.[1]||'Validation';
+  const header=<CardHeader><CardTitle>{section}. {title}</CardTitle></CardHeader>;
+  if(section==='01')return <Card>{header}<CardContent>{d.intendedUse.length?<RecordView record={d.intendedUse[0]}/>:<Empty text="No Intended Use revision has been authored."/ >}</CardContent></Card>;
+  if(section==='02')return <Register title={title} records={d.requirements} columns={['requirement_id','module','category','statement','criticality','status']}/>;
+  if(section==='03')return <Register title={title} records={d.risks} columns={['risk_id','module','failure_mode','initial_risk_rating','residual_risk','status']}/>;
+  if(section==='04')return <Card>{header}<CardContent>{d.plans.length?<RecordView record={d.plans[0]}/>:<Empty text="No Validation Plan revision exists."/ >}</CardContent></Card>;
+  if(section==='05')return <Register title={title} records={d.protocols} columns={['test_id','title','module','criticality','revision','status']}/>;
+  if(section==='06')return <Register title={title} records={d.executions} columns={['execution_id','protocol_revision','tester_display_name','overall_result','review_decision','started_at']}/>;
+  if(section==='07')return <Register title={title} records={d.defects} columns={['defect_number','module','severity','description','retest_required','status']}/>;
+  if(section==='08')return <Card>{header}<CardContent><RecordView record={d.readiness}/></CardContent></Card>;
+  if(section==='09')return <Register title={title} records={d.approvals.filter(x=>x.record_type==='FINAL')} columns={['approval_role','decision','actor_display_name','actor_role','meaning','decided_at','status']}/>;
+  return <Register title={title} records={d.periodicReviews} columns={['review_date','current_production_version','revalidation_required','revalidation_scope','next_review_date','status']}/>;
+}
+function Register({title,records,columns}:{title:string;records:any[];columns:string[]}){
+  return <Card><CardHeader><CardTitle>{title}</CardTitle></CardHeader><CardContent className="overflow-x-auto">{records.length?
+    <Table><TableHeader><TableRow>{columns.map(c=><TableHead key={c}>{pretty(c)}</TableHead>)}</TableRow></TableHeader><TableBody>
+      {records.map((r,i)=><TableRow key={r.id||i}>{columns.map(c=><TableCell key={c} className="max-w-sm">{String(r[c]??'—')}</TableCell>)}</TableRow>)}
+    </TableBody></Table>:<Empty text={`No ${title.toLowerCase()} records exist.`}/>}</CardContent></Card>;
+}
+function RecordView({record}:{record:Record<string,any>}){return <dl className="grid gap-3 md:grid-cols-2">{Object.entries(record).filter(([k])=>!['id','package_id','created_by_user_id','updated_by_user_id'].includes(k)).map(([k,v])=>
+  <div key={k} className="rounded border p-2"><dt className="text-xs text-muted-foreground">{pretty(k)}</dt><dd className="whitespace-pre-wrap text-sm">{Array.isArray(v)?v.join(', '):typeof v==='object'?JSON.stringify(v):String(v??'—')}</dd></div>)}</dl>;}
+function Empty({text}:{text:string}){return <div className="py-12 text-center text-sm text-muted-foreground"><FileCheck2 className="mx-auto mb-3 h-8 w-8"/>{text}</div>;}
+function Metric({label,value,ok,danger}:{label:string;value:string;ok?:boolean;danger?:boolean}){return <Card><CardContent className="flex items-center gap-3 pt-5">{ok?<CheckCircle2 className="text-emerald-600"/>:danger?<AlertTriangle className="text-red-600"/>:<FileCheck2 className="text-primary"/>}<div><p className="text-xs text-muted-foreground">{label}</p><p className="text-xl font-bold">{value}</p></div></CardContent></Card>;}
+function ExportMenu({id}:{id:string}){return <Select onValueChange={v=>window.open(`/api/qms/epoch-software-validation/${id}/export?view=${v}`,'_blank')}><SelectTrigger className="w-56"><SelectValue placeholder="Export controlled report"/></SelectTrigger><SelectContent>
+  {['validation-plan','requirements-matrix','risk-register','test-protocols','test-executions','defects','summary','complete-package'].map(v=><SelectItem key={v} value={v}>{pretty(v)}</SelectItem>)}
+</SelectContent></Select>;}
+function Field({name,label,type='text',required,defaultValue}:{name:string;label:string;type?:string;required?:boolean;defaultValue?:string}){return <div><Label htmlFor={name}>{label}</Label><Input id={name} name={name} type={type} required={required} defaultValue={defaultValue}/></div>;}
+function Pick({name,label,values}:{name:string;label:string;values:string[]}){return <div><Label>{label}</Label><Select name={name} defaultValue={values[0]}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{values.map(v=><SelectItem key={v} value={v}>{pretty(v)}</SelectItem>)}</SelectContent></Select></div>;}

--- a/migrations/0229_epoch_software_validation.sql
+++ b/migrations/0229_epoch_software_validation.sql
@@ -1,0 +1,381 @@
+-- Migration 0229: persistent EPOCH intended-use software-validation packages.
+-- Additive and idempotent; no existing QMS or production records are modified.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE SEQUENCE IF NOT EXISTS qms_epoch_validation_package_number_seq;
+CREATE SEQUENCE IF NOT EXISTS qms_epoch_validation_requirement_number_seq;
+CREATE SEQUENCE IF NOT EXISTS qms_epoch_validation_risk_number_seq;
+CREATE SEQUENCE IF NOT EXISTS qms_epoch_validation_test_number_seq;
+CREATE SEQUENCE IF NOT EXISTS qms_epoch_validation_execution_number_seq;
+CREATE SEQUENCE IF NOT EXISTS qms_epoch_validation_defect_number_seq;
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_packages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_number text NOT NULL UNIQUE,
+  title text NOT NULL,
+  system_name text NOT NULL DEFAULT 'EPOCH',
+  validation_type text NOT NULL CHECK (validation_type IN
+    ('INITIAL_INTENDED_USE','MAJOR_RELEASE','CRITICAL_CHANGE','DATABASE_MIGRATION',
+     'SECURITY_ACCESS_CONTROL','BACKUP_RECOVERY','PERIODIC_REVIEW','PRE_AUDIT_REVALIDATION','CORRECTIVE_REVALIDATION')),
+  status text NOT NULL DEFAULT 'DRAFT' CHECK (status IN
+    ('DRAFT','PLANNING','READY_FOR_APPROVAL','PLAN_APPROVED','TESTING','TESTING_BLOCKED',
+     'CORRECTIONS_REQUIRED','RETESTING','READY_FOR_FINAL_REVIEW','APPROVED_FOR_INTENDED_USE',
+     'APPROVED_WITH_LIMITATIONS','REJECTED','SUPERSEDED','CANCELLED')),
+  production_version text NOT NULL,
+  commit_or_release_identifier text,
+  production_deployment_date date,
+  validation_environment text NOT NULL,
+  production_environment_reference text NOT NULL,
+  database_provider text NOT NULL,
+  hosting_provider text NOT NULL,
+  software_owner_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  quality_owner_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  validation_lead_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  planned_start_date date NOT NULL,
+  planned_completion_date date NOT NULL,
+  actual_completion_date date,
+  reason_for_validation text NOT NULL,
+  previous_approved_package_id uuid REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  superseded_package_id uuid REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  audit_readiness_assessment_id uuid REFERENCES qms_audit_readiness_assessments(id) ON DELETE RESTRICT,
+  notes text,
+  revision integer NOT NULL DEFAULT 1,
+  row_version integer NOT NULL DEFAULT 1,
+  locked_at timestamptz,
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_by_display_name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  updated_by_display_name text NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_intended_use_revisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  revision integer NOT NULL,
+  system_name text NOT NULL,
+  epoch_version text NOT NULL,
+  production_environment text NOT NULL,
+  software_owner_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  quality_owner_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  hosting_provider text NOT NULL,
+  database_provider text NOT NULL,
+  intended_use_statement text NOT NULL,
+  qms_processes_supported text NOT NULL,
+  official_records_controlled text NOT NULL,
+  outside_processes_records text,
+  user_groups_departments text NOT NULL,
+  interfaces_dependencies text,
+  customer_contractual_requirements text,
+  compliance_considerations text,
+  known_limitations text,
+  excluded_functionality text,
+  data_retention_responsibilities text NOT NULL,
+  backup_responsibilities text NOT NULL,
+  approval_status text NOT NULL DEFAULT 'DRAFT' CHECK (approval_status IN ('DRAFT','READY_FOR_APPROVAL','APPROVED','REJECTED','SUPERSEDED')),
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(package_id, revision)
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_requirements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  requirement_id text NOT NULL UNIQUE,
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  module text NOT NULL,
+  category text NOT NULL,
+  statement text NOT NULL,
+  purpose text NOT NULL,
+  source text NOT NULL,
+  criticality text NOT NULL CHECK (criticality IN ('CRITICAL','HIGH','NORMAL','INFORMATIONAL')),
+  product_quality_record_impact text, traceability_impact text, security_access_impact text,
+  data_integrity_impact text, regulatory_customer_impact text,
+  validation_method text NOT NULL,
+  test_required boolean NOT NULL DEFAULT true,
+  status text NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT','READY_FOR_APPROVAL','APPROVED','REJECTED','SUPERSEDED')),
+  owner_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  revision integer NOT NULL DEFAULT 1,
+  supersedes_requirement_id uuid REFERENCES qms_epoch_validation_requirements(id) ON DELETE RESTRICT,
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  updated_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_risks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  risk_id text NOT NULL UNIQUE,
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  requirement_id uuid REFERENCES qms_epoch_validation_requirements(id) ON DELETE RESTRICT,
+  module text NOT NULL, failure_mode text NOT NULL, cause text NOT NULL, potential_effect text NOT NULL,
+  quality_traceability_impact text NOT NULL,
+  severity integer NOT NULL CHECK (severity BETWEEN 1 AND 5),
+  likelihood integer NOT NULL CHECK (likelihood BETWEEN 1 AND 5),
+  detectability integer NOT NULL CHECK (detectability BETWEEN 1 AND 5),
+  initial_risk_rating integer GENERATED ALWAYS AS (severity * likelihood * detectability) STORED,
+  existing_controls text, additional_mitigation text,
+  mitigation_owner_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  due_date date, residual_risk text,
+  residual_risk_level text NOT NULL DEFAULT 'NORMAL' CHECK (residual_risk_level IN ('CRITICAL','HIGH','NORMAL','LOW')),
+  risk_accepted boolean NOT NULL DEFAULT false,
+  required_test boolean NOT NULL DEFAULT false,
+  status text NOT NULL DEFAULT 'DRAFT',
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  updated_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_plans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  revision integer NOT NULL, purpose text NOT NULL, scope text NOT NULL, epoch_version text NOT NULL,
+  commit_or_release_identifier text, included_modules text NOT NULL, excluded_modules text,
+  validation_environment text NOT NULL, test_database_environment text NOT NULL,
+  production_comparison_method text NOT NULL, responsibilities text NOT NULL, required_resources text,
+  testing_approach text NOT NULL, risk_based_selection text NOT NULL, evidence_requirements text NOT NULL,
+  acceptance_criteria text NOT NULL, defect_severity_rules text NOT NULL, retesting_requirements text NOT NULL,
+  regression_requirements text NOT NULL, backup_restore_requirements text NOT NULL,
+  outage_drill_requirements text NOT NULL, approval_roles text NOT NULL, schedule text NOT NULL,
+  deviations text, status text NOT NULL DEFAULT 'DRAFT',
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(), UNIQUE(package_id,revision)
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_protocols (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  test_id text NOT NULL UNIQUE,
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  title text NOT NULL, module text NOT NULL,
+  criticality text NOT NULL CHECK (criticality IN ('CRITICAL','HIGH','NORMAL','INFORMATIONAL')),
+  objective text NOT NULL, preconditions text, required_user_role text, required_test_data text,
+  test_environment text NOT NULL, overall_acceptance_criteria text NOT NULL, required_evidence text NOT NULL,
+  regression_classification text, independent_review_required boolean NOT NULL DEFAULT false,
+  revision integer NOT NULL DEFAULT 1, status text NOT NULL DEFAULT 'DRAFT',
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  updated_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_protocol_steps (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  protocol_id uuid NOT NULL REFERENCES qms_epoch_validation_protocols(id) ON DELETE RESTRICT,
+  step_number integer NOT NULL, instruction text NOT NULL, expected_result text NOT NULL,
+  required boolean NOT NULL DEFAULT true, UNIQUE(protocol_id,step_number)
+);
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_protocol_requirements (
+  protocol_id uuid NOT NULL REFERENCES qms_epoch_validation_protocols(id) ON DELETE RESTRICT,
+  requirement_id uuid NOT NULL REFERENCES qms_epoch_validation_requirements(id) ON DELETE RESTRICT,
+  PRIMARY KEY(protocol_id,requirement_id)
+);
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_protocol_risks (
+  protocol_id uuid NOT NULL REFERENCES qms_epoch_validation_protocols(id) ON DELETE RESTRICT,
+  risk_id uuid NOT NULL REFERENCES qms_epoch_validation_risks(id) ON DELETE RESTRICT,
+  PRIMARY KEY(protocol_id,risk_id)
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_executions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  execution_id text NOT NULL UNIQUE,
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  protocol_id uuid NOT NULL REFERENCES qms_epoch_validation_protocols(id) ON DELETE RESTRICT,
+  protocol_revision integer NOT NULL, epoch_version text NOT NULL, commit_or_release_identifier text,
+  test_environment text NOT NULL, test_database text NOT NULL,
+  tester_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  tester_display_name text NOT NULL, started_at timestamptz NOT NULL DEFAULT now(), ended_at timestamptz,
+  overall_result text NOT NULL DEFAULT 'NOT_RUN' CHECK (overall_result IN
+    ('NOT_RUN','IN_PROGRESS','PASSED','FAILED','BLOCKED','PASSED_WITH_APPROVED_DEVIATION','INVALIDATED','SUPERSEDED')),
+  linked_epoch_records text, github_reference text, deviations text, comments text,
+  reviewer_user_id integer REFERENCES users(id) ON DELETE RESTRICT, review_decision text, reviewed_at timestamptz,
+  retest_of_execution_id uuid REFERENCES qms_epoch_validation_executions(id) ON DELETE RESTRICT,
+  snapshot jsonb, snapshot_checksum text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_execution_steps (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  execution_id uuid NOT NULL REFERENCES qms_epoch_validation_executions(id) ON DELETE RESTRICT,
+  protocol_step_id uuid NOT NULL REFERENCES qms_epoch_validation_protocol_steps(id) ON DELETE RESTRICT,
+  step_number integer NOT NULL, instruction_snapshot text NOT NULL, expected_result_snapshot text NOT NULL,
+  actual_result text, status text NOT NULL DEFAULT 'NOT_RUN' CHECK (status IN ('NOT_RUN','IN_PROGRESS','PASSED','FAILED','BLOCKED')),
+  required boolean NOT NULL DEFAULT true, UNIQUE(execution_id,step_number)
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_evidence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  execution_id uuid REFERENCES qms_epoch_validation_executions(id) ON DELETE RESTRICT,
+  risk_id uuid REFERENCES qms_epoch_validation_risks(id) ON DELETE RESTRICT,
+  evidence_type text NOT NULL, attachment_id uuid, source_module text, source_record_id text,
+  record_number text, title text NOT NULL, revision text, open_route text, checksum text, notes text,
+  added_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  added_at timestamptz NOT NULL DEFAULT now(), removed_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_defects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  defect_number text NOT NULL UNIQUE,
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  failed_execution_id uuid REFERENCES qms_epoch_validation_executions(id) ON DELETE RESTRICT,
+  module text NOT NULL, description text NOT NULL,
+  severity text NOT NULL CHECK (severity IN ('CRITICAL','HIGH','MEDIUM','LOW')),
+  quality_record_impact text, traceability_impact text, existing_production_impact text,
+  containment text, root_cause text, corrective_action text,
+  owner_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT, due_date date,
+  github_reference text, database_migration_reference text,
+  retest_required boolean NOT NULL DEFAULT false,
+  retest_execution_id uuid REFERENCES qms_epoch_validation_executions(id) ON DELETE RESTRICT,
+  closure_evidence text, status text NOT NULL DEFAULT 'OPEN',
+  limitation_accepted boolean NOT NULL DEFAULT false,
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  updated_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_approvals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  record_type text NOT NULL, record_id uuid NOT NULL, record_revision integer NOT NULL,
+  approval_role text NOT NULL, decision text NOT NULL CHECK (decision IN ('APPROVED','REJECTED','RETURNED','RISK_ACCEPTED','LIMITATION_ACCEPTED')),
+  meaning text NOT NULL, actor_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  actor_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  actor_display_name text NOT NULL, actor_role text NOT NULL, capability_used text NOT NULL,
+  comments text, snapshot_checksum text NOT NULL,
+  status text NOT NULL DEFAULT 'VALID' CHECK (status IN ('VALID','INVALIDATED')),
+  decided_at timestamptz NOT NULL DEFAULT now(), invalidated_at timestamptz, invalidation_reason text
+);
+CREATE UNIQUE INDEX IF NOT EXISTS qms_epoch_validation_valid_approval_slot
+  ON qms_epoch_validation_approvals(record_type,record_id,record_revision,approval_role)
+  WHERE status='VALID' AND decision='APPROVED';
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_snapshots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  snapshot_type text NOT NULL, package_revision integer NOT NULL, snapshot jsonb NOT NULL,
+  checksum text NOT NULL, created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(), UNIQUE(package_id,snapshot_type,package_revision)
+);
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_periodic_reviews (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  review_date date NOT NULL, reviewer_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  current_production_version text NOT NULL, previously_approved_version text NOT NULL,
+  changes_since_approval text, critical_changes text, database_migrations text,
+  security_authentication_changes text, hosting_database_changes text, backup_recovery_changes text,
+  serious_defects_incidents text, new_official_qms_modules text, audit_findings text, customer_findings text,
+  revalidation_required boolean NOT NULL, revalidation_scope text, next_review_date date NOT NULL,
+  status text NOT NULL DEFAULT 'DRAFT', created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_events (
+  id bigserial PRIMARY KEY,
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  entity_type text NOT NULL, entity_id text, action text NOT NULL,
+  actor_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  actor_display_name text NOT NULL, actor_role text NOT NULL,
+  previous_value jsonb, new_value jsonb, reason text,
+  package_revision integer NOT NULL, created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_requirement_library (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  library_key text NOT NULL UNIQUE, module text NOT NULL, category text NOT NULL,
+  suggested_statement text NOT NULL, criticality text NOT NULL,
+  lifecycle_status text NOT NULL DEFAULT 'DRAFT' CHECK (lifecycle_status IN ('DRAFT','RELEASED','OBSOLETE')),
+  revision integer NOT NULL DEFAULT 1, created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_protocol_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_key text NOT NULL UNIQUE, title text NOT NULL, module text NOT NULL,
+  criticality text NOT NULL, objective text NOT NULL,
+  lifecycle_status text NOT NULL DEFAULT 'DRAFT' CHECK (lifecycle_status IN ('DRAFT','RELEASED','OBSOLETE')),
+  revision integer NOT NULL DEFAULT 1, created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS qms_esv_package_status_idx ON qms_epoch_validation_packages(status,updated_at DESC);
+CREATE INDEX IF NOT EXISTS qms_esv_requirement_package_idx ON qms_epoch_validation_requirements(package_id,criticality,status);
+CREATE INDEX IF NOT EXISTS qms_esv_risk_package_idx ON qms_epoch_validation_risks(package_id,status);
+CREATE INDEX IF NOT EXISTS qms_esv_protocol_package_idx ON qms_epoch_validation_protocols(package_id,criticality,status);
+CREATE INDEX IF NOT EXISTS qms_esv_execution_package_idx ON qms_epoch_validation_executions(package_id,overall_result);
+CREATE INDEX IF NOT EXISTS qms_esv_defect_package_idx ON qms_epoch_validation_defects(package_id,severity,status);
+CREATE INDEX IF NOT EXISTS qms_esv_event_package_idx ON qms_epoch_validation_events(package_id,created_at DESC);
+
+CREATE OR REPLACE FUNCTION prevent_qms_esv_append_only_delete() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN RAISE EXCEPTION 'EPOCH software validation approvals, snapshots, and events are append-only'; END $$;
+DROP TRIGGER IF EXISTS qms_esv_approval_no_delete ON qms_epoch_validation_approvals;
+CREATE TRIGGER qms_esv_approval_no_delete BEFORE DELETE ON qms_epoch_validation_approvals FOR EACH ROW EXECUTE FUNCTION prevent_qms_esv_append_only_delete();
+DROP TRIGGER IF EXISTS qms_esv_snapshot_no_delete ON qms_epoch_validation_snapshots;
+CREATE TRIGGER qms_esv_snapshot_no_delete BEFORE DELETE ON qms_epoch_validation_snapshots FOR EACH ROW EXECUTE FUNCTION prevent_qms_esv_append_only_delete();
+DROP TRIGGER IF EXISTS qms_esv_event_no_delete ON qms_epoch_validation_events;
+CREATE TRIGGER qms_esv_event_no_delete BEFORE DELETE ON qms_epoch_validation_events FOR EACH ROW EXECUTE FUNCTION prevent_qms_esv_append_only_delete();
+
+INSERT INTO perm_capabilities(key,description,category) VALUES
+ ('EPOCH_VALIDATION_VIEW','View EPOCH software-validation records','qms'),
+ ('EPOCH_VALIDATION_CREATE','Create EPOCH software-validation packages','qms'),
+ ('EPOCH_VALIDATION_EDIT','Edit unlocked EPOCH software-validation records','qms'),
+ ('EPOCH_VALIDATION_PLAN_APPROVE','Approve validation plans and baselines','qms'),
+ ('EPOCH_VALIDATION_TEST_EXECUTE','Execute approved validation protocols','qms'),
+ ('EPOCH_VALIDATION_TEST_REVIEW','Independently review test executions','qms'),
+ ('EPOCH_VALIDATION_DEFECT_MANAGE','Manage software-validation defects','qms'),
+ ('EPOCH_VALIDATION_FINAL_APPROVE','Approve EPOCH for its documented intended use','qms'),
+ ('EPOCH_VALIDATION_REOPEN','Reopen a controlled validation package','qms'),
+ ('EPOCH_VALIDATION_EXPORT','Export software-validation records','qms'),
+ ('EPOCH_VALIDATION_ADMIN','Administer EPOCH software validation','qms')
+ON CONFLICT(key) DO NOTHING;
+INSERT INTO perm_role_capabilities(role_id,capability_id)
+SELECT r.id,c.id FROM perm_roles r CROSS JOIN perm_capabilities c
+WHERE r.name IN ('ADMIN','OWNER','QUALITY','QUALITY_MANAGER')
+AND c.key LIKE 'EPOCH_VALIDATION_%' ON CONFLICT(role_id,capability_id) DO NOTHING;
+INSERT INTO perm_role_capabilities(role_id,capability_id)
+SELECT r.id,c.id FROM perm_roles r CROSS JOIN perm_capabilities c
+WHERE r.name IN ('MANAGER','PROGRAM_MANAGER','ENGINEERING','ENGINEER')
+AND c.key IN ('EPOCH_VALIDATION_VIEW','EPOCH_VALIDATION_CREATE','EPOCH_VALIDATION_EDIT',
+  'EPOCH_VALIDATION_TEST_EXECUTE','EPOCH_VALIDATION_EXPORT')
+ON CONFLICT(role_id,capability_id) DO NOTHING;
+
+INSERT INTO qms_epoch_validation_requirement_library
+  (library_key,module,category,suggested_statement,criticality,lifecycle_status) VALUES
+ ('AUTH-UNIQUE','Authentication','Authentication','EPOCH requires unique authenticated users.','CRITICAL','DRAFT'),
+ ('AUTHZ-SERVER','Platform','Authorization/permissions','Server endpoints enforce role/capability authorization.','CRITICAL','DRAFT'),
+ ('APPROVAL-IDENTITY','Platform','Electronic approvals','Electronic approvals identify the authenticated approver, role, date/time and approved record revision.','CRITICAL','DRAFT'),
+ ('APPROVAL-STALE','Platform','Electronic approvals','Changes after approval invalidate or supersede affected approvals.','CRITICAL','DRAFT'),
+ ('RECORD-IMMUTABLE','QMS','Data integrity','Released quality records cannot be silently overwritten.','CRITICAL','DRAFT'),
+ ('RECORD-CORRECTION','QMS','Audit trail','Record corrections preserve an audit history.','CRITICAL','DRAFT'),
+ ('MATERIAL-BLOCK','Inventory','Inventory','Rejected, quarantined, expired or blocked material cannot be issued to production.','CRITICAL','DRAFT'),
+ ('LOT-SPLIT','Inventory','Material genealogy','Material lot splitting preserves parent-child genealogy.','CRITICAL','DRAFT'),
+ ('TRACE-BACK','Traceability','Material genealogy','A finished product can be traced backward to consumed materials and components.','CRITICAL','DRAFT'),
+ ('TRACE-FORWARD','Traceability','Material genealogy','A material lot can be traced forward to affected work orders and finished products.','CRITICAL','DRAFT'),
+ ('WO-REVISION','Production','Work orders','Work orders use the correct part and revision.','CRITICAL','DRAFT'),
+ ('ROUTING-SEQUENCE','Production','Routing','Routing controls the required manufacturing sequence.','CRITICAL','DRAFT'),
+ ('CURRENT-INSTRUCTIONS','Document Control','Document control','Technicians receive current released instructions.','CRITICAL','DRAFT'),
+ ('INSPECTION-GATE','Quality','Final release','Required inspections and final release cannot be bypassed.','CRITICAL','DRAFT'),
+ ('TRAINING-GATE','Training','Training and qualification','Unqualified employees are blocked from restricted operations where configured.','HIGH','DRAFT'),
+ ('NCR-AUTH','Quality','NCR/CAR','NCR dispositions are authorized and traceable.','CRITICAL','DRAFT'),
+ ('DC-FAIL-CLOSED','Design Control','Design Control','Design Control release gates fail closed when required evidence is incomplete.','CRITICAL','DRAFT'),
+ ('ER-BASELINE','Engineering Release','Engineering Release','Engineering Release preserves an immutable approved baseline.','CRITICAL','DRAFT'),
+ ('BACKUP-RESTORE','Infrastructure','Backup','Backups are available and representative records can be restored.','CRITICAL','DRAFT'),
+ ('OUTAGE','Infrastructure','Outage continuity','EPOCH has a controlled outage process.','CRITICAL','DRAFT')
+ON CONFLICT(library_key) DO NOTHING;
+
+INSERT INTO qms_epoch_validation_protocol_templates
+  (template_key,title,module,criticality,objective,lifecycle_status) VALUES
+ ('AUTHENTICATION','Authentication','Platform','CRITICAL','Verify unique authenticated access and rejection of invalid credentials.','DRAFT'),
+ ('ROLE-PERMISSIONS','Role permissions','Platform','CRITICAL','Verify allowed actions and server denial of unauthorized actions.','DRAFT'),
+ ('UNAUTHORIZED-APPROVAL','Unauthorized approval prevention','Platform','CRITICAL','Verify approval endpoints fail closed for unauthorized identities.','DRAFT'),
+ ('AUDIT-CORRECTION','Record correction and audit history','QMS','CRITICAL','Verify correction preserves attributable history.','DRAFT'),
+ ('RECEIVING-LOT','Receiving and lot creation','Receiving','HIGH','Verify controlled receipt and lot identity.','DRAFT'),
+ ('REJECTED-BLOCK','Rejected-material blocking','Inventory','CRITICAL','Verify blocked material cannot be issued.','DRAFT'),
+ ('LOT-GENEALOGY','Lot split and genealogy','Inventory','CRITICAL','Verify parent-child genealogy after split.','DRAFT'),
+ ('TRACE-BACK','Finished-product backward trace','Traceability','CRITICAL','Verify complete backward product genealogy.','DRAFT'),
+ ('TRACE-FORWARD','Material-lot forward trace','Traceability','CRITICAL','Verify complete forward lot genealogy.','DRAFT'),
+ ('WO-REVISION','Work-order revision','Production','CRITICAL','Verify correct part and released revision.','DRAFT'),
+ ('ROUTING','Routing and department sequence','Production','CRITICAL','Verify required manufacturing sequence.','DRAFT'),
+ ('TRAVELER','Traveler completion','Production','CRITICAL','Verify traveler completion controls and evidence.','DRAFT'),
+ ('TRAINING','Employee training restriction','Training','HIGH','Verify configured qualification restrictions.','DRAFT'),
+ ('FINAL-RELEASE','Inspection and final release','Quality','CRITICAL','Verify required inspection and release gates.','DRAFT'),
+ ('NCR','NCR creation and disposition','Quality','CRITICAL','Verify attributable NCR lifecycle and disposition.','DRAFT'),
+ ('DOC-SUPERSESSION','Document supersession','Document Control','CRITICAL','Verify obsolete instructions cannot be silently used.','DRAFT'),
+ ('DC-RELEASE','Design Control release gate','Design Control','CRITICAL','Verify incomplete evidence fails closed.','DRAFT'),
+ ('ER-BASELINE','Engineering Release baseline','Engineering Release','CRITICAL','Verify immutable approved baseline.','DRAFT'),
+ ('BACKUP','Backup verification','Infrastructure','CRITICAL','Verify current backup evidence.','DRAFT'),
+ ('RESTORE','Restore test','Infrastructure','CRITICAL','Restore representative records and verify integrity.','DRAFT'),
+ ('OUTAGE','Outage and recovery drill','Infrastructure','CRITICAL','Verify controlled outage continuity and recovery.','DRAFT')
+ON CONFLICT(template_key) DO NOTHING;
+
+COMMENT ON TABLE qms_epoch_validation_packages IS 'Authoritative EPOCH software intended-use validation packages; never a substitute for the AS9100 readiness assessment.';

--- a/server/__tests__/epochSoftwareValidationArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationArchitecture.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const root=path.resolve(import.meta.dirname,'../..');
+const read=(file:string)=>fs.readFileSync(path.join(root,file),'utf8');
+const migration=read('migrations/0229_epoch_software_validation.sql');
+const route=read('server/src/routes/epochSoftwareValidation.ts');
+const auditRoute=read('server/src/routes/auditReadiness.ts');
+const app=read('client/src/App.tsx');
+const nav=read('client/src/components/Navigation.tsx');
+const safeBoot=read('server/scripts/migrations/runSafeBootMigrations.ts');
+
+describe('EPOCH software-validation architecture',()=>{
+  it('registers the direct QMS route and Section 2 source integration',()=>{
+    expect(app).toContain('path="/qms/epoch-software-validation"');
+    expect(nav).toContain("path: '/qms/epoch-software-validation'");
+    expect(route).toContain("router.use(authenticateToken)");
+    expect(auditRoute).toContain('getAuditReadinessValidationStatus');
+    expect(auditRoute).toContain('EPOCH_VALIDATION_INCOMPLETE');
+  });
+  it('uses server sequences and normalized records',()=>{
+    for(const seq of ['package_number','requirement_number','risk_number','test_number','execution_number','defect_number'])
+      expect(migration).toContain(`qms_epoch_validation_${seq}_seq`);
+    for(const table of ['packages','intended_use_revisions','requirements','risks','plans','protocols',
+      'protocol_steps','executions','execution_steps','evidence','defects','approvals','snapshots','periodic_reviews','events'])
+      expect(migration).toContain(`qms_epoch_validation_${table}`);
+    expect(route).toContain("nextval('qms_epoch_validation_package_number_seq')");
+    expect(route).not.toMatch(/count\(\*\).+package_number/s);
+  });
+  it('enforces capabilities, server-derived results, locking, and controlled reopening',()=>{
+    for(const capability of ['VIEW','CREATE','EDIT','PLAN_APPROVE','TEST_EXECUTE','TEST_REVIEW',
+      'DEFECT_MANAGE','FINAL_APPROVE','REOPEN','EXPORT','ADMIN'])
+      expect(migration).toContain(`EPOCH_VALIDATION_${capability}`);
+    expect(route).toContain('deriveExecutionResult');
+    expect(route).toContain('VALIDATION_PACKAGE_LOCKED');
+    expect(route).toContain('PACKAGE_REOPENED');
+    expect(route).toContain('FINAL_READINESS_BLOCKED');
+    expect(route).toContain('CRITICAL_HIGH_RISK_REQUIRES_APPROVED_PROTOCOL');
+  });
+  it('seeds draft-only suggested libraries and never auto-approves',()=>{
+    expect(migration).toContain('qms_epoch_validation_requirement_library');
+    expect(migration).toContain('qms_epoch_validation_protocol_templates');
+    expect(migration).toContain("'Backups are available and representative records can be restored.'");
+    expect(migration).toContain("'Outage and recovery drill'");
+    expect(migration).not.toMatch(/protocol_templates[\s\S]+lifecycle_status[\s\S]+,'RELEASED'/);
+  });
+  it('registers the additive migration in both safe-boot lists',()=>{
+    expect(safeBoot.match(/0229_epoch_software_validation\.sql/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(migration).toContain('ON CONFLICT(library_key) DO NOTHING');
+    expect(migration).toContain('ON CONFLICT(template_key) DO NOTHING');
+  });
+});

--- a/server/__tests__/epochSoftwareValidationRules.test.ts
+++ b/server/__tests__/epochSoftwareValidationRules.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateReadiness,
+  canTransition,
+  deriveExecutionResult,
+  type ReadinessCounts,
+} from '../src/services/epochSoftwareValidation';
+
+const ready: ReadinessCounts = {
+  intendedUseApproved: true,
+  requirementsBaselineApproved: true,
+  riskAssessmentApproved: true,
+  validationPlanApproved: true,
+  criticalRequirements: 3,
+  criticalRequirementsTested: 3,
+  criticalTests: 3,
+  criticalTestsPassed: 3,
+  openCriticalDefects: 0,
+  openHighDefects: 0,
+  acceptedHighDefects: 0,
+  requiredRetests: 1,
+  passedRetests: 1,
+  backupPassed: true,
+  restorePassed: true,
+  outageDrillPassed: true,
+  approvalsCurrent: true,
+  exactProductionVersionIdentified: true,
+};
+
+describe('EPOCH software-validation control rules', () => {
+  it('enforces explicit status transitions', () => {
+    expect(canTransition('DRAFT', 'PLANNING')).toBe(true);
+    expect(canTransition('DRAFT', 'APPROVED_FOR_INTENDED_USE')).toBe(false);
+    expect(canTransition('APPROVED_FOR_INTENDED_USE', 'TESTING')).toBe(false);
+  });
+
+  it('derives execution results from required steps', () => {
+    expect(deriveExecutionResult([{ status: 'PASSED' }, { status: 'FAILED' }])).toBe('FAILED');
+    expect(deriveExecutionResult([{ status: 'PASSED' }, { status: 'BLOCKED' }])).toBe('BLOCKED');
+    expect(deriveExecutionResult([{ status: 'PASSED' }, { status: 'FAILED', required: false }])).toBe('PASSED');
+  });
+
+  it('fails final readiness closed with named blockers', () => {
+    expect(calculateReadiness(ready)).toEqual({ ready: true, blockers: [] });
+    const blocked = calculateReadiness({ ...ready, openCriticalDefects: 1, restorePassed: false });
+    expect(blocked.ready).toBe(false);
+    expect(blocked.blockers).toContain('Critical validation defects remain open');
+    expect(blocked.blockers).toContain('Restore testing has not passed');
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -253,6 +253,7 @@ export const safeMigrationFiles = [
   '0224_p2_v2_quality_release_hardening.sql',
   '0225_p2_v2_shipping_project_closeout.sql',
   '0226_project_production_launch_composite_key.sql',
+  '0229_epoch_software_validation.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -293,6 +294,7 @@ export const criticalMigrationFiles = new Set([
   '0224_p2_v2_quality_release_hardening.sql',
   '0225_p2_v2_shipping_project_closeout.sql',
   '0226_project_production_launch_composite_key.sql',
+  '0229_epoch_software_validation.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/auditReadiness.ts
+++ b/server/src/routes/auditReadiness.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { pool } from '../../db';
 import { authenticateToken } from '../../middleware/auth';
 import { requirePermission } from '../../middleware/requirePermission';
+import { getAuditReadinessValidationStatus } from './epochSoftwareValidation';
 
 const router = Router();
 router.use(authenticateToken);
@@ -180,7 +181,18 @@ router.get('/:id', requirePermission('qms.audit_readiness.view'), async (req, re
     `SELECT i.*, count(e.id) FILTER (WHERE NOT e.is_removed)::int AS evidence_count
      FROM qms_audit_readiness_items i LEFT JOIN qms_audit_readiness_evidence e ON e.item_id=i.id
      WHERE i.assessment_id=$1 GROUP BY i.id ORDER BY i.sequence`, [assessmentId]);
-  res.json({ assessment, items, readiness: await readiness(assessmentId) });
+  res.json({
+    assessment,
+    items,
+    readiness: await readiness(assessmentId),
+    epochSoftwareValidation: await getAuditReadinessValidationStatus(assessmentId),
+  });
+});
+
+router.get('/:id/epoch-software-validation', requirePermission('qms.audit_readiness.view'), async (req, res) => {
+  const status = await getAuditReadinessValidationStatus(id.parse(req.params.id));
+  if (!status) return res.status(404).json({ error: 'ASSESSMENT_NOT_FOUND' });
+  res.json(status);
 });
 
 router.get('/:id/readiness', requirePermission('qms.audit_readiness.view'), async (req, res) => {
@@ -281,6 +293,15 @@ router.post('/:assessmentId/items/:itemId/verify', requirePermission('qms.audit_
   const assessment=await getAssessment(assessmentId),a=actor(req);
   if(!assessment)return res.status(404).json({error:'ASSESSMENT_NOT_FOUND'});
   if(locked(assessment))return res.status(409).json({error:'ASSESSMENT_LOCKED'});
+  const currentItem=(await rows(`SELECT * FROM qms_audit_readiness_items WHERE id=$1 AND assessment_id=$2`,[itemId,assessmentId]))[0];
+  if(currentItem?.section_key==='02'){
+    const validation=await getAuditReadinessValidationStatus(assessmentId);
+    if(!validation?.complete)return res.status(409).json({
+      error:'EPOCH_VALIDATION_INCOMPLETE',
+      message:'Section 2 is server-derived and cannot be manually completed until the linked EPOCH Software Validation Package is current.',
+      blockers:validation?.blockers||['No linked validation package'],
+    });
+  }
   const updated=(await rows(`UPDATE qms_audit_readiness_items SET status='VERIFIED',verification_result=$1,
    reviewer_comments=$2,verified_by_user_id=$3,verified_by_display_name=$4,verified_at=now(),completed_at=now(),
    completion_percentage=100,row_version=row_version+1,last_updated_by_user_id=$3,updated_at=now()

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -1,0 +1,575 @@
+import { Router, type Request } from 'express';
+import { z } from 'zod';
+import { pool } from '../../db';
+import { authenticateToken } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/requirePermission';
+import {
+  calculateReadiness, canTransition, checksum, deriveExecutionResult,
+  type ReadinessCounts, type ValidationStatus,
+} from '../services/epochSoftwareValidation';
+
+const router = Router();
+router.use(authenticateToken);
+const uuid = z.string().uuid();
+type Query = (sql: string, params?: unknown[]) => Promise<any[]>;
+const query: Query = async (sql, params = []) => (await pool.query(sql, params as any[])).rows;
+async function tx<T>(work: (q: Query) => Promise<T>) {
+  const client = await pool.connect();
+  const q: Query = async (sql, params = []) => (await client.query(sql, params as any[])).rows;
+  try { await client.query('BEGIN'); const value = await work(q); await client.query('COMMIT'); return value; }
+  catch (error) { await client.query('ROLLBACK'); throw error; } finally { client.release(); }
+}
+const actor = (req: Request) => {
+  const u = req.user as any;
+  return { id: Number(u.id), employeeId: u.employeeId ? Number(u.employeeId) : null,
+    name: String(u.displayName || u.name || u.username), role: String(u.role) };
+};
+const isLocked = (p: any) => Boolean(p.locked_at) ||
+  ['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS','SUPERSEDED'].includes(p.status);
+const getPackage = async (id: string, q: Query = query) =>
+  (await q('SELECT * FROM qms_epoch_validation_packages WHERE id=$1',[id]))[0];
+async function logEvent(req: Request, p: any, entityType: string, action: string,
+  options: { entityId?: string; previous?: unknown; next?: unknown; reason?: string } = {}, q: Query = query) {
+  const a=actor(req);
+  await q(`INSERT INTO qms_epoch_validation_events
+    (package_id,entity_type,entity_id,action,actor_user_id,actor_display_name,actor_role,
+     previous_value,new_value,reason,package_revision)
+    VALUES($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11)`,
+    [p.id,entityType,options.entityId||null,action,a.id,a.name,a.role,
+     options.previous ? JSON.stringify(options.previous) : null,
+     options.next ? JSON.stringify(options.next) : null,options.reason||null,p.revision]);
+}
+async function invalidateApprovals(packageId: string, reason: string, q: Query = query) {
+  await q(`UPDATE qms_epoch_validation_approvals SET status='INVALIDATED',invalidated_at=now(),invalidation_reason=$2
+    WHERE package_id=$1 AND status='VALID'`,[packageId,reason]);
+}
+async function editable(req: Request, res: any) {
+  const p=await getPackage(uuid.parse(req.params.id || req.params.packageId));
+  if(!p){res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});return null;}
+  if(isLocked(p)){res.status(409).json({error:'VALIDATION_PACKAGE_LOCKED',message:'Approved packages are immutable. Use controlled reopening.'});return null;}
+  return p;
+}
+
+const createSchema=z.object({
+  title:z.string().min(3).max(240), systemName:z.string().min(1).default('EPOCH'),
+  validationType:z.enum(['INITIAL_INTENDED_USE','MAJOR_RELEASE','CRITICAL_CHANGE','DATABASE_MIGRATION',
+    'SECURITY_ACCESS_CONTROL','BACKUP_RECOVERY','PERIODIC_REVIEW','PRE_AUDIT_REVALIDATION','CORRECTIVE_REVALIDATION']),
+  productionVersion:z.string().min(1), commitOrReleaseIdentifier:z.string().max(240).optional(),
+  productionDeploymentDate:z.string().date().optional(), validationEnvironment:z.string().min(1),
+  productionEnvironmentReference:z.string().min(1), databaseProvider:z.string().min(1), hostingProvider:z.string().min(1),
+  softwareOwnerEmployeeId:z.number().int().positive().optional(),qualityOwnerEmployeeId:z.number().int().positive().optional(),
+  validationLeadEmployeeId:z.number().int().positive().optional(),plannedStartDate:z.string().date(),
+  plannedCompletionDate:z.string().date(),reasonForValidation:z.string().min(3),
+  previousApprovedPackageId:z.string().uuid().optional(),auditReadinessAssessmentId:z.string().uuid().optional(),
+  notes:z.string().max(20000).optional(),
+});
+router.get('/',requirePermission('EPOCH_VALIDATION_VIEW'),async(_req,res)=>{
+  res.json(await query(`SELECT p.*,
+    (SELECT count(*)::int FROM qms_epoch_validation_requirements r WHERE r.package_id=p.id) requirement_count,
+    (SELECT count(*)::int FROM qms_epoch_validation_executions e WHERE e.package_id=p.id) execution_count,
+    (SELECT count(*)::int FROM qms_epoch_validation_defects d WHERE d.package_id=p.id AND d.status NOT IN ('CLOSED','CANCELLED')) open_defect_count
+    FROM qms_epoch_validation_packages p ORDER BY p.created_at DESC`));
+});
+router.post('/',requirePermission('EPOCH_VALIDATION_CREATE'),async(req,res)=>{
+  const parsed=createSchema.safeParse(req.body);
+  if(!parsed.success)return res.status(400).json({error:'VALIDATION_ERROR',details:parsed.error.flatten()});
+  const v=parsed.data,a=actor(req);
+  const created=await tx(async q=>{
+    const seq=(await q(`SELECT nextval('qms_epoch_validation_package_number_seq') value`))[0].value;
+    const number=`ESV-${new Date().getUTCFullYear()}-${String(seq).padStart(4,'0')}`;
+    const p=(await q(`INSERT INTO qms_epoch_validation_packages
+      (package_number,title,system_name,validation_type,production_version,commit_or_release_identifier,
+       production_deployment_date,validation_environment,production_environment_reference,database_provider,
+       hosting_provider,software_owner_employee_id,quality_owner_employee_id,validation_lead_employee_id,
+       planned_start_date,planned_completion_date,reason_for_validation,previous_approved_package_id,
+       audit_readiness_assessment_id,notes,created_by_user_id,created_by_display_name,updated_by_user_id,updated_by_display_name)
+      VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$21,$22) RETURNING *`,
+      [number,v.title,v.systemName,v.validationType,v.productionVersion,v.commitOrReleaseIdentifier||null,
+       v.productionDeploymentDate||null,v.validationEnvironment,v.productionEnvironmentReference,v.databaseProvider,
+       v.hostingProvider,v.softwareOwnerEmployeeId||null,v.qualityOwnerEmployeeId||null,v.validationLeadEmployeeId||null,
+       v.plannedStartDate,v.plannedCompletionDate,v.reasonForValidation,v.previousApprovedPackageId||null,
+       v.auditReadinessAssessmentId||null,v.notes||null,a.id,a.name]))[0];
+    await logEvent(req,p,'PACKAGE','PACKAGE_CREATED',{next:{packageNumber:number,productionVersion:v.productionVersion}},q);
+    return p;
+  });
+  res.status(201).json(created);
+});
+
+async function counts(packageId:string):Promise<ReadinessCounts>{
+  const r=(await query(`SELECT
+    EXISTS(SELECT 1 FROM qms_epoch_validation_intended_use_revisions u WHERE u.package_id=$1 AND u.approval_status='APPROVED') intended_use,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_requirements x WHERE x.package_id=$1) AND
+      NOT EXISTS(SELECT 1 FROM qms_epoch_validation_requirements x WHERE x.package_id=$1 AND x.status<>'APPROVED') requirements_approved,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_risks x WHERE x.package_id=$1) AND
+      NOT EXISTS(SELECT 1 FROM qms_epoch_validation_risks x WHERE x.package_id=$1 AND
+        (x.status<>'APPROVED' OR (x.residual_risk_level IN ('CRITICAL','HIGH') AND NOT x.risk_accepted))) risks_approved,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_plans x WHERE x.package_id=$1 AND x.status='APPROVED') plan_approved,
+    (SELECT count(*)::int FROM qms_epoch_validation_requirements x WHERE x.package_id=$1 AND x.criticality='CRITICAL') critical_requirements,
+    (SELECT count(DISTINCT pr.requirement_id)::int FROM qms_epoch_validation_protocol_requirements pr
+      JOIN qms_epoch_validation_protocols p ON p.id=pr.protocol_id
+      JOIN qms_epoch_validation_requirements x ON x.id=pr.requirement_id
+      JOIN qms_epoch_validation_executions e ON e.protocol_id=p.id
+      WHERE x.package_id=$1 AND x.criticality='CRITICAL' AND e.overall_result IN ('PASSED','PASSED_WITH_APPROVED_DEVIATION')) critical_requirements_tested,
+    (SELECT count(*)::int FROM qms_epoch_validation_protocols x WHERE x.package_id=$1 AND x.criticality='CRITICAL' AND x.status='APPROVED') critical_tests,
+    (SELECT count(DISTINCT e.protocol_id)::int FROM qms_epoch_validation_executions e JOIN qms_epoch_validation_protocols p ON p.id=e.protocol_id
+      WHERE e.package_id=$1 AND p.criticality='CRITICAL' AND e.overall_result IN ('PASSED','PASSED_WITH_APPROVED_DEVIATION') AND e.review_decision='APPROVED') critical_tests_passed,
+    (SELECT count(*)::int FROM qms_epoch_validation_defects x WHERE x.package_id=$1 AND x.severity='CRITICAL' AND x.status NOT IN ('CLOSED','CANCELLED')) open_critical,
+    (SELECT count(*)::int FROM qms_epoch_validation_defects x WHERE x.package_id=$1 AND x.severity='HIGH' AND x.status NOT IN ('CLOSED','CANCELLED')) open_high,
+    (SELECT count(*)::int FROM qms_epoch_validation_defects x WHERE x.package_id=$1 AND x.severity='HIGH' AND x.status NOT IN ('CLOSED','CANCELLED') AND x.limitation_accepted) accepted_high,
+    (SELECT count(*)::int FROM qms_epoch_validation_defects x WHERE x.package_id=$1 AND x.retest_required) required_retests,
+    (SELECT count(*)::int FROM qms_epoch_validation_defects x JOIN qms_epoch_validation_executions e ON e.id=x.retest_execution_id
+      WHERE x.package_id=$1 AND x.retest_required AND e.overall_result IN ('PASSED','PASSED_WITH_APPROVED_DEVIATION') AND e.review_decision='APPROVED') passed_retests,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_protocols p JOIN qms_epoch_validation_executions e ON e.protocol_id=p.id
+      WHERE p.package_id=$1 AND lower(p.title) LIKE '%backup%' AND e.overall_result='PASSED' AND e.review_decision='APPROVED') backup_passed,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_protocols p JOIN qms_epoch_validation_executions e ON e.protocol_id=p.id
+      WHERE p.package_id=$1 AND lower(p.title) LIKE '%restore%' AND e.overall_result='PASSED' AND e.review_decision='APPROVED') restore_passed,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_protocols p JOIN qms_epoch_validation_executions e ON e.protocol_id=p.id
+      WHERE p.package_id=$1 AND (lower(p.title) LIKE '%outage%' OR lower(p.title) LIKE '%recovery drill%') AND e.overall_result='PASSED' AND e.review_decision='APPROVED') outage_passed,
+    NOT EXISTS(SELECT 1 FROM qms_epoch_validation_approvals a WHERE a.package_id=$1 AND a.status='INVALIDATED') AND
+      (SELECT count(DISTINCT approval_role) FROM qms_epoch_validation_approvals a WHERE a.package_id=$1 AND a.record_type='FINAL' AND a.status='VALID' AND a.decision='APPROVED')>=3 approvals_current,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_packages p WHERE p.id=$1 AND nullif(trim(p.production_version),'') IS NOT NULL) version_identified`,[packageId]))[0];
+  return {intendedUseApproved:r.intended_use,requirementsBaselineApproved:r.requirements_approved,
+    riskAssessmentApproved:r.risks_approved,validationPlanApproved:r.plan_approved,
+    criticalRequirements:r.critical_requirements,criticalRequirementsTested:r.critical_requirements_tested,
+    criticalTests:r.critical_tests,criticalTestsPassed:r.critical_tests_passed,
+    openCriticalDefects:r.open_critical,openHighDefects:r.open_high,acceptedHighDefects:r.accepted_high,
+    requiredRetests:r.required_retests,passedRetests:r.passed_retests,backupPassed:r.backup_passed,
+    restorePassed:r.restore_passed,outageDrillPassed:r.outage_passed,approvalsCurrent:r.approvals_current,
+    exactProductionVersionIdentified:r.version_identified};
+}
+async function detail(packageId:string){
+  const p=await getPackage(packageId); if(!p)return null;
+  const [intendedUse,requirements,risks,plans,protocols,executions,defects,approvals,reviews,events]=await Promise.all([
+    query('SELECT * FROM qms_epoch_validation_intended_use_revisions WHERE package_id=$1 ORDER BY revision DESC',[packageId]),
+    query('SELECT * FROM qms_epoch_validation_requirements WHERE package_id=$1 ORDER BY requirement_id',[packageId]),
+    query('SELECT * FROM qms_epoch_validation_risks WHERE package_id=$1 ORDER BY risk_id',[packageId]),
+    query('SELECT * FROM qms_epoch_validation_plans WHERE package_id=$1 ORDER BY revision DESC',[packageId]),
+    query(`SELECT p.*,(SELECT count(*)::int FROM qms_epoch_validation_protocol_steps s WHERE s.protocol_id=p.id) step_count
+      FROM qms_epoch_validation_protocols p WHERE package_id=$1 ORDER BY test_id`,[packageId]),
+    query('SELECT * FROM qms_epoch_validation_executions WHERE package_id=$1 ORDER BY created_at DESC',[packageId]),
+    query('SELECT * FROM qms_epoch_validation_defects WHERE package_id=$1 ORDER BY created_at DESC',[packageId]),
+    query('SELECT * FROM qms_epoch_validation_approvals WHERE package_id=$1 ORDER BY decided_at DESC',[packageId]),
+    query('SELECT * FROM qms_epoch_validation_periodic_reviews WHERE package_id=$1 ORDER BY review_date DESC',[packageId]),
+    query('SELECT * FROM qms_epoch_validation_events WHERE package_id=$1 ORDER BY created_at DESC LIMIT 250',[packageId]),
+  ]);
+  const c=await counts(packageId),r=calculateReadiness(c);
+  return {package:p,intendedUse,requirements,risks,plans,protocols,executions,defects,approvals,periodicReviews:reviews,events,
+    readiness:{...c,...r}};
+}
+router.get('/:id',requirePermission('EPOCH_VALIDATION_VIEW'),async(req,res)=>{
+  const d=await detail(uuid.parse(req.params.id)); if(!d)return res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});res.json(d);
+});
+router.get('/:id/readiness',requirePermission('EPOCH_VALIDATION_VIEW'),async(req,res)=>{
+  const id=uuid.parse(req.params.id);res.json({...await counts(id),...calculateReadiness(await counts(id))});
+});
+router.post('/:id/status',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;
+  const body=z.object({status:z.string(),reason:z.string().min(3)}).parse(req.body);
+  if(!canTransition(p.status as ValidationStatus,body.status as ValidationStatus))
+    return res.status(409).json({error:'ILLEGAL_STATUS_TRANSITION',from:p.status,to:body.status});
+  if(body.status==='TESTING'&&!await query(`SELECT 1 FROM qms_epoch_validation_plans WHERE package_id=$1 AND status='APPROVED'`,[p.id]).then(x=>x.length))
+    return res.status(409).json({error:'VALIDATION_PLAN_APPROVAL_REQUIRED'});
+  if(body.status==='READY_FOR_FINAL_REVIEW'){
+    const structural=await counts(p.id); structural.approvalsCurrent=true;
+    if(!calculateReadiness(structural).ready)
+      return res.status(409).json({error:'FINAL_READINESS_BLOCKED',...calculateReadiness(structural)});
+  }
+  const a=actor(req),updated=(await query(`UPDATE qms_epoch_validation_packages SET status=$1,row_version=row_version+1,
+    revision=revision+1,updated_by_user_id=$2,updated_by_display_name=$3,updated_at=now() WHERE id=$4 RETURNING *`,
+    [body.status,a.id,a.name,p.id]))[0];
+  await invalidateApprovals(p.id,'Package status changed');await logEvent(req,updated,'PACKAGE','STATUS_CHANGED',{previous:p.status,next:body.status,reason:body.reason});
+  res.json(updated);
+});
+
+const intendedUseSchema=z.object({
+  systemName:z.string().min(1),epochVersion:z.string().min(1),productionEnvironment:z.string().min(1),
+  softwareOwnerEmployeeId:z.number().int().positive().optional(),qualityOwnerEmployeeId:z.number().int().positive().optional(),
+  hostingProvider:z.string().min(1),databaseProvider:z.string().min(1),intendedUseStatement:z.string().min(20),
+  qmsProcessesSupported:z.string().min(1),officialRecordsControlled:z.string().min(1),outsideProcessesRecords:z.string().optional(),
+  userGroupsDepartments:z.string().min(1),interfacesDependencies:z.string().optional(),
+  customerContractualRequirements:z.string().optional(),complianceConsiderations:z.string().optional(),
+  knownLimitations:z.string().optional(),excludedFunctionality:z.string().optional(),
+  dataRetentionResponsibilities:z.string().min(1),backupResponsibilities:z.string().min(1),
+});
+router.post('/:id/intended-use',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const v=intendedUseSchema.parse(req.body),a=actor(req);
+  const record=await tx(async q=>{
+    await q(`SELECT id FROM qms_epoch_validation_packages WHERE id=$1 FOR UPDATE`,[p.id]);
+    const revision=Number((await q(`SELECT coalesce(max(revision),0)+1 revision FROM qms_epoch_validation_intended_use_revisions WHERE package_id=$1`,[p.id]))[0].revision);
+    await q(`UPDATE qms_epoch_validation_intended_use_revisions SET approval_status='SUPERSEDED' WHERE package_id=$1 AND approval_status<>'SUPERSEDED'`,[p.id]);
+    const x=(await q(`INSERT INTO qms_epoch_validation_intended_use_revisions
+      (package_id,revision,system_name,epoch_version,production_environment,software_owner_employee_id,quality_owner_employee_id,
+       hosting_provider,database_provider,intended_use_statement,qms_processes_supported,official_records_controlled,
+       outside_processes_records,user_groups_departments,interfaces_dependencies,customer_contractual_requirements,
+       compliance_considerations,known_limitations,excluded_functionality,data_retention_responsibilities,
+       backup_responsibilities,created_by_user_id)
+      VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22) RETURNING *`,
+      [p.id,revision,v.systemName,v.epochVersion,v.productionEnvironment,v.softwareOwnerEmployeeId||null,
+       v.qualityOwnerEmployeeId||null,v.hostingProvider,v.databaseProvider,v.intendedUseStatement,v.qmsProcessesSupported,
+       v.officialRecordsControlled,v.outsideProcessesRecords||null,v.userGroupsDepartments,v.interfacesDependencies||null,
+       v.customerContractualRequirements||null,v.complianceConsiderations||null,v.knownLimitations||null,
+       v.excludedFunctionality||null,v.dataRetentionResponsibilities,v.backupResponsibilities,a.id]))[0];
+    await invalidateApprovals(p.id,'Intended Use revised',q);await logEvent(req,p,'INTENDED_USE','INTENDED_USE_REVISED',{entityId:x.id,next:{revision}},q);return x;
+  });res.status(201).json(record);
+});
+
+const requirementSchema=z.object({module:z.string().min(1),category:z.string().min(1),statement:z.string().min(5),
+  purpose:z.string().min(1),source:z.string().min(1),criticality:z.enum(['CRITICAL','HIGH','NORMAL','INFORMATIONAL']),
+  productQualityRecordImpact:z.string().optional(),traceabilityImpact:z.string().optional(),securityAccessImpact:z.string().optional(),
+  dataIntegrityImpact:z.string().optional(),regulatoryCustomerImpact:z.string().optional(),validationMethod:z.string().min(1),
+  testRequired:z.boolean().default(true),ownerEmployeeId:z.number().int().positive().optional()});
+router.post('/:id/requirements',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const v=requirementSchema.parse(req.body),a=actor(req);
+  const seq=(await query(`SELECT nextval('qms_epoch_validation_requirement_number_seq') value`))[0].value;
+  const rid=`ESR-${String(seq).padStart(4,'0')}`;
+  const x=(await query(`INSERT INTO qms_epoch_validation_requirements
+    (requirement_id,package_id,module,category,statement,purpose,source,criticality,product_quality_record_impact,
+     traceability_impact,security_access_impact,data_integrity_impact,regulatory_customer_impact,
+     validation_method,test_required,owner_employee_id,created_by_user_id,updated_by_user_id)
+    VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$17) RETURNING *`,
+    [rid,p.id,v.module,v.category,v.statement,v.purpose,v.source,v.criticality,v.productQualityRecordImpact||null,
+     v.traceabilityImpact||null,v.securityAccessImpact||null,v.dataIntegrityImpact||null,v.regulatoryCustomerImpact||null,
+     v.validationMethod,v.testRequired,v.ownerEmployeeId||null,a.id]))[0];
+  await invalidateApprovals(p.id,'Requirement added');await logEvent(req,p,'REQUIREMENT','REQUIREMENT_CREATED',{entityId:x.id,next:x});res.status(201).json(x);
+});
+router.post('/:id/requirements/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
+  const x=(await query(`UPDATE qms_epoch_validation_requirements SET status='APPROVED',updated_at=now()
+    WHERE id=$1 AND package_id=$2 AND status IN ('DRAFT','READY_FOR_APPROVAL') RETURNING *`,[recordId,p.id]))[0];
+  if(!x)return res.status(409).json({error:'REQUIREMENT_NOT_APPROVABLE'});await approve(req,p,'REQUIREMENT',x.id,x.revision,'REQUIREMENTS_APPROVER','Approved requirement baseline item','EPOCH_VALIDATION_PLAN_APPROVE');res.json(x);
+});
+
+const riskSchema=z.object({requirementId:z.string().uuid().optional(),module:z.string().min(1),failureMode:z.string().min(3),
+  cause:z.string().min(1),potentialEffect:z.string().min(1),qualityTraceabilityImpact:z.string().min(1),
+  severity:z.number().int().min(1).max(5),likelihood:z.number().int().min(1).max(5),detectability:z.number().int().min(1).max(5),
+  existingControls:z.string().optional(),additionalMitigation:z.string().optional(),
+  mitigationOwnerEmployeeId:z.number().int().positive().optional(),dueDate:z.string().date().optional(),
+  residualRisk:z.string().optional(),residualRiskLevel:z.enum(['CRITICAL','HIGH','NORMAL','LOW']).default('NORMAL'),
+  requiredTest:z.boolean().default(false)});
+router.post('/:id/risks',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const v=riskSchema.parse(req.body),a=actor(req);
+  if(v.requirementId&&!await query('SELECT 1 FROM qms_epoch_validation_requirements WHERE id=$1 AND package_id=$2',[v.requirementId,p.id]).then(x=>x.length))
+    return res.status(409).json({error:'REQUIREMENT_LINK_INVALID'});
+  const seq=(await query(`SELECT nextval('qms_epoch_validation_risk_number_seq') value`))[0].value,rid=`ESRISK-${String(seq).padStart(4,'0')}`;
+  const x=(await query(`INSERT INTO qms_epoch_validation_risks
+    (risk_id,package_id,requirement_id,module,failure_mode,cause,potential_effect,quality_traceability_impact,
+     severity,likelihood,detectability,existing_controls,additional_mitigation,mitigation_owner_employee_id,
+     due_date,residual_risk,residual_risk_level,required_test,created_by_user_id,updated_by_user_id)
+    VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$19) RETURNING *`,
+    [rid,p.id,v.requirementId||null,v.module,v.failureMode,v.cause,v.potentialEffect,v.qualityTraceabilityImpact,
+     v.severity,v.likelihood,v.detectability,v.existingControls||null,v.additionalMitigation||null,
+     v.mitigationOwnerEmployeeId||null,v.dueDate||null,v.residualRisk||null,v.residualRiskLevel,
+     v.requiredTest||v.severity>=4,a.id]))[0];
+  await invalidateApprovals(p.id,'Risk added');await logEvent(req,p,'RISK','RISK_CREATED',{entityId:x.id,next:x});res.status(201).json(x);
+});
+router.post('/:id/risks/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
+  const risk=(await query('SELECT * FROM qms_epoch_validation_risks WHERE id=$1 AND package_id=$2',[recordId,p.id]))[0];
+  if(!risk)return res.status(404).json({error:'VALIDATION_RISK_NOT_FOUND'});
+  if((risk.severity>=4||risk.required_test)&&!await query(`SELECT 1 FROM qms_epoch_validation_protocol_risks pr
+    JOIN qms_epoch_validation_protocols p ON p.id=pr.protocol_id WHERE pr.risk_id=$1 AND p.status='APPROVED'`,[recordId]).then(x=>x.length))
+    return res.status(409).json({error:'CRITICAL_HIGH_RISK_REQUIRES_APPROVED_PROTOCOL'});
+  await query(`UPDATE qms_epoch_validation_risks SET status='APPROVED',updated_at=now() WHERE id=$1`,[recordId]);
+  await approve(req,p,'RISK',risk.id,1,'RISK_APPROVER','Approved software risk assessment item','EPOCH_VALIDATION_PLAN_APPROVE');
+  res.json({...risk,status:'APPROVED'});
+});
+router.post('/:id/risks/:recordId/accept',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
+  const body=z.object({authorityRole:z.enum(['QUALITY_APPROVER','TOP_MANAGEMENT']),comments:z.string().min(20)}).parse(req.body);
+  const risk=(await query(`UPDATE qms_epoch_validation_risks SET risk_accepted=true,updated_at=now()
+    WHERE id=$1 AND package_id=$2 AND residual_risk_level IN ('CRITICAL','HIGH') RETURNING *`,[recordId,p.id]))[0];
+  if(!risk)return res.status(409).json({error:'CRITICAL_HIGH_RESIDUAL_RISK_REQUIRED'});
+  await approve(req,p,'RISK_ACCEPTANCE',risk.id,1,body.authorityRole,'Accepted documented critical/high residual software risk','EPOCH_VALIDATION_FINAL_APPROVE',body.comments);
+  res.json(risk);
+});
+
+const planSchema=z.object({purpose:z.string().min(1),scope:z.string().min(1),epochVersion:z.string().min(1),
+  commitOrReleaseIdentifier:z.string().optional(),includedModules:z.string().min(1),excludedModules:z.string().optional(),
+  validationEnvironment:z.string().min(1),testDatabaseEnvironment:z.string().min(1),productionComparisonMethod:z.string().min(1),
+  responsibilities:z.string().min(1),requiredResources:z.string().optional(),testingApproach:z.string().min(1),
+  riskBasedSelection:z.string().min(1),evidenceRequirements:z.string().min(1),acceptanceCriteria:z.string().min(1),
+  defectSeverityRules:z.string().min(1),retestingRequirements:z.string().min(1),regressionRequirements:z.string().min(1),
+  backupRestoreRequirements:z.string().min(1),outageDrillRequirements:z.string().min(1),approvalRoles:z.string().min(1),
+  schedule:z.string().min(1),deviations:z.string().optional()});
+router.post('/:id/plans',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const v=planSchema.parse(req.body),a=actor(req);
+  const revision=Number((await query('SELECT coalesce(max(revision),0)+1 revision FROM qms_epoch_validation_plans WHERE package_id=$1',[p.id]))[0].revision);
+  await query(`UPDATE qms_epoch_validation_plans SET status='SUPERSEDED' WHERE package_id=$1 AND status<>'SUPERSEDED'`,[p.id]);
+  const keys=Object.keys(v),values=Object.values(v);
+  const x=(await query(`INSERT INTO qms_epoch_validation_plans
+    (package_id,revision,purpose,scope,epoch_version,commit_or_release_identifier,included_modules,excluded_modules,
+     validation_environment,test_database_environment,production_comparison_method,responsibilities,required_resources,
+     testing_approach,risk_based_selection,evidence_requirements,acceptance_criteria,defect_severity_rules,
+     retesting_requirements,regression_requirements,backup_restore_requirements,outage_drill_requirements,approval_roles,
+     schedule,deviations,created_by_user_id)
+    VALUES($1,$2,${values.map((_,i)=>`$${i+3}`).join(',')},$${values.length+3}) RETURNING *`,
+    [p.id,revision,...values,a.id]))[0];
+  void keys;await invalidateApprovals(p.id,'Validation Plan revised');await logEvent(req,p,'PLAN','PLAN_REVISED',{entityId:x.id,next:{revision}});res.status(201).json(x);
+});
+router.post('/:id/plans/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
+  const body=z.object({approvalRole:z.enum(['VALIDATION_LEAD','EPOCH_IT_OWNER','QUALITY_APPROVER']),comments:z.string().optional()}).parse(req.body);
+  const plan=(await query('SELECT * FROM qms_epoch_validation_plans WHERE id=$1 AND package_id=$2',[recordId,p.id]))[0];
+  if(!plan)return res.status(404).json({error:'VALIDATION_PLAN_NOT_FOUND'});
+  await approve(req,p,'PLAN',plan.id,plan.revision,body.approvalRole,'Approved Validation Plan revision','EPOCH_VALIDATION_PLAN_APPROVE',body.comments);
+  const n=Number((await query(`SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals WHERE record_type='PLAN' AND record_id=$1 AND record_revision=$2 AND status='VALID' AND decision='APPROVED'`,[plan.id,plan.revision]))[0].n);
+  if(n>=3)await query(`UPDATE qms_epoch_validation_plans SET status='APPROVED' WHERE id=$1`,[plan.id]);res.json({approvedRoles:n,complete:n>=3});
+});
+
+const protocolSchema=z.object({title:z.string().min(1),module:z.string().min(1),criticality:z.enum(['CRITICAL','HIGH','NORMAL','INFORMATIONAL']),
+  objective:z.string().min(1),preconditions:z.string().optional(),requiredUserRole:z.string().optional(),requiredTestData:z.string().optional(),
+  testEnvironment:z.string().min(1),overallAcceptanceCriteria:z.string().min(1),requiredEvidence:z.string().min(1),
+  regressionClassification:z.string().optional(),independentReviewRequired:z.boolean().default(false),
+  requirementIds:z.array(z.string().uuid()).default([]),riskIds:z.array(z.string().uuid()).default([]),
+  steps:z.array(z.object({instruction:z.string().min(1),expectedResult:z.string().min(1),required:z.boolean().default(true)})).min(1)});
+router.post('/:id/protocols',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const v=protocolSchema.parse(req.body),a=actor(req);
+  const x=await tx(async q=>{
+    const seq=(await q(`SELECT nextval('qms_epoch_validation_test_number_seq') value`))[0].value,tid=`EVT-${String(seq).padStart(4,'0')}`;
+    const protocol=(await q(`INSERT INTO qms_epoch_validation_protocols
+      (test_id,package_id,title,module,criticality,objective,preconditions,required_user_role,required_test_data,
+       test_environment,overall_acceptance_criteria,required_evidence,regression_classification,
+       independent_review_required,created_by_user_id,updated_by_user_id)
+      VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$15) RETURNING *`,
+      [tid,p.id,v.title,v.module,v.criticality,v.objective,v.preconditions||null,v.requiredUserRole||null,
+       v.requiredTestData||null,v.testEnvironment,v.overallAcceptanceCriteria,v.requiredEvidence,
+       v.regressionClassification||null,v.independentReviewRequired,a.id]))[0];
+    for(let i=0;i<v.steps.length;i++)await q(`INSERT INTO qms_epoch_validation_protocol_steps
+      (protocol_id,step_number,instruction,expected_result,required) VALUES($1,$2,$3,$4,$5)`,
+      [protocol.id,i+1,v.steps[i].instruction,v.steps[i].expectedResult,v.steps[i].required]);
+    for(const id of v.requirementIds)await q(`INSERT INTO qms_epoch_validation_protocol_requirements VALUES($1,$2) ON CONFLICT DO NOTHING`,[protocol.id,id]);
+    for(const id of v.riskIds)await q(`INSERT INTO qms_epoch_validation_protocol_risks VALUES($1,$2) ON CONFLICT DO NOTHING`,[protocol.id,id]);
+    await logEvent(req,p,'PROTOCOL','PROTOCOL_CREATED',{entityId:protocol.id,next:{testId:tid,revision:1}},q);return protocol;
+  });await invalidateApprovals(p.id,'Test protocol added');res.status(201).json(x);
+});
+router.post('/:id/protocols/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
+  const x=(await query(`UPDATE qms_epoch_validation_protocols SET status='APPROVED',updated_at=now()
+    WHERE id=$1 AND package_id=$2 AND status='DRAFT' RETURNING *`,[recordId,p.id]))[0];
+  if(!x)return res.status(409).json({error:'PROTOCOL_NOT_APPROVABLE'});await approve(req,p,'PROTOCOL',x.id,x.revision,'PROTOCOL_APPROVER','Approved protocol revision','EPOCH_VALIDATION_PLAN_APPROVE');res.json(x);
+});
+
+router.post('/:id/protocols/:recordId/executions',requirePermission('EPOCH_VALIDATION_TEST_EXECUTE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const protocolId=uuid.parse(req.params.recordId),a=actor(req);
+  if(!['PLAN_APPROVED','TESTING','TESTING_BLOCKED','RETESTING','CORRECTIONS_REQUIRED'].includes(p.status))
+    return res.status(409).json({error:'FORMAL_TEST_EXECUTION_NOT_ALLOWED',message:'The Validation Plan must be approved before execution.'});
+  const protocol=(await query('SELECT * FROM qms_epoch_validation_protocols WHERE id=$1 AND package_id=$2',[protocolId,p.id]))[0];
+  if(!protocol||protocol.status!=='APPROVED')return res.status(409).json({error:'APPROVED_PROTOCOL_REQUIRED'});
+  const body=z.object({epochVersion:z.string().min(1),commitOrReleaseIdentifier:z.string().optional(),
+    testEnvironment:z.string().min(1),testDatabase:z.string().min(1),retestOfExecutionId:z.string().uuid().optional()}).parse(req.body);
+  const execution=await tx(async q=>{
+    const seq=(await q(`SELECT nextval('qms_epoch_validation_execution_number_seq') value`))[0].value,eid=`EVE-${String(seq).padStart(4,'0')}`;
+    const x=(await q(`INSERT INTO qms_epoch_validation_executions
+      (execution_id,package_id,protocol_id,protocol_revision,epoch_version,commit_or_release_identifier,
+       test_environment,test_database,tester_user_id,tester_display_name,overall_result,retest_of_execution_id)
+      VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'IN_PROGRESS',$11) RETURNING *`,
+      [eid,p.id,protocol.id,protocol.revision,body.epochVersion,body.commitOrReleaseIdentifier||null,
+       body.testEnvironment,body.testDatabase,a.id,a.name,body.retestOfExecutionId||null]))[0];
+    await q(`INSERT INTO qms_epoch_validation_execution_steps
+      (execution_id,protocol_step_id,step_number,instruction_snapshot,expected_result_snapshot,required)
+      SELECT $1,id,step_number,instruction,expected_result,required FROM qms_epoch_validation_protocol_steps
+      WHERE protocol_id=$2 ORDER BY step_number`,[x.id,protocol.id]);
+    await logEvent(req,p,'EXECUTION','TEST_EXECUTION_STARTED',{entityId:x.id,next:{executionId:eid,protocolRevision:protocol.revision}},q);return x;
+  });res.status(201).json(execution);
+});
+router.put('/:id/executions/:recordId/steps',requirePermission('EPOCH_VALIDATION_TEST_EXECUTE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const executionId=uuid.parse(req.params.recordId);
+  const body=z.object({steps:z.array(z.object({stepNumber:z.number().int().positive(),actualResult:z.string().min(1),
+    status:z.enum(['NOT_RUN','IN_PROGRESS','PASSED','FAILED','BLOCKED'])})).min(1),
+    linkedEpochRecords:z.string().optional(),githubReference:z.string().optional(),deviations:z.string().optional(),comments:z.string().optional()}).parse(req.body);
+  const result=deriveExecutionResult(body.steps.map(s=>({required:true,status:s.status})));
+  const updated=await tx(async q=>{
+    for(const s of body.steps)await q(`UPDATE qms_epoch_validation_execution_steps SET actual_result=$1,status=$2
+      WHERE execution_id=$3 AND step_number=$4`,[s.actualResult,s.status,executionId,s.stepNumber]);
+    const all=await q(`SELECT step_number,instruction_snapshot,expected_result_snapshot,actual_result,status,required
+      FROM qms_epoch_validation_execution_steps WHERE execution_id=$1 ORDER BY step_number`,[executionId]);
+    const derived=deriveExecutionResult(all.map(s=>({required:s.required,status:s.status})));
+    const snapshot={protocolSteps:all,overallResult:derived,epochVersion:p.production_version};
+    const x=(await q(`UPDATE qms_epoch_validation_executions SET overall_result=$1,ended_at=CASE WHEN $1 IN ('PASSED','FAILED','BLOCKED') THEN now() ELSE ended_at END,
+      linked_epoch_records=$2,github_reference=$3,deviations=$4,comments=$5,snapshot=$6::jsonb,snapshot_checksum=$7
+      WHERE id=$8 AND package_id=$9 AND review_decision IS NULL RETURNING *`,
+      [derived,body.linkedEpochRecords||null,body.githubReference||null,body.deviations||null,body.comments||null,
+       JSON.stringify(snapshot),checksum(snapshot),executionId,p.id]))[0];
+    if(!x)throw Object.assign(new Error('Execution is immutable after review'),{status:409});
+    if(['FAILED','BLOCKED'].includes(derived)){
+      const seq=(await q(`SELECT nextval('qms_epoch_validation_defect_number_seq') value`))[0].value;
+      const number=`ESD-${new Date().getUTCFullYear()}-${String(seq).padStart(4,'0')}`;
+      await q(`INSERT INTO qms_epoch_validation_defects
+        (defect_number,package_id,failed_execution_id,module,description,severity,retest_required,created_by_user_id,updated_by_user_id)
+        SELECT $1,$2,$3,p.module,$4,CASE WHEN p.criticality='CRITICAL' THEN 'CRITICAL' ELSE 'HIGH' END,true,$5,$5
+        FROM qms_epoch_validation_protocols p JOIN qms_epoch_validation_executions e ON e.protocol_id=p.id WHERE e.id=$3
+        ON CONFLICT(defect_number) DO NOTHING`,[number,p.id,executionId,`Automatically opened from ${x.execution_id} ${derived}`,actor(req).id]);
+    }
+    await logEvent(req,p,'EXECUTION','TEST_EXECUTION_RECORDED',{entityId:executionId,next:{derivedResult:derived,clientCandidate:result}},q);return x;
+  });res.json(updated);
+});
+router.post('/:id/executions/:recordId/review',requirePermission('EPOCH_VALIDATION_TEST_REVIEW'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const executionId=uuid.parse(req.params.recordId),a=actor(req);
+  const body=z.object({decision:z.enum(['APPROVED','REJECTED','RETURNED']),comments:z.string().min(1)}).parse(req.body);
+  const x=(await query(`UPDATE qms_epoch_validation_executions SET reviewer_user_id=$1,review_decision=$2,reviewed_at=now(),comments=concat_ws(E'\\n',comments,$3)
+    WHERE id=$4 AND package_id=$5 AND overall_result NOT IN ('NOT_RUN','IN_PROGRESS') AND tester_user_id<>$1 AND review_decision IS NULL RETURNING *`,
+    [a.id,body.decision,body.comments,executionId,p.id]))[0];
+  if(!x)return res.status(409).json({error:'INDEPENDENT_REVIEW_REQUIRED_OR_EXECUTION_NOT_REVIEWABLE'});
+  await logEvent(req,p,'EXECUTION','EXECUTION_REVIEWED',{entityId:x.id,next:{decision:body.decision}});res.json(x);
+});
+
+router.patch('/:id/defects/:recordId',requirePermission('EPOCH_VALIDATION_DEFECT_MANAGE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId),a=actor(req);
+  const body=z.object({containment:z.string().optional(),rootCause:z.string().optional(),correctiveAction:z.string().optional(),
+    ownerEmployeeId:z.number().int().positive().optional(),dueDate:z.string().date().optional(),
+    githubReference:z.string().optional(),databaseMigrationReference:z.string().optional(),
+    retestRequired:z.boolean().optional(),retestExecutionId:z.string().uuid().optional(),
+    closureEvidence:z.string().optional(),status:z.enum(['OPEN','CONTAINED','CORRECTION_IN_PROGRESS','READY_FOR_RETEST','CLOSED','CANCELLED']).optional()}).parse(req.body);
+  if(body.status==='CLOSED'){
+    const defect=(await query('SELECT * FROM qms_epoch_validation_defects WHERE id=$1 AND package_id=$2',[recordId,p.id]))[0];
+    if(!defect)return res.status(404).json({error:'VALIDATION_DEFECT_NOT_FOUND'});
+    if(defect.retest_required&&!body.retestExecutionId&&!defect.retest_execution_id)
+      return res.status(409).json({error:'REQUIRED_RETEST_MISSING'});
+  }
+  const x=(await query(`UPDATE qms_epoch_validation_defects SET containment=COALESCE($1,containment),
+    root_cause=COALESCE($2,root_cause),corrective_action=COALESCE($3,corrective_action),
+    owner_employee_id=COALESCE($4,owner_employee_id),due_date=COALESCE($5,due_date),
+    github_reference=COALESCE($6,github_reference),database_migration_reference=COALESCE($7,database_migration_reference),
+    retest_required=COALESCE($8,retest_required),retest_execution_id=COALESCE($9,retest_execution_id),
+    closure_evidence=COALESCE($10,closure_evidence),status=COALESCE($11,status),
+    updated_by_user_id=$12,updated_at=now() WHERE id=$13 AND package_id=$14 RETURNING *`,
+    [body.containment,body.rootCause,body.correctiveAction,body.ownerEmployeeId,body.dueDate,
+     body.githubReference,body.databaseMigrationReference,body.retestRequired,body.retestExecutionId,
+     body.closureEvidence,body.status,a.id,recordId,p.id]))[0];
+  if(!x)return res.status(404).json({error:'VALIDATION_DEFECT_NOT_FOUND'});
+  await invalidateApprovals(p.id,'Validation defect changed');await logEvent(req,p,'DEFECT','DEFECT_UPDATED',{entityId:x.id,next:x});res.json(x);
+});
+router.post('/:id/defects/:recordId/accept-limitation',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
+  const body=z.object({comments:z.string().min(20)}).parse(req.body);
+  const defect=(await query(`UPDATE qms_epoch_validation_defects SET limitation_accepted=true,updated_at=now()
+    WHERE id=$1 AND package_id=$2 AND severity='HIGH' AND status NOT IN ('CLOSED','CANCELLED') RETURNING *`,[recordId,p.id]))[0];
+  if(!defect)return res.status(409).json({error:'ONLY_OPEN_HIGH_DEFECTS_MAY_BE_ACCEPTED'});
+  await approve(req,p,'DEFECT_LIMITATION',defect.id,1,'QUALITY_MANAGEMENT','Accepted documented high-severity limitation and residual risk','EPOCH_VALIDATION_FINAL_APPROVE',body.comments);
+  res.json(defect);
+});
+
+router.post('/:id/periodic-reviews',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const a=actor(req);
+  const schema=z.object({reviewDate:z.string().date(),currentProductionVersion:z.string().min(1),
+    previouslyApprovedVersion:z.string().min(1),changesSinceApproval:z.string().optional(),criticalChanges:z.string().optional(),
+    databaseMigrations:z.string().optional(),securityAuthenticationChanges:z.string().optional(),
+    hostingDatabaseChanges:z.string().optional(),backupRecoveryChanges:z.string().optional(),
+    seriousDefectsIncidents:z.string().optional(),newOfficialQmsModules:z.string().optional(),
+    auditFindings:z.string().optional(),customerFindings:z.string().optional(),revalidationRequired:z.boolean(),
+    revalidationScope:z.string().optional(),nextReviewDate:z.string().date()});
+  const v=schema.parse(req.body),values=Object.values(v);
+  const x=(await query(`INSERT INTO qms_epoch_validation_periodic_reviews
+    (package_id,review_date,reviewer_user_id,current_production_version,previously_approved_version,
+     changes_since_approval,critical_changes,database_migrations,security_authentication_changes,
+     hosting_database_changes,backup_recovery_changes,serious_defects_incidents,new_official_qms_modules,
+     audit_findings,customer_findings,revalidation_required,revalidation_scope,next_review_date)
+    VALUES($1,$2,$3,${values.slice(1).map((_,i)=>`$${i+4}`).join(',')}) RETURNING *`,
+    [p.id,v.reviewDate,a.id,...values.slice(1)]))[0];
+  await logEvent(req,p,'PERIODIC_REVIEW','PERIODIC_REVIEW_CREATED',{entityId:x.id,next:{revalidationRequired:v.revalidationRequired}});res.status(201).json(x);
+});
+
+async function approve(req:Request,p:any,recordType:string,recordId:string,revision:number,role:string,meaning:string,capability:string,comments?:string){
+  const a=actor(req),snap={recordType,recordId,revision,packageRevision:p.revision,productionVersion:p.production_version};
+  await query(`INSERT INTO qms_epoch_validation_approvals
+    (package_id,record_type,record_id,record_revision,approval_role,decision,meaning,actor_user_id,actor_employee_id,
+     actor_display_name,actor_role,capability_used,comments,snapshot_checksum)
+    VALUES($1,$2,$3,$4,$5,'APPROVED',$6,$7,$8,$9,$10,$11,$12,$13)
+    ON CONFLICT DO NOTHING`,[p.id,recordType,recordId,revision,role,meaning,a.id,a.employeeId,a.name,a.role,capability,comments||null,checksum(snap)]);
+  await logEvent(req,p,recordType,`${recordType}_APPROVED`,{entityId:recordId,next:{revision,role}});
+}
+router.post('/:id/intended-use/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
+  const body=z.object({approvalRole:z.enum(['EPOCH_IT_OWNER','QUALITY_APPROVER']),comments:z.string().optional()}).parse(req.body);
+  const record=(await query('SELECT * FROM qms_epoch_validation_intended_use_revisions WHERE id=$1 AND package_id=$2',[recordId,p.id]))[0];
+  if(!record)return res.status(404).json({error:'INTENDED_USE_NOT_FOUND'});
+  await approve(req,p,'INTENDED_USE',record.id,record.revision,body.approvalRole,'Approved Intended Use revision','EPOCH_VALIDATION_PLAN_APPROVE',body.comments);
+  const n=Number((await query(`SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals WHERE record_type='INTENDED_USE' AND record_id=$1 AND status='VALID' AND decision='APPROVED'`,[record.id]))[0].n);
+  if(n>=2)await query(`UPDATE qms_epoch_validation_intended_use_revisions SET approval_status='APPROVED' WHERE id=$1`,[record.id]);res.json({approvedRoles:n,complete:n>=2});
+});
+router.post('/:id/final-approvals',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;
+  const body=z.object({approvalRole:z.enum(['EPOCH_IT_OWNER','VALIDATION_LEAD','QUALITY_APPROVER','PROCESS_OWNER','TOP_MANAGEMENT']),
+    outcome:z.enum(['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS','REJECTED','RETURNED_FOR_CORRECTION']),
+    comments:z.string().min(1),approvedLimitations:z.string().optional()}).parse(req.body);
+  const finalCounts=await counts(p.id); finalCounts.approvalsCurrent=true;
+  const r=calculateReadiness(finalCounts);
+  if(!r.ready&&body.outcome.startsWith('APPROVED'))return res.status(409).json({error:'FINAL_READINESS_BLOCKED',...r});
+  const d=await detail(p.id),snap={package:d?.package,intendedUse:d?.intendedUse[0],readiness:d?.readiness,
+    requirements:d?.requirements,risks:d?.risks,plans:d?.plans,protocols:d?.protocols,
+    executions:d?.executions,defects:d?.defects,limitations:body.approvedLimitations||null};
+  await approve(req,p,'FINAL',p.id,p.revision,body.approvalRole,
+    `Authenticated ${body.outcome} decision for exact EPOCH version ${p.production_version}`,
+    'EPOCH_VALIDATION_FINAL_APPROVE',body.comments);
+  const required=body.outcome==='APPROVED_WITH_LIMITATIONS'?4:3;
+  const approvals=Number((await query(`SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals
+    WHERE package_id=$1 AND record_type='FINAL' AND record_revision=$2 AND status='VALID' AND decision='APPROVED'`,[p.id,p.revision]))[0].n);
+  if(approvals>=required&&body.outcome.startsWith('APPROVED')){
+    await tx(async q=>{await q(`INSERT INTO qms_epoch_validation_snapshots
+      (package_id,snapshot_type,package_revision,snapshot,checksum,created_by_user_id)
+      VALUES($1,'FINAL_APPROVAL',$2,$3::jsonb,$4,$5) ON CONFLICT DO NOTHING`,
+      [p.id,p.revision,JSON.stringify(snap),checksum(snap),actor(req).id]);
+      await q(`UPDATE qms_epoch_validation_packages SET status=$1,locked_at=now(),actual_completion_date=current_date,
+        updated_at=now() WHERE id=$2`,[body.outcome,p.id]);});
+  } else if(!body.outcome.startsWith('APPROVED')) await query(`UPDATE qms_epoch_validation_packages SET status=$1 WHERE id=$2`,
+    [body.outcome==='RETURNED_FOR_CORRECTION'?'CORRECTIONS_REQUIRED':'REJECTED',p.id]);
+  res.json({approvalCount:approvals,required,locked:approvals>=required&&body.outcome.startsWith('APPROVED')});
+});
+router.post('/:id/reopen',requirePermission('EPOCH_VALIDATION_REOPEN'),async(req,res)=>{
+  const id=uuid.parse(req.params.id),p=await getPackage(id);if(!p)return res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});
+  const body=z.object({reason:z.string().min(20)}).parse(req.body);const a=actor(req);
+  const snapshot=(await query(`SELECT * FROM qms_epoch_validation_snapshots WHERE package_id=$1 AND snapshot_type='FINAL_APPROVAL' ORDER BY created_at DESC LIMIT 1`,[id]))[0];
+  if(!snapshot)return res.status(409).json({error:'APPROVED_SNAPSHOT_REQUIRED'});
+  await tx(async q=>{await invalidateApprovals(id,`Controlled reopening: ${body.reason}`,q);
+    await q(`UPDATE qms_epoch_validation_packages SET status='CORRECTIONS_REQUIRED',locked_at=NULL,revision=revision+1,
+      updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3`,[a.id,a.name,id]);
+    await logEvent(req,p,'PACKAGE','PACKAGE_REOPENED',{reason:body.reason,next:{preservedSnapshot:snapshot.id}},q);});
+  res.json(await getPackage(id));
+});
+
+router.get('/:id/export',requirePermission('EPOCH_VALIDATION_EXPORT'),async(req,res)=>{
+  const id=uuid.parse(req.params.id),d=await detail(id);if(!d)return res.status(404).send('Validation package not found');
+  const view=z.enum(['validation-plan','requirements-matrix','risk-register','test-protocols','test-executions','defects','summary','complete-package']).catch('complete-package').parse(req.query.view);
+  const approved=['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS'].includes(d.package.status);
+  const mark=approved?'CONTROLLED EPOCH SOFTWARE VALIDATION RECORD':'DRAFT - NOT APPROVED FOR INTENDED USE';
+  const esc=(v:unknown)=>String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]!));
+  const table=(title:string,records:any[],fields:string[])=>`<h2>${esc(title)}</h2><table><thead><tr>${fields.map(f=>`<th>${esc(f.replaceAll('_',' '))}</th>`).join('')}</tr></thead><tbody>${records.map(x=>`<tr>${fields.map(f=>`<td>${esc(x[f])}</td>`).join('')}</tr>`).join('')}</tbody></table>`;
+  const sections:Record<string,string>={
+    'validation-plan':table('Validation Plan',d.plans,['revision','status','purpose','scope','included_modules','excluded_modules','acceptance_criteria']),
+    'requirements-matrix':table('Requirements Traceability Matrix',d.requirements,['requirement_id','module','category','statement','criticality','validation_method','status']),
+    'risk-register':table('Risk Register',d.risks,['risk_id','module','failure_mode','potential_effect','initial_risk_rating','residual_risk','status']),
+    'test-protocols':table('Test Protocol Package',d.protocols,['test_id','title','module','criticality','revision','status']),
+    'test-executions':table('Test Execution Report',d.executions,['execution_id','protocol_revision','tester_display_name','overall_result','review_decision','started_at','ended_at']),
+    defects:table('Validation Defect Report',d.defects,['defect_number','module','severity','description','status','retest_required']),
+    summary:`<h2>Validation Summary</h2><pre>${esc(JSON.stringify(d.readiness,null,2))}</pre>`,
+    'complete-package':'',
+  };
+  const body=view==='complete-package'?Object.entries(sections).filter(([k])=>k!=='complete-package').map(([,v])=>v).join(''):sections[view];
+  res.type('html').send(`<!doctype html><html><head><meta charset="utf-8"><title>${esc(d.package.package_number)}</title>
+  <style>body{font:12px Arial;margin:32px;color:#172033}header{border-bottom:3px solid #214d74}h1,h2{color:#173f63}table{border-collapse:collapse;width:100%;margin:12px 0 24px}th,td{border:1px solid #bbb;padding:6px;text-align:left;vertical-align:top}th{background:#edf4f8}.mark{font-weight:bold;padding:8px;border:2px solid #173f63}</style></head>
+  <body><header><div class="mark">${mark}</div><h1>${esc(d.package.package_number)} - ${esc(d.package.title)}</h1>
+  <p>Exact EPOCH version: ${esc(d.package.production_version)} | Commit/release: ${esc(d.package.commit_or_release_identifier||'Not recorded')}</p></header>${body}
+  <p>Attachment contents are excluded. Controlled evidence references remain available in EPOCH.</p></body></html>`);
+});
+
+export async function getAuditReadinessValidationStatus(assessmentId:string){
+  const assessment=(await query('SELECT id,epoch_version FROM qms_audit_readiness_assessments WHERE id=$1',[assessmentId]))[0];
+  if(!assessment)return null;
+  const p=(await query(`SELECT * FROM qms_epoch_validation_packages WHERE audit_readiness_assessment_id=$1
+    ORDER BY CASE WHEN status IN ('APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS') THEN 0 ELSE 1 END,updated_at DESC LIMIT 1`,[assessmentId]))[0];
+  if(!p)return {state:'NOT_VALIDATED',message:'Not validated - create or link an EPOCH Software Validation Package.',package:null,complete:false,blockers:['No linked validation package']};
+  const c=await counts(p.id),r=calculateReadiness(c);
+  const review=(await query(`SELECT * FROM qms_epoch_validation_periodic_reviews WHERE package_id=$1 AND status='APPROVED' ORDER BY review_date DESC LIMIT 1`,[p.id]))[0];
+  const periodicCurrent=Boolean(review)&&new Date(review.next_review_date)>=new Date(new Date().toISOString().slice(0,10));
+  const versionMatches=p.production_version===assessment.epoch_version;
+  const approved=['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS'].includes(p.status);
+  const blockers=[...r.blockers,...(!approved?['Linked package is not approved for intended use']:[]),
+    ...(!versionMatches?['Approved EPOCH version does not match the assessment']:[]),
+    ...(!periodicCurrent?['Periodic review is missing or overdue']:[])];
+  return {state:blockers.length?'BLOCKED':'COMPLETE',message:blockers.length?blockers.join('; '):'EPOCH intended-use validation is current.',
+    package:{id:p.id,packageNumber:p.package_number,status:p.status,productionVersion:p.production_version},
+    assessmentVersion:assessment.epoch_version,versionMatches,periodicReviewCurrent:periodicCurrent,
+    complete:blockers.length===0,blockers,readiness:{...c,...r}};
+}
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -40,6 +40,7 @@ import pdfTemplatesRoutes from './pdfTemplates';
 import qualityRoutes from './quality';
 import qmsDesignControlRoutes from './qmsDesignControl';
 import auditReadinessRoutes from './auditReadiness';
+import epochSoftwareValidationRoutes from './epochSoftwareValidation';
 import engineeringReleasesRoutes from './engineeringReleases';
 import postReleaseEngineeringReleasesRoutes from './postReleaseEngineeringReleases';
 import documentsRoutes from './documents';
@@ -1266,6 +1267,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   app.use('/api/qms/design-control', qmsDesignControlRoutes);
   app.use('/api/engineering-releases', postReleaseEngineeringReleasesRoutes);
   app.use('/api/qms/as9100-audit-readiness', auditReadinessRoutes);
+  app.use('/api/qms/epoch-software-validation', epochSoftwareValidationRoutes);
   app.use('/api/engineering-releases', engineeringReleasesRoutes);
 
   // Asset Management routes

--- a/server/src/services/epochSoftwareValidation.ts
+++ b/server/src/services/epochSoftwareValidation.ts
@@ -1,0 +1,89 @@
+import crypto from 'crypto';
+
+export const VALIDATION_STATUSES = [
+  'DRAFT', 'PLANNING', 'READY_FOR_APPROVAL', 'PLAN_APPROVED', 'TESTING',
+  'TESTING_BLOCKED', 'CORRECTIONS_REQUIRED', 'RETESTING',
+  'READY_FOR_FINAL_REVIEW', 'APPROVED_FOR_INTENDED_USE',
+  'APPROVED_WITH_LIMITATIONS', 'REJECTED', 'SUPERSEDED', 'CANCELLED',
+] as const;
+
+export type ValidationStatus = typeof VALIDATION_STATUSES[number];
+
+export const LEGAL_TRANSITIONS: Record<ValidationStatus, readonly ValidationStatus[]> = {
+  DRAFT: ['PLANNING', 'CANCELLED'],
+  PLANNING: ['READY_FOR_APPROVAL', 'CANCELLED'],
+  READY_FOR_APPROVAL: ['PLAN_APPROVED', 'PLANNING', 'REJECTED'],
+  PLAN_APPROVED: ['TESTING', 'CORRECTIONS_REQUIRED', 'CANCELLED'],
+  TESTING: ['TESTING_BLOCKED', 'CORRECTIONS_REQUIRED', 'RETESTING', 'READY_FOR_FINAL_REVIEW'],
+  TESTING_BLOCKED: ['TESTING', 'CORRECTIONS_REQUIRED', 'CANCELLED'],
+  CORRECTIONS_REQUIRED: ['RETESTING', 'PLANNING', 'CANCELLED'],
+  RETESTING: ['TESTING_BLOCKED', 'CORRECTIONS_REQUIRED', 'READY_FOR_FINAL_REVIEW'],
+  READY_FOR_FINAL_REVIEW: [
+    'APPROVED_FOR_INTENDED_USE', 'APPROVED_WITH_LIMITATIONS',
+    'CORRECTIONS_REQUIRED', 'REJECTED',
+  ],
+  APPROVED_FOR_INTENDED_USE: ['SUPERSEDED'],
+  APPROVED_WITH_LIMITATIONS: ['SUPERSEDED'],
+  REJECTED: ['PLANNING', 'CANCELLED'],
+  SUPERSEDED: [],
+  CANCELLED: [],
+};
+
+export function canTransition(from: ValidationStatus, to: ValidationStatus) {
+  return LEGAL_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export type StepResult = { required?: boolean; status: string };
+
+export function deriveExecutionResult(steps: StepResult[]) {
+  const required = steps.filter(step => step.required !== false);
+  if (!required.length || required.some(step => step.status === 'NOT_RUN')) return 'NOT_RUN';
+  if (required.some(step => step.status === 'FAILED')) return 'FAILED';
+  if (required.some(step => step.status === 'BLOCKED')) return 'BLOCKED';
+  if (required.some(step => step.status === 'IN_PROGRESS')) return 'IN_PROGRESS';
+  return 'PASSED';
+}
+
+export type ReadinessCounts = {
+  intendedUseApproved: boolean;
+  requirementsBaselineApproved: boolean;
+  riskAssessmentApproved: boolean;
+  validationPlanApproved: boolean;
+  criticalRequirements: number;
+  criticalRequirementsTested: number;
+  criticalTests: number;
+  criticalTestsPassed: number;
+  openCriticalDefects: number;
+  openHighDefects: number;
+  acceptedHighDefects: number;
+  requiredRetests: number;
+  passedRetests: number;
+  backupPassed: boolean;
+  restorePassed: boolean;
+  outageDrillPassed: boolean;
+  approvalsCurrent: boolean;
+  exactProductionVersionIdentified: boolean;
+};
+
+export function calculateReadiness(counts: ReadinessCounts) {
+  const blockers: string[] = [];
+  if (!counts.intendedUseApproved) blockers.push('Intended Use is not approved');
+  if (!counts.requirementsBaselineApproved) blockers.push('Requirements baseline is not approved');
+  if (!counts.riskAssessmentApproved) blockers.push('Risk assessment is not approved');
+  if (!counts.validationPlanApproved) blockers.push('Validation Plan is not approved');
+  if (counts.criticalRequirementsTested < counts.criticalRequirements) blockers.push('Critical requirements remain untested');
+  if (counts.criticalTestsPassed < counts.criticalTests) blockers.push('Critical tests have not all passed');
+  if (counts.openCriticalDefects > 0) blockers.push('Critical validation defects remain open');
+  if (counts.openHighDefects > counts.acceptedHighDefects) blockers.push('High validation defects remain unaccepted');
+  if (counts.passedRetests < counts.requiredRetests) blockers.push('Required retests have not passed');
+  if (!counts.backupPassed) blockers.push('Backup verification has not passed');
+  if (!counts.restorePassed) blockers.push('Restore testing has not passed');
+  if (!counts.outageDrillPassed) blockers.push('Outage drill has not passed');
+  if (!counts.approvalsCurrent) blockers.push('Required approvals are missing or stale');
+  if (!counts.exactProductionVersionIdentified) blockers.push('Exact production version is not identified');
+  return { ready: blockers.length === 0, blockers };
+}
+
+export function checksum(value: unknown) {
+  return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}


### PR DESCRIPTION
## Summary

- add persistent, normalized EPOCH Software Validation packages with sequence-generated identifiers
- enforce validation planning, risk-based protocols, server-derived execution results, defects, approvals, locking, reopening, and periodic review
- connect live approved validation status to AS9100 Audit Readiness Section 2
- add QMS navigation, ten-section workspace, auditor view, controlled exports, capabilities, migration 0229, and safe-boot registration

## Why

EPOCH needs durable objective evidence that its defined QMS functions are suitable for their approved intended use. The existing Audit Readiness checklist identified this need but did not contain a persistent software-validation source of truth.

## Validation

- scoped TypeScript check passed with no diagnostics
- server TypeScript syntax checks passed
- pure workflow/readiness checks passed
- `git diff --check` and `git diff --cached --check` passed
- Vitest runner attempted but blocked by the existing missing `rollup` dependency
- scoped ESLint attempted but blocked by the existing missing `@eslint/js` resolution
- PostgreSQL migration execution remains pending against an authorized disposable database

## Deployment and configuration

- run additive migration `0229_epoch_software_validation.sql` through safe boot
- assign the new `EPOCH_VALIDATION_*` capabilities to authorized roles
- review draft requirement/protocol libraries before controlled use
- provide actual backup, restore, outage-drill, and periodic-review evidence

## Scope protection

This change only reads or links existing EPOCH source records. It does not create, approve, release, edit, or execute production, inventory, NCR/CAR, Design Control, Engineering Release, controlled-document, training, or GitHub source records.