### PR TITLE
Expose missing P2 units for scheduling

### DIFF
--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../src/lib/p2ShipmentEvidence';
 import {
   countDistinctP2DemandUnits,
+  countDistinctP2SerializedUnits,
   isHistoricalP2Unit,
 } from '../src/lib/p2SchedulingReconciliation';
 
@@ -45,6 +46,19 @@ describe('P2 shipment and scheduling reconciliation', () => {
       { id: 'scrap-1', serialNumber: 'S-001', status: 'SCRAPPED' },
       { id: 'remake-1', serialNumber: 'S-002', status: 'COMPLETED' },
     ], new Set())).toBe(1);
+  });
+
+  it('creates pending capacity for duplicate historical serialized rows', () => {
+    const generated = countDistinctP2SerializedUnits([
+      { id: 'original', serialNumber: 'ROC2600001', status: 'ACTIVE', currentDepartment: 'Layup' },
+      { id: 'duplicate', serialNumber: 'ROC2600001', status: 'ACTIVE', currentDepartment: 'Layup' },
+      { id: 'active', serialNumber: 'ROC2600002', status: 'ACTIVE' },
+      { id: 'scrap', serialNumber: 'ROC2600003', status: 'SCRAPPED' },
+      { id: 'historical', serialNumber: 'ROC2600004', status: 'COMPLETED', currentDepartment: 'Inventory' },
+    ], new Set());
+
+    expect(generated).toBe(2);
+    expect(3 - generated).toBe(1);
   });
 
   it('counts shipped, finalization, active, and scheduled units once by serial', () => {

--- a/server/src/lib/p2SchedulingReconciliation.ts
+++ b/server/src/lib/p2SchedulingReconciliation.ts
@@ -5,6 +5,27 @@ const normalized = (value: unknown) => String(value ?? '').trim().toUpperCase();
 export const isHistoricalP2Unit = (row: P2SerializedUnitLedgerRow) =>
   ['SCRAP', 'SCRAPPED', 'CANCELED', 'CANCELLED', 'VOID'].includes(normalized(row.status));
 
+export function countDistinctP2SerializedUnits(
+  rows: readonly P2SerializedUnitLedgerRow[],
+  shippedItemIds: ReadonlySet<string>,
+): number {
+  const identities = new Set<string>();
+  for (const row of rows) {
+    if (isHistoricalP2Unit(row)) continue;
+    const status = normalized(row.status);
+    const department = normalized(row.currentDepartment ?? row.current_department);
+    const isSchedulablePending = status === 'ACTIVE'
+      && (department === '' || department === 'PENDING LAYUP');
+    if (!isSchedulablePending && !p2UnitConsumesOrderedDemand(row, shippedItemIds)) {
+      continue;
+    }
+    const serial = normalized(row.serialNumber ?? row.serial_number);
+    const id = String(row.id ?? '').trim().toLowerCase();
+    if (serial || id) identities.add(serial || `ID:${id}`);
+  }
+  return identities.size;
+}
+
 export function p2UnitConsumesOrderedDemand(
   row: P2SerializedUnitLedgerRow,
   shippedItemIds: ReadonlySet<string>,

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -27,7 +27,7 @@ import {
 } from '../lib/p2ShipmentEvidence';
 import {
   countDistinctP2DemandUnits,
-  isHistoricalP2Unit,
+  countDistinctP2SerializedUnits,
 } from '../lib/p2SchedulingReconciliation';
 import { softAuth, authenticateToken, sessionAwareAuth, requireAdminOrOwner } from '../../middleware/auth';
 import { computeEffectivePriority, getEffectivePriorityScore } from '../../../shared/utils/computeEffectivePriority';
@@ -5044,8 +5044,8 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const poItemId = Number(poItem.poItemId);
         const orderedQuantity = Number(poItem.orderedQuantity) || 0;
         const existingItems = serializedByPoItemId.get(poItemId) ?? [];
-        const nonHistoricalItems = existingItems.filter((item: any) => !isHistoricalP2Unit(item));
-        const missingCount = Math.max(0, orderedQuantity - nonHistoricalItems.length);
+        const generatedUnitCount = countDistinctP2SerializedUnits(existingItems, shippedItemIds);
+        const missingCount = Math.max(0, orderedQuantity - generatedUnitCount);
 
         if (missingCount === 0) continue;
 


### PR DESCRIPTION
## What changed

- Count distinct legitimate P2 demand identities when reconciling serialized units for a PO line.
- Treat active blank/Pending Layup units as already generated schedulable capacity.
- Exclude scrap, canceled units, and completed historical inventory from blocking pending-unit generation.
- Create only the true missing pending units and add regression coverage for duplicate historical rows.

## Root cause

The status card used the distinct serialized-unit ledger and correctly reported nine units available for PO014332-RA. The scheduling endpoint used the raw serialized-row count. Historical duplicate and completed-inventory rows inflated that count to the ordered quantity, so the endpoint generated no Pending Layup rows and the Schedule tab showed zero.

## User impact

When the ledger reports nine missing units, the scheduling reconciliation now creates exactly nine idempotent Pending Layup units and returns them in the Production Scheduling table.

## Data and audit safety

The change does not rewrite historical shipment, packing-slip, scrap, nonconformance, or audit records. It only adds genuinely missing pending serialized units through the existing authoritative creation service. Existing pending identities are counted so repeated reads cannot create duplicates.

## Validation

- `git diff --cached --check`: passed before commit
- focused Vitest suites: unavailable because the repository dependency installation timed out without producing a Vitest binary