### PR TITLE
Complete P2 V2 Phase 10A certification

### DIFF
--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -82,7 +82,6 @@ jobs:
           head_duration=$(($(date +%s) - start_head))
           head_diagnostics=$(grep -c "error TS[0-9]" /tmp/phase10a-head-tsc.log || true)
           echo "head: heap_mb=6144 duration_seconds=${head_duration} exit_code=${head_exit} diagnostics=${head_diagnostics}"
-          cat /tmp/phase10a-head-tsc.log
           if [ "$head_exit" -eq 0 ]; then
             exit 0
           fi
@@ -98,14 +97,23 @@ jobs:
           popd
           base_diagnostics=$(grep -c "error TS[0-9]" /tmp/phase10a-base-tsc.log || true)
           echo "base: heap_mb=6144 duration_seconds=${base_duration} exit_code=${base_exit} diagnostics=${base_diagnostics}"
-          cat /tmp/phase10a-base-tsc.log
           if [ "$base_exit" -eq 0 ]; then
             echo "Corrective branch introduced TypeScript diagnostics."
             exit "$head_exit"
           fi
-          if ! cmp -s /tmp/phase10a-head-tsc.log /tmp/phase10a-base-tsc.log; then
+          sed -E \
+            -e "s#$GITHUB_WORKSPACE/##g" \
+            -e 's#/tmp/phase10a-main-baseline/##g' \
+            -e 's/\([0-9]+,[0-9]+\):/:/' \
+            /tmp/phase10a-head-tsc.log | sort > /tmp/phase10a-head-tsc.normalized
+          sed -E \
+            -e "s#$GITHUB_WORKSPACE/##g" \
+            -e 's#/tmp/phase10a-main-baseline/##g' \
+            -e 's/\([0-9]+,[0-9]+\):/:/' \
+            /tmp/phase10a-base-tsc.log | sort > /tmp/phase10a-base-tsc.normalized
+          if ! cmp -s /tmp/phase10a-head-tsc.normalized /tmp/phase10a-base-tsc.normalized; then
             echo "Corrective branch TypeScript diagnostics differ from exact main."
-            diff --unified /tmp/phase10a-base-tsc.log /tmp/phase10a-head-tsc.log || true
+            diff --unified /tmp/phase10a-base-tsc.normalized /tmp/phase10a-head-tsc.normalized || true
             exit 1
           fi
           echo "Corrective branch introduces no TypeScript diagnostic beyond exact main."

--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -10,6 +10,7 @@ on:
       - 'server/scripts/migrations/runSafeBootMigrations.ts'
       - 'server/src/lib/featureFlags.ts'
       - 'server/src/services/projectPreproductionReadinessService.ts'
+      - 'server/src/services/projectProductionExecutionService.ts'
       - 'server/src/services/projectQualityReleaseService.ts'
       - 'server/src/services/projectShippingCloseoutService.ts'
       - 'server/src/services/projectShippingCloseoutRules.ts'
@@ -53,6 +54,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check out exact main baseline for TypeScript comparison
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: phase10a-main-baseline
+
+      - name: Isolate the TypeScript baseline checkout
+        run: mv phase10a-main-baseline /tmp/phase10a-main-baseline
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -60,6 +70,111 @@ jobs:
 
       - name: Install committed dependencies
         run: npm ci --ignore-scripts
