### PR TITLE
Harden ROM Builder approvals and persistence

### DIFF
--- a/client/src/pages/RFQBuilderPage.tsx
+++ b/client/src/pages/RFQBuilderPage.tsx
@@ -400,6 +400,7 @@ export default function RFQBuilderPage() {
   const [createdQuoteId, setCreatedQuoteId] = useState<string | null>(null);
   const [createdQuoteNumber, setCreatedQuoteNumber] = useState<string | null>(null);
   const [isHandingOff, setIsHandingOff] = useState(false);
+  const [isSavingApproval, setIsSavingApproval] = useState(false);
   const [controlMessage, setControlMessage] = useState("");
   const [versionSummary, setVersionSummary] = useState("");
   const [assumptionDraft, setAssumptionDraft] = useState({
@@ -413,7 +414,6 @@ export default function RFQBuilderPage() {
   const [approvalDraft, setApprovalDraft] = useState({
     approvalRole: "ESTIMATOR",
     approvalStatus: "APPROVED",
-    signerDisplayName: "",
     digitalSignature: "",
     approvalComments: "",
   });
@@ -630,8 +630,7 @@ export default function RFQBuilderPage() {
       materialSpec: p.materialSpec, processFamily: p.processFamily,
       makeBuyType: p.makeBuyType, partType: p.partType, notes: p.notes,
     }));
-    await apiRequest(`/api/estimating/rfqs/${id}/parts`, { method: "DELETE" });
-    for (const p of valid) await apiRequest(`/api/estimating/rfqs/${id}/parts`, { method: "POST", body: p });
+    await apiRequest(`/api/estimating/rfqs/${id}/parts`, { method: "PUT", body: { parts: valid } });
   };
 
   const handleHeaderChange = (field: keyof RfqHeader, value: string) =>
@@ -1394,16 +1393,24 @@ export default function RFQBuilderPage() {
 
   const saveApproval = async () => {
     if (!rfqId) { setControlMessage("Save the RFQ before recording approvals."); return; }
-    await apiRequest(`/api/estimating/rfqs/${rfqId}/approvals`, { method: "POST", body: {
-      ...approvalDraft,
-      estimateVersionId: latestVersion?.id ?? null,
-      signerDisplayName: approvalDraft.signerDisplayName || null,
-      digitalSignature: approvalDraft.digitalSignature || null,
-      approvalComments: approvalDraft.approvalComments || null,
-    } });
-    setApprovalDraft((prev) => ({ ...prev, digitalSignature: "", approvalComments: "" }));
-    setControlMessage(`${approvalDraft.approvalRole} approval ${approvalDraft.approvalStatus.toLowerCase()} and audit event recorded.`);
-    await refreshControls();
+    setIsSavingApproval(true);
+    setControlMessage("");
+    try {
+      await apiRequest(`/api/estimating/rfqs/${rfqId}/approvals`, { method: "POST", body: {
+        approvalRole: approvalDraft.approvalRole,
+        approvalStatus: approvalDraft.approvalStatus,
+        estimateVersionId: latestVersion?.id ?? null,
+        digitalSignature: approvalDraft.digitalSignature || null,
+        approvalComments: approvalDraft.approvalComments || null,
+      } });
+      setApprovalDraft((prev) => ({ ...prev, digitalSignature: "", approvalComments: "" }));
+      setControlMessage(`${approvalDraft.approvalRole} approval ${approvalDraft.approvalStatus.toLowerCase()} under your authenticated identity.`);
+      await refreshControls();
+    } catch (error: any) {
+      setControlMessage(error?.message || `You are not authorized to record the ${approvalDraft.approvalRole} decision.`);
+    } finally {
+      setIsSavingApproval(false);
+    }
   };
 
   const ensureRiskAssessment = async () => {
@@ -1484,6 +1491,7 @@ export default function RFQBuilderPage() {
 
   const isSaving = createRfqMutation.isPending || updateRfqMutation.isPending;
   const isLoading = rfqQuery.isLoading || partsQuery.isLoading;
+  const linkedQuoteId = createdQuoteId ?? (rfqQuery.data as any)?.quoteId ?? null;
 
   // ── Render ───────────────────────────────────────────────────────────────────
 
@@ -2330,11 +2338,13 @@ export default function RFQBuilderPage() {
                   <select className="border rounded px-3 py-2 text-sm" value={approvalDraft.approvalStatus} onChange={(e) => setApprovalDraft((prev) => ({ ...prev, approvalStatus: e.target.value }))}>
                     {["PENDING", "APPROVED", "REJECTED", "CHANGES_REQUESTED"].map((status) => <option key={status} value={status}>{status}</option>)}
                   </select>
-                  <input className="border rounded px-3 py-2 text-sm" placeholder="Signer display name" value={approvalDraft.signerDisplayName} onChange={(e) => setApprovalDraft((prev) => ({ ...prev, signerDisplayName: e.target.value }))} />
+                  <div className="border rounded px-3 py-2 text-sm text-muted-foreground">Signer identity comes from your authenticated account.</div>
                   <input className="border rounded px-3 py-2 text-sm" placeholder="Digital signature / initials" value={approvalDraft.digitalSignature} onChange={(e) => setApprovalDraft((prev) => ({ ...prev, digitalSignature: e.target.value }))} />
                 </div>
                 <textarea className="w-full border rounded px-3 py-2 text-sm min-h-[64px]" placeholder="Approval comments" value={approvalDraft.approvalComments} onChange={(e) => setApprovalDraft((prev) => ({ ...prev, approvalComments: e.target.value }))} />
-                <button type="button" className="border rounded px-3 py-2 text-sm" onClick={saveApproval}>Save Approval</button>
+                <button type="button" className="border rounded px-3 py-2 text-sm disabled:opacity-50" onClick={saveApproval} disabled={isSavingApproval}>
+                  {isSavingApproval ? "Saving decision…" : "Save Approval"}
+                </button>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   {(approvalsQuery.data ?? []).map((approval) => (
                     <div key={approval.id} className="rounded border px-3 py-2 text-sm">
@@ -2415,13 +2425,18 @@ export default function RFQBuilderPage() {
                 <button
                   className="bg-primary text-primary-foreground rounded px-4 py-2 text-sm disabled:opacity-50"
                   onClick={createDraftQuoteFromRfq}
-                  disabled={!rfqId || !pricingSnapshotRows.length || isHandingOff || !releaseReadiness?.readyForQuoteRelease}
+                  disabled={!rfqId || !pricingSnapshotRows.length || isHandingOff || Boolean(linkedQuoteId) || !releaseReadiness?.readyForQuoteRelease}
                   type="button"
                 >
-                  {isHandingOff ? "Creating…" : "Create Draft Quote"}
+                  {isHandingOff ? "Creating…" : linkedQuoteId ? "Draft Quote Created" : "Create Draft Quote"}
                 </button>
               </div>
             </div>
+            {linkedQuoteId && (
+              <div className="rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">
+                Linked draft quote: {createdQuoteNumber ?? linkedQuoteId}
+              </div>
+            )}
 
             {/* Quote summary table per break */}
             {pricingMatrix.length === 0 ? (

--- a/migrations/0236_rom_builder_approval_authority.sql
+++ b/migrations/0236_rom_builder_approval_authority.sql
@@ -1,0 +1,24 @@
+-- Capability-bound authority for controlled ROM estimate approvals.
+
+INSERT INTO perm_capabilities (key, description, category) VALUES
+  ('estimating.approve.estimator', 'Record controlled estimator decisions for ROM estimates', 'estimating'),
+  ('estimating.approve.engineering', 'Record controlled engineering decisions for ROM estimates', 'engineering'),
+  ('estimating.approve.finance', 'Record controlled finance decisions for ROM estimates', 'finance'),
+  ('estimating.approve.executive', 'Record controlled executive decisions for ROM estimates', 'executive')
+ON CONFLICT (key) DO UPDATE
+SET description = EXCLUDED.description, category = EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities (role_id, capability_id)
+SELECT role.id, capability.id
+FROM perm_roles role
+JOIN perm_capabilities capability ON (
+  (role.name IN ('ADMIN', 'OWNER') AND capability.key LIKE 'estimating.approve.%') OR
+  (role.name IN ('ESTIMATOR', 'SALES', 'SALES_MANAGER', 'CONTRACTS', 'PROJECT_MANAGER', 'PROGRAM_MANAGER')
+    AND capability.key = 'estimating.approve.estimator') OR
+  (role.name IN ('ENGINEERING', 'ENGINEER', 'ENGINEERING_MANAGER', 'MANUFACTURING_ENGINEERING')
+    AND capability.key = 'estimating.approve.engineering') OR
+  (role.name IN ('FINANCE', 'FINANCE_MANAGER', 'ACCOUNTING', 'CONTROLLER')
+    AND capability.key = 'estimating.approve.finance') OR
+  (role.name = 'EXECUTIVE' AND capability.key = 'estimating.approve.executive')
+)
+ON CONFLICT (role_id, capability_id) DO NOTHING;

--- a/server/__tests__/estimatingLimitClamping.test.ts
+++ b/server/__tests__/estimatingLimitClamping.test.ts
@@ -32,8 +32,6 @@ vi.mock('../middleware/auth', () => ({
   requireRole: vi.fn(() => (_req: Request, _res: Response, next: NextFunction) => next()),
 }));
 
-vi.mock('../schema', () => ({}));
-
 import { pool } from '../db';
 
 describe('GET /api/estimating/rfqs – limit clamping', () => {

--- a/server/__tests__/romBuilderHardening.test.ts
+++ b/server/__tests__/romBuilderHardening.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
+
+describe('ROM Builder hardening', () => {
+  const route = read('server/src/routes/estimating.ts');
+  const page = read('client/src/pages/RFQBuilderPage.tsx');
+  const migration = read('migrations/0236_rom_builder_approval_authority.sql');
+
+  it('binds controlled approvals to capability-authorized authenticated actors', () => {
+    expect(route).toContain('requireEstimatingApprovalAuthority');
+    expect(route).toContain('getUserPermissions(actor.id, actor.role)');
+    expect(route).toContain('signerUserId: actor.id');
+    expect(route).toContain('signerDisplayName: actor.username');
+    expect(route).not.toContain('data.signerUserId');
+    expect(route).not.toContain('data.signerDisplayName');
+    expect(migration).toContain('estimating.approve.estimator');
+    expect(migration).toContain('estimating.approve.engineering');
+    expect(migration).toContain('estimating.approve.finance');
+    expect(migration).toContain('estimating.approve.executive');
+  });
+
+  it('replaces RFQ parts through one transactional bulk request', () => {
+    expect(route).toMatch(/router\.put\('\/rfqs\/:id\/parts'[\s\S]*?db\.transaction/);
+    expect(route).toContain('FOR UPDATE');
+    expect(page).toContain('method: "PUT", body: { parts: valid }');
+    const saveParts = page.match(/const saveParts[\s\S]*?\n  };/)?.[0] ?? '';
+    expect(saveParts).not.toContain('method: "DELETE"');
+  });
+
+  it('makes quote handoff transactional and retry-safe', () => {
+    expect(route).toMatch(/create-draft-quote'[\s\S]*?db\.transaction/);
+    expect(route).toContain('return { quoteId: existingQuote.id, quoteNumber: existingQuote.quoteNumber, reused: true }');
+    expect(route).toContain('ESTIMATING_PRICING_REQUIRED');
+    expect(route).toMatch(/recordAuditEvent\([\s\S]*?, tx\);/);
+    expect(page).toContain('Boolean(linkedQuoteId)');
+    expect(page).toContain('Draft Quote Created');
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -299,6 +299,7 @@ export const safeMigrationFiles = [
   '0234_epoch_validation_readiness_controls.sql',
   '0129a_capa_records_base_table.sql',
   '0235_quality_action_change_control.sql',
+  '0236_rom_builder_approval_authority.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -349,6 +350,7 @@ export const criticalMigrationFiles = new Set([
   '0234_epoch_validation_readiness_controls.sql',
   '0129a_capa_records_base_table.sql',
   '0235_quality_action_change_control.sql',
+  '0236_rom_builder_approval_authority.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/estimating.ts
+++ b/server/src/routes/estimating.ts
@@ -1,13 +1,19 @@
 import { Router } from 'express';
 import { z } from 'zod';
-import { pool, pgPool } from '../../db';
+import { db, pool, pgPool } from '../../db';
 import { storage } from '../../storage';
 import { DEFAULT_ESTIMATING_RFQS_LIMIT, MAX_ESTIMATING_RFQS_LIMIT } from '../constants/estimating';
 import { recordAuditEvent } from '../services/auditLedgerService';
+import { getUserPermissions } from '../services/permissionService';
+import { eq, sql } from 'drizzle-orm';
 import {
+  estimatingPricingSnapshots,
+  estimatingRfqParts,
+  estimatingRfqs,
   insertEstimatingRfqSchema,
   insertEstimatingRfqPartSchema,
   insertEstimatingToolingSchema,
+  quotes,
 } from '../../schema';
 
 const router = Router();
@@ -28,10 +34,23 @@ const approvalSchema = z.object({
   approvalRole: z.enum(['ESTIMATOR', 'ENGINEERING', 'FINANCE', 'EXECUTIVE']),
   approvalStatus: z.enum(['PENDING', 'APPROVED', 'REJECTED', 'CHANGES_REQUESTED']).default('PENDING'),
   approvalThreshold: z.union([z.string(), z.number()]).nullable().optional(),
-  signerUserId: z.number().int().nullable().optional(),
-  signerDisplayName: z.string().nullable().optional(),
-  digitalSignature: z.string().nullable().optional(),
+  digitalSignature: z.string().trim().min(1).nullable().optional(),
   approvalComments: z.string().nullable().optional(),
+});
+
+const approvalCapabilities = {
+  ESTIMATOR: 'estimating.approve.estimator',
+  ENGINEERING: 'estimating.approve.engineering',
+  FINANCE: 'estimating.approve.finance',
+  EXECUTIVE: 'estimating.approve.executive',
+} as const;
+
+const replacePartsSchema = z.object({
+  parts: z.array(
+    insertEstimatingRfqPartSchema.omit({ rfqId: true, lineNumber: true }).extend({
+      lineNumber: insertEstimatingRfqPartSchema.shape.lineNumber.optional(),
+    })
+  ),
 });
 
 const riskAssessmentSchema = z.object({
@@ -87,6 +106,27 @@ function getActor(req: any) {
     username: req.user?.username ?? req.session?.user?.username ?? null,
     role: req.user?.role ?? req.session?.user?.role ?? null,
   };
+}
+
+async function requireEstimatingApprovalAuthority(req: any, approvalRole: keyof typeof approvalCapabilities) {
+  const actor = getActor(req);
+  if (!actor.id || !actor.username || !actor.role) {
+    const error = new Error('Authenticated actor identity is required.') as Error & { status?: number; code?: string };
+    error.status = 401;
+    error.code = 'ACTOR_REQUIRED';
+    throw error;
+  }
+  const capability = approvalCapabilities[approvalRole];
+  if (actor.role !== 'ADMIN' && actor.role !== 'OWNER') {
+    const { permissionSet } = await getUserPermissions(actor.id, actor.role);
+    if (!permissionSet.has(capability)) {
+      const error = new Error(`The ${capability} capability is required.`) as Error & { status?: number; code?: string };
+      error.status = 403;
+      error.code = 'ESTIMATING_APPROVAL_FORBIDDEN';
+      throw error;
+    }
+  }
+  return { ...actor, capability };
 }
 
 function money(value: unknown): number {
@@ -390,6 +430,30 @@ router.post('/rfqs/:id/parts', async (req, res) => {
   }
 });
 
+router.put('/rfqs/:id/parts', async (req, res) => {
+  try {
+    const data = replacePartsSchema.parse(req.body);
+    const saved = await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT id FROM estimating_rfqs WHERE id = ${req.params.id} FOR UPDATE`);
+      const [rfq] = await tx.select({ id: estimatingRfqs.id }).from(estimatingRfqs).where(eq(estimatingRfqs.id, req.params.id));
+      if (!rfq) {
+        const error = new Error('RFQ not found') as Error & { status?: number };
+        error.status = 404;
+        throw error;
+      }
+      await tx.delete(estimatingRfqParts).where(eq(estimatingRfqParts.rfqId, req.params.id));
+      if (data.parts.length === 0) return [];
+      return tx.insert(estimatingRfqParts).values(data.parts.map((part, index) => ({
+        ...part, rfqId: req.params.id, lineNumber: part.lineNumber ?? index + 1,
+      }))).returning();
+    });
+    res.json(saved);
+  } catch (err: any) {
+    if (err instanceof z.ZodError) return res.status(400).json({ error: 'Validation failed', details: err.errors });
+    res.status(err.status ?? 500).json({ error: err.message });
+  }
+});
+
 // ── Tooling ───────────────────────────────────────────────────────────────────
 
 router.get('/rfqs/:id/tooling', async (req, res) => {
@@ -619,78 +683,77 @@ router.post('/rfqs/:id/pricing-snapshots', async (req, res) => {
 router.post('/rfqs/:id/create-draft-quote', async (req, res) => {
   try {
     const rfqId = req.params.id;
-    const rfq = await storage.getEstimatingRfqById(rfqId);
-    if (!rfq) return res.status(404).json({ error: 'RFQ not found' });
+    const result = await db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT id FROM estimating_rfqs WHERE id = ${rfqId} FOR UPDATE`);
+      const [rfq] = await tx.select().from(estimatingRfqs).where(eq(estimatingRfqs.id, rfqId));
+      if (!rfq) {
+        const error = new Error('RFQ not found') as Error & { status?: number };
+        error.status = 404;
+        throw error;
+      }
+      if (rfq.quoteId) {
+        const [existingQuote] = await tx.select().from(quotes).where(eq(quotes.id, rfq.quoteId));
+        if (!existingQuote) {
+          const error = new Error('RFQ references a quote that no longer exists.') as Error & { status?: number; code?: string };
+          error.status = 409;
+          error.code = 'ESTIMATING_QUOTE_LINK_BROKEN';
+          throw error;
+        }
+        return { quoteId: existingQuote.id, quoteNumber: existingQuote.quoteNumber, reused: true };
+      }
 
-    const readiness = await getEstimatingReleaseReadiness(rfqId, {
-      requiresExecutiveApproval: Boolean(req.body?.requiresExecutiveApproval),
-    });
-    if (!readiness.readyForQuoteRelease) {
-      return res.status(409).json({
-        error: 'RFQ estimating controls are not complete. Resolve approvals and risk assessment before quote release.',
-        readiness,
+      const readiness = await getEstimatingReleaseReadiness(rfqId, {
+        requiresExecutiveApproval: Boolean(req.body?.requiresExecutiveApproval),
       });
-    }
+      if (!readiness.readyForQuoteRelease) {
+        const error = new Error('RFQ estimating controls are not complete. Resolve approvals and risk assessment before quote release.') as Error & { status?: number; readiness?: unknown };
+        error.status = 409;
+        error.readiness = readiness;
+        throw error;
+      }
 
-    const parts = await storage.getEstimatingRfqParts(rfqId);
-    const snapshots = await storage.getEstimatingPricingSnapshots(rfqId);
+      const parts = await tx.select().from(estimatingRfqParts).where(eq(estimatingRfqParts.rfqId, rfqId));
+      const snapshots = await tx.select().from(estimatingPricingSnapshots).where(eq(estimatingPricingSnapshots.rfqId, rfqId));
+      const breakTotals: Record<string, number> = {};
+      for (const snapshot of snapshots) {
+        breakTotals[snapshot.quantityBreakId] = (breakTotals[snapshot.quantityBreakId] ?? 0) + Number(snapshot.extendedPrice);
+      }
+      const totalAmount = Object.values(breakTotals).reduce((max, value) => Math.max(max, value), 0);
+      if (!snapshots.length || totalAmount <= 0) {
+        const error = new Error('Positive pricing snapshots are required before quote handoff.') as Error & { status?: number; code?: string };
+        error.status = 409;
+        error.code = 'ESTIMATING_PRICING_REQUIRED';
+        throw error;
+      }
 
-    // Group snapshots by quantity break and sum extended prices
-    const breakTotals: Record<string, number> = {};
-    for (const snap of snapshots) {
-      const key = snap.quantityBreakId;
-      breakTotals[key] = (breakTotals[key] ?? 0) + Number(snap.extendedPrice);
-    }
-
-    // Use largest break total as the quote total amount
-    const totalAmount = Object.values(breakTotals).reduce((max, v) => Math.max(max, v), 0);
-
-    const partNumberList = parts.map((p) => p.partNumber).join(', ');
-    const description = rfq.notes
-      ? `${partNumberList} — ${rfq.notes}`
-      : partNumberList || rfq.rfqNumber;
-
-    const validUntil = new Date();
-    validUntil.setDate(validUntil.getDate() + 30);
-
-    const quote = await storage.createQuote({
-      quoteNumber: `Q-${rfq.rfqNumber}`,
-      customerId: rfq.customerId ? String(rfq.customerId) : 'ESTIMATING',
-      customerName: rfq.customerNameSnapshot ?? rfq.rfqNumber,
-      description,
-      totalAmount,
-      status: 'DRAFT',
-      validUntil,
-      quotedBy: null,
-      notes: `Generated from RFQ ${rfq.rfqNumber}. Assumptions: ${rfq.assumptions ?? 'N/A'}.`,
-      // Carry the integer FK directly from the RFQ so the customer link is explicit
-      customersIntegerId: rfq.customerId ?? null,
+      const partNumberList = parts.map((part) => part.partNumber).join(', ');
+      const validUntil = new Date();
+      validUntil.setDate(validUntil.getDate() + 30);
+      const [quote] = await tx.insert(quotes).values({
+        quoteNumber: `Q-${rfq.rfqNumber}`,
+        customerId: rfq.customerId ? String(rfq.customerId) : 'ESTIMATING',
+        customerName: rfq.customerNameSnapshot ?? rfq.rfqNumber,
+        description: rfq.notes ? `${partNumberList} — ${rfq.notes}` : partNumberList || rfq.rfqNumber,
+        totalAmount,
+        status: 'DRAFT',
+        validUntil,
+        quotedBy: getActor(req).username,
+        notes: `Generated from RFQ ${rfq.rfqNumber}. Assumptions: ${rfq.assumptions ?? 'N/A'}.`,
+        customersIntegerId: rfq.customerId ?? null,
+      }).returning();
+      await tx.update(estimatingRfqs).set({ quoteId: quote.id, status: 'QUOTED', updatedAt: new Date() }).where(eq(estimatingRfqs.id, rfqId));
+      await recordAuditEvent({
+        eventType: 'ESTIMATING_QUOTE_RELEASED', subjectType: 'estimating_rfq', subjectId: rfqId,
+        sourceService: 'estimating.routes', actor: getActor(req),
+        payload: { quoteId: quote.id, quoteNumber: quote.quoteNumber, readiness: readiness as any },
+        reason: 'RFQ approval-readiness and risk controls satisfied before quote handoff',
+        ipAddress: req.ip, userAgent: req.get('user-agent') ?? null,
+      }, tx);
+      return { quoteId: quote.id, quoteNumber: quote.quoteNumber, reused: false };
     });
-
-    await pool.query(
-      `UPDATE estimating_rfqs SET quote_id = $2, status = 'QUOTED', updated_at = NOW() WHERE id = $1`,
-      [rfqId, quote.id]
-    );
-
-    await recordAuditEvent({
-      eventType: 'ESTIMATING_QUOTE_RELEASED',
-      subjectType: 'estimating_rfq',
-      subjectId: rfqId,
-      sourceService: 'estimating.routes',
-      actor: getActor(req),
-      payload: {
-        quoteId: quote.id,
-        quoteNumber: quote.quoteNumber,
-        readiness: readiness as any,
-      },
-      reason: 'RFQ approval-readiness and risk controls satisfied before quote handoff',
-      ipAddress: req.ip,
-      userAgent: req.get('user-agent') ?? null,
-    });
-
-    res.json({ quoteId: quote.id, quoteNumber: quote.quoteNumber });
+    res.json(result);
   } catch (err: any) {
-    res.status(500).json({ error: err.message });
+    res.status(err.status ?? 500).json({ error: err.message, code: err.code, readiness: err.readiness });
   }
 });
 
@@ -969,7 +1032,14 @@ router.get('/rfqs/:id/approvals', async (req, res) => {
 router.post('/rfqs/:id/approvals', async (req, res) => {
   try {
     const data = approvalSchema.parse(req.body);
-    const signedAt = data.approvalStatus === 'APPROVED' ? new Date() : null;
+    const actor = await requireEstimatingApprovalAuthority(req, data.approvalRole);
+    if (data.approvalStatus !== 'PENDING' && !data.digitalSignature) {
+      return res.status(400).json({
+        error: 'Digital signature or initials are required for an approval decision.',
+        code: 'ESTIMATING_SIGNATURE_REQUIRED',
+      });
+    }
+    const signedAt = data.approvalStatus === 'PENDING' ? null : new Date();
     const rows = await pool.query(
       `INSERT INTO estimating_approvals
         (rfq_id, estimate_version_id, approval_role, approval_status, approval_threshold, signer_user_id,
@@ -992,8 +1062,8 @@ router.post('/rfqs/:id/approvals', async (req, res) => {
         data.approvalRole,
         data.approvalStatus,
         data.approvalThreshold ?? null,
-        data.signerUserId ?? null,
-        data.signerDisplayName ?? null,
+        actor.id,
+        actor.username,
         data.digitalSignature ?? null,
         data.approvalComments ?? null,
         signedAt,
@@ -1014,8 +1084,9 @@ router.post('/rfqs/:id/approvals', async (req, res) => {
         estimateVersionId: data.estimateVersionId ?? null,
         approvalRole: data.approvalRole,
         approvalStatus: data.approvalStatus,
-        signerUserId: data.signerUserId ?? null,
-        signerDisplayName: data.signerDisplayName ?? null,
+        signerUserId: actor.id,
+        signerDisplayName: actor.username,
+        authorityCapability: actor.capability,
       },
       reason: data.approvalComments ?? null,
       ipAddress: req.ip,
@@ -1024,7 +1095,7 @@ router.post('/rfqs/:id/approvals', async (req, res) => {
     res.status(201).json(rows[0]);
   } catch (err: any) {
     if (err instanceof z.ZodError) return res.status(400).json({ error: 'Validation failed', details: err.errors });
-    res.status(500).json({ error: err.message });
+    res.status(err.status ?? 500).json({ error: err.message, code: err.code });
   }
 });
 


### PR DESCRIPTION
## What changed

- bind ROM estimate approvals to capability-authorized authenticated users
- derive signer identity on the server and require signature initials for decisions
- replace destructive delete-and-recreate part saves with one transactional bulk replacement
- make draft quote handoff transactional, audited, positive-price gated, and idempotent
- show authorization, save, and existing-quote state in the ROM Builder UI
- add the additive approval capability migration and focused hardening coverage

## Why

The ROM Builder allowed client-supplied approval identity, could lose RFQ parts when a multi-request save failed, and could attempt quote creation repeatedly. These changes close those authority and persistence gaps without changing unrelated workflows.

## Validation

- 8 focused Vitest checks passed across ROM hardening and RFQ limit behavior
- bundled Node syntax check passed for the estimating route and focused test
- safe-migration synchronization check passed
- source contract assertions passed
- `git diff --cached --check` passed before commit

## Validation limits

- repository-wide TypeScript checking exhausted both 2 GB and 4 GB Node heaps, so it is not reported as passing
- no authenticated browser/runtime database was configured in the clean worktree, so live workflow and migration execution remain for CI/deployment validation
