### PR TITLE
Stop migration 0167 from replaying fulfilled orders

### DIFF
--- a/migrations/0167_repair_customer_signature_fulfilled_orders.sql
+++ b/migrations/0167_repair_customer_signature_fulfilled_orders.sql
@@ -27,6 +27,17 @@ WHERE (
 DO $$
 BEGIN
   IF to_regclass('public.order_activity_events') IS NOT NULL THEN
+    -- Never reopen an order whose erroneous 0167 move has already been
+    -- explicitly reversed. Safe-boot executes this historical migration on
+    -- every deploy, so the compensating audit event is the durable guard.
+    DELETE FROM tmp_customer_signature_fulfilled_repair candidate
+    WHERE EXISTS (
+      SELECT 1
+      FROM order_activity_events reversal
+      WHERE reversal.order_id = candidate.order_id
+        AND reversal.reason_code = 'REVERSE_0167_FULFILLED_RESTORE'
+    );
+
     INSERT INTO order_activity_events (
       order_id,
       event_type,

--- a/migrations/0240_restore_0167_replay_orders.sql
+++ b/migrations/0240_restore_0167_replay_orders.sql
@@ -1,0 +1,72 @@
+-- Restore only the orders that migration 0167 replayed after migration 0238
+-- had already returned them to FULFILLED / Shipping Management.
+--
+-- The paired audit events provide exact provenance: an order must have a
+-- 0238 reversal and then a later 0167 repair event. No other P1 queue order is
+-- inferred from dates, shipping fields, or department alone.
+
+CREATE TEMP TABLE tmp_restore_0167_replay_orders ON COMMIT DROP AS
+SELECT DISTINCT ON (ao.order_id)
+  ao.order_id,
+  replay.id AS replay_event_id,
+  replay.occurred_at AS replay_occurred_at
+FROM all_orders ao
+JOIN order_activity_events reversal
+  ON reversal.order_id = ao.order_id
+ AND reversal.reason_code = 'REVERSE_0167_FULFILLED_RESTORE'
+JOIN order_activity_events replay
+  ON replay.order_id = ao.order_id
+ AND replay.source_route = 'migrations/0167_repair_customer_signature_fulfilled_orders.sql'
+ AND replay.reason_code = 'CUSTOMER_SIGNATURE_FULFILLED_REPAIR'
+ AND replay.occurred_at > reversal.occurred_at
+WHERE ao.status = 'FINALIZED'
+  AND ao.current_department = 'P1 Production Queue'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM order_activity_events correction
+    WHERE correction.order_id = ao.order_id
+      AND correction.reason_code = 'RESTORE_0167_POST_0238_REPLAY'
+      AND correction.metadata->>'replayEventId' = replay.id::text
+  )
+ORDER BY ao.order_id, replay.occurred_at DESC, replay.id DESC;
+
+INSERT INTO order_activity_events (
+  order_id, event_type, event_category, occurred_at, actor_type,
+  actor_display_name, source, source_route, reason_code, reason_text,
+  status_from, status_to, department_from, department_to, field_diff, metadata
+)
+SELECT
+  repair.order_id,
+  'STATUS_DEPARTMENT_RESTORED',
+  'admin',
+  NOW(),
+  'system',
+  'migration 0240',
+  'migration',
+  'migrations/0240_restore_0167_replay_orders.sql',
+  'RESTORE_0167_POST_0238_REPLAY',
+  'Restored an order replayed by migration 0167 after its audited 0238 reversal.',
+  'FINALIZED',
+  'FULFILLED',
+  'P1 Production Queue',
+  'Shipping Management',
+  jsonb_build_object(
+    'status', jsonb_build_object('before', 'FINALIZED', 'after', 'FULFILLED', 'label', 'Order Status'),
+    'currentDepartment', jsonb_build_object('before', 'P1 Production Queue', 'after', 'Shipping Management', 'label', 'Current Department')
+  ),
+  jsonb_build_object(
+    'migration', '0240_restore_0167_replay_orders',
+    'replayEventId', repair.replay_event_id,
+    'replayOccurredAt', repair.replay_occurred_at
+  )
+FROM tmp_restore_0167_replay_orders repair;
+
+UPDATE all_orders ao
+SET
+  status = 'FULFILLED',
+  current_department = 'Shipping Management',
+  updated_at = NOW()
+FROM tmp_restore_0167_replay_orders repair
+WHERE ao.order_id = repair.order_id
+  AND ao.status = 'FINALIZED'
+  AND ao.current_department = 'P1 Production Queue';

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -304,6 +304,7 @@ export const safeMigrationFiles = [
   '0237_freezer_temperature_log_crud.sql',
   '0238_reverse_0167_fulfilled_orders.sql',
   '0239_correct_0238_non_unique_id_collateral.sql',
+  '0240_restore_0167_replay_orders.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -351,6 +352,7 @@ export const criticalMigrationFiles = new Set([
   '0237_freezer_temperature_log_crud.sql',
   '0238_reverse_0167_fulfilled_orders.sql',
   '0239_correct_0238_non_unique_id_collateral.sql',
+  '0240_restore_0167_replay_orders.sql',
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
   '0233a_spec_sheets_base_table.sql',


### PR DESCRIPTION
## Summary
- prevent safe-boot migration 0167 from reopening orders that already have an audited 0238 reversal
- restore only orders with the exact sequence: 0238 reversal followed by a later 0167 replay
- register migration 0240 in both safe and critical boot migration sets

## Production evidence
- deployed Regular Orders query currently returns 711 rows
- 213 current P1 rows have the exact 0167 -> 0238 reversal -> later 0167 replay audit chain
- the later replay occurred at 2026-08-03 14:09:19.945163
- read-only production dry run selects exactly 213 restoration candidates

## Safety
- does not infer candidates from due dates or queue membership alone
- does not alter legitimate production queue orders
- uses order_id rather than non-unique legacy numeric id
- idempotent per replay audit event

## Validation
- git diff --check
- migration 0240 registered exactly twice (safe + critical)
- read-only production selector dry run: 213 candidates