### PR TITLE
Fix missing spec_sheets production boot migration

### DIFF
--- a/migrations/0233a_spec_sheets_base_table.sql
+++ b/migrations/0233a_spec_sheets_base_table.sql
@@ -1,0 +1,52 @@
+-- Additive production repair for deployments that received the document
+-- management routes without the original spec_sheets base table.
+-- This must run before 0233_part_specification_sheet_control.sql, which
+-- extends spec_sheets with the controlled revision workflow.
+
+CREATE TABLE IF NOT EXISTS spec_sheets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  part_routing_id UUID,
+  part_number VARCHAR(255),
+  title VARCHAR(500) NOT NULL,
+  description TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  source_type VARCHAR(50) NOT NULL DEFAULT 'uploaded',
+  file_url TEXT,
+  file_name VARCHAR(500),
+  file_type VARCHAR(100),
+  file_size INTEGER,
+  specifications JSONB,
+  ai_extracted_content JSONB,
+  ai_extracted_fields JSONB,
+  ai_processed_at TIMESTAMPTZ,
+  is_template BOOLEAN DEFAULT false,
+  is_active BOOLEAN DEFAULT true,
+  created_by VARCHAR(255),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Repair partially-created legacy tables without replacing or deleting data.
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS part_routing_id UUID;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS part_number VARCHAR(255);
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS title VARCHAR(500);
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS description TEXT;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS version INTEGER DEFAULT 1;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS source_type VARCHAR(50) DEFAULT 'uploaded';
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS file_url TEXT;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS file_name VARCHAR(500);
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS file_type VARCHAR(100);
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS file_size INTEGER;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS specifications JSONB;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS ai_extracted_content JSONB;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS ai_extracted_fields JSONB;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS ai_processed_at TIMESTAMPTZ;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS is_template BOOLEAN DEFAULT false;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS is_active BOOLEAN DEFAULT true;
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS created_by VARCHAR(255);
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE spec_sheets ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS spec_sheets_part_routing_idx ON spec_sheets(part_routing_id);
+CREATE INDEX IF NOT EXISTS spec_sheets_part_number_idx ON spec_sheets(part_number);

--- a/server/__tests__/specSheetsSafeBootMigration.test.ts
+++ b/server/__tests__/specSheetsSafeBootMigration.test.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  criticalMigrationFiles,
+  safeMigrationFiles,
+} from '../scripts/migrations/runSafeBootMigrations';
+
+const migrationName = '0233a_spec_sheets_base_table.sql';
+const controlledMigrationName = '0233_part_specification_sheet_control.sql';
+const root = path.resolve(__dirname, '../..');
+const migration = fs.readFileSync(
+  path.join(root, 'migrations', migrationName),
+  'utf8'
+);
+
+describe('spec_sheets safe-boot prerequisite', () => {
+  it('creates the legacy base table additively with the columns used by the schema', () => {
+    expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS spec_sheets/i);
+    for (const column of [
+      'id',
+      'part_routing_id',
+      'part_number',
+      'title',
+      'version',
+      'source_type',
+      'specifications',
+      'is_active',
+      'created_at',
+      'updated_at',
+    ]) {
+      expect(migration).toMatch(new RegExp(`\\b${column}\\b`, 'i'));
+    }
+    expect(migration).not.toMatch(/\b(DROP|TRUNCATE|DELETE)\b/i);
+  });
+
+  it('runs as a critical migration before the controlled spec-sheet migration', () => {
+    const baseIndex = safeMigrationFiles.indexOf(migrationName);
+    const controlledIndex = safeMigrationFiles.indexOf(controlledMigrationName);
+
+    expect(baseIndex).toBeGreaterThanOrEqual(0);
+    expect(controlledIndex).toBeGreaterThan(baseIndex);
+    expect(criticalMigrationFiles.has(migrationName)).toBe(true);
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -263,6 +263,7 @@ export const safeMigrationFiles = [
   '0231_quality_action_change_control.sql',
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
+  '0233a_spec_sheets_base_table.sql',
   '0233_part_specification_sheet_control.sql',
   '0234_epoch_validation_readiness_controls.sql',
   'investigation_308_order_duplication.sql',
@@ -310,6 +311,7 @@ export const criticalMigrationFiles = new Set([
   '0231_quality_action_change_control.sql',
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
+  '0233a_spec_sheets_base_table.sql',
   '0233_part_specification_sheet_control.sql',
   '0234_epoch_validation_readiness_controls.sql',
 ]);


### PR DESCRIPTION
## What changed
- add an idempotent base migration for the legacy `spec_sheets` table
- register the prerequisite as a critical safe-boot migration before `0233_part_specification_sheet_control.sql`
- add a regression test for additive SQL and migration ordering

## Root cause
The document-management feature added the `spec_sheets` application schema and routes without a SQL migration that created the base table. Production safe boot now runs migration `0233`, which attempts to alter `spec_sheets` and fails when the table is absent. Route registration consequently remains unavailable and login returns 503.

## Impact
After this PR is merged and EPOCH is redeployed or restarted in Replit, safe boot can create the missing table and continue through the controlled specification-sheet migration. Existing tables and rows are preserved.

## Validation
- static safe-boot ordering check passed
- destructive-SQL contract check passed
- `git diff --check` passed
- focused Vitest unavailable because dependencies are not installed in the clean worktree
- live PostgreSQL migration execution not performed; the production database identity and credentials were not available locally