### PR TITLE
Restore fulfilled orders reopened by migration 0167

### DIFF
--- a/migrations/0238_reverse_0167_fulfilled_orders.sql
+++ b/migrations/0238_reverse_0167_fulfilled_orders.sql
@@ -1,0 +1,102 @@
+-- Restore the exact orders that migration 0167 incorrectly reopened on
+-- 2026-07-31. The append-only activity ledger is the authoritative scope:
+-- every candidate was FULFILLED / Shipping Management immediately before
+-- 0167 changed it to FINALIZED / P1 Production Queue.
+--
+-- This repair is idempotent. It records one compensating event per original
+-- migration event and never infers additional fulfilled orders from dates,
+-- customer data, or missing shipment fields.
+
+CREATE TEMP TABLE tmp_reverse_0167_fulfilled_orders ON COMMIT DROP AS
+WITH original_events AS (
+  SELECT DISTINCT ON (oae.order_id)
+    oae.id AS original_event_id,
+    oae.order_id,
+    oae.occurred_at AS original_occurred_at,
+    oae.status_from,
+    oae.status_to,
+    oae.department_from,
+    oae.department_to
+  FROM order_activity_events oae
+  WHERE oae.source_route = 'migrations/0167_repair_customer_signature_fulfilled_orders.sql'
+    AND oae.reason_code = 'CUSTOMER_SIGNATURE_FULFILLED_REPAIR'
+    AND oae.occurred_at >= TIMESTAMP '2026-07-31 14:18:47'
+    AND oae.occurred_at < TIMESTAMP '2026-07-31 14:18:48'
+    AND oae.status_from = 'FULFILLED'
+    AND oae.department_from = 'Shipping Management'
+    AND oae.status_to = 'FINALIZED'
+    AND oae.department_to = 'P1 Production Queue'
+  ORDER BY oae.order_id, oae.id DESC
+)
+SELECT
+  ao.order_id,
+  ao.status AS current_status,
+  ao.current_department AS current_department,
+  oe.original_event_id,
+  oe.original_occurred_at
+FROM original_events oe
+JOIN all_orders ao ON ao.order_id = oe.order_id
+WHERE ao.status IN ('FINALIZED', 'IN_PROGRESS')
+  AND ao.current_department IN ('P1 Production Queue', 'Barcode')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM order_activity_events reversal
+    WHERE reversal.order_id = oe.order_id
+      AND reversal.reason_code = 'REVERSE_0167_FULFILLED_RESTORE'
+      AND reversal.metadata->>'originalMigrationEventId' = oe.original_event_id::text
+  );
+
+INSERT INTO order_activity_events (
+  order_id,
+  event_type,
+  event_category,
+  occurred_at,
+  actor_type,
+  actor_display_name,
+  source,
+  source_route,
+  reason_code,
+  reason_text,
+  status_from,
+  status_to,
+  department_from,
+  department_to,
+  field_diff,
+  metadata
+)
+SELECT
+  repair.order_id,
+  'STATUS_DEPARTMENT_RESTORED',
+  'admin',
+  NOW(),
+  'system',
+  'migration 0238',
+  'migration',
+  'migrations/0238_reverse_0167_fulfilled_orders.sql',
+  'REVERSE_0167_FULFILLED_RESTORE',
+  'Restored the fulfilled state recorded immediately before the erroneous July 31 execution of migration 0167.',
+  repair.current_status,
+  'FULFILLED',
+  repair.current_department,
+  'Shipping Management',
+  jsonb_build_object(
+    'status', jsonb_build_object('before', repair.current_status, 'after', 'FULFILLED', 'label', 'Order Status'),
+    'currentDepartment', jsonb_build_object('before', repair.current_department, 'after', 'Shipping Management', 'label', 'Current Department')
+  ),
+  jsonb_build_object(
+    'migration', '0238_reverse_0167_fulfilled_orders',
+    'originalMigration', '0167_repair_customer_signature_fulfilled_orders',
+    'originalMigrationEventId', repair.original_event_id,
+    'originalMigrationOccurredAt', repair.original_occurred_at
+  )
+FROM tmp_reverse_0167_fulfilled_orders repair;
+
+UPDATE all_orders ao
+SET
+  status = 'FULFILLED',
+  current_department = 'Shipping Management',
+  updated_at = NOW()
+FROM tmp_reverse_0167_fulfilled_orders repair
+WHERE ao.order_id = repair.order_id
+  AND ao.status = repair.current_status
+  AND ao.current_department = repair.current_department;

