### PR TITLE
Prevent missing form templates from crashing Design Control

### DIFF
--- a/client/src/components/design-control/ProjectFormInstancesPanel.tsx
+++ b/client/src/components/design-control/ProjectFormInstancesPanel.tsx
@@ -53,6 +53,16 @@ type Props = {
   oversightMode?: boolean;
 };
 
+type TemplateReadiness = {
+  stepKey: string;
+  ready: boolean;
+  reason: string | null;
+  errorCode?: string;
+  templateKey: string | null;
+  templateRevisionId: string | null;
+  documentRevisionId: string | null;
+};
+
 const emptyContent = (): ProjectFormContent => ({
   fields: {},
   sections: {},
@@ -98,6 +108,9 @@ export function ProjectFormInstancesPanel({
   const { can } = usePermissions();
   const [catalog, setCatalog] = useState<DesignControlFormDefinition[]>([]);
   const [forms, setForms] = useState<ProjectFormInstance[]>([]);
+  const [templateReadiness, setTemplateReadiness] = useState<
+    Map<string, TemplateReadiness>
+  >(new Map());
   const [editing, setEditing] = useState<ProjectFormInstance | null>(null);
   const [content, setContent] = useState<ProjectFormContent>(emptyContent);
   const [message, setMessage] = useState('');
@@ -108,15 +121,19 @@ export function ProjectFormInstancesPanel({
   );
 
   const load = async () => {
-    const [catalogResponse, formsResponse] = await Promise.all([
-      fetch('/api/design-control-form-templates/catalog', {
-        credentials: 'include',
-      }),
-      fetch(`/api/design-control/${recordId}/forms`, {
-        credentials: 'include',
-      }),
-    ]);
-    if (!catalogResponse.ok || !formsResponse.ok) {
+    const [catalogResponse, formsResponse, readinessResponse] =
+      await Promise.all([
+        fetch('/api/design-control-form-templates/catalog', {
+          credentials: 'include',
+        }),
+        fetch(`/api/design-control/${recordId}/forms`, {
+          credentials: 'include',
+        }),
+        fetch(`/api/design-control/${recordId}/forms/template-readiness`, {
+          credentials: 'include',
+        }),
+      ]);
+    if (!catalogResponse.ok || !formsResponse.ok || !readinessResponse.ok) {
       throw new Error('Unable to load controlled Project Form Instances');
     }
     const definitions =
@@ -125,6 +142,12 @@ export function ProjectFormInstancesPanel({
       definitions.filter((item) => item.formCategory === 'DESIGN_CONTROL_STEP')
     );
     setForms(await formsResponse.json());
+    const readiness = (await readinessResponse.json()) as {
+      steps: TemplateReadiness[];
+    };
+    setTemplateReadiness(
+      new Map(readiness.steps.map((item) => [item.stepKey, item]))
+    );
   };
 
   useEffect(() => {
@@ -168,7 +191,7 @@ export function ProjectFormInstancesPanel({
       return payload;
     } catch (error: any) {
       setMessage(error.message);
-      throw error;
+      return null;
     } finally {
       setBusy(false);
     }
@@ -230,7 +253,7 @@ export function ProjectFormInstancesPanel({
 
   const saveDraft = async () => {
     if (!editing) return;
-    await mutate(
+    const result = await mutate(
       `/api/project-forms/${editing.id}/draft`,
       {
         method: 'PATCH',
@@ -241,7 +264,7 @@ export function ProjectFormInstancesPanel({
       },
       'Draft saved with audit evidence'
     );
-    setEditing(null);
+    if (result) setEditing(null);
   };
 
   const uploadPaper = async (file: File) => {
@@ -255,12 +278,12 @@ export function ProjectFormInstancesPanel({
         originalRemainsAuthoritative: true,
       })
     );
-    await mutate(
+    const result = await mutate(
       `/api/project-forms/${paperTarget.id}/upload-paper`,
       { method: 'POST', body },
       'Immutable original paper scan uploaded'
     );
-    setPaperTarget(null);
+    if (result) setPaperTarget(null);
   };
 
   return (
@@ -277,7 +300,7 @@ export function ProjectFormInstancesPanel({
         <Button
           variant="outline"
           size="sm"
-          onClick={() => load()}
+          onClick={() => load().catch((error) => setMessage(error.message))}
           disabled={busy}
         >
           <RefreshCw className="mr-2 h-4 w-4" />
@@ -292,6 +315,9 @@ export function ProjectFormInstancesPanel({
         )}
         {catalog.map((definition) => {
           const form = formsByStep.get(definition.workflowStepKey ?? '');
+          const readiness = templateReadiness.get(
+            definition.workflowStepKey ?? ''
+          );
           return (
             <div
               key={definition.templateKey}
@@ -304,7 +330,9 @@ export function ProjectFormInstancesPanel({
                 <div className="text-xs text-muted-foreground">
                   {form
                     ? `${form.instanceNumber} · ${form.completionMethod} · template Rev ${form.templateRevisionSnapshot}`
-                    : `${definition.documentNumber} · released template required`}
+                    : readiness?.ready
+                      ? `${definition.documentNumber} · released template ready`
+                      : `${definition.documentNumber} · ${readiness?.reason ?? 'released template readiness unavailable'}`}
                 </div>
               </div>
               <div className="flex flex-wrap items-center gap-2">
@@ -315,7 +343,7 @@ export function ProjectFormInstancesPanel({
                 >
                   {form?.lifecycleStatus ?? 'NOT STARTED'}
                 </Badge>
-                {!form && can('design.forms.create') && (
+                {!form && can('design.forms.create') && readiness?.ready && (
                   <>
                     <Button
                       size="sm"
@@ -334,6 +362,19 @@ export function ProjectFormInstancesPanel({
                       Paper
                     </Button>
                   </>
+                )}
+                {!form && can('design.forms.create') && !readiness?.ready && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled
+                    title={
+                      readiness?.reason ??
+                      'A released template revision is required'
+                    }
+                  >
+                    Template not released
+                  </Button>
                 )}
                 {form &&
                   form.completionMethod === 'ELECTRONIC' &&

--- a/server/__tests__/projectFormTemplateReadinessUi.test.ts
+++ b/server/__tests__/projectFormTemplateReadinessUi.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+const read = (relative: string) =>
+  readFileSync(join(process.cwd(), relative), 'utf8');
+
+describe('Project Form template readiness UI', () => {
+  it('publishes per-step released-template readiness through the Design Control route', () => {
+    const routes = read('server/src/routes/projectForms.ts');
+    const service = read('server/src/services/projectFormInstanceService.ts');
+
+    expect(routes).toContain('/:recordId/forms/template-readiness');
+    expect(routes).toContain("requirePermission('design.forms.view')");
+    expect(service).toContain('getProjectFormTemplateReadiness');
+    expect(service).toContain('selectableTemplateForStep(stepKey, client)');
+    expect(service).toContain('ready: false');
+    expect(service).toContain('reason: error.message');
+  });
+
+  it('keeps missing-template API errors inside the panel instead of rethrowing globally', () => {
+    const panel = read(
+      'client/src/components/design-control/ProjectFormInstancesPanel.tsx'
+    );
+
+    expect(panel).toContain('/forms/template-readiness');
+    expect(panel).toContain('setMessage(error.message)');
+    expect(panel).toContain('return null');
+    expect(panel).not.toContain('throw error;');
+  });
+
+  it('disables instance creation until the exact released template is ready', () => {
+    const panel = read(
+      'client/src/components/design-control/ProjectFormInstancesPanel.tsx'
+    );
+
+    expect(panel).toContain("readiness?.ready &&");
+    expect(panel).toContain("!readiness?.ready &&");
+    expect(panel).toContain('Template not released');
+    expect(panel).toContain('released template ready');
+  });
+});

--- a/server/src/routes/projectForms.ts
+++ b/server/src/routes/projectForms.ts
@@ -17,6 +17,7 @@ import {
   decideProjectForm,
   getProjectForm,
   getProjectFormReleaseReadiness,
+  getProjectFormTemplateReadiness,
   listProjectForms,
   ProjectFormError,
   renderProjectForm,
@@ -137,6 +138,17 @@ designControlProjectFormsRouter.get(
   async (req, res) => {
     try {
       res.json(await getProjectFormReleaseReadiness(req.params.recordId));
+    } catch (error) {
+      sendError(res, error);
+    }
+  }
+);
+designControlProjectFormsRouter.get(
+  '/:recordId/forms/template-readiness',
+  requirePermission('design.forms.view'),
+  async (req, res) => {
+    try {
+      res.json(await getProjectFormTemplateReadiness(req.params.recordId));
     } catch (error) {
       sendError(res, error);
     }

--- a/server/src/services/projectFormInstanceService.ts
+++ b/server/src/services/projectFormInstanceService.ts
@@ -204,6 +204,40 @@ async function selectableTemplateForStep(stepKey: string, client: any) {
   return { template, revision, documentRevision };
 }
 
+export async function getProjectFormTemplateReadiness(
+  recordId: string,
+  client: any = db
+) {
+  await authoritativeContext(recordId, '1', client);
+  const steps = [];
+  for (let index = 1; index <= 12; index += 1) {
+    const stepKey = String(index);
+    try {
+      const selection = await selectableTemplateForStep(stepKey, client);
+      steps.push({
+        stepKey,
+        ready: true,
+        reason: null,
+        templateKey: selection.template.templateKey,
+        templateRevisionId: selection.revision.id,
+        documentRevisionId: selection.documentRevision.id,
+      });
+    } catch (error) {
+      if (!(error instanceof ProjectFormError)) throw error;
+      steps.push({
+        stepKey,
+        ready: false,
+        reason: error.message,
+        errorCode: error.code,
+        templateKey: null,
+        templateRevisionId: null,
+        documentRevisionId: null,
+      });
+    }
+  }
+  return { steps };
+}
+
 async function loadInstance(instanceId: string, client: any) {
   const [instance] = await client
     .select()


### PR DESCRIPTION
## Summary

- expose exact released-template readiness for each of the 12 Design Control steps
- disable Project Form creation when the mapped template or MDR revision is not released
- display the server readiness reason in the Design Control panel
- retain handled API failures inside the panel instead of rethrowing them to the global application error screen
- preserve the edit and paper-upload dialogs when their save operation fails

## Root cause

Phase 5 correctly rejected Project Form creation when a step lacked an active released template revision. The client still displayed enabled Electronic and Paper creation buttons and rethrew the handled API error. That rejected event promise reached the global error handler and replaced the application with the Application Error screen.

## Validation

- server route, service, and focused-test TypeScript syntax checks passed
- touched TSX component transpilation passed with esbuild
- `git diff --check` and `git diff --cached --check` passed
- focused Vitest execution was attempted but blocked by the existing shared dependency installation missing `rollup`; a bounded dependency repair also failed to restore that external test runner

## Scope

- no template lifecycle rules were weakened
- no automatic template approval or release was added
- no P2 route, project, PO, traveler, work-order, or manufacturing behavior changed
