### PR TITLE
Strengthen EPOCH software validation readiness controls

### DIFF
--- a/client/src/__tests__/epochSoftwareValidationReadiness.component.test.tsx
+++ b/client/src/__tests__/epochSoftwareValidationReadiness.component.test.tsx
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const source = fs.readFileSync(
+  path.resolve(import.meta.dirname, '../pages/EpochSoftwareValidationPage.tsx'),
+  'utf8'
+);
+
+describe('EPOCH software validation readiness UI', () => {
+  it('renders the server-derived checklist and opens controlled editing', () => {
+    expect(source).toContain('d.packageReadiness.items.map');
+    expect(source).toContain('Edit package readiness');
+    expect(source).toContain("method:'PATCH'");
+  });
+
+  it('provides exact identifier guidance and separate authenticated confirmations', () => {
+    expect(source).toContain(
+      'Production commit SHA, release tag, or deployment identifier'
+    );
+    expect(source).toContain('A PR number alone is not sufficient.');
+    expect(source).toContain('/confirm-${kind}');
+    expect(source).toContain('Confirm deployment date');
+    expect(source).toContain('Confirm environment separation');
+  });
+
+  it('uses active employee and Audit Readiness option sources', () => {
+    expect(source).toContain("queryKey:['/api/employees']");
+    expect(source).toContain("queryKey:['/api/qms/as9100-audit-readiness']");
+    expect(source).toContain('Software owner');
+    expect(source).toContain('Quality owner');
+    expect(source).toContain('Validation lead');
+  });
+});

--- a/client/src/pages/EpochSoftwareValidationPage.tsx
+++ b/client/src/pages/EpochSoftwareValidationPage.tsx
@@ -5,7 +5,7 @@ import { apiRequest } from '@/lib/queryClient';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
@@ -16,7 +16,10 @@ import { useToast } from '@/hooks/use-toast';
 
 type Package = {
   id:string;package_number:string;title:string;system_name:string;validation_type:string;status:string;
-  production_version:string;commit_or_release_identifier?:string;validation_environment:string;
+  production_version:string;commit_or_release_identifier?:string;validation_environment:string;production_deployment_date?:string;
+  production_environment_reference:string;environment_differences?:string;notes?:string;row_version:number;
+  software_owner_employee_id?:number;quality_owner_employee_id?:number;validation_lead_employee_id?:number;
+  audit_readiness_assessment_id?:string;deployment_date_confirmed?:boolean;environment_separation_confirmed?:boolean;
   planned_start_date:string;planned_completion_date:string;locked_at?:string;
   requirement_count?:number;execution_count?:number;open_defect_count?:number;
 };
@@ -24,7 +27,10 @@ type Detail = {
   package:Package;intendedUse:any[];requirements:any[];risks:any[];plans:any[];protocols:any[];
   executions:any[];defects:any[];approvals:any[];periodicReviews:any[];events:any[];
   readiness:Record<string,any>&{ready:boolean;blockers:string[]};
+  packageReadiness:{items:Array<{key:string;label:string;state:string;field:string;message?:string}>;executionReady:boolean;blockers:any[]};
 };
