### PR TITLE
Phase 1: serve released Master Document Register revisions

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -444,9 +444,6 @@ export default function MasterDocumentRegister() {
   const isPdfDocument = (doc: ControlledDocument) =>
     Boolean(doc.filePath?.toLowerCase().endsWith('.pdf'));
 
-  const isExternalDocument = (doc: ControlledDocument) =>
-    Boolean(doc.filePath && /^https?:\/\//i.test(doc.filePath));
-
   const getAuthHeaders = (): Record<string, string> => {
     const storedToken = localStorage.getItem('sessionToken') || localStorage.getItem('jwtToken');
     return storedToken ? { Authorization: `Bearer ${storedToken}` } : {};
@@ -482,11 +479,6 @@ export default function MasterDocumentRegister() {
   };
 
   const openDocumentFile = async (doc: ControlledDocument, mode: 'view' | 'download', targetWindowOverride?: Window | null) => {
-    if (isExternalDocument(doc)) {
-      window.open(doc.filePath!, '_blank', 'noopener,noreferrer');
-      return;
-    }
-
     const path = `/api/controlled-documents/${doc.id}/${mode}`;
     const targetWindow =
       targetWindowOverride ?? (mode === 'view'
@@ -522,7 +514,7 @@ export default function MasterDocumentRegister() {
         }
 
         targetWindow?.close();
-        throw new Error(errorData?.error || `Failed to ${mode} document`);
+        throw new Error(errorData?.message || errorData?.error || `Failed to ${mode} document`);
       }
 
       const blob = await response.blob();

--- a/server/__tests__/controlledDocumentLifecycleHardening.test.ts
+++ b/server/__tests__/controlledDocumentLifecycleHardening.test.ts
@@ -71,7 +71,9 @@ describe('Master Document Register lifecycle hardening', () => {
   it('serves and verifies authoritative revision bytes before approval', () => {
     const route = read('server/src/routes/controlledDocuments.ts');
     const service = read('server/src/services/controlledDocumentLifecycleService.ts');
-    expect(route).toContain('const authoritativeFilePath = revision?.filePath || doc.filePath');
+    expect(route).toContain('getReleasedRevisionForControlledUse');
+    expect(route).toContain('document.currentReleasedRevisionId');
+    expect(route).not.toMatch(/if \(action === 'approve' \|\| action === 'release'\)[\s\S]{0,700}revision\.filePath \|\| state\.document\.filePath/);
     expect(route).toContain('await verifyStoredRevision(state.document.id, revision, filePath, buffer, req)');
     expect(route).toContain("if (action === 'approve')");
     expect(service).toContain('CONTROLLED_DOCUMENT_FILE_CHECKSUM_VERIFIED');

--- a/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
+++ b/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (file: string) => readFileSync(join(process.cwd(), file), 'utf8');
+const route = read('server/src/routes/controlledDocuments.ts');
+const client = read('client/src/pages/MasterDocumentRegister.tsx');
+const lifecycleService = read('server/src/services/controlledDocumentLifecycleService.ts');
+const releasedHandler = route.slice(
+  route.indexOf("const serveReleasedControlledDocument"),
+  route.indexOf("// Delete document"),
+);
+
+describe('Master Document Register released-revision access', () => {
+  it('serves released 1.1 instead of a working draft 1.2 for normal View and Download', () => {
+    expect(releasedHandler).toContain('getReleasedRevisionForControlledUse');
+    expect(route).toContain('candidate.id === document.currentReleasedRevisionId');
+    expect(releasedHandler).not.toContain('state.currentRevision');
+    expect(releasedHandler).not.toContain('state.document.filePath');
+    expect(releasedHandler).not.toContain('revisions[revisions.length - 1]');
+  });
+
+  it('fails closed when no released revision exists or the pointer crosses documents', () => {
+    expect(route).toContain("'NO_RELEASED_REVISION'");
+    expect(route).toContain("'RELEASED_REVISION_POINTER_INVALID'");
+    expect(route).toContain('revision.documentId !== document.id');
+    expect(route).toContain("eventType: 'CONTROLLED_DOCUMENT_RELEASE_POINTER_INVALID'");
+  });
+
+  it('stamps the exact served revision identity and lifecycle in PDF footers', () => {
+    expect(route).toContain('revision.versionNumber');
+    expect(route).toContain('revision.effectiveDate || revision.releasedAt || revision.createdAt');
+    expect(route).toContain('revision.lifecycleStatus || revision.status');
+    expect(releasedHandler).toContain('addControlledDocumentFooter(buffer, state.document, revision)');
+  });
+
+  it('keeps external references behind the API and out of controlled release', () => {
+    expect(client).not.toMatch(/window\.open\(doc\.filePath/);
+    expect(client).toContain('/api/controlled-documents/${doc.id}/${mode}');
+    expect(releasedHandler).toContain("'IMMUTABLE_REVISION_FILE_REQUIRED'");
+    expect(route).toContain('External references cannot be approved or released');
+  });
+
+  it('requires lifecycle permission for exact draft and review revision bytes', () => {
+    expect(route).toContain('assertExactRevisionPermission(actor, revision)');
+    expect(route).toContain("['documents.edit_draft', 'documents.revise']");
+    expect(route).toContain("['documents.approve', 'documents.release']");
+    expect(route).toContain("'DRAFT_REVISION_ACCESS_DENIED'");
+  });
+
+  it('centralizes restricted, explicit-grant, and admin-only enforcement', () => {
+    expect(route.match(/authorizeControlledDocumentAccess\(req, /g)).toHaveLength(2);
+    expect(route).toContain("accessRule === 'explicit_grant'");
+    expect(route).toContain("classification === 'restricted'");
+    expect(route).toContain("classification === 'classified'");
+    expect(route).toContain("accessRule !== 'admin_only'");
+    expect(route).toContain('hasControlledDocumentGrant');
+    expect(route).toContain("router.get('/:id/view', requireAuth, requirePermission('documents.view'), requireStepUp()");
+    expect(route).toContain("router.get('/:id/download', requireAuth, requirePermission('documents.view'), requireStepUp()");
+    expect(route).toContain("router.get('/:id/revisions/:revisionId/download', requireAuth, requirePermission('documents.view'), requireStepUp()");
+  });
+
+  it('verifies the selected revision checksum before recording allowed access', () => {
+    const verifyIndex = releasedHandler.indexOf('await verifyStoredRevision');
+    const logIndex = releasedHandler.indexOf('await writeAccessLog');
+    expect(verifyIndex).toBeGreaterThan(-1);
+    expect(logIndex).toBeGreaterThan(verifyIndex);
+    expect(lifecycleService).toContain("'CONTROLLED_DOCUMENT_CHECKSUM_MISMATCH'");
+  });
+});

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -11,6 +11,8 @@ import { z } from 'zod';
 import Papa from 'papaparse';
 import { requireStepUp } from '../../../server/middleware/auth';
 import { writeAccessLog } from './vault';
+import { getUserPermissions } from '../services/permissionService';
+import { recordAuditEvent } from '../services/auditLedgerService';
 import { fileURLToPath } from 'url';
 import { PDFDocument, PDFFont, StandardFonts, rgb } from 'pdf-lib';
 import { getFileStorageProvider, getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
@@ -197,6 +199,144 @@ const verifyStoredRevision = async (
   request: requestEvidence(req),
 });
 
+type ControlledDocumentRecord = typeof controlledDocuments.$inferSelect;
+type ControlledRevisionRecord = typeof documentVersionHistory.$inferSelect;
+
+const isPrivilegedDocumentActor = (actor: { role: string }) =>
+  actor.role === 'ADMIN' || actor.role === 'OWNER';
+
+const hasControlledDocumentGrant = async (
+  documentId: string,
+  actor: { username: string; role: string },
+) => {
+  const result = await pool.query<{ id: number }>(
+    `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
+       (grantee_type = 'user' AND grantee_name = $2)
+       OR (grantee_type = 'role' AND grantee_name = $3)
+     ) LIMIT 1`,
+    [documentId, actor.username, actor.role],
+  );
+  return result.rows.length > 0;
+};
+
+const authorizeControlledDocumentAccess = async (
+  req: Request,
+  document: ControlledDocumentRecord,
+) => {
+  const actor = lifecycleActor(req);
+  if (isPrivilegedDocumentActor(actor)) return actor;
+
+  const classification = String(
+    document.classification || 'internal',
+  ).toLowerCase();
+  const accessRule = String(
+    document.accessRule || 'authenticated',
+  ).toLowerCase();
+  const grantRequired =
+    accessRule === 'explicit_grant' ||
+    classification === 'restricted' ||
+    classification === 'classified';
+  const allowed =
+    accessRule !== 'admin_only' &&
+    (!grantRequired || (await hasControlledDocumentGrant(document.id, actor)));
+
+  if (!allowed) {
+    await writeAccessLog({
+      documentId: document.id,
+      userId: actor.username,
+      action: 'denied',
+      ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+    });
+    throw new ControlledDocumentError(
+      403,
+      'CONTROLLED_DOCUMENT_ACCESS_DENIED',
+      accessRule === 'admin_only'
+        ? 'This document is restricted to administrators and owners'
+        : 'An explicit vault grant is required to access this document',
+      { classification, accessRule },
+    );
+  }
+  return actor;
+};
+
+const assertExactRevisionPermission = async (
+  actor: { id: number; role: string },
+  revision: ControlledRevisionRecord,
+) => {
+  if (isPrivilegedDocumentActor(actor)) return;
+  const lifecycle = String(
+    revision.lifecycleStatus || revision.status || '',
+  ).toUpperCase();
+  if (['RELEASED', 'SUPERSEDED', 'OBSOLETE'].includes(lifecycle)) return;
+
+  const { permissionSet } = await getUserPermissions(actor.id, actor.role);
+  const required =
+    lifecycle === 'IN_REVIEW' || lifecycle === 'APPROVED'
+      ? ['documents.approve', 'documents.release']
+      : ['documents.edit_draft', 'documents.revise'];
+  if (!required.some((capability) => permissionSet.has(capability))) {
+    throw new ControlledDocumentError(
+      403,
+      'DRAFT_REVISION_ACCESS_DENIED',
+      'Draft and review revisions require an appropriate document lifecycle permission',
+      { lifecycleStatus: lifecycle, requiredAnyCapability: required },
+    );
+  }
+};
+
+const getReleasedRevisionForControlledUse = async (
+  req: Request,
+  document: ControlledDocumentRecord,
+  revisions: ControlledRevisionRecord[],
+) => {
+  if (!document.currentReleasedRevisionId) {
+    const actor = lifecycleActor(req);
+    await writeAccessLog({
+      documentId: document.id,
+      userId: actor.username,
+      action: 'denied',
+      ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+    });
+    throw new ControlledDocumentError(
+      409,
+      'NO_RELEASED_REVISION',
+      'This controlled document has not been released',
+    );
+  }
+  const revision = revisions.find(
+    (candidate) => candidate.id === document.currentReleasedRevisionId,
+  );
+  if (!revision || revision.documentId !== document.id) {
+    const actor = lifecycleActor(req);
+    await writeAccessLog({
+      documentId: document.id,
+      userId: actor.username,
+      action: 'denied',
+      ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+    });
+    await recordAuditEvent({
+      eventType: 'CONTROLLED_DOCUMENT_RELEASE_POINTER_INVALID',
+      subjectType: 'controlled_document',
+      subjectId: document.id,
+      sourceService: 'controlledDocuments.route',
+      actor,
+      reason: 'Normal controlled-use access rejected an invalid released revision pointer',
+      ipAddress: requestEvidence(req).ipAddress,
+      userAgent: requestEvidence(req).userAgent,
+      payload: {
+        controlledDocumentId: document.id,
+        currentReleasedRevisionId: document.currentReleasedRevisionId,
+      },
+    });
+    throw new ControlledDocumentError(
+      409,
+      'RELEASED_REVISION_POINTER_INVALID',
+      'The released revision reference is invalid; access has been denied and recorded',
+    );
+  }
+  return revision;
+};
+
 // Separate multer configuration for CSV imports
 const csvUpload = multer({
   storage: multer.memoryStorage(), // Store in memory for CSV parsing
@@ -359,14 +499,20 @@ const truncateTextToWidth = (text: string, maxWidth: number, font: PDFFont, size
 
 const addControlledDocumentFooter = async (
   pdfBytes: Buffer,
-  doc: typeof controlledDocuments.$inferSelect
+  doc: ControlledDocumentRecord,
+  revision: ControlledRevisionRecord,
 ) => {
   const pdfDoc = await PDFDocument.load(pdfBytes);
   const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
   const pages = pdfDoc.getPages();
 
-  const footerDate = formatControlledDocumentFooterDate(doc.effectiveDate || doc.updatedAt || doc.createdAt);
-  const footerText = `Doc #: ${doc.documentNumber || 'N/A'} | Version: ${doc.currentVersion || 'N/A'} | Date: ${footerDate}`;
+  const footerDate = formatControlledDocumentFooterDate(
+    revision.effectiveDate || revision.releasedAt || revision.createdAt,
+  );
+  const lifecycleStatus = String(
+    revision.lifecycleStatus || revision.status || 'UNKNOWN',
+  ).toUpperCase();
+  const footerText = `Doc #: ${doc.documentNumber || 'N/A'} | Version: ${revision.versionNumber || 'N/A'} | Effective: ${footerDate} | Status: ${lifecycleStatus}`;
 
   for (const page of pages) {
     const { width } = page.getSize();
@@ -522,29 +668,18 @@ router.get('/:id/revisions/:revisionId', requireAuth, requirePermission('documen
 
 router.get('/:id/revisions/:revisionId/download', requireAuth, requirePermission('documents.view'), requireStepUp(), async (req: Request, res: Response) => {
   try {
-    const actor = lifecycleActor(req);
     const state = await getControlledDocumentState(req.params.id);
     const revision = state.revisions.find((candidate) => candidate.id === req.params.revisionId);
     if (!revision?.filePath) return res.status(404).json({ error: 'REVISION_FILE_NOT_FOUND' });
-    if (state.document.classification === 'restricted' || state.document.classification === 'classified') {
-      if (actor.role !== 'ADMIN' && actor.role !== 'OWNER') {
-        const grants = await pool.query<{ id: number }>(
-          `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
-             (grantee_type = 'user' AND grantee_name = $2)
-             OR (grantee_type = 'role' AND grantee_name = $3)
-           ) LIMIT 1`,
-          [state.document.id, actor.username, actor.role]
-        );
-        if (!grants.rows.length) {
-          await writeAccessLog({ documentId: state.document.id, userId: actor.username, action: 'denied', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
-          return res.status(403).json({ error: 'Access denied: insufficient clearance for this revision' });
-        }
-      }
+    const actor = await authorizeControlledDocumentAccess(req, state.document);
+    try {
+      await assertExactRevisionPermission(actor, revision);
+    } catch (error) {
+      await writeAccessLog({ documentId: state.document.id, userId: actor.username, action: 'denied', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
+      throw error;
     }
-    const external = getExternalRedirectUrl(revision.filePath);
-    if (external) {
-      await writeAccessLog({ documentId: state.document.id, userId: actor.username, action: 'download', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
-      return res.redirect(external);
+    if (getExternalRedirectUrl(revision.filePath)) {
+      throw new ControlledDocumentError(422, 'IMMUTABLE_REVISION_FILE_REQUIRED', 'External references are not authoritative controlled revision files; upload an immutable verified copy');
     }
     const buffer = await readControlledDocumentBytes(revision.filePath);
     await verifyStoredRevision(state.document.id, revision, revision.filePath, buffer, req);
@@ -580,7 +715,7 @@ const lifecycleHandler = (
   action: 'submit' | 'approve' | 'release' | 'supersede' | 'obsolete' | 'void'
 ) => async (req: Request, res: Response) => {
   try {
-    if (action === 'approve') {
+    if (action === 'approve' || action === 'release') {
       const state = await getControlledDocumentState(req.params.id);
       const requestedRevisionId = typeof req.body?.revisionId === 'string' ? req.body.revisionId : null;
       const revision = requestedRevisionId
@@ -589,7 +724,7 @@ const lifecycleHandler = (
       if (!revision) {
         throw new ControlledDocumentError(404, 'REVISION_NOT_FOUND', 'Controlled document revision not found');
       }
-      const filePath = revision.filePath || state.document.filePath;
+      const filePath = revision.filePath;
       if (!filePath) {
         throw new ControlledDocumentError(
           422,
@@ -597,10 +732,11 @@ const lifecycleHandler = (
           'Exact stored file bytes are required before approval'
         );
       }
-      if (!getExternalRedirectUrl(filePath)) {
-        const buffer = await readControlledDocumentBytes(filePath);
-        await verifyStoredRevision(state.document.id, revision, filePath, buffer, req);
+      if (getExternalRedirectUrl(filePath)) {
+        throw new ControlledDocumentError(422, 'IMMUTABLE_REVISION_FILE_REQUIRED', 'External references cannot be approved or released; upload an immutable verified copy');
       }
+      const buffer = await readControlledDocumentBytes(filePath);
+      await verifyStoredRevision(state.document.id, revision, filePath, buffer, req);
     }
     const result = await transitionControlledRevision({
       documentId: req.params.id,
@@ -750,8 +886,18 @@ router.put('/:id', requireDocumentEditor, requirePermission('documents.edit_draf
 });
 
 // Approve document — requires documents.approve capability
-router.post('/:id/approve', requirePermission('documents.approve'), async (req: Request, res: Response) => {
+router.post('/:id/approve', requireAuth, requirePermission('documents.approve'), async (req: Request, res: Response) => {
   try {
+    const preflight = await getControlledDocumentState(req.params.id);
+    const requestedRevisionId = typeof req.body?.revisionId === 'string' ? req.body.revisionId : null;
+    const revision = requestedRevisionId
+      ? preflight.revisions.find((candidate) => candidate.id === requestedRevisionId)
+      : preflight.currentRevision;
+    if (!revision?.filePath || getExternalRedirectUrl(revision.filePath)) {
+      throw new ControlledDocumentError(422, 'IMMUTABLE_REVISION_FILE_REQUIRED', 'External references cannot be approved; upload an immutable verified copy');
+    }
+    const bytes = await readControlledDocumentBytes(revision.filePath);
+    await verifyStoredRevision(preflight.document.id, revision, revision.filePath, bytes, req);
     const state = await transitionControlledRevision({
       documentId: req.params.id,
       revisionId: typeof req.body?.revisionId === 'string' ? req.body.revisionId : undefined,
@@ -771,7 +917,7 @@ router.post('/:id/approve', requirePermission('documents.approve'), async (req: 
 
 // View PDF document file inline - requires authentication + step-up re-auth (credentials verified within 30 min)
 // ACL enforcement: restricted/classified docs require an explicit vault access grant or admin/owner role
-router.get('/:id/view', requireAuth, requirePermission('documents.view'), requireStepUp(), async (req: Request, res: Response) => {
+const legacyViewHandler = async (req: Request, res: Response) => {
   const actor = (req as any).user as { id: number; username: string; role: string };
   const ipAddress = (
     (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
@@ -830,6 +976,7 @@ router.get('/:id/view', requireAuth, requirePermission('documents.view'), requir
       const stampedPdf = await addControlledDocumentFooter(
         buffer,
         doc,
+        revision!,
       );
       await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'view', ipAddress });
       res.setHeader('Content-Type', 'application/pdf');
@@ -858,7 +1005,7 @@ router.get('/:id/view', requireAuth, requirePermission('documents.view'), requir
 
     const buffer = await fs.readFile(filePath);
     if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
-    const stampedPdf = await addControlledDocumentFooter(buffer, doc);
+    const stampedPdf = await addControlledDocumentFooter(buffer, doc, revision!);
 
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `inline; filename="${path.basename(filePath)}"`);
@@ -866,11 +1013,11 @@ router.get('/:id/view', requireAuth, requirePermission('documents.view'), requir
   } catch (error) {
     sendLifecycleError(res, error, 'Failed to view document');
   }
-});
+};
 
 // Download document file - requires authentication + step-up re-auth (credentials verified within 30 min)
 // ACL enforcement: restricted/classified docs require an explicit vault access grant or admin/owner role
-router.get('/:id/download', requireAuth, requirePermission('documents.view'), requireStepUp(), async (req: Request, res: Response) => {
+const legacyDownloadHandler = async (req: Request, res: Response) => {
   const actor = (req as any).user as { id: number; username: string; role: string };
   const ipAddress = (
     (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
@@ -929,6 +1076,7 @@ router.get('/:id/download', requireAuth, requirePermission('documents.view'), re
       const stampedPdf = await addControlledDocumentFooter(
         buffer,
         doc,
+        revision!,
       );
       await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
       res.setHeader('Content-Type', 'application/pdf');
@@ -954,7 +1102,7 @@ router.get('/:id/download', requireAuth, requirePermission('documents.view'), re
     if (path.extname(filePath).toLowerCase() === '.pdf') {
       const buffer = await fs.readFile(filePath);
       if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
-      const stampedPdf = await addControlledDocumentFooter(buffer, doc);
+      const stampedPdf = await addControlledDocumentFooter(buffer, doc, revision!);
       res.setHeader('Content-Type', 'application/pdf');
       res.setHeader('Content-Disposition', `attachment; filename="${path.basename(filePath)}"`);
       return res.send(stampedPdf);
@@ -969,7 +1117,53 @@ router.get('/:id/download', requireAuth, requirePermission('documents.view'), re
   } catch (error) {
     sendLifecycleError(res, error, 'Failed to download document');
   }
-});
+};
+
+// These former handlers are intentionally unregistered; controlled-use routes below
+// replace them with a single released-revision implementation.
+void legacyViewHandler;
+void legacyDownloadHandler;
+
+const serveReleasedControlledDocument = (mode: 'view' | 'download') => async (req: Request, res: Response) => {
+  try {
+    const state = await getControlledDocumentState(req.params.id);
+    const actor = await authorizeControlledDocumentAccess(req, state.document);
+    const revision = await getReleasedRevisionForControlledUse(req, state.document, state.revisions);
+    if (!revision.filePath) {
+      throw new ControlledDocumentError(422, 'RELEASED_REVISION_FILE_NOT_FOUND', 'The released revision has no immutable file attached');
+    }
+    if (getExternalRedirectUrl(revision.filePath)) {
+      throw new ControlledDocumentError(422, 'IMMUTABLE_REVISION_FILE_REQUIRED', 'External references cannot be used for controlled View or Download; upload an immutable verified copy');
+    }
+
+    const buffer = await readControlledDocumentBytes(revision.filePath);
+    await verifyStoredRevision(state.document.id, revision, revision.filePath, buffer, req);
+    const isPdf = revision.mediaType === 'application/pdf'
+      || revision.fileName?.toLowerCase().endsWith('.pdf')
+      || revision.filePath.toLowerCase().endsWith('.pdf');
+    if (mode === 'view' && !isPdf) {
+      throw new ControlledDocumentError(415, 'PDF_VIEW_REQUIRED', 'Only released PDF revisions can be viewed inline');
+    }
+    const responseBytes = isPdf
+      ? await addControlledDocumentFooter(buffer, state.document, revision)
+      : buffer;
+    await writeAccessLog({
+      documentId: state.document.id,
+      userId: actor.username,
+      action: mode,
+      ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+    });
+    const filename = revision.fileName || `${state.document.documentNumber}-${revision.versionNumber}${isPdf ? '.pdf' : ''}`;
+    res.setHeader('Content-Type', isPdf ? 'application/pdf' : revision.mediaType || 'application/octet-stream');
+    res.setHeader('Content-Disposition', `${mode === 'view' ? 'inline' : 'attachment'}; filename="${path.basename(filename)}"`);
+    res.send(responseBytes);
+  } catch (error) {
+    sendLifecycleError(res, error, `Failed to ${mode} released controlled document`);
+  }
+};
+
+router.get('/:id/view', requireAuth, requirePermission('documents.view'), requireStepUp(), serveReleasedControlledDocument('view'));
+router.get('/:id/download', requireAuth, requirePermission('documents.view'), requireStepUp(), serveReleasedControlledDocument('download'));
 
 // Delete document (admin/owner only)
 router.delete('/:id', requireAdminOrOwner, async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- normal Master Document Register View and Download now resolve only `controlled_documents.current_released_revision_id`
- fail closed for missing, invalid, cross-document, external-reference, unreadable, or checksum-mismatched released revisions
- centralize classification, `access_rule`, vault-grant, step-up, and access-log enforcement across normal and exact-revision delivery
- require lifecycle permissions for exact draft/review revision downloads
- stamp PDFs from the exact served revision's version, effective date, and lifecycle status
- remove the client-side external URL bypass and block approval/release unless EPOCH can read and verify immutable revision bytes

## Current-main finding
The branch was created from exact `origin/main` commit `78660e2d89a216691996f5f835e7bad155d31c43`. Current main still selected `state.currentRevision`, fell back to document-level `file_path`, redirected external revision URLs, and skipped external-byte verification during approval. The prompt's critical conclusions therefore remained current.

## Verification
Passed:
- focused source behavior assertions: 9/9
- Node TypeScript syntax checks: 3/3
- `git diff --check` and `git diff --cached --check`

Unavailable on this host:
- Vitest: 43 controlled-document cases not executed because the cached Vitest entrypoint is missing
- full TypeScript: stopped before compilation because `vite/client` type definitions are missing
- ESLint and Prettier: cached executables point to missing packages
- browser/API/live database validation: not run; no production data was modified

## Migration notes
No database migration is required. Phase 1 uses the additive `current_released_revision_id`, lifecycle, checksum, classification, access-rule, and vault-grant schema already introduced by `0210_master_document_control_hardening.sql`. No historical revisions are changed or deleted.

## Rollback notes
Revert commit `3c82d55b7` to restore the prior application behavior. There is no schema or data rollback. Reverting would re-enable unsafe draft/document-path and external-link fallback behavior, so rollback should only be used as an emergency application rollback while access is otherwise disabled.