### PR TITLE
Fill daily P1 mold capacity before advancing

### DIFF
--- a/server/__tests__/layupSchedulePOUnitParsing.test.ts
+++ b/server/__tests__/layupSchedulePOUnitParsing.test.ts
@@ -87,6 +87,15 @@ describe('layup schedule PO progression scope', () => {
     expect(route).toContain("errorCode: 'NO_AVAILABLE_CAPACITY'");
   });
 
+  it('fills parallel mold capacity on the earliest selected day before advancing', () => {
+    expect(route).toContain(
+      'const daysInScheduleOrder = [...workDays].sort((a, b) => a - b)'
+    );
+    expect(route).toContain('for (const day of daysInScheduleOrder)');
+    expect(route).not.toContain('currentDayIndex');
+    expect(route).not.toContain('rotatedDays');
+  });
+
   it('preserves snake-case and camel-case action length and inlet fields', () => {
     expect(route).toContain('features.action_length || features.actionLength');
     expect(route).toContain('features.action_inlet || features.actionInlet');

--- a/server/src/routes/layupSchedule.ts
+++ b/server/src/routes/layupSchedule.ts
@@ -617,9 +617,6 @@ router.post('/generate', async (req: Request, res: Response) => {
       });
     });
     
-    // Round-robin day index for even distribution
-    let currentDayIndex = 0;
-    
     // Try to schedule each item
     for (const item of allItems) {
       let scheduled = false;
@@ -651,15 +648,12 @@ router.post('/generate', async (req: Request, res: Response) => {
         continue;
       }
       
-      // Try to find a slot using round-robin distribution across all selected days
-      // Start from current day index and try all days in rotation
-      const attemptOrder = [...workDays];
-      const rotatedDays = [
-        ...attemptOrder.slice(currentDayIndex),
-        ...attemptOrder.slice(0, currentDayIndex)
-      ];
+      // Fill the earliest selected day's compatible mold capacity before moving
+      // forward. Rotating after every unit under-used parallel molds and made a
+      // four-mold stock model appear capped below its actual daily capacity.
+      const daysInScheduleOrder = [...workDays].sort((a, b) => a - b);
       
-      for (const day of rotatedDays) {
+      for (const day of daysInScheduleOrder) {
         if (scheduled) break;
         
         for (const mold of compatibleMolds) {
@@ -698,8 +692,6 @@ router.post('/generate', async (req: Request, res: Response) => {
             scheduled = true;
             console.log(`✅ Scheduled ${item.orderId} → ${mold.moldId} on ${['', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'][day]}`);
             
-            // Move to next day in rotation for balanced distribution
-            currentDayIndex = (currentDayIndex + 1) % workDays.length;
             break;
           }
         }


### PR DESCRIPTION
## What changed

- Fill compatible P1 mold capacity on the earliest selected workday before advancing to the next day.
- Remove the per-unit weekday rotation that artificially spread units across the week.
- Add regression coverage preventing the round-robin behavior from returning.

## Root cause

The layup schedule generator advanced its weekday index after every scheduled unit. For stock models such as the Wilson Combat model with four compatible molds, this distributed units across Monday through Thursday before filling the remaining same-day mold slots, making the schedule appear capped at two units per day.

## Impact

Wilson Combat P1 PO units can now use all configured compatible mold capacity for a day before scheduling continues onto the next selected workday. Existing stock-model compatibility and per-mold multiplier limits remain in force.

## Validation

- `git diff --check`
- Focused static scheduling regression check passed.
- Full Vitest execution was unavailable because the offline dependency store is missing `@replit/vite-plugin-cartographer@0.2.8`; this remains for CI.