### PR TITLE
Allocate P2 scheduling gaps by PO line

### DIFF
--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -8,6 +8,7 @@ import {
   countDistinctP2DemandUnits,
   countDistinctP2SerializedUnits,
   isHistoricalP2Unit,
+  p2PendingUnitDeficit,
 } from '../src/lib/p2SchedulingReconciliation';
 
 describe('P2 shipment and scheduling reconciliation', () => {
@@ -59,6 +60,12 @@ describe('P2 shipment and scheduling reconciliation', () => {
 
     expect(generated).toBe(2);
     expect(3 - generated).toBe(1);
+  });
+
+  it('places a nine-unit family gap on the remaining PO line without duplicating pending rows', () => {
+    expect(p2PendingUnitDeficit(90, 81, 0)).toBe(9);
+    expect(p2PendingUnitDeficit(90, 81, 9)).toBe(0);
+    expect(p2PendingUnitDeficit(90, 81, 12)).toBe(0);
   });
 
   it('counts shipped, finalization, active, and scheduled units once by serial', () => {

--- a/server/src/lib/p2SchedulingReconciliation.ts
+++ b/server/src/lib/p2SchedulingReconciliation.ts
@@ -26,6 +26,15 @@ export function countDistinctP2SerializedUnits(
   return identities.size;
 }
 
+export function p2PendingUnitDeficit(
+  orderedQuantity: number,
+  consumedQuantity: number,
+  existingPendingQuantity: number,
+): number {
+  const earlyStageCapacity = Math.max(0, orderedQuantity - consumedQuantity);
+  return Math.max(0, earlyStageCapacity - existingPendingQuantity);
+}
+
 export function p2UnitConsumesOrderedDemand(
   row: P2SerializedUnitLedgerRow,
   shippedItemIds: ReadonlySet<string>,

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -27,7 +27,7 @@ import {
 } from '../lib/p2ShipmentEvidence';
 import {
   countDistinctP2DemandUnits,
-  countDistinctP2SerializedUnits,
+  p2PendingUnitDeficit,
 } from '../lib/p2SchedulingReconciliation';
 import { softAuth, authenticateToken, sessionAwareAuth, requireAdminOrOwner } from '../../middleware/auth';
 import { computeEffectivePriority, getEffectivePriorityScore } from '../../../shared/utils/computeEffectivePriority';
@@ -5040,23 +5040,6 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         serializedByPoItemId.get(poItemId)!.push(item);
       }
 
-      for (const poItem of poItems) {
-        const poItemId = Number(poItem.poItemId);
-        const orderedQuantity = Number(poItem.orderedQuantity) || 0;
-        const existingItems = serializedByPoItemId.get(poItemId) ?? [];
-        const generatedUnitCount = countDistinctP2SerializedUnits(existingItems, shippedItemIds);
-        const missingCount = Math.max(0, orderedQuantity - generatedUnitCount);
-
-        if (missingCount === 0) continue;
-
-        // Historical POs can have ordered quantity that outruns generated
-        // serialized units, which makes pending work disappear from Schedule.
-        const createdItems = await storage.addP2SerializedItemsForPoItem(poItemId, missingCount);
-        if (createdItems.length > 0) {
-          serializedByPoItemId.set(poItemId, [...existingItems, ...createdItems]);
-        }
-      }
-
       const sortBySequence = (a: any, b: any) =>
         (Number(a.sequenceNumber) || 0) - (Number(b.sequenceNumber) || 0) ||
         String(a.id).localeCompare(String(b.id));
@@ -5091,22 +5074,36 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
       const schedulingList: any[] = [];
       for (const poItem of poItems) {
-        const items = (serializedByPoItemId.get(Number(poItem.poItemId)) ?? [])
+        const poItemId = Number(poItem.poItemId);
+        let items = (serializedByPoItemId.get(poItemId) ?? [])
           .sort(sortBySequence);
-        if (items.length === 0) continue;
 
         const orderedQuantity = Number(poItem.orderedQuantity) || 0;
-        const completedCount = consumedCapacityByPoItemId.get(Number(poItem.poItemId)) ?? 0;
+        const completedCount = consumedCapacityByPoItemId.get(poItemId) ?? 0;
         const earlyStageCapacity = Math.max(
           0,
           orderedQuantity - completedCount
         );
 
-        const pendingItems = items.filter((s: any) => {
+        let pendingItems = items.filter((s: any) => {
           if (s.status !== 'ACTIVE') return false;
           const dept = String(s.currentDepartment || '').trim();
           return dept === '' || dept === 'Pending Layup';
         });
+
+        const pendingDeficit = p2PendingUnitDeficit(
+          orderedQuantity,
+          completedCount,
+          pendingItems.length,
+        );
+        if (pendingDeficit > 0) {
+          const createdItems = await storage.addP2SerializedItemsForPoItem(poItemId, pendingDeficit);
+          if (createdItems.length > 0) {
+            items = [...items, ...createdItems].sort(sortBySequence);
+            pendingItems = [...pendingItems, ...createdItems].sort(sortBySequence);
+            serializedByPoItemId.set(poItemId, items);
+          }
+        }
 
         const pendingToShow = pendingItems.slice(0, earlyStageCapacity);
 


### PR DESCRIPTION
## What changed

- Allocate revision-family consumed demand across the current PO's ordered line items before creating pending serialized units.
- Calculate each line's exact pending deficit after that allocation.
- Reuse existing active Pending Layup units and create only the remaining deficit.
- Add regression coverage for the nine-unit PO-line gap and repeated-read idempotency.

## Root cause

PO014332-RA has seven current line items totaling 390 units. The shared ledger identified 381 consumed units and nine available units, but the Schedule endpoint attempted to generate missing units independently per line before allocating family consumption. Historical serialized rows were associated differently across the revision family, so the final 90-unit line received a nine-unit scheduling gap but no pending rows.

## User impact

The endpoint now assigns the 381 consumed units across the seven ordered lines first, identifies the final line as 81 consumed of 90, and exposes exactly nine Pending Layup units in Production Scheduling.

## Data and audit safety

No historical PO, shipment, packing-slip, scrap, nonconformance, or audit records are rewritten. Pending rows are created through the existing authoritative serialized-item service only when the allocated line deficit exceeds existing pending capacity. Repeated requests therefore create no duplicates.

## Validation

- live PO inspection confirmed status OPEN and line quantities 15 + 15 + 88 + 2 + 90 + 90 + 90 = 390
- `git diff --cached --check`: passed before commit
- focused Vitest suites: unavailable because dependency installation timed out without producing a Vitest binary