### PR TITLE
Add auditable P1 PO demand reconciliation

### DIFF
--- a/client/src/__tests__/p1POReconciliation.component.test.ts
+++ b/client/src/__tests__/p1POReconciliation.component.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = fs.readFileSync(
+  path.resolve('client/src/components/POManager.tsx'),
+  'utf8'
+);
+
+describe('P1 Purchase Orders reconciliation UI contract', () => {
+  it('renders the authoritative line-level reconciliation breakdown', () => {
+    for (const label of [
+      'Original PO Qty',
+      'Customer-Canceled Qty',
+      'Active PO Qty',
+      'Shipped',
+      'In Progress',
+      'Pending Queue',
+      'Available to Progress',
+      'Variance',
+      'Reconciled',
+      'Needs Review',
+    ]) {
+      expect(source).toContain(label);
+    }
+    expect(source).toContain('In Progress detail (included above)');
+  });
+
+  it('uses the backend reconciliation rather than the legacy production badge', () => {
+    expect(source).toContain('`/api/pos/${po.id}/reconciliation`');
+    expect(source).not.toContain(
+      '<ProductionStatusBadge productionOrders={productionOrders}'
+    );
+  });
+
+  it('gates adjustment actions and requires a reason before confirmation', () => {
+    expect(source).toContain("can('purchasing.manage_pos')");
+    expect(source).toContain('reason.trim().length === 0');
+    expect(source).toContain('Cancel Remaining Quantity');
+    expect(source).toContain('Restore Canceled Quantity');
+    expect(source).toContain('View Quantity Adjustment History');
+    expect(source).toContain('It does not cancel or create production units.');
+  });
+});

--- a/client/src/components/POManager.tsx
+++ b/client/src/components/POManager.tsx
@@ -97,6 +97,31 @@ import AddressInput from './AddressInput';
 import { type AddressData } from '@/utils/addressUtils';
 import { format as formatDate } from 'date-fns';
 import { formatDateOnly } from '@shared/utils/dateNormalization';
+import { usePermissions } from '@/hooks/usePermissions';
+
+interface P1POLineReconciliation {
+  purchaseOrderItemId: number;
+  originalOrderedQuantity: number;
+  canceledDemandQuantity: number;
+  activePoQuantity: number;
+  shippedQuantity: number;
+  workInProgressQuantity: number;
+  pendingQueueQuantity: number;
+  accountedQuantity: number;
+  variance: number;
+  availableToProgressQuantity: number;
+  inProgressDepartmentBreakdown: Record<string, number>;
+  isCanceled: boolean;
+}
+
+interface P1QuantityAdjustmentHistoryEntry {
+  id: string;
+  adjustmentType: 'CANCEL_QUANTITY' | 'RESTORE_QUANTITY';
+  quantity: number;
+  reason: string;
+  effectiveAt: string;
+  createdByDisplayName: string | null;
+}
 
 // Component to display PO quantity
 function POQuantityDisplay({ poId }: { poId: number }) {
@@ -829,6 +854,282 @@ function POProductionOrdersTab({ poId }: { poId: number }) {
   );
 }
 
