### PR TITLE
Fix project form template readiness lookup

### DIFF
--- a/server/__tests__/projectFormTemplateReadinessUi.test.ts
+++ b/server/__tests__/projectFormTemplateReadinessUi.test.ts
@@ -14,6 +14,8 @@ describe('Project Form template readiness UI', () => {
     expect(routes).toContain('/:recordId/forms/template-readiness');
     expect(routes).toContain("requirePermission('design.forms.view')");
     expect(service).toContain('getProjectFormTemplateReadiness');
+    expect(service).toContain("await loadRecordStep(recordId, '1', client)");
+    expect(service).not.toContain('authoritativeContext(');
     expect(service).toContain('selectableTemplateForStep(stepKey, client)');
     expect(service).toContain('ready: false');
     expect(service).toContain('reason: error.message');

--- a/server/src/services/projectFormInstanceService.ts
+++ b/server/src/services/projectFormInstanceService.ts
@@ -208,7 +208,7 @@ export async function getProjectFormTemplateReadiness(
   recordId: string,
   client: any = db
 ) {
-  await authoritativeContext(recordId, '1', client);
+  await loadRecordStep(recordId, '1', client);
   const steps = [];
   for (let index = 1; index <= 12; index += 1) {
     const stepKey = String(index);


### PR DESCRIPTION
## Summary

- fix the Design Control template-readiness endpoint to call the existing `loadRecordStep` helper
- add a regression assertion that prevents the undefined `authoritativeContext` reference from returning

## Root cause

`getProjectFormTemplateReadiness()` called `authoritativeContext()`, but that symbol is neither defined nor imported. Every request therefore threw a runtime `ReferenceError`, which the route converted into a `500 PROJECT_FORM_OPERATION_FAILED` response.

## Impact

The Design Control workspace can load per-step template readiness again. Existing record/project/step validation remains authoritative because the endpoint now uses the same `loadRecordStep()` helper as the rest of the Project Form service.

## Validation

- `git diff --check` passed
- focused regression coverage was updated
- focused Vitest execution was unavailable because dependencies are not installed in the isolated worktree