### PR TITLE
Reconcile durable P2 shipment evidence

### DIFF
--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL,
   indexP2ShippedSerializedItemIds,
   normalizeP2ShipmentSerialIdentity,
 } from '../src/lib/p2ShipmentEvidence';
@@ -9,6 +10,18 @@ import {
 } from '../src/lib/p2SchedulingReconciliation';
 
 describe('P2 shipment and scheduling reconciliation', () => {
+  it('treats a durable non-void packing slip as shipment evidence', () => {
+    expect(P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL).toContain(
+      'lot.packing_slip_id IS NOT NULL',
+    );
+    expect(P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL).toContain(
+      'OR slip.id IS NOT NULL',
+    );
+    expect(P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL).toContain(
+      "COALESCE(UPPER(lot.status), '') <> 'VOID'",
+    );
+  });
+
   it('matches customer-facing serials to replacement-suffixed production identities', () => {
     expect(normalizeP2ShipmentSerialIdentity(' ROC2600034-RMA-2 ')).toBe('ROC2600034');
     expect(normalizeP2ShipmentSerialIdentity('roc2600034-r2')).toBe('ROC2600034');

--- a/server/src/lib/p2ShipmentEvidence.ts
+++ b/server/src/lib/p2ShipmentEvidence.ts
@@ -25,8 +25,11 @@ export const P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL = `
       LIMIT 1
     ) certificate ON TRUE
     WHERE lot.po_id = ANY($1)
+      AND COALESCE(UPPER(lot.status), '') <> 'VOID'
       AND (
-        COALESCE(UPPER(lot.status), '') = 'SHIPPED'
+        lot.packing_slip_id IS NOT NULL
+        OR slip.id IS NOT NULL
+        OR COALESCE(UPPER(lot.status), '') = 'SHIPPED'
         OR lot.shipped_at IS NOT NULL
         OR COALESCE(UPPER(slip.status), '') = 'SHIPPED'
       )


### PR DESCRIPTION
## What changed

- Treat a durable packing slip link as authoritative P2 shipment evidence.
- Continue accepting explicit shipped status and shipped timestamps.
- Exclude void shipment lots.
- Add regression coverage for historical packing-slip evidence.

## Root cause

The Shipping module lists non-void lots with durable packing slips as issued shipments, but the P2 Control Center only counted serialized units when the lot or slip had a literal SHIPPED status or a shipped timestamp. Historical PO014332-RA packing slips therefore appeared in Shipping while the status card showed 0 shipped and inflated availability.

## User impact

The Control Center and scheduling list now consume the same historical serialized shipment membership. For PO014332-RA this restores the shipped bucket and allows the remaining unscheduled demand to resolve to the final eight units instead of hundreds.

## Data and audit safety

This is a read-only reconciliation change. It does not update, delete, backfill, or rewrite purchase orders, lots, packing slips, serialized items, scrap records, nonconformance records, or audit history. Void lots remain excluded.

## Validation

- `git diff --cached --check`: passed before commit
- focused Vitest suites: unavailable because dependency installation timed out before producing a Vitest binary