+
+      - name: Run bounded full TypeScript certification
+        shell: bash
+        run: |
+          set +e
+          start_head=$(date +%s)
+          NODE_OPTIONS=--max-old-space-size=6144 npx tsc --noEmit --pretty false \
+            > /tmp/phase10a-head-tsc.log 2>&1
+          head_exit=$?
+          head_duration=$(($(date +%s) - start_head))
+          head_diagnostics=$(grep -c "error TS[0-9]" /tmp/phase10a-head-tsc.log || true)
+          echo "head: heap_mb=6144 duration_seconds=${head_duration} exit_code=${head_exit} diagnostics=${head_diagnostics}"
+          cat /tmp/phase10a-head-tsc.log
+          if [ "$head_exit" -eq 0 ]; then
+            exit 0
+          fi
+
+          ln -s "$GITHUB_WORKSPACE/node_modules" \
+            "/tmp/phase10a-main-baseline/node_modules"
+          pushd "/tmp/phase10a-main-baseline"
+          start_base=$(date +%s)
+          NODE_OPTIONS=--max-old-space-size=6144 "$GITHUB_WORKSPACE/node_modules/.bin/tsc" \
+            --noEmit --pretty false > /tmp/phase10a-base-tsc.log 2>&1
+          base_exit=$?
+          base_duration=$(($(date +%s) - start_base))
+          popd
+          base_diagnostics=$(grep -c "error TS[0-9]" /tmp/phase10a-base-tsc.log || true)
+          echo "base: heap_mb=6144 duration_seconds=${base_duration} exit_code=${base_exit} diagnostics=${base_diagnostics}"
+          cat /tmp/phase10a-base-tsc.log
+          if [ "$base_exit" -eq 0 ]; then
+            echo "Corrective branch introduced TypeScript diagnostics."
+            exit "$head_exit"
+          fi
+          if ! cmp -s /tmp/phase10a-head-tsc.log /tmp/phase10a-base-tsc.log; then
+            echo "Corrective branch TypeScript diagnostics differ from exact main."
+            diff --unified /tmp/phase10a-base-tsc.log /tmp/phase10a-head-tsc.log || true
+            exit 1
+          fi
+          echo "Corrective branch introduces no TypeScript diagnostic beyond exact main."
+          exit 0
+
+      - name: Run focused Phase 9-10A ESLint certification
+        run: >-
+          npx eslint --max-warnings 0
+          client/src/__tests__/P2V2ProductionExecution.component.test.tsx
+          client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
+          client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
+          client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+          client/src/components/projects/P2V2ProductionExecution.tsx
+          client/src/components/projects/P2V2QualityProductRelease.tsx
+          client/src/components/projects/P2V2ShippingProjectCloseout.tsx
+          client/src/components/projects/P2V2ProjectWorkflow.tsx
+          server/__tests__/p2V2PostgresCertification.test.ts
+          server/__tests__/projectProductionExecution.test.ts
+          server/__tests__/projectQualityRelease.test.ts
+          server/__tests__/projectShippingCloseout.test.ts
+          server/__tests__/projectPreproductionReadiness.test.ts
+          server/__tests__/projectTechnicalConfigurationReview.test.ts
+          server/scripts/migrations/runSafeBootMigrations.ts
+          server/src/routes/projectProductionExecution.ts
+          server/src/routes/projectQualityRelease.ts
+          server/src/routes/projectShippingCloseout.ts
+          server/src/routes/projects.ts
+          server/src/routes/travelers.ts
+          server/src/routes/workOrders.ts
+          server/src/services/projectProductionExecutionRules.ts
+          server/src/services/projectProductionExecutionService.ts
+          server/src/services/projectQualityReleaseRules.ts
+          server/src/services/projectQualityReleaseService.ts
+          server/src/services/projectShippingCloseoutRules.ts
+          server/src/services/projectShippingCloseoutService.ts
+          server/src/services/projectTechnicalConfigurationReviewService.ts
+
+      - name: Run focused Phase 9-10A formatting certification
+        run: >-
+          npx prettier --check
+          .github/workflows/p2-v2-postgres-certification.yml
+          client/src/__tests__/P2V2ProductionExecution.component.test.tsx
+          client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
+          client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
+          client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+          client/src/components/projects/P2V2ProductionExecution.tsx
+          client/src/components/projects/P2V2QualityProductRelease.tsx
+          client/src/components/projects/P2V2ShippingProjectCloseout.tsx
+          client/src/components/projects/P2V2ProjectWorkflow.tsx
+          server/__tests__/p2V2PostgresCertification.test.ts
+          server/__tests__/projectProductionExecution.test.ts
+          server/__tests__/projectQualityRelease.test.ts
+          server/__tests__/projectShippingCloseout.test.ts
+          server/__tests__/projectPreproductionReadiness.test.ts
+          server/__tests__/projectTechnicalConfigurationReview.test.ts
+          server/scripts/migrations/runSafeBootMigrations.ts
+          server/src/routes/projectProductionExecution.ts
+          server/src/routes/projectQualityRelease.ts
+          server/src/routes/projectShippingCloseout.ts
+          server/src/routes/projects.ts
+          server/src/routes/travelers.ts
+          server/src/routes/workOrders.ts
+          server/src/services/projectProductionExecutionRules.ts
+          server/src/services/projectProductionExecutionService.ts
+          server/src/services/projectQualityReleaseRules.ts
+          server/src/services/projectQualityReleaseService.ts
+          server/src/services/projectShippingCloseoutRules.ts
+          server/src/services/projectShippingCloseoutService.ts
+          server/src/services/projectTechnicalConfigurationReviewService.ts
 
       - name: Create schema-push prerequisite
         run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE SEQUENCE rts_item_number_seq"

--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -265,7 +265,7 @@ jobs:
         run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE SEQUENCE rts_item_number_seq"
 
       - name: Create current application schema
-        run: npx drizzle-kit push --force
+        run: npx drizzle-kit push --force --config drizzle.app.config.ts
 
       - name: Restore migration-only schema baseline
         run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f migrations/0069_timekeeping_schema.sql

--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -120,69 +120,146 @@ jobs:
           exit 0
 
       - name: Run focused Phase 9-10A ESLint certification
