### PR TITLE
Persist layup schedules when print popups are blocked

### DIFF
--- a/client/src/__tests__/layupSchedulePreview.component.test.tsx
+++ b/client/src/__tests__/layupSchedulePreview.component.test.tsx
@@ -85,4 +85,33 @@ describe('LayupSchedulePreview printing', () => {
     expect(printDocument.open).toHaveBeenCalledTimes(1);
     expect(printDocument.close).toHaveBeenCalledTimes(1);
   });
+
+  it('still saves the schedule when the browser blocks the print popup', async () => {
+    vi.spyOn(window, 'open').mockReturnValue(null);
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const onApprove = vi.fn().mockResolvedValue({ entriesSaved: 1 });
+
+    render(
+      <LayupSchedulePreview
+        open
+        onClose={vi.fn()}
+        scheduledItems={scheduledItems}
+        overflowItems={[]}
+        weekStart="2026-07-20"
+        totalItems={1}
+        onApprove={onApprove}
+        isApproving={false}
+      />
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector('svg rect')).not.toBeNull()
+    );
+    fireEvent.click(screen.getByTestId('button-print-schedule'));
+
+    await waitFor(() => expect(onApprove).toHaveBeenCalledTimes(1));
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Schedule saved. Please allow popups, then reprint it from Schedule History.'
+    );
+  });
 });

--- a/client/src/components/LayupSchedulePreview.tsx
+++ b/client/src/components/LayupSchedulePreview.tsx
@@ -175,21 +175,31 @@ export function LayupSchedulePreview({
     // newly generated schedule must be committed before anything is printed;
     // otherwise the paper schedule has no durable history record.
     const printWindow = window.open('', '_blank', 'width=1200,height=800');
-    if (!printWindow) {
+    if (!printWindow && isHistoricalReprint) {
       alert('Please allow popups to print the schedule');
       return;
     }
 
-    if (!isHistoricalReprint) {
+    if (printWindow && !isHistoricalReprint) {
       printWindow.document.write('<p style="font-family: sans-serif; padding: 24px">Saving schedule before printing...</p>');
+    }
 
+    if (!isHistoricalReprint) {
       try {
         await onApprove();
       } catch (error) {
         console.error('Failed to save schedule before printing:', error);
-        printWindow.close();
+        printWindow?.close();
         return;
       }
+    }
+
+    // Popup blocking must never prevent the approved schedule from being
+    // persisted. The user can enable popups and reprint the saved schedule
+    // from history without recreating or progressing the schedule again.
+    if (!printWindow) {
+      alert('Schedule saved. Please allow popups, then reprint it from Schedule History.');
+      return;
     }
     
     printWindow.document.open();


### PR DESCRIPTION
## What changed
- always run schedule approval and persistence for newly generated schedules, even when the browser blocks the print popup
- keep historical reprints non-mutating
- tell the user that the schedule was saved and can be reprinted from Schedule History after popups are enabled
- add a component regression proving `onApprove` runs when `window.open()` returns `null`

## Root cause
The Save & Print handler attempted to open the print window before calling the save mutation. When the browser blocked that popup, the handler returned immediately, so the schedule was neither inserted into history nor printed.

## Impact
- popup availability no longer controls whether an approved schedule is persisted
- successful saves remain available in Schedule History
- printing still requires the browser to allow the print popup, but a blocked popup no longer loses the generated schedule

## Validation
- `git diff --check` passed
- focused component test was attempted, but the shared local Vite installation cannot resolve `rollup`; this is documented as a runner limitation, not a passing test