### PR TITLE
Show generated P1 purchase-order lines in queue cards

### DIFF
--- a/server/__tests__/p1POQueueHelper.test.ts
+++ b/server/__tests__/p1POQueueHelper.test.ts
@@ -266,14 +266,31 @@ describe('computeP1Queue — Shipping QC fulfillment rule (RC-5)', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('filters out items that are not stock_model type', () => {
-    const po = makePO();
-    const item = makeItem({ itemType: 'custom_model' });
+  it('shows custom_model PO lines when their generated units are waiting in P1', () => {
+    const po = makePO({ poNumber: 'PO-WC-103437', customerName: 'Wilson Combat' });
+    const item = makeItem({
+      itemName: 'C-NULA-STOCK-M20-KR-708',
+      itemType: 'custom_model',
+      specifications: { stockModel: 'C-NULA-STOCK-M20-KR-708' },
+      quantity: 15,
+    });
     const itemsByPoId = new Map([[po.id, [item]]]);
+    const prodRows = Array.from({ length: 15 }, () =>
+      makeProdRow({
+        production_status: 'PENDING',
+        current_department: 'P1 Production Queue',
+      }),
+    );
 
-    const result = computeP1Queue([po], itemsByPoId, []);
+    const result = computeP1Queue([po], itemsByPoId, prodRows);
 
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.purchaseOrders[0]?.poNumber).toBe('PO-WC-103437');
+    expect(result[0]?.purchaseOrders[0]?.items[0]).toMatchObject({
+      itemType: 'custom_model',
+      quantity: 15,
+      availableQuantity: 15,
+    });
   });
 
   it('ignores stale cached order_count when no production rows exist', () => {

--- a/server/src/helpers/p1POQueueHelper.ts
+++ b/server/src/helpers/p1POQueueHelper.ts
@@ -222,9 +222,6 @@ export function computeP1Queue(
         };
       })
       .filter((item) => {
-        if (!item.itemType || item.itemType.toLowerCase() !== 'stock_model') {
-          return false;
-        }
         if (!item.stockModel || item.stockModel.trim() === '') {
           return false;
         }
@@ -236,9 +233,10 @@ export function computeP1Queue(
         if (!hasValidStockModel) {
           return false;
         }
-        // An operational P1 queue contains only lines with at least one exact
-        // unit still waiting in P1. Downstream-only and ungenerated lines do
-        // not belong here, although their history remains stored.
+        // Exact production rows are the source of truth for this operational
+        // queue. Some manufactured PO lines are catalogued as custom_model,
+        // so itemType must not hide units that are actually waiting in P1.
+        // Downstream-only and ungenerated lines still remain excluded.
         return item.availableQuantity > 0;
       });
 


### PR DESCRIPTION
## What changed
- make exact generated `production_orders` rows in `P1 Production Queue` the source of truth for purchase-order card visibility
- stop hiding manufactured PO lines solely because their catalog `itemType` is `custom_model`
- add focused regression coverage for a custom-model PO line with multiple pending P1 units

## Root cause
The P1 purchase-order card helper required `itemType === stock_model` even after confirming that exact production units were pending in the P1 queue. Manufactured lines catalogued as `custom_model` were therefore visible in the Purchase Order UI but discarded from the P1 card.

## Impact
- manufactured PO lines appear under their per-PO cards when they have exact pending or active units in P1
- ungenerated lines, invalid or no-stock lines, and units that have progressed out of P1 remain excluded
- the regular production queue remains scoped to `all_orders`

## Validation
- `git diff --check` passed
- Node syntax checks passed for the helper and focused test
- direct TSX execution of a representative custom-model fixture returned the expected PO card and pending quantity
- focused Vitest was attempted, but the shared local Vite installation could not resolve `rollup`; this is a runner limitation, not a passing test