### PR TITLE
Reconcile P2 shipment and scheduling counts

### DIFF
--- a/client/src/__tests__/p2ShippingUnitStatus.test.ts
+++ b/client/src/__tests__/p2ShippingUnitStatus.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { isHistoricalP2InventoryUnit } from '../lib/p2ShippingUnitStatus';
+
+describe('isHistoricalP2InventoryUnit', () => {
+  it('excludes completed non-finalized inventory records from active production', () => {
+    expect(isHistoricalP2InventoryUnit({
+      status: 'COMPLETED',
+      currentDepartment: 'Inventory',
+      finalizedAt: null,
+    })).toBe(true);
+  });
+
+  it('keeps active QC and finalized inventory out of the historical bucket', () => {
+    expect(isHistoricalP2InventoryUnit({
+      status: 'ACTIVE',
+      currentDepartment: 'Quality Control',
+      finalizedAt: null,
+    })).toBe(false);
+    expect(isHistoricalP2InventoryUnit({
+      status: 'COMPLETED',
+      currentDepartment: 'Inventory',
+      finalizedAt: '2026-07-31T12:00:00Z',
+    })).toBe(false);
+  });
+});

--- a/client/src/components/p2/P2ShippingTab.tsx
+++ b/client/src/components/p2/P2ShippingTab.tsx
@@ -40,6 +40,7 @@ import { queryClient, apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import ShipmentSummaryModal from './ShipmentSummaryModal';
 import P2InvoicePreviewButton from './P2InvoicePreviewButton';
+import { isHistoricalP2InventoryUnit } from '@/lib/p2ShippingUnitStatus';
 
 type SerializedUnit = {
   id: string;
@@ -304,6 +305,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
         };
       }
       groups[key].units.push(unit);