--- a/migrations/0239_correct_0238_non_unique_id_collateral.sql
+++ b/migrations/0239_correct_0238_non_unique_id_collateral.sql
@@ -1,0 +1,122 @@
+-- Correct collateral rows touched during the initial manual production run of
+-- migration 0238. Production contains legacy duplicate all_orders.id values;
+-- the reviewed migration now joins by order_id, but that first run joined by
+-- id and also updated unrelated rows sharing those numeric identifiers.
+--
+-- Preserve collateral rows with shipment evidence as FULFILLED. For the
+-- remaining exact transaction set, restore cancellation when the canonical
+-- flag or audit ledger proves it; otherwise restore the P1 queue placement
+-- captured immediately before the manual run.
+
+CREATE TEMP TABLE tmp_correct_0238_collateral ON COMMIT DROP AS
+WITH intended_orders AS (
+  SELECT DISTINCT order_id
+  FROM order_activity_events
+  WHERE reason_code = 'REVERSE_0167_FULFILLED_RESTORE'
+), collateral AS (
+  SELECT ao.*
+  FROM all_orders ao
+  WHERE ao.updated_at = TIMESTAMP '2026-08-03 13:41:12.251739'
+    AND ao.status = 'FULFILLED'
+    AND ao.current_department = 'Shipping Management'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM intended_orders intended
+      WHERE intended.order_id = ao.order_id
+    )
+    AND ao.shipped_date IS NULL
+    AND ao.shipping_completed_at IS NULL
+    AND NULLIF(TRIM(COALESCE(ao.tracking_number, '')), '') IS NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM order_activity_events prior_correction
+      WHERE prior_correction.order_id = ao.order_id
+        AND prior_correction.reason_code = 'CORRECT_0238_NON_UNIQUE_ID_COLLATERAL'
+    )
+)
+SELECT
+  collateral.order_id,
+  CASE
+    WHEN collateral.is_cancelled IS TRUE
+      OR EXISTS (
+        SELECT 1
+        FROM order_activity_events cancellation
+        WHERE cancellation.order_id = collateral.order_id
+          AND cancellation.occurred_at < TIMESTAMP '2026-08-03 13:41:12.251739'
+          AND (
+            cancellation.status_to = 'CANCELLED'
+            OR cancellation.department_to = 'Cancelled'
+          )
+      )
+      THEN 'CANCELLED'
+    ELSE 'FINALIZED'
+  END AS restored_status,
+  CASE
+    WHEN collateral.is_cancelled IS TRUE
+      OR EXISTS (
+        SELECT 1
+        FROM order_activity_events cancellation
+        WHERE cancellation.order_id = collateral.order_id
+          AND cancellation.occurred_at < TIMESTAMP '2026-08-03 13:41:12.251739'
+          AND (
+            cancellation.status_to = 'CANCELLED'
+            OR cancellation.department_to = 'Cancelled'
+          )
+      )
+      THEN 'Cancelled'
+    ELSE 'P1 Production Queue'
+  END AS restored_department
+FROM collateral;
+
+INSERT INTO order_activity_events (
+  order_id,
+  event_type,
+  event_category,
+  occurred_at,
+  actor_type,
+  actor_display_name,
+  source,
+  source_route,
+  reason_code,
+  reason_text,
+  status_from,
+  status_to,
+  department_from,
+  department_to,
+  field_diff,
+  metadata
+)
+SELECT
+  repair.order_id,
+  'STATUS_DEPARTMENT_COLLATERAL_CORRECTED',
+  'admin',
+  NOW(),
+  'system',
+  'migration 0239',
+  'migration',
+  'migrations/0239_correct_0238_non_unique_id_collateral.sql',
+  'CORRECT_0238_NON_UNIQUE_ID_COLLATERAL',
+  'Corrected collateral from the initial manual migration 0238 run while preserving rows with shipment evidence.',
+  'FULFILLED',
+  repair.restored_status,
+  'Shipping Management',
+  repair.restored_department,
+  jsonb_build_object(
+    'status', jsonb_build_object('before', 'FULFILLED', 'after', repair.restored_status, 'label', 'Order Status'),
+    'currentDepartment', jsonb_build_object('before', 'Shipping Management', 'after', repair.restored_department, 'label', 'Current Department')
+  ),
+  jsonb_build_object(
+    'migration', '0239_correct_0238_non_unique_id_collateral',
+    'cause', 'non_unique_legacy_all_orders_id'
+  )
+FROM tmp_correct_0238_collateral repair;
+
+UPDATE all_orders ao
+SET
+  status = repair.restored_status,
+  current_department = repair.restored_department,
+  updated_at = NOW()
+FROM tmp_correct_0238_collateral repair
+WHERE ao.order_id = repair.order_id
+  AND ao.status = 'FULFILLED'
+  AND ao.current_department = 'Shipping Management';

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -301,6 +301,8 @@ export const safeMigrationFiles = [
   '0235_quality_action_change_control.sql',
   '0236_salaried_holiday_calendar.sql',
   '0237_freezer_temperature_log_crud.sql',
+  '0238_reverse_0167_fulfilled_orders.sql',
+  '0239_correct_0238_non_unique_id_collateral.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -346,6 +348,8 @@ export const criticalMigrationFiles = new Set([
   '0235_quality_action_change_control.sql',
   '0236_salaried_holiday_calendar.sql',
   '0237_freezer_temperature_log_crud.sql',
+  '0238_reverse_0167_fulfilled_orders.sql',
+  '0239_correct_0238_non_unique_id_collateral.sql',
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
   '0233a_spec_sheets_base_table.sql',


### PR DESCRIPTION
## What changed

- adds migration 0238 to restore the exact 213 orders changed by the July 31 execution of migration 0167 to their audit-recorded `FULFILLED / Shipping Management` state
- scopes the reversal through append-only `order_activity_events` and updates by `order_id`, not legacy numeric `all_orders.id`
- adds migration 0239 to correct the initial manual 0238 collateral transaction:
  - restores 140 verified live-queue orders to `FINALIZED / P1 Production Queue`
  - restores 7 cancellation-proven orders to `CANCELLED / Cancelled`
  - preserves 62 orders with genuine shipment evidence as fulfilled
- registers both repairs as critical safe-boot migrations

## Root cause

Migration 0167 treated historical fulfilled orders without migrated shipment fields as incorrectly fulfilled and reopened 213 of them on July 31. Production also contains non-unique legacy `all_orders.id` values; the first manual compensating update used that numeric field and touched collateral rows. The reviewed migration now uses the business-unique `order_id` seam throughout.

## Validation

- production audit ledger: 213 exact migration-0167 events
- production dry run for migration 0239: 147 candidates = 140 verified P1 + 7 cancelled
- confirmed 62 collateral rows with shipment evidence are excluded
- confirmed zero linked `production_orders` for the 213 original records
- safe-boot registration assertions passed
- unsafe numeric-id join assertion passed
- `git diff --check` passed

Full automated tests were not run because the clean worktree has no installed dependencies.