+type Employee={id:number;name:string};
+type Assessment={id:string;assessment_number:string;title:string};
 const sections=[
   ['01','Intended Use','Controlled scope and dual authenticated approval'],
   ['02','Software Requirements','Normalized, revision-controlled requirements baseline'],
@@ -44,6 +50,7 @@ const tone=(v:string)=>v.includes('APPROVED')||v==='PASSED'||v==='CLOSED'?'bg-em
 export default function EpochSoftwareValidationPage(){
   const [selected,setSelected]=useState<string>();
   const [createOpen,setCreateOpen]=useState(false);
+  const [editOpen,setEditOpen]=useState(false);
   const [auditor,setAuditor]=useState(false);
   const [activeSection,setActiveSection]=useState('01');
   const qc=useQueryClient(),{toast}=useToast();
@@ -51,12 +58,33 @@ export default function EpochSoftwareValidationPage(){
     queryFn:async()=>(await apiRequest('/api/qms/epoch-software-validation')).json()});
   const detail=useQuery<Detail>({queryKey:['/api/qms/epoch-software-validation',selected],enabled:Boolean(selected),
     queryFn:async()=>(await apiRequest(`/api/qms/epoch-software-validation/${selected}`)).json()});
+  const employees=useQuery<Employee[]>({queryKey:['/api/employees'],queryFn:async()=>(await apiRequest('/api/employees')).json()});
+  const assessments=useQuery<Assessment[]>({queryKey:['/api/qms/as9100-audit-readiness'],
+    queryFn:async()=>(await apiRequest('/api/qms/as9100-audit-readiness')).json()});
   const create=useMutation({mutationFn:async(form:HTMLFormElement)=>{
     const f=new FormData(form);const body=Object.fromEntries(f.entries());
     return (await apiRequest('/api/qms/epoch-software-validation',{method:'POST',body})).json();
   },onSuccess:(p:Package)=>{qc.invalidateQueries({queryKey:['/api/qms/epoch-software-validation']});
     setCreateOpen(false);setSelected(p.id);toast({title:`${p.package_number} created`});},
     onError:(e:Error)=>toast({title:'Package was not created',description:e.message,variant:'destructive'})});
+  const refresh=()=>qc.invalidateQueries({queryKey:['/api/qms/epoch-software-validation',selected]});
+  const edit=useMutation({mutationFn:async(form:HTMLFormElement)=>{
+    const f=new FormData(form),num=(name:string)=>{const value=f.get(name);return value&&value!=='NONE'?Number(value):null;};
+    const assessment=f.get('auditReadinessAssessmentId');
+    return (await apiRequest(`/api/qms/epoch-software-validation/${selected}`,{method:'PATCH',body:{
+      rowVersion:detail.data!.package.row_version,commitOrReleaseIdentifier:f.get('commitOrReleaseIdentifier')||null,
+      productionDeploymentDate:f.get('productionDeploymentDate')||null,validationEnvironment:f.get('validationEnvironment'),
+      productionEnvironmentReference:f.get('productionEnvironmentReference'),environmentDifferences:f.get('environmentDifferences')||null,
+      softwareOwnerEmployeeId:num('softwareOwnerEmployeeId'),qualityOwnerEmployeeId:num('qualityOwnerEmployeeId'),
+      validationLeadEmployeeId:num('validationLeadEmployeeId'),auditReadinessAssessmentId:assessment==='NONE'||assessment===null?null:String(assessment),
+      notes:f.get('notes')||null,
+    }})).json();
+  },onSuccess:()=>{refresh();setEditOpen(false);toast({title:'Controlled package fields updated'});},
+    onError:(e:Error)=>toast({title:'Package update blocked',description:e.message,variant:'destructive'})});
+  const confirm=useMutation({mutationFn:async(kind:'deployment-date'|'environment-separation')=>
+    (await apiRequest(`/api/qms/epoch-software-validation/${selected}/confirm-${kind}`,{method:'POST',body:{}})).json(),
+    onSuccess:()=>{refresh();toast({title:'Authenticated confirmation recorded'});},
+    onError:(e:Error)=>toast({title:'Confirmation blocked',description:e.message,variant:'destructive'})});
   const progress=useMemo(()=>{
     const d=detail.data;if(!d)return 0;let complete=0;
     if(d.readiness.intendedUseApproved)complete++;
@@ -79,6 +107,7 @@ export default function EpochSoftwareValidationPage(){
         <h1 className="text-2xl font-bold">{p.package_number} · {p.title}</h1>
         <p className="text-sm text-muted-foreground">EPOCH {p.production_version} · {pretty(p.validation_type)} · {p.validation_environment}</p>
       </div><div className="flex flex-wrap gap-2">
+        <Button variant="outline" onClick={()=>setEditOpen(true)}>Edit package readiness</Button>
         <Button variant={auditor?'default':'outline'} onClick={()=>setAuditor(v=>!v)}><ShieldCheck className="mr-2 h-4 w-4"/>Auditor View</Button>
         <ExportMenu id={p.id}/>
       </div></div>
@@ -93,6 +122,15 @@ export default function EpochSoftwareValidationPage(){
         <Metric label="Overall readiness" value={d.readiness.ready?'Ready':'Blocked'} ok={d.readiness.ready} danger={!d.readiness.ready}/>
       </div>
       <Progress value={progress}/>
+      <Card id="package-readiness" className={d.packageReadiness.executionReady?'border-emerald-300':'border-amber-300'}>
+        <CardHeader><CardTitle className="flex items-center justify-between gap-3 text-base"><span>Package readiness</span>
+          <Badge className={d.packageReadiness.executionReady?'bg-emerald-100 text-emerald-800':'bg-amber-100 text-amber-900'}>
+            {d.packageReadiness.executionReady?'Execution ready':'Action required'}</Badge></CardTitle></CardHeader>
+        <CardContent className="grid gap-2 md:grid-cols-2">{d.packageReadiness.items.map(item=><button key={item.key}
+          type="button" onClick={()=>setEditOpen(true)} className="flex items-start justify-between gap-3 rounded-md border p-3 text-left hover:bg-muted">
+          <span><span className="block text-sm font-medium">{item.label}</span>{item.message&&<span className="text-xs text-muted-foreground">{item.message}</span>}</span>
+          <Badge variant="outline">{pretty(item.state)}</Badge></button>)}</CardContent>
+      </Card>
       {!d.readiness.ready&&<Card className="border-red-300"><CardHeader><CardTitle className="flex items-center gap-2 text-base text-red-800"><AlertTriangle className="h-4 w-4"/>Readiness blockers</CardTitle></CardHeader>
         <CardContent><ul className="list-disc space-y-1 pl-5 text-sm">{d.readiness.blockers.map(x=><li key={x}>{x}</li>)}</ul></CardContent></Card>}
       <div className="grid gap-4 lg:grid-cols-[310px_1fr]">
@@ -104,6 +142,35 @@ export default function EpochSoftwareValidationPage(){
         </CardContent></Card>
         <SectionWorkspace section={activeSection} detail={d} auditor={auditor}/>
       </div>
+      <Dialog open={editOpen} onOpenChange={setEditOpen}><DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+        <DialogHeader><DialogTitle>Edit package readiness</DialogTitle><DialogDescription>
+          Complete controlled metadata for the exact production deployment. Saving does not record either authenticated confirmation.
+        </DialogDescription></DialogHeader>
+        <form className="grid gap-4 md:grid-cols-2" onSubmit={e=>{e.preventDefault();edit.mutate(e.currentTarget)}}>
+          <div><Field name="commitOrReleaseIdentifier" label="Production commit SHA, release tag, or deployment identifier" defaultValue={p.commit_or_release_identifier||''}/>
+            <p className="mt-1 text-xs text-muted-foreground">Enter the exact deployed commit SHA, release tag, or deployment ID. A PR number alone is not sufficient.</p></div>
+          <Field name="productionDeploymentDate" label="Production deployment date" type="date" defaultValue={p.production_deployment_date?.slice(0,10)||''}/>
+          <EmployeePick name="softwareOwnerEmployeeId" label="Software owner" value={p.software_owner_employee_id} employees={employees.data||[]}/>
+          <EmployeePick name="qualityOwnerEmployeeId" label="Quality owner" value={p.quality_owner_employee_id} employees={employees.data||[]}/>
+          <EmployeePick name="validationLeadEmployeeId" label="Validation lead" value={p.validation_lead_employee_id} employees={employees.data||[]}/>
+          <div><Label>Audit readiness assessment</Label><Select name="auditReadinessAssessmentId" defaultValue={p.audit_readiness_assessment_id||'NONE'}>
+            <SelectTrigger><SelectValue/></SelectTrigger><SelectContent><SelectItem value="NONE">Not linked</SelectItem>
+              {assessments.data?.map(a=><SelectItem key={a.id} value={a.id}>{a.assessment_number} · {a.title}</SelectItem>)}</SelectContent></Select></div>
+          <Field name="validationEnvironment" label="Validation environment reference" defaultValue={p.validation_environment||''}/>
+          <Field name="productionEnvironmentReference" label="Production environment reference" defaultValue={p.production_environment_reference||''}/>
+          <div className="md:col-span-2"><Label>Validation-to-production environment differences</Label>
+            <Textarea name="environmentDifferences" defaultValue={p.environment_differences||''}/></div>
+          <div className="md:col-span-2"><Label>Package notes</Label><Textarea name="notes" defaultValue={p.notes||''}
+            placeholder="Describe package-specific validation context; replace generic placeholder text."/></div>
+          <DialogFooter className="md:col-span-2"><Button type="submit" disabled={edit.isPending}>Save controlled fields</Button></DialogFooter>
+        </form>
+        <div className="grid gap-3 border-t pt-4 md:grid-cols-2">
+          <div><Button type="button" variant="outline" disabled={confirm.isPending||!p.production_deployment_date}
+            onClick={()=>confirm.mutate('deployment-date')}>Confirm deployment date</Button></div>
+          <div><Button type="button" variant="outline" disabled={confirm.isPending||!p.environment_differences}
+            onClick={()=>confirm.mutate('environment-separation')}>Confirm environment separation</Button></div>
+        </div>
+      </DialogContent></Dialog>
       {auditor&&<Card><CardHeader><CardTitle className="flex items-center gap-2"><History className="h-5 w-5"/>Immutable audit history</CardTitle></CardHeader>
         <CardContent><Table><TableHeader><TableRow><TableHead>Date</TableHead><TableHead>Action</TableHead><TableHead>Actor</TableHead><TableHead>Reason</TableHead></TableRow></TableHeader>
           <TableBody>{d.events.map(e=><TableRow key={e.id}><TableCell>{new Date(e.created_at).toLocaleString()}</TableCell><TableCell>{pretty(e.action)}</TableCell><TableCell>{e.actor_display_name} · {e.actor_role}</TableCell><TableCell>{e.reason||'—'}</TableCell></TableRow>)}</TableBody></Table></CardContent></Card>}
@@ -114,12 +181,14 @@ export default function EpochSoftwareValidationPage(){
     <div className="flex flex-wrap items-start justify-between gap-3"><div><h1 className="text-2xl font-bold">EPOCH Software Validation</h1>
       <p className="text-muted-foreground">Objective evidence that EPOCH is suitable for its approved, documented QMS intended use.</p></div>
       <Dialog open={createOpen} onOpenChange={setCreateOpen}><DialogTrigger asChild><Button><Plus className="mr-2 h-4 w-4"/>New validation package</Button></DialogTrigger>
-      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto"><DialogHeader><DialogTitle>Create EPOCH Software Validation Package</DialogTitle></DialogHeader>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto"><DialogHeader><DialogTitle>Create EPOCH Software Validation Package</DialogTitle>
+        <DialogDescription>Create a controlled draft. Production evidence and authenticated confirmations are completed after creation.</DialogDescription></DialogHeader>
         <form className="grid gap-4 md:grid-cols-2" onSubmit={e=>{e.preventDefault();create.mutate(e.currentTarget)}}>
           <Field name="title" label="Package title" required/><Field name="systemName" label="System name" defaultValue="EPOCH" required/>
           <Pick name="validationType" label="Validation type" values={['INITIAL_INTENDED_USE','MAJOR_RELEASE','CRITICAL_CHANGE','DATABASE_MIGRATION','SECURITY_ACCESS_CONTROL','BACKUP_RECOVERY','PERIODIC_REVIEW','PRE_AUDIT_REVALIDATION','CORRECTIVE_REVALIDATION']}/>
           <Field name="productionVersion" label="Production version being validated" required/>
-          <Field name="commitOrReleaseIdentifier" label="Commit SHA or release identifier"/>
+          <div><Field name="commitOrReleaseIdentifier" label="Production commit SHA, release tag, or deployment identifier"/>
+            <p className="mt-1 text-xs text-muted-foreground">Enter the exact deployed commit SHA, release tag, or deployment ID. A PR number alone is not sufficient.</p></div>
           <Field name="productionDeploymentDate" label="Production deployment date" type="date"/>
           <Field name="validationEnvironment" label="Validation environment" required/>
           <Field name="productionEnvironmentReference" label="Production environment reference" required/>
@@ -169,3 +238,7 @@ function ExportMenu({id}:{id:string}){return <Select onValueChange={v=>window.op
 </SelectContent></Select>;}
 function Field({name,label,type='text',required,defaultValue}:{name:string;label:string;type?:string;required?:boolean;defaultValue?:string}){return <div><Label htmlFor={name}>{label}</Label><Input id={name} name={name} type={type} required={required} defaultValue={defaultValue}/></div>;}
 function Pick({name,label,values}:{name:string;label:string;values:string[]}){return <div><Label>{label}</Label><Select name={name} defaultValue={values[0]}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{values.map(v=><SelectItem key={v} value={v}>{pretty(v)}</SelectItem>)}</SelectContent></Select></div>;}
+function EmployeePick({name,label,value,employees}:{name:string;label:string;value?:number;employees:Employee[]}){return <div><Label>{label}</Label>
+  <Select name={name} defaultValue={value?String(value):'NONE'}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>
+    <SelectItem value="NONE">Not assigned</SelectItem>{employees.map(e=><SelectItem key={e.id} value={String(e.id)}>{e.name}</SelectItem>)}
+  </SelectContent></Select></div>;}

--- a/migrations/0234_epoch_validation_readiness_controls.sql
+++ b/migrations/0234_epoch_validation_readiness_controls.sql
@@ -1,0 +1,28 @@
+-- Migration 0234: additive readiness controls for existing EPOCH validation packages.
+-- Existing values, package numbers, owners, evidence, approvals, and statuses are preserved.
+ALTER TABLE qms_epoch_validation_packages
+  ADD COLUMN IF NOT EXISTS deployment_date_confirmed boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS deployment_date_confirmed_by_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS deployment_date_confirmed_by_display_name text,
+  ADD COLUMN IF NOT EXISTS deployment_date_confirmed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS environment_separation_confirmed boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS environment_separation_confirmed_by_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS environment_separation_confirmed_by_display_name text,
+  ADD COLUMN IF NOT EXISTS environment_separation_confirmed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS environment_differences text,
+  ADD COLUMN IF NOT EXISTS audit_readiness_not_applicable boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS audit_readiness_na_justification text,
+  ADD COLUMN IF NOT EXISTS audit_readiness_na_approved_by_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS audit_readiness_na_approved_by_display_name text,
+  ADD COLUMN IF NOT EXISTS audit_readiness_na_approved_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS qms_esv_audit_readiness_link_idx
+  ON qms_epoch_validation_packages(audit_readiness_assessment_id)
+  WHERE audit_readiness_assessment_id IS NOT NULL;
+
+COMMENT ON COLUMN qms_epoch_validation_packages.deployment_date_confirmed IS
+  'Authenticated confirmation that production_deployment_date belongs to the exact identified production build.';
+COMMENT ON COLUMN qms_epoch_validation_packages.environment_separation_confirmed IS
+  'Authenticated confirmation that validation uses controlled non-production data and does not intentionally modify production QMS records.';
+COMMENT ON COLUMN qms_epoch_validation_packages.audit_readiness_not_applicable IS
+  'Quality-approved determination used only when no applicable Audit Readiness assessment exists.';

--- a/server/__tests__/epochSoftwareValidationReadinessArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationReadinessArchitecture.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
+const route = read('server/src/routes/epochSoftwareValidation.ts');
+const migration = read(
+  'migrations/0234_epoch_validation_readiness_controls.sql'
+);
+const ui = read('client/src/pages/EpochSoftwareValidationPage.tsx');
+const safeBoot = read('server/scripts/migrations/runSafeBootMigrations.ts');
+
+describe('EPOCH validation package-readiness architecture', () => {
+  it('adds only additive readiness metadata without rewriting existing packages', () => {
+    expect(migration).toContain('ALTER TABLE qms_epoch_validation_packages');
+    expect(migration).not.toMatch(
+      /\b(?:UPDATE|DELETE FROM|INSERT INTO)\s+qms_epoch_validation_packages\b/i
+    );
+    expect(migration).not.toContain('0229_epoch_software_validation');
+    expect(
+      safeBoot.match(/0234_epoch_validation_readiness_controls\.sql/g)?.length
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('uses active employee and authoritative assessment sources', () => {
+    expect(route).toContain(
+      'FROM employees WHERE id=ANY($1::int[]) AND is_active=true'
+    );
+    expect(route).toContain('qms_audit_readiness_assessments');
+    expect(route).toContain("error:'INACTIVE_EMPLOYEE_ASSIGNMENT'");
+    expect(route).toContain(
+      "router.post('/:id/audit-readiness-na',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE')"
+    );
+  });
+
+  it('requires authenticated confirmations and invalidates stale deployment confirmation', () => {
+    expect(route).toContain(
+      "router.post('/:id/confirm-deployment-date',requirePermission('EPOCH_VALIDATION_EDIT')"
+    );
+    expect(route).toContain(
+      "router.post('/:id/confirm-environment-separation',requirePermission('EPOCH_VALIDATION_EDIT')"
+    );
+    expect(route).toContain(
+      'deployment_date_confirmed=CASE WHEN $19 THEN false'
+    );
+    expect(route).toContain('DEPLOYMENT_DATE_CONFIRMED');
+    expect(route).toContain('ENVIRONMENT_SEPARATION_CONFIRMED');
+  });
+
+  it('blocks execution and final approval on incomplete package or protocol evidence', () => {
+    expect(route).toContain("error:'PACKAGE_EXECUTION_READINESS_BLOCKED'");
+    expect(route).toContain("error:'PACKAGE_FINAL_READINESS_BLOCKED'");
+    expect(route).toContain("error:'PROTOCOL_EXECUTION_OR_REVIEW_INCOMPLETE'");
+    expect(route).toContain(
+      "e.overall_result IN ('PASSED','PASSED_WITH_APPROVED_DEVIATION')"
+    );
+    expect(route).toContain('snapshot_checksum IS NOT NULL');
+  });
+
+  it('exposes actionable readiness UI with the required production identifier guidance', () => {
+    expect(ui).toContain('Package readiness');
+    expect(ui).toContain('Edit package readiness');
+    expect(ui).toContain(
+      'Production commit SHA, release tag, or deployment identifier'
+    );
+    expect(ui).toContain('A PR number alone is not sufficient.');
+    expect(ui).toContain('Confirm deployment date');
+    expect(ui).toContain('Confirm environment separation');
+  });
+});

--- a/server/__tests__/epochSoftwareValidationRules.test.ts
+++ b/server/__tests__/epochSoftwareValidationRules.test.ts
@@ -3,6 +3,10 @@ import {
   calculateReadiness,
   canTransition,
   deriveExecutionResult,
+  hasMeaningfulNotes,
+  packageReadinessBlockers,
+  productionIdentifierStatus,
+  type PackageReadinessItem,
   type ReadinessCounts,
 } from '../src/services/epochSoftwareValidation';
 
@@ -46,5 +50,30 @@ describe('EPOCH software-validation control rules', () => {
     expect(blocked.ready).toBe(false);
     expect(blocked.blockers).toContain('Critical validation defects remain open');
     expect(blocked.blockers).toContain('Restore testing has not passed');
+  });
+
+  it('accepts exact production identifiers and rejects PR-only references', () => {
+    expect(productionIdentifierStatus('8f14e45fceea167a5a36dedd4bea2543ad6d0f21').valid).toBe(true);
+    expect(productionIdentifierStatus('v8.3.0').valid).toBe(true);
+    expect(productionIdentifierStatus('deploy-2026-07-30').valid).toBe(true);
+    expect(productionIdentifierStatus('pull request #1576')).toEqual({
+      valid: false,
+      code: 'PRODUCTION_IDENTIFIER_AMBIGUOUS',
+    });
+    expect(productionIdentifierStatus('1576').valid).toBe(false);
+  });
+
+  it('rejects placeholder notes and returns structured package blockers', () => {
+    expect(hasMeaningfulNotes('TBD')).toBe(false);
+    expect(hasMeaningfulNotes('Validated against the controlled production release.')).toBe(true);
+    const items: PackageReadinessItem[] = [
+      { key: 'OWNER', label: 'Owner', field: 'ownerId', state: 'MISSING' },
+      { key: 'DATE', label: 'Date', field: 'date', state: 'REQUIRES_CONFIRMATION' },
+      { key: 'RISK', label: 'Risk', field: 'risk', state: 'COMPLETE' },
+    ];
+    expect(packageReadinessBlockers(items)).toEqual([
+      { field: 'ownerId', code: 'OWNER_INCOMPLETE', message: 'Owner is incomplete.' },
+      { field: 'date', code: 'DATE_INCOMPLETE', message: 'Date is incomplete.' },
+    ]);
   });
 });

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -262,6 +262,7 @@ export const safeMigrationFiles = [
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
   '0233_part_specification_sheet_control.sql',
+  '0234_epoch_validation_readiness_controls.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -306,6 +307,7 @@ export const criticalMigrationFiles = new Set([
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
   '0233_part_specification_sheet_control.sql',
+  '0234_epoch_validation_readiness_controls.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -5,6 +5,8 @@ import { authenticateToken } from '../../middleware/auth';
 import { requirePermission } from '../../middleware/requirePermission';
 import {
   calculateReadiness, canTransition, checksum, deriveExecutionResult,
+  hasMeaningfulNotes, packageReadinessBlockers, productionIdentifierStatus,
+  type PackageReadinessItem,
   type ReadinessCounts, type ValidationStatus,
 } from '../services/epochSoftwareValidation';
 
@@ -95,6 +97,122 @@ router.post('/',requirePermission('EPOCH_VALIDATION_CREATE'),async(req,res)=>{
   res.status(201).json(created);
 });
 
+async function packageReadiness(p:any):Promise<{items:PackageReadinessItem[];executionReady:boolean;blockers:any[]}>{
+  const identifier=productionIdentifierStatus(p.commit_or_release_identifier);
+  const facts=(await query(`SELECT
+    EXISTS(SELECT 1 FROM qms_epoch_validation_intended_use_revisions u WHERE u.package_id=$1
+      AND nullif(trim(u.intended_use_statement),'') IS NOT NULL) intended_use,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_risks r WHERE r.package_id=$1) risk_exists,
+    EXISTS(SELECT 1 FROM qms_epoch_validation_protocols x WHERE x.package_id=$1) protocols_exist,
+    NOT EXISTS(SELECT 1 FROM qms_epoch_validation_protocols x WHERE x.package_id=$1 AND
+      (nullif(trim(x.overall_acceptance_criteria),'') IS NULL OR
+       NOT EXISTS(SELECT 1 FROM qms_epoch_validation_protocol_steps s WHERE s.protocol_id=x.id) OR
+       EXISTS(SELECT 1 FROM qms_epoch_validation_protocol_steps s WHERE s.protocol_id=x.id
+         AND nullif(trim(s.expected_result),'') IS NULL))) protocols_complete,
+    EXISTS(SELECT 1 FROM qms_audit_readiness_assessments a WHERE a.id=$2) assessment_exists`,
+    [p.id,p.audit_readiness_assessment_id||null]))[0];
+  const item=(key:string,label:string,state:PackageReadinessItem['state'],field:string,message?:string):PackageReadinessItem=>
+    ({key,label,state,field,message});
+  const items=[
+    item('PRODUCTION_IDENTIFIER','Exact production identifier',identifier.valid?'COMPLETE':'MISSING','commitOrReleaseIdentifier',
+      identifier.code==='PRODUCTION_IDENTIFIER_AMBIGUOUS'?'A pull-request number alone does not uniquely identify the deployed build.':'Enter a full commit SHA, controlled release tag, or documented deployment ID.'),
+    item('DEPLOYMENT_CONFIRMATION','Deployment-date confirmation',p.deployment_date_confirmed?'COMPLETE':'REQUIRES_CONFIRMATION','deploymentDateConfirmed'),
+    item('SOFTWARE_OWNER','Software owner',p.software_owner_employee_id?'COMPLETE':'MISSING','softwareOwnerEmployeeId','Assign an active Software owner.'),
+    item('QUALITY_OWNER','Quality owner',p.quality_owner_employee_id?'COMPLETE':'MISSING','qualityOwnerEmployeeId','Assign an active Quality owner.'),
+    item('VALIDATION_LEAD','Validation lead',p.validation_lead_employee_id?'COMPLETE':'MISSING','validationLeadEmployeeId','Assign an active Validation lead.'),
+    item('INTENDED_USE','Intended-use statement',facts.intended_use?'COMPLETE':'MISSING','intendedUse'),
+    item('VALIDATION_REASON','Reason for validation',String(p.reason_for_validation||'').trim().length>=3?'COMPLETE':'MISSING','reasonForValidation'),
+    item('VALIDATION_ENVIRONMENT','Validation-environment reference',String(p.validation_environment||'').trim()?'COMPLETE':'MISSING','validationEnvironment'),
+    item('PRODUCTION_ENVIRONMENT','Production-environment reference',String(p.production_environment_reference||'').trim()?'COMPLETE':'MISSING','productionEnvironmentReference'),
+    item('ENVIRONMENT_CONFIRMATION','Environment-separation confirmation',p.environment_separation_confirmed?'COMPLETE':'REQUIRES_CONFIRMATION','environmentSeparationConfirmed'),
+    item('ENVIRONMENT_DIFFERENCES','Environment-differences statement',String(p.environment_differences||'').trim().length>=10?'COMPLETE':'MISSING','environmentDifferences'),
+    item('NOTES','Meaningful notes',hasMeaningfulNotes(p.notes)?'COMPLETE':'MISSING','notes'),
+    item('AUDIT_READINESS','Audit-readiness assessment or justified N/A',
+      facts.assessment_exists?'COMPLETE':p.audit_readiness_not_applicable&&p.audit_readiness_na_approved_at?'NOT_APPLICABLE':'MISSING',
+      'auditReadinessAssessmentId'),
+    item('RISK_ASSESSMENT','Risk assessment',facts.risk_exists?'COMPLETE':'MISSING','riskAssessment'),
+    item('VALIDATION_PROTOCOLS','Validation protocols',facts.protocols_exist?'COMPLETE':'MISSING','protocols'),
+    item('EXPECTED_RESULTS','Expected results',facts.protocols_exist&&facts.protocols_complete?'COMPLETE':'MISSING','protocols'),
+    item('ACCEPTANCE_CRITERIA','Acceptance criteria',facts.protocols_exist&&facts.protocols_complete?'COMPLETE':'MISSING','protocols'),
+  ];
+  const blockers=packageReadinessBlockers(items);
+  return {items,executionReady:blockers.length===0,blockers};
+}
+
+const packageUpdateSchema=z.object({
+  rowVersion:z.number().int().positive(),commitOrReleaseIdentifier:z.string().max(240).nullable().optional(),
+  productionDeploymentDate:z.string().date().nullable().optional(),validationEnvironment:z.string().min(1).optional(),
+  productionEnvironmentReference:z.string().min(1).optional(),environmentDifferences:z.string().max(10000).nullable().optional(),
+  softwareOwnerEmployeeId:z.number().int().positive().nullable().optional(),qualityOwnerEmployeeId:z.number().int().positive().nullable().optional(),
+  validationLeadEmployeeId:z.number().int().positive().nullable().optional(),
+  auditReadinessAssessmentId:z.string().uuid().nullable().optional(),notes:z.string().max(20000).nullable().optional(),
+});
+router.patch('/:id',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const v=packageUpdateSchema.parse(req.body),a=actor(req);
+  const ownerIds=[v.softwareOwnerEmployeeId,v.qualityOwnerEmployeeId,v.validationLeadEmployeeId].filter((x):x is number=>Boolean(x));
+  if(ownerIds.length){
+    const active=await query(`SELECT id FROM employees WHERE id=ANY($1::int[]) AND is_active=true`,[ownerIds]);
+    const activeIds=new Set(active.map(x=>Number(x.id))),invalid=ownerIds.filter(x=>!activeIds.has(x));
+    if(invalid.length)return res.status(409).json({error:'INACTIVE_EMPLOYEE_ASSIGNMENT',fields:invalid});
+  }
+  if(v.auditReadinessAssessmentId&&!(await query(`SELECT 1 FROM qms_audit_readiness_assessments WHERE id=$1`,[v.auditReadinessAssessmentId])).length)
+    return res.status(409).json({error:'AUDIT_READINESS_ASSESSMENT_NOT_FOUND',field:'auditReadinessAssessmentId'});
+  const identifierChanged=v.commitOrReleaseIdentifier!==undefined&&v.commitOrReleaseIdentifier!==p.commit_or_release_identifier;
+  const dateChanged=v.productionDeploymentDate!==undefined&&v.productionDeploymentDate!==p.production_deployment_date;
+  const updated=(await query(`UPDATE qms_epoch_validation_packages SET
+    commit_or_release_identifier=CASE WHEN $1 THEN $2 ELSE commit_or_release_identifier END,
+    production_deployment_date=CASE WHEN $3 THEN $4::date ELSE production_deployment_date END,
+    validation_environment=COALESCE($5,validation_environment),production_environment_reference=COALESCE($6,production_environment_reference),
+    environment_differences=CASE WHEN $7 THEN $8 ELSE environment_differences END,
+    software_owner_employee_id=CASE WHEN $9 THEN $10 ELSE software_owner_employee_id END,
+    quality_owner_employee_id=CASE WHEN $11 THEN $12 ELSE quality_owner_employee_id END,
+    validation_lead_employee_id=CASE WHEN $13 THEN $14 ELSE validation_lead_employee_id END,
+    audit_readiness_assessment_id=CASE WHEN $15 THEN $16::uuid ELSE audit_readiness_assessment_id END,
+    audit_readiness_not_applicable=CASE WHEN $15 AND $16::uuid IS NOT NULL THEN false ELSE audit_readiness_not_applicable END,
+    notes=CASE WHEN $17 THEN $18 ELSE notes END,
+    deployment_date_confirmed=CASE WHEN $19 THEN false ELSE deployment_date_confirmed END,
+    deployment_date_confirmed_by_user_id=CASE WHEN $19 THEN NULL ELSE deployment_date_confirmed_by_user_id END,
+    deployment_date_confirmed_by_display_name=CASE WHEN $19 THEN NULL ELSE deployment_date_confirmed_by_display_name END,
+    deployment_date_confirmed_at=CASE WHEN $19 THEN NULL ELSE deployment_date_confirmed_at END,
+    row_version=row_version+1,revision=revision+1,updated_by_user_id=$20,updated_by_display_name=$21,updated_at=now()
+    WHERE id=$22 AND row_version=$23 RETURNING *`,
+    [v.commitOrReleaseIdentifier!==undefined,v.commitOrReleaseIdentifier??null,v.productionDeploymentDate!==undefined,v.productionDeploymentDate??null,
+     v.validationEnvironment,v.productionEnvironmentReference,v.environmentDifferences!==undefined,v.environmentDifferences??null,
+     v.softwareOwnerEmployeeId!==undefined,v.softwareOwnerEmployeeId??null,v.qualityOwnerEmployeeId!==undefined,v.qualityOwnerEmployeeId??null,
+     v.validationLeadEmployeeId!==undefined,v.validationLeadEmployeeId??null,v.auditReadinessAssessmentId!==undefined,v.auditReadinessAssessmentId??null,
+     v.notes!==undefined,v.notes??null,identifierChanged||dateChanged,a.id,a.name,p.id,v.rowVersion]))[0];
+  if(!updated)return res.status(409).json({error:'STALE_RECORD'});
+  await invalidateApprovals(p.id,'Validation package fields changed');
+  await logEvent(req,updated,'PACKAGE','PACKAGE_FIELDS_UPDATED',{previous:p,next:updated});
+  res.json({package:updated,readiness:await packageReadiness(updated)});
+});
+router.post('/:id/confirm-deployment-date',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const a=actor(req);
+  if(!productionIdentifierStatus(p.commit_or_release_identifier).valid||!p.production_deployment_date)
+    return res.status(409).json({error:'DEPLOYMENT_CONFIRMATION_BLOCKED',fields:['commitOrReleaseIdentifier','productionDeploymentDate']});
+  const updated=(await query(`UPDATE qms_epoch_validation_packages SET deployment_date_confirmed=true,
+    deployment_date_confirmed_by_user_id=$1,deployment_date_confirmed_by_display_name=$2,deployment_date_confirmed_at=now(),
+    row_version=row_version+1,updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3 RETURNING *`,[a.id,a.name,p.id]))[0];
+  await logEvent(req,updated,'PACKAGE','DEPLOYMENT_DATE_CONFIRMED',{next:{confirmed:true}});res.json(updated);
+});
+router.post('/:id/confirm-environment-separation',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const a=actor(req);
+  if(String(p.environment_differences||'').trim().length<10)return res.status(409).json({error:'ENVIRONMENT_DIFFERENCES_REQUIRED',field:'environmentDifferences'});
+  const updated=(await query(`UPDATE qms_epoch_validation_packages SET environment_separation_confirmed=true,
+    environment_separation_confirmed_by_user_id=$1,environment_separation_confirmed_by_display_name=$2,environment_separation_confirmed_at=now(),
+    row_version=row_version+1,updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3 RETURNING *`,[a.id,a.name,p.id]))[0];
+  await logEvent(req,updated,'PACKAGE','ENVIRONMENT_SEPARATION_CONFIRMED',{next:{confirmed:true}});res.json(updated);
+});
+router.post('/:id/audit-readiness-na',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),async(req,res)=>{
+  const p=await editable(req,res);if(!p)return;const body=z.object({justification:z.string().min(20)}).parse(req.body),a=actor(req);
+  if(p.audit_readiness_assessment_id)return res.status(409).json({error:'ASSESSMENT_ALREADY_LINKED'});
+  const updated=(await query(`UPDATE qms_epoch_validation_packages SET audit_readiness_not_applicable=true,
+    audit_readiness_na_justification=$1,audit_readiness_na_approved_by_user_id=$2,audit_readiness_na_approved_by_display_name=$3,
+    audit_readiness_na_approved_at=now(),row_version=row_version+1,updated_by_user_id=$2,updated_by_display_name=$3,updated_at=now()
+    WHERE id=$4 RETURNING *`,[body.justification,a.id,a.name,p.id]))[0];
+  await logEvent(req,updated,'PACKAGE','AUDIT_READINESS_NOT_APPLICABLE_APPROVED',{reason:body.justification});res.json(updated);
+});
+
 async function counts(packageId:string):Promise<ReadinessCounts>{
   const r=(await query(`SELECT
     EXISTS(SELECT 1 FROM qms_epoch_validation_intended_use_revisions u WHERE u.package_id=$1 AND u.approval_status='APPROVED') intended_use,
@@ -154,7 +272,7 @@ async function detail(packageId:string){
   ]);
   const c=await counts(packageId),r=calculateReadiness(c);
   return {package:p,intendedUse,requirements,risks,plans,protocols,executions,defects,approvals,periodicReviews:reviews,events,
-    readiness:{...c,...r}};
+    readiness:{...c,...r},packageReadiness:await packageReadiness(p)};
 }
 router.get('/:id',requirePermission('EPOCH_VALIDATION_VIEW'),async(req,res)=>{
   const d=await detail(uuid.parse(req.params.id)); if(!d)return res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});res.json(d);
@@ -167,6 +285,10 @@ router.post('/:id/status',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,r
   const body=z.object({status:z.string(),reason:z.string().min(3)}).parse(req.body);
   if(!canTransition(p.status as ValidationStatus,body.status as ValidationStatus))
     return res.status(409).json({error:'ILLEGAL_STATUS_TRANSITION',from:p.status,to:body.status});
+  if(['PLAN_APPROVED','TESTING','RETESTING','READY_FOR_FINAL_REVIEW'].includes(body.status)){
+    const gate=await packageReadiness(p);
+    if(!gate.executionReady)return res.status(409).json({error:'PACKAGE_STATUS_READINESS_BLOCKED',blockers:gate.blockers});
+  }
   if(body.status==='TESTING'&&!await query(`SELECT 1 FROM qms_epoch_validation_plans WHERE package_id=$1 AND status='APPROVED'`,[p.id]).then(x=>x.length))
     return res.status(409).json({error:'VALIDATION_PLAN_APPROVAL_REQUIRED'});
   if(body.status==='READY_FOR_FINAL_REVIEW'){
@@ -351,6 +473,8 @@ router.post('/:id/protocols/:recordId/approve',requirePermission('EPOCH_VALIDATI
 
 router.post('/:id/protocols/:recordId/executions',requirePermission('EPOCH_VALIDATION_TEST_EXECUTE'),async(req,res)=>{
   const p=await editable(req,res);if(!p)return;const protocolId=uuid.parse(req.params.recordId),a=actor(req);
+  const packageGate=await packageReadiness(p);
+  if(!packageGate.executionReady)return res.status(409).json({error:'PACKAGE_EXECUTION_READINESS_BLOCKED',blockers:packageGate.blockers});
   if(!['PLAN_APPROVED','TESTING','TESTING_BLOCKED','RETESTING','CORRECTIONS_REQUIRED'].includes(p.status))
     return res.status(409).json({error:'FORMAL_TEST_EXECUTION_NOT_ALLOWED',message:'The Validation Plan must be approved before execution.'});
   const protocol=(await query('SELECT * FROM qms_epoch_validation_protocols WHERE id=$1 AND package_id=$2',[protocolId,p.id]))[0];
@@ -492,6 +616,18 @@ router.post('/:id/final-approvals',requirePermission('EPOCH_VALIDATION_FINAL_APP
   const body=z.object({approvalRole:z.enum(['EPOCH_IT_OWNER','VALIDATION_LEAD','QUALITY_APPROVER','PROCESS_OWNER','TOP_MANAGEMENT']),
     outcome:z.enum(['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS','REJECTED','RETURNED_FOR_CORRECTION']),
     comments:z.string().min(1),approvedLimitations:z.string().optional()}).parse(req.body);
+  const packageGate=await packageReadiness(p);
+  if(!packageGate.executionReady)return res.status(409).json({error:'PACKAGE_FINAL_READINESS_BLOCKED',blockers:packageGate.blockers});
+  const incompleteProtocols=await query(`SELECT p.test_id,
+    NOT EXISTS(SELECT 1 FROM qms_epoch_validation_executions e WHERE e.protocol_id=p.id
+      AND e.overall_result IN ('PASSED','PASSED_WITH_APPROVED_DEVIATION')
+      AND e.review_decision='APPROVED' AND e.snapshot_checksum IS NOT NULL) incomplete
+    FROM qms_epoch_validation_protocols p WHERE p.package_id=$1 AND p.status='APPROVED'`,[p.id]);
+  const missing=incompleteProtocols.filter(x=>x.incomplete).map(x=>x.test_id);
+  if(missing.length)return res.status(409).json({error:'PROTOCOL_EXECUTION_OR_REVIEW_INCOMPLETE',protocols:missing});
+  const unresolvedDeviations=await query(`SELECT execution_id FROM qms_epoch_validation_executions
+    WHERE package_id=$1 AND overall_result='PASSED_WITH_APPROVED_DEVIATION' AND review_decision<>'APPROVED'`,[p.id]);
+  if(unresolvedDeviations.length)return res.status(409).json({error:'UNRESOLVED_PROTOCOL_DEVIATIONS',executions:unresolvedDeviations.map(x=>x.execution_id)});
   const finalCounts=await counts(p.id); finalCounts.approvalsCurrent=true;
   const r=calculateReadiness(finalCounts);
   if(!r.ready&&body.outcome.startsWith('APPROVED'))return res.status(409).json({error:'FINAL_READINESS_BLOCKED',...r});

--- a/server/src/services/epochSoftwareValidation.ts
+++ b/server/src/services/epochSoftwareValidation.ts
@@ -87,3 +87,33 @@ export function calculateReadiness(counts: ReadinessCounts) {
 export function checksum(value: unknown) {
   return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');
 }
+
+const PLACEHOLDER_NOTES = /^(?:n\/?a|none|test|tbd)$/i;
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+const RELEASE_TAG = /^(?:v|release[-_/])?[0-9]+\.[0-9]+(?:\.[0-9]+)?(?:[-+][0-9a-z.-]+)?$/i;
+const DEPLOYMENT_ID = /^(?=.*\d)(?=.*[-_:])[a-z0-9][a-z0-9._:/-]{7,}$/i;
+const PR_ONLY = /^(?:merged\s+)?pull\s+request\s+#?\d+$/i;
+
+export function productionIdentifierStatus(value: unknown) {
+  const identifier=String(value??'').trim();
+  if(!identifier)return {valid:false,code:'PRODUCTION_IDENTIFIER_MISSING'};
+  if(PR_ONLY.test(identifier)||/^#?\d+$/.test(identifier))
+    return {valid:false,code:'PRODUCTION_IDENTIFIER_AMBIGUOUS'};
+  return {valid:FULL_SHA.test(identifier)||RELEASE_TAG.test(identifier)||DEPLOYMENT_ID.test(identifier),
+    code:'PRODUCTION_IDENTIFIER_INVALID'};
+}
+
+export function hasMeaningfulNotes(value: unknown) {
+  const notes=String(value??'').trim();
+  return notes.length>=20&&!PLACEHOLDER_NOTES.test(notes);
+}
+
+export type PackageReadinessItem = {
+  key:string;label:string;state:'COMPLETE'|'MISSING'|'REQUIRES_CONFIRMATION'|'NOT_APPLICABLE';
+  field:string;message?:string;
+};
+
+export function packageReadinessBlockers(items:PackageReadinessItem[]) {
+  return items.filter(item=>item.state==='MISSING'||item.state==='REQUIRES_CONFIRMATION')
+    .map(item=>({field:item.field,code:`${item.key}_INCOMPLETE`,message:item.message||`${item.label} is incomplete.`}));
+}


### PR DESCRIPTION
## Summary
- add additive package-readiness metadata and authenticated deployment/environment confirmations
- validate exact production identifiers, active owner assignments, meaningful notes, environment differences, and Audit Readiness linkage or authorized N/A
- expose an actionable Package readiness panel and controlled edit workflow
- fail closed before execution/status advancement/final approval when package or protocol evidence is incomplete or failed
- preserve all existing packages, identifiers, owners, evidence, approvals, and DRAFT status

## Scope and safety
- adds migration `0234_epoch_validation_readiness_controls.sql`; migration `0229` is unchanged
- coexists with main's `0233_part_specification_sheet_control.sql` in both safe-boot lists
- no package rows are inserted, updated, deleted, or backfilled by the migration
- no fabricated evidence, approvals, owner assignments, or confirmations
- no source QMS record module is mutated by validation-package editing

## Verification
- rebased onto current `main` at `acc0bebe2bb77cd9d96e7d0d310e128a795837d3`
- `git diff --check` — passed
- conflict-marker scan across changed files — passed
- pure service readiness assertions via Node TypeScript stripping — passed
- focused static server/client architecture assertions added
- migration registered after `0233_part_specification_sheet_control.sql` in both safe-boot lists
- production route opened in browser, but the existing authenticated session expired to Login before package-level inspection; no production data was changed

## Local runner limits
- focused Vitest/migration-safety execution was blocked by the existing shared workspace dependency tree: Vite could not resolve a broken Rollup junction
- full TypeScript check reached the existing 2 GB Node heap limit; an alternate type-root attempt likewise exhausted memory
- focused Prettier check flags the pre-existing compact style of the touched legacy files; new test files pass formatting

CI should be treated as required before review/merge.