### PR TITLE
Enable CoC uploads for received POs

### DIFF
--- a/client/src/pages/InventoryReceivingControlCenter.tsx
+++ b/client/src/pages/InventoryReceivingControlCenter.tsx
@@ -733,6 +733,7 @@ function LeftPanel({
                       <div className="text-gray-500 mt-0.5 truncate">
                         {receipt.vendorName ?? 'Manual receipt'} {receipt.vendorPoNumber ? `· PO ${receipt.vendorPoNumber}` : ''}
                       </div>
+                      <div className="text-blue-600 mt-1">Open documents</div>
                     </button>
                     <Button
                       size="sm"
@@ -958,7 +959,7 @@ function CenterPanel({
               <CheckCircle2 className="w-8 h-8 text-green-600 mx-auto" />
               <div>
                 <div className="text-sm font-semibold">Receipt Complete</div>
-                <div className="text-xs text-gray-500 mt-1">Reopen this receipt before correcting quantities, traceability, documents, or putaway details.</div>
+                <div className="text-xs text-gray-500 mt-1">Use the Docs tab to attach a CoC or other receiving record. Reopen only when receiving data itself needs correction.</div>
               </div>
               <Button size="sm" onClick={() => reopenActiveReceiptMutation.mutate()} disabled={reopenActiveReceiptMutation.isPending}>
                 {reopenActiveReceiptMutation.isPending ? <Loader2 className="w-3 h-3 animate-spin mr-1" /> : <RefreshCw className="w-3 h-3 mr-1" />}
@@ -3435,11 +3436,15 @@ function DocumentsTab({ receipt, onUpdate }: { receipt: Receipt; onUpdate: (r: R
   const units = receipt.units ?? [];
   const queryClient = useQueryClient();
   const fileRef = useRef<HTMLInputElement>(null);
-  const [docType, setDocType] = useState('other');
+  const [docType, setDocType] = useState(receipt.status === 'complete' ? 'CoC' : 'other');
   const [docNotes, setDocNotes] = useState('');
   const RECEIPT_LEVEL = '__receipt_level__';
   const [assignToUnit, setAssignToUnit] = useState(RECEIPT_LEVEL);
   const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    setDocType(receipt.status === 'complete' ? 'CoC' : 'other');
+  }, [receipt.id, receipt.status]);
 
   const handleUpload = async (file: File) => {
     setUploading(true);
@@ -3824,6 +3829,16 @@ export default function InventoryReceivingControlCenter() {
 
   const handleUpdate = (r: Receipt) => setActiveReceipt(r);
 
+  const handleSelectReceipt = async (receipt: Receipt) => {
+    try {
+      const fullReceipt = await apiRequest(`/api/receipts/${receipt.id}`) as Receipt;
+      setActiveReceipt(fullReceipt);
+      setMobileTab('sidebar');
+    } catch (err: any) {
+      toast.error(err?.message ?? 'Failed to open receipt documents');
+    }
+  };
+
   return (
     <div className="h-[calc(100vh-120px)] flex flex-col">
       {/* Header */}
@@ -3881,7 +3896,7 @@ export default function InventoryReceivingControlCenter() {
         {/* Desktop grid */}
         <div className="hidden md:grid h-full" style={{ gridTemplateColumns: '280px 1fr 320px' }}>
           <div className="border-r overflow-hidden">
-            <LeftPanel onStartReceipt={handleStartReceipt} onSelectReceipt={handleUpdate} activeReceiptId={activeReceipt?.id ?? null} />
+            <LeftPanel onStartReceipt={handleStartReceipt} onSelectReceipt={handleSelectReceipt} activeReceiptId={activeReceipt?.id ?? null} />
           </div>
           <div className="overflow-hidden border-r">
             {showSupervisorQueue ? (
@@ -3904,7 +3919,7 @@ export default function InventoryReceivingControlCenter() {
         {/* Mobile single-panel */}
         <div className="md:hidden h-full overflow-hidden">
           {mobileTab === 'pos' && (
-            <LeftPanel onStartReceipt={handleStartReceipt} onSelectReceipt={handleUpdate} activeReceiptId={activeReceipt?.id ?? null} />
+            <LeftPanel onStartReceipt={handleStartReceipt} onSelectReceipt={handleSelectReceipt} activeReceiptId={activeReceipt?.id ?? null} />
           )}
           {mobileTab === 'workflow' && (
             showSupervisorQueue ? (


### PR DESCRIPTION
## What changed

- make completed receipt rows explicitly open their documents
- load the full receipt record before showing its document list
- switch mobile users directly to **Docs & Labels**
- default completed-receipt uploads to **CoC**
- clarify that attaching a receiving document does not require reopening the completed receipt

## Why

Completed POs were visible under **Recently Received**, but selecting one only passed the receipt summary and did not navigate mobile users to the document panel. This made the existing receipt-level upload path effectively inaccessible or misleading for CoCs received after the PO was completed.

## Impact

Users can attach a CoC to a completed receipt without reopening or changing its receiving data. The existing receipt-document and Media Library storage path remains authoritative.

## Validation

- `git diff --check`
- scoped one-file diff review
- automated Vitest/TypeScript execution was unavailable because the clean worktree did not have project dependencies installed