+export function P1POReconciliationPanel({
+  po,
+  items,
+}: {
+  po: PurchaseOrder;
+  items: PurchaseOrderItem[];
+}) {
+  const queryClient = useQueryClient();
+  const { can } = usePermissions();
+  const canAdjust = can('purchasing.manage_pos');
+  const [dialog, setDialog] = useState<{
+    itemId: number;
+    type: 'CANCEL_QUANTITY' | 'RESTORE_QUANTITY' | 'HISTORY';
+  } | null>(null);
+  const [quantity, setQuantity] = useState(1);
+  const [reason, setReason] = useState('');
+
+  const { data: lines = [], isLoading } = useQuery<P1POLineReconciliation[]>({
+    queryKey: [`/api/pos/${po.id}/reconciliation`],
+    queryFn: () => apiRequest(`/api/pos/${po.id}/reconciliation`),
+  });
+
+  const historyItemId = dialog?.type === 'HISTORY' ? dialog.itemId : null;
+  const { data: history = [], isLoading: historyLoading } = useQuery<
+    P1QuantityAdjustmentHistoryEntry[]
+  >({
+    queryKey: [
+      `/api/pos/${po.id}/items/${historyItemId}/quantity-adjustments`,
+    ],
+    queryFn: () =>
+      apiRequest(
+        `/api/pos/${po.id}/items/${historyItemId}/quantity-adjustments`,
+      ),
+    enabled: historyItemId != null,
+  });
+
+  const adjustmentMutation = useMutation({
+    mutationFn: async () => {
+      if (!dialog || dialog.type === 'HISTORY') return;
+      return apiRequest(
+        `/api/pos/${po.id}/items/${dialog.itemId}/quantity-adjustments`,
+        {
+          method: 'POST',
+          body: {
+            adjustmentType: dialog.type,
+            quantity,
+            reason,
+            idempotencyKey: crypto.randomUUID(),
+          },
+        },
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [`/api/pos/${po.id}/reconciliation`],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/p1-po-queue/purchase-orders/open'],
+      });
+      toast.success(
+        dialog?.type === 'CANCEL_QUANTITY'
+          ? 'Customer demand canceled.'
+          : 'Customer demand restored.',
+      );
+      setDialog(null);
+      setQuantity(1);
+      setReason('');
+    },
+    onError: (error: any) => {
+      toast.error(error?.message || 'Quantity adjustment failed.');
+    },
+  });
+
+  const itemById = useMemo(
+    () => new Map(items.map((item) => [item.id, item])),
+    [items],
+  );
+  const openAdjustment = (
+    itemId: number,
+    type: 'CANCEL_QUANTITY' | 'RESTORE_QUANTITY',
+  ) => {
+    setQuantity(1);
+    setReason('');
+    setDialog({ itemId, type });
+  };
+
+  if (isLoading) {
+    return <span className="text-xs text-muted-foreground">Reconciling…</span>;
+  }
+
+  return (
+    <div className="mt-3 space-y-3">
+      {lines.map((line) => {
+        const item = itemById.get(line.purchaseOrderItemId);
+        const lineName =
+          item?.itemName || `Line ${line.purchaseOrderItemId}`;
+        return (
+          <div
+            key={line.purchaseOrderItemId}
+            className="rounded-md border bg-muted/20 p-3 text-xs"
+            data-testid={`p1-reconciliation-line-${line.purchaseOrderItemId}`}
+          >
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <span className="font-semibold">{lineName}</span>
+              <Badge
+                className={
+                  line.isCanceled
+                    ? 'bg-red-100 text-red-800'
+                    : line.variance === 0
+                    ? 'bg-green-100 text-green-800'
+                    : 'bg-amber-100 text-amber-800'
+                }
+              >
+                {line.isCanceled
+                  ? 'Canceled'
+                  : line.variance === 0
+                    ? 'Reconciled'
+                    : 'Needs Review'}
+              </Badge>
+            </div>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1 md:grid-cols-4">
+              <span>Original PO Qty: {line.originalOrderedQuantity}</span>
+              <span>Customer-Canceled Qty: {line.canceledDemandQuantity}</span>
+              <span>Active PO Qty: {line.activePoQuantity}</span>
+              <span>Shipped: {line.shippedQuantity}</span>
+              <span>In Progress: {line.workInProgressQuantity}</span>
+              <span>Pending Queue: {line.pendingQueueQuantity}</span>
+              <span>Available to Progress: {line.availableToProgressQuantity}</span>
+              <span>Variance: {line.variance}</span>
+            </div>
+            {Object.keys(line.inProgressDepartmentBreakdown).length > 0 && (
+              <div className="mt-2 text-muted-foreground">
+                In Progress detail (included above):{' '}
+                {Object.entries(line.inProgressDepartmentBreakdown)
+                  .map(([department, count]) => `${department}: ${count}`)
+                  .join(' · ')}
+              </div>
+            )}
+            <div className="mt-3 flex flex-wrap gap-2">
+              {canAdjust && !line.isCanceled && (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      openAdjustment(line.purchaseOrderItemId, 'CANCEL_QUANTITY')
+                    }
+                  >
+                    Cancel Remaining Quantity
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={line.canceledDemandQuantity === 0}
+                    onClick={() =>
+                      openAdjustment(line.purchaseOrderItemId, 'RESTORE_QUANTITY')
+                    }
+                  >
+                    Restore Canceled Quantity
+                  </Button>
+                </>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  setDialog({
+                    itemId: line.purchaseOrderItemId,
+                    type: 'HISTORY',
+                  })
+                }
+              >
+                View Quantity Adjustment History
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+
+      <Dialog
+        open={dialog != null}
+        onOpenChange={(open) => {
+          if (!open) setDialog(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {dialog?.type === 'HISTORY'
+                ? 'Quantity Adjustment History'
+                : dialog?.type === 'CANCEL_QUANTITY'
+                  ? 'Cancel Remaining Quantity'
+                  : 'Restore Canceled Quantity'}
+            </DialogTitle>
+            <DialogDescription>
+              {dialog?.type === 'HISTORY'
+                ? 'Immutable customer-demand adjustments for this P1 PO line.'
+                : 'This changes customer PO demand only. It does not cancel or create production units.'}
+            </DialogDescription>
+          </DialogHeader>
+          {dialog?.type === 'HISTORY' ? (
+            <div className="max-h-80 space-y-2 overflow-y-auto">
+              {historyLoading ? (
+                <p>Loading…</p>
+              ) : history.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No quantity adjustments recorded.
+                </p>
+              ) : (
+                history.map((entry) => (
+                  <div key={entry.id} className="rounded border p-3 text-sm">
+                    <div className="font-medium">
+                      {entry.adjustmentType === 'CANCEL_QUANTITY'
+                        ? 'Canceled'
+                        : 'Restored'}{' '}
+                      {entry.quantity}
+                    </div>
+                    <div>{entry.reason}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {entry.createdByDisplayName || 'Unknown User'} ·{' '}
+                      {new Date(entry.effectiveAt).toLocaleString()}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="p1-adjustment-quantity">Quantity</Label>
+                <Input
+                  id="p1-adjustment-quantity"
+                  type="number"
+                  min={1}
+                  value={quantity}
+                  onChange={(event) =>
+                    setQuantity(Math.max(1, Number(event.target.value) || 1))
+                  }
+                />
+              </div>
+              <div>
+                <Label htmlFor="p1-adjustment-reason">Reason</Label>
+                <Textarea
+                  id="p1-adjustment-reason"
+                  value={reason}
+                  onChange={(event) => setReason(event.target.value)}
+                  placeholder="Required"
+                />
+              </div>
+              <div className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                Confirm that this customer-demand adjustment is intentional.
+                Production units must be resolved separately.
+              </div>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setDialog(null)}>
+                  Cancel
+                </Button>
+                <Button
+                  disabled={
+                    adjustmentMutation.isPending ||
+                    quantity < 1 ||
+                    reason.trim().length === 0
+                  }
+                  onClick={() => adjustmentMutation.mutate()}
+                >
+                  {adjustmentMutation.isPending ? 'Saving…' : 'Confirm Adjustment'}
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
 // Component for PO Attachments management
 function POAttachments({ poId, poNumber }: { poId: number; poNumber: string }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -1157,14 +1458,13 @@ function POCard({
   isLoadingPreview: boolean;
   isGeneratingOrdersForThisPO: boolean;
 }) {
-  const { data: productionOrders = [] } = useQuery({
-    queryKey: [`/api/production-orders/by-po/${po.id}`],
-    queryFn: () => apiRequest(`/api/production-orders/by-po/${po.id}`),
-  });
-
   const { data: poItems = [] } = useQuery({
     queryKey: [`/api/pos/${po.id}/items`],
     queryFn: () => fetchPOItems(po.id),
+  });
+  const { data: reconciliation = [] } = useQuery<P1POLineReconciliation[]>({
+    queryKey: [`/api/pos/${po.id}/reconciliation`],
+    queryFn: () => apiRequest(`/api/pos/${po.id}/reconciliation`),
   });
 
   const totalPoQuantity = (poItems as PurchaseOrderItem[]).reduce(
@@ -1172,9 +1472,18 @@ function POCard({
     0
   );
 
-  const hasOrders = productionOrders.length > 0;
-  const orderCount = productionOrders.length;
-
+  const activePoTotal = reconciliation.reduce(
+    (sum, line) => sum + line.activePoQuantity,
+    0,
+  );
+  const accountedTotal = reconciliation.reduce(
+    (sum, line) => sum + line.accountedQuantity,
+    0,
+  );
+  const availableToProgressTotal = reconciliation.reduce(
+    (sum, line) => sum + line.availableToProgressQuantity,
+    0,
+  );
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'OPEN':
@@ -1213,7 +1522,6 @@ function POCard({
           </div>
           <div className="flex gap-2 flex-wrap">
             <Badge className={getStatusColor(po.status)}>{po.status}</Badge>
-            <ProductionStatusBadge productionOrders={productionOrders} totalPoQuantity={totalPoQuantity} poNumber={po.poNumber} />
             <div className="flex gap-1 flex-wrap">
               <Button
                 variant="outline"
@@ -1251,8 +1559,10 @@ function POCard({
                   Calculate Schedule
                 </Button>
                 {(() => {
-                  const hasGap = hasOrders && orderCount < totalPoQuantity;
-                  const fullyGenerated = hasOrders && orderCount >= totalPoQuantity;
+                  const hasGap = availableToProgressTotal > 0;
+                  const fullyGenerated =
+                    reconciliation.length > 0 &&
+                    availableToProgressTotal === 0;
                   return (
                     <Button
                       variant={hasGap ? 'default' : 'outline'}
@@ -1262,9 +1572,9 @@ function POCard({
                       className={hasGap ? 'bg-amber-500 hover:bg-amber-600 text-white border-0' : ''}
                       title={
                         fullyGenerated
-                          ? `All ${orderCount} production orders already generated`
+                          ? `All ${accountedTotal} active production units accounted for`
                           : hasGap
-                            ? `${totalPoQuantity - orderCount} item(s) missing production orders — click to fill gaps`
+                            ? `${availableToProgressTotal} active customer-demand unit(s) available to generate`
                             : 'Generate production orders from this PO'
                       }
                     >
@@ -1273,9 +1583,9 @@ function POCard({
                         : isLoadingPreview
                           ? 'Loading Preview...'
                           : fullyGenerated
-                            ? `Orders Generated (${orderCount})`
+                            ? `Orders Generated (${accountedTotal}/${activePoTotal})`
                             : hasGap
-                              ? `Fill Missing Orders (${totalPoQuantity - orderCount})`
+                              ? `Fill Missing Orders (${availableToProgressTotal})`
                               : 'Generate Production Orders'}
                     </Button>
                   );
@@ -1294,6 +1604,10 @@ function POCard({
         </div>
       </CardHeader>
       <CardContent>
+        <P1POReconciliationPanel
+          po={po}
+          items={poItems as PurchaseOrderItem[]}
+        />
         <div className="grid grid-cols-2 gap-4 text-sm">
           <div>
             <span className="font-medium">PO Date:</span>{' '}

--- a/migrations/0231_p1_po_item_quantity_adjustments.sql
+++ b/migrations/0231_p1_po_item_quantity_adjustments.sql
@@ -1,0 +1,47 @@
+-- Additive, immutable ledger for explicit customer-demand changes on P1 PO lines.
+-- Production-unit cancellations remain operational history and are intentionally unrelated.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS purchase_order_item_quantity_adjustments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  purchase_order_item_id integer NOT NULL
+    REFERENCES purchase_order_items(id) ON DELETE RESTRICT,
+  adjustment_type text NOT NULL
+    CHECK (adjustment_type IN ('CANCEL_QUANTITY', 'RESTORE_QUANTITY')),
+  quantity integer NOT NULL CHECK (quantity > 0),
+  reason text NOT NULL CHECK (length(trim(reason)) > 0),
+  effective_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_by_display_name text NOT NULL,
+  source text,
+  reference text,
+  idempotency_key text,
+  UNIQUE (purchase_order_item_id, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS po_item_quantity_adjustments_item_effective_idx
+  ON purchase_order_item_quantity_adjustments
+  (purchase_order_item_id, effective_at, created_at);
+
+CREATE OR REPLACE FUNCTION reject_p1_po_item_quantity_adjustment_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION
+    'purchase_order_item_quantity_adjustments rows are immutable; insert a compensating adjustment';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS p1_po_item_quantity_adjustments_no_update
+  ON purchase_order_item_quantity_adjustments;
+CREATE TRIGGER p1_po_item_quantity_adjustments_no_update
+  BEFORE UPDATE ON purchase_order_item_quantity_adjustments
+  FOR EACH ROW EXECUTE FUNCTION reject_p1_po_item_quantity_adjustment_mutation();
+
+DROP TRIGGER IF EXISTS p1_po_item_quantity_adjustments_no_delete
+  ON purchase_order_item_quantity_adjustments;
+CREATE TRIGGER p1_po_item_quantity_adjustments_no_delete
+  BEFORE DELETE ON purchase_order_item_quantity_adjustments
+  FOR EACH ROW EXECUTE FUNCTION reject_p1_po_item_quantity_adjustment_mutation();

--- a/server/__tests__/p1POQuantityAdjustmentMigration.test.ts
+++ b/server/__tests__/p1POQuantityAdjustmentMigration.test.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migration = fs.readFileSync(
+  path.resolve('migrations/0231_p1_po_item_quantity_adjustments.sql'),
+  'utf8'
+);
+
+describe('P1 PO quantity-adjustment migration', () => {
+  it('is additive and preserves the original PO-line quantity', () => {
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS purchase_order_item_quantity_adjustments'
+    );
+    expect(migration).not.toMatch(/UPDATE\s+purchase_order_items/i);
+    expect(migration).not.toMatch(/ALTER\s+TABLE\s+purchase_order_items/i);
+  });
+
+  it('enforces positive constrained adjustments and immutable history', () => {
+    expect(migration).toContain(
+      "CHECK (adjustment_type IN ('CANCEL_QUANTITY', 'RESTORE_QUANTITY'))"
+    );
+    expect(migration).toContain('CHECK (quantity > 0)');
+    expect(migration).toContain(
+      'BEFORE UPDATE ON purchase_order_item_quantity_adjustments'
+    );
+    expect(migration).toContain(
+      'BEFORE DELETE ON purchase_order_item_quantity_adjustments'
+    );
+  });
+
+  it('records user identity and supports line-scoped idempotency', () => {
+    expect(migration).toContain('created_by_user_id integer NOT NULL');
+    expect(migration).toContain('created_by_display_name text NOT NULL');
+    expect(migration).toContain(
+      'UNIQUE (purchase_order_item_id, idempotency_key)'
+    );
+  });
+});

--- a/server/__tests__/p1POQuantityAdjustmentRouteContract.test.ts
+++ b/server/__tests__/p1POQuantityAdjustmentRouteContract.test.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const routeSource = fs.readFileSync(
+  path.resolve('server/src/routes/p1POQuantityAdjustments.ts'),
+  'utf8'
+);
+const generationSource = fs.readFileSync(
+  path.resolve('server/src/routes/index.ts'),
+  'utf8'
+);
+const serviceSource = fs.readFileSync(
+  path.resolve('server/src/services/p1POReconciliationService.ts'),
+  'utf8'
+);
+
+describe('P1 PO quantity-adjustment route contract', () => {
+  it('authenticates reads and capability-gates writes', () => {
+    expect(routeSource).toContain('authenticateToken');
+    expect(routeSource).toContain("requirePermission('purchasing.manage_pos')");
+  });
+
+  it('derives actor identity on the server and never accepts a browser user ID', () => {
+    expect(routeSource).toContain('resolveUserSnapshot(req.user!.id)');
+    expect(routeSource).not.toContain('req.body.createdByUserId');
+  });
+
+  it('requires positive quantity and a non-empty reason', () => {
+    expect(routeSource).toContain('z.number().int().positive()');
+    expect(routeSource).toContain('z.string().trim().min(1)');
+  });
+
+  it('serializes adjustments with a transaction and row lock', () => {
+    expect(serviceSource).toContain("client.query('BEGIN')");
+    expect(serviceSource).toContain('FOR UPDATE OF poi, po');
+    expect(serviceSource).toContain("client.query('COMMIT')");
+    expect(serviceSource).toContain("client.query('ROLLBACK')");
+  });
+
+  it('does not mutate production units or original PO-line quantities', () => {
+    expect(serviceSource).not.toMatch(/UPDATE\s+production_orders/i);
+    expect(serviceSource).not.toMatch(/UPDATE\s+purchase_order_items/i);
+    expect(serviceSource).not.toMatch(/DELETE\s+FROM/i);
+  });
+
+  it('uses active demand in preview and replacement generation', () => {
+    expect(generationSource).toContain(
+      'reconciliationByItemId.get(item.id)?.activePoQuantity'
+    );
+    expect(generationSource).toContain(
+      'generationReconciliationByItemId.get(item.id)?.activePoQuantity'
+    );
+    expect(generationSource).toContain(
+      "order.productionStatus !== 'CANCELLED'"
+    );
+    expect(generationSource).not.toContain(
+      'INSERT INTO purchase_order_item_quantity_adjustments'
+    );
+  });
+});

--- a/server/__tests__/p1POReconciliationService.test.ts
+++ b/server/__tests__/p1POReconciliationService.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  pool: {
+    connect: vi.fn(),
+    query: vi.fn(),
+  },
+}));
+import {
+  P1QuantityAdjustmentConflict,
+  reconcileP1POLine,
+  validateP1QuantityAdjustment,
+  type P1ProductionUnitRow,
+} from '../src/services/p1POReconciliationService';
+
+function unit(
+  orderId: string,
+  currentDepartment: string,
+  overrides: Partial<P1ProductionUnitRow> = {}
+): P1ProductionUnitRow {
+  return {
+    orderId,
+    currentDepartment,
+    productionStatus:
+      currentDepartment === 'P1 Production Queue' ? 'PENDING' : 'IN_PROGRESS',
+    isFulfilled: false,
+    hasShipment: false,
+    ...overrides,
+  };
+}
+
+describe('P1 PO line reconciliation', () => {
+  it('reconciles 12 active units into shipped, in-progress, and pending buckets', () => {
+    const productionUnits = [
+      unit('SHIP-1', 'Shipped', {
+        hasShipment: true,
+        productionStatus: 'SHIPPED',
+      }),
+      ...Array.from({ length: 4 }, (_, index) =>
+        unit(`WIP-${index}`, index % 2 ? 'Finish QC' : 'Barcode')
+      ),
+      ...Array.from({ length: 7 }, (_, index) =>
+        unit(`PENDING-${index}`, 'P1 Production Queue')
+      ),
+    ];
+    const result = reconcileP1POLine({
+      purchaseOrderItemId: 10,
+      originalOrderedQuantity: 12,
+      canceledDemandQuantity: 0,
+      purchaseOrderStatus: 'OPEN',
+      productionUnits,
+    });
+
+    expect(result).toMatchObject({
+      activePoQuantity: 12,
+      shippedQuantity: 1,
+      workInProgressQuantity: 4,
+      pendingQueueQuantity: 7,
+      accountedQuantity: 12,
+      variance: 0,
+      availableToProgressQuantity: 0,
+    });
+    expect(result.inProgressDepartmentBreakdown).toEqual({
+      Barcode: 2,
+      'Finish QC': 2,
+    });
+  });
+
+  it('uses explicit customer cancellation without changing original quantity', () => {
+    const result = reconcileP1POLine({
+      purchaseOrderItemId: 10,
+      originalOrderedQuantity: 12,
+      canceledDemandQuantity: 2,
+      purchaseOrderStatus: 'OPEN',
+      productionUnits: Array.from({ length: 10 }, (_, index) =>
+        unit(`PENDING-${index}`, 'P1 Production Queue')
+      ),
+    });
+    expect(result.originalOrderedQuantity).toBe(12);
+    expect(result.activePoQuantity).toBe(10);
+    expect(result.accountedQuantity).toBe(10);
+    expect(result.variance).toBe(0);
+  });
+
+  it('excludes a canceled unit while counting its replacement once', () => {
+    const result = reconcileP1POLine({
+      purchaseOrderItemId: 10,
+      originalOrderedQuantity: 2,
+      canceledDemandQuantity: 0,
+      purchaseOrderStatus: 'OPEN',
+      productionUnits: [
+        unit('UNIT-1', 'Barcode', { productionStatus: 'CANCELLED' }),
+        unit('UNIT-1-R', 'Barcode'),
+        unit('UNIT-2', 'P1 Production Queue'),
+      ],
+    });
+    expect(result.activePoQuantity).toBe(2);
+    expect(result.workInProgressQuantity).toBe(1);
+    expect(result.pendingQueueQuantity).toBe(1);
+    expect(result.variance).toBe(0);
+  });
+
+  it('deduplicates repeated joined rows by production order ID', () => {
+    const repeated = unit('UNIT-1', 'Barcode');
+    const result = reconcileP1POLine({
+      purchaseOrderItemId: 10,
+      originalOrderedQuantity: 1,
+      canceledDemandQuantity: 0,
+      purchaseOrderStatus: 'OPEN',
+      productionUnits: [repeated, repeated, repeated],
+    });
+    expect(result.workInProgressQuantity).toBe(1);
+    expect(result.variance).toBe(0);
+  });
+
+  it('requires shipment or fulfillment evidence rather than a status string alone', () => {
+    const result = reconcileP1POLine({
+      purchaseOrderItemId: 10,
+      originalOrderedQuantity: 1,
+      canceledDemandQuantity: 0,
+      purchaseOrderStatus: 'OPEN',
+      productionUnits: [
+        unit('UNIT-1', 'Shipping QC', { productionStatus: 'SHIPPED' }),
+      ],
+    });
+    expect(result.shippedQuantity).toBe(0);
+    expect(result.workInProgressQuantity).toBe(1);
+  });
+
+  it('makes a fully canceled PO inactive and unavailable without mutating units', () => {
+    const result = reconcileP1POLine({
+      purchaseOrderItemId: 10,
+      originalOrderedQuantity: 4,
+      canceledDemandQuantity: 0,
+      purchaseOrderStatus: 'CANCELED',
+      productionUnits: [],
+    });
+    expect(result.activePoQuantity).toBe(0);
+    expect(result.availableToProgressQuantity).toBe(0);
+    expect(result.isCanceled).toBe(true);
+  });
+});
+
+describe('P1 PO quantity-adjustment validation', () => {
+  const current = reconcileP1POLine({
+    purchaseOrderItemId: 10,
+    originalOrderedQuantity: 12,
+    canceledDemandQuantity: 2,
+    purchaseOrderStatus: 'OPEN',
+    productionUnits: Array.from({ length: 8 }, (_, index) =>
+      unit(`PENDING-${index}`, 'P1 Production Queue')
+    ),
+  });
+
+  it('allows cancel and restore quantities inside ledger bounds', () => {
+    expect(validateP1QuantityAdjustment(current, 'CANCEL_QUANTITY', 2)).toBe(4);
+    expect(validateP1QuantityAdjustment(current, 'RESTORE_QUANTITY', 1)).toBe(
+      1
+    );
+  });
+
+  it('rejects cancellation beyond original demand', () => {
+    expect(() =>
+      validateP1QuantityAdjustment(current, 'CANCEL_QUANTITY', 11)
+    ).toThrow(P1QuantityAdjustmentConflict);
+  });
+
+  it('rejects restoration beyond net canceled demand', () => {
+    expect(() =>
+      validateP1QuantityAdjustment(current, 'RESTORE_QUANTITY', 3)
+    ).toThrow('Restore quantity exceeds');
+  });
+
+  it('rejects cancellation that would orphan already-accounted units', () => {
+    expect(() =>
+      validateP1QuantityAdjustment(current, 'CANCEL_QUANTITY', 3)
+    ).toThrow('below shipped, in-progress, and pending units');
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -5334,6 +5334,41 @@ export const purchaseOrderItems = pgTable('purchase_order_items', {
   updatedAt: timestamp('updated_at').defaultNow(),
 });
 
+export const purchaseOrderItemQuantityAdjustments = pgTable(
+  'purchase_order_item_quantity_adjustments',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    purchaseOrderItemId: integer('purchase_order_item_id')
+      .references(() => purchaseOrderItems.id, { onDelete: 'restrict' })
+      .notNull(),
+    adjustmentType: text('adjustment_type').notNull(),
+    quantity: integer('quantity').notNull(),
+    reason: text('reason').notNull(),
+    effectiveAt: timestamp('effective_at', { withTimezone: true }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    createdByUserId: integer('created_by_user_id')
+      .references(() => users.id, { onDelete: 'restrict' })
+      .notNull(),
+    createdByDisplayName: text('created_by_display_name').notNull(),
+    source: text('source'),
+    reference: text('reference'),
+    idempotencyKey: text('idempotency_key'),
+  },
+  (table) => ({
+    itemEffectiveIdx: index('po_item_quantity_adjustments_item_effective_idx').on(
+      table.purchaseOrderItemId,
+      table.effectiveAt,
+      table.createdAt,
+    ),
+    itemIdempotencyUnique: uniqueIndex(
+      'purchase_order_item_quantity_adjustments_purchase_order_item_id_idempotency_key_key',
+    ).on(table.purchaseOrderItemId, table.idempotencyKey),
+  }),
+);
+
+export type PurchaseOrderItemQuantityAdjustment =
+  typeof purchaseOrderItemQuantityAdjustments.$inferSelect;
+
 // P2 Customer Management - separate customer database for P2 operations
 export const p2Customers = pgTable('p2_customers', {
   id: integer('id').generatedByDefaultAsIdentity().primaryKey(),

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -254,6 +254,7 @@ export const safeMigrationFiles = [
   '0225_p2_v2_shipping_project_closeout.sql',
   '0226_project_production_launch_composite_key.sql',
   '0229_epoch_software_validation.sql',
+  '0231_p1_po_item_quantity_adjustments.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -295,6 +296,7 @@ export const criticalMigrationFiles = new Set([
   '0225_p2_v2_shipping_project_closeout.sql',
   '0226_project_production_launch_composite_key.sql',
   '0229_epoch_software_validation.sql',
+  '0231_p1_po_item_quantity_adjustments.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -70,6 +70,7 @@ import customerSatisfactionRoutes from './customerSatisfaction';
 import surveyEngineRoutes from './surveyEngine';
 import poProductsRoutes from './poProducts';
 import p1POQueueRoutes from './p1POQueue';
+import p1POQuantityAdjustmentsRoutes from './p1POQuantityAdjustments';
 import poShippingQCRoutes from './poShippingQC';
 import weeklyScheduleRoutes from './weeklySchedule';
 import refundRoutes from './refunds';
@@ -1470,6 +1471,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   // P1 PO Queue routes
   app.use('/api/p1-po-queue', p1POQueueRoutes);
+  app.use('/api/pos', p1POQuantityAdjustmentsRoutes);
 
   // Product Labels routes
   app.use('/api/product-labels', productLabelsRoutes);
@@ -10145,6 +10147,15 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         storage.getPurchaseOrderItems(poId),
         storage.getProductionOrdersByPoId(poId),
       ]);
+      const { getP1POReconciliation } = await import(
+        '../services/p1POReconciliationService'
+      );
+      const reconciliationByItemId = new Map(
+        (await getP1POReconciliation(poId)).map((line) => [
+          line.purchaseOrderItemId,
+          line,
+        ]),
+      );
 
       // Build per-item existing count map using active poItemId children.
       // Cancelled rows are history and must not block a safe missing-line backfill.
@@ -10173,14 +10184,16 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         }
 
         const alreadyGenerated = existingByItemId.get(item.id) ?? 0;
-        const remaining = item.quantity - alreadyGenerated;
+        const activePoQuantity =
+          reconciliationByItemId.get(item.id)?.activePoQuantity ?? item.quantity;
+        const remaining = activePoQuantity - alreadyGenerated;
 
         if (remaining <= 0) {
-          willSkip.push({ name, quantity: item.quantity, reason: `Already generated (${alreadyGenerated}/${item.quantity})` });
+          willSkip.push({ name, quantity: activePoQuantity, reason: `Already generated (${alreadyGenerated}/${activePoQuantity})` });
           continue;
         }
 
-        willGenerate.push({ name, quantity: item.quantity, orderCount: remaining, alreadyGenerated });
+        willGenerate.push({ name, quantity: activePoQuantity, orderCount: remaining, alreadyGenerated });
       }
 
       const totalOrderCount = willGenerate.reduce((sum, i) => sum + i.orderCount, 0);
@@ -10213,6 +10226,15 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         storage.getPurchaseOrderItems(poId),
         storage.getProductionOrdersByPoId(poId),
       ]);
+      const { getP1POReconciliation: getGenerationReconciliation } = await import(
+        '../services/p1POReconciliationService'
+      );
+      const generationReconciliationByItemId = new Map(
+        (await getGenerationReconciliation(poId)).map((line) => [
+          line.purchaseOrderItemId,
+          line,
+        ]),
+      );
 
       // Build per-item existing count map from active production children.
       // Cancelled rows remain audit history and do not satisfy the PO line quantity.
@@ -10255,12 +10277,15 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       for (const item of stockModelItems) {
         // Gap-fill: only create orders for units that haven't been generated yet
         const alreadyGenerated = existingByItemId.get(item.id) ?? 0;
-        const remaining = item.quantity - alreadyGenerated;
+        const activePoQuantity =
+          generationReconciliationByItemId.get(item.id)?.activePoQuantity ??
+          item.quantity;
+        const remaining = activePoQuantity - alreadyGenerated;
         if (remaining <= 0) {
-          console.log(`⏭ Skipping item ${item.id} (${item.itemName || item.stockModelId}): already generated ${alreadyGenerated}/${item.quantity}`);
+          console.log(`⏭ Skipping item ${item.id} (${item.itemName || item.stockModelId}): already generated ${alreadyGenerated}/${activePoQuantity}`);
           continue;
         }
-        console.log(`🏭 Item ${item.id} (${item.itemName || item.stockModelId}): generating ${remaining} of ${item.quantity} (${alreadyGenerated} already exist)`);
+        console.log(`🏭 Item ${item.id} (${item.itemName || item.stockModelId}): generating ${remaining} of ${activePoQuantity} active customer-demand units (${alreadyGenerated} already exist)`);
         for (let i = 0; i < remaining; i++) {
           // Use stockModelId for mold/schedule matching; fall back to itemName (AG part number)
           // or itemId for POs entered with product codes rather than stock model slugs

--- a/server/src/routes/p1POQuantityAdjustments.ts
+++ b/server/src/routes/p1POQuantityAdjustments.ts
@@ -1,0 +1,126 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+
+import { authenticateToken } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/requirePermission';
+import { resolveUserSnapshot } from '../../utils/userSnapshot';
+import {
+  createP1QuantityAdjustment,
+  getP1POReconciliation,
+  getP1QuantityAdjustmentHistory,
+  P1QuantityAdjustmentConflict,
+} from '../services/p1POReconciliationService';
+
+const router = Router();
+
+const adjustmentSchema = z.object({
+  adjustmentType: z.enum(['CANCEL_QUANTITY', 'RESTORE_QUANTITY']),
+  quantity: z.number().int().positive(),
+  reason: z.string().trim().min(1).max(2000),
+  reference: z.string().trim().max(255).optional().nullable(),
+  idempotencyKey: z.string().trim().min(1).max(255).optional().nullable(),
+});
+
+router.get(
+  '/:poId/reconciliation',
+  authenticateToken,
+  async (req: Request, res: Response) => {
+    const poId = Number(req.params.poId);
+    if (!Number.isInteger(poId) || poId <= 0) {
+      return res.status(400).json({ error: 'Invalid P1 purchase-order ID' });
+    }
+    try {
+      return res.json(await getP1POReconciliation(poId));
+    } catch (error) {
+      console.error('[p1-po-reconciliation]', error);
+      return res
+        .status(500)
+        .json({ error: 'Failed to load P1 PO reconciliation' });
+    }
+  }
+);
+
+router.get(
+  '/:poId/items/:itemId/quantity-adjustments',
+  authenticateToken,
+  async (req: Request, res: Response) => {
+    const itemId = Number(req.params.itemId);
+    const poId = Number(req.params.poId);
+    if (
+      !Number.isInteger(poId) ||
+      poId <= 0 ||
+      !Number.isInteger(itemId) ||
+      itemId <= 0
+    ) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid P1 purchase-order or line ID' });
+    }
+    try {
+      return res.json(await getP1QuantityAdjustmentHistory(itemId, poId));
+    } catch (error) {
+      console.error('[p1-po-quantity-adjustment-history]', error);
+      return res
+        .status(500)
+        .json({ error: 'Failed to load quantity-adjustment history' });
+    }
+  }
+);
+
+router.post(
+  '/:poId/items/:itemId/quantity-adjustments',
+  authenticateToken,
+  requirePermission('purchasing.manage_pos'),
+  async (req: Request, res: Response) => {
+    const itemId = Number(req.params.itemId);
+    const poId = Number(req.params.poId);
+    if (
+      !Number.isInteger(poId) ||
+      poId <= 0 ||
+      !Number.isInteger(itemId) ||
+      itemId <= 0
+    ) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid P1 purchase-order or line ID' });
+    }
+    const parsed = adjustmentSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Invalid quantity adjustment',
+        details: parsed.error.flatten(),
+      });
+    }
+
+    try {
+      const actor = await resolveUserSnapshot(req.user!.id);
+      const result = await createP1QuantityAdjustment({
+        purchaseOrderId: poId,
+        purchaseOrderItemId: itemId,
+        ...parsed.data,
+        createdByUserId: actor.userId,
+        createdByDisplayName: actor.displayName,
+      });
+      return res.status(result.replayed ? 200 : 201).json(result);
+    } catch (error) {
+      if (error instanceof P1QuantityAdjustmentConflict) {
+        return res.status(409).json({
+          error: error.message,
+          reconciliation: error.reconciliation,
+        });
+      }
+      if (
+        error instanceof Error &&
+        error.message === 'P1 purchase-order line not found'
+      ) {
+        return res.status(404).json({ error: error.message });
+      }
+      console.error('[p1-po-quantity-adjustment-create]', error);
+      return res
+        .status(500)
+        .json({ error: 'Failed to create quantity adjustment' });
+    }
+  }
+);
+
+export default router;

--- a/server/src/services/p1POReconciliationService.ts
+++ b/server/src/services/p1POReconciliationService.ts
@@ -1,0 +1,447 @@
+import type { PoolClient } from 'pg';
+
+import { pool } from '../../db';
+
+export type P1AdjustmentType = 'CANCEL_QUANTITY' | 'RESTORE_QUANTITY';
+
+export interface P1ProductionUnitRow {
+  orderId: string;
+  productionStatus: string | null;
+  currentDepartment: string | null;
+  isFulfilled: boolean | null;
+  hasShipment: boolean;
+}
+
+export interface P1POLineReconciliation {
+  purchaseOrderItemId: number;
+  originalOrderedQuantity: number;
+  canceledDemandQuantity: number;
+  activePoQuantity: number;
+  shippedQuantity: number;
+  workInProgressQuantity: number;
+  pendingQueueQuantity: number;
+  accountedQuantity: number;
+  variance: number;
+  availableToProgressQuantity: number;
+  inProgressDepartmentBreakdown: Record<string, number>;
+  isCanceled: boolean;
+}
+
+export interface P1QuantityAdjustment {
+  id: string;
+  purchaseOrderItemId: number;
+  adjustmentType: P1AdjustmentType;
+  quantity: number;
+  reason: string;
+  effectiveAt: string;
+  createdAt: string;
+  createdByDisplayName: string | null;
+  source: string | null;
+  reference: string | null;
+  idempotencyKey: string | null;
+}
+
+const CANCELED_STATUSES = new Set([
+  'CANCELLED',
+  'CANCELED',
+  'SCRAPPED',
+  'VOIDED',
+]);
+const FULL_PO_CANCELED_STATUSES = new Set(['CANCELLED', 'CANCELED']);
+
+function normalized(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase();
+}
+
+export function reconcileP1POLine(input: {
+  purchaseOrderItemId: number;
+  originalOrderedQuantity: number;
+  canceledDemandQuantity: number;
+  purchaseOrderStatus: string | null;
+  productionUnits: P1ProductionUnitRow[];
+}): P1POLineReconciliation {
+  const unitsByOrderId = new Map<string, P1ProductionUnitRow>();
+  for (const unit of input.productionUnits) {
+    if (!unit.orderId || unitsByOrderId.has(unit.orderId)) continue;
+    unitsByOrderId.set(unit.orderId, unit);
+  }
+
+  let shippedQuantity = 0;
+  let workInProgressQuantity = 0;
+  let pendingQueueQuantity = 0;
+  const inProgressDepartmentBreakdown: Record<string, number> = {};
+
+  for (const unit of unitsByOrderId.values()) {
+    const status = normalized(unit.productionStatus);
+    if (CANCELED_STATUSES.has(status)) continue;
+
+    if (unit.hasShipment || unit.isFulfilled) {
+      shippedQuantity += 1;
+      continue;
+    }
+
+    const department =
+      String(unit.currentDepartment ?? '').trim() || 'Unassigned';
+    if (normalized(department) === 'P1 PRODUCTION QUEUE') {
+      pendingQueueQuantity += 1;
+      continue;
+    }
+
+    workInProgressQuantity += 1;
+    inProgressDepartmentBreakdown[department] =
+      (inProgressDepartmentBreakdown[department] ?? 0) + 1;
+  }
+
+  const isCanceled = FULL_PO_CANCELED_STATUSES.has(
+    normalized(input.purchaseOrderStatus)
+  );
+  const activePoQuantity = isCanceled
+    ? 0
+    : input.originalOrderedQuantity - input.canceledDemandQuantity;
+  const accountedQuantity =
+    shippedQuantity + workInProgressQuantity + pendingQueueQuantity;
+  const variance = activePoQuantity - accountedQuantity;
+
+  return {
+    purchaseOrderItemId: input.purchaseOrderItemId,
+    originalOrderedQuantity: input.originalOrderedQuantity,
+    canceledDemandQuantity: input.canceledDemandQuantity,
+    activePoQuantity,
+    shippedQuantity,
+    workInProgressQuantity,
+    pendingQueueQuantity,
+    accountedQuantity,
+    variance,
+    availableToProgressQuantity: Math.max(variance, 0),
+    inProgressDepartmentBreakdown,
+    isCanceled,
+  };
+}
+
+async function getLineReconciliationWithClient(
+  client: PoolClient,
+  purchaseOrderItemId: number,
+  lockLine = false,
+  expectedPurchaseOrderId?: number
+): Promise<P1POLineReconciliation | null> {
+  const lineResult = await client.query<{
+    id: number;
+    quantity: number;
+    po_status: string | null;
+  }>(
+    `SELECT poi.id, poi.quantity, po.status AS po_status
+       FROM purchase_order_items poi
+      JOIN purchase_orders po ON po.id = poi.po_id
+      WHERE poi.id = $1
+      ${expectedPurchaseOrderId ? 'AND po.id = $2' : ''}
+      ${lockLine ? 'FOR UPDATE OF poi, po' : ''}`,
+    expectedPurchaseOrderId
+      ? [purchaseOrderItemId, expectedPurchaseOrderId]
+      : [purchaseOrderItemId]
+  );
+  const line = lineResult.rows[0];
+  if (!line) return null;
+
+  const adjustmentResult = await client.query<{ net_canceled: string }>(
+    `SELECT COALESCE(SUM(
+       CASE adjustment_type
+         WHEN 'CANCEL_QUANTITY' THEN quantity
+         WHEN 'RESTORE_QUANTITY' THEN -quantity
+       END
+     ), 0)::text AS net_canceled
+       FROM purchase_order_item_quantity_adjustments
+      WHERE purchase_order_item_id = $1`,
+    [purchaseOrderItemId]
+  );
+  const canceledDemandQuantity = Number(
+    adjustmentResult.rows[0]?.net_canceled ?? 0
+  );
+
+  const unitResult = await client.query<{
+    order_id: string;
+    production_status: string | null;
+    current_department: string | null;
+    is_fulfilled: boolean | null;
+    has_shipment: boolean;
+  }>(
+    `SELECT DISTINCT ON (prod.order_id)
+       prod.order_id,
+       prod.production_status,
+       prod.current_department,
+       prod.is_fulfilled,
+       EXISTS (
+         SELECT 1
+           FROM shipment_items si
+           JOIN shipment_records sr ON sr.id = si.shipment_id
+          WHERE si.order_id = prod.order_id
+       ) AS has_shipment
+       FROM production_orders prod
+      WHERE prod.po_item_id = $1
+      ORDER BY prod.order_id, prod.id DESC`,
+    [purchaseOrderItemId]
+  );
+  const shipmentOnlyResult = await client.query<{
+    order_id: string;
+    quantity: number;
+  }>(
+    `SELECT si.order_id, MAX(si.quantity)::integer AS quantity
+       FROM shipment_items si
+       JOIN shipment_records sr ON sr.id = si.shipment_id
+      WHERE si.po_item_id = $1
+        AND NOT EXISTS (
+          SELECT 1 FROM production_orders prod
+           WHERE prod.po_item_id = $1
+             AND prod.order_id = si.order_id
+        )
+      GROUP BY si.order_id`,
+    [purchaseOrderItemId]
+  );
+
+  const productionUnits: P1ProductionUnitRow[] = unitResult.rows.map((row) => ({
+    orderId: row.order_id,
+    productionStatus: row.production_status,
+    currentDepartment: row.current_department,
+    isFulfilled: row.is_fulfilled,
+    hasShipment: row.has_shipment,
+  }));
+  for (const shipment of shipmentOnlyResult.rows) {
+    for (let index = 0; index < Number(shipment.quantity); index += 1) {
+      productionUnits.push({
+        orderId: `${shipment.order_id}#shipment-${index + 1}`,
+        productionStatus: 'SHIPPED',
+        currentDepartment: 'Shipped',
+        isFulfilled: false,
+        hasShipment: true,
+      });
+    }
+  }
+
+  return reconcileP1POLine({
+    purchaseOrderItemId,
+    originalOrderedQuantity: Number(line.quantity),
+    canceledDemandQuantity,
+    purchaseOrderStatus: line.po_status,
+    productionUnits,
+  });
+}
+
+export async function getP1POLineReconciliation(
+  purchaseOrderItemId: number
+): Promise<P1POLineReconciliation | null> {
+  const client = await pool.connect();
+  try {
+    return await getLineReconciliationWithClient(client, purchaseOrderItemId);
+  } finally {
+    client.release();
+  }
+}
+
+export async function getP1POReconciliation(
+  purchaseOrderId: number
+): Promise<P1POLineReconciliation[]> {
+  const client = await pool.connect();
+  try {
+    const items = await client.query<{ id: number }>(
+      'SELECT id FROM purchase_order_items WHERE po_id = $1 ORDER BY id',
+      [purchaseOrderId]
+    );
+    const lines: P1POLineReconciliation[] = [];
+    for (const item of items.rows) {
+      const line = await getLineReconciliationWithClient(client, item.id);
+      if (line) lines.push(line);
+    }
+    return lines;
+  } finally {
+    client.release();
+  }
+}
+
+export async function getP1QuantityAdjustmentHistory(
+  purchaseOrderItemId: number,
+  expectedPurchaseOrderId?: number
+): Promise<P1QuantityAdjustment[]> {
+  const result = await pool.query<{
+    id: string;
+    purchase_order_item_id: number;
+    adjustment_type: P1AdjustmentType;
+    quantity: number;
+    reason: string;
+    effective_at: Date;
+    created_at: Date;
+    created_by_user_id: number;
+    created_by_display_name: string | null;
+    source: string | null;
+    reference: string | null;
+    idempotency_key: string | null;
+  }>(
+    `SELECT adj.*
+       FROM purchase_order_item_quantity_adjustments adj
+       JOIN purchase_order_items poi ON poi.id = adj.purchase_order_item_id
+      WHERE adj.purchase_order_item_id = $1
+       ${expectedPurchaseOrderId ? 'AND poi.po_id = $2' : ''}
+      ORDER BY adj.effective_at, adj.created_at, adj.id`,
+    expectedPurchaseOrderId
+      ? [purchaseOrderItemId, expectedPurchaseOrderId]
+      : [purchaseOrderItemId]
+  );
+  return result.rows.map((row) => ({
+    id: row.id,
+    purchaseOrderItemId: row.purchase_order_item_id,
+    adjustmentType: row.adjustment_type,
+    quantity: Number(row.quantity),
+    reason: row.reason,
+    effectiveAt: row.effective_at.toISOString(),
+    createdAt: row.created_at.toISOString(),
+    createdByDisplayName: row.created_by_display_name,
+    source: row.source,
+    reference: row.reference,
+    idempotencyKey: row.idempotency_key,
+  }));
+}
+
+export class P1QuantityAdjustmentConflict extends Error {
+  constructor(
+    message: string,
+    public readonly reconciliation: P1POLineReconciliation
+  ) {
+    super(message);
+  }
+}
+
+export function validateP1QuantityAdjustment(
+  current: P1POLineReconciliation,
+  adjustmentType: P1AdjustmentType,
+  quantity: number
+): number {
+  const proposedCanceled =
+    adjustmentType === 'CANCEL_QUANTITY'
+      ? current.canceledDemandQuantity + quantity
+      : current.canceledDemandQuantity - quantity;
+
+  if (proposedCanceled < 0) {
+    throw new P1QuantityAdjustmentConflict(
+      'Restore quantity exceeds currently canceled customer demand',
+      current
+    );
+  }
+  if (proposedCanceled > current.originalOrderedQuantity) {
+    throw new P1QuantityAdjustmentConflict(
+      'Cancellation exceeds the original ordered quantity',
+      current
+    );
+  }
+
+  const proposedActive = current.isCanceled
+    ? 0
+    : current.originalOrderedQuantity - proposedCanceled;
+  if (
+    adjustmentType === 'CANCEL_QUANTITY' &&
+    proposedActive < current.accountedQuantity
+  ) {
+    throw new P1QuantityAdjustmentConflict(
+      'Cancellation would reduce active PO demand below shipped, in-progress, and pending units',
+      current
+    );
+  }
+  return proposedCanceled;
+}
+
+export async function createP1QuantityAdjustment(input: {
+  purchaseOrderId: number;
+  purchaseOrderItemId: number;
+  adjustmentType: P1AdjustmentType;
+  quantity: number;
+  reason: string;
+  createdByUserId: number;
+  createdByDisplayName: string;
+  effectiveAt?: Date;
+  source?: string | null;
+  reference?: string | null;
+  idempotencyKey?: string | null;
+}): Promise<{
+  adjustment: P1QuantityAdjustment;
+  reconciliation: P1POLineReconciliation;
+  replayed: boolean;
+}> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const current = await getLineReconciliationWithClient(
+      client,
+      input.purchaseOrderItemId,
+      true,
+      input.purchaseOrderId
+    );
+    if (!current) throw new Error('P1 purchase-order line not found');
+
+    if (input.idempotencyKey) {
+      const existing = await client.query<{ id: string }>(
+        `SELECT id FROM purchase_order_item_quantity_adjustments
+          WHERE purchase_order_item_id = $1 AND idempotency_key = $2`,
+        [input.purchaseOrderItemId, input.idempotencyKey]
+      );
+      if (existing.rows[0]) {
+        await client.query('COMMIT');
+        const history = await getP1QuantityAdjustmentHistory(
+          input.purchaseOrderItemId,
+          input.purchaseOrderId
+        );
+        return {
+          adjustment: history.find(
+            (entry) => entry.id === existing.rows[0].id
+          )!,
+          reconciliation: current,
+          replayed: true,
+        };
+      }
+    }
+
+    validateP1QuantityAdjustment(current, input.adjustmentType, input.quantity);
+
+    const insertResult = await client.query<{ id: string }>(
+      `INSERT INTO purchase_order_item_quantity_adjustments (
+         purchase_order_item_id, adjustment_type, quantity, reason,
+         effective_at, created_by_user_id, created_by_display_name,
+         source, reference, idempotency_key
+       ) VALUES ($1,$2,$3,$4,COALESCE($5, now()),$6,$7,$8,$9,$10)
+       RETURNING id`,
+      [
+        input.purchaseOrderItemId,
+        input.adjustmentType,
+        input.quantity,
+        input.reason.trim(),
+        input.effectiveAt ?? null,
+        input.createdByUserId,
+        input.createdByDisplayName,
+        input.source ?? 'P1_PURCHASE_ORDERS_UI',
+        input.reference ?? null,
+        input.idempotencyKey ?? null,
+      ]
+    );
+    const reconciliation = await getLineReconciliationWithClient(
+      client,
+      input.purchaseOrderItemId
+    );
+    await client.query('COMMIT');
+
+    const history = await getP1QuantityAdjustmentHistory(
+      input.purchaseOrderItemId,
+      input.purchaseOrderId
+    );
+    return {
+      adjustment: history.find(
+        (entry) => entry.id === insertResult.rows[0].id
+      )!,
+      reconciliation: reconciliation!,
+      replayed: false,
+    };
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}


### PR DESCRIPTION
## Summary

Adds the minimum additive prerequisite for auditable partial P1 purchase-order line demand cancellation and makes the P1 Purchase Orders UI consume one authoritative backend reconciliation.

## Root cause

P1 customer demand was represented only by the original `purchase_order_items.quantity`, while operational production-unit cancellation had separate semantics. The PO UI and availability/generation paths also calculated quantities independently, so canceled production units could be mistaken for reduced customer demand and browser-side counts could drift from the scheduling calculation.

## Changes

- Add immutable migration `0231_p1_po_item_quantity_adjustments.sql` for explicit `CANCEL_QUANTITY` and compensating `RESTORE_QUANTITY` records.
- Store reason, effective/created timestamps, authenticated-user snapshot, optional reference, and per-line idempotency key.
- Reject ledger updates/deletes and validate adjustments inside a transaction with PO-line row locking.
- Add authoritative reconciliation for original, canceled, active, shipped, WIP, pending queue, accounted, variance, and available-to-progress quantities.
- Count current physical units once; exclude canceled production units without subtracting customer demand.
- Add authenticated reconciliation/history endpoints and a `purchasing.manage_pos`-protected adjustment endpoint.
- Update P1 Purchase Orders to render the backend breakdown and authorized cancel/restore/history actions.
- Make PO generation preview and generation use active customer demand while retaining existing production cancel-and-replace behavior.

## Safety and data impact

- Additive migration only; no existing rows are rewritten or backfilled.
- Does not modify `purchase_order_items.quantity`.
- Does not infer demand adjustments from historical canceled production units.
- Does not update/delete production orders, shipment history, routing, travelers, barcode state, Finish QC, inventory, or material consumption.
- No production database or production data was touched.

## Validation

- Post-rebase targeted server suites: 92/92 passed.
- Client reconciliation contract suite: 3/3 passed.
- Narrow ESLint for new standalone files: passed.
- `git diff --check`: passed.
- Production Vite build: passed with existing unrelated duplicate-case/chunk-size warnings.
- Full TypeScript check was attempted with 2 GB and 4 GB heaps but exhausted memory without emitting diagnostics.
- PostgreSQL migration execution was not run because no isolated `DATABASE_URL` or `FORCE_DATABASE_URL` was available; the migration was not run against production.