### PR TITLE
Phase 1A: restore controlled document compatibility viewing

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -213,6 +213,7 @@ export default function MasterDocumentRegister() {
   const [pendingDocumentAccess, setPendingDocumentAccess] = useState<{
     doc: ControlledDocument;
     mode: 'view' | 'download';
+    apiPath?: string;
   } | null>(null);
   const [stepUpPassword, setStepUpPassword] = useState('');
   const [stepUpError, setStepUpError] = useState<string | null>(null);
@@ -366,6 +367,20 @@ export default function MasterDocumentRegister() {
   });
 
   const getStatusBadge = (doc: ControlledDocument) => {
+    const compatibilityStatus = (doc as any).compatibilityStatus as string | undefined;
+    if (compatibilityStatus === 'Released and Verified') {
+      return <Badge className="bg-emerald-700">Released and Verified</Badge>;
+    }
+    if (compatibilityStatus === 'Legacy Approved — Verification Required') {
+      return <Badge variant="outline" className="border-amber-500 text-amber-700">Legacy Approved — Verification Required</Badge>;
+    }
+    if (compatibilityStatus === 'File Reconciliation Required') {
+      return <Badge variant="destructive">File Reconciliation Required</Badge>;
+    }
+    if (compatibilityStatus === 'Awaiting Approval') {
+      return <Badge variant="outline" className="border-blue-500 text-blue-700">Awaiting Approval</Badge>;
+    }
+
     if (isExpired(doc)) {
       return (
         <Badge variant="destructive" className="flex items-center gap-1">
@@ -444,8 +459,15 @@ export default function MasterDocumentRegister() {
   const isPdfDocument = (doc: ControlledDocument) =>
     Boolean(doc.filePath?.toLowerCase().endsWith('.pdf'));
 
-  const isExternalDocument = (doc: ControlledDocument) =>
-    Boolean(doc.filePath && /^https?:\/\//i.test(doc.filePath));
+  const getFileTypeLabel = (filePath?: string | null) => {
+    if (!filePath) return 'No file';
+    if (/^https?:\/\//i.test(filePath)) return 'External reference';
+    const extension = filePath.split(/[?#]/)[0].split('.').pop()?.toUpperCase();
+    if (extension === 'PDF') return 'PDF';
+    if (['DOC', 'DOCX'].includes(extension || '')) return 'Word document';
+    if (['XLS', 'XLSX'].includes(extension || '')) return 'Excel workbook';
+    return extension ? `${extension} file` : 'Original file';
+  };
 
   const getAuthHeaders = (): Record<string, string> => {
     const storedToken = localStorage.getItem('sessionToken') || localStorage.getItem('jwtToken');
@@ -481,13 +503,13 @@ export default function MasterDocumentRegister() {
     URL.revokeObjectURL(blobUrl);
   };
 
-  const openDocumentFile = async (doc: ControlledDocument, mode: 'view' | 'download', targetWindowOverride?: Window | null) => {
-    if (isExternalDocument(doc)) {
-      window.open(doc.filePath!, '_blank', 'noopener,noreferrer');
-      return;
-    }
-
-    const path = `/api/controlled-documents/${doc.id}/${mode}`;
+  const openDocumentFile = async (
+    doc: ControlledDocument,
+    mode: 'view' | 'download',
+    targetWindowOverride?: Window | null,
+    apiPathOverride?: string,
+  ) => {
+    const path = apiPathOverride || `/api/controlled-documents/${doc.id}/${mode}`;
     const targetWindow =
       targetWindowOverride ?? (mode === 'view'
         ? window.open('', '_blank')
@@ -514,7 +536,7 @@ export default function MasterDocumentRegister() {
 
         if (response.status === 401 && errorData?.requireStepUp) {
           targetWindow?.close();
-          setPendingDocumentAccess({ doc, mode });
+          setPendingDocumentAccess({ doc, mode, apiPath: apiPathOverride });
           setStepUpPassword('');
           setStepUpError(null);
           setIsStepUpOpen(true);
@@ -522,7 +544,7 @@ export default function MasterDocumentRegister() {
         }
 
         targetWindow?.close();
-        throw new Error(errorData?.error || `Failed to ${mode} document`);
+        throw new Error(errorData?.message || errorData?.error || `Failed to ${mode} document`);
       }
 
       const blob = await response.blob();
@@ -540,6 +562,27 @@ export default function MasterDocumentRegister() {
       });
     } finally {
       setOpeningDocumentId(null);
+    }
+  };
+
+  const downloadLegacyAuditReport = async () => {
+    try {
+      const response = await fetch('/api/controlled-documents/legacy-audit', {
+        credentials: 'include',
+        headers: getAuthHeaders(),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(payload.message || payload.error || 'Failed to generate legacy audit report');
+      const blobUrl = URL.createObjectURL(new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' }));
+      const link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = `controlled-document-legacy-audit-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(blobUrl);
+    } catch (error: any) {
+      toast({ title: 'Unable to generate audit report', description: error.message, variant: 'destructive' });
     }
   };
 
@@ -588,7 +631,7 @@ export default function MasterDocumentRegister() {
       setIsStepUpOpen(false);
       setPendingDocumentAccess(null);
       setStepUpPassword('');
-      await openDocumentFile(access.doc, access.mode, targetWindow);
+      await openDocumentFile(access.doc, access.mode, targetWindow, access.apiPath);
     } catch (error: any) {
       setStepUpError(error.message || 'Credential verification failed');
     } finally {
@@ -833,8 +876,14 @@ export default function MasterDocumentRegister() {
                 Controlled documents for P1 and P2 operations
               </p>
             </div>
-            {canCreateEdit && (
-              <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2">
+              {can('documents.number_admin') && (
+                <Button variant="outline" onClick={downloadLegacyAuditReport}>
+                  Legacy Audit Report
+                </Button>
+              )}
+              {canCreateEdit && (
+                <>
                 <Button
                   variant="outline"
                   className="flex items-center gap-2"
@@ -856,8 +905,9 @@ export default function MasterDocumentRegister() {
                   <Plus className="h-4 w-4" />
                   New Document
                 </Button>
-              </div>
-            )}
+                </>
+              )}
+            </div>
           </div>
         </div>
 
@@ -1137,13 +1187,14 @@ export default function MasterDocumentRegister() {
                           <div className="flex items-center gap-2">
                             {doc.filePath && (
                               <>
-                                {(isPdfDocument(doc) || isExternalDocument(doc)) && (
+                                <span className="text-xs text-muted-foreground">{getFileTypeLabel(doc.filePath)}</span>
+                                {isPdfDocument(doc) && (
                                   <Badge
                                     variant="outline"
                                     role="button"
                                     tabIndex={0}
                                     className="h-8 cursor-pointer gap-1 border-blue-300 px-2 text-blue-700 hover:bg-blue-50"
-                                    title={isExternalDocument(doc) ? 'Open linked document' : 'View PDF'}
+                                    title="View PDF"
                                     data-testid={`badge-view-pdf-${doc.id}`}
                                     onClick={() => openDocumentFile(doc, 'view')}
                                     onKeyDown={(event) => {
@@ -1154,14 +1205,14 @@ export default function MasterDocumentRegister() {
                                     }}
                                   >
                                     <Eye className="h-3.5 w-3.5" />
-                                    {openingDocumentId === doc.id ? 'Opening' : isExternalDocument(doc) ? 'Open' : 'View'}
+                                    {openingDocumentId === doc.id ? 'Opening' : 'View'}
                                   </Badge>
                                 )}
                                 <Button
                                   size="sm"
                                   variant="ghost"
                                   className="h-8 w-8 p-0"
-                                  title={isExternalDocument(doc) ? 'Open linked document' : 'Download'}
+                                  title="Download Original"
                                   disabled={openingDocumentId === doc.id}
                                   onClick={() => openDocumentFile(doc, 'download')}
                                   data-testid={`button-download-${doc.id}`}
@@ -1810,13 +1861,14 @@ export default function MasterDocumentRegister() {
                           <Button
                             size="sm"
                             variant="outline"
-                            onClick={() => window.open(
+                            onClick={() => openDocumentFile(
+                              selectedDocument,
+                              'download',
+                              null,
                               `/api/controlled-documents/${selectedDocument.id}/revisions/${version.id}/download`,
-                              '_blank',
-                              'noopener,noreferrer'
                             )}
                           >
-                            Exact Revision
+                            Download Exact Revision
                           </Button>
                         )}
                       </TableCell>

--- a/server/__tests__/controlledDocumentPhase1ACompatibility.test.ts
+++ b/server/__tests__/controlledDocumentPhase1ACompatibility.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (file: string) => readFileSync(join(process.cwd(), file), 'utf8');
+const route = read('server/src/routes/controlledDocuments.ts');
+const client = read('client/src/pages/MasterDocumentRegister.tsx');
+const auth = read('server/middleware/auth.ts');
+const auditRoute = route.slice(route.indexOf("router.get('/legacy-audit'"), route.indexOf('// Get single document'));
+
+describe('Master Document Register Phase 1A compatibility', () => {
+  it('does not require step-up for every ordinary internal document', () => {
+    expect(route).toContain('controlledDocumentRequiresStepUp');
+    expect(route).toContain("accessRule || 'authenticated'");
+    expect(route).not.toContain("requirePermission('documents.view'), requireStepUp(), async");
+  });
+
+  it('requires stronger authentication for protected policies', () => {
+    expect(route).toContain('doc.mfaRequired');
+    expect(route).toContain("['restricted', 'classified', 'cui', 'itar']");
+    expect(route).toContain("accessRule === 'explicit_grant'");
+    expect(route).toContain("accessRule === 'admin_only'");
+    expect(auth).toContain("code: 'STEP_UP_REQUIRED'");
+  });
+
+  it('uses one access-policy evaluator for View, Download, and Exact Revision', () => {
+    expect(route.match(/requirePermission\('documents\.view'\), controlledDocumentAccessPolicy/g)).toHaveLength(3);
+    expect(route).toContain('hasControlledDocumentGrant');
+    expect(route).toContain("action: 'denied'");
+  });
+
+  it('handles Exact Revision step-up through the credential dialog', () => {
+    expect(client).toContain('apiPath?: string');
+    expect(client).toContain('apiPath: apiPathOverride');
+    expect(client).toContain('access.apiPath');
+    expect(client).not.toMatch(/onClick=\{\(\) => window\.open\([\s\S]{0,200}revisions\/\$\{version\.id\}/);
+  });
+
+  it('offers inline View only for PDF and labels original file types', () => {
+    expect(client).toContain('{isPdfDocument(doc) && (');
+    expect(client).toContain('getFileTypeLabel');
+    expect(client).toContain('Download Original');
+    expect(route).toContain("'UNSUPPORTED_PREVIEW_TYPE'");
+  });
+
+  it('returns useful file, access, revision, and reconciliation errors', () => {
+    for (const code of [
+      'FILE_REFERENCE_MISSING', 'FILE_NOT_ACCESSIBLE', 'UNSUPPORTED_PREVIEW_TYPE',
+      'ACCESS_DENIED', 'REVISION_RECORD_MISSING', 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
+    ]) expect(route).toContain(code);
+    expect(auth).toContain('STEP_UP_REQUIRED');
+  });
+
+  it('keeps external references behind EPOCH APIs', () => {
+    expect(client).not.toMatch(/window\.open\(doc\.filePath/);
+    expect(route).not.toContain('return res.redirect(external');
+  });
+
+  it('retains truthful legacy compatibility labels', () => {
+    for (const label of [
+      'Released and Verified', 'Legacy Approved — Verification Required',
+      'File Reconciliation Required', 'Draft', 'Awaiting Approval',
+      'Superseded', 'Obsolete', 'Void',
+    ]) expect(`${route}\n${client}`).toContain(label);
+  });
+
+  it('categorizes the required legacy reconciliation conditions', () => {
+    for (const category of [
+      'HAS_MATCHING_RELEASE_POINTER', 'RELEASED_MISSING_POINTER', 'LEGACY_APPROVED_OR_ACTIVE',
+      'PARENT_FILE_WITHOUT_REVISION', 'REVISION_CHECKSUM_MISSING', 'FILE_ACCESSIBLE',
+      'FILE_INACCESSIBLE', 'EXTERNAL_MUTABLE_URL', 'DUPLICATE_NORMALIZED_DOCUMENT_NUMBER',
+      'CROSS_DOCUMENT_POINTER', 'MULTIPLE_ACTIVE_WORKING_REVISIONS',
+      'MISSING_APPROVAL_IDENTITY_OR_DATE', 'EXPIRED_OR_REVIEW_DUE', 'NO_FILE_ATTACHED',
+    ]) expect(auditRoute).toContain(category);
+  });
+
+  it('keeps the audit report read-only and preserves access logs', () => {
+    expect(auditRoute).toContain('readOnly: true');
+    expect(auditRoute).not.toMatch(/\.insert\(|\.update\(|\.delete\(|\bINSERT\b|\bUPDATE\b|\bDELETE\b/);
+    expect(route).toContain('writeAccessLog');
+  });
+});

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -247,7 +247,7 @@ export function requireStepUp(maxAgeMs: number = 30 * 60 * 1000) {
 
       if (!sessionToken) {
         res.setHeader('WWW-Authenticate', 'StepUp');
-        return res.status(401).json({ error: 'Step-up authentication required', requireStepUp: true });
+        return res.status(401).json({ error: 'Step-up authentication required', code: 'STEP_UP_REQUIRED', requireStepUp: true });
       }
 
       const result = await pool.query(
@@ -258,7 +258,7 @@ export function requireStepUp(maxAgeMs: number = 30 * 60 * 1000) {
 
       if (!row || !row.last_credential_verified_at) {
         res.setHeader('WWW-Authenticate', 'StepUp');
-        return res.status(401).json({ error: 'Step-up authentication required', requireStepUp: true });
+        return res.status(401).json({ error: 'Step-up authentication required', code: 'STEP_UP_REQUIRED', requireStepUp: true });
       }
 
       const verifiedAt = new Date(row.last_credential_verified_at).getTime();
@@ -266,6 +266,7 @@ export function requireStepUp(maxAgeMs: number = 30 * 60 * 1000) {
         res.setHeader('WWW-Authenticate', 'StepUp');
         return res.status(401).json({
           error: 'Credential verification has expired. Please re-authenticate.',
+          code: 'STEP_UP_REQUIRED',
           requireStepUp: true,
         });
       }
@@ -274,7 +275,7 @@ export function requireStepUp(maxAgeMs: number = 30 * 60 * 1000) {
     } catch (err) {
       console.error('requireStepUp error:', err);
       res.setHeader('WWW-Authenticate', 'StepUp');
-      return res.status(401).json({ error: 'Step-up authentication required', requireStepUp: true });
+      return res.status(401).json({ error: 'Step-up authentication required', code: 'STEP_UP_REQUIRED', requireStepUp: true });
     }
   };
 }

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -1,10 +1,10 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import path from 'path';
 import { db } from '../../../server/db';
 import { pool } from '../../../server/db';
 import { requirePermission } from '../../../server/middleware/requirePermission';
-import { controlledDocumentNumberRegistry, controlledDocuments, documentVersionHistory, insertControlledDocumentSchema, insertDocumentVersionHistorySchema } from '../../../server/schema';
+import { controlledDocumentNumberRegistry, controlledDocumentRevisionApprovals, controlledDocuments, documentVersionHistory, insertControlledDocumentSchema, insertDocumentVersionHistorySchema } from '../../../server/schema';
 import { eq, desc, and, inArray, sql } from 'drizzle-orm';
 import fs from 'fs/promises';
 import { z } from 'zod';
@@ -164,8 +164,8 @@ const readControlledDocumentBytes = async (filePath: string) => {
   if (!resolvedPath) {
     throw new ControlledDocumentError(
       422,
-      'REVISION_FILE_LOCATION_UNSUPPORTED',
-      'Document file path is not a supported app-accessible location'
+      'FILE_NOT_ACCESSIBLE',
+      'The file reference is not supported by this EPOCH server'
     );
   }
   try {
@@ -174,8 +174,8 @@ const readControlledDocumentBytes = async (filePath: string) => {
     if (error?.code === 'ENOENT') {
       throw new ControlledDocumentError(
         404,
-        'REVISION_FILE_NOT_ACCESSIBLE',
-        'Document file is not accessible from this server'
+        'FILE_NOT_ACCESSIBLE',
+        'The referenced file is not accessible from this EPOCH server'
       );
     }
     throw error;
@@ -332,6 +332,72 @@ const resolveControlledDocumentFile = (filePath: string | null | undefined) => {
   return null;
 };
 
+const getControlledFileReferenceType = (filePath: string | null | undefined) => {
+  const value = String(filePath || '').trim();
+  if (!value) return 'NONE';
+  if (getExternalRedirectUrl(value)) return 'EXTERNAL_MUTABLE_URL';
+  if (value.startsWith('/objects/')) return 'OBJECT_STORAGE';
+  if (value.startsWith('/supabase-objects/')) return 'SUPABASE_OBJECT_STORAGE';
+  if (value.startsWith('/api/media/file/') || /uploads[\\/]media-library/i.test(value)) return 'CENTRAL_MEDIA_LIBRARY';
+  if (/^\/?assets\/documents\//i.test(value)) return 'ASSETS_DOCUMENTS';
+  if (/^file:\/\//i.test(value)) return 'FILE_URI';
+  if (isUncPath(value)) return 'UNC_PATH';
+  if (isWindowsAbsolutePath(value) || path.isAbsolute(value)) return 'LEGACY_LOCAL_PATH';
+  return 'UNSUPPORTED_REFERENCE';
+};
+
+const controlledDocumentRequiresStepUp = (doc: typeof controlledDocuments.$inferSelect) => {
+  const classification = String(doc.classification || 'internal').toLowerCase();
+  const accessRule = String(doc.accessRule || 'authenticated').toLowerCase();
+  return Boolean(
+    doc.mfaRequired
+    || ['restricted', 'classified', 'cui', 'itar'].includes(classification)
+    || accessRule === 'explicit_grant'
+    || accessRule === 'admin_only'
+    || doc.cuiCategory
+    || doc.itarCategory
+  );
+};
+
+const hasControlledDocumentGrant = async (documentId: string, username: string, role: string) => {
+  const result = await pool.query<{ id: number }>(
+    `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
+       (grantee_type = 'user' AND grantee_name = $2)
+       OR (grantee_type = 'role' AND grantee_name = $3)
+     ) LIMIT 1`,
+    [documentId, username, role],
+  );
+  return result.rows.length > 0;
+};
+
+const controlledDocumentAccessPolicy = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const actor = lifecycleActor(req);
+    const [doc] = await db.select().from(controlledDocuments)
+      .where(eq(controlledDocuments.id, req.params.id)).limit(1);
+    if (!doc) return res.status(404).json({ error: 'REVISION_RECORD_MISSING', message: 'Controlled document record was not found' });
+
+    const privileged = actor.role === 'ADMIN' || actor.role === 'OWNER';
+    const classification = String(doc.classification || 'internal').toLowerCase();
+    const accessRule = String(doc.accessRule || 'authenticated').toLowerCase();
+    const grantRequired = accessRule === 'explicit_grant'
+      || ['restricted', 'classified', 'cui', 'itar'].includes(classification)
+      || Boolean(doc.cuiCategory || doc.itarCategory);
+    const allowed = privileged || (accessRule !== 'admin_only'
+      && (!grantRequired || await hasControlledDocumentGrant(doc.id, actor.username, actor.role)));
+    if (!allowed) {
+      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'denied', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
+      return res.status(403).json({ error: 'ACCESS_DENIED', message: 'The document access policy does not permit this request' });
+    }
+
+    (req as any).controlledDocument = doc;
+    if (!controlledDocumentRequiresStepUp(doc)) return next();
+    return requireStepUp()(req, res, next);
+  } catch (error) {
+    sendLifecycleError(res, error, 'Failed to evaluate controlled document access policy');
+  }
+};
+
 const formatControlledDocumentFooterDate = (value: Date | string | null | undefined) => {
   if (!value) return 'N/A';
   const date = value instanceof Date
@@ -450,7 +516,33 @@ router.use(async (_req, res, next) => {
 router.get('/', requireAuth, requirePermission('documents.view'), async (req: Request, res: Response) => {
   try {
     const docs = await db.select().from(controlledDocuments).orderBy(desc(controlledDocuments.createdAt));
-    res.json(docs);
+    const revisionIds = docs.map((doc) => doc.currentReleasedRevisionId).filter((id): id is string => Boolean(id));
+    const releasedRevisions = revisionIds.length
+      ? await db.select().from(documentVersionHistory).where(inArray(documentVersionHistory.id, revisionIds))
+      : [];
+    const releasedById = new Map(releasedRevisions.map((revision) => [revision.id, revision]));
+    res.json(docs.map((doc) => {
+      const released = doc.currentReleasedRevisionId ? releasedById.get(doc.currentReleasedRevisionId) : null;
+      const releasedVerified = released?.documentId === doc.id
+        && released.checksumStatus === 'VERIFIED'
+        && Boolean(released.filePath)
+        && !getExternalRedirectUrl(released.filePath)
+        && String(released.lifecycleStatus || released.status || '').toUpperCase() === 'RELEASED';
+      const legacyApproved = ['approved', 'active'].includes(String(doc.status || '').toLowerCase())
+        || String(doc.lifecycleStatus || '').toUpperCase() === 'RELEASED';
+      return {
+        ...doc,
+        compatibilityStatus: releasedVerified
+          ? 'Released and Verified'
+          : legacyApproved && doc.filePath ? 'Legacy Approved — Verification Required'
+          : legacyApproved ? 'File Reconciliation Required'
+          : String(doc.lifecycleStatus || '').toUpperCase() === 'IN_REVIEW' ? 'Awaiting Approval'
+          : doc.lifecycleStatus === 'SUPERSEDED' ? 'Superseded'
+          : doc.lifecycleStatus === 'OBSOLETE' ? 'Obsolete'
+          : doc.lifecycleStatus === 'VOID' ? 'Void'
+          : 'Draft',
+      };
+    }));
   } catch (error) {
     console.error('Error fetching controlled documents:', error);
     res.status(500).json({ error: 'Failed to fetch controlled documents' });
@@ -462,6 +554,133 @@ router.get('/number-conflicts', requireAuth, requirePermission('documents.number
     res.json({ conflicts: await getDocumentNumberConflicts() });
   } catch (error) {
     sendLifecycleError(res, error, 'Failed to load controlled document number conflicts');
+  }
+});
+
+router.get('/legacy-audit', requireAuth, requirePermission('documents.number_admin'), async (_req: Request, res: Response) => {
+  try {
+    const [documents, revisions, approvals] = await Promise.all([
+      db.select().from(controlledDocuments).orderBy(desc(controlledDocuments.createdAt)),
+      db.select().from(documentVersionHistory).orderBy(desc(documentVersionHistory.createdAt)),
+      db.select().from(controlledDocumentRevisionApprovals),
+    ]);
+    const revisionsByDocument = new Map<string, typeof revisions>();
+    const revisionById = new Map(revisions.map((revision) => [revision.id, revision]));
+    const normalizedCounts = new Map<string, number>();
+    for (const document of documents) {
+      const normalized = String(document.documentNumber || '').trim().toUpperCase();
+      normalizedCounts.set(normalized, (normalizedCounts.get(normalized) || 0) + 1);
+    }
+    for (const revision of revisions) {
+      const rows = revisionsByDocument.get(revision.documentId) || [];
+      rows.push(revision);
+      revisionsByDocument.set(revision.documentId, rows);
+    }
+
+    const report = await Promise.all(documents.map(async (document) => {
+      const documentRevisions = revisionsByDocument.get(document.id) || [];
+      const releasedRevision = document.currentReleasedRevisionId
+        ? revisionById.get(document.currentReleasedRevisionId)
+        : null;
+      const currentRevision = document.currentRevisionId
+        ? revisionById.get(document.currentRevisionId)
+        : documentRevisions[0] || null;
+      const workingRevision = document.workingDraftRevisionId
+        ? revisionById.get(document.workingDraftRevisionId)
+        : null;
+      const authoritativeReference = releasedRevision?.documentId === document.id
+        ? releasedRevision.filePath
+        : currentRevision?.documentId === document.id
+          ? currentRevision.filePath
+          : document.filePath;
+      const fileReferenceType = getControlledFileReferenceType(authoritativeReference);
+      let fileAccessibility: 'ACCESSIBLE' | 'INACCESSIBLE' | 'EXTERNAL_MUTABLE' | 'MISSING' = 'MISSING';
+      if (fileReferenceType === 'EXTERNAL_MUTABLE_URL') {
+        fileAccessibility = 'EXTERNAL_MUTABLE';
+      } else if (authoritativeReference) {
+        try {
+          if (authoritativeReference.startsWith('/objects/') || authoritativeReference.startsWith('/supabase-objects/')) {
+            await getFileStorageProviderForObjectPath(authoritativeReference).downloadBuffer(authoritativeReference);
+          } else {
+            const resolved = resolveControlledDocumentFile(authoritativeReference);
+            if (!resolved) throw new Error('unsupported reference');
+            await fs.access(resolved);
+          }
+          fileAccessibility = 'ACCESSIBLE';
+        } catch {
+          fileAccessibility = 'INACCESSIBLE';
+        }
+      }
+
+      const activeWorkingRevisions = documentRevisions.filter((revision) =>
+        ['DRAFT', 'IN_REVIEW', 'APPROVED'].includes(String(revision.lifecycleStatus || revision.status || '').toUpperCase()));
+      const approvalRows = approvals.filter((approval) => approval.controlledDocumentId === document.id);
+      const approvalEvidenceState = approvalRows.length > 0
+        && approvalRows.every((approval) => approval.actorUsernameSnapshot && approval.createdAt)
+        ? 'PRESENT'
+        : approvalRows.length > 0 ? 'INCOMPLETE' : 'MISSING';
+      const pointerState = {
+        released: !document.currentReleasedRevisionId ? 'MISSING' : releasedRevision?.documentId === document.id ? 'MATCH' : 'CROSS_DOCUMENT',
+        current: !document.currentRevisionId ? 'MISSING' : currentRevision?.documentId === document.id ? 'MATCH' : 'CROSS_DOCUMENT',
+        working: !document.workingDraftRevisionId ? 'NONE' : workingRevision?.documentId === document.id ? 'MATCH' : 'CROSS_DOCUMENT',
+      };
+      const lifecycle = String(document.lifecycleStatus || '').toUpperCase();
+      const legacyStatus = String(document.status || '').toLowerCase();
+      const releasedAndVerified = lifecycle === 'RELEASED'
+        && pointerState.released === 'MATCH'
+        && releasedRevision?.checksumStatus === 'VERIFIED'
+        && fileAccessibility === 'ACCESSIBLE';
+      const compatibilityStatus = releasedAndVerified
+        ? 'Released and Verified'
+        : ['approved', 'active'].includes(legacyStatus) || lifecycle === 'RELEASED'
+          ? fileAccessibility === 'ACCESSIBLE' ? 'Legacy Approved — Verification Required' : 'File Reconciliation Required'
+          : lifecycle === 'IN_REVIEW' || lifecycle === 'APPROVED' ? 'Awaiting Approval'
+          : lifecycle === 'SUPERSEDED' ? 'Superseded'
+          : lifecycle === 'OBSOLETE' ? 'Obsolete'
+          : lifecycle === 'VOID' ? 'Void'
+          : 'Draft';
+      const categories = [
+        pointerState.released === 'MATCH' && 'HAS_MATCHING_RELEASE_POINTER',
+        lifecycle === 'RELEASED' && pointerState.released === 'MISSING' && 'RELEASED_MISSING_POINTER',
+        ['approved', 'active'].includes(legacyStatus) && lifecycle !== 'RELEASED' && 'LEGACY_APPROVED_OR_ACTIVE',
+        Boolean(document.filePath) && documentRevisions.length === 0 && 'PARENT_FILE_WITHOUT_REVISION',
+        documentRevisions.some((revision) => !revision.fileChecksum) && 'REVISION_CHECKSUM_MISSING',
+        fileAccessibility === 'ACCESSIBLE' && 'FILE_ACCESSIBLE',
+        fileAccessibility === 'INACCESSIBLE' && 'FILE_INACCESSIBLE',
+        fileAccessibility === 'EXTERNAL_MUTABLE' && 'EXTERNAL_MUTABLE_URL',
+        (normalizedCounts.get(String(document.documentNumber || '').trim().toUpperCase()) || 0) > 1 && 'DUPLICATE_NORMALIZED_DOCUMENT_NUMBER',
+        Object.values(pointerState).includes('CROSS_DOCUMENT') && 'CROSS_DOCUMENT_POINTER',
+        activeWorkingRevisions.length > 1 && 'MULTIPLE_ACTIVE_WORKING_REVISIONS',
+        approvalEvidenceState !== 'PRESENT' && 'MISSING_APPROVAL_IDENTITY_OR_DATE',
+        Boolean(document.expirationDate && new Date(document.expirationDate) < new Date()) && 'EXPIRED_OR_REVIEW_DUE',
+        !authoritativeReference && 'NO_FILE_ATTACHED',
+      ].filter(Boolean);
+      return {
+        documentId: document.id,
+        documentNumber: document.documentNumber,
+        title: document.documentName,
+        legacyStatus: document.status,
+        lifecycleStatus: document.lifecycleStatus,
+        version: document.currentVersion,
+        pointerState,
+        fileReferenceType,
+        fileAccessibility,
+        checksumState: releasedRevision?.checksumStatus || currentRevision?.checksumStatus || 'MISSING',
+        approvalEvidenceState,
+        compatibilityStatus,
+        categories,
+        recommendedReconciliationAction: releasedAndVerified
+          ? 'No reconciliation required'
+          : fileAccessibility === 'EXTERNAL_MUTABLE' ? 'Upload an immutable EPOCH-managed copy and verify its checksum'
+          : fileAccessibility !== 'ACCESSIBLE' ? 'Locate or upload the authoritative file before lifecycle reconciliation'
+          : pointerState.released !== 'MATCH' ? 'Review lifecycle evidence and assign the released revision through an authorized reconciliation workflow'
+          : 'Verify checksum and approval evidence without rewriting history',
+      };
+    }));
+
+    res.json({ generatedAt: new Date().toISOString(), readOnly: true, total: report.length, report });
+  } catch (error) {
+    sendLifecycleError(res, error, 'Failed to generate legacy controlled-document audit');
   }
 });
 
@@ -520,12 +739,13 @@ router.get('/:id/revisions/:revisionId', requireAuth, requirePermission('documen
   }
 });
 
-router.get('/:id/revisions/:revisionId/download', requireAuth, requirePermission('documents.view'), requireStepUp(), async (req: Request, res: Response) => {
+router.get('/:id/revisions/:revisionId/download', requireAuth, requirePermission('documents.view'), controlledDocumentAccessPolicy, async (req: Request, res: Response) => {
   try {
     const actor = lifecycleActor(req);
     const state = await getControlledDocumentState(req.params.id);
     const revision = state.revisions.find((candidate) => candidate.id === req.params.revisionId);
-    if (!revision?.filePath) return res.status(404).json({ error: 'REVISION_FILE_NOT_FOUND' });
+    if (!revision) return res.status(404).json({ error: 'REVISION_RECORD_MISSING', message: 'The requested revision record does not exist for this document' });
+    if (!revision.filePath) return res.status(422).json({ error: 'FILE_REFERENCE_MISSING', message: 'This revision has no file reference' });
     if (state.document.classification === 'restricted' || state.document.classification === 'classified') {
       if (actor.role !== 'ADMIN' && actor.role !== 'OWNER') {
         const grants = await pool.query<{ id: number }>(
@@ -543,8 +763,8 @@ router.get('/:id/revisions/:revisionId/download', requireAuth, requirePermission
     }
     const external = getExternalRedirectUrl(revision.filePath);
     if (external) {
-      await writeAccessLog({ documentId: state.document.id, userId: actor.username, action: 'download', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
-      return res.redirect(external);
+      await writeAccessLog({ documentId: state.document.id, userId: actor.username, action: 'denied', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
+      return res.status(422).json({ error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION', message: 'This external reference must be reconciled to an EPOCH-managed file before controlled access is available' });
     }
     const buffer = await readControlledDocumentBytes(revision.filePath);
     await verifyStoredRevision(state.document.id, revision, revision.filePath, buffer, req);
@@ -771,7 +991,7 @@ router.post('/:id/approve', requirePermission('documents.approve'), async (req: 
 
 // View PDF document file inline - requires authentication + step-up re-auth (credentials verified within 30 min)
 // ACL enforcement: restricted/classified docs require an explicit vault access grant or admin/owner role
-router.get('/:id/view', requireAuth, requirePermission('documents.view'), requireStepUp(), async (req: Request, res: Response) => {
+router.get('/:id/view', requireAuth, requirePermission('documents.view'), controlledDocumentAccessPolicy, async (req: Request, res: Response) => {
   const actor = (req as any).user as { id: number; username: string; role: string };
   const ipAddress = (
     (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
@@ -815,13 +1035,13 @@ router.get('/:id/view', requireAuth, requirePermission('documents.view'), requir
     const authoritativeFilePath = revision?.filePath || doc.filePath;
 
     if (!authoritativeFilePath) {
-      return res.status(404).json({ error: 'No file attached to this document' });
+      return res.status(422).json({ error: 'FILE_REFERENCE_MISSING', message: 'No file reference is attached to this document' });
     }
 
     const externalRedirectUrl = getExternalRedirectUrl(authoritativeFilePath);
     if (externalRedirectUrl) {
-      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'view', ipAddress });
-      return res.redirect(externalRedirectUrl);
+      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'denied', ipAddress });
+      return res.status(422).json({ error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION', message: 'This external reference must be reconciled to an EPOCH-managed file before controlled access is available' });
     }
 
     if (authoritativeFilePath.startsWith('/objects/') || authoritativeFilePath.startsWith('/supabase-objects/')) {
@@ -839,26 +1059,24 @@ router.get('/:id/view', requireAuth, requirePermission('documents.view'), requir
 
     const filePath = resolveControlledDocumentFile(authoritativeFilePath);
     if (!filePath) {
-      return res.status(422).json({ error: 'Document file path is not a supported app-accessible location' });
+      return res.status(422).json({ error: 'FILE_NOT_ACCESSIBLE', message: 'The file reference is not supported by this EPOCH server' });
     }
     
     // Check if file exists
     try {
       await fs.access(filePath);
     } catch {
-      return res.status(404).json({ error: 'Document file is not accessible from this server' });
+      return res.status(404).json({ error: 'FILE_NOT_ACCESSIBLE', message: 'The referenced file is not accessible from this EPOCH server' });
     }
 
     if (path.extname(filePath).toLowerCase() !== '.pdf') {
-      return res.status(415).json({ error: 'Only PDF documents can be viewed inline' });
+      return res.status(415).json({ error: 'UNSUPPORTED_PREVIEW_TYPE', message: 'This file type cannot be previewed; use Download Original' });
     }
-
-    // Write view access log entry before sending the file
-    await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'view', ipAddress });
 
     const buffer = await fs.readFile(filePath);
     if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
     const stampedPdf = await addControlledDocumentFooter(buffer, doc);
+    await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'view', ipAddress });
 
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `inline; filename="${path.basename(filePath)}"`);
@@ -870,7 +1088,7 @@ router.get('/:id/view', requireAuth, requirePermission('documents.view'), requir
 
 // Download document file - requires authentication + step-up re-auth (credentials verified within 30 min)
 // ACL enforcement: restricted/classified docs require an explicit vault access grant or admin/owner role
-router.get('/:id/download', requireAuth, requirePermission('documents.view'), requireStepUp(), async (req: Request, res: Response) => {
+router.get('/:id/download', requireAuth, requirePermission('documents.view'), controlledDocumentAccessPolicy, async (req: Request, res: Response) => {
   const actor = (req as any).user as { id: number; username: string; role: string };
   const ipAddress = (
     (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
@@ -914,55 +1132,49 @@ router.get('/:id/download', requireAuth, requirePermission('documents.view'), re
     const authoritativeFilePath = revision?.filePath || doc.filePath;
 
     if (!authoritativeFilePath) {
-      return res.status(404).json({ error: 'No file attached to this document' });
+      return res.status(422).json({ error: 'FILE_REFERENCE_MISSING', message: 'No file reference is attached to this document' });
     }
 
     const externalRedirectUrl = getExternalRedirectUrl(authoritativeFilePath);
     if (externalRedirectUrl) {
-      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
-      return res.redirect(externalRedirectUrl);
+      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'denied', ipAddress });
+      return res.status(422).json({ error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION', message: 'This external reference must be reconciled to an EPOCH-managed file before controlled access is available' });
     }
 
     if (authoritativeFilePath.startsWith('/objects/') || authoritativeFilePath.startsWith('/supabase-objects/')) {
       const buffer = await readControlledDocumentBytes(authoritativeFilePath);
       if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
-      const stampedPdf = await addControlledDocumentFooter(
-        buffer,
-        doc,
-      );
       await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
-      res.setHeader('Content-Type', 'application/pdf');
-      res.setHeader('Content-Disposition', `attachment; filename="${doc.documentNumber}.pdf"`);
-      return res.send(stampedPdf);
+      res.setHeader('Content-Type', revision?.mediaType || 'application/octet-stream');
+      res.setHeader('Content-Disposition', `attachment; filename="${revision?.fileName || doc.documentNumber}"`);
+      return res.send(buffer);
     }
 
     const filePath = resolveControlledDocumentFile(authoritativeFilePath);
     if (!filePath) {
-      return res.status(422).json({ error: 'Document file path is not a supported app-accessible location' });
+      return res.status(422).json({ error: 'FILE_NOT_ACCESSIBLE', message: 'The file reference is not supported by this EPOCH server' });
     }
 
     // Check if file exists
     try {
       await fs.access(filePath);
     } catch {
-      return res.status(404).json({ error: 'Document file is not accessible from this server' });
+      return res.status(404).json({ error: 'FILE_NOT_ACCESSIBLE', message: 'The referenced file is not accessible from this EPOCH server' });
     }
-
-    // Write download access log entry before sending the file
-    await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
 
     if (path.extname(filePath).toLowerCase() === '.pdf') {
       const buffer = await fs.readFile(filePath);
       if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
-      const stampedPdf = await addControlledDocumentFooter(buffer, doc);
+      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
       res.setHeader('Content-Type', 'application/pdf');
       res.setHeader('Content-Disposition', `attachment; filename="${path.basename(filePath)}"`);
-      return res.send(stampedPdf);
+      return res.send(buffer);
     }
 
     // Send file with appropriate content type
     const buffer = await fs.readFile(filePath);
     if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
+    await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
     res.setHeader('Content-Type', revision?.mediaType || 'application/octet-stream');
     res.setHeader('Content-Disposition', `attachment; filename="${revision?.fileName || path.basename(filePath)}"`);
     res.send(buffer);


### PR DESCRIPTION
## Summary
- restore ordinary internal controlled-document viewing without unconditional credential step-up
- centralize classification, access-rule, CUI/ITAR, MFA, vault-grant, and admin-only policy evaluation for View, Download, and Exact Revision
- route Exact Revision through the existing in-app credential dialog and retry path
- expose PDF View only for PDFs, label file types, and keep original-file Download available
- remove direct external-link navigation and return explicit reconciliation errors
- add an authorized, read-only legacy audit report with compatibility categories and reconciliation recommendations
- add truthful compatibility labels without changing lifecycle data

## Root causes
1. All View, Download, and Exact Revision routes applied `requireStepUp()` unconditionally, including ordinary internal/authenticated documents.
2. Exact Revision opened the API URL directly, so a step-up 401 appeared as raw JSON instead of invoking the credential dialog.
3. Access enforcement was duplicated and did not consistently apply `access_rule`, MFA, CUI/ITAR, and vault policy.
4. External document paths could bypass the API through client-side direct navigation and server redirects.
5. The UI inferred previewability too broadly and did not clearly distinguish original-file download.

## Legacy safety
This PR does **not** universally require `current_released_revision_id`, perform a lifecycle backfill, mutate production data, or rewrite historical revisions. Existing revision/document file fallback remains available for compatible internal records while the read-only report identifies records needing reconciliation.

The report includes document identity/status/version, pointer state, reference type/accessibility, checksum state, approval-evidence state, compatibility status, required legacy categories, and a recommended action. It does not return file contents or raw file paths.

## Verification
Passed:
- focused Phase 1A source assertions: 10/10
- TypeScript syntax checks: 3/3
- `git diff --check` and `git diff --cached --check`

Unavailable on this host:
- 70 relevant Vitest cases were not executed; dependency installation timed out after 120 seconds and produced no runnable Vitest package
- full TypeScript, ESLint, and Prettier were unavailable for the same missing toolchain
- local application/browser launch was unavailable, so no truthful successful-view screenshot could be captured
- no live database, storage provider, migration, or production-data validation was run

## Migration notes
No migration is included. The implementation reads the existing controlled-document, revision-history, approval, access-policy, vault-grant, and access-log schema. No lifecycle backfill is performed.

## Rollback notes
Revert commit `35a429b91` to restore the prior application behavior. There is no schema or data rollback. The audit endpoint is read-only and creates no records.

## Sequencing note
Draft PR #1611 enforces released pointers universally and should not be merged ahead of this compatibility inventory/reconciliation phase without an explicit sequencing decision.