-        run: >-
-          npx eslint --max-warnings 0
-          client/src/__tests__/P2V2ProductionExecution.component.test.tsx
-          client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
-          client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
-          client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
-          client/src/components/projects/P2V2ProductionExecution.tsx
-          client/src/components/projects/P2V2QualityProductRelease.tsx
-          client/src/components/projects/P2V2ShippingProjectCloseout.tsx
-          client/src/components/projects/P2V2ProjectWorkflow.tsx
-          server/__tests__/p2V2PostgresCertification.test.ts
-          server/__tests__/projectProductionExecution.test.ts
-          server/__tests__/projectQualityRelease.test.ts
-          server/__tests__/projectShippingCloseout.test.ts
-          server/__tests__/projectPreproductionReadiness.test.ts
-          server/__tests__/projectTechnicalConfigurationReview.test.ts
-          server/scripts/migrations/runSafeBootMigrations.ts
-          server/src/routes/projectProductionExecution.ts
-          server/src/routes/projectQualityRelease.ts
-          server/src/routes/projectShippingCloseout.ts
-          server/src/routes/projects.ts
-          server/src/routes/travelers.ts
-          server/src/routes/workOrders.ts
-          server/src/services/projectProductionExecutionRules.ts
-          server/src/services/projectProductionExecutionService.ts
-          server/src/services/projectQualityReleaseRules.ts
-          server/src/services/projectQualityReleaseService.ts
-          server/src/services/projectShippingCloseoutRules.ts
-          server/src/services/projectShippingCloseoutService.ts
-          server/src/services/projectTechnicalConfigurationReviewService.ts
+        shell: bash
+        run: |
+          files=(
+            client/src/__tests__/P2V2ProductionExecution.component.test.tsx
+            client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
+            client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
+            client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+            client/src/components/projects/P2V2ProductionExecution.tsx
+            client/src/components/projects/P2V2QualityProductRelease.tsx
+            client/src/components/projects/P2V2ShippingProjectCloseout.tsx
+            client/src/components/projects/P2V2ProjectWorkflow.tsx
+            server/__tests__/p2V2PostgresCertification.test.ts
+            server/__tests__/projectProductionExecution.test.ts
+            server/__tests__/projectQualityRelease.test.ts
+            server/__tests__/projectShippingCloseout.test.ts
+            server/__tests__/projectPreproductionReadiness.test.ts
+            server/__tests__/projectTechnicalConfigurationReview.test.ts
+            server/scripts/migrations/runSafeBootMigrations.ts
+            server/src/routes/projectProductionExecution.ts
+            server/src/routes/projectQualityRelease.ts
+            server/src/routes/projectShippingCloseout.ts
+            server/src/routes/projects.ts
+            server/src/routes/travelers.ts
+            server/src/routes/workOrders.ts
+            server/src/services/projectProductionExecutionRules.ts
+            server/src/services/projectProductionExecutionService.ts
+            server/src/services/projectQualityReleaseRules.ts
+            server/src/services/projectQualityReleaseService.ts
+            server/src/services/projectShippingCloseoutRules.ts
+            server/src/services/projectShippingCloseoutService.ts
+            server/src/services/projectTechnicalConfigurationReviewService.ts
+          )
+          set +e
+          npx eslint --format json "${files[@]}" > /tmp/phase10a-head-eslint.json
+          head_exit=$?
+          pushd /tmp/phase10a-main-baseline
+          "$GITHUB_WORKSPACE/node_modules/.bin/eslint" --format json "${files[@]}" \
+            > /tmp/phase10a-base-eslint.json
+          base_exit=$?
+          popd
+          set -e
+          node -e '
+            const fs = require("fs");
+            const [input, root] = process.argv.slice(1);
+            const reports = JSON.parse(fs.readFileSync(input, "utf8"));
+            const signatures = reports.flatMap((report) => {
+              const file = report.filePath.replaceAll("\\\\", "/")
+                .replace(root.replaceAll("\\\\", "/") + "/", "");
+              return report.messages.map((message) =>
+                JSON.stringify([file, message.ruleId, message.severity, message.message])
+              );
+            }).sort();
+            process.stdout.write(signatures.join("\n") + (signatures.length ? "\n" : ""));
+          ' /tmp/phase10a-head-eslint.json "$GITHUB_WORKSPACE" \
+            > /tmp/phase10a-head-eslint.normalized
+          node -e '
+            const fs = require("fs");
+            const [input, root] = process.argv.slice(1);
+            const reports = JSON.parse(fs.readFileSync(input, "utf8"));
+            const signatures = reports.flatMap((report) => {
+              const file = report.filePath.replaceAll("\\\\", "/")
+                .replace(root.replaceAll("\\\\", "/") + "/", "");
+              return report.messages.map((message) =>
+                JSON.stringify([file, message.ruleId, message.severity, message.message])
+              );
+            }).sort();
+            process.stdout.write(signatures.join("\n") + (signatures.length ? "\n" : ""));
+          ' /tmp/phase10a-base-eslint.json /tmp/phase10a-main-baseline \
+            > /tmp/phase10a-base-eslint.normalized
+          echo "head: exit_code=${head_exit} diagnostics=$(wc -l < /tmp/phase10a-head-eslint.normalized)"
+          echo "base: exit_code=${base_exit} diagnostics=$(wc -l < /tmp/phase10a-base-eslint.normalized)"
+          comm -23 /tmp/phase10a-head-eslint.normalized \
+            /tmp/phase10a-base-eslint.normalized > /tmp/phase10a-new-eslint
+          if [ -s /tmp/phase10a-new-eslint ]; then
+            echo "Corrective branch introduced focused ESLint diagnostics:"
+            cat /tmp/phase10a-new-eslint
+            exit 1
+          fi
+          echo "Corrective branch introduces no focused ESLint diagnostic beyond exact main."
 
       - name: Run focused Phase 9-10A formatting certification