+      if (isHistoricalP2InventoryUnit(unit)) continue;
       groups[key].totalUnits++;
       if (unit.finalizedAt && unit.sku && unit.drawingName) {
         groups[key].finalizedCount++;
@@ -672,10 +674,11 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
   const summary = useMemo(() => {
     let totalUnits = 0, finalized = 0, readyToShip = 0, needsFinalization = 0;
     for (const g of poGroups) {
-      totalUnits += g.totalUnits;
+      const currentUnits = g.units.filter((u) => !isHistoricalP2InventoryUnit(u));
+      totalUnits += currentUnits.length;
       finalized += g.finalizedCount;
       readyToShip += g.readyToShip;
-      needsFinalization += g.units.filter(
+      needsFinalization += currentUnits.filter(
         (u) => u.completedAt && (!u.finalizedAt || !u.sku || !u.drawingName)
       ).length;
     }
@@ -940,9 +943,11 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
 
                     {/* ── Unit table grouped by status ── */}
                     {(() => {
-                      const inProductionUnits = group.units.filter((u) => !u.completedAt);
+                      const historicalInventoryUnits = group.units.filter(isHistoricalP2InventoryUnit);
+                      const currentUnits = group.units.filter((u) => !isHistoricalP2InventoryUnit(u));
+                      const inProductionUnits = currentUnits.filter((u) => !u.completedAt);
                       const needsFinalizationUnits = group.units.filter(
-                        (u) => u.completedAt && !(u.finalizedAt && u.sku && u.drawingName)
+                        (u) => !isHistoricalP2InventoryUnit(u) && u.completedAt && !(u.finalizedAt && u.sku && u.drawingName)
                       );
 
                       // Build status sections — only render non-empty ones
@@ -951,6 +956,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
                       if (needsFinalizationUnits.length > 0) sections.push({ label: 'Needs Finalization', units: needsFinalizationUnits, key: 'needs-finalization' });
                       if (shipments.length === 0 && finalizedUnits.length > 0) sections.push({ label: 'Ready to Ship', units: finalizedUnits, key: 'ready-to-ship' });
                       if (shipments.length > 0 && finalizedUnits.length > 0) sections.push({ label: 'Shipment Created', units: finalizedUnits, key: 'shipment-created' });
+                      if (historicalInventoryUnits.length > 0) sections.push({ label: 'Historical Nonconforming Inventory', units: historicalInventoryUnits, key: 'historical-inventory' });
 
                       const renderTableRows = (units: SerializedUnit[]) =>
                         units.map((unit) => {

--- a/client/src/components/p2/P2StatusDashboard.tsx
+++ b/client/src/components/p2/P2StatusDashboard.tsx
@@ -370,7 +370,7 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                           {(po.missingItems ?? po.pendingItems) > 0 && (
                             <span className="flex items-center gap-1 text-amber-600">
                               <AlertCircle className="h-3 w-3" />
-                              {po.missingItems ?? po.pendingItems} missing
+                              {po.missingItems ?? po.pendingItems} available to schedule
                             </span>
                           )}
                         </div>

--- a/client/src/lib/p2ShippingUnitStatus.ts
+++ b/client/src/lib/p2ShippingUnitStatus.ts
@@ -1,0 +1,13 @@
+export interface P2ShippingUnitStatusInput {
+  status?: string | null;
+  currentDepartment?: string | null;
+  finalizedAt?: string | Date | null;
+}
+
+const normalized = (value: unknown) => String(value ?? '').trim().toUpperCase();
+
+export function isHistoricalP2InventoryUnit(unit: P2ShippingUnitStatusInput): boolean {
+  return normalized(unit.currentDepartment) === 'INVENTORY'
+    && ['COMPLETE', 'COMPLETED', 'CLOSED'].includes(normalized(unit.status))
+    && !unit.finalizedAt;
+}

--- a/server/__tests__/p2SerializedUnitLedger.test.ts
+++ b/server/__tests__/p2SerializedUnitLedger.test.ts
@@ -93,4 +93,24 @@ describe('buildP2SerializedUnitLedger', () => {
     expect(ledger.shipped).toBe(0);
     expect(ledger.missing).toBe(1);
   });
+
+  it('treats Pending Layup placeholders as available capacity, not scheduled work', () => {
+    const ledger = buildP2SerializedUnitLedger(3, [
+      {
+        id: 'pending-1',
+        serialNumber: 'SERIAL-1',
+        status: 'ACTIVE',
+        currentDepartment: 'Pending Layup',
+      },
+      {
+        id: 'scheduled-1',
+        serialNumber: 'SERIAL-2',
+        status: 'ACTIVE',
+        currentDepartment: 'Layup',
+      },
+    ], []);
+
+    expect(ledger.scheduled).toBe(1);
+    expect(ledger.missing).toBe(2);
+  });
 });

--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { indexP2ShippedSerializedItemIds } from '../src/lib/p2ShipmentEvidence';
+import {
+  countDistinctP2DemandUnits,
+  isHistoricalP2Unit,
+} from '../src/lib/p2SchedulingReconciliation';
+
+describe('P2 shipment and scheduling reconciliation', () => {
+  it('deduplicates recovered shipment membership by PO and item id', () => {
+    const indexed = indexP2ShippedSerializedItemIds([
+      { poId: 14332, serializedItemId: 'ABC' },
+      { poId: '14332', serializedItemId: ' abc ' },
+      { poId: 14332, serializedItemId: 'DEF' },
+      { poId: null, serializedItemId: null },
+    ]);
+
+    expect([...indexed.get(14332)!]).toEqual(['abc', 'def']);
+  });
+
+  it('does not let historical scrap consume ordered demand', () => {
+    expect(isHistoricalP2Unit({ status: 'SCRAPPED' })).toBe(true);
+    expect(countDistinctP2DemandUnits([
+      { id: 'scrap-1', serialNumber: 'S-001', status: 'SCRAPPED' },
+      { id: 'remake-1', serialNumber: 'S-002', status: 'COMPLETED' },
+    ], new Set())).toBe(1);
+  });
+
+  it('counts shipped, finalization, active, and scheduled units once by serial', () => {
+    const rows = [
+      { id: 'ship-1', serialNumber: 'S-001', status: 'ACTIVE', currentDepartment: 'Inventory' },
+      { id: 'ship-duplicate', serialNumber: 'S-001', status: 'COMPLETED' },
+      { id: 'final-1', serialNumber: 'S-002', status: 'ACTIVE', finalizedAt: new Date() },
+      { id: 'active-1', serialNumber: 'S-003', status: 'ACTIVE', currentDepartment: 'Oven/Cure' },
+      { id: 'scheduled-1', serialNumber: 'S-004', status: 'ACTIVE', currentDepartment: 'Layup' },
+      { id: 'pending-1', serialNumber: 'S-005', status: 'ACTIVE', currentDepartment: 'Pending Layup' },
+    ];
+
+    expect(countDistinctP2DemandUnits(rows, new Set(['ship-1']))).toBe(4);
+  });
+
+  it('leaves nine schedulable units for the accepted PO014332-RA counts', () => {
+    const ordered = 390;
+    const consumed = 336 + 4 + 34 + 7;
+    expect(ordered - consumed).toBe(9);
+  });
+});

--- a/server/src/lib/p2SchedulingReconciliation.ts
+++ b/server/src/lib/p2SchedulingReconciliation.ts
@@ -1,0 +1,37 @@
+import type { P2SerializedUnitLedgerRow } from './p2SerializedUnitLedger';
+
+const normalized = (value: unknown) => String(value ?? '').trim().toUpperCase();
+
+export const isHistoricalP2Unit = (row: P2SerializedUnitLedgerRow) =>
+  ['SCRAP', 'SCRAPPED', 'CANCELED', 'CANCELLED', 'VOID'].includes(normalized(row.status));
+
+export function p2UnitConsumesOrderedDemand(
+  row: P2SerializedUnitLedgerRow,
+  shippedItemIds: ReadonlySet<string>,
+): boolean {
+  const id = String(row.id ?? '').trim().toLowerCase();
+  if (id && shippedItemIds.has(id)) return true;
+  if (isHistoricalP2Unit(row)) return false;
+  if (row.finalizedAt ?? row.finalized_at) return true;
+
+  const status = normalized(row.status);
+  if (['COMPLETE', 'COMPLETED', 'CLOSED'].includes(status)) return true;
+  if (status !== 'ACTIVE') return false;
+
+  const department = normalized(row.currentDepartment ?? row.current_department);
+  return department !== '' && department !== 'PENDING LAYUP';
+}
+
+export function countDistinctP2DemandUnits(
+  rows: readonly P2SerializedUnitLedgerRow[],
+  shippedItemIds: ReadonlySet<string>,
+): number {
+  const identities = new Set<string>();
+  for (const row of rows) {
+    if (!p2UnitConsumesOrderedDemand(row, shippedItemIds)) continue;
+    const serial = normalized(row.serialNumber ?? row.serial_number);
+    const id = String(row.id ?? '').trim().toLowerCase();
+    if (serial || id) identities.add(serial || `ID:${id}`);
+  }
+  return identities.size;
+}

--- a/server/src/lib/p2SerializedUnitLedger.ts
+++ b/server/src/lib/p2SerializedUnitLedger.ts
@@ -39,7 +39,7 @@ const department = (row: P2SerializedUnitLedgerRow) =>
     .replace(/\s+/g, ' ');
 
 const isScheduledDepartment = (value: string) =>
-  value === 'LAYUP' || value === 'PENDING LAYUP' || value === 'SCHEDULED';
+  value === 'LAYUP' || value === 'SCHEDULED';
 
 const isExcludedHistoricalRecord = (row: P2SerializedUnitLedgerRow) => {
   const status = normalized(row.status);
@@ -63,6 +63,7 @@ const classify = (
   if (['SCRAP', 'SCRAPPED', 'CANCELED', 'CANCELLED', 'VOID'].includes(status)) {
     return null;
   }
+  if (dept === 'PENDING LAYUP') return null;
   if (isScheduledDepartment(dept)) return 'scheduled';
   if (
     dept

--- a/server/src/lib/p2ShipmentEvidence.ts
+++ b/server/src/lib/p2ShipmentEvidence.ts
@@ -1,0 +1,62 @@
+export const P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL = `
+  WITH shipped_lots AS (
+    SELECT
+      lot.po_id,
+      COALESCE(lot.serialized_item_ids, '[]'::jsonb) AS serialized_item_ids,
+      slip.line_items
+    FROM p2_lot_numbers lot
+    LEFT JOIN p2_packing_slips slip ON slip.id = lot.packing_slip_id
+    WHERE lot.po_id = ANY($1)
+      AND (
+        COALESCE(UPPER(lot.status), '') = 'SHIPPED'
+        OR lot.shipped_at IS NOT NULL
+        OR COALESCE(UPPER(slip.status), '') = 'SHIPPED'
+      )
+  ), explicit_membership AS (
+    SELECT
+      lot.po_id AS "poId",
+      shipped_item.id AS "serializedItemId"
+    FROM shipped_lots lot
+    CROSS JOIN LATERAL jsonb_array_elements_text(lot.serialized_item_ids) AS shipped_item(id)
+  ), packing_slip_serials AS (
+    SELECT
+      lot.po_id AS "poId",
+      UPPER(TRIM(serial.value)) AS "serialNumber"
+    FROM shipped_lots lot
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE WHEN jsonb_typeof(lot.line_items) = 'array' THEN lot.line_items ELSE '[]'::jsonb END
+    ) AS line_item(value)
+    CROSS JOIN LATERAL jsonb_array_elements_text(
+      CASE
+        WHEN jsonb_typeof(line_item.value -> 'serialNumbers') = 'array'
+          THEN line_item.value -> 'serialNumbers'
+        ELSE '[]'::jsonb
+      END
+    ) AS serial(value)
+  ), packing_slip_membership AS (
+    SELECT DISTINCT
+      evidence."poId",
+      item.id::text AS "serializedItemId"
+    FROM packing_slip_serials evidence
+    JOIN p2_serialized_items item
+      ON UPPER(TRIM(item.serial_number)) = evidence."serialNumber"
+  )
+  SELECT "poId", "serializedItemId" FROM explicit_membership
+  UNION
+  SELECT "poId", "serializedItemId" FROM packing_slip_membership
+`;
+
+export function indexP2ShippedSerializedItemIds(
+  rows: readonly { poId?: unknown; serializedItemId?: unknown }[],
+): Map<number, Set<string>> {
+  const result = new Map<number, Set<string>>();
+  for (const row of rows) {
+    const poId = Number(row.poId);
+    const serializedItemId = String(row.serializedItemId ?? '').trim().toLowerCase();
+    if (!Number.isFinite(poId) || !serializedItemId) continue;
+    const ids = result.get(poId) ?? new Set<string>();
+    ids.add(serializedItemId);
+    result.set(poId, ids);
+  }
+  return result;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -21,6 +21,14 @@ import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
 import { buildP2SerializedUnitLedger } from '../lib/p2SerializedUnitLedger';
+import {
+  P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL,
+  indexP2ShippedSerializedItemIds,
+} from '../lib/p2ShipmentEvidence';
+import {
+  countDistinctP2DemandUnits,
+  isHistoricalP2Unit,
+} from '../lib/p2SchedulingReconciliation';
 import { softAuth, authenticateToken, sessionAwareAuth, requireAdminOrOwner } from '../../middleware/auth';
 import { computeEffectivePriority, getEffectivePriorityScore } from '../../../shared/utils/computeEffectivePriority';
 import employeesRoutes from './employees';
@@ -4513,6 +4521,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const familyRootId = familyRootByPoId.get(poId) ?? poId;
         return currentPoIdByFamilyRoot.get(familyRootId)?.poId ?? poId;
       };
+
       const familyPoIdsByDisplayPoId = new Map<number, number[]>();
       for (const poId of allPoIds) {
         const displayPoId = displayPoIdForPoId(poId);
@@ -4856,32 +4865,12 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const shippedSerializedItemRows = allPoIds.length > 0
         ? await optionalP2Rows(
             'shipped serialized-unit membership',
-            dbPool.query(
-              `SELECT
-                 lot.po_id AS "poId",
-                 shipped_item.id AS "serializedItemId"
-               FROM p2_lot_numbers lot
-               CROSS JOIN LATERAL jsonb_array_elements_text(
-                 COALESCE(lot.serialized_item_ids, '[]'::jsonb)
-               ) AS shipped_item(id)
-               WHERE lot.po_id = ANY($1)
-                 AND (
-                   COALESCE(UPPER(lot.status), '') = 'SHIPPED'
-                   OR lot.shipped_at IS NOT NULL
-                 )`,
-              [allPoIds]
-            )
+            dbPool.query(P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL, [allPoIds])
           )
         : [];
-      const shippedSerializedItemIdsByPoId = new Map<number, Set<string>>();
-      for (const row of shippedSerializedItemRows) {
-        const poId = Number(row.poId);
-        const serializedItemId = String(row.serializedItemId ?? '').trim().toLowerCase();
-        if (!Number.isFinite(poId) || !serializedItemId) continue;
-        const ids = shippedSerializedItemIdsByPoId.get(poId) ?? new Set<string>();
-        ids.add(serializedItemId);
-        shippedSerializedItemIdsByPoId.set(poId, ids);
-      }
+      const shippedSerializedItemIdsByPoId = indexP2ShippedSerializedItemIds(
+        shippedSerializedItemRows
+      );
       
       p2StatusStage = 'building P2 status response';
       const poStatuses = pos.map((po: any) => {
@@ -5005,6 +4994,18 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         return currentPoIdByFamilyRoot.get(familyRootId)?.poId ?? poId;
       };
 
+      const shippedMembershipRows = poFamilyRows.length > 0
+        ? p2ControlRows(await dbPool.query(
+            P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL,
+            [poFamilyRows.map((po: any) => Number(po.id)).filter(Number.isFinite)]
+          ))
+        : [];
+      const shippedItemIdsByPoId = indexP2ShippedSerializedItemIds(shippedMembershipRows);
+      const shippedItemIds = new Set<string>();
+      for (const ids of shippedItemIdsByPoId.values()) {
+        for (const id of ids) shippedItemIds.add(id);
+      }
+
       const poItemResult = await dbPool.query(
         `SELECT
            poi.id AS "poItemId",
@@ -5043,7 +5044,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const poItemId = Number(poItem.poItemId);
         const orderedQuantity = Number(poItem.orderedQuantity) || 0;
         const existingItems = serializedByPoItemId.get(poItemId) ?? [];
-        const missingCount = Math.max(0, orderedQuantity - existingItems.length);
+        const nonHistoricalItems = existingItems.filter((item: any) => !isHistoricalP2Unit(item));
+        const missingCount = Math.max(0, orderedQuantity - nonHistoricalItems.length);
 
         if (missingCount === 0) continue;
 
@@ -5059,13 +5061,6 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         (Number(a.sequenceNumber) || 0) - (Number(b.sequenceNumber) || 0) ||
         String(a.id).localeCompare(String(b.id));
 
-      const consumesCurrentRevisionCapacity = (s: any) => {
-        if (s.status === 'COMPLETED' || s.status === 'SCRAPPED') return true;
-        if (s.status !== 'ACTIVE') return false;
-        const dept = String(s.currentDepartment || '').trim();
-        return dept !== '' && dept !== 'Pending Layup';
-      };
-
       const poItemsByDisplayPoId = new Map<number, any[]>();
       for (const poItem of poItems) {
         const displayPoId = displayPoIdForPoId(Number(poItem.poId));
@@ -5077,12 +5072,13 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
       const consumedCapacityByPoItemId = new Map<number, number>();
       for (const [displayPoId, poLineItems] of poItemsByDisplayPoId.entries()) {
-        let consumedRevisionFamilyCount = (serializedItems as any[])
-          .filter((s: any) =>
-            displayPoIdForPoId(Number(s.poId)) === displayPoId &&
-            consumesCurrentRevisionCapacity(s)
-          )
-          .length;
+        const familyItems = (serializedItems as any[]).filter(
+          (s: any) => displayPoIdForPoId(Number(s.poId)) === displayPoId
+        );
+        let consumedRevisionFamilyCount = countDistinctP2DemandUnits(
+          familyItems,
+          shippedItemIds
+        );
 
         for (const poItem of poLineItems) {
           const poItemId = Number(poItem.poItemId);


### PR DESCRIPTION
## What changed

- recover shipped serialized-unit membership from shipped packing-slip serial numbers when lot membership is incomplete
- classify Pending Layup placeholders as available-to-schedule capacity rather than scheduled or active work
- exclude historical scrapped units from current ordered demand while preserving their audit records
- deduplicate revision-family demand by serial and cap the scheduling list from the same reconciled evidence
- classify completed, non-finalized Inventory rows as historical nonconforming inventory instead of active production
- label remaining capacity as available to schedule in the PO status card

## Why

PO014332-RA showed zero shipped and hundreds scheduled because historical shipped lots did not have usable serialized-item membership and Pending Layup placeholders were counted as scheduled. Completed nonconforming Inventory records were also displayed as active production.

The corrected model uses mutually exclusive serialized-unit evidence so the accepted 390-unit reconciliation can resolve to 336 shipped, 4 needing finalization, 34 active, 7 scheduled, and 9 available to schedule. Quantity alone is never used to guess shipment identity.

## Audit-trail preservation

This change does not update, delete, or rewrite any existing PO, shipment, packing-slip, scrap, nonconformance, or audit-trail record. Shipment identity recovery is read-only. The existing scheduling path may add only genuinely missing replacement unit slots; historical source records remain unchanged.

## Validation

- server reconciliation tests: 2 files, 7 tests passed
- client nonconforming-inventory tests: 1 file, 2 tests passed
- `git diff --cached --check`: passed before commit
- full `tsc --noEmit`: attempted but exceeded the 120-second validation window; not reported as a pass