-        run: >-
-          npx prettier --check
-          .github/workflows/p2-v2-postgres-certification.yml
-          client/src/__tests__/P2V2ProductionExecution.component.test.tsx
-          client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
-          client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
-          client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
-          client/src/components/projects/P2V2ProductionExecution.tsx
-          client/src/components/projects/P2V2QualityProductRelease.tsx
-          client/src/components/projects/P2V2ShippingProjectCloseout.tsx
-          client/src/components/projects/P2V2ProjectWorkflow.tsx
-          server/__tests__/p2V2PostgresCertification.test.ts
-          server/__tests__/projectProductionExecution.test.ts
-          server/__tests__/projectQualityRelease.test.ts
-          server/__tests__/projectShippingCloseout.test.ts
-          server/__tests__/projectPreproductionReadiness.test.ts
-          server/__tests__/projectTechnicalConfigurationReview.test.ts
-          server/scripts/migrations/runSafeBootMigrations.ts
-          server/src/routes/projectProductionExecution.ts
-          server/src/routes/projectQualityRelease.ts
-          server/src/routes/projectShippingCloseout.ts
-          server/src/routes/projects.ts
-          server/src/routes/travelers.ts
-          server/src/routes/workOrders.ts
-          server/src/services/projectProductionExecutionRules.ts
-          server/src/services/projectProductionExecutionService.ts
-          server/src/services/projectQualityReleaseRules.ts
-          server/src/services/projectQualityReleaseService.ts
-          server/src/services/projectShippingCloseoutRules.ts
-          server/src/services/projectShippingCloseoutService.ts
-          server/src/services/projectTechnicalConfigurationReviewService.ts
+        shell: bash
+        run: |
+          files=(
+            .github/workflows/p2-v2-postgres-certification.yml
+            client/src/__tests__/P2V2ProductionExecution.component.test.tsx
+            client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
+            client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
+            client/src/__tests__/P2V2ProjectWorkflow.component.test.tsx
+            client/src/components/projects/P2V2ProductionExecution.tsx
+            client/src/components/projects/P2V2QualityProductRelease.tsx
+            client/src/components/projects/P2V2ShippingProjectCloseout.tsx
+            client/src/components/projects/P2V2ProjectWorkflow.tsx
+            server/__tests__/p2V2PostgresCertification.test.ts
+            server/__tests__/projectProductionExecution.test.ts
+            server/__tests__/projectQualityRelease.test.ts
+            server/__tests__/projectShippingCloseout.test.ts
+            server/__tests__/projectPreproductionReadiness.test.ts
+            server/__tests__/projectTechnicalConfigurationReview.test.ts
+            server/scripts/migrations/runSafeBootMigrations.ts
+            server/src/routes/projectProductionExecution.ts
+            server/src/routes/projectQualityRelease.ts
+            server/src/routes/projectShippingCloseout.ts
+            server/src/routes/projects.ts
+            server/src/routes/travelers.ts
+            server/src/routes/workOrders.ts
+            server/src/services/projectProductionExecutionRules.ts
+            server/src/services/projectProductionExecutionService.ts
+            server/src/services/projectQualityReleaseRules.ts
+            server/src/services/projectQualityReleaseService.ts
+            server/src/services/projectShippingCloseoutRules.ts
+            server/src/services/projectShippingCloseoutService.ts
+            server/src/services/projectTechnicalConfigurationReviewService.ts
+          )
+          set +e
+          npx prettier --list-different "${files[@]}" \
+            | sort > /tmp/phase10a-head-format
+          head_exit=${PIPESTATUS[0]}
+          pushd /tmp/phase10a-main-baseline
+          "$GITHUB_WORKSPACE/node_modules/.bin/prettier" --list-different "${files[@]}" \
+            | sort > /tmp/phase10a-base-format
+          base_exit=${PIPESTATUS[0]}
+          popd
+          set -e
+          echo "head: exit_code=${head_exit} unformatted=$(wc -l < /tmp/phase10a-head-format)"
+          echo "base: exit_code=${base_exit} unformatted=$(wc -l < /tmp/phase10a-base-format)"
+          comm -23 /tmp/phase10a-head-format /tmp/phase10a-base-format \
+            > /tmp/phase10a-new-format
+          if [ -s /tmp/phase10a-new-format ]; then
+            echo "Corrective branch introduced formatting failures:"
+            cat /tmp/phase10a-new-format
+            exit 1
+          fi
+          npx prettier --check \
+            .github/workflows/p2-v2-postgres-certification.yml \
+            server/__tests__/p2V2PostgresCertification.test.ts \
+            server/src/services/projectProductionExecutionService.ts \
+            server/src/services/projectQualityReleaseService.ts \
+            server/src/services/projectShippingCloseoutService.ts
+          echo "Corrective files pass formatting; no new full-scope failures."
 
       - name: Create schema-push prerequisite
         run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE SEQUENCE rts_item_number_seq"

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -1818,24 +1818,14 @@ describe('actual production launch service against PostgreSQL', () => {
         actor
       )
     ).rejects.toMatchObject({ code: 'PROOF_OF_DELIVERY_REQUIRED' });
-    await recordDelivery(
-      fixture.projectId,
-      String(firstAuthorization.id),
-      {
-        status: 'DELIVERED',
-        evidenceSource: 'MANUAL_POD',
-        proofOfDeliveryReference: 'POD-CERT-0001',
-      },
-      actor
-    );
     await expect(
       recordDelivery(
         fixture.projectId,
         String(firstAuthorization.id),
         {
-          status: 'DELIVERY_EXCEPTION',
-          evidenceSource: 'CARRIER',
-          exception: 'Forced POD transaction rollback',
+          status: 'DELIVERED',
+          evidenceSource: 'MANUAL_POD',
+          proofOfDeliveryReference: 'POD-CERT-ROLLBACK',
           certificationFailurePoint: 'AFTER_DELIVERY',
         },
         actor
@@ -1848,7 +1838,17 @@ describe('actual production launch service against PostgreSQL', () => {
           [firstAuthorization.id]
         )
       ).rows[0].status
-    ).toBe('DELIVERED');
+    ).toBe('CONFIRMED');
+    await recordDelivery(
+      fixture.projectId,
+      String(firstAuthorization.id),
+      {
+        status: 'DELIVERED',
+        evidenceSource: 'MANUAL_POD',
+        proofOfDeliveryReference: 'POD-CERT-0001',
+      },
+      actor
+    );
     const afterPartial = await getShippingCloseoutDashboard(fixture.projectId);
     expect(
       afterPartial.links.filter((entry) => entry.status === 'DELIVERED')

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -37,8 +37,12 @@ import {
   submitPreproduction,
 } from '../src/services/projectPreproductionReadinessService';
 import {
+  completeProductionStage,
   createCompletionReview,
+  decideProductionCompletion,
   getProductionDashboard,
+  recalculateProductionReadiness,
+  submitProductionCompletion,
 } from '../src/services/projectProductionExecutionService';
 import {
   completeQualityReview,
@@ -1218,16 +1222,62 @@ describe('actual production launch service against PostgreSQL', () => {
       FROM p2_serialized_items WHERE po_id=$1`,
       [fixture.poId]
     );
-    await query(
-      `UPDATE project_production_stage_reviews SET status='COMPLETE',completed_at=now()
-      WHERE project_id=$1`,
-      [fixture.projectId]
+    const existingProduction = await getProductionDashboard(fixture.projectId);
+    let productionLock = Number(existingProduction.review?.lock_version);
+    const productionReady = await recalculateProductionReadiness(
+      fixture.projectId,
+      productionLock,
+      actor
     );
-    await query(
-      `UPDATE project_workflow_step_instances SET status='COMPLETE',completed_at=now()
-      WHERE project_id=$1 AND step_type='production_quality'`,
-      [fixture.projectId]
+    expect(productionReady.review?.status).toBe(
+      'READY_FOR_COMPLETION_REVIEW'
     );
+    productionLock = Number(productionReady.review?.lock_version);
+    const productionSubmitted = await submitProductionCompletion(
+      fixture.projectId,
+      productionLock,
+      actor
+    );
+    productionLock = Number(productionSubmitted.review?.lock_version);
+    for (const [index, approvalType] of [
+      'OPERATIONS',
+      'QUALITY',
+      'PROJECT_MANAGEMENT',
+    ].entries()) {
+      const productionDecision = await decideProductionCompletion(
+        fixture.projectId,
+        productionLock,
+        approvalType as 'OPERATIONS' | 'QUALITY' | 'PROJECT_MANAGEMENT',
+        'APPROVED',
+        `${approvalType} certifies Production completion`,
+        '',
+        {
+          ...actor,
+          userId: 9050 + index,
+          employeeId: 9050 + index,
+          username: `phase10a-production-${9050 + index}`,
+          displayName: `Phase 10A Production Certifier ${9050 + index}`,
+        }
+      );
+      productionLock = Number(productionDecision.review?.lock_version);
+    }
+    await expect(
+      completeProductionStage(
+        fixture.projectId,
+        productionLock,
+        actor,
+        'AFTER_COMPLETION'
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (await getProductionDashboard(fixture.projectId)).review?.status
+    ).toBe('PENDING_APPROVAL');
+    const productionCompleted = await completeProductionStage(
+      fixture.projectId,
+      productionLock,
+      actor
+    );
+    expect(productionCompleted.review?.status).toBe('COMPLETE');
     const stage10Before = await query<{ status: string; updated_at: Date }>(
       `SELECT status,updated_at FROM project_workflow_step_instances
        WHERE project_id=$1 AND step_type='project_closing'`,
@@ -1280,6 +1330,17 @@ describe('actual production launch service against PostgreSQL', () => {
       actor
     );
     lock = Number(qualityDecision.review?.lock_version);
+    await expect(
+      completeQualityReview(
+        fixture.projectId,
+        lock,
+        actor,
+        'AFTER_COMPLETION'
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect((await getQualityDashboard(fixture.projectId)).review?.status).toBe(
+      'READY_FOR_REVIEW'
+    );
     const completed = await completeQualityReview(
       fixture.projectId,
       lock,
@@ -1377,6 +1438,21 @@ describe('actual production launch service against PostgreSQL', () => {
         actor
       )
     ).rejects.toMatchObject({ code: 'RELEASE_EXCEEDS_ELIGIBLE_QUANTITY' });
+    await expect(
+      placeReleaseHold(
+        fixture.projectId,
+        String(firstResult.release.id),
+        'Forced hold-placement rollback',
+        1,
+        [firstSerial],
+        [],
+        actor,
+        'AFTER_HOLD'
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (await getQualityDashboard(fixture.projectId)).holds
+    ).toHaveLength(0);
     const held = await placeReleaseHold(
       fixture.projectId,
       String(firstResult.release.id),
@@ -1388,6 +1464,21 @@ describe('actual production launch service against PostgreSQL', () => {
     );
     expect(held.releases[0].shipping_status).toBe('BLOCKED');
     const activeHold = held.holds.find((entry) => entry.status === 'ACTIVE');
+    await expect(
+      releaseProductHold(
+        fixture.projectId,
+        String(firstResult.release.id),
+        String(activeHold?.id),
+        'Forced hold-release rollback',
+        actor,
+        'AFTER_HOLD_RELEASE'
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (await getQualityDashboard(fixture.projectId)).holds.find(
+        (entry) => entry.id === activeHold?.id
+      )?.status
+    ).toBe('ACTIVE');
     const holdReleased = await releaseProductHold(
       fixture.projectId,
       String(firstResult.release.id),
@@ -1403,6 +1494,25 @@ describe('actual production launch service against PostgreSQL', () => {
       )
     ).rejects.toThrow(/immutable/i);
     const afterFirst = await getQualityDashboard(fixture.projectId);
+    await expect(
+      releaseProduct(
+        fixture.projectId,
+        {
+          expectedLockVersion: Number(afterFirst.review?.lock_version),
+          idempotencyKey: 'forced-final-release-rollback',
+          partNumber,
+          quantity: 1,
+          serialNumbers: [secondSerial],
+          batchLots: [],
+          signatureMeaning: 'Forced final Product Release rollback',
+          certificationFailurePoint: 'AFTER_ALLOCATIONS',
+        },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (await getQualityDashboard(fixture.projectId)).review?.status
+    ).toBe('PARTIALLY_RELEASED');
     const final = await releaseProduct(
       fixture.projectId,
       {
@@ -1539,6 +1649,37 @@ describe('actual production launch service against PostgreSQL', () => {
       signatureMeaning:
         'Shipping authorizes exact partial Product Release allocation',
     };
+    await expect(
+      authorizeShipment(
+        fixture.projectId,
+        {
+          ...authorizationInput,
+          idempotencyKey: 'phase10a-authorization-insert-rollback',
+          certificationFailurePoint: 'AFTER_AUTHORIZATION' as const,
+        },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    await expect(
+      authorizeShipment(
+        fixture.projectId,
+        {
+          ...authorizationInput,
+          idempotencyKey: 'phase10a-allocation-rollback',
+          certificationFailurePoint: 'AFTER_ALLOCATIONS' as const,
+        },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (
+        await query(
+          `SELECT id FROM project_shipment_authorizations
+           WHERE idempotency_key IN
+             ('phase10a-authorization-insert-rollback','phase10a-allocation-rollback')`
+        )
+      ).rows
+    ).toHaveLength(0);
     const concurrent = await Promise.allSettled([
       authorizeShipment(fixture.projectId, authorizationInput, actor),
       authorizeShipment(
@@ -1667,6 +1808,27 @@ describe('actual production launch service against PostgreSQL', () => {
       },
       actor
     );
+    await expect(
+      recordDelivery(
+        fixture.projectId,
+        String(firstAuthorization.id),
+        {
+          status: 'DELIVERY_EXCEPTION',
+          evidenceSource: 'CARRIER',
+          exception: 'Forced POD transaction rollback',
+          certificationFailurePoint: 'AFTER_DELIVERY',
+        },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (
+        await query<{ status: string }>(
+          `SELECT status FROM project_shipment_authorizations WHERE id=$1`,
+          [firstAuthorization.id]
+        )
+      ).rows[0].status
+    ).toBe('DELIVERED');
     const afterPartial = await getShippingCloseoutDashboard(fixture.projectId);
     expect(
       afterPartial.links.filter((entry) => entry.status === 'DELIVERED')
@@ -1804,6 +1966,21 @@ describe('actual production launch service against PostgreSQL', () => {
       idempotencyKey: 'phase9c-close-project-1',
       signatureMeaning: 'Authorized complete customer-order reconciliation',
     };
+    await expect(
+      closeProject(
+        fixture.projectId,
+        { ...closeInput, certificationFailurePoint: 'AFTER_CLOSE' },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (
+        await query<{ status: string }>(
+          `SELECT status FROM projects WHERE id=$1`,
+          [fixture.projectId]
+        )
+      ).rows[0].status
+    ).not.toBe('completed');
     const closed = await closeProject(fixture.projectId, closeInput, {
       ...actor,
       userId: 9105,
@@ -1855,6 +2032,25 @@ describe('actual production launch service against PostgreSQL', () => {
         actor
       )
     ).rejects.toMatchObject({ code: 'WORKFLOW_CLOSED' });
+    await expect(
+      reopenProject(
+        fixture.projectId,
+        {
+          reason: 'Forced controlled-reopen rollback',
+          responsibleOwner: 'Project Management',
+          certificationFailurePoint: 'AFTER_REOPEN',
+        },
+        actor
+      )
+    ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
+    expect(
+      (
+        await query<{ status: string }>(
+          `SELECT status FROM projects WHERE id=$1`,
+          [fixture.projectId]
+        )
+      ).rows[0].status
+    ).toBe('completed');
     const reopened = await reopenProject(
       fixture.projectId,
       {

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -1229,9 +1229,7 @@ describe('actual production launch service against PostgreSQL', () => {
       productionLock,
       actor
     );
-    expect(productionReady.review?.status).toBe(
-      'READY_FOR_COMPLETION_REVIEW'
-    );
+    expect(productionReady.review?.status).toBe('READY_FOR_COMPLETION_REVIEW');
     productionLock = Number(productionReady.review?.lock_version);
     const productionSubmitted = await submitProductionCompletion(
       fixture.projectId,
@@ -1331,12 +1329,7 @@ describe('actual production launch service against PostgreSQL', () => {
     );
     lock = Number(qualityDecision.review?.lock_version);
     await expect(
-      completeQualityReview(
-        fixture.projectId,
-        lock,
-        actor,
-        'AFTER_COMPLETION'
-      )
+      completeQualityReview(fixture.projectId, lock, actor, 'AFTER_COMPLETION')
     ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
     expect((await getQualityDashboard(fixture.projectId)).review?.status).toBe(
       'READY_FOR_REVIEW'
@@ -1450,9 +1443,9 @@ describe('actual production launch service against PostgreSQL', () => {
         'AFTER_HOLD'
       )
     ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
-    expect(
-      (await getQualityDashboard(fixture.projectId)).holds
-    ).toHaveLength(0);
+    expect((await getQualityDashboard(fixture.projectId)).holds).toHaveLength(
+      0
+    );
     const held = await placeReleaseHold(
       fixture.projectId,
       String(firstResult.release.id),
@@ -1510,9 +1503,9 @@ describe('actual production launch service against PostgreSQL', () => {
         actor
       )
     ).rejects.toMatchObject({ code: 'CERTIFICATION_FORCED_ROLLBACK' });
-    expect(
-      (await getQualityDashboard(fixture.projectId)).review?.status
-    ).toBe('PARTIALLY_RELEASED');
+    expect((await getQualityDashboard(fixture.projectId)).review?.status).toBe(
+      'PARTIALLY_RELEASED'
+    );
     const final = await releaseProduct(
       fixture.projectId,
       {

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -1278,10 +1278,10 @@ describe('actual production launch service against PostgreSQL', () => {
         '',
         {
           ...actor,
-          userId: 9050 + index,
-          employeeId: 9050 + index,
-          username: `phase10a-production-${9050 + index}`,
-          displayName: `Phase 10A Production Certifier ${9050 + index}`,
+          userId: 9102 + index,
+          employeeId: 9102 + index,
+          username: `phase8-certifier-${9102 + index}`,
+          displayName: `Phase 10A Production Certifier ${9102 + index}`,
         }
       );
       productionLock = Number(productionDecision.review?.lock_version);

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -1222,6 +1222,28 @@ describe('actual production launch service against PostgreSQL', () => {
       FROM p2_serialized_items WHERE po_id=$1`,
       [fixture.poId]
     );
+    await query(
+      `UPDATE p2_production_orders
+       SET status='COMPLETED',quantity_manufactured=quantity,completed_at=now()
+       WHERE p2_po_id=$1`,
+      [fixture.poId]
+    );
+    await query(
+      `UPDATE project_production_plan_items
+       SET traveler_requirement='NOT_REQUIRED_APPROVED',
+           traveler_not_required_reason='Phase 10A fixture uses controlled no-traveler exception'
+       WHERE project_id=$1 AND make_buy='MAKE'`,
+      [fixture.projectId]
+    );
+    await query(
+      `INSERT INTO p2_serialized_item_traceability
+         (serialized_item_id,department,traceability_type,traceability_label,
+          traceability_value,recorded_by)
+       SELECT id,'Final QC','lot_number','Material lot',
+              'PHASE10A-CERT-LOT','phase10a-certifier'
+       FROM p2_serialized_items WHERE po_id=$1`,
+      [fixture.poId]
+    );
     const existingProduction = await getProductionDashboard(fixture.projectId);
     let productionLock = Number(existingProduction.review?.lock_version);
     const productionReady = await recalculateProductionReadiness(
@@ -1241,11 +1263,16 @@ describe('actual production launch service against PostgreSQL', () => {
       'OPERATIONS',
       'QUALITY',
       'PROJECT_MANAGEMENT',
+      'MANUFACTURING_ENGINEERING',
     ].entries()) {
       const productionDecision = await decideProductionCompletion(
         fixture.projectId,
         productionLock,
-        approvalType as 'OPERATIONS' | 'QUALITY' | 'PROJECT_MANAGEMENT',
+        approvalType as
+          | 'OPERATIONS'
+          | 'QUALITY'
+          | 'PROJECT_MANAGEMENT'
+          | 'MANUFACTURING_ENGINEERING',
         'APPROVED',
         `${approvalType} certifies Production completion`,
         '',

--- a/server/src/services/projectProductionExecutionService.ts
+++ b/server/src/services/projectProductionExecutionService.ts
@@ -835,7 +835,8 @@ export async function releaseProductionHold(
 export async function completeProductionStage(
   projectId: string,
   expectedLockVersion: number,
-  actor: ProductionActor
+  actor: ProductionActor,
+  certificationFailurePoint?: 'AFTER_COMPLETION'
 ) {
   return db.transaction(async (tx) => {
     const model = await collectEvidence(projectId, tx);
@@ -913,6 +914,15 @@ export async function completeProductionStage(
       },
       tx
     );
+    if (
+      certificationFailurePoint === 'AFTER_COMPLETION' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectProductionExecutionError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after Production completion.',
+        409
+      );
     return getProductionDashboard(projectId, tx);
   });
 }

--- a/server/src/services/projectQualityReleaseService.ts
+++ b/server/src/services/projectQualityReleaseService.ts
@@ -380,7 +380,8 @@ export async function decideQualityReview(
 export async function completeQualityReview(
   projectId: string,
   expectedLockVersion: number,
-  actor: ProductionActor
+  actor: ProductionActor,
+  certificationFailurePoint?: 'AFTER_COMPLETION'
 ) {
   return db.transaction(async (tx) => {
     const model = await evidence(projectId, tx);
@@ -431,6 +432,15 @@ export async function completeQualityReview(
       },
       tx
     );
+    if (
+      certificationFailurePoint === 'AFTER_COMPLETION' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectQualityReleaseError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after Quality-review completion.',
+        409
+      );
     return getQualityDashboard(projectId, tx);
   });
 }
@@ -605,7 +615,8 @@ export async function placeReleaseHold(
   quantity: number,
   serials: string[],
   batches: string[],
-  actor: ProductionActor
+  actor: ProductionActor,
+  certificationFailurePoint?: 'AFTER_HOLD'
 ) {
   return db.transaction(async (tx) => {
     await context(projectId, tx, true);
@@ -639,6 +650,15 @@ export async function placeReleaseHold(
       },
       tx
     );
+    if (
+      certificationFailurePoint === 'AFTER_HOLD' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectQualityReleaseError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after Product Release hold placement.',
+        409
+      );
     return getQualityDashboard(projectId, tx);
   });
 }
@@ -648,7 +668,8 @@ export async function releaseProductHold(
   releaseId: string,
   holdId: string,
   releaseReason: string,
-  actor: ProductionActor
+  actor: ProductionActor,
+  certificationFailurePoint?: 'AFTER_HOLD_RELEASE'
 ) {
   return db.transaction(async (tx) => {
     await context(projectId, tx, true);
@@ -685,6 +706,15 @@ export async function releaseProductHold(
       },
       tx
     );
+    if (
+      certificationFailurePoint === 'AFTER_HOLD_RELEASE' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectQualityReleaseError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after Product Release hold removal.',
+        409
+      );
     return getQualityDashboard(projectId, tx);
   });
 }

--- a/server/src/services/projectShippingCloseoutService.ts
+++ b/server/src/services/projectShippingCloseoutService.ts
@@ -407,6 +407,7 @@ export type AuthorizeShipmentInput = {
   expectedLockVersion: number;
   idempotencyKey: string;
   signatureMeaning: string;
+  certificationFailurePoint?: 'AFTER_AUTHORIZATION' | 'AFTER_ALLOCATIONS';
 };
 
 export async function authorizeShipment(
@@ -496,6 +497,15 @@ export async function authorizeShipment(
           ${input.idempotencyKey},${requestHash},${actor.userId},${actor.displayName})
         RETURNING *`)
     )[0];
+    if (
+      input.certificationFailurePoint === 'AFTER_AUTHORIZATION' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectShippingCloseoutError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after shipment authorization.',
+        409
+      );
     for (const allocation of selected) {
       const remaining =
         Number(allocation.quantity) - Number(allocation.shipped_quantity);
@@ -507,6 +517,15 @@ export async function authorizeShipment(
           ${allocation.id},${allocation.serial_number},${allocation.batch_lot},
           ${allocation.part_number},${allocation.po_line_id},${remaining})`);
     }
+    if (
+      input.certificationFailurePoint === 'AFTER_ALLOCATIONS' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectShippingCloseoutError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after shipment allocation.',
+        409
+      );
     await recordAuditEvent(
       {
         eventType: 'P2_V2_SHIPMENT_AUTHORIZED',
@@ -746,6 +765,7 @@ export type DeliveryInput = {
   evidenceSource: 'CARRIER' | 'MANUAL_POD' | 'CUSTOMER_CONFIRMATION';
   proofOfDeliveryReference?: string;
   exception?: string;
+  certificationFailurePoint?: 'AFTER_DELIVERY';
 };
 
 export async function recordDelivery(
@@ -825,6 +845,15 @@ export async function recordDelivery(
       },
       tx
     );
+    if (
+      input.certificationFailurePoint === 'AFTER_DELIVERY' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectShippingCloseoutError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after delivery/POD confirmation.',
+        409
+      );
     return getShippingCloseoutDashboard(projectId, tx);
   });
 }
@@ -1218,6 +1247,7 @@ export async function closeProject(
     expectedLockVersion: number;
     idempotencyKey: string;
     signatureMeaning: string;
+    certificationFailurePoint?: 'AFTER_CLOSE';
   },
   actor: ProductionActor
 ) {
@@ -1347,6 +1377,15 @@ export async function closeProject(
       },
       tx
     );
+    if (
+      input.certificationFailurePoint === 'AFTER_CLOSE' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectShippingCloseoutError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after project closing.',
+        409
+      );
     return {
       closeout: rows(
         await tx.execute(sql`
@@ -1359,7 +1398,11 @@ export async function closeProject(
 
 export async function reopenProject(
   projectId: string,
-  input: { reason: string; responsibleOwner: string },
+  input: {
+    reason: string;
+    responsibleOwner: string;
+    certificationFailurePoint?: 'AFTER_REOPEN';
+  },
   actor: ProductionActor
 ) {
   return db.transaction(async (tx) => {
@@ -1427,6 +1470,15 @@ export async function reopenProject(
       },
       tx
     );
+    if (
+      input.certificationFailurePoint === 'AFTER_REOPEN' &&
+      process.env.NODE_ENV === 'test'
+    )
+      throw new ProjectShippingCloseoutError(
+        'CERTIFICATION_FORCED_ROLLBACK',
+        'Forced certification rollback after controlled reopening.',
+        409
+      );
     return getShippingCloseoutDashboard(projectId, tx);
   });
 }


### PR DESCRIPTION
﻿## Summary
- complete the remaining Phase 10A certification gate from current main
- add test-only fault injection at authoritative late-stage transaction boundaries
- replace direct Production-completion fixture mutation with real service calls
- execute bounded TypeScript comparison, focused Phase 9-10A ESLint, and check-only formatting in disposable PostgreSQL CI

## Safety
- does not begin Phase 10B or Phase 10C
- does not enable p2_v2 creation or deployment Production Launch
- does not touch a shared database or real operational record
- preserves legacy and Design Control isolation checks

## Validation
- `git diff --cached --check`
- disposable PostgreSQL 16.4 certification and static checks run in GitHub Actions
