### PR TITLE
Prevent duplicate EPOCH validation package creation

### DIFF
--- a/client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
+++ b/client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const source = fs.readFileSync(
+  path.resolve(import.meta.dirname, '../pages/EpochSoftwareValidationPage.tsx'),
+  'utf8'
+);
+
+describe('EPOCH software validation create submission', () => {
+  it('has one authoritative form submission path and no create click handler', () => {
+    expect(source).toContain(
+      'onSubmit={e=>{e.preventDefault();submitCreate(e.currentTarget)}}'
+    );
+    expect(source).not.toMatch(/onClick=.*create\.mutate/);
+    expect(source).not.toMatch(/useEffect[\s\S]{0,300}create\.mutate/);
+  });
+
+  it('synchronously ignores rapid repeat submissions before React rerenders', () => {
+    expect(source).toContain('if(createSubmission.current)return;');
+    expect(source).toContain('createSubmission.current=idempotencyKey;');
+    expect(
+      source.indexOf('createSubmission.current=idempotencyKey;')
+    ).toBeLessThan(source.indexOf('create.mutate({body:'));
+  });
+
+  it('uses a fresh key per deliberate action and disables the pending submit', () => {
+    expect(source).toContain('const idempotencyKey=crypto.randomUUID()');
+    expect(source).toContain(
+      "headers:{'Idempotency-Key':input.idempotencyKey}"
+    );
+    expect(source).toContain('retry:false');
+    expect(source).toContain(
+      'disabled={create.isPending||Boolean(createSubmission.current)}'
+    );
+    expect(source).toContain("'Creating package\\u2026'");
+    expect(source).toContain('setSelected(p.id)');
+  });
+});

--- a/client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
+++ b/client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
@@ -1,39 +1,41 @@
 import fs from 'fs';
 import path from 'path';
+
 import { describe, expect, it } from 'vitest';
 
 const source = fs.readFileSync(
   path.resolve(import.meta.dirname, '../pages/EpochSoftwareValidationPage.tsx'),
   'utf8'
 );
+const compact = source.replace(/\s+/g, '');
 
 describe('EPOCH software validation create submission', () => {
   it('has one authoritative form submission path and no create click handler', () => {
-    expect(source).toContain(
-      'onSubmit={e=>{e.preventDefault();submitCreate(e.currentTarget)}}'
+    expect(compact).toContain(
+      'onSubmit={(e)=>{e.preventDefault();submitCreate(e.currentTarget);}}'
     );
     expect(source).not.toMatch(/onClick=.*create\.mutate/);
     expect(source).not.toMatch(/useEffect[\s\S]{0,300}create\.mutate/);
   });
 
   it('synchronously ignores rapid repeat submissions before React rerenders', () => {
-    expect(source).toContain('if(createSubmission.current)return;');
-    expect(source).toContain('createSubmission.current=idempotencyKey;');
+    expect(compact).toContain('if(createSubmission.current)return;');
+    expect(compact).toContain('createSubmission.current=idempotencyKey;');
     expect(
-      source.indexOf('createSubmission.current=idempotencyKey;')
-    ).toBeLessThan(source.indexOf('create.mutate({body:'));
+      compact.indexOf('createSubmission.current=idempotencyKey;')
+    ).toBeLessThan(compact.indexOf('create.mutate({body:'));
   });
 
   it('uses a fresh key per deliberate action and disables the pending submit', () => {
-    expect(source).toContain('const idempotencyKey=crypto.randomUUID()');
-    expect(source).toContain(
+    expect(compact).toContain('constidempotencyKey=crypto.randomUUID()');
+    expect(compact).toContain(
       "headers:{'Idempotency-Key':input.idempotencyKey}"
     );
-    expect(source).toContain('retry:false');
-    expect(source).toContain(
+    expect(compact).toContain('retry:false');
+    expect(compact).toContain(
       'disabled={create.isPending||Boolean(createSubmission.current)}'
     );
-    expect(source).toContain("'Creating package\\u2026'");
-    expect(source).toContain('setSelected(p.id)');
+    expect(compact).toContain("'Creatingpackage\\u2026'");
+    expect(compact).toContain('setSelected(p.id)');
   });
 });

--- a/client/src/__tests__/epochSoftwareValidationReadiness.component.test.tsx
+++ b/client/src/__tests__/epochSoftwareValidationReadiness.component.test.tsx
@@ -1,17 +1,19 @@
 import fs from 'fs';
 import path from 'path';
+
 import { describe, expect, it } from 'vitest';
 
 const source = fs.readFileSync(
   path.resolve(import.meta.dirname, '../pages/EpochSoftwareValidationPage.tsx'),
   'utf8'
 );
+const compact = source.replace(/\s+/g, '');
 
 describe('EPOCH software validation readiness UI', () => {
   it('renders the server-derived checklist and opens controlled editing', () => {
     expect(source).toContain('d.packageReadiness.items.map');
     expect(source).toContain('Edit package readiness');
-    expect(source).toContain("method:'PATCH'");
+    expect(compact).toContain("method:'PATCH'");
   });
 
   it('provides exact identifier guidance and separate authenticated confirmations', () => {
@@ -25,8 +27,8 @@ describe('EPOCH software validation readiness UI', () => {
   });
 
   it('uses active employee and Audit Readiness option sources', () => {
-    expect(source).toContain("queryKey:['/api/employees']");
-    expect(source).toContain("queryKey:['/api/qms/as9100-audit-readiness']");
+    expect(compact).toContain("queryKey:['/api/employees']");
+    expect(compact).toContain("queryKey:['/api/qms/as9100-audit-readiness']");
     expect(source).toContain('Software owner');
     expect(source).toContain('Quality owner');
     expect(source).toContain('Validation lead');

--- a/client/src/pages/EpochSoftwareValidationPage.tsx
+++ b/client/src/pages/EpochSoftwareValidationPage.tsx
@@ -1,252 +1,1222 @@
 import { useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { AlertTriangle, ArrowLeft, CheckCircle2, FileCheck2, History, Lock, Plus, ShieldCheck } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  FileCheck2,
+  History,
+  Lock,
+  Plus,
+  ShieldCheck,
+} from 'lucide-react';
+
 import { apiRequest } from '@/lib/queryClient';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 
 type Package = {
-  id:string;package_number:string;title:string;system_name:string;validation_type:string;status:string;
-  production_version:string;commit_or_release_identifier?:string;validation_environment:string;production_deployment_date?:string;
-  production_environment_reference:string;environment_differences?:string;notes?:string;row_version:number;
-  software_owner_employee_id?:number;quality_owner_employee_id?:number;validation_lead_employee_id?:number;
-  audit_readiness_assessment_id?:string;deployment_date_confirmed?:boolean;environment_separation_confirmed?:boolean;
-  planned_start_date:string;planned_completion_date:string;locked_at?:string;
-  requirement_count?:number;execution_count?:number;open_defect_count?:number;
+  id: string;
+  package_number: string;
+  title: string;
+  system_name: string;
+  validation_type: string;
+  status: string;
+  production_version: string;
+  commit_or_release_identifier?: string;
+  validation_environment: string;
+  production_deployment_date?: string;
+  production_environment_reference: string;
+  environment_differences?: string;
+  notes?: string;
+  row_version: number;
+  software_owner_employee_id?: number;
+  quality_owner_employee_id?: number;
+  validation_lead_employee_id?: number;
+  audit_readiness_assessment_id?: string;
+  deployment_date_confirmed?: boolean;
+  environment_separation_confirmed?: boolean;
+  planned_start_date: string;
+  planned_completion_date: string;
+  locked_at?: string;
+  requirement_count?: number;
+  execution_count?: number;
+  open_defect_count?: number;
 };
 type Detail = {
-  package:Package;intendedUse:any[];requirements:any[];risks:any[];plans:any[];protocols:any[];
-  executions:any[];defects:any[];approvals:any[];periodicReviews:any[];events:any[];
-  readiness:Record<string,any>&{ready:boolean;blockers:string[]};
-  packageReadiness:{items:Array<{key:string;label:string;state:string;field:string;message?:string}>;executionReady:boolean;blockers:any[]};
-};
-type Employee={id:number;name:string};
-type Assessment={id:string;assessment_number:string;title:string};
-const sections=[
-  ['01','Intended Use','Controlled scope and dual authenticated approval'],
-  ['02','Software Requirements','Normalized, revision-controlled requirements baseline'],
-  ['03','Software Risk Assessment','Requirement-linked risk and mitigation register'],
-  ['04','Validation Plan','Approved plan required before formal execution'],
-  ['05','Test Protocols','Revision-controlled protocols, steps, requirements and risks'],
-  ['06','Test Execution and Evidence','Server-derived results and independent review'],
-  ['07','Defects and Corrections','Controlled defects, containment, correction and retest'],
-  ['08','Validation Summary','Server-calculated authoritative readiness'],
-  ['09','Production Approval','Authenticated approval and immutable final snapshot'],
-  ['10','Periodic Review','Change review and revalidation decision'],
-] as const;
-const pretty=(v:string)=>v.replaceAll('_',' ').replace(/\b\w/g,c=>c.toUpperCase());
-const tone=(v:string)=>v.includes('APPROVED')||v==='PASSED'||v==='CLOSED'?'bg-emerald-100 text-emerald-800':
-  v.includes('BLOCK')||v.includes('REJECT')||v==='FAILED'?'bg-red-100 text-red-800':'bg-amber-100 text-amber-900';
-
-export default function EpochSoftwareValidationPage(){
-  const [selected,setSelected]=useState<string>();
-  const [createOpen,setCreateOpen]=useState(false);
-  const [editOpen,setEditOpen]=useState(false);
-  const [auditor,setAuditor]=useState(false);
-  const [activeSection,setActiveSection]=useState('01');
-  const createSubmission=useRef<string|null>(null);
-  const qc=useQueryClient(),{toast}=useToast();
-  const list=useQuery<Package[]>({queryKey:['/api/qms/epoch-software-validation'],
-    queryFn:async()=>(await apiRequest('/api/qms/epoch-software-validation')).json()});
-  const detail=useQuery<Detail>({queryKey:['/api/qms/epoch-software-validation',selected],enabled:Boolean(selected),
-    queryFn:async()=>(await apiRequest(`/api/qms/epoch-software-validation/${selected}`)).json()});
-  const employees=useQuery<Employee[]>({queryKey:['/api/employees'],queryFn:async()=>(await apiRequest('/api/employees')).json()});
-  const assessments=useQuery<Assessment[]>({queryKey:['/api/qms/as9100-audit-readiness'],
-    queryFn:async()=>(await apiRequest('/api/qms/as9100-audit-readiness')).json()});
-  const create=useMutation({retry:false,mutationFn:async(input:{body:Record<string,FormDataEntryValue>;idempotencyKey:string})=>{
-    return (await apiRequest('/api/qms/epoch-software-validation',{method:'POST',body:input.body,
-      headers:{'Idempotency-Key':input.idempotencyKey}})).json();
-  },onSuccess:(p:Package)=>{qc.invalidateQueries({queryKey:['/api/qms/epoch-software-validation']});
-    createSubmission.current=null;setCreateOpen(false);setSelected(p.id);toast({title:`${p.package_number} created`});},
-    onError:(e:Error)=>{createSubmission.current=null;toast({title:'Package was not created',description:e.message,variant:'destructive'});}});
-  const submitCreate=(form:HTMLFormElement)=>{
-    if(createSubmission.current)return;
-    const idempotencyKey=crypto.randomUUID();
-    createSubmission.current=idempotencyKey;
-    create.mutate({body:Object.fromEntries(new FormData(form).entries()),idempotencyKey});
+  package: Package;
+  intendedUse: any[];
+  requirements: any[];
+  risks: any[];
+  plans: any[];
+  protocols: any[];
+  executions: any[];
+  defects: any[];
+  approvals: any[];
+  periodicReviews: any[];
+  events: any[];
+  readiness: Record<string, any> & { ready: boolean; blockers: string[] };
+  packageReadiness: {
+    items: Array<{
+      key: string;
+      label: string;
+      state: string;
+      field: string;
+      message?: string;
+    }>;
+    executionReady: boolean;
+    blockers: any[];
   };
-  const refresh=()=>qc.invalidateQueries({queryKey:['/api/qms/epoch-software-validation',selected]});
-  const edit=useMutation({mutationFn:async(form:HTMLFormElement)=>{
-    const f=new FormData(form),num=(name:string)=>{const value=f.get(name);return value&&value!=='NONE'?Number(value):null;};
-    const assessment=f.get('auditReadinessAssessmentId');
-    return (await apiRequest(`/api/qms/epoch-software-validation/${selected}`,{method:'PATCH',body:{
-      rowVersion:detail.data!.package.row_version,commitOrReleaseIdentifier:f.get('commitOrReleaseIdentifier')||null,
-      productionDeploymentDate:f.get('productionDeploymentDate')||null,validationEnvironment:f.get('validationEnvironment'),
-      productionEnvironmentReference:f.get('productionEnvironmentReference'),environmentDifferences:f.get('environmentDifferences')||null,
-      softwareOwnerEmployeeId:num('softwareOwnerEmployeeId'),qualityOwnerEmployeeId:num('qualityOwnerEmployeeId'),
-      validationLeadEmployeeId:num('validationLeadEmployeeId'),auditReadinessAssessmentId:assessment==='NONE'||assessment===null?null:String(assessment),
-      notes:f.get('notes')||null,
-    }})).json();
-  },onSuccess:()=>{refresh();setEditOpen(false);toast({title:'Controlled package fields updated'});},
-    onError:(e:Error)=>toast({title:'Package update blocked',description:e.message,variant:'destructive'})});
-  const confirm=useMutation({mutationFn:async(kind:'deployment-date'|'environment-separation')=>
-    (await apiRequest(`/api/qms/epoch-software-validation/${selected}/confirm-${kind}`,{method:'POST',body:{}})).json(),
-    onSuccess:()=>{refresh();toast({title:'Authenticated confirmation recorded'});},
-    onError:(e:Error)=>toast({title:'Confirmation blocked',description:e.message,variant:'destructive'})});
-  const progress=useMemo(()=>{
-    const d=detail.data;if(!d)return 0;let complete=0;
-    if(d.readiness.intendedUseApproved)complete++;
-    if(d.readiness.requirementsBaselineApproved)complete++;
-    if(d.readiness.riskAssessmentApproved)complete++;
-    if(d.readiness.validationPlanApproved)complete++;
-    if(d.protocols.length&&d.protocols.every(x=>x.status==='APPROVED'))complete++;
-    if(d.executions.length&&d.executions.every(x=>['PASSED','PASSED_WITH_APPROVED_DEVIATION'].includes(x.overall_result)))complete++;
-    if(!d.readiness.openCriticalDefects&&!d.readiness.openHighDefects)complete++;
-    if(d.readiness.ready)complete+=2;
-    if(d.periodicReviews.length)complete++;
-    return complete*10;
-  },[detail.data]);
+};
+type Employee = { id: number; name: string };
+type Assessment = { id: string; assessment_number: string; title: string };
+const sections = [
+  ['01', 'Intended Use', 'Controlled scope and dual authenticated approval'],
+  [
+    '02',
+    'Software Requirements',
+    'Normalized, revision-controlled requirements baseline',
+  ],
+  [
+    '03',
+    'Software Risk Assessment',
+    'Requirement-linked risk and mitigation register',
+  ],
+  ['04', 'Validation Plan', 'Approved plan required before formal execution'],
+  [
+    '05',
+    'Test Protocols',
+    'Revision-controlled protocols, steps, requirements and risks',
+  ],
+  [
+    '06',
+    'Test Execution and Evidence',
+    'Server-derived results and independent review',
+  ],
+  [
+    '07',
+    'Defects and Corrections',
+    'Controlled defects, containment, correction and retest',
+  ],
+  ['08', 'Validation Summary', 'Server-calculated authoritative readiness'],
+  [
+    '09',
+    'Production Approval',
+    'Authenticated approval and immutable final snapshot',
+  ],
+  ['10', 'Periodic Review', 'Change review and revalidation decision'],
+] as const;
+const pretty = (v: string) =>
+  v.replaceAll('_', ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+const tone = (v: string) =>
+  v.includes('APPROVED') || v === 'PASSED' || v === 'CLOSED'
+    ? 'bg-emerald-100 text-emerald-800'
+    : v.includes('BLOCK') || v.includes('REJECT') || v === 'FAILED'
+      ? 'bg-red-100 text-red-800'
+      : 'bg-amber-100 text-amber-900';
 
-  if(selected&&detail.data){
-    const d=detail.data,p=d.package,locked=Boolean(p.locked_at)||p.status.startsWith('APPROVED');
-    return <div className="container mx-auto space-y-5 p-4 lg:p-6">
-      <div className="flex flex-wrap items-start justify-between gap-3"><div>
-        <Button variant="ghost" className="px-0" onClick={()=>setSelected(undefined)}><ArrowLeft className="mr-2 h-4 w-4"/>Validation packages</Button>
-        <h1 className="text-2xl font-bold">{p.package_number} · {p.title}</h1>
-        <p className="text-sm text-muted-foreground">EPOCH {p.production_version} · {pretty(p.validation_type)} · {p.validation_environment}</p>
-      </div><div className="flex flex-wrap gap-2">
-        <Button variant="outline" onClick={()=>setEditOpen(true)}>Edit package readiness</Button>
-        <Button variant={auditor?'default':'outline'} onClick={()=>setAuditor(v=>!v)}><ShieldCheck className="mr-2 h-4 w-4"/>Auditor View</Button>
-        <ExportMenu id={p.id}/>
-      </div></div>
-      <div className={`rounded-md border p-3 text-sm font-semibold ${locked?'border-emerald-500 bg-emerald-50 text-emerald-900':'border-amber-400 bg-amber-50 text-amber-900'}`}>
-        {locked?<><Lock className="mr-2 inline h-4 w-4"/>CONTROLLED EPOCH SOFTWARE VALIDATION RECORD</>:'DRAFT — NOT APPROVED FOR INTENDED USE'}
-      </div>
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-        <Metric label="Workflow progress" value={`${progress}%`} ok={progress===100}/>
-        <Metric label="Requirements" value={String(d.requirements.length)} ok={d.readiness.requirementsBaselineApproved}/>
-        <Metric label="Tests passed" value={String(d.executions.filter(x=>x.overall_result==='PASSED').length)} ok={d.readiness.criticalTestsPassed===d.readiness.criticalTests}/>
-        <Metric label="Critical defects" value={String(d.readiness.openCriticalDefects||0)} danger={Boolean(d.readiness.openCriticalDefects)}/>
-        <Metric label="Overall readiness" value={d.readiness.ready?'Ready':'Blocked'} ok={d.readiness.ready} danger={!d.readiness.ready}/>
-      </div>
-      <Progress value={progress}/>
-      <Card id="package-readiness" className={d.packageReadiness.executionReady?'border-emerald-300':'border-amber-300'}>
-        <CardHeader><CardTitle className="flex items-center justify-between gap-3 text-base"><span>Package readiness</span>
-          <Badge className={d.packageReadiness.executionReady?'bg-emerald-100 text-emerald-800':'bg-amber-100 text-amber-900'}>
-            {d.packageReadiness.executionReady?'Execution ready':'Action required'}</Badge></CardTitle></CardHeader>
-        <CardContent className="grid gap-2 md:grid-cols-2">{d.packageReadiness.items.map(item=><button key={item.key}
-          type="button" onClick={()=>setEditOpen(true)} className="flex items-start justify-between gap-3 rounded-md border p-3 text-left hover:bg-muted">
-          <span><span className="block text-sm font-medium">{item.label}</span>{item.message&&<span className="text-xs text-muted-foreground">{item.message}</span>}</span>
-          <Badge variant="outline">{pretty(item.state)}</Badge></button>)}</CardContent>
-      </Card>
-      {!d.readiness.ready&&<Card className="border-red-300"><CardHeader><CardTitle className="flex items-center gap-2 text-base text-red-800"><AlertTriangle className="h-4 w-4"/>Readiness blockers</CardTitle></CardHeader>
-        <CardContent><ul className="list-disc space-y-1 pl-5 text-sm">{d.readiness.blockers.map(x=><li key={x}>{x}</li>)}</ul></CardContent></Card>}
-      <div className="grid gap-4 lg:grid-cols-[310px_1fr]">
-        <Card><CardHeader><CardTitle className="text-base">10 validation sections</CardTitle></CardHeader><CardContent className="space-y-2">
-          {sections.map(([key,title,description])=><button key={key} onClick={()=>setActiveSection(key)}
-            className={`w-full rounded-md border p-3 text-left ${activeSection===key?'border-primary bg-primary/5':'hover:bg-muted'}`}>
-            <div className="font-medium">{key}. {title}</div><div className="text-xs text-muted-foreground">{description}</div>
-          </button>)}
-        </CardContent></Card>
-        <SectionWorkspace section={activeSection} detail={d} auditor={auditor}/>
-      </div>
-      <Dialog open={editOpen} onOpenChange={setEditOpen}><DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
-        <DialogHeader><DialogTitle>Edit package readiness</DialogTitle><DialogDescription>
-          Complete controlled metadata for the exact production deployment. Saving does not record either authenticated confirmation.
-        </DialogDescription></DialogHeader>
-        <form className="grid gap-4 md:grid-cols-2" onSubmit={e=>{e.preventDefault();edit.mutate(e.currentTarget)}}>
-          <div><Field name="commitOrReleaseIdentifier" label="Production commit SHA, release tag, or deployment identifier" defaultValue={p.commit_or_release_identifier||''}/>
-            <p className="mt-1 text-xs text-muted-foreground">Enter the exact deployed commit SHA, release tag, or deployment ID. A PR number alone is not sufficient.</p></div>
-          <Field name="productionDeploymentDate" label="Production deployment date" type="date" defaultValue={p.production_deployment_date?.slice(0,10)||''}/>
-          <EmployeePick name="softwareOwnerEmployeeId" label="Software owner" value={p.software_owner_employee_id} employees={employees.data||[]}/>
-          <EmployeePick name="qualityOwnerEmployeeId" label="Quality owner" value={p.quality_owner_employee_id} employees={employees.data||[]}/>
-          <EmployeePick name="validationLeadEmployeeId" label="Validation lead" value={p.validation_lead_employee_id} employees={employees.data||[]}/>
-          <div><Label>Audit readiness assessment</Label><Select name="auditReadinessAssessmentId" defaultValue={p.audit_readiness_assessment_id||'NONE'}>
-            <SelectTrigger><SelectValue/></SelectTrigger><SelectContent><SelectItem value="NONE">Not linked</SelectItem>
-              {assessments.data?.map(a=><SelectItem key={a.id} value={a.id}>{a.assessment_number} · {a.title}</SelectItem>)}</SelectContent></Select></div>
-          <Field name="validationEnvironment" label="Validation environment reference" defaultValue={p.validation_environment||''}/>
-          <Field name="productionEnvironmentReference" label="Production environment reference" defaultValue={p.production_environment_reference||''}/>
-          <div className="md:col-span-2"><Label>Validation-to-production environment differences</Label>
-            <Textarea name="environmentDifferences" defaultValue={p.environment_differences||''}/></div>
-          <div className="md:col-span-2"><Label>Package notes</Label><Textarea name="notes" defaultValue={p.notes||''}
-            placeholder="Describe package-specific validation context; replace generic placeholder text."/></div>
-          <DialogFooter className="md:col-span-2"><Button type="submit" disabled={edit.isPending}>Save controlled fields</Button></DialogFooter>
-        </form>
-        <div className="grid gap-3 border-t pt-4 md:grid-cols-2">
-          <div><Button type="button" variant="outline" disabled={confirm.isPending||!p.production_deployment_date}
-            onClick={()=>confirm.mutate('deployment-date')}>Confirm deployment date</Button></div>
-          <div><Button type="button" variant="outline" disabled={confirm.isPending||!p.environment_differences}
-            onClick={()=>confirm.mutate('environment-separation')}>Confirm environment separation</Button></div>
+export default function EpochSoftwareValidationPage() {
+  const [selected, setSelected] = useState<string>();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [auditor, setAuditor] = useState(false);
+  const [activeSection, setActiveSection] = useState('01');
+  const createSubmission = useRef<string | null>(null);
+  const qc = useQueryClient(),
+    { toast } = useToast();
+  const list = useQuery<Package[]>({
+    queryKey: ['/api/qms/epoch-software-validation'],
+    queryFn: async () =>
+      (await apiRequest('/api/qms/epoch-software-validation')).json(),
+  });
+  const detail = useQuery<Detail>({
+    queryKey: ['/api/qms/epoch-software-validation', selected],
+    enabled: Boolean(selected),
+    queryFn: async () =>
+      (
+        await apiRequest(`/api/qms/epoch-software-validation/${selected}`)
+      ).json(),
+  });
+  const employees = useQuery<Employee[]>({
+    queryKey: ['/api/employees'],
+    queryFn: async () => (await apiRequest('/api/employees')).json(),
+  });
+  const assessments = useQuery<Assessment[]>({
+    queryKey: ['/api/qms/as9100-audit-readiness'],
+    queryFn: async () =>
+      (await apiRequest('/api/qms/as9100-audit-readiness')).json(),
+  });
+  const create = useMutation({
+    retry: false,
+    mutationFn: async (input: {
+      body: Record<string, string>;
+      idempotencyKey: string;
+    }) => {
+      return (
+        await apiRequest('/api/qms/epoch-software-validation', {
+          method: 'POST',
+          body: input.body,
+          headers: { 'Idempotency-Key': input.idempotencyKey },
+        })
+      ).json();
+    },
+    onSuccess: (p: Package) => {
+      qc.invalidateQueries({
+        queryKey: ['/api/qms/epoch-software-validation'],
+      });
+      createSubmission.current = null;
+      setCreateOpen(false);
+      setSelected(p.id);
+      toast({ title: `${p.package_number} created` });
+    },
+    onError: (e: Error) => {
+      createSubmission.current = null;
+      toast({
+        title: 'Package was not created',
+        description: e.message,
+        variant: 'destructive',
+      });
+    },
+  });
+  const submitCreate = (form: HTMLFormElement) => {
+    if (createSubmission.current) return;
+    const idempotencyKey = crypto.randomUUID();
+    createSubmission.current = idempotencyKey;
+    create.mutate({
+      body: Object.fromEntries(new FormData(form).entries()) as Record<
+        string,
+        string
+      >,
+      idempotencyKey,
+    });
+  };
+  const refresh = () =>
+    qc.invalidateQueries({
+      queryKey: ['/api/qms/epoch-software-validation', selected],
+    });
+  const edit = useMutation({
+    mutationFn: async (form: HTMLFormElement) => {
+      const f = new FormData(form),
+        num = (name: string) => {
+          const value = f.get(name);
+          return value && value !== 'NONE' ? Number(value) : null;
+        };
+      const assessment = f.get('auditReadinessAssessmentId');
+      return (
+        await apiRequest(`/api/qms/epoch-software-validation/${selected}`, {
+          method: 'PATCH',
+          body: {
+            rowVersion: detail.data!.package.row_version,
+            commitOrReleaseIdentifier:
+              f.get('commitOrReleaseIdentifier') || null,
+            productionDeploymentDate: f.get('productionDeploymentDate') || null,
+            validationEnvironment: f.get('validationEnvironment'),
+            productionEnvironmentReference: f.get(
+              'productionEnvironmentReference'
+            ),
+            environmentDifferences: f.get('environmentDifferences') || null,
+            softwareOwnerEmployeeId: num('softwareOwnerEmployeeId'),
+            qualityOwnerEmployeeId: num('qualityOwnerEmployeeId'),
+            validationLeadEmployeeId: num('validationLeadEmployeeId'),
+            auditReadinessAssessmentId:
+              assessment === 'NONE' || assessment === null
+                ? null
+                : String(assessment),
+            notes: f.get('notes') || null,
+          },
+        })
+      ).json();
+    },
+    onSuccess: () => {
+      refresh();
+      setEditOpen(false);
+      toast({ title: 'Controlled package fields updated' });
+    },
+    onError: (e: Error) =>
+      toast({
+        title: 'Package update blocked',
+        description: e.message,
+        variant: 'destructive',
+      }),
+  });
+  const confirm = useMutation({
+    mutationFn: async (kind: 'deployment-date' | 'environment-separation') =>
+      (
+        await apiRequest(
+          `/api/qms/epoch-software-validation/${selected}/confirm-${kind}`,
+          { method: 'POST', body: {} }
+        )
+      ).json(),
+    onSuccess: () => {
+      refresh();
+      toast({ title: 'Authenticated confirmation recorded' });
+    },
+    onError: (e: Error) =>
+      toast({
+        title: 'Confirmation blocked',
+        description: e.message,
+        variant: 'destructive',
+      }),
+  });
+  const progress = useMemo(() => {
+    const d = detail.data;
+    if (!d) return 0;
+    let complete = 0;
+    if (d.readiness.intendedUseApproved) complete++;
+    if (d.readiness.requirementsBaselineApproved) complete++;
+    if (d.readiness.riskAssessmentApproved) complete++;
+    if (d.readiness.validationPlanApproved) complete++;
+    if (d.protocols.length && d.protocols.every((x) => x.status === 'APPROVED'))
+      complete++;
+    if (
+      d.executions.length &&
+      d.executions.every((x) =>
+        ['PASSED', 'PASSED_WITH_APPROVED_DEVIATION'].includes(x.overall_result)
+      )
+    )
+      complete++;
+    if (!d.readiness.openCriticalDefects && !d.readiness.openHighDefects)
+      complete++;
+    if (d.readiness.ready) complete += 2;
+    if (d.periodicReviews.length) complete++;
+    return complete * 10;
+  }, [detail.data]);
+
+  if (selected && detail.data) {
+    const d = detail.data,
+      p = d.package,
+      locked = Boolean(p.locked_at) || p.status.startsWith('APPROVED');
+    return (
+      <div className="container mx-auto space-y-5 p-4 lg:p-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <Button
+              variant="ghost"
+              className="px-0"
+              onClick={() => setSelected(undefined)}
+            >
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Validation packages
+            </Button>
+            <h1 className="text-2xl font-bold">
+              {p.package_number} · {p.title}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              EPOCH {p.production_version} · {pretty(p.validation_type)} ·{' '}
+              {p.validation_environment}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => setEditOpen(true)}>
+              Edit package readiness
+            </Button>
+            <Button
+              variant={auditor ? 'default' : 'outline'}
+              onClick={() => setAuditor((v) => !v)}
+            >
+              <ShieldCheck className="mr-2 h-4 w-4" />
+              Auditor View
+            </Button>
+            <ExportMenu id={p.id} />
+          </div>
         </div>
-      </DialogContent></Dialog>
-      {auditor&&<Card><CardHeader><CardTitle className="flex items-center gap-2"><History className="h-5 w-5"/>Immutable audit history</CardTitle></CardHeader>
-        <CardContent><Table><TableHeader><TableRow><TableHead>Date</TableHead><TableHead>Action</TableHead><TableHead>Actor</TableHead><TableHead>Reason</TableHead></TableRow></TableHeader>
-          <TableBody>{d.events.map(e=><TableRow key={e.id}><TableCell>{new Date(e.created_at).toLocaleString()}</TableCell><TableCell>{pretty(e.action)}</TableCell><TableCell>{e.actor_display_name} · {e.actor_role}</TableCell><TableCell>{e.reason||'—'}</TableCell></TableRow>)}</TableBody></Table></CardContent></Card>}
-    </div>;
+        <div
+          className={`rounded-md border p-3 text-sm font-semibold ${locked ? 'border-emerald-500 bg-emerald-50 text-emerald-900' : 'border-amber-400 bg-amber-50 text-amber-900'}`}
+        >
+          {locked ? (
+            <>
+              <Lock className="mr-2 inline h-4 w-4" />
+              CONTROLLED EPOCH SOFTWARE VALIDATION RECORD
+            </>
+          ) : (
+            'DRAFT — NOT APPROVED FOR INTENDED USE'
+          )}
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          <Metric
+            label="Workflow progress"
+            value={`${progress}%`}
+            ok={progress === 100}
+          />
+          <Metric
+            label="Requirements"
+            value={String(d.requirements.length)}
+            ok={d.readiness.requirementsBaselineApproved}
+          />
+          <Metric
+            label="Tests passed"
+            value={String(
+              d.executions.filter((x) => x.overall_result === 'PASSED').length
+            )}
+            ok={d.readiness.criticalTestsPassed === d.readiness.criticalTests}
+          />
+          <Metric
+            label="Critical defects"
+            value={String(d.readiness.openCriticalDefects || 0)}
+            danger={Boolean(d.readiness.openCriticalDefects)}
+          />
+          <Metric
+            label="Overall readiness"
+            value={d.readiness.ready ? 'Ready' : 'Blocked'}
+            ok={d.readiness.ready}
+            danger={!d.readiness.ready}
+          />
+        </div>
+        <Progress value={progress} />
+        <Card
+          id="package-readiness"
+          className={
+            d.packageReadiness.executionReady
+              ? 'border-emerald-300'
+              : 'border-amber-300'
+          }
+        >
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between gap-3 text-base">
+              <span>Package readiness</span>
+              <Badge
+                className={
+                  d.packageReadiness.executionReady
+                    ? 'bg-emerald-100 text-emerald-800'
+                    : 'bg-amber-100 text-amber-900'
+                }
+              >
+                {d.packageReadiness.executionReady
+                  ? 'Execution ready'
+                  : 'Action required'}
+              </Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-2 md:grid-cols-2">
+            {d.packageReadiness.items.map((item) => (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => setEditOpen(true)}
+                className="flex items-start justify-between gap-3 rounded-md border p-3 text-left hover:bg-muted"
+              >
+                <span>
+                  <span className="block text-sm font-medium">
+                    {item.label}
+                  </span>
+                  {item.message && (
+                    <span className="text-xs text-muted-foreground">
+                      {item.message}
+                    </span>
+                  )}
+                </span>
+                <Badge variant="outline">{pretty(item.state)}</Badge>
+              </button>
+            ))}
+          </CardContent>
+        </Card>
+        {!d.readiness.ready && (
+          <Card className="border-red-300">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base text-red-800">
+                <AlertTriangle className="h-4 w-4" />
+                Readiness blockers
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc space-y-1 pl-5 text-sm">
+                {d.readiness.blockers.map((x) => (
+                  <li key={x}>{x}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
+        <div className="grid gap-4 lg:grid-cols-[310px_1fr]">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                10 validation sections
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {sections.map(([key, title, description]) => (
+                <button
+                  key={key}
+                  onClick={() => setActiveSection(key)}
+                  className={`w-full rounded-md border p-3 text-left ${activeSection === key ? 'border-primary bg-primary/5' : 'hover:bg-muted'}`}
+                >
+                  <div className="font-medium">
+                    {key}. {title}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {description}
+                  </div>
+                </button>
+              ))}
+            </CardContent>
+          </Card>
+          <SectionWorkspace
+            section={activeSection}
+            detail={d}
+            auditor={auditor}
+          />
+        </div>
+        <Dialog open={editOpen} onOpenChange={setEditOpen}>
+          <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>Edit package readiness</DialogTitle>
+              <DialogDescription>
+                Complete controlled metadata for the exact production
+                deployment. Saving does not record either authenticated
+                confirmation.
+              </DialogDescription>
+            </DialogHeader>
+            <form
+              className="grid gap-4 md:grid-cols-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                edit.mutate(e.currentTarget);
+              }}
+            >
+              <div>
+                <Field
+                  name="commitOrReleaseIdentifier"
+                  label="Production commit SHA, release tag, or deployment identifier"
+                  defaultValue={p.commit_or_release_identifier || ''}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Enter the exact deployed commit SHA, release tag, or
+                  deployment ID. A PR number alone is not sufficient.
+                </p>
+              </div>
+              <Field
+                name="productionDeploymentDate"
+                label="Production deployment date"
+                type="date"
+                defaultValue={p.production_deployment_date?.slice(0, 10) || ''}
+              />
+              <EmployeePick
+                name="softwareOwnerEmployeeId"
+                label="Software owner"
+                value={p.software_owner_employee_id}
+                employees={employees.data || []}
+              />
+              <EmployeePick
+                name="qualityOwnerEmployeeId"
+                label="Quality owner"
+                value={p.quality_owner_employee_id}
+                employees={employees.data || []}
+              />
+              <EmployeePick
+                name="validationLeadEmployeeId"
+                label="Validation lead"
+                value={p.validation_lead_employee_id}
+                employees={employees.data || []}
+              />
+              <div>
+                <Label>Audit readiness assessment</Label>
+                <Select
+                  name="auditReadinessAssessmentId"
+                  defaultValue={p.audit_readiness_assessment_id || 'NONE'}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="NONE">Not linked</SelectItem>
+                    {assessments.data?.map((a) => (
+                      <SelectItem key={a.id} value={a.id}>
+                        {a.assessment_number} · {a.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Field
+                name="validationEnvironment"
+                label="Validation environment reference"
+                defaultValue={p.validation_environment || ''}
+              />
+              <Field
+                name="productionEnvironmentReference"
+                label="Production environment reference"
+                defaultValue={p.production_environment_reference || ''}
+              />
+              <div className="md:col-span-2">
+                <Label>Validation-to-production environment differences</Label>
+                <Textarea
+                  name="environmentDifferences"
+                  defaultValue={p.environment_differences || ''}
+                />
+              </div>
+              <div className="md:col-span-2">
+                <Label>Package notes</Label>
+                <Textarea
+                  name="notes"
+                  defaultValue={p.notes || ''}
+                  placeholder="Describe package-specific validation context; replace generic placeholder text."
+                />
+              </div>
+              <DialogFooter className="md:col-span-2">
+                <Button type="submit" disabled={edit.isPending}>
+                  Save controlled fields
+                </Button>
+              </DialogFooter>
+            </form>
+            <div className="grid gap-3 border-t pt-4 md:grid-cols-2">
+              <div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={confirm.isPending || !p.production_deployment_date}
+                  onClick={() => confirm.mutate('deployment-date')}
+                >
+                  Confirm deployment date
+                </Button>
+              </div>
+              <div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={confirm.isPending || !p.environment_differences}
+                  onClick={() => confirm.mutate('environment-separation')}
+                >
+                  Confirm environment separation
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+        {auditor && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <History className="h-5 w-5" />
+                Immutable audit history
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Action</TableHead>
+                    <TableHead>Actor</TableHead>
+                    <TableHead>Reason</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {d.events.map((e) => (
+                    <TableRow key={e.id}>
+                      <TableCell>
+                        {new Date(e.created_at).toLocaleString()}
+                      </TableCell>
+                      <TableCell>{pretty(e.action)}</TableCell>
+                      <TableCell>
+                        {e.actor_display_name} · {e.actor_role}
+                      </TableCell>
+                      <TableCell>{e.reason || '—'}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    );
   }
 
-  return <div className="container mx-auto space-y-5 p-4 lg:p-6">
-    <div className="flex flex-wrap items-start justify-between gap-3"><div><h1 className="text-2xl font-bold">EPOCH Software Validation</h1>
-      <p className="text-muted-foreground">Objective evidence that EPOCH is suitable for its approved, documented QMS intended use.</p></div>
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}><DialogTrigger asChild><Button><Plus className="mr-2 h-4 w-4"/>New validation package</Button></DialogTrigger>
-      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto"><DialogHeader><DialogTitle>Create EPOCH Software Validation Package</DialogTitle>
-        <DialogDescription>Create a controlled draft. Production evidence and authenticated confirmations are completed after creation.</DialogDescription></DialogHeader>
-        <form className="grid gap-4 md:grid-cols-2" onSubmit={e=>{e.preventDefault();submitCreate(e.currentTarget)}}>
-          <Field name="title" label="Package title" required/><Field name="systemName" label="System name" defaultValue="EPOCH" required/>
-          <Pick name="validationType" label="Validation type" values={['INITIAL_INTENDED_USE','MAJOR_RELEASE','CRITICAL_CHANGE','DATABASE_MIGRATION','SECURITY_ACCESS_CONTROL','BACKUP_RECOVERY','PERIODIC_REVIEW','PRE_AUDIT_REVALIDATION','CORRECTIVE_REVALIDATION']}/>
-          <Field name="productionVersion" label="Production version being validated" required/>
-          <div><Field name="commitOrReleaseIdentifier" label="Production commit SHA, release tag, or deployment identifier"/>
-            <p className="mt-1 text-xs text-muted-foreground">Enter the exact deployed commit SHA, release tag, or deployment ID. A PR number alone is not sufficient.</p></div>
-          <Field name="productionDeploymentDate" label="Production deployment date" type="date"/>
-          <Field name="validationEnvironment" label="Validation environment" required/>
-          <Field name="productionEnvironmentReference" label="Production environment reference" required/>
-          <Field name="databaseProvider" label="Database type/provider" required/><Field name="hostingProvider" label="Hosting provider" required/>
-          <Field name="plannedStartDate" label="Planned start" type="date" required/><Field name="plannedCompletionDate" label="Planned completion" type="date" required/>
-          <div className="md:col-span-2"><Label>Reason for validation</Label><Textarea name="reasonForValidation" required/></div>
-          <div className="md:col-span-2"><Label>Notes</Label><Textarea name="notes"/></div>
-          <DialogFooter className="md:col-span-2"><Button type="submit" disabled={create.isPending||Boolean(createSubmission.current)}>
-            {create.isPending||createSubmission.current?'Creating package\u2026':'Create controlled draft'}</Button></DialogFooter>
-        </form></DialogContent></Dialog>
+  return (
+    <div className="container mx-auto space-y-5 p-4 lg:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold">EPOCH Software Validation</h1>
+          <p className="text-muted-foreground">
+            Objective evidence that EPOCH is suitable for its approved,
+            documented QMS intended use.
+          </p>
+        </div>
+        <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+          <DialogTrigger asChild>
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              New validation package
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>
+                Create EPOCH Software Validation Package
+              </DialogTitle>
+              <DialogDescription>
+                Create a controlled draft. Production evidence and authenticated
+                confirmations are completed after creation.
+              </DialogDescription>
+            </DialogHeader>
+            <form
+              className="grid gap-4 md:grid-cols-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                submitCreate(e.currentTarget);
+              }}
+            >
+              <Field name="title" label="Package title" required />
+              <Field
+                name="systemName"
+                label="System name"
+                defaultValue="EPOCH"
+                required
+              />
+              <Pick
+                name="validationType"
+                label="Validation type"
+                values={[
+                  'INITIAL_INTENDED_USE',
+                  'MAJOR_RELEASE',
+                  'CRITICAL_CHANGE',
+                  'DATABASE_MIGRATION',
+                  'SECURITY_ACCESS_CONTROL',
+                  'BACKUP_RECOVERY',
+                  'PERIODIC_REVIEW',
+                  'PRE_AUDIT_REVALIDATION',
+                  'CORRECTIVE_REVALIDATION',
+                ]}
+              />
+              <Field
+                name="productionVersion"
+                label="Production version being validated"
+                required
+              />
+              <div>
+                <Field
+                  name="commitOrReleaseIdentifier"
+                  label="Production commit SHA, release tag, or deployment identifier"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Enter the exact deployed commit SHA, release tag, or
+                  deployment ID. A PR number alone is not sufficient.
+                </p>
+              </div>
+              <Field
+                name="productionDeploymentDate"
+                label="Production deployment date"
+                type="date"
+              />
+              <Field
+                name="validationEnvironment"
+                label="Validation environment"
+                required
+              />
+              <Field
+                name="productionEnvironmentReference"
+                label="Production environment reference"
+                required
+              />
+              <Field
+                name="databaseProvider"
+                label="Database type/provider"
+                required
+              />
+              <Field name="hostingProvider" label="Hosting provider" required />
+              <Field
+                name="plannedStartDate"
+                label="Planned start"
+                type="date"
+                required
+              />
+              <Field
+                name="plannedCompletionDate"
+                label="Planned completion"
+                type="date"
+                required
+              />
+              <div className="md:col-span-2">
+                <Label>Reason for validation</Label>
+                <Textarea name="reasonForValidation" required />
+              </div>
+              <div className="md:col-span-2">
+                <Label>Notes</Label>
+                <Textarea name="notes" />
+              </div>
+              <DialogFooter className="md:col-span-2">
+                <Button
+                  type="submit"
+                  disabled={
+                    create.isPending || Boolean(createSubmission.current)
+                  }
+                >
+                  {create.isPending || createSubmission.current
+                    ? 'Creating package\u2026'
+                    : 'Create controlled draft'}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+      <Card>
+        <CardContent className="pt-6 text-sm text-muted-foreground">
+          This workflow does not assert that AS9100 requires a commercial ERP or
+          a named validation format. It preserves objective evidence for EPOCH's
+          defined QMS intended use.
+        </CardContent>
+      </Card>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {list.data?.map((p) => (
+          <Card
+            key={p.id}
+            className="cursor-pointer hover:border-primary"
+            onClick={() => setSelected(p.id)}
+          >
+            <CardHeader>
+              <div className="flex justify-between gap-2">
+                <CardTitle className="text-lg">{p.package_number}</CardTitle>
+                <Badge className={tone(p.status)}>{pretty(p.status)}</Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="font-semibold">{p.title}</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                EPOCH {p.production_version} · {pretty(p.validation_type)}
+              </p>
+              <div className="mt-4 grid grid-cols-3 text-center text-xs">
+                <div>
+                  {p.requirement_count || 0}
+                  <br />
+                  requirements
+                </div>
+                <div>
+                  {p.execution_count || 0}
+                  <br />
+                  executions
+                </div>
+                <div>
+                  {p.open_defect_count || 0}
+                  <br />
+                  open defects
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      {!list.isLoading && !list.data?.length && (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            No validation package exists. Create the first controlled draft
+            package.
+          </CardContent>
+        </Card>
+      )}
     </div>
-    <Card><CardContent className="pt-6 text-sm text-muted-foreground">This workflow does not assert that AS9100 requires a commercial ERP or a named validation format. It preserves objective evidence for EPOCH's defined QMS intended use.</CardContent></Card>
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">{list.data?.map(p=><Card key={p.id} className="cursor-pointer hover:border-primary" onClick={()=>setSelected(p.id)}>
-      <CardHeader><div className="flex justify-between gap-2"><CardTitle className="text-lg">{p.package_number}</CardTitle><Badge className={tone(p.status)}>{pretty(p.status)}</Badge></div></CardHeader>
-      <CardContent><p className="font-semibold">{p.title}</p><p className="mt-2 text-sm text-muted-foreground">EPOCH {p.production_version} · {pretty(p.validation_type)}</p>
-        <div className="mt-4 grid grid-cols-3 text-center text-xs"><div>{p.requirement_count||0}<br/>requirements</div><div>{p.execution_count||0}<br/>executions</div><div>{p.open_defect_count||0}<br/>open defects</div></div></CardContent>
-    </Card>)}</div>
-    {!list.isLoading&&!list.data?.length&&<Card><CardContent className="py-12 text-center text-muted-foreground">No validation package exists. Create the first controlled draft package.</CardContent></Card>}
-  </div>;
+  );
 }
 
-function SectionWorkspace({section,detail:d,auditor}:{section:string;detail:Detail;auditor:boolean}){
-  const title=sections.find(x=>x[0]===section)?.[1]||'Validation';
-  const header=<CardHeader><CardTitle>{section}. {title}</CardTitle></CardHeader>;
-  if(section==='01')return <Card>{header}<CardContent>{d.intendedUse.length?<RecordView record={d.intendedUse[0]}/>:<Empty text="No Intended Use revision has been authored."/ >}</CardContent></Card>;
-  if(section==='02')return <Register title={title} records={d.requirements} columns={['requirement_id','module','category','statement','criticality','status']}/>;
-  if(section==='03')return <Register title={title} records={d.risks} columns={['risk_id','module','failure_mode','initial_risk_rating','residual_risk','status']}/>;
-  if(section==='04')return <Card>{header}<CardContent>{d.plans.length?<RecordView record={d.plans[0]}/>:<Empty text="No Validation Plan revision exists."/ >}</CardContent></Card>;
-  if(section==='05')return <Register title={title} records={d.protocols} columns={['test_id','title','module','criticality','revision','status']}/>;
-  if(section==='06')return <Register title={title} records={d.executions} columns={['execution_id','protocol_revision','tester_display_name','overall_result','review_decision','started_at']}/>;
-  if(section==='07')return <Register title={title} records={d.defects} columns={['defect_number','module','severity','description','retest_required','status']}/>;
-  if(section==='08')return <Card>{header}<CardContent><RecordView record={d.readiness}/></CardContent></Card>;
-  if(section==='09')return <Register title={title} records={d.approvals.filter(x=>x.record_type==='FINAL')} columns={['approval_role','decision','actor_display_name','actor_role','meaning','decided_at','status']}/>;
-  return <Register title={title} records={d.periodicReviews} columns={['review_date','current_production_version','revalidation_required','revalidation_scope','next_review_date','status']}/>;
+function SectionWorkspace({
+  section,
+  detail: d,
+  auditor: _auditor,
+}: {
+  section: string;
+  detail: Detail;
+  auditor: boolean;
+}) {
+  const title = sections.find((x) => x[0] === section)?.[1] || 'Validation';
+  const header = (
+    <CardHeader>
+      <CardTitle>
+        {section}. {title}
+      </CardTitle>
+    </CardHeader>
+  );
+  if (section === '01')
+    return (
+      <Card>
+        {header}
+        <CardContent>
+          {d.intendedUse.length ? (
+            <RecordView record={d.intendedUse[0]} />
+          ) : (
+            <Empty text="No Intended Use revision has been authored." />
+          )}
+        </CardContent>
+      </Card>
+    );
+  if (section === '02')
+    return (
+      <Register
+        title={title}
+        records={d.requirements}
+        columns={[
+          'requirement_id',
+          'module',
+          'category',
+          'statement',
+          'criticality',
+          'status',
+        ]}
+      />
+    );
+  if (section === '03')
+    return (
+      <Register
+        title={title}
+        records={d.risks}
+        columns={[
+          'risk_id',
+          'module',
+          'failure_mode',
+          'initial_risk_rating',
+          'residual_risk',
+          'status',
+        ]}
+      />
+    );
+  if (section === '04')
+    return (
+      <Card>
+        {header}
+        <CardContent>
+          {d.plans.length ? (
+            <RecordView record={d.plans[0]} />
+          ) : (
+            <Empty text="No Validation Plan revision exists." />
+          )}
+        </CardContent>
+      </Card>
+    );
+  if (section === '05')
+    return (
+      <Register
+        title={title}
+        records={d.protocols}
+        columns={[
+          'test_id',
+          'title',
+          'module',
+          'criticality',
+          'revision',
+          'status',
+        ]}
+      />
+    );
+  if (section === '06')
+    return (
+      <Register
+        title={title}
+        records={d.executions}
+        columns={[
+          'execution_id',
+          'protocol_revision',
+          'tester_display_name',
+          'overall_result',
+          'review_decision',
+          'started_at',
+        ]}
+      />
+    );
+  if (section === '07')
+    return (
+      <Register
+        title={title}
+        records={d.defects}
+        columns={[
+          'defect_number',
+          'module',
+          'severity',
+          'description',
+          'retest_required',
+          'status',
+        ]}
+      />
+    );
+  if (section === '08')
+    return (
+      <Card>
+        {header}
+        <CardContent>
+          <RecordView record={d.readiness} />
+        </CardContent>
+      </Card>
+    );
+  if (section === '09')
+    return (
+      <Register
+        title={title}
+        records={d.approvals.filter((x) => x.record_type === 'FINAL')}
+        columns={[
+          'approval_role',
+          'decision',
+          'actor_display_name',
+          'actor_role',
+          'meaning',
+          'decided_at',
+          'status',
+        ]}
+      />
+    );
+  return (
+    <Register
+      title={title}
+      records={d.periodicReviews}
+      columns={[
+        'review_date',
+        'current_production_version',
+        'revalidation_required',
+        'revalidation_scope',
+        'next_review_date',
+        'status',
+      ]}
+    />
+  );
 }
-function Register({title,records,columns}:{title:string;records:any[];columns:string[]}){
-  return <Card><CardHeader><CardTitle>{title}</CardTitle></CardHeader><CardContent className="overflow-x-auto">{records.length?
-    <Table><TableHeader><TableRow>{columns.map(c=><TableHead key={c}>{pretty(c)}</TableHead>)}</TableRow></TableHeader><TableBody>
-      {records.map((r,i)=><TableRow key={r.id||i}>{columns.map(c=><TableCell key={c} className="max-w-sm">{String(r[c]??'—')}</TableCell>)}</TableRow>)}
-    </TableBody></Table>:<Empty text={`No ${title.toLowerCase()} records exist.`}/>}</CardContent></Card>;
+function Register({
+  title,
+  records,
+  columns,
+}: {
+  title: string;
+  records: any[];
+  columns: string[];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {records.length ? (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                {columns.map((c) => (
+                  <TableHead key={c}>{pretty(c)}</TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {records.map((r, i) => (
+                <TableRow key={r.id || i}>
+                  {columns.map((c) => (
+                    <TableCell key={c} className="max-w-sm">
+                      {String(r[c] ?? '—')}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <Empty text={`No ${title.toLowerCase()} records exist.`} />
+        )}
+      </CardContent>
+    </Card>
+  );
 }
-function RecordView({record}:{record:Record<string,any>}){return <dl className="grid gap-3 md:grid-cols-2">{Object.entries(record).filter(([k])=>!['id','package_id','created_by_user_id','updated_by_user_id'].includes(k)).map(([k,v])=>
-  <div key={k} className="rounded border p-2"><dt className="text-xs text-muted-foreground">{pretty(k)}</dt><dd className="whitespace-pre-wrap text-sm">{Array.isArray(v)?v.join(', '):typeof v==='object'?JSON.stringify(v):String(v??'—')}</dd></div>)}</dl>;}
-function Empty({text}:{text:string}){return <div className="py-12 text-center text-sm text-muted-foreground"><FileCheck2 className="mx-auto mb-3 h-8 w-8"/>{text}</div>;}
-function Metric({label,value,ok,danger}:{label:string;value:string;ok?:boolean;danger?:boolean}){return <Card><CardContent className="flex items-center gap-3 pt-5">{ok?<CheckCircle2 className="text-emerald-600"/>:danger?<AlertTriangle className="text-red-600"/>:<FileCheck2 className="text-primary"/>}<div><p className="text-xs text-muted-foreground">{label}</p><p className="text-xl font-bold">{value}</p></div></CardContent></Card>;}
-function ExportMenu({id}:{id:string}){return <Select onValueChange={v=>window.open(`/api/qms/epoch-software-validation/${id}/export?view=${v}`,'_blank')}><SelectTrigger className="w-56"><SelectValue placeholder="Export controlled report"/></SelectTrigger><SelectContent>
-  {['validation-plan','requirements-matrix','risk-register','test-protocols','test-executions','defects','summary','complete-package'].map(v=><SelectItem key={v} value={v}>{pretty(v)}</SelectItem>)}
-</SelectContent></Select>;}
-function Field({name,label,type='text',required,defaultValue}:{name:string;label:string;type?:string;required?:boolean;defaultValue?:string}){return <div><Label htmlFor={name}>{label}</Label><Input id={name} name={name} type={type} required={required} defaultValue={defaultValue}/></div>;}
-function Pick({name,label,values}:{name:string;label:string;values:string[]}){return <div><Label>{label}</Label><Select name={name} defaultValue={values[0]}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{values.map(v=><SelectItem key={v} value={v}>{pretty(v)}</SelectItem>)}</SelectContent></Select></div>;}
-function EmployeePick({name,label,value,employees}:{name:string;label:string;value?:number;employees:Employee[]}){return <div><Label>{label}</Label>
-  <Select name={name} defaultValue={value?String(value):'NONE'}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>
-    <SelectItem value="NONE">Not assigned</SelectItem>{employees.map(e=><SelectItem key={e.id} value={String(e.id)}>{e.name}</SelectItem>)}
-  </SelectContent></Select></div>;}
+function RecordView({ record }: { record: Record<string, any> }) {
+  return (
+    <dl className="grid gap-3 md:grid-cols-2">
+      {Object.entries(record)
+        .filter(
+          ([k]) =>
+            ![
+              'id',
+              'package_id',
+              'created_by_user_id',
+              'updated_by_user_id',
+            ].includes(k)
+        )
+        .map(([k, v]) => (
+          <div key={k} className="rounded border p-2">
+            <dt className="text-xs text-muted-foreground">{pretty(k)}</dt>
+            <dd className="whitespace-pre-wrap text-sm">
+              {Array.isArray(v)
+                ? v.join(', ')
+                : typeof v === 'object'
+                  ? JSON.stringify(v)
+                  : String(v ?? '—')}
+            </dd>
+          </div>
+        ))}
+    </dl>
+  );
+}
+function Empty({ text }: { text: string }) {
+  return (
+    <div className="py-12 text-center text-sm text-muted-foreground">
+      <FileCheck2 className="mx-auto mb-3 h-8 w-8" />
+      {text}
+    </div>
+  );
+}
+function Metric({
+  label,
+  value,
+  ok,
+  danger,
+}: {
+  label: string;
+  value: string;
+  ok?: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-3 pt-5">
+        {ok ? (
+          <CheckCircle2 className="text-emerald-600" />
+        ) : danger ? (
+          <AlertTriangle className="text-red-600" />
+        ) : (
+          <FileCheck2 className="text-primary" />
+        )}
+        <div>
+          <p className="text-xs text-muted-foreground">{label}</p>
+          <p className="text-xl font-bold">{value}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+function ExportMenu({ id }: { id: string }) {
+  return (
+    <Select
+      onValueChange={(v) =>
+        window.open(
+          `/api/qms/epoch-software-validation/${id}/export?view=${v}`,
+          '_blank'
+        )
+      }
+    >
+      <SelectTrigger className="w-56">
+        <SelectValue placeholder="Export controlled report" />
+      </SelectTrigger>
+      <SelectContent>
+        {[
+          'validation-plan',
+          'requirements-matrix',
+          'risk-register',
+          'test-protocols',
+          'test-executions',
+          'defects',
+          'summary',
+          'complete-package',
+        ].map((v) => (
+          <SelectItem key={v} value={v}>
+            {pretty(v)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+function Field({
+  name,
+  label,
+  type = 'text',
+  required,
+  defaultValue,
+}: {
+  name: string;
+  label: string;
+  type?: string;
+  required?: boolean;
+  defaultValue?: string;
+}) {
+  return (
+    <div>
+      <Label htmlFor={name}>{label}</Label>
+      <Input
+        id={name}
+        name={name}
+        type={type}
+        required={required}
+        defaultValue={defaultValue}
+      />
+    </div>
+  );
+}
+function Pick({
+  name,
+  label,
+  values,
+}: {
+  name: string;
+  label: string;
+  values: string[];
+}) {
+  return (
+    <div>
+      <Label>{label}</Label>
+      <Select name={name} defaultValue={values[0]}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {values.map((v) => (
+            <SelectItem key={v} value={v}>
+              {pretty(v)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+function EmployeePick({
+  name,
+  label,
+  value,
+  employees,
+}: {
+  name: string;
+  label: string;
+  value?: number;
+  employees: Employee[];
+}) {
+  return (
+    <div>
+      <Label>{label}</Label>
+      <Select name={name} defaultValue={value ? String(value) : 'NONE'}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="NONE">Not assigned</SelectItem>
+          {employees.map((e) => (
+            <SelectItem key={e.id} value={String(e.id)}>
+              {e.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/client/src/pages/EpochSoftwareValidationPage.tsx
+++ b/client/src/pages/EpochSoftwareValidationPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, ArrowLeft, CheckCircle2, FileCheck2, History, Lock, Plus, ShieldCheck } from 'lucide-react';
 import { apiRequest } from '@/lib/queryClient';
@@ -53,6 +53,7 @@ export default function EpochSoftwareValidationPage(){
   const [editOpen,setEditOpen]=useState(false);
   const [auditor,setAuditor]=useState(false);
   const [activeSection,setActiveSection]=useState('01');
+  const createSubmission=useRef<string|null>(null);
   const qc=useQueryClient(),{toast}=useToast();
   const list=useQuery<Package[]>({queryKey:['/api/qms/epoch-software-validation'],
     queryFn:async()=>(await apiRequest('/api/qms/epoch-software-validation')).json()});
@@ -61,12 +62,18 @@ export default function EpochSoftwareValidationPage(){
   const employees=useQuery<Employee[]>({queryKey:['/api/employees'],queryFn:async()=>(await apiRequest('/api/employees')).json()});
   const assessments=useQuery<Assessment[]>({queryKey:['/api/qms/as9100-audit-readiness'],
     queryFn:async()=>(await apiRequest('/api/qms/as9100-audit-readiness')).json()});
-  const create=useMutation({mutationFn:async(form:HTMLFormElement)=>{
-    const f=new FormData(form);const body=Object.fromEntries(f.entries());
-    return (await apiRequest('/api/qms/epoch-software-validation',{method:'POST',body})).json();
+  const create=useMutation({retry:false,mutationFn:async(input:{body:Record<string,FormDataEntryValue>;idempotencyKey:string})=>{
+    return (await apiRequest('/api/qms/epoch-software-validation',{method:'POST',body:input.body,
+      headers:{'Idempotency-Key':input.idempotencyKey}})).json();
   },onSuccess:(p:Package)=>{qc.invalidateQueries({queryKey:['/api/qms/epoch-software-validation']});
-    setCreateOpen(false);setSelected(p.id);toast({title:`${p.package_number} created`});},
-    onError:(e:Error)=>toast({title:'Package was not created',description:e.message,variant:'destructive'})});
+    createSubmission.current=null;setCreateOpen(false);setSelected(p.id);toast({title:`${p.package_number} created`});},
+    onError:(e:Error)=>{createSubmission.current=null;toast({title:'Package was not created',description:e.message,variant:'destructive'});}});
+  const submitCreate=(form:HTMLFormElement)=>{
+    if(createSubmission.current)return;
+    const idempotencyKey=crypto.randomUUID();
+    createSubmission.current=idempotencyKey;
+    create.mutate({body:Object.fromEntries(new FormData(form).entries()),idempotencyKey});
+  };
   const refresh=()=>qc.invalidateQueries({queryKey:['/api/qms/epoch-software-validation',selected]});
   const edit=useMutation({mutationFn:async(form:HTMLFormElement)=>{
     const f=new FormData(form),num=(name:string)=>{const value=f.get(name);return value&&value!=='NONE'?Number(value):null;};
@@ -183,7 +190,7 @@ export default function EpochSoftwareValidationPage(){
       <Dialog open={createOpen} onOpenChange={setCreateOpen}><DialogTrigger asChild><Button><Plus className="mr-2 h-4 w-4"/>New validation package</Button></DialogTrigger>
       <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto"><DialogHeader><DialogTitle>Create EPOCH Software Validation Package</DialogTitle>
         <DialogDescription>Create a controlled draft. Production evidence and authenticated confirmations are completed after creation.</DialogDescription></DialogHeader>
-        <form className="grid gap-4 md:grid-cols-2" onSubmit={e=>{e.preventDefault();create.mutate(e.currentTarget)}}>
+        <form className="grid gap-4 md:grid-cols-2" onSubmit={e=>{e.preventDefault();submitCreate(e.currentTarget)}}>
           <Field name="title" label="Package title" required/><Field name="systemName" label="System name" defaultValue="EPOCH" required/>
           <Pick name="validationType" label="Validation type" values={['INITIAL_INTENDED_USE','MAJOR_RELEASE','CRITICAL_CHANGE','DATABASE_MIGRATION','SECURITY_ACCESS_CONTROL','BACKUP_RECOVERY','PERIODIC_REVIEW','PRE_AUDIT_REVALIDATION','CORRECTIVE_REVALIDATION']}/>
           <Field name="productionVersion" label="Production version being validated" required/>
@@ -196,7 +203,8 @@ export default function EpochSoftwareValidationPage(){
           <Field name="plannedStartDate" label="Planned start" type="date" required/><Field name="plannedCompletionDate" label="Planned completion" type="date" required/>
           <div className="md:col-span-2"><Label>Reason for validation</Label><Textarea name="reasonForValidation" required/></div>
           <div className="md:col-span-2"><Label>Notes</Label><Textarea name="notes"/></div>
-          <DialogFooter className="md:col-span-2"><Button type="submit" disabled={create.isPending}>Create controlled draft</Button></DialogFooter>
+          <DialogFooter className="md:col-span-2"><Button type="submit" disabled={create.isPending||Boolean(createSubmission.current)}>
+            {create.isPending||createSubmission.current?'Creating package\u2026':'Create controlled draft'}</Button></DialogFooter>
         </form></DialogContent></Dialog>
     </div>
     <Card><CardContent className="pt-6 text-sm text-muted-foreground">This workflow does not assert that AS9100 requires a commercial ERP or a named validation format. It preserves objective evidence for EPOCH's defined QMS intended use.</CardContent></Card>

--- a/migrations/0242_epoch_validation_create_idempotency.sql
+++ b/migrations/0242_epoch_validation_create_idempotency.sql
@@ -1,0 +1,24 @@
+-- Durable, user-scoped idempotency for deliberate EPOCH validation package creation.
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_create_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  operation text NOT NULL CHECK (operation = 'CREATE_PACKAGE'),
+  actor_user_id integer NOT NULL,
+  idempotency_key uuid NOT NULL,
+  request_hash text NOT NULL,
+  package_id uuid REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  CONSTRAINT qms_esv_create_request_scope_unique UNIQUE(operation, actor_user_id, idempotency_key),
+  CONSTRAINT qms_esv_create_request_completion_consistent CHECK (
+    (package_id IS NULL AND completed_at IS NULL) OR (package_id IS NOT NULL AND completed_at IS NOT NULL)
+  )
+);
+
+ALTER TABLE qms_epoch_validation_packages DROP CONSTRAINT IF EXISTS qms_epoch_validation_packages_status_check;
+ALTER TABLE qms_epoch_validation_packages ADD CONSTRAINT qms_epoch_validation_packages_status_check CHECK (status IN
+  ('DRAFT','PLANNING','READY_FOR_APPROVAL','PLAN_APPROVED','TESTING','TESTING_BLOCKED',
+   'CORRECTIONS_REQUIRED','RETESTING','READY_FOR_FINAL_REVIEW','APPROVED_FOR_INTENDED_USE',
+   'APPROVED_WITH_LIMITATIONS','REJECTED','SUPERSEDED','CANCELLED','VOID_DUPLICATE'));
+
+CREATE INDEX IF NOT EXISTS qms_esv_create_request_package_idx
+  ON qms_epoch_validation_create_requests(package_id) WHERE package_id IS NOT NULL;

--- a/server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
@@ -1,10 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+
 import { describe, expect, it } from 'vitest';
 
 const root = path.resolve(import.meta.dirname, '../..');
 const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
 const route = read('server/src/routes/epochSoftwareValidation.ts');
+const compactRoute = route.replace(/\s+/g, '');
 const migration = read(
   'migrations/0242_epoch_validation_create_idempotency.sql'
 );
@@ -30,20 +32,22 @@ describe('EPOCH validation package create idempotency architecture', () => {
     );
     expect(lock).toBeGreaterThan(0);
     expect(allocation).toBeGreaterThan(lock);
-    expect(route).toContain('if(existing)return {package:existing,replay:true');
-    expect(route).toContain('res.status(result.replay?200:201)');
+    expect(compactRoute).toContain(
+      'if(existing)return{package:existing,replay:true'
+    );
+    expect(compactRoute).toContain('res.status(result.replay?200:201)');
   });
 
   it('keeps allocation, package creation, event logging, and request completion in one transaction', () => {
-    const create = route.slice(
-      route.indexOf("router.post('/',"),
-      route.indexOf("router.post('/:id/void-duplicate'")
+    const create = compactRoute.slice(
+      compactRoute.indexOf("router.post('/',"),
+      compactRoute.indexOf("router.post('/:id/void-duplicate'")
     );
-    expect(create).toContain('const result=await tx(async q=>');
-    expect(create).toContain('INSERT INTO qms_epoch_validation_packages');
+    expect(create).toContain('constresult=awaittx(async(q)=>');
+    expect(create).toContain('INSERTINTOqms_epoch_validation_packages');
     expect(create).toContain("'PACKAGE_CREATED'");
     expect(create).toContain(
-      'UPDATE qms_epoch_validation_create_requests SET package_id=$1,completed_at=now()'
+      'UPDATEqms_epoch_validation_create_requestsSETpackage_id=$1,completed_at=now()'
     );
     expect(create).not.toMatch(/count\(\*\)[^\n]*package_number/);
   });
@@ -58,7 +62,7 @@ describe('EPOCH validation package create idempotency architecture', () => {
     expect(route).toContain("requirePermission('EPOCH_VALIDATION_ADMIN')");
     expect(route).toContain("status='VOID_DUPLICATE',locked_at=now()");
     expect(route).toContain("'PACKAGE_VOIDED_DUPLICATE'");
-    expect(route).toContain("'VOID_DUPLICATE'].includes(p.status)");
+    expect(compactRoute).toContain("'VOID_DUPLICATE',].includes(p.status)");
     expect(migration).toContain("'VOID_DUPLICATE'");
   });
 });

--- a/server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
+const route = read('server/src/routes/epochSoftwareValidation.ts');
+const migration = read(
+  'migrations/0242_epoch_validation_create_idempotency.sql'
+);
+const safeBoot = read('server/scripts/migrations/runSafeBootMigrations.ts');
+
+describe('EPOCH validation package create idempotency architecture', () => {
+  it('requires a user-scoped durable idempotency key and rejects payload drift', () => {
+    expect(route).toContain("req.header('Idempotency-Key')");
+    expect(route).toContain(
+      "operation='CREATE_PACKAGE' AND actor_user_id=$1 AND idempotency_key=$2 FOR UPDATE"
+    );
+    expect(route).toContain('IDEMPOTENCY_KEY_REUSE_CONFLICT');
+    expect(migration).toContain(
+      'UNIQUE(operation, actor_user_id, idempotency_key)'
+    );
+    expect(migration).toContain('request_hash text NOT NULL');
+  });
+
+  it('serializes same-key requests before allocating a package number', () => {
+    const lock = route.indexOf('idempotency_key=$2 FOR UPDATE');
+    const allocation = route.indexOf(
+      "nextval('qms_epoch_validation_package_number_seq')"
+    );
+    expect(lock).toBeGreaterThan(0);
+    expect(allocation).toBeGreaterThan(lock);
+    expect(route).toContain('if(existing)return {package:existing,replay:true');
+    expect(route).toContain('res.status(result.replay?200:201)');
+  });
+
+  it('keeps allocation, package creation, event logging, and request completion in one transaction', () => {
+    const create = route.slice(
+      route.indexOf("router.post('/',"),
+      route.indexOf("router.post('/:id/void-duplicate'")
+    );
+    expect(create).toContain('const result=await tx(async q=>');
+    expect(create).toContain('INSERT INTO qms_epoch_validation_packages');
+    expect(create).toContain("'PACKAGE_CREATED'");
+    expect(create).toContain(
+      'UPDATE qms_epoch_validation_create_requests SET package_id=$1,completed_at=now()'
+    );
+    expect(create).not.toMatch(/count\(\*\)[^\n]*package_number/);
+  });
+
+  it('registers the additive migration in both boot lists', () => {
+    expect(
+      safeBoot.match(/0242_epoch_validation_create_idempotency\.sql/g)?.length
+    ).toBe(2);
+  });
+
+  it('retains voided duplicates and locks them from downstream mutation', () => {
+    expect(route).toContain("requirePermission('EPOCH_VALIDATION_ADMIN')");
+    expect(route).toContain("status='VOID_DUPLICATE',locked_at=now()");
+    expect(route).toContain("'PACKAGE_VOIDED_DUPLICATE'");
+    expect(route).toContain("'VOID_DUPLICATE'].includes(p.status)");
+    expect(migration).toContain("'VOID_DUPLICATE'");
+  });
+});

--- a/server/__tests__/epochSoftwareValidationReadinessArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationReadinessArchitecture.test.ts
@@ -1,10 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+
 import { describe, expect, it } from 'vitest';
 
 const root = path.resolve(import.meta.dirname, '../..');
 const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
 const route = read('server/src/routes/epochSoftwareValidation.ts');
+const compactRoute = route.replace(/\s+/g, '');
 const migration = read(
   'migrations/0234_epoch_validation_readiness_controls.sql'
 );
@@ -28,17 +30,17 @@ describe('EPOCH validation package-readiness architecture', () => {
       'FROM employees WHERE id=ANY($1::int[]) AND is_active=true'
     );
     expect(route).toContain('qms_audit_readiness_assessments');
-    expect(route).toContain("error:'INACTIVE_EMPLOYEE_ASSIGNMENT'");
-    expect(route).toContain(
+    expect(compactRoute).toContain("error:'INACTIVE_EMPLOYEE_ASSIGNMENT'");
+    expect(compactRoute).toContain(
       "router.post('/:id/audit-readiness-na',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE')"
     );
   });
 
   it('requires authenticated confirmations and invalidates stale deployment confirmation', () => {
-    expect(route).toContain(
+    expect(compactRoute).toContain(
       "router.post('/:id/confirm-deployment-date',requirePermission('EPOCH_VALIDATION_EDIT')"
     );
-    expect(route).toContain(
+    expect(compactRoute).toContain(
       "router.post('/:id/confirm-environment-separation',requirePermission('EPOCH_VALIDATION_EDIT')"
     );
     expect(route).toContain(
@@ -49,9 +51,13 @@ describe('EPOCH validation package-readiness architecture', () => {
   });
 
   it('blocks execution and final approval on incomplete package or protocol evidence', () => {
-    expect(route).toContain("error:'PACKAGE_EXECUTION_READINESS_BLOCKED'");
-    expect(route).toContain("error:'PACKAGE_FINAL_READINESS_BLOCKED'");
-    expect(route).toContain("error:'PROTOCOL_EXECUTION_OR_REVIEW_INCOMPLETE'");
+    expect(compactRoute).toContain(
+      "error:'PACKAGE_EXECUTION_READINESS_BLOCKED'"
+    );
+    expect(compactRoute).toContain("error:'PACKAGE_FINAL_READINESS_BLOCKED'");
+    expect(compactRoute).toContain(
+      "error:'PROTOCOL_EXECUTION_OR_REVIEW_INCOMPLETE'"
+    );
     expect(route).toContain(
       "e.overall_result IN ('PASSED','PASSED_WITH_APPROVED_DEVIATION')"
     );

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -301,6 +301,7 @@ export const safeMigrationFiles = [
   '0235_quality_action_change_control.sql',
   '0236_salaried_holiday_calendar.sql',
   '0241_rom_builder_approval_authority.sql',
+  '0242_epoch_validation_create_idempotency.sql',
   '0237_freezer_temperature_log_crud.sql',
   '0238_reverse_0167_fulfilled_orders.sql',
   '0239_correct_0238_non_unique_id_collateral.sql',
@@ -361,6 +362,7 @@ export const criticalMigrationFiles = new Set([
   '0129a_capa_records_base_table.sql',
   '0235_quality_action_change_control.sql',
   '0241_rom_builder_approval_authority.sql',
+  '0242_epoch_validation_create_idempotency.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -417,8 +417,9 @@ export async function runSafeBootMigrations() {
   if (process.env.SAFE_BOOT_MIGRATIONS_ONLY === 'true') return;
 
   try {
-    const { logCriticalSchemaHealth } =
-      await import('../../utils/schemaHealth');
+    const { logCriticalSchemaHealth } = await import(
+      '../../utils/schemaHealth'
+    );
     await logCriticalSchemaHealth();
   } catch (caughtSchemaHealthErr: unknown) {
     const schemaHealthErr = caughtSchemaHealthErr as MigrationError;
@@ -429,8 +430,9 @@ export async function runSafeBootMigrations() {
   }
 
   try {
-    const { migrateVendorDocumentUrls } =
-      await import('../../src/routes/vendors');
+    const { migrateVendorDocumentUrls } = await import(
+      '../../src/routes/vendors'
+    );
     await migrateVendorDocumentUrls();
   } catch (caughtVendorMigrErr: unknown) {
     const vendorMigrErr = caughtVendorMigrErr as MigrationError;

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -417,9 +417,8 @@ export async function runSafeBootMigrations() {
   if (process.env.SAFE_BOOT_MIGRATIONS_ONLY === 'true') return;
 
   try {
-    const { logCriticalSchemaHealth } = await import(
-      '../../utils/schemaHealth'
-    );
+    const { logCriticalSchemaHealth } =
+      await import('../../utils/schemaHealth');
     await logCriticalSchemaHealth();
   } catch (caughtSchemaHealthErr: unknown) {
     const schemaHealthErr = caughtSchemaHealthErr as MigrationError;
@@ -430,9 +429,8 @@ export async function runSafeBootMigrations() {
   }
 
   try {
-    const { migrateVendorDocumentUrls } = await import(
-      '../../src/routes/vendors'
-    );
+    const { migrateVendorDocumentUrls } =
+      await import('../../src/routes/vendors');
     await migrateVendorDocumentUrls();
   } catch (caughtVendorMigrErr: unknown) {
     const vendorMigrErr = caughtVendorMigrErr as MigrationError;

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -1,4 +1,5 @@
 import { Router, type Request } from 'express';
+import crypto from 'crypto';
 import { z } from 'zod';
 import { pool } from '../../db';
 import { authenticateToken } from '../../middleware/auth';
@@ -27,7 +28,7 @@ const actor = (req: Request) => {
     name: String(u.displayName || u.name || u.username), role: String(u.role) };
 };
 const isLocked = (p: any) => Boolean(p.locked_at) ||
-  ['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS','SUPERSEDED'].includes(p.status);
+  ['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS','SUPERSEDED','VOID_DUPLICATE'].includes(p.status);
 const getPackage = async (id: string, q: Query = query) =>
   (await q('SELECT * FROM qms_epoch_validation_packages WHERE id=$1',[id]))[0];
 async function logEvent(req: Request, p: any, entityType: string, action: string,
@@ -75,8 +76,22 @@ router.get('/',requirePermission('EPOCH_VALIDATION_VIEW'),async(_req,res)=>{
 router.post('/',requirePermission('EPOCH_VALIDATION_CREATE'),async(req,res)=>{
   const parsed=createSchema.safeParse(req.body);
   if(!parsed.success)return res.status(400).json({error:'VALIDATION_ERROR',details:parsed.error.flatten()});
-  const v=parsed.data,a=actor(req);
-  const created=await tx(async q=>{
+  const key=z.string().uuid().safeParse(req.header('Idempotency-Key'));
+  if(!key.success)return res.status(400).json({error:'IDEMPOTENCY_KEY_REQUIRED',message:'A unique Idempotency-Key is required for package creation.'});
+  const v=parsed.data,a=actor(req),requestHash=crypto.createHash('sha256').update(JSON.stringify(v)).digest('hex');
+  const result=await tx(async q=>{
+    const claimed=await q(`INSERT INTO qms_epoch_validation_create_requests
+      (operation,actor_user_id,idempotency_key,request_hash)
+      VALUES('CREATE_PACKAGE',$1,$2,$3) ON CONFLICT (operation,actor_user_id,idempotency_key) DO NOTHING RETURNING id`,
+      [a.id,key.data,requestHash]);
+    const request=(await q(`SELECT * FROM qms_epoch_validation_create_requests
+      WHERE operation='CREATE_PACKAGE' AND actor_user_id=$1 AND idempotency_key=$2 FOR UPDATE`,[a.id,key.data]))[0];
+    if(request.request_hash!==requestHash)return {conflict:true as const};
+    if(!claimed.length){
+      const existing=(await q(`SELECT p.* FROM qms_epoch_validation_packages p
+        JOIN qms_epoch_validation_create_requests r ON r.package_id=p.id WHERE r.id=$1`,[request.id]))[0];
+      if(existing)return {package:existing,replay:true,conflict:false as const};
+    }
     const seq=(await q(`SELECT nextval('qms_epoch_validation_package_number_seq') value`))[0].value;
     const number=`ESV-${new Date().getUTCFullYear()}-${String(seq).padStart(4,'0')}`;
     const p=(await q(`INSERT INTO qms_epoch_validation_packages
@@ -92,9 +107,29 @@ router.post('/',requirePermission('EPOCH_VALIDATION_CREATE'),async(req,res)=>{
        v.plannedStartDate,v.plannedCompletionDate,v.reasonForValidation,v.previousApprovedPackageId||null,
        v.auditReadinessAssessmentId||null,v.notes||null,a.id,a.name]))[0];
     await logEvent(req,p,'PACKAGE','PACKAGE_CREATED',{next:{packageNumber:number,productionVersion:v.productionVersion}},q);
-    return p;
+    await q(`UPDATE qms_epoch_validation_create_requests SET package_id=$1,completed_at=now() WHERE id=$2`,[p.id,request.id]);
+    return {package:p,replay:false,conflict:false as const};
   });
-  res.status(201).json(created);
+  if(result.conflict)return res.status(409).json({error:'IDEMPOTENCY_KEY_REUSE_CONFLICT',message:'This idempotency key was already used with a different package payload.'});
+  res.status(result.replay?200:201).json(result.package);
+});
+
+router.post('/:id/void-duplicate',requirePermission('EPOCH_VALIDATION_ADMIN'),async(req,res)=>{
+  const p=await getPackage(uuid.parse(req.params.id));
+  if(!p)return res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});
+  if(p.status!=='DRAFT')return res.status(409).json({error:'DUPLICATE_VOID_DRAFT_ONLY'});
+  const body=z.object({reason:z.string().trim().min(10).max(2000)}).parse(req.body),a=actor(req);
+  const updated=await tx(async q=>{
+    const locked=(await q(`SELECT * FROM qms_epoch_validation_packages WHERE id=$1 FOR UPDATE`,[p.id]))[0];
+    if(locked.status!=='DRAFT')return null;
+    const next=(await q(`UPDATE qms_epoch_validation_packages SET status='VOID_DUPLICATE',locked_at=now(),
+      row_version=row_version+1,revision=revision+1,updated_by_user_id=$2,updated_by_display_name=$3,updated_at=now()
+      WHERE id=$1 RETURNING *`,[p.id,a.id,a.name]))[0];
+    await logEvent(req,next,'PACKAGE','PACKAGE_VOIDED_DUPLICATE',{previous:p.status,next:'VOID_DUPLICATE',reason:body.reason},q);
+    return next;
+  });
+  if(!updated)return res.status(409).json({error:'DUPLICATE_VOID_DRAFT_ONLY'});
+  res.json(updated);
 });
 
 async function packageReadiness(p:any):Promise<{items:PackageReadinessItem[];executionReady:boolean;blockers:any[]}>{

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -1,140 +1,342 @@
-import { Router, type Request } from 'express';
 import crypto from 'crypto';
+
+import { Router, type Request } from 'express';
 import { z } from 'zod';
+
 import { pool } from '../../db';
 import { authenticateToken } from '../../middleware/auth';
 import { requirePermission } from '../../middleware/requirePermission';
 import {
-  calculateReadiness, canTransition, checksum, deriveExecutionResult,
-  hasMeaningfulNotes, packageReadinessBlockers, productionIdentifierStatus,
+  calculateReadiness,
+  canTransition,
+  checksum,
+  deriveExecutionResult,
+  hasMeaningfulNotes,
+  packageReadinessBlockers,
+  productionIdentifierStatus,
   type PackageReadinessItem,
-  type ReadinessCounts, type ValidationStatus,
+  type ReadinessCounts,
+  type ValidationStatus,
 } from '../services/epochSoftwareValidation';
 
 const router = Router();
 router.use(authenticateToken);
 const uuid = z.string().uuid();
 type Query = (sql: string, params?: unknown[]) => Promise<any[]>;
-const query: Query = async (sql, params = []) => (await pool.query(sql, params as any[])).rows;
+const query: Query = async (sql, params = []) =>
+  (await pool.query(sql, params as any[])).rows;
 async function tx<T>(work: (q: Query) => Promise<T>) {
   const client = await pool.connect();
-  const q: Query = async (sql, params = []) => (await client.query(sql, params as any[])).rows;
-  try { await client.query('BEGIN'); const value = await work(q); await client.query('COMMIT'); return value; }
-  catch (error) { await client.query('ROLLBACK'); throw error; } finally { client.release(); }
+  const q: Query = async (sql, params = []) =>
+    (await client.query(sql, params as any[])).rows;
+  try {
+    await client.query('BEGIN');
+    const value = await work(q);
+    await client.query('COMMIT');
+    return value;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 const actor = (req: Request) => {
   const u = req.user as any;
-  return { id: Number(u.id), employeeId: u.employeeId ? Number(u.employeeId) : null,
-    name: String(u.displayName || u.name || u.username), role: String(u.role) };
+  return {
+    id: Number(u.id),
+    employeeId: u.employeeId ? Number(u.employeeId) : null,
+    name: String(u.displayName || u.name || u.username),
+    role: String(u.role),
+  };
 };
-const isLocked = (p: any) => Boolean(p.locked_at) ||
-  ['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS','SUPERSEDED','VOID_DUPLICATE'].includes(p.status);
+const isLocked = (p: any) =>
+  Boolean(p.locked_at) ||
+  [
+    'APPROVED_FOR_INTENDED_USE',
+    'APPROVED_WITH_LIMITATIONS',
+    'SUPERSEDED',
+    'VOID_DUPLICATE',
+  ].includes(p.status);
 const getPackage = async (id: string, q: Query = query) =>
-  (await q('SELECT * FROM qms_epoch_validation_packages WHERE id=$1',[id]))[0];
-async function logEvent(req: Request, p: any, entityType: string, action: string,
-  options: { entityId?: string; previous?: unknown; next?: unknown; reason?: string } = {}, q: Query = query) {
-  const a=actor(req);
-  await q(`INSERT INTO qms_epoch_validation_events
+  (await q('SELECT * FROM qms_epoch_validation_packages WHERE id=$1', [id]))[0];
+async function logEvent(
+  req: Request,
+  p: any,
+  entityType: string,
+  action: string,
+  options: {
+    entityId?: string;
+    previous?: unknown;
+    next?: unknown;
+    reason?: string;
+  } = {},
+  q: Query = query
+) {
+  const a = actor(req);
+  await q(
+    `INSERT INTO qms_epoch_validation_events
     (package_id,entity_type,entity_id,action,actor_user_id,actor_display_name,actor_role,
      previous_value,new_value,reason,package_revision)
     VALUES($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11)`,
-    [p.id,entityType,options.entityId||null,action,a.id,a.name,a.role,
-     options.previous ? JSON.stringify(options.previous) : null,
-     options.next ? JSON.stringify(options.next) : null,options.reason||null,p.revision]);
+    [
+      p.id,
+      entityType,
+      options.entityId || null,
+      action,
+      a.id,
+      a.name,
+      a.role,
+      options.previous ? JSON.stringify(options.previous) : null,
+      options.next ? JSON.stringify(options.next) : null,
+      options.reason || null,
+      p.revision,
+    ]
+  );
 }
-async function invalidateApprovals(packageId: string, reason: string, q: Query = query) {
-  await q(`UPDATE qms_epoch_validation_approvals SET status='INVALIDATED',invalidated_at=now(),invalidation_reason=$2
-    WHERE package_id=$1 AND status='VALID'`,[packageId,reason]);
+async function invalidateApprovals(
+  packageId: string,
+  reason: string,
+  q: Query = query
+) {
+  await q(
+    `UPDATE qms_epoch_validation_approvals SET status='INVALIDATED',invalidated_at=now(),invalidation_reason=$2
+    WHERE package_id=$1 AND status='VALID'`,
+    [packageId, reason]
+  );
 }
 async function editable(req: Request, res: any) {
-  const p=await getPackage(uuid.parse(req.params.id || req.params.packageId));
-  if(!p){res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});return null;}
-  if(isLocked(p)){res.status(409).json({error:'VALIDATION_PACKAGE_LOCKED',message:'Approved packages are immutable. Use controlled reopening.'});return null;}
+  const p = await getPackage(uuid.parse(req.params.id || req.params.packageId));
+  if (!p) {
+    res.status(404).json({ error: 'VALIDATION_PACKAGE_NOT_FOUND' });
+    return null;
+  }
+  if (isLocked(p)) {
+    res.status(409).json({
+      error: 'VALIDATION_PACKAGE_LOCKED',
+      message: 'Approved packages are immutable. Use controlled reopening.',
+    });
+    return null;
+  }
   return p;
 }
 
-const createSchema=z.object({
-  title:z.string().min(3).max(240), systemName:z.string().min(1).default('EPOCH'),
-  validationType:z.enum(['INITIAL_INTENDED_USE','MAJOR_RELEASE','CRITICAL_CHANGE','DATABASE_MIGRATION',
-    'SECURITY_ACCESS_CONTROL','BACKUP_RECOVERY','PERIODIC_REVIEW','PRE_AUDIT_REVALIDATION','CORRECTIVE_REVALIDATION']),
-  productionVersion:z.string().min(1), commitOrReleaseIdentifier:z.string().max(240).optional(),
-  productionDeploymentDate:z.string().date().optional(), validationEnvironment:z.string().min(1),
-  productionEnvironmentReference:z.string().min(1), databaseProvider:z.string().min(1), hostingProvider:z.string().min(1),
-  softwareOwnerEmployeeId:z.number().int().positive().optional(),qualityOwnerEmployeeId:z.number().int().positive().optional(),
-  validationLeadEmployeeId:z.number().int().positive().optional(),plannedStartDate:z.string().date(),
-  plannedCompletionDate:z.string().date(),reasonForValidation:z.string().min(3),
-  previousApprovedPackageId:z.string().uuid().optional(),auditReadinessAssessmentId:z.string().uuid().optional(),
-  notes:z.string().max(20000).optional(),
+const createSchema = z.object({
+  title: z.string().min(3).max(240),
+  systemName: z.string().min(1).default('EPOCH'),
+  validationType: z.enum([
+    'INITIAL_INTENDED_USE',
+    'MAJOR_RELEASE',
+    'CRITICAL_CHANGE',
+    'DATABASE_MIGRATION',
+    'SECURITY_ACCESS_CONTROL',
+    'BACKUP_RECOVERY',
+    'PERIODIC_REVIEW',
+    'PRE_AUDIT_REVALIDATION',
+    'CORRECTIVE_REVALIDATION',
+  ]),
+  productionVersion: z.string().min(1),
+  commitOrReleaseIdentifier: z.string().max(240).optional(),
+  productionDeploymentDate: z.string().date().optional(),
+  validationEnvironment: z.string().min(1),
+  productionEnvironmentReference: z.string().min(1),
+  databaseProvider: z.string().min(1),
+  hostingProvider: z.string().min(1),
+  softwareOwnerEmployeeId: z.number().int().positive().optional(),
+  qualityOwnerEmployeeId: z.number().int().positive().optional(),
+  validationLeadEmployeeId: z.number().int().positive().optional(),
+  plannedStartDate: z.string().date(),
+  plannedCompletionDate: z.string().date(),
+  reasonForValidation: z.string().min(3),
+  previousApprovedPackageId: z.string().uuid().optional(),
+  auditReadinessAssessmentId: z.string().uuid().optional(),
+  notes: z.string().max(20000).optional(),
 });
-router.get('/',requirePermission('EPOCH_VALIDATION_VIEW'),async(_req,res)=>{
-  res.json(await query(`SELECT p.*,
+router.get(
+  '/',
+  requirePermission('EPOCH_VALIDATION_VIEW'),
+  async (_req, res) => {
+    res.json(
+      await query(`SELECT p.*,
     (SELECT count(*)::int FROM qms_epoch_validation_requirements r WHERE r.package_id=p.id) requirement_count,
     (SELECT count(*)::int FROM qms_epoch_validation_executions e WHERE e.package_id=p.id) execution_count,
     (SELECT count(*)::int FROM qms_epoch_validation_defects d WHERE d.package_id=p.id AND d.status NOT IN ('CLOSED','CANCELLED')) open_defect_count
-    FROM qms_epoch_validation_packages p ORDER BY p.created_at DESC`));
-});
-router.post('/',requirePermission('EPOCH_VALIDATION_CREATE'),async(req,res)=>{
-  const parsed=createSchema.safeParse(req.body);
-  if(!parsed.success)return res.status(400).json({error:'VALIDATION_ERROR',details:parsed.error.flatten()});
-  const key=z.string().uuid().safeParse(req.header('Idempotency-Key'));
-  if(!key.success)return res.status(400).json({error:'IDEMPOTENCY_KEY_REQUIRED',message:'A unique Idempotency-Key is required for package creation.'});
-  const v=parsed.data,a=actor(req),requestHash=crypto.createHash('sha256').update(JSON.stringify(v)).digest('hex');
-  const result=await tx(async q=>{
-    const claimed=await q(`INSERT INTO qms_epoch_validation_create_requests
+    FROM qms_epoch_validation_packages p ORDER BY p.created_at DESC`)
+    );
+  }
+);
+router.post(
+  '/',
+  requirePermission('EPOCH_VALIDATION_CREATE'),
+  async (req, res) => {
+    const parsed = createSchema.safeParse(req.body);
+    if (!parsed.success)
+      return res
+        .status(400)
+        .json({ error: 'VALIDATION_ERROR', details: parsed.error.flatten() });
+    const key = z.string().uuid().safeParse(req.header('Idempotency-Key'));
+    if (!key.success)
+      return res.status(400).json({
+        error: 'IDEMPOTENCY_KEY_REQUIRED',
+        message: 'A unique Idempotency-Key is required for package creation.',
+      });
+    const v = parsed.data,
+      a = actor(req),
+      requestHash = crypto
+        .createHash('sha256')
+        .update(JSON.stringify(v))
+        .digest('hex');
+    const result = await tx(async (q) => {
+      const claimed = await q(
+        `INSERT INTO qms_epoch_validation_create_requests
       (operation,actor_user_id,idempotency_key,request_hash)
       VALUES('CREATE_PACKAGE',$1,$2,$3) ON CONFLICT (operation,actor_user_id,idempotency_key) DO NOTHING RETURNING id`,
-      [a.id,key.data,requestHash]);
-    const request=(await q(`SELECT * FROM qms_epoch_validation_create_requests
-      WHERE operation='CREATE_PACKAGE' AND actor_user_id=$1 AND idempotency_key=$2 FOR UPDATE`,[a.id,key.data]))[0];
-    if(request.request_hash!==requestHash)return {conflict:true as const};
-    if(!claimed.length){
-      const existing=(await q(`SELECT p.* FROM qms_epoch_validation_packages p
-        JOIN qms_epoch_validation_create_requests r ON r.package_id=p.id WHERE r.id=$1`,[request.id]))[0];
-      if(existing)return {package:existing,replay:true,conflict:false as const};
-    }
-    const seq=(await q(`SELECT nextval('qms_epoch_validation_package_number_seq') value`))[0].value;
-    const number=`ESV-${new Date().getUTCFullYear()}-${String(seq).padStart(4,'0')}`;
-    const p=(await q(`INSERT INTO qms_epoch_validation_packages
+        [a.id, key.data, requestHash]
+      );
+      const request = (
+        await q(
+          `SELECT * FROM qms_epoch_validation_create_requests
+      WHERE operation='CREATE_PACKAGE' AND actor_user_id=$1 AND idempotency_key=$2 FOR UPDATE`,
+          [a.id, key.data]
+        )
+      )[0];
+      if (request.request_hash !== requestHash)
+        return { conflict: true as const };
+      if (!claimed.length) {
+        const existing = (
+          await q(
+            `SELECT p.* FROM qms_epoch_validation_packages p
+        JOIN qms_epoch_validation_create_requests r ON r.package_id=p.id WHERE r.id=$1`,
+            [request.id]
+          )
+        )[0];
+        if (existing)
+          return { package: existing, replay: true, conflict: false as const };
+      }
+      const seq = (
+        await q(
+          `SELECT nextval('qms_epoch_validation_package_number_seq') value`
+        )
+      )[0].value;
+      const number = `ESV-${new Date().getUTCFullYear()}-${String(seq).padStart(4, '0')}`;
+      const p = (
+        await q(
+          `INSERT INTO qms_epoch_validation_packages
       (package_number,title,system_name,validation_type,production_version,commit_or_release_identifier,
        production_deployment_date,validation_environment,production_environment_reference,database_provider,
        hosting_provider,software_owner_employee_id,quality_owner_employee_id,validation_lead_employee_id,
        planned_start_date,planned_completion_date,reason_for_validation,previous_approved_package_id,
        audit_readiness_assessment_id,notes,created_by_user_id,created_by_display_name,updated_by_user_id,updated_by_display_name)
       VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$21,$22) RETURNING *`,
-      [number,v.title,v.systemName,v.validationType,v.productionVersion,v.commitOrReleaseIdentifier||null,
-       v.productionDeploymentDate||null,v.validationEnvironment,v.productionEnvironmentReference,v.databaseProvider,
-       v.hostingProvider,v.softwareOwnerEmployeeId||null,v.qualityOwnerEmployeeId||null,v.validationLeadEmployeeId||null,
-       v.plannedStartDate,v.plannedCompletionDate,v.reasonForValidation,v.previousApprovedPackageId||null,
-       v.auditReadinessAssessmentId||null,v.notes||null,a.id,a.name]))[0];
-    await logEvent(req,p,'PACKAGE','PACKAGE_CREATED',{next:{packageNumber:number,productionVersion:v.productionVersion}},q);
-    await q(`UPDATE qms_epoch_validation_create_requests SET package_id=$1,completed_at=now() WHERE id=$2`,[p.id,request.id]);
-    return {package:p,replay:false,conflict:false as const};
-  });
-  if(result.conflict)return res.status(409).json({error:'IDEMPOTENCY_KEY_REUSE_CONFLICT',message:'This idempotency key was already used with a different package payload.'});
-  res.status(result.replay?200:201).json(result.package);
-});
+          [
+            number,
+            v.title,
+            v.systemName,
+            v.validationType,
+            v.productionVersion,
+            v.commitOrReleaseIdentifier || null,
+            v.productionDeploymentDate || null,
+            v.validationEnvironment,
+            v.productionEnvironmentReference,
+            v.databaseProvider,
+            v.hostingProvider,
+            v.softwareOwnerEmployeeId || null,
+            v.qualityOwnerEmployeeId || null,
+            v.validationLeadEmployeeId || null,
+            v.plannedStartDate,
+            v.plannedCompletionDate,
+            v.reasonForValidation,
+            v.previousApprovedPackageId || null,
+            v.auditReadinessAssessmentId || null,
+            v.notes || null,
+            a.id,
+            a.name,
+          ]
+        )
+      )[0];
+      await logEvent(
+        req,
+        p,
+        'PACKAGE',
+        'PACKAGE_CREATED',
+        {
+          next: {
+            packageNumber: number,
+            productionVersion: v.productionVersion,
+          },
+        },
+        q
+      );
+      await q(
+        `UPDATE qms_epoch_validation_create_requests SET package_id=$1,completed_at=now() WHERE id=$2`,
+        [p.id, request.id]
+      );
+      return { package: p, replay: false, conflict: false as const };
+    });
+    if (result.conflict)
+      return res.status(409).json({
+        error: 'IDEMPOTENCY_KEY_REUSE_CONFLICT',
+        message:
+          'This idempotency key was already used with a different package payload.',
+      });
+    res.status(result.replay ? 200 : 201).json(result.package);
+  }
+);
 
-router.post('/:id/void-duplicate',requirePermission('EPOCH_VALIDATION_ADMIN'),async(req,res)=>{
-  const p=await getPackage(uuid.parse(req.params.id));
-  if(!p)return res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});
-  if(p.status!=='DRAFT')return res.status(409).json({error:'DUPLICATE_VOID_DRAFT_ONLY'});
-  const body=z.object({reason:z.string().trim().min(10).max(2000)}).parse(req.body),a=actor(req);
-  const updated=await tx(async q=>{
-    const locked=(await q(`SELECT * FROM qms_epoch_validation_packages WHERE id=$1 FOR UPDATE`,[p.id]))[0];
-    if(locked.status!=='DRAFT')return null;
-    const next=(await q(`UPDATE qms_epoch_validation_packages SET status='VOID_DUPLICATE',locked_at=now(),
+router.post(
+  '/:id/void-duplicate',
+  requirePermission('EPOCH_VALIDATION_ADMIN'),
+  async (req, res) => {
+    const p = await getPackage(uuid.parse(req.params.id));
+    if (!p)
+      return res.status(404).json({ error: 'VALIDATION_PACKAGE_NOT_FOUND' });
+    if (p.status !== 'DRAFT')
+      return res.status(409).json({ error: 'DUPLICATE_VOID_DRAFT_ONLY' });
+    const body = z
+        .object({ reason: z.string().trim().min(10).max(2000) })
+        .parse(req.body),
+      a = actor(req);
+    const updated = await tx(async (q) => {
+      const locked = (
+        await q(
+          `SELECT * FROM qms_epoch_validation_packages WHERE id=$1 FOR UPDATE`,
+          [p.id]
+        )
+      )[0];
+      if (locked.status !== 'DRAFT') return null;
+      const next = (
+        await q(
+          `UPDATE qms_epoch_validation_packages SET status='VOID_DUPLICATE',locked_at=now(),
       row_version=row_version+1,revision=revision+1,updated_by_user_id=$2,updated_by_display_name=$3,updated_at=now()
-      WHERE id=$1 RETURNING *`,[p.id,a.id,a.name]))[0];
-    await logEvent(req,next,'PACKAGE','PACKAGE_VOIDED_DUPLICATE',{previous:p.status,next:'VOID_DUPLICATE',reason:body.reason},q);
-    return next;
-  });
-  if(!updated)return res.status(409).json({error:'DUPLICATE_VOID_DRAFT_ONLY'});
-  res.json(updated);
-});
+      WHERE id=$1 RETURNING *`,
+          [p.id, a.id, a.name]
+        )
+      )[0];
+      await logEvent(
+        req,
+        next,
+        'PACKAGE',
+        'PACKAGE_VOIDED_DUPLICATE',
+        { previous: p.status, next: 'VOID_DUPLICATE', reason: body.reason },
+        q
+      );
+      return next;
+    });
+    if (!updated)
+      return res.status(409).json({ error: 'DUPLICATE_VOID_DRAFT_ONLY' });
+    res.json(updated);
+  }
+);
 
-async function packageReadiness(p:any):Promise<{items:PackageReadinessItem[];executionReady:boolean;blockers:any[]}>{
-  const identifier=productionIdentifierStatus(p.commit_or_release_identifier);
-  const facts=(await query(`SELECT
+async function packageReadiness(p: any): Promise<{
+  items: PackageReadinessItem[];
+  executionReady: boolean;
+  blockers: any[];
+}> {
+  const identifier = productionIdentifierStatus(p.commit_or_release_identifier);
+  const facts = (
+    await query(
+      `SELECT
     EXISTS(SELECT 1 FROM qms_epoch_validation_intended_use_revisions u WHERE u.package_id=$1
       AND nullif(trim(u.intended_use_statement),'') IS NOT NULL) intended_use,
     EXISTS(SELECT 1 FROM qms_epoch_validation_risks r WHERE r.package_id=$1) risk_exists,
@@ -145,56 +347,204 @@ async function packageReadiness(p:any):Promise<{items:PackageReadinessItem[];exe
        EXISTS(SELECT 1 FROM qms_epoch_validation_protocol_steps s WHERE s.protocol_id=x.id
          AND nullif(trim(s.expected_result),'') IS NULL))) protocols_complete,
     EXISTS(SELECT 1 FROM qms_audit_readiness_assessments a WHERE a.id=$2) assessment_exists`,
-    [p.id,p.audit_readiness_assessment_id||null]))[0];
-  const item=(key:string,label:string,state:PackageReadinessItem['state'],field:string,message?:string):PackageReadinessItem=>
-    ({key,label,state,field,message});
-  const items=[
-    item('PRODUCTION_IDENTIFIER','Exact production identifier',identifier.valid?'COMPLETE':'MISSING','commitOrReleaseIdentifier',
-      identifier.code==='PRODUCTION_IDENTIFIER_AMBIGUOUS'?'A pull-request number alone does not uniquely identify the deployed build.':'Enter a full commit SHA, controlled release tag, or documented deployment ID.'),
-    item('DEPLOYMENT_CONFIRMATION','Deployment-date confirmation',p.deployment_date_confirmed?'COMPLETE':'REQUIRES_CONFIRMATION','deploymentDateConfirmed'),
-    item('SOFTWARE_OWNER','Software owner',p.software_owner_employee_id?'COMPLETE':'MISSING','softwareOwnerEmployeeId','Assign an active Software owner.'),
-    item('QUALITY_OWNER','Quality owner',p.quality_owner_employee_id?'COMPLETE':'MISSING','qualityOwnerEmployeeId','Assign an active Quality owner.'),
-    item('VALIDATION_LEAD','Validation lead',p.validation_lead_employee_id?'COMPLETE':'MISSING','validationLeadEmployeeId','Assign an active Validation lead.'),
-    item('INTENDED_USE','Intended-use statement',facts.intended_use?'COMPLETE':'MISSING','intendedUse'),
-    item('VALIDATION_REASON','Reason for validation',String(p.reason_for_validation||'').trim().length>=3?'COMPLETE':'MISSING','reasonForValidation'),
-    item('VALIDATION_ENVIRONMENT','Validation-environment reference',String(p.validation_environment||'').trim()?'COMPLETE':'MISSING','validationEnvironment'),
-    item('PRODUCTION_ENVIRONMENT','Production-environment reference',String(p.production_environment_reference||'').trim()?'COMPLETE':'MISSING','productionEnvironmentReference'),
-    item('ENVIRONMENT_CONFIRMATION','Environment-separation confirmation',p.environment_separation_confirmed?'COMPLETE':'REQUIRES_CONFIRMATION','environmentSeparationConfirmed'),
-    item('ENVIRONMENT_DIFFERENCES','Environment-differences statement',String(p.environment_differences||'').trim().length>=10?'COMPLETE':'MISSING','environmentDifferences'),
-    item('NOTES','Meaningful notes',hasMeaningfulNotes(p.notes)?'COMPLETE':'MISSING','notes'),
-    item('AUDIT_READINESS','Audit-readiness assessment or justified N/A',
-      facts.assessment_exists?'COMPLETE':p.audit_readiness_not_applicable&&p.audit_readiness_na_approved_at?'NOT_APPLICABLE':'MISSING',
-      'auditReadinessAssessmentId'),
-    item('RISK_ASSESSMENT','Risk assessment',facts.risk_exists?'COMPLETE':'MISSING','riskAssessment'),
-    item('VALIDATION_PROTOCOLS','Validation protocols',facts.protocols_exist?'COMPLETE':'MISSING','protocols'),
-    item('EXPECTED_RESULTS','Expected results',facts.protocols_exist&&facts.protocols_complete?'COMPLETE':'MISSING','protocols'),
-    item('ACCEPTANCE_CRITERIA','Acceptance criteria',facts.protocols_exist&&facts.protocols_complete?'COMPLETE':'MISSING','protocols'),
+      [p.id, p.audit_readiness_assessment_id || null]
+    )
+  )[0];
+  const item = (
+    key: string,
+    label: string,
+    state: PackageReadinessItem['state'],
+    field: string,
+    message?: string
+  ): PackageReadinessItem => ({ key, label, state, field, message });
+  const items = [
+    item(
+      'PRODUCTION_IDENTIFIER',
+      'Exact production identifier',
+      identifier.valid ? 'COMPLETE' : 'MISSING',
+      'commitOrReleaseIdentifier',
+      identifier.code === 'PRODUCTION_IDENTIFIER_AMBIGUOUS'
+        ? 'A pull-request number alone does not uniquely identify the deployed build.'
+        : 'Enter a full commit SHA, controlled release tag, or documented deployment ID.'
+    ),
+    item(
+      'DEPLOYMENT_CONFIRMATION',
+      'Deployment-date confirmation',
+      p.deployment_date_confirmed ? 'COMPLETE' : 'REQUIRES_CONFIRMATION',
+      'deploymentDateConfirmed'
+    ),
+    item(
+      'SOFTWARE_OWNER',
+      'Software owner',
+      p.software_owner_employee_id ? 'COMPLETE' : 'MISSING',
+      'softwareOwnerEmployeeId',
+      'Assign an active Software owner.'
+    ),
+    item(
+      'QUALITY_OWNER',
+      'Quality owner',
+      p.quality_owner_employee_id ? 'COMPLETE' : 'MISSING',
+      'qualityOwnerEmployeeId',
+      'Assign an active Quality owner.'
+    ),
+    item(
+      'VALIDATION_LEAD',
+      'Validation lead',
+      p.validation_lead_employee_id ? 'COMPLETE' : 'MISSING',
+      'validationLeadEmployeeId',
+      'Assign an active Validation lead.'
+    ),
+    item(
+      'INTENDED_USE',
+      'Intended-use statement',
+      facts.intended_use ? 'COMPLETE' : 'MISSING',
+      'intendedUse'
+    ),
+    item(
+      'VALIDATION_REASON',
+      'Reason for validation',
+      String(p.reason_for_validation || '').trim().length >= 3
+        ? 'COMPLETE'
+        : 'MISSING',
+      'reasonForValidation'
+    ),
+    item(
+      'VALIDATION_ENVIRONMENT',
+      'Validation-environment reference',
+      String(p.validation_environment || '').trim() ? 'COMPLETE' : 'MISSING',
+      'validationEnvironment'
+    ),
+    item(
+      'PRODUCTION_ENVIRONMENT',
+      'Production-environment reference',
+      String(p.production_environment_reference || '').trim()
+        ? 'COMPLETE'
+        : 'MISSING',
+      'productionEnvironmentReference'
+    ),
+    item(
+      'ENVIRONMENT_CONFIRMATION',
+      'Environment-separation confirmation',
+      p.environment_separation_confirmed ? 'COMPLETE' : 'REQUIRES_CONFIRMATION',
+      'environmentSeparationConfirmed'
+    ),
+    item(
+      'ENVIRONMENT_DIFFERENCES',
+      'Environment-differences statement',
+      String(p.environment_differences || '').trim().length >= 10
+        ? 'COMPLETE'
+        : 'MISSING',
+      'environmentDifferences'
+    ),
+    item(
+      'NOTES',
+      'Meaningful notes',
+      hasMeaningfulNotes(p.notes) ? 'COMPLETE' : 'MISSING',
+      'notes'
+    ),
+    item(
+      'AUDIT_READINESS',
+      'Audit-readiness assessment or justified N/A',
+      facts.assessment_exists
+        ? 'COMPLETE'
+        : p.audit_readiness_not_applicable && p.audit_readiness_na_approved_at
+          ? 'NOT_APPLICABLE'
+          : 'MISSING',
+      'auditReadinessAssessmentId'
+    ),
+    item(
+      'RISK_ASSESSMENT',
+      'Risk assessment',
+      facts.risk_exists ? 'COMPLETE' : 'MISSING',
+      'riskAssessment'
+    ),
+    item(
+      'VALIDATION_PROTOCOLS',
+      'Validation protocols',
+      facts.protocols_exist ? 'COMPLETE' : 'MISSING',
+      'protocols'
+    ),
+    item(
+      'EXPECTED_RESULTS',
+      'Expected results',
+      facts.protocols_exist && facts.protocols_complete
+        ? 'COMPLETE'
+        : 'MISSING',
+      'protocols'
+    ),
+    item(
+      'ACCEPTANCE_CRITERIA',
+      'Acceptance criteria',
+      facts.protocols_exist && facts.protocols_complete
+        ? 'COMPLETE'
+        : 'MISSING',
+      'protocols'
+    ),
   ];
-  const blockers=packageReadinessBlockers(items);
-  return {items,executionReady:blockers.length===0,blockers};
+  const blockers = packageReadinessBlockers(items);
+  return { items, executionReady: blockers.length === 0, blockers };
 }
 
-const packageUpdateSchema=z.object({
-  rowVersion:z.number().int().positive(),commitOrReleaseIdentifier:z.string().max(240).nullable().optional(),
-  productionDeploymentDate:z.string().date().nullable().optional(),validationEnvironment:z.string().min(1).optional(),
-  productionEnvironmentReference:z.string().min(1).optional(),environmentDifferences:z.string().max(10000).nullable().optional(),
-  softwareOwnerEmployeeId:z.number().int().positive().nullable().optional(),qualityOwnerEmployeeId:z.number().int().positive().nullable().optional(),
-  validationLeadEmployeeId:z.number().int().positive().nullable().optional(),
-  auditReadinessAssessmentId:z.string().uuid().nullable().optional(),notes:z.string().max(20000).nullable().optional(),
+const packageUpdateSchema = z.object({
+  rowVersion: z.number().int().positive(),
+  commitOrReleaseIdentifier: z.string().max(240).nullable().optional(),
+  productionDeploymentDate: z.string().date().nullable().optional(),
+  validationEnvironment: z.string().min(1).optional(),
+  productionEnvironmentReference: z.string().min(1).optional(),
+  environmentDifferences: z.string().max(10000).nullable().optional(),
+  softwareOwnerEmployeeId: z.number().int().positive().nullable().optional(),
+  qualityOwnerEmployeeId: z.number().int().positive().nullable().optional(),
+  validationLeadEmployeeId: z.number().int().positive().nullable().optional(),
+  auditReadinessAssessmentId: z.string().uuid().nullable().optional(),
+  notes: z.string().max(20000).nullable().optional(),
 });
-router.patch('/:id',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const v=packageUpdateSchema.parse(req.body),a=actor(req);
-  const ownerIds=[v.softwareOwnerEmployeeId,v.qualityOwnerEmployeeId,v.validationLeadEmployeeId].filter((x):x is number=>Boolean(x));
-  if(ownerIds.length){
-    const active=await query(`SELECT id FROM employees WHERE id=ANY($1::int[]) AND is_active=true`,[ownerIds]);
-    const activeIds=new Set(active.map(x=>Number(x.id))),invalid=ownerIds.filter(x=>!activeIds.has(x));
-    if(invalid.length)return res.status(409).json({error:'INACTIVE_EMPLOYEE_ASSIGNMENT',fields:invalid});
-  }
-  if(v.auditReadinessAssessmentId&&!(await query(`SELECT 1 FROM qms_audit_readiness_assessments WHERE id=$1`,[v.auditReadinessAssessmentId])).length)
-    return res.status(409).json({error:'AUDIT_READINESS_ASSESSMENT_NOT_FOUND',field:'auditReadinessAssessmentId'});
-  const identifierChanged=v.commitOrReleaseIdentifier!==undefined&&v.commitOrReleaseIdentifier!==p.commit_or_release_identifier;
-  const dateChanged=v.productionDeploymentDate!==undefined&&v.productionDeploymentDate!==p.production_deployment_date;
-  const updated=(await query(`UPDATE qms_epoch_validation_packages SET
+router.patch(
+  '/:id',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const v = packageUpdateSchema.parse(req.body),
+      a = actor(req);
+    const ownerIds = [
+      v.softwareOwnerEmployeeId,
+      v.qualityOwnerEmployeeId,
+      v.validationLeadEmployeeId,
+    ].filter((x): x is number => Boolean(x));
+    if (ownerIds.length) {
+      const active = await query(
+        `SELECT id FROM employees WHERE id=ANY($1::int[]) AND is_active=true`,
+        [ownerIds]
+      );
+      const activeIds = new Set(active.map((x) => Number(x.id))),
+        invalid = ownerIds.filter((x) => !activeIds.has(x));
+      if (invalid.length)
+        return res
+          .status(409)
+          .json({ error: 'INACTIVE_EMPLOYEE_ASSIGNMENT', fields: invalid });
+    }
+    if (
+      v.auditReadinessAssessmentId &&
+      !(
+        await query(
+          `SELECT 1 FROM qms_audit_readiness_assessments WHERE id=$1`,
+          [v.auditReadinessAssessmentId]
+        )
+      ).length
+    )
+      return res.status(409).json({
+        error: 'AUDIT_READINESS_ASSESSMENT_NOT_FOUND',
+        field: 'auditReadinessAssessmentId',
+      });
+    const identifierChanged =
+      v.commitOrReleaseIdentifier !== undefined &&
+      v.commitOrReleaseIdentifier !== p.commit_or_release_identifier;
+    const dateChanged =
+      v.productionDeploymentDate !== undefined &&
+      v.productionDeploymentDate !== p.production_deployment_date;
+    const updated = (
+      await query(
+        `UPDATE qms_epoch_validation_packages SET
     commit_or_release_identifier=CASE WHEN $1 THEN $2 ELSE commit_or_release_identifier END,
     production_deployment_date=CASE WHEN $3 THEN $4::date ELSE production_deployment_date END,
     validation_environment=COALESCE($5,validation_environment),production_environment_reference=COALESCE($6,production_environment_reference),
@@ -211,45 +561,137 @@ router.patch('/:id',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
     deployment_date_confirmed_at=CASE WHEN $19 THEN NULL ELSE deployment_date_confirmed_at END,
     row_version=row_version+1,revision=revision+1,updated_by_user_id=$20,updated_by_display_name=$21,updated_at=now()
     WHERE id=$22 AND row_version=$23 RETURNING *`,
-    [v.commitOrReleaseIdentifier!==undefined,v.commitOrReleaseIdentifier??null,v.productionDeploymentDate!==undefined,v.productionDeploymentDate??null,
-     v.validationEnvironment,v.productionEnvironmentReference,v.environmentDifferences!==undefined,v.environmentDifferences??null,
-     v.softwareOwnerEmployeeId!==undefined,v.softwareOwnerEmployeeId??null,v.qualityOwnerEmployeeId!==undefined,v.qualityOwnerEmployeeId??null,
-     v.validationLeadEmployeeId!==undefined,v.validationLeadEmployeeId??null,v.auditReadinessAssessmentId!==undefined,v.auditReadinessAssessmentId??null,
-     v.notes!==undefined,v.notes??null,identifierChanged||dateChanged,a.id,a.name,p.id,v.rowVersion]))[0];
-  if(!updated)return res.status(409).json({error:'STALE_RECORD'});
-  await invalidateApprovals(p.id,'Validation package fields changed');
-  await logEvent(req,updated,'PACKAGE','PACKAGE_FIELDS_UPDATED',{previous:p,next:updated});
-  res.json({package:updated,readiness:await packageReadiness(updated)});
-});
-router.post('/:id/confirm-deployment-date',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const a=actor(req);
-  if(!productionIdentifierStatus(p.commit_or_release_identifier).valid||!p.production_deployment_date)
-    return res.status(409).json({error:'DEPLOYMENT_CONFIRMATION_BLOCKED',fields:['commitOrReleaseIdentifier','productionDeploymentDate']});
-  const updated=(await query(`UPDATE qms_epoch_validation_packages SET deployment_date_confirmed=true,
+        [
+          v.commitOrReleaseIdentifier !== undefined,
+          v.commitOrReleaseIdentifier ?? null,
+          v.productionDeploymentDate !== undefined,
+          v.productionDeploymentDate ?? null,
+          v.validationEnvironment,
+          v.productionEnvironmentReference,
+          v.environmentDifferences !== undefined,
+          v.environmentDifferences ?? null,
+          v.softwareOwnerEmployeeId !== undefined,
+          v.softwareOwnerEmployeeId ?? null,
+          v.qualityOwnerEmployeeId !== undefined,
+          v.qualityOwnerEmployeeId ?? null,
+          v.validationLeadEmployeeId !== undefined,
+          v.validationLeadEmployeeId ?? null,
+          v.auditReadinessAssessmentId !== undefined,
+          v.auditReadinessAssessmentId ?? null,
+          v.notes !== undefined,
+          v.notes ?? null,
+          identifierChanged || dateChanged,
+          a.id,
+          a.name,
+          p.id,
+          v.rowVersion,
+        ]
+      )
+    )[0];
+    if (!updated) return res.status(409).json({ error: 'STALE_RECORD' });
+    await invalidateApprovals(p.id, 'Validation package fields changed');
+    await logEvent(req, updated, 'PACKAGE', 'PACKAGE_FIELDS_UPDATED', {
+      previous: p,
+      next: updated,
+    });
+    res.json({ package: updated, readiness: await packageReadiness(updated) });
+  }
+);
+router.post(
+  '/:id/confirm-deployment-date',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const a = actor(req);
+    if (
+      !productionIdentifierStatus(p.commit_or_release_identifier).valid ||
+      !p.production_deployment_date
+    )
+      return res.status(409).json({
+        error: 'DEPLOYMENT_CONFIRMATION_BLOCKED',
+        fields: ['commitOrReleaseIdentifier', 'productionDeploymentDate'],
+      });
+    const updated = (
+      await query(
+        `UPDATE qms_epoch_validation_packages SET deployment_date_confirmed=true,
     deployment_date_confirmed_by_user_id=$1,deployment_date_confirmed_by_display_name=$2,deployment_date_confirmed_at=now(),
-    row_version=row_version+1,updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3 RETURNING *`,[a.id,a.name,p.id]))[0];
-  await logEvent(req,updated,'PACKAGE','DEPLOYMENT_DATE_CONFIRMED',{next:{confirmed:true}});res.json(updated);
-});
-router.post('/:id/confirm-environment-separation',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const a=actor(req);
-  if(String(p.environment_differences||'').trim().length<10)return res.status(409).json({error:'ENVIRONMENT_DIFFERENCES_REQUIRED',field:'environmentDifferences'});
-  const updated=(await query(`UPDATE qms_epoch_validation_packages SET environment_separation_confirmed=true,
+    row_version=row_version+1,updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3 RETURNING *`,
+        [a.id, a.name, p.id]
+      )
+    )[0];
+    await logEvent(req, updated, 'PACKAGE', 'DEPLOYMENT_DATE_CONFIRMED', {
+      next: { confirmed: true },
+    });
+    res.json(updated);
+  }
+);
+router.post(
+  '/:id/confirm-environment-separation',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const a = actor(req);
+    if (String(p.environment_differences || '').trim().length < 10)
+      return res.status(409).json({
+        error: 'ENVIRONMENT_DIFFERENCES_REQUIRED',
+        field: 'environmentDifferences',
+      });
+    const updated = (
+      await query(
+        `UPDATE qms_epoch_validation_packages SET environment_separation_confirmed=true,
     environment_separation_confirmed_by_user_id=$1,environment_separation_confirmed_by_display_name=$2,environment_separation_confirmed_at=now(),
-    row_version=row_version+1,updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3 RETURNING *`,[a.id,a.name,p.id]))[0];
-  await logEvent(req,updated,'PACKAGE','ENVIRONMENT_SEPARATION_CONFIRMED',{next:{confirmed:true}});res.json(updated);
-});
-router.post('/:id/audit-readiness-na',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const body=z.object({justification:z.string().min(20)}).parse(req.body),a=actor(req);
-  if(p.audit_readiness_assessment_id)return res.status(409).json({error:'ASSESSMENT_ALREADY_LINKED'});
-  const updated=(await query(`UPDATE qms_epoch_validation_packages SET audit_readiness_not_applicable=true,
+    row_version=row_version+1,updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3 RETURNING *`,
+        [a.id, a.name, p.id]
+      )
+    )[0];
+    await logEvent(
+      req,
+      updated,
+      'PACKAGE',
+      'ENVIRONMENT_SEPARATION_CONFIRMED',
+      { next: { confirmed: true } }
+    );
+    res.json(updated);
+  }
+);
+router.post(
+  '/:id/audit-readiness-na',
+  requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const body = z
+        .object({ justification: z.string().min(20) })
+        .parse(req.body),
+      a = actor(req);
+    if (p.audit_readiness_assessment_id)
+      return res.status(409).json({ error: 'ASSESSMENT_ALREADY_LINKED' });
+    const updated = (
+      await query(
+        `UPDATE qms_epoch_validation_packages SET audit_readiness_not_applicable=true,
     audit_readiness_na_justification=$1,audit_readiness_na_approved_by_user_id=$2,audit_readiness_na_approved_by_display_name=$3,
     audit_readiness_na_approved_at=now(),row_version=row_version+1,updated_by_user_id=$2,updated_by_display_name=$3,updated_at=now()
-    WHERE id=$4 RETURNING *`,[body.justification,a.id,a.name,p.id]))[0];
-  await logEvent(req,updated,'PACKAGE','AUDIT_READINESS_NOT_APPLICABLE_APPROVED',{reason:body.justification});res.json(updated);
-});
+    WHERE id=$4 RETURNING *`,
+        [body.justification, a.id, a.name, p.id]
+      )
+    )[0];
+    await logEvent(
+      req,
+      updated,
+      'PACKAGE',
+      'AUDIT_READINESS_NOT_APPLICABLE_APPROVED',
+      { reason: body.justification }
+    );
+    res.json(updated);
+  }
+);
 
-async function counts(packageId:string):Promise<ReadinessCounts>{
-  const r=(await query(`SELECT
+async function counts(packageId: string): Promise<ReadinessCounts> {
+  const r = (
+    await query(
+      `SELECT
     EXISTS(SELECT 1 FROM qms_epoch_validation_intended_use_revisions u WHERE u.package_id=$1 AND u.approval_status='APPROVED') intended_use,
     EXISTS(SELECT 1 FROM qms_epoch_validation_requirements x WHERE x.package_id=$1) AND
       NOT EXISTS(SELECT 1 FROM qms_epoch_validation_requirements x WHERE x.package_id=$1 AND x.status<>'APPROVED') requirements_approved,
@@ -280,467 +722,1660 @@ async function counts(packageId:string):Promise<ReadinessCounts>{
       WHERE p.package_id=$1 AND (lower(p.title) LIKE '%outage%' OR lower(p.title) LIKE '%recovery drill%') AND e.overall_result='PASSED' AND e.review_decision='APPROVED') outage_passed,
     NOT EXISTS(SELECT 1 FROM qms_epoch_validation_approvals a WHERE a.package_id=$1 AND a.status='INVALIDATED') AND
       (SELECT count(DISTINCT approval_role) FROM qms_epoch_validation_approvals a WHERE a.package_id=$1 AND a.record_type='FINAL' AND a.status='VALID' AND a.decision='APPROVED')>=3 approvals_current,
-    EXISTS(SELECT 1 FROM qms_epoch_validation_packages p WHERE p.id=$1 AND nullif(trim(p.production_version),'') IS NOT NULL) version_identified`,[packageId]))[0];
-  return {intendedUseApproved:r.intended_use,requirementsBaselineApproved:r.requirements_approved,
-    riskAssessmentApproved:r.risks_approved,validationPlanApproved:r.plan_approved,
-    criticalRequirements:r.critical_requirements,criticalRequirementsTested:r.critical_requirements_tested,
-    criticalTests:r.critical_tests,criticalTestsPassed:r.critical_tests_passed,
-    openCriticalDefects:r.open_critical,openHighDefects:r.open_high,acceptedHighDefects:r.accepted_high,
-    requiredRetests:r.required_retests,passedRetests:r.passed_retests,backupPassed:r.backup_passed,
-    restorePassed:r.restore_passed,outageDrillPassed:r.outage_passed,approvalsCurrent:r.approvals_current,
-    exactProductionVersionIdentified:r.version_identified};
+    EXISTS(SELECT 1 FROM qms_epoch_validation_packages p WHERE p.id=$1 AND nullif(trim(p.production_version),'') IS NOT NULL) version_identified`,
+      [packageId]
+    )
+  )[0];
+  return {
+    intendedUseApproved: r.intended_use,
+    requirementsBaselineApproved: r.requirements_approved,
+    riskAssessmentApproved: r.risks_approved,
+    validationPlanApproved: r.plan_approved,
+    criticalRequirements: r.critical_requirements,
+    criticalRequirementsTested: r.critical_requirements_tested,
+    criticalTests: r.critical_tests,
+    criticalTestsPassed: r.critical_tests_passed,
+    openCriticalDefects: r.open_critical,
+    openHighDefects: r.open_high,
+    acceptedHighDefects: r.accepted_high,
+    requiredRetests: r.required_retests,
+    passedRetests: r.passed_retests,
+    backupPassed: r.backup_passed,
+    restorePassed: r.restore_passed,
+    outageDrillPassed: r.outage_passed,
+    approvalsCurrent: r.approvals_current,
+    exactProductionVersionIdentified: r.version_identified,
+  };
 }
-async function detail(packageId:string){
-  const p=await getPackage(packageId); if(!p)return null;
-  const [intendedUse,requirements,risks,plans,protocols,executions,defects,approvals,reviews,events]=await Promise.all([
-    query('SELECT * FROM qms_epoch_validation_intended_use_revisions WHERE package_id=$1 ORDER BY revision DESC',[packageId]),
-    query('SELECT * FROM qms_epoch_validation_requirements WHERE package_id=$1 ORDER BY requirement_id',[packageId]),
-    query('SELECT * FROM qms_epoch_validation_risks WHERE package_id=$1 ORDER BY risk_id',[packageId]),
-    query('SELECT * FROM qms_epoch_validation_plans WHERE package_id=$1 ORDER BY revision DESC',[packageId]),
-    query(`SELECT p.*,(SELECT count(*)::int FROM qms_epoch_validation_protocol_steps s WHERE s.protocol_id=p.id) step_count
-      FROM qms_epoch_validation_protocols p WHERE package_id=$1 ORDER BY test_id`,[packageId]),
-    query('SELECT * FROM qms_epoch_validation_executions WHERE package_id=$1 ORDER BY created_at DESC',[packageId]),
-    query('SELECT * FROM qms_epoch_validation_defects WHERE package_id=$1 ORDER BY created_at DESC',[packageId]),
-    query('SELECT * FROM qms_epoch_validation_approvals WHERE package_id=$1 ORDER BY decided_at DESC',[packageId]),
-    query('SELECT * FROM qms_epoch_validation_periodic_reviews WHERE package_id=$1 ORDER BY review_date DESC',[packageId]),
-    query('SELECT * FROM qms_epoch_validation_events WHERE package_id=$1 ORDER BY created_at DESC LIMIT 250',[packageId]),
+async function detail(packageId: string) {
+  const p = await getPackage(packageId);
+  if (!p) return null;
+  const [
+    intendedUse,
+    requirements,
+    risks,
+    plans,
+    protocols,
+    executions,
+    defects,
+    approvals,
+    reviews,
+    events,
+  ] = await Promise.all([
+    query(
+      'SELECT * FROM qms_epoch_validation_intended_use_revisions WHERE package_id=$1 ORDER BY revision DESC',
+      [packageId]
+    ),
+    query(
+      'SELECT * FROM qms_epoch_validation_requirements WHERE package_id=$1 ORDER BY requirement_id',
+      [packageId]
+    ),
+    query(
+      'SELECT * FROM qms_epoch_validation_risks WHERE package_id=$1 ORDER BY risk_id',
+      [packageId]
+    ),
+    query(
+      'SELECT * FROM qms_epoch_validation_plans WHERE package_id=$1 ORDER BY revision DESC',
+      [packageId]
+    ),
+    query(
+      `SELECT p.*,(SELECT count(*)::int FROM qms_epoch_validation_protocol_steps s WHERE s.protocol_id=p.id) step_count
+      FROM qms_epoch_validation_protocols p WHERE package_id=$1 ORDER BY test_id`,
+      [packageId]
+    ),
+    query(
+      'SELECT * FROM qms_epoch_validation_executions WHERE package_id=$1 ORDER BY created_at DESC',
+      [packageId]
+    ),
+    query(
+      'SELECT * FROM qms_epoch_validation_defects WHERE package_id=$1 ORDER BY created_at DESC',
+      [packageId]
+    ),
+    query(
+      'SELECT * FROM qms_epoch_validation_approvals WHERE package_id=$1 ORDER BY decided_at DESC',
+      [packageId]
+    ),
+    query(
+      'SELECT * FROM qms_epoch_validation_periodic_reviews WHERE package_id=$1 ORDER BY review_date DESC',
+      [packageId]
+    ),
+    query(
+      'SELECT * FROM qms_epoch_validation_events WHERE package_id=$1 ORDER BY created_at DESC LIMIT 250',
+      [packageId]
+    ),
   ]);
-  const c=await counts(packageId),r=calculateReadiness(c);
-  return {package:p,intendedUse,requirements,risks,plans,protocols,executions,defects,approvals,periodicReviews:reviews,events,
-    readiness:{...c,...r},packageReadiness:await packageReadiness(p)};
+  const c = await counts(packageId),
+    r = calculateReadiness(c);
+  return {
+    package: p,
+    intendedUse,
+    requirements,
+    risks,
+    plans,
+    protocols,
+    executions,
+    defects,
+    approvals,
+    periodicReviews: reviews,
+    events,
+    readiness: { ...c, ...r },
+    packageReadiness: await packageReadiness(p),
+  };
 }
-router.get('/:id',requirePermission('EPOCH_VALIDATION_VIEW'),async(req,res)=>{
-  const d=await detail(uuid.parse(req.params.id)); if(!d)return res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});res.json(d);
-});
-router.get('/:id/readiness',requirePermission('EPOCH_VALIDATION_VIEW'),async(req,res)=>{
-  const id=uuid.parse(req.params.id);res.json({...await counts(id),...calculateReadiness(await counts(id))});
-});
-router.post('/:id/status',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;
-  const body=z.object({status:z.string(),reason:z.string().min(3)}).parse(req.body);
-  if(!canTransition(p.status as ValidationStatus,body.status as ValidationStatus))
-    return res.status(409).json({error:'ILLEGAL_STATUS_TRANSITION',from:p.status,to:body.status});
-  if(['PLAN_APPROVED','TESTING','RETESTING','READY_FOR_FINAL_REVIEW'].includes(body.status)){
-    const gate=await packageReadiness(p);
-    if(!gate.executionReady)return res.status(409).json({error:'PACKAGE_STATUS_READINESS_BLOCKED',blockers:gate.blockers});
+router.get(
+  '/:id',
+  requirePermission('EPOCH_VALIDATION_VIEW'),
+  async (req, res) => {
+    const d = await detail(uuid.parse(req.params.id));
+    if (!d)
+      return res.status(404).json({ error: 'VALIDATION_PACKAGE_NOT_FOUND' });
+    res.json(d);
   }
-  if(body.status==='TESTING'&&!await query(`SELECT 1 FROM qms_epoch_validation_plans WHERE package_id=$1 AND status='APPROVED'`,[p.id]).then(x=>x.length))
-    return res.status(409).json({error:'VALIDATION_PLAN_APPROVAL_REQUIRED'});
-  if(body.status==='READY_FOR_FINAL_REVIEW'){
-    const structural=await counts(p.id); structural.approvalsCurrent=true;
-    if(!calculateReadiness(structural).ready)
-      return res.status(409).json({error:'FINAL_READINESS_BLOCKED',...calculateReadiness(structural)});
+);
+router.get(
+  '/:id/readiness',
+  requirePermission('EPOCH_VALIDATION_VIEW'),
+  async (req, res) => {
+    const id = uuid.parse(req.params.id);
+    res.json({
+      ...(await counts(id)),
+      ...calculateReadiness(await counts(id)),
+    });
   }
-  const a=actor(req),updated=(await query(`UPDATE qms_epoch_validation_packages SET status=$1,row_version=row_version+1,
+);
+router.post(
+  '/:id/status',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const body = z
+      .object({ status: z.string(), reason: z.string().min(3) })
+      .parse(req.body);
+    if (
+      !canTransition(
+        p.status as ValidationStatus,
+        body.status as ValidationStatus
+      )
+    )
+      return res.status(409).json({
+        error: 'ILLEGAL_STATUS_TRANSITION',
+        from: p.status,
+        to: body.status,
+      });
+    if (
+      [
+        'PLAN_APPROVED',
+        'TESTING',
+        'RETESTING',
+        'READY_FOR_FINAL_REVIEW',
+      ].includes(body.status)
+    ) {
+      const gate = await packageReadiness(p);
+      if (!gate.executionReady)
+        return res.status(409).json({
+          error: 'PACKAGE_STATUS_READINESS_BLOCKED',
+          blockers: gate.blockers,
+        });
+    }
+    if (
+      body.status === 'TESTING' &&
+      !(await query(
+        `SELECT 1 FROM qms_epoch_validation_plans WHERE package_id=$1 AND status='APPROVED'`,
+        [p.id]
+      ).then((x) => x.length))
+    )
+      return res
+        .status(409)
+        .json({ error: 'VALIDATION_PLAN_APPROVAL_REQUIRED' });
+    if (body.status === 'READY_FOR_FINAL_REVIEW') {
+      const structural = await counts(p.id);
+      structural.approvalsCurrent = true;
+      if (!calculateReadiness(structural).ready)
+        return res.status(409).json({
+          error: 'FINAL_READINESS_BLOCKED',
+          ...calculateReadiness(structural),
+        });
+    }
+    const a = actor(req),
+      updated = (
+        await query(
+          `UPDATE qms_epoch_validation_packages SET status=$1,row_version=row_version+1,
     revision=revision+1,updated_by_user_id=$2,updated_by_display_name=$3,updated_at=now() WHERE id=$4 RETURNING *`,
-    [body.status,a.id,a.name,p.id]))[0];
-  await invalidateApprovals(p.id,'Package status changed');await logEvent(req,updated,'PACKAGE','STATUS_CHANGED',{previous:p.status,next:body.status,reason:body.reason});
-  res.json(updated);
-});
+          [body.status, a.id, a.name, p.id]
+        )
+      )[0];
+    await invalidateApprovals(p.id, 'Package status changed');
+    await logEvent(req, updated, 'PACKAGE', 'STATUS_CHANGED', {
+      previous: p.status,
+      next: body.status,
+      reason: body.reason,
+    });
+    res.json(updated);
+  }
+);
 
-const intendedUseSchema=z.object({
-  systemName:z.string().min(1),epochVersion:z.string().min(1),productionEnvironment:z.string().min(1),
-  softwareOwnerEmployeeId:z.number().int().positive().optional(),qualityOwnerEmployeeId:z.number().int().positive().optional(),
-  hostingProvider:z.string().min(1),databaseProvider:z.string().min(1),intendedUseStatement:z.string().min(20),
-  qmsProcessesSupported:z.string().min(1),officialRecordsControlled:z.string().min(1),outsideProcessesRecords:z.string().optional(),
-  userGroupsDepartments:z.string().min(1),interfacesDependencies:z.string().optional(),
-  customerContractualRequirements:z.string().optional(),complianceConsiderations:z.string().optional(),
-  knownLimitations:z.string().optional(),excludedFunctionality:z.string().optional(),
-  dataRetentionResponsibilities:z.string().min(1),backupResponsibilities:z.string().min(1),
+const intendedUseSchema = z.object({
+  systemName: z.string().min(1),
+  epochVersion: z.string().min(1),
+  productionEnvironment: z.string().min(1),
+  softwareOwnerEmployeeId: z.number().int().positive().optional(),
+  qualityOwnerEmployeeId: z.number().int().positive().optional(),
+  hostingProvider: z.string().min(1),
+  databaseProvider: z.string().min(1),
+  intendedUseStatement: z.string().min(20),
+  qmsProcessesSupported: z.string().min(1),
+  officialRecordsControlled: z.string().min(1),
+  outsideProcessesRecords: z.string().optional(),
+  userGroupsDepartments: z.string().min(1),
+  interfacesDependencies: z.string().optional(),
+  customerContractualRequirements: z.string().optional(),
+  complianceConsiderations: z.string().optional(),
+  knownLimitations: z.string().optional(),
+  excludedFunctionality: z.string().optional(),
+  dataRetentionResponsibilities: z.string().min(1),
+  backupResponsibilities: z.string().min(1),
 });
-router.post('/:id/intended-use',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const v=intendedUseSchema.parse(req.body),a=actor(req);
-  const record=await tx(async q=>{
-    await q(`SELECT id FROM qms_epoch_validation_packages WHERE id=$1 FOR UPDATE`,[p.id]);
-    const revision=Number((await q(`SELECT coalesce(max(revision),0)+1 revision FROM qms_epoch_validation_intended_use_revisions WHERE package_id=$1`,[p.id]))[0].revision);
-    await q(`UPDATE qms_epoch_validation_intended_use_revisions SET approval_status='SUPERSEDED' WHERE package_id=$1 AND approval_status<>'SUPERSEDED'`,[p.id]);
-    const x=(await q(`INSERT INTO qms_epoch_validation_intended_use_revisions
+router.post(
+  '/:id/intended-use',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const v = intendedUseSchema.parse(req.body),
+      a = actor(req);
+    const record = await tx(async (q) => {
+      await q(
+        `SELECT id FROM qms_epoch_validation_packages WHERE id=$1 FOR UPDATE`,
+        [p.id]
+      );
+      const revision = Number(
+        (
+          await q(
+            `SELECT coalesce(max(revision),0)+1 revision FROM qms_epoch_validation_intended_use_revisions WHERE package_id=$1`,
+            [p.id]
+          )
+        )[0].revision
+      );
+      await q(
+        `UPDATE qms_epoch_validation_intended_use_revisions SET approval_status='SUPERSEDED' WHERE package_id=$1 AND approval_status<>'SUPERSEDED'`,
+        [p.id]
+      );
+      const x = (
+        await q(
+          `INSERT INTO qms_epoch_validation_intended_use_revisions
       (package_id,revision,system_name,epoch_version,production_environment,software_owner_employee_id,quality_owner_employee_id,
        hosting_provider,database_provider,intended_use_statement,qms_processes_supported,official_records_controlled,
        outside_processes_records,user_groups_departments,interfaces_dependencies,customer_contractual_requirements,
        compliance_considerations,known_limitations,excluded_functionality,data_retention_responsibilities,
        backup_responsibilities,created_by_user_id)
       VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22) RETURNING *`,
-      [p.id,revision,v.systemName,v.epochVersion,v.productionEnvironment,v.softwareOwnerEmployeeId||null,
-       v.qualityOwnerEmployeeId||null,v.hostingProvider,v.databaseProvider,v.intendedUseStatement,v.qmsProcessesSupported,
-       v.officialRecordsControlled,v.outsideProcessesRecords||null,v.userGroupsDepartments,v.interfacesDependencies||null,
-       v.customerContractualRequirements||null,v.complianceConsiderations||null,v.knownLimitations||null,
-       v.excludedFunctionality||null,v.dataRetentionResponsibilities,v.backupResponsibilities,a.id]))[0];
-    await invalidateApprovals(p.id,'Intended Use revised',q);await logEvent(req,p,'INTENDED_USE','INTENDED_USE_REVISED',{entityId:x.id,next:{revision}},q);return x;
-  });res.status(201).json(record);
-});
+          [
+            p.id,
+            revision,
+            v.systemName,
+            v.epochVersion,
+            v.productionEnvironment,
+            v.softwareOwnerEmployeeId || null,
+            v.qualityOwnerEmployeeId || null,
+            v.hostingProvider,
+            v.databaseProvider,
+            v.intendedUseStatement,
+            v.qmsProcessesSupported,
+            v.officialRecordsControlled,
+            v.outsideProcessesRecords || null,
+            v.userGroupsDepartments,
+            v.interfacesDependencies || null,
+            v.customerContractualRequirements || null,
+            v.complianceConsiderations || null,
+            v.knownLimitations || null,
+            v.excludedFunctionality || null,
+            v.dataRetentionResponsibilities,
+            v.backupResponsibilities,
+            a.id,
+          ]
+        )
+      )[0];
+      await invalidateApprovals(p.id, 'Intended Use revised', q);
+      await logEvent(
+        req,
+        p,
+        'INTENDED_USE',
+        'INTENDED_USE_REVISED',
+        { entityId: x.id, next: { revision } },
+        q
+      );
+      return x;
+    });
+    res.status(201).json(record);
+  }
+);
 
-const requirementSchema=z.object({module:z.string().min(1),category:z.string().min(1),statement:z.string().min(5),
-  purpose:z.string().min(1),source:z.string().min(1),criticality:z.enum(['CRITICAL','HIGH','NORMAL','INFORMATIONAL']),
-  productQualityRecordImpact:z.string().optional(),traceabilityImpact:z.string().optional(),securityAccessImpact:z.string().optional(),
-  dataIntegrityImpact:z.string().optional(),regulatoryCustomerImpact:z.string().optional(),validationMethod:z.string().min(1),
-  testRequired:z.boolean().default(true),ownerEmployeeId:z.number().int().positive().optional()});
-router.post('/:id/requirements',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const v=requirementSchema.parse(req.body),a=actor(req);
-  const seq=(await query(`SELECT nextval('qms_epoch_validation_requirement_number_seq') value`))[0].value;
-  const rid=`ESR-${String(seq).padStart(4,'0')}`;
-  const x=(await query(`INSERT INTO qms_epoch_validation_requirements
+const requirementSchema = z.object({
+  module: z.string().min(1),
+  category: z.string().min(1),
+  statement: z.string().min(5),
+  purpose: z.string().min(1),
+  source: z.string().min(1),
+  criticality: z.enum(['CRITICAL', 'HIGH', 'NORMAL', 'INFORMATIONAL']),
+  productQualityRecordImpact: z.string().optional(),
+  traceabilityImpact: z.string().optional(),
+  securityAccessImpact: z.string().optional(),
+  dataIntegrityImpact: z.string().optional(),
+  regulatoryCustomerImpact: z.string().optional(),
+  validationMethod: z.string().min(1),
+  testRequired: z.boolean().default(true),
+  ownerEmployeeId: z.number().int().positive().optional(),
+});
+router.post(
+  '/:id/requirements',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const v = requirementSchema.parse(req.body),
+      a = actor(req);
+    const seq = (
+      await query(
+        `SELECT nextval('qms_epoch_validation_requirement_number_seq') value`
+      )
+    )[0].value;
+    const rid = `ESR-${String(seq).padStart(4, '0')}`;
+    const x = (
+      await query(
+        `INSERT INTO qms_epoch_validation_requirements
     (requirement_id,package_id,module,category,statement,purpose,source,criticality,product_quality_record_impact,
      traceability_impact,security_access_impact,data_integrity_impact,regulatory_customer_impact,
      validation_method,test_required,owner_employee_id,created_by_user_id,updated_by_user_id)
     VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$17) RETURNING *`,
-    [rid,p.id,v.module,v.category,v.statement,v.purpose,v.source,v.criticality,v.productQualityRecordImpact||null,
-     v.traceabilityImpact||null,v.securityAccessImpact||null,v.dataIntegrityImpact||null,v.regulatoryCustomerImpact||null,
-     v.validationMethod,v.testRequired,v.ownerEmployeeId||null,a.id]))[0];
-  await invalidateApprovals(p.id,'Requirement added');await logEvent(req,p,'REQUIREMENT','REQUIREMENT_CREATED',{entityId:x.id,next:x});res.status(201).json(x);
-});
-router.post('/:id/requirements/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
-  const x=(await query(`UPDATE qms_epoch_validation_requirements SET status='APPROVED',updated_at=now()
-    WHERE id=$1 AND package_id=$2 AND status IN ('DRAFT','READY_FOR_APPROVAL') RETURNING *`,[recordId,p.id]))[0];
-  if(!x)return res.status(409).json({error:'REQUIREMENT_NOT_APPROVABLE'});await approve(req,p,'REQUIREMENT',x.id,x.revision,'REQUIREMENTS_APPROVER','Approved requirement baseline item','EPOCH_VALIDATION_PLAN_APPROVE');res.json(x);
-});
+        [
+          rid,
+          p.id,
+          v.module,
+          v.category,
+          v.statement,
+          v.purpose,
+          v.source,
+          v.criticality,
+          v.productQualityRecordImpact || null,
+          v.traceabilityImpact || null,
+          v.securityAccessImpact || null,
+          v.dataIntegrityImpact || null,
+          v.regulatoryCustomerImpact || null,
+          v.validationMethod,
+          v.testRequired,
+          v.ownerEmployeeId || null,
+          a.id,
+        ]
+      )
+    )[0];
+    await invalidateApprovals(p.id, 'Requirement added');
+    await logEvent(req, p, 'REQUIREMENT', 'REQUIREMENT_CREATED', {
+      entityId: x.id,
+      next: x,
+    });
+    res.status(201).json(x);
+  }
+);
+router.post(
+  '/:id/requirements/:recordId/approve',
+  requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const recordId = uuid.parse(req.params.recordId);
+    const x = (
+      await query(
+        `UPDATE qms_epoch_validation_requirements SET status='APPROVED',updated_at=now()
+    WHERE id=$1 AND package_id=$2 AND status IN ('DRAFT','READY_FOR_APPROVAL') RETURNING *`,
+        [recordId, p.id]
+      )
+    )[0];
+    if (!x)
+      return res.status(409).json({ error: 'REQUIREMENT_NOT_APPROVABLE' });
+    await approve(
+      req,
+      p,
+      'REQUIREMENT',
+      x.id,
+      x.revision,
+      'REQUIREMENTS_APPROVER',
+      'Approved requirement baseline item',
+      'EPOCH_VALIDATION_PLAN_APPROVE'
+    );
+    res.json(x);
+  }
+);
 
-const riskSchema=z.object({requirementId:z.string().uuid().optional(),module:z.string().min(1),failureMode:z.string().min(3),
-  cause:z.string().min(1),potentialEffect:z.string().min(1),qualityTraceabilityImpact:z.string().min(1),
-  severity:z.number().int().min(1).max(5),likelihood:z.number().int().min(1).max(5),detectability:z.number().int().min(1).max(5),
-  existingControls:z.string().optional(),additionalMitigation:z.string().optional(),
-  mitigationOwnerEmployeeId:z.number().int().positive().optional(),dueDate:z.string().date().optional(),
-  residualRisk:z.string().optional(),residualRiskLevel:z.enum(['CRITICAL','HIGH','NORMAL','LOW']).default('NORMAL'),
-  requiredTest:z.boolean().default(false)});
-router.post('/:id/risks',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const v=riskSchema.parse(req.body),a=actor(req);
-  if(v.requirementId&&!await query('SELECT 1 FROM qms_epoch_validation_requirements WHERE id=$1 AND package_id=$2',[v.requirementId,p.id]).then(x=>x.length))
-    return res.status(409).json({error:'REQUIREMENT_LINK_INVALID'});
-  const seq=(await query(`SELECT nextval('qms_epoch_validation_risk_number_seq') value`))[0].value,rid=`ESRISK-${String(seq).padStart(4,'0')}`;
-  const x=(await query(`INSERT INTO qms_epoch_validation_risks
+const riskSchema = z.object({
+  requirementId: z.string().uuid().optional(),
+  module: z.string().min(1),
+  failureMode: z.string().min(3),
+  cause: z.string().min(1),
+  potentialEffect: z.string().min(1),
+  qualityTraceabilityImpact: z.string().min(1),
+  severity: z.number().int().min(1).max(5),
+  likelihood: z.number().int().min(1).max(5),
+  detectability: z.number().int().min(1).max(5),
+  existingControls: z.string().optional(),
+  additionalMitigation: z.string().optional(),
+  mitigationOwnerEmployeeId: z.number().int().positive().optional(),
+  dueDate: z.string().date().optional(),
+  residualRisk: z.string().optional(),
+  residualRiskLevel: z
+    .enum(['CRITICAL', 'HIGH', 'NORMAL', 'LOW'])
+    .default('NORMAL'),
+  requiredTest: z.boolean().default(false),
+});
+router.post(
+  '/:id/risks',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const v = riskSchema.parse(req.body),
+      a = actor(req);
+    if (
+      v.requirementId &&
+      !(await query(
+        'SELECT 1 FROM qms_epoch_validation_requirements WHERE id=$1 AND package_id=$2',
+        [v.requirementId, p.id]
+      ).then((x) => x.length))
+    )
+      return res.status(409).json({ error: 'REQUIREMENT_LINK_INVALID' });
+    const seq = (
+        await query(
+          `SELECT nextval('qms_epoch_validation_risk_number_seq') value`
+        )
+      )[0].value,
+      rid = `ESRISK-${String(seq).padStart(4, '0')}`;
+    const x = (
+      await query(
+        `INSERT INTO qms_epoch_validation_risks
     (risk_id,package_id,requirement_id,module,failure_mode,cause,potential_effect,quality_traceability_impact,
      severity,likelihood,detectability,existing_controls,additional_mitigation,mitigation_owner_employee_id,
      due_date,residual_risk,residual_risk_level,required_test,created_by_user_id,updated_by_user_id)
     VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$19) RETURNING *`,
-    [rid,p.id,v.requirementId||null,v.module,v.failureMode,v.cause,v.potentialEffect,v.qualityTraceabilityImpact,
-     v.severity,v.likelihood,v.detectability,v.existingControls||null,v.additionalMitigation||null,
-     v.mitigationOwnerEmployeeId||null,v.dueDate||null,v.residualRisk||null,v.residualRiskLevel,
-     v.requiredTest||v.severity>=4,a.id]))[0];
-  await invalidateApprovals(p.id,'Risk added');await logEvent(req,p,'RISK','RISK_CREATED',{entityId:x.id,next:x});res.status(201).json(x);
-});
-router.post('/:id/risks/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
-  const risk=(await query('SELECT * FROM qms_epoch_validation_risks WHERE id=$1 AND package_id=$2',[recordId,p.id]))[0];
-  if(!risk)return res.status(404).json({error:'VALIDATION_RISK_NOT_FOUND'});
-  if((risk.severity>=4||risk.required_test)&&!await query(`SELECT 1 FROM qms_epoch_validation_protocol_risks pr
-    JOIN qms_epoch_validation_protocols p ON p.id=pr.protocol_id WHERE pr.risk_id=$1 AND p.status='APPROVED'`,[recordId]).then(x=>x.length))
-    return res.status(409).json({error:'CRITICAL_HIGH_RISK_REQUIRES_APPROVED_PROTOCOL'});
-  await query(`UPDATE qms_epoch_validation_risks SET status='APPROVED',updated_at=now() WHERE id=$1`,[recordId]);
-  await approve(req,p,'RISK',risk.id,1,'RISK_APPROVER','Approved software risk assessment item','EPOCH_VALIDATION_PLAN_APPROVE');
-  res.json({...risk,status:'APPROVED'});
-});
-router.post('/:id/risks/:recordId/accept',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
-  const body=z.object({authorityRole:z.enum(['QUALITY_APPROVER','TOP_MANAGEMENT']),comments:z.string().min(20)}).parse(req.body);
-  const risk=(await query(`UPDATE qms_epoch_validation_risks SET risk_accepted=true,updated_at=now()
-    WHERE id=$1 AND package_id=$2 AND residual_risk_level IN ('CRITICAL','HIGH') RETURNING *`,[recordId,p.id]))[0];
-  if(!risk)return res.status(409).json({error:'CRITICAL_HIGH_RESIDUAL_RISK_REQUIRED'});
-  await approve(req,p,'RISK_ACCEPTANCE',risk.id,1,body.authorityRole,'Accepted documented critical/high residual software risk','EPOCH_VALIDATION_FINAL_APPROVE',body.comments);
-  res.json(risk);
-});
+        [
+          rid,
+          p.id,
+          v.requirementId || null,
+          v.module,
+          v.failureMode,
+          v.cause,
+          v.potentialEffect,
+          v.qualityTraceabilityImpact,
+          v.severity,
+          v.likelihood,
+          v.detectability,
+          v.existingControls || null,
+          v.additionalMitigation || null,
+          v.mitigationOwnerEmployeeId || null,
+          v.dueDate || null,
+          v.residualRisk || null,
+          v.residualRiskLevel,
+          v.requiredTest || v.severity >= 4,
+          a.id,
+        ]
+      )
+    )[0];
+    await invalidateApprovals(p.id, 'Risk added');
+    await logEvent(req, p, 'RISK', 'RISK_CREATED', { entityId: x.id, next: x });
+    res.status(201).json(x);
+  }
+);
+router.post(
+  '/:id/risks/:recordId/approve',
+  requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const recordId = uuid.parse(req.params.recordId);
+    const risk = (
+      await query(
+        'SELECT * FROM qms_epoch_validation_risks WHERE id=$1 AND package_id=$2',
+        [recordId, p.id]
+      )
+    )[0];
+    if (!risk)
+      return res.status(404).json({ error: 'VALIDATION_RISK_NOT_FOUND' });
+    if (
+      (risk.severity >= 4 || risk.required_test) &&
+      !(await query(
+        `SELECT 1 FROM qms_epoch_validation_protocol_risks pr
+    JOIN qms_epoch_validation_protocols p ON p.id=pr.protocol_id WHERE pr.risk_id=$1 AND p.status='APPROVED'`,
+        [recordId]
+      ).then((x) => x.length))
+    )
+      return res
+        .status(409)
+        .json({ error: 'CRITICAL_HIGH_RISK_REQUIRES_APPROVED_PROTOCOL' });
+    await query(
+      `UPDATE qms_epoch_validation_risks SET status='APPROVED',updated_at=now() WHERE id=$1`,
+      [recordId]
+    );
+    await approve(
+      req,
+      p,
+      'RISK',
+      risk.id,
+      1,
+      'RISK_APPROVER',
+      'Approved software risk assessment item',
+      'EPOCH_VALIDATION_PLAN_APPROVE'
+    );
+    res.json({ ...risk, status: 'APPROVED' });
+  }
+);
+router.post(
+  '/:id/risks/:recordId/accept',
+  requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const recordId = uuid.parse(req.params.recordId);
+    const body = z
+      .object({
+        authorityRole: z.enum(['QUALITY_APPROVER', 'TOP_MANAGEMENT']),
+        comments: z.string().min(20),
+      })
+      .parse(req.body);
+    const risk = (
+      await query(
+        `UPDATE qms_epoch_validation_risks SET risk_accepted=true,updated_at=now()
+    WHERE id=$1 AND package_id=$2 AND residual_risk_level IN ('CRITICAL','HIGH') RETURNING *`,
+        [recordId, p.id]
+      )
+    )[0];
+    if (!risk)
+      return res
+        .status(409)
+        .json({ error: 'CRITICAL_HIGH_RESIDUAL_RISK_REQUIRED' });
+    await approve(
+      req,
+      p,
+      'RISK_ACCEPTANCE',
+      risk.id,
+      1,
+      body.authorityRole,
+      'Accepted documented critical/high residual software risk',
+      'EPOCH_VALIDATION_FINAL_APPROVE',
+      body.comments
+    );
+    res.json(risk);
+  }
+);
 
-const planSchema=z.object({purpose:z.string().min(1),scope:z.string().min(1),epochVersion:z.string().min(1),
-  commitOrReleaseIdentifier:z.string().optional(),includedModules:z.string().min(1),excludedModules:z.string().optional(),
-  validationEnvironment:z.string().min(1),testDatabaseEnvironment:z.string().min(1),productionComparisonMethod:z.string().min(1),
-  responsibilities:z.string().min(1),requiredResources:z.string().optional(),testingApproach:z.string().min(1),
-  riskBasedSelection:z.string().min(1),evidenceRequirements:z.string().min(1),acceptanceCriteria:z.string().min(1),
-  defectSeverityRules:z.string().min(1),retestingRequirements:z.string().min(1),regressionRequirements:z.string().min(1),
-  backupRestoreRequirements:z.string().min(1),outageDrillRequirements:z.string().min(1),approvalRoles:z.string().min(1),
-  schedule:z.string().min(1),deviations:z.string().optional()});
-router.post('/:id/plans',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const v=planSchema.parse(req.body),a=actor(req);
-  const revision=Number((await query('SELECT coalesce(max(revision),0)+1 revision FROM qms_epoch_validation_plans WHERE package_id=$1',[p.id]))[0].revision);
-  await query(`UPDATE qms_epoch_validation_plans SET status='SUPERSEDED' WHERE package_id=$1 AND status<>'SUPERSEDED'`,[p.id]);
-  const keys=Object.keys(v),values=Object.values(v);
-  const x=(await query(`INSERT INTO qms_epoch_validation_plans
+const planSchema = z.object({
+  purpose: z.string().min(1),
+  scope: z.string().min(1),
+  epochVersion: z.string().min(1),
+  commitOrReleaseIdentifier: z.string().optional(),
+  includedModules: z.string().min(1),
+  excludedModules: z.string().optional(),
+  validationEnvironment: z.string().min(1),
+  testDatabaseEnvironment: z.string().min(1),
+  productionComparisonMethod: z.string().min(1),
+  responsibilities: z.string().min(1),
+  requiredResources: z.string().optional(),
+  testingApproach: z.string().min(1),
+  riskBasedSelection: z.string().min(1),
+  evidenceRequirements: z.string().min(1),
+  acceptanceCriteria: z.string().min(1),
+  defectSeverityRules: z.string().min(1),
+  retestingRequirements: z.string().min(1),
+  regressionRequirements: z.string().min(1),
+  backupRestoreRequirements: z.string().min(1),
+  outageDrillRequirements: z.string().min(1),
+  approvalRoles: z.string().min(1),
+  schedule: z.string().min(1),
+  deviations: z.string().optional(),
+});
+router.post(
+  '/:id/plans',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const v = planSchema.parse(req.body),
+      a = actor(req);
+    const revision = Number(
+      (
+        await query(
+          'SELECT coalesce(max(revision),0)+1 revision FROM qms_epoch_validation_plans WHERE package_id=$1',
+          [p.id]
+        )
+      )[0].revision
+    );
+    await query(
+      `UPDATE qms_epoch_validation_plans SET status='SUPERSEDED' WHERE package_id=$1 AND status<>'SUPERSEDED'`,
+      [p.id]
+    );
+    const keys = Object.keys(v),
+      values = Object.values(v);
+    const x = (
+      await query(
+        `INSERT INTO qms_epoch_validation_plans
     (package_id,revision,purpose,scope,epoch_version,commit_or_release_identifier,included_modules,excluded_modules,
      validation_environment,test_database_environment,production_comparison_method,responsibilities,required_resources,
      testing_approach,risk_based_selection,evidence_requirements,acceptance_criteria,defect_severity_rules,
      retesting_requirements,regression_requirements,backup_restore_requirements,outage_drill_requirements,approval_roles,
      schedule,deviations,created_by_user_id)
-    VALUES($1,$2,${values.map((_,i)=>`$${i+3}`).join(',')},$${values.length+3}) RETURNING *`,
-    [p.id,revision,...values,a.id]))[0];
-  void keys;await invalidateApprovals(p.id,'Validation Plan revised');await logEvent(req,p,'PLAN','PLAN_REVISED',{entityId:x.id,next:{revision}});res.status(201).json(x);
-});
-router.post('/:id/plans/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
-  const body=z.object({approvalRole:z.enum(['VALIDATION_LEAD','EPOCH_IT_OWNER','QUALITY_APPROVER']),comments:z.string().optional()}).parse(req.body);
-  const plan=(await query('SELECT * FROM qms_epoch_validation_plans WHERE id=$1 AND package_id=$2',[recordId,p.id]))[0];
-  if(!plan)return res.status(404).json({error:'VALIDATION_PLAN_NOT_FOUND'});
-  await approve(req,p,'PLAN',plan.id,plan.revision,body.approvalRole,'Approved Validation Plan revision','EPOCH_VALIDATION_PLAN_APPROVE',body.comments);
-  const n=Number((await query(`SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals WHERE record_type='PLAN' AND record_id=$1 AND record_revision=$2 AND status='VALID' AND decision='APPROVED'`,[plan.id,plan.revision]))[0].n);
-  if(n>=3)await query(`UPDATE qms_epoch_validation_plans SET status='APPROVED' WHERE id=$1`,[plan.id]);res.json({approvedRoles:n,complete:n>=3});
-});
+    VALUES($1,$2,${values.map((_, i) => `$${i + 3}`).join(',')},$${values.length + 3}) RETURNING *`,
+        [p.id, revision, ...values, a.id]
+      )
+    )[0];
+    void keys;
+    await invalidateApprovals(p.id, 'Validation Plan revised');
+    await logEvent(req, p, 'PLAN', 'PLAN_REVISED', {
+      entityId: x.id,
+      next: { revision },
+    });
+    res.status(201).json(x);
+  }
+);
+router.post(
+  '/:id/plans/:recordId/approve',
+  requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const recordId = uuid.parse(req.params.recordId);
+    const body = z
+      .object({
+        approvalRole: z.enum([
+          'VALIDATION_LEAD',
+          'EPOCH_IT_OWNER',
+          'QUALITY_APPROVER',
+        ]),
+        comments: z.string().optional(),
+      })
+      .parse(req.body);
+    const plan = (
+      await query(
+        'SELECT * FROM qms_epoch_validation_plans WHERE id=$1 AND package_id=$2',
+        [recordId, p.id]
+      )
+    )[0];
+    if (!plan)
+      return res.status(404).json({ error: 'VALIDATION_PLAN_NOT_FOUND' });
+    await approve(
+      req,
+      p,
+      'PLAN',
+      plan.id,
+      plan.revision,
+      body.approvalRole,
+      'Approved Validation Plan revision',
+      'EPOCH_VALIDATION_PLAN_APPROVE',
+      body.comments
+    );
+    const n = Number(
+      (
+        await query(
+          `SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals WHERE record_type='PLAN' AND record_id=$1 AND record_revision=$2 AND status='VALID' AND decision='APPROVED'`,
+          [plan.id, plan.revision]
+        )
+      )[0].n
+    );
+    if (n >= 3)
+      await query(
+        `UPDATE qms_epoch_validation_plans SET status='APPROVED' WHERE id=$1`,
+        [plan.id]
+      );
+    res.json({ approvedRoles: n, complete: n >= 3 });
+  }
+);
 
-const protocolSchema=z.object({title:z.string().min(1),module:z.string().min(1),criticality:z.enum(['CRITICAL','HIGH','NORMAL','INFORMATIONAL']),
-  objective:z.string().min(1),preconditions:z.string().optional(),requiredUserRole:z.string().optional(),requiredTestData:z.string().optional(),
-  testEnvironment:z.string().min(1),overallAcceptanceCriteria:z.string().min(1),requiredEvidence:z.string().min(1),
-  regressionClassification:z.string().optional(),independentReviewRequired:z.boolean().default(false),
-  requirementIds:z.array(z.string().uuid()).default([]),riskIds:z.array(z.string().uuid()).default([]),
-  steps:z.array(z.object({instruction:z.string().min(1),expectedResult:z.string().min(1),required:z.boolean().default(true)})).min(1)});
-router.post('/:id/protocols',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const v=protocolSchema.parse(req.body),a=actor(req);
-  const x=await tx(async q=>{
-    const seq=(await q(`SELECT nextval('qms_epoch_validation_test_number_seq') value`))[0].value,tid=`EVT-${String(seq).padStart(4,'0')}`;
-    const protocol=(await q(`INSERT INTO qms_epoch_validation_protocols
+const protocolSchema = z.object({
+  title: z.string().min(1),
+  module: z.string().min(1),
+  criticality: z.enum(['CRITICAL', 'HIGH', 'NORMAL', 'INFORMATIONAL']),
+  objective: z.string().min(1),
+  preconditions: z.string().optional(),
+  requiredUserRole: z.string().optional(),
+  requiredTestData: z.string().optional(),
+  testEnvironment: z.string().min(1),
+  overallAcceptanceCriteria: z.string().min(1),
+  requiredEvidence: z.string().min(1),
+  regressionClassification: z.string().optional(),
+  independentReviewRequired: z.boolean().default(false),
+  requirementIds: z.array(z.string().uuid()).default([]),
+  riskIds: z.array(z.string().uuid()).default([]),
+  steps: z
+    .array(
+      z.object({
+        instruction: z.string().min(1),
+        expectedResult: z.string().min(1),
+        required: z.boolean().default(true),
+      })
+    )
+    .min(1),
+});
+router.post(
+  '/:id/protocols',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const v = protocolSchema.parse(req.body),
+      a = actor(req);
+    const x = await tx(async (q) => {
+      const seq = (
+          await q(
+            `SELECT nextval('qms_epoch_validation_test_number_seq') value`
+          )
+        )[0].value,
+        tid = `EVT-${String(seq).padStart(4, '0')}`;
+      const protocol = (
+        await q(
+          `INSERT INTO qms_epoch_validation_protocols
       (test_id,package_id,title,module,criticality,objective,preconditions,required_user_role,required_test_data,
        test_environment,overall_acceptance_criteria,required_evidence,regression_classification,
        independent_review_required,created_by_user_id,updated_by_user_id)
       VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$15) RETURNING *`,
-      [tid,p.id,v.title,v.module,v.criticality,v.objective,v.preconditions||null,v.requiredUserRole||null,
-       v.requiredTestData||null,v.testEnvironment,v.overallAcceptanceCriteria,v.requiredEvidence,
-       v.regressionClassification||null,v.independentReviewRequired,a.id]))[0];
-    for(let i=0;i<v.steps.length;i++)await q(`INSERT INTO qms_epoch_validation_protocol_steps
+          [
+            tid,
+            p.id,
+            v.title,
+            v.module,
+            v.criticality,
+            v.objective,
+            v.preconditions || null,
+            v.requiredUserRole || null,
+            v.requiredTestData || null,
+            v.testEnvironment,
+            v.overallAcceptanceCriteria,
+            v.requiredEvidence,
+            v.regressionClassification || null,
+            v.independentReviewRequired,
+            a.id,
+          ]
+        )
+      )[0];
+      for (let i = 0; i < v.steps.length; i++)
+        await q(
+          `INSERT INTO qms_epoch_validation_protocol_steps
       (protocol_id,step_number,instruction,expected_result,required) VALUES($1,$2,$3,$4,$5)`,
-      [protocol.id,i+1,v.steps[i].instruction,v.steps[i].expectedResult,v.steps[i].required]);
-    for(const id of v.requirementIds)await q(`INSERT INTO qms_epoch_validation_protocol_requirements VALUES($1,$2) ON CONFLICT DO NOTHING`,[protocol.id,id]);
-    for(const id of v.riskIds)await q(`INSERT INTO qms_epoch_validation_protocol_risks VALUES($1,$2) ON CONFLICT DO NOTHING`,[protocol.id,id]);
-    await logEvent(req,p,'PROTOCOL','PROTOCOL_CREATED',{entityId:protocol.id,next:{testId:tid,revision:1}},q);return protocol;
-  });await invalidateApprovals(p.id,'Test protocol added');res.status(201).json(x);
-});
-router.post('/:id/protocols/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
-  const x=(await query(`UPDATE qms_epoch_validation_protocols SET status='APPROVED',updated_at=now()
-    WHERE id=$1 AND package_id=$2 AND status='DRAFT' RETURNING *`,[recordId,p.id]))[0];
-  if(!x)return res.status(409).json({error:'PROTOCOL_NOT_APPROVABLE'});await approve(req,p,'PROTOCOL',x.id,x.revision,'PROTOCOL_APPROVER','Approved protocol revision','EPOCH_VALIDATION_PLAN_APPROVE');res.json(x);
-});
+          [
+            protocol.id,
+            i + 1,
+            v.steps[i].instruction,
+            v.steps[i].expectedResult,
+            v.steps[i].required,
+          ]
+        );
+      for (const id of v.requirementIds)
+        await q(
+          `INSERT INTO qms_epoch_validation_protocol_requirements VALUES($1,$2) ON CONFLICT DO NOTHING`,
+          [protocol.id, id]
+        );
+      for (const id of v.riskIds)
+        await q(
+          `INSERT INTO qms_epoch_validation_protocol_risks VALUES($1,$2) ON CONFLICT DO NOTHING`,
+          [protocol.id, id]
+        );
+      await logEvent(
+        req,
+        p,
+        'PROTOCOL',
+        'PROTOCOL_CREATED',
+        { entityId: protocol.id, next: { testId: tid, revision: 1 } },
+        q
+      );
+      return protocol;
+    });
+    await invalidateApprovals(p.id, 'Test protocol added');
+    res.status(201).json(x);
+  }
+);
+router.post(
+  '/:id/protocols/:recordId/approve',
+  requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const recordId = uuid.parse(req.params.recordId);
+    const x = (
+      await query(
+        `UPDATE qms_epoch_validation_protocols SET status='APPROVED',updated_at=now()
+    WHERE id=$1 AND package_id=$2 AND status='DRAFT' RETURNING *`,
+        [recordId, p.id]
+      )
+    )[0];
+    if (!x) return res.status(409).json({ error: 'PROTOCOL_NOT_APPROVABLE' });
+    await approve(
+      req,
+      p,
+      'PROTOCOL',
+      x.id,
+      x.revision,
+      'PROTOCOL_APPROVER',
+      'Approved protocol revision',
+      'EPOCH_VALIDATION_PLAN_APPROVE'
+    );
+    res.json(x);
+  }
+);
 
-router.post('/:id/protocols/:recordId/executions',requirePermission('EPOCH_VALIDATION_TEST_EXECUTE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const protocolId=uuid.parse(req.params.recordId),a=actor(req);
-  const packageGate=await packageReadiness(p);
-  if(!packageGate.executionReady)return res.status(409).json({error:'PACKAGE_EXECUTION_READINESS_BLOCKED',blockers:packageGate.blockers});
-  if(!['PLAN_APPROVED','TESTING','TESTING_BLOCKED','RETESTING','CORRECTIONS_REQUIRED'].includes(p.status))
-    return res.status(409).json({error:'FORMAL_TEST_EXECUTION_NOT_ALLOWED',message:'The Validation Plan must be approved before execution.'});
-  const protocol=(await query('SELECT * FROM qms_epoch_validation_protocols WHERE id=$1 AND package_id=$2',[protocolId,p.id]))[0];
-  if(!protocol||protocol.status!=='APPROVED')return res.status(409).json({error:'APPROVED_PROTOCOL_REQUIRED'});
-  const body=z.object({epochVersion:z.string().min(1),commitOrReleaseIdentifier:z.string().optional(),
-    testEnvironment:z.string().min(1),testDatabase:z.string().min(1),retestOfExecutionId:z.string().uuid().optional()}).parse(req.body);
-  const execution=await tx(async q=>{
-    const seq=(await q(`SELECT nextval('qms_epoch_validation_execution_number_seq') value`))[0].value,eid=`EVE-${String(seq).padStart(4,'0')}`;
-    const x=(await q(`INSERT INTO qms_epoch_validation_executions
+router.post(
+  '/:id/protocols/:recordId/executions',
+  requirePermission('EPOCH_VALIDATION_TEST_EXECUTE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const protocolId = uuid.parse(req.params.recordId),
+      a = actor(req);
+    const packageGate = await packageReadiness(p);
+    if (!packageGate.executionReady)
+      return res.status(409).json({
+        error: 'PACKAGE_EXECUTION_READINESS_BLOCKED',
+        blockers: packageGate.blockers,
+      });
+    if (
+      ![
+        'PLAN_APPROVED',
+        'TESTING',
+        'TESTING_BLOCKED',
+        'RETESTING',
+        'CORRECTIONS_REQUIRED',
+      ].includes(p.status)
+    )
+      return res.status(409).json({
+        error: 'FORMAL_TEST_EXECUTION_NOT_ALLOWED',
+        message: 'The Validation Plan must be approved before execution.',
+      });
+    const protocol = (
+      await query(
+        'SELECT * FROM qms_epoch_validation_protocols WHERE id=$1 AND package_id=$2',
+        [protocolId, p.id]
+      )
+    )[0];
+    if (!protocol || protocol.status !== 'APPROVED')
+      return res.status(409).json({ error: 'APPROVED_PROTOCOL_REQUIRED' });
+    const body = z
+      .object({
+        epochVersion: z.string().min(1),
+        commitOrReleaseIdentifier: z.string().optional(),
+        testEnvironment: z.string().min(1),
+        testDatabase: z.string().min(1),
+        retestOfExecutionId: z.string().uuid().optional(),
+      })
+      .parse(req.body);
+    const execution = await tx(async (q) => {
+      const seq = (
+          await q(
+            `SELECT nextval('qms_epoch_validation_execution_number_seq') value`
+          )
+        )[0].value,
+        eid = `EVE-${String(seq).padStart(4, '0')}`;
+      const x = (
+        await q(
+          `INSERT INTO qms_epoch_validation_executions
       (execution_id,package_id,protocol_id,protocol_revision,epoch_version,commit_or_release_identifier,
        test_environment,test_database,tester_user_id,tester_display_name,overall_result,retest_of_execution_id)
       VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'IN_PROGRESS',$11) RETURNING *`,
-      [eid,p.id,protocol.id,protocol.revision,body.epochVersion,body.commitOrReleaseIdentifier||null,
-       body.testEnvironment,body.testDatabase,a.id,a.name,body.retestOfExecutionId||null]))[0];
-    await q(`INSERT INTO qms_epoch_validation_execution_steps
+          [
+            eid,
+            p.id,
+            protocol.id,
+            protocol.revision,
+            body.epochVersion,
+            body.commitOrReleaseIdentifier || null,
+            body.testEnvironment,
+            body.testDatabase,
+            a.id,
+            a.name,
+            body.retestOfExecutionId || null,
+          ]
+        )
+      )[0];
+      await q(
+        `INSERT INTO qms_epoch_validation_execution_steps
       (execution_id,protocol_step_id,step_number,instruction_snapshot,expected_result_snapshot,required)
       SELECT $1,id,step_number,instruction,expected_result,required FROM qms_epoch_validation_protocol_steps
-      WHERE protocol_id=$2 ORDER BY step_number`,[x.id,protocol.id]);
-    await logEvent(req,p,'EXECUTION','TEST_EXECUTION_STARTED',{entityId:x.id,next:{executionId:eid,protocolRevision:protocol.revision}},q);return x;
-  });res.status(201).json(execution);
-});
-router.put('/:id/executions/:recordId/steps',requirePermission('EPOCH_VALIDATION_TEST_EXECUTE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const executionId=uuid.parse(req.params.recordId);
-  const body=z.object({steps:z.array(z.object({stepNumber:z.number().int().positive(),actualResult:z.string().min(1),
-    status:z.enum(['NOT_RUN','IN_PROGRESS','PASSED','FAILED','BLOCKED'])})).min(1),
-    linkedEpochRecords:z.string().optional(),githubReference:z.string().optional(),deviations:z.string().optional(),comments:z.string().optional()}).parse(req.body);
-  const result=deriveExecutionResult(body.steps.map(s=>({required:true,status:s.status})));
-  const updated=await tx(async q=>{
-    for(const s of body.steps)await q(`UPDATE qms_epoch_validation_execution_steps SET actual_result=$1,status=$2
-      WHERE execution_id=$3 AND step_number=$4`,[s.actualResult,s.status,executionId,s.stepNumber]);
-    const all=await q(`SELECT step_number,instruction_snapshot,expected_result_snapshot,actual_result,status,required
-      FROM qms_epoch_validation_execution_steps WHERE execution_id=$1 ORDER BY step_number`,[executionId]);
-    const derived=deriveExecutionResult(all.map(s=>({required:s.required,status:s.status})));
-    const snapshot={protocolSteps:all,overallResult:derived,epochVersion:p.production_version};
-    const x=(await q(`UPDATE qms_epoch_validation_executions SET overall_result=$1,ended_at=CASE WHEN $1 IN ('PASSED','FAILED','BLOCKED') THEN now() ELSE ended_at END,
+      WHERE protocol_id=$2 ORDER BY step_number`,
+        [x.id, protocol.id]
+      );
+      await logEvent(
+        req,
+        p,
+        'EXECUTION',
+        'TEST_EXECUTION_STARTED',
+        {
+          entityId: x.id,
+          next: { executionId: eid, protocolRevision: protocol.revision },
+        },
+        q
+      );
+      return x;
+    });
+    res.status(201).json(execution);
+  }
+);
+router.put(
+  '/:id/executions/:recordId/steps',
+  requirePermission('EPOCH_VALIDATION_TEST_EXECUTE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const executionId = uuid.parse(req.params.recordId);
+    const body = z
+      .object({
+        steps: z
+          .array(
+            z.object({
+              stepNumber: z.number().int().positive(),
+              actualResult: z.string().min(1),
+              status: z.enum([
+                'NOT_RUN',
+                'IN_PROGRESS',
+                'PASSED',
+                'FAILED',
+                'BLOCKED',
+              ]),
+            })
+          )
+          .min(1),
+        linkedEpochRecords: z.string().optional(),
+        githubReference: z.string().optional(),
+        deviations: z.string().optional(),
+        comments: z.string().optional(),
+      })
+      .parse(req.body);
+    const result = deriveExecutionResult(
+      body.steps.map((s) => ({ required: true, status: s.status }))
+    );
+    const updated = await tx(async (q) => {
+      for (const s of body.steps)
+        await q(
+          `UPDATE qms_epoch_validation_execution_steps SET actual_result=$1,status=$2
+      WHERE execution_id=$3 AND step_number=$4`,
+          [s.actualResult, s.status, executionId, s.stepNumber]
+        );
+      const all = await q(
+        `SELECT step_number,instruction_snapshot,expected_result_snapshot,actual_result,status,required
+      FROM qms_epoch_validation_execution_steps WHERE execution_id=$1 ORDER BY step_number`,
+        [executionId]
+      );
+      const derived = deriveExecutionResult(
+        all.map((s) => ({ required: s.required, status: s.status }))
+      );
+      const snapshot = {
+        protocolSteps: all,
+        overallResult: derived,
+        epochVersion: p.production_version,
+      };
+      const x = (
+        await q(
+          `UPDATE qms_epoch_validation_executions SET overall_result=$1,ended_at=CASE WHEN $1 IN ('PASSED','FAILED','BLOCKED') THEN now() ELSE ended_at END,
       linked_epoch_records=$2,github_reference=$3,deviations=$4,comments=$5,snapshot=$6::jsonb,snapshot_checksum=$7
       WHERE id=$8 AND package_id=$9 AND review_decision IS NULL RETURNING *`,
-      [derived,body.linkedEpochRecords||null,body.githubReference||null,body.deviations||null,body.comments||null,
-       JSON.stringify(snapshot),checksum(snapshot),executionId,p.id]))[0];
-    if(!x)throw Object.assign(new Error('Execution is immutable after review'),{status:409});
-    if(['FAILED','BLOCKED'].includes(derived)){
-      const seq=(await q(`SELECT nextval('qms_epoch_validation_defect_number_seq') value`))[0].value;
-      const number=`ESD-${new Date().getUTCFullYear()}-${String(seq).padStart(4,'0')}`;
-      await q(`INSERT INTO qms_epoch_validation_defects
+          [
+            derived,
+            body.linkedEpochRecords || null,
+            body.githubReference || null,
+            body.deviations || null,
+            body.comments || null,
+            JSON.stringify(snapshot),
+            checksum(snapshot),
+            executionId,
+            p.id,
+          ]
+        )
+      )[0];
+      if (!x)
+        throw Object.assign(new Error('Execution is immutable after review'), {
+          status: 409,
+        });
+      if (['FAILED', 'BLOCKED'].includes(derived)) {
+        const seq = (
+          await q(
+            `SELECT nextval('qms_epoch_validation_defect_number_seq') value`
+          )
+        )[0].value;
+        const number = `ESD-${new Date().getUTCFullYear()}-${String(seq).padStart(4, '0')}`;
+        await q(
+          `INSERT INTO qms_epoch_validation_defects
         (defect_number,package_id,failed_execution_id,module,description,severity,retest_required,created_by_user_id,updated_by_user_id)
         SELECT $1,$2,$3,p.module,$4,CASE WHEN p.criticality='CRITICAL' THEN 'CRITICAL' ELSE 'HIGH' END,true,$5,$5
         FROM qms_epoch_validation_protocols p JOIN qms_epoch_validation_executions e ON e.protocol_id=p.id WHERE e.id=$3
-        ON CONFLICT(defect_number) DO NOTHING`,[number,p.id,executionId,`Automatically opened from ${x.execution_id} ${derived}`,actor(req).id]);
-    }
-    await logEvent(req,p,'EXECUTION','TEST_EXECUTION_RECORDED',{entityId:executionId,next:{derivedResult:derived,clientCandidate:result}},q);return x;
-  });res.json(updated);
-});
-router.post('/:id/executions/:recordId/review',requirePermission('EPOCH_VALIDATION_TEST_REVIEW'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const executionId=uuid.parse(req.params.recordId),a=actor(req);
-  const body=z.object({decision:z.enum(['APPROVED','REJECTED','RETURNED']),comments:z.string().min(1)}).parse(req.body);
-  const x=(await query(`UPDATE qms_epoch_validation_executions SET reviewer_user_id=$1,review_decision=$2,reviewed_at=now(),comments=concat_ws(E'\\n',comments,$3)
-    WHERE id=$4 AND package_id=$5 AND overall_result NOT IN ('NOT_RUN','IN_PROGRESS') AND tester_user_id<>$1 AND review_decision IS NULL RETURNING *`,
-    [a.id,body.decision,body.comments,executionId,p.id]))[0];
-  if(!x)return res.status(409).json({error:'INDEPENDENT_REVIEW_REQUIRED_OR_EXECUTION_NOT_REVIEWABLE'});
-  await logEvent(req,p,'EXECUTION','EXECUTION_REVIEWED',{entityId:x.id,next:{decision:body.decision}});res.json(x);
-});
-
-router.patch('/:id/defects/:recordId',requirePermission('EPOCH_VALIDATION_DEFECT_MANAGE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId),a=actor(req);
-  const body=z.object({containment:z.string().optional(),rootCause:z.string().optional(),correctiveAction:z.string().optional(),
-    ownerEmployeeId:z.number().int().positive().optional(),dueDate:z.string().date().optional(),
-    githubReference:z.string().optional(),databaseMigrationReference:z.string().optional(),
-    retestRequired:z.boolean().optional(),retestExecutionId:z.string().uuid().optional(),
-    closureEvidence:z.string().optional(),status:z.enum(['OPEN','CONTAINED','CORRECTION_IN_PROGRESS','READY_FOR_RETEST','CLOSED','CANCELLED']).optional()}).parse(req.body);
-  if(body.status==='CLOSED'){
-    const defect=(await query('SELECT * FROM qms_epoch_validation_defects WHERE id=$1 AND package_id=$2',[recordId,p.id]))[0];
-    if(!defect)return res.status(404).json({error:'VALIDATION_DEFECT_NOT_FOUND'});
-    if(defect.retest_required&&!body.retestExecutionId&&!defect.retest_execution_id)
-      return res.status(409).json({error:'REQUIRED_RETEST_MISSING'});
+        ON CONFLICT(defect_number) DO NOTHING`,
+          [
+            number,
+            p.id,
+            executionId,
+            `Automatically opened from ${x.execution_id} ${derived}`,
+            actor(req).id,
+          ]
+        );
+      }
+      await logEvent(
+        req,
+        p,
+        'EXECUTION',
+        'TEST_EXECUTION_RECORDED',
+        {
+          entityId: executionId,
+          next: { derivedResult: derived, clientCandidate: result },
+        },
+        q
+      );
+      return x;
+    });
+    res.json(updated);
   }
-  const x=(await query(`UPDATE qms_epoch_validation_defects SET containment=COALESCE($1,containment),
+);
+router.post(
+  '/:id/executions/:recordId/review',
+  requirePermission('EPOCH_VALIDATION_TEST_REVIEW'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const executionId = uuid.parse(req.params.recordId),
+      a = actor(req);
+    const body = z
+      .object({
+        decision: z.enum(['APPROVED', 'REJECTED', 'RETURNED']),
+        comments: z.string().min(1),
+      })
+      .parse(req.body);
+    const x = (
+      await query(
+        `UPDATE qms_epoch_validation_executions SET reviewer_user_id=$1,review_decision=$2,reviewed_at=now(),comments=concat_ws(E'\\n',comments,$3)
+    WHERE id=$4 AND package_id=$5 AND overall_result NOT IN ('NOT_RUN','IN_PROGRESS') AND tester_user_id<>$1 AND review_decision IS NULL RETURNING *`,
+        [a.id, body.decision, body.comments, executionId, p.id]
+      )
+    )[0];
+    if (!x)
+      return res.status(409).json({
+        error: 'INDEPENDENT_REVIEW_REQUIRED_OR_EXECUTION_NOT_REVIEWABLE',
+      });
+    await logEvent(req, p, 'EXECUTION', 'EXECUTION_REVIEWED', {
+      entityId: x.id,
+      next: { decision: body.decision },
+    });
+    res.json(x);
+  }
+);
+
+router.patch(
+  '/:id/defects/:recordId',
+  requirePermission('EPOCH_VALIDATION_DEFECT_MANAGE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const recordId = uuid.parse(req.params.recordId),
+      a = actor(req);
+    const body = z
+      .object({
+        containment: z.string().optional(),
+        rootCause: z.string().optional(),
+        correctiveAction: z.string().optional(),
+        ownerEmployeeId: z.number().int().positive().optional(),
+        dueDate: z.string().date().optional(),
+        githubReference: z.string().optional(),
+        databaseMigrationReference: z.string().optional(),
+        retestRequired: z.boolean().optional(),
+        retestExecutionId: z.string().uuid().optional(),
+        closureEvidence: z.string().optional(),
+        status: z
+          .enum([
+            'OPEN',
+            'CONTAINED',
+            'CORRECTION_IN_PROGRESS',
+            'READY_FOR_RETEST',
+            'CLOSED',
+            'CANCELLED',
+          ])
+          .optional(),
+      })
+      .parse(req.body);
+    if (body.status === 'CLOSED') {
+      const defect = (
+        await query(
+          'SELECT * FROM qms_epoch_validation_defects WHERE id=$1 AND package_id=$2',
+          [recordId, p.id]
+        )
+      )[0];
+      if (!defect)
+        return res.status(404).json({ error: 'VALIDATION_DEFECT_NOT_FOUND' });
+      if (
+        defect.retest_required &&
+        !body.retestExecutionId &&
+        !defect.retest_execution_id
+      )
+        return res.status(409).json({ error: 'REQUIRED_RETEST_MISSING' });
+    }
+    const x = (
+      await query(
+        `UPDATE qms_epoch_validation_defects SET containment=COALESCE($1,containment),
     root_cause=COALESCE($2,root_cause),corrective_action=COALESCE($3,corrective_action),
     owner_employee_id=COALESCE($4,owner_employee_id),due_date=COALESCE($5,due_date),
     github_reference=COALESCE($6,github_reference),database_migration_reference=COALESCE($7,database_migration_reference),
     retest_required=COALESCE($8,retest_required),retest_execution_id=COALESCE($9,retest_execution_id),
     closure_evidence=COALESCE($10,closure_evidence),status=COALESCE($11,status),
     updated_by_user_id=$12,updated_at=now() WHERE id=$13 AND package_id=$14 RETURNING *`,
-    [body.containment,body.rootCause,body.correctiveAction,body.ownerEmployeeId,body.dueDate,
-     body.githubReference,body.databaseMigrationReference,body.retestRequired,body.retestExecutionId,
-     body.closureEvidence,body.status,a.id,recordId,p.id]))[0];
-  if(!x)return res.status(404).json({error:'VALIDATION_DEFECT_NOT_FOUND'});
-  await invalidateApprovals(p.id,'Validation defect changed');await logEvent(req,p,'DEFECT','DEFECT_UPDATED',{entityId:x.id,next:x});res.json(x);
-});
-router.post('/:id/defects/:recordId/accept-limitation',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
-  const body=z.object({comments:z.string().min(20)}).parse(req.body);
-  const defect=(await query(`UPDATE qms_epoch_validation_defects SET limitation_accepted=true,updated_at=now()
-    WHERE id=$1 AND package_id=$2 AND severity='HIGH' AND status NOT IN ('CLOSED','CANCELLED') RETURNING *`,[recordId,p.id]))[0];
-  if(!defect)return res.status(409).json({error:'ONLY_OPEN_HIGH_DEFECTS_MAY_BE_ACCEPTED'});
-  await approve(req,p,'DEFECT_LIMITATION',defect.id,1,'QUALITY_MANAGEMENT','Accepted documented high-severity limitation and residual risk','EPOCH_VALIDATION_FINAL_APPROVE',body.comments);
-  res.json(defect);
-});
+        [
+          body.containment,
+          body.rootCause,
+          body.correctiveAction,
+          body.ownerEmployeeId,
+          body.dueDate,
+          body.githubReference,
+          body.databaseMigrationReference,
+          body.retestRequired,
+          body.retestExecutionId,
+          body.closureEvidence,
+          body.status,
+          a.id,
+          recordId,
+          p.id,
+        ]
+      )
+    )[0];
+    if (!x)
+      return res.status(404).json({ error: 'VALIDATION_DEFECT_NOT_FOUND' });
+    await invalidateApprovals(p.id, 'Validation defect changed');
+    await logEvent(req, p, 'DEFECT', 'DEFECT_UPDATED', {
+      entityId: x.id,
+      next: x,
+    });
+    res.json(x);
+  }
+);
+router.post(
+  '/:id/defects/:recordId/accept-limitation',
+  requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const recordId = uuid.parse(req.params.recordId);
+    const body = z.object({ comments: z.string().min(20) }).parse(req.body);
+    const defect = (
+      await query(
+        `UPDATE qms_epoch_validation_defects SET limitation_accepted=true,updated_at=now()
+    WHERE id=$1 AND package_id=$2 AND severity='HIGH' AND status NOT IN ('CLOSED','CANCELLED') RETURNING *`,
+        [recordId, p.id]
+      )
+    )[0];
+    if (!defect)
+      return res
+        .status(409)
+        .json({ error: 'ONLY_OPEN_HIGH_DEFECTS_MAY_BE_ACCEPTED' });
+    await approve(
+      req,
+      p,
+      'DEFECT_LIMITATION',
+      defect.id,
+      1,
+      'QUALITY_MANAGEMENT',
+      'Accepted documented high-severity limitation and residual risk',
+      'EPOCH_VALIDATION_FINAL_APPROVE',
+      body.comments
+    );
+    res.json(defect);
+  }
+);
 
-router.post('/:id/periodic-reviews',requirePermission('EPOCH_VALIDATION_EDIT'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const a=actor(req);
-  const schema=z.object({reviewDate:z.string().date(),currentProductionVersion:z.string().min(1),
-    previouslyApprovedVersion:z.string().min(1),changesSinceApproval:z.string().optional(),criticalChanges:z.string().optional(),
-    databaseMigrations:z.string().optional(),securityAuthenticationChanges:z.string().optional(),
-    hostingDatabaseChanges:z.string().optional(),backupRecoveryChanges:z.string().optional(),
-    seriousDefectsIncidents:z.string().optional(),newOfficialQmsModules:z.string().optional(),
-    auditFindings:z.string().optional(),customerFindings:z.string().optional(),revalidationRequired:z.boolean(),
-    revalidationScope:z.string().optional(),nextReviewDate:z.string().date()});
-  const v=schema.parse(req.body),values=Object.values(v);
-  const x=(await query(`INSERT INTO qms_epoch_validation_periodic_reviews
+router.post(
+  '/:id/periodic-reviews',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const a = actor(req);
+    const schema = z.object({
+      reviewDate: z.string().date(),
+      currentProductionVersion: z.string().min(1),
+      previouslyApprovedVersion: z.string().min(1),
+      changesSinceApproval: z.string().optional(),
+      criticalChanges: z.string().optional(),
+      databaseMigrations: z.string().optional(),
+      securityAuthenticationChanges: z.string().optional(),
+      hostingDatabaseChanges: z.string().optional(),
+      backupRecoveryChanges: z.string().optional(),
+      seriousDefectsIncidents: z.string().optional(),
+      newOfficialQmsModules: z.string().optional(),
+      auditFindings: z.string().optional(),
+      customerFindings: z.string().optional(),
+      revalidationRequired: z.boolean(),
+      revalidationScope: z.string().optional(),
+      nextReviewDate: z.string().date(),
+    });
+    const v = schema.parse(req.body),
+      values = Object.values(v);
+    const x = (
+      await query(
+        `INSERT INTO qms_epoch_validation_periodic_reviews
     (package_id,review_date,reviewer_user_id,current_production_version,previously_approved_version,
      changes_since_approval,critical_changes,database_migrations,security_authentication_changes,
      hosting_database_changes,backup_recovery_changes,serious_defects_incidents,new_official_qms_modules,
      audit_findings,customer_findings,revalidation_required,revalidation_scope,next_review_date)
-    VALUES($1,$2,$3,${values.slice(1).map((_,i)=>`$${i+4}`).join(',')}) RETURNING *`,
-    [p.id,v.reviewDate,a.id,...values.slice(1)]))[0];
-  await logEvent(req,p,'PERIODIC_REVIEW','PERIODIC_REVIEW_CREATED',{entityId:x.id,next:{revalidationRequired:v.revalidationRequired}});res.status(201).json(x);
-});
+    VALUES($1,$2,$3,${values
+      .slice(1)
+      .map((_, i) => `$${i + 4}`)
+      .join(',')}) RETURNING *`,
+        [p.id, v.reviewDate, a.id, ...values.slice(1)]
+      )
+    )[0];
+    await logEvent(req, p, 'PERIODIC_REVIEW', 'PERIODIC_REVIEW_CREATED', {
+      entityId: x.id,
+      next: { revalidationRequired: v.revalidationRequired },
+    });
+    res.status(201).json(x);
+  }
+);
 
-async function approve(req:Request,p:any,recordType:string,recordId:string,revision:number,role:string,meaning:string,capability:string,comments?:string){
-  const a=actor(req),snap={recordType,recordId,revision,packageRevision:p.revision,productionVersion:p.production_version};
-  await query(`INSERT INTO qms_epoch_validation_approvals
+async function approve(
+  req: Request,
+  p: any,
+  recordType: string,
+  recordId: string,
+  revision: number,
+  role: string,
+  meaning: string,
+  capability: string,
+  comments?: string
+) {
+  const a = actor(req),
+    snap = {
+      recordType,
+      recordId,
+      revision,
+      packageRevision: p.revision,
+      productionVersion: p.production_version,
+    };
+  await query(
+    `INSERT INTO qms_epoch_validation_approvals
     (package_id,record_type,record_id,record_revision,approval_role,decision,meaning,actor_user_id,actor_employee_id,
      actor_display_name,actor_role,capability_used,comments,snapshot_checksum)
     VALUES($1,$2,$3,$4,$5,'APPROVED',$6,$7,$8,$9,$10,$11,$12,$13)
-    ON CONFLICT DO NOTHING`,[p.id,recordType,recordId,revision,role,meaning,a.id,a.employeeId,a.name,a.role,capability,comments||null,checksum(snap)]);
-  await logEvent(req,p,recordType,`${recordType}_APPROVED`,{entityId:recordId,next:{revision,role}});
+    ON CONFLICT DO NOTHING`,
+    [
+      p.id,
+      recordType,
+      recordId,
+      revision,
+      role,
+      meaning,
+      a.id,
+      a.employeeId,
+      a.name,
+      a.role,
+      capability,
+      comments || null,
+      checksum(snap),
+    ]
+  );
+  await logEvent(req, p, recordType, `${recordType}_APPROVED`, {
+    entityId: recordId,
+    next: { revision, role },
+  });
 }
-router.post('/:id/intended-use/:recordId/approve',requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;const recordId=uuid.parse(req.params.recordId);
-  const body=z.object({approvalRole:z.enum(['EPOCH_IT_OWNER','QUALITY_APPROVER']),comments:z.string().optional()}).parse(req.body);
-  const record=(await query('SELECT * FROM qms_epoch_validation_intended_use_revisions WHERE id=$1 AND package_id=$2',[recordId,p.id]))[0];
-  if(!record)return res.status(404).json({error:'INTENDED_USE_NOT_FOUND'});
-  await approve(req,p,'INTENDED_USE',record.id,record.revision,body.approvalRole,'Approved Intended Use revision','EPOCH_VALIDATION_PLAN_APPROVE',body.comments);
-  const n=Number((await query(`SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals WHERE record_type='INTENDED_USE' AND record_id=$1 AND status='VALID' AND decision='APPROVED'`,[record.id]))[0].n);
-  if(n>=2)await query(`UPDATE qms_epoch_validation_intended_use_revisions SET approval_status='APPROVED' WHERE id=$1`,[record.id]);res.json({approvedRoles:n,complete:n>=2});
-});
-router.post('/:id/final-approvals',requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),async(req,res)=>{
-  const p=await editable(req,res);if(!p)return;
-  const body=z.object({approvalRole:z.enum(['EPOCH_IT_OWNER','VALIDATION_LEAD','QUALITY_APPROVER','PROCESS_OWNER','TOP_MANAGEMENT']),
-    outcome:z.enum(['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS','REJECTED','RETURNED_FOR_CORRECTION']),
-    comments:z.string().min(1),approvedLimitations:z.string().optional()}).parse(req.body);
-  const packageGate=await packageReadiness(p);
-  if(!packageGate.executionReady)return res.status(409).json({error:'PACKAGE_FINAL_READINESS_BLOCKED',blockers:packageGate.blockers});
-  const incompleteProtocols=await query(`SELECT p.test_id,
+router.post(
+  '/:id/intended-use/:recordId/approve',
+  requirePermission('EPOCH_VALIDATION_PLAN_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const recordId = uuid.parse(req.params.recordId);
+    const body = z
+      .object({
+        approvalRole: z.enum(['EPOCH_IT_OWNER', 'QUALITY_APPROVER']),
+        comments: z.string().optional(),
+      })
+      .parse(req.body);
+    const record = (
+      await query(
+        'SELECT * FROM qms_epoch_validation_intended_use_revisions WHERE id=$1 AND package_id=$2',
+        [recordId, p.id]
+      )
+    )[0];
+    if (!record)
+      return res.status(404).json({ error: 'INTENDED_USE_NOT_FOUND' });
+    await approve(
+      req,
+      p,
+      'INTENDED_USE',
+      record.id,
+      record.revision,
+      body.approvalRole,
+      'Approved Intended Use revision',
+      'EPOCH_VALIDATION_PLAN_APPROVE',
+      body.comments
+    );
+    const n = Number(
+      (
+        await query(
+          `SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals WHERE record_type='INTENDED_USE' AND record_id=$1 AND status='VALID' AND decision='APPROVED'`,
+          [record.id]
+        )
+      )[0].n
+    );
+    if (n >= 2)
+      await query(
+        `UPDATE qms_epoch_validation_intended_use_revisions SET approval_status='APPROVED' WHERE id=$1`,
+        [record.id]
+      );
+    res.json({ approvedRoles: n, complete: n >= 2 });
+  }
+);
+router.post(
+  '/:id/final-approvals',
+  requirePermission('EPOCH_VALIDATION_FINAL_APPROVE'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const body = z
+      .object({
+        approvalRole: z.enum([
+          'EPOCH_IT_OWNER',
+          'VALIDATION_LEAD',
+          'QUALITY_APPROVER',
+          'PROCESS_OWNER',
+          'TOP_MANAGEMENT',
+        ]),
+        outcome: z.enum([
+          'APPROVED_FOR_INTENDED_USE',
+          'APPROVED_WITH_LIMITATIONS',
+          'REJECTED',
+          'RETURNED_FOR_CORRECTION',
+        ]),
+        comments: z.string().min(1),
+        approvedLimitations: z.string().optional(),
+      })
+      .parse(req.body);
+    const packageGate = await packageReadiness(p);
+    if (!packageGate.executionReady)
+      return res.status(409).json({
+        error: 'PACKAGE_FINAL_READINESS_BLOCKED',
+        blockers: packageGate.blockers,
+      });
+    const incompleteProtocols = await query(
+      `SELECT p.test_id,
     NOT EXISTS(SELECT 1 FROM qms_epoch_validation_executions e WHERE e.protocol_id=p.id
       AND e.overall_result IN ('PASSED','PASSED_WITH_APPROVED_DEVIATION')
       AND e.review_decision='APPROVED' AND e.snapshot_checksum IS NOT NULL) incomplete
-    FROM qms_epoch_validation_protocols p WHERE p.package_id=$1 AND p.status='APPROVED'`,[p.id]);
-  const missing=incompleteProtocols.filter(x=>x.incomplete).map(x=>x.test_id);
-  if(missing.length)return res.status(409).json({error:'PROTOCOL_EXECUTION_OR_REVIEW_INCOMPLETE',protocols:missing});
-  const unresolvedDeviations=await query(`SELECT execution_id FROM qms_epoch_validation_executions
-    WHERE package_id=$1 AND overall_result='PASSED_WITH_APPROVED_DEVIATION' AND review_decision<>'APPROVED'`,[p.id]);
-  if(unresolvedDeviations.length)return res.status(409).json({error:'UNRESOLVED_PROTOCOL_DEVIATIONS',executions:unresolvedDeviations.map(x=>x.execution_id)});
-  const finalCounts=await counts(p.id); finalCounts.approvalsCurrent=true;
-  const r=calculateReadiness(finalCounts);
-  if(!r.ready&&body.outcome.startsWith('APPROVED'))return res.status(409).json({error:'FINAL_READINESS_BLOCKED',...r});
-  const d=await detail(p.id),snap={package:d?.package,intendedUse:d?.intendedUse[0],readiness:d?.readiness,
-    requirements:d?.requirements,risks:d?.risks,plans:d?.plans,protocols:d?.protocols,
-    executions:d?.executions,defects:d?.defects,limitations:body.approvedLimitations||null};
-  await approve(req,p,'FINAL',p.id,p.revision,body.approvalRole,
-    `Authenticated ${body.outcome} decision for exact EPOCH version ${p.production_version}`,
-    'EPOCH_VALIDATION_FINAL_APPROVE',body.comments);
-  const required=body.outcome==='APPROVED_WITH_LIMITATIONS'?4:3;
-  const approvals=Number((await query(`SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals
-    WHERE package_id=$1 AND record_type='FINAL' AND record_revision=$2 AND status='VALID' AND decision='APPROVED'`,[p.id,p.revision]))[0].n);
-  if(approvals>=required&&body.outcome.startsWith('APPROVED')){
-    await tx(async q=>{await q(`INSERT INTO qms_epoch_validation_snapshots
+    FROM qms_epoch_validation_protocols p WHERE p.package_id=$1 AND p.status='APPROVED'`,
+      [p.id]
+    );
+    const missing = incompleteProtocols
+      .filter((x) => x.incomplete)
+      .map((x) => x.test_id);
+    if (missing.length)
+      return res.status(409).json({
+        error: 'PROTOCOL_EXECUTION_OR_REVIEW_INCOMPLETE',
+        protocols: missing,
+      });
+    const unresolvedDeviations = await query(
+      `SELECT execution_id FROM qms_epoch_validation_executions
+    WHERE package_id=$1 AND overall_result='PASSED_WITH_APPROVED_DEVIATION' AND review_decision<>'APPROVED'`,
+      [p.id]
+    );
+    if (unresolvedDeviations.length)
+      return res.status(409).json({
+        error: 'UNRESOLVED_PROTOCOL_DEVIATIONS',
+        executions: unresolvedDeviations.map((x) => x.execution_id),
+      });
+    const finalCounts = await counts(p.id);
+    finalCounts.approvalsCurrent = true;
+    const r = calculateReadiness(finalCounts);
+    if (!r.ready && body.outcome.startsWith('APPROVED'))
+      return res.status(409).json({ error: 'FINAL_READINESS_BLOCKED', ...r });
+    const d = await detail(p.id),
+      snap = {
+        package: d?.package,
+        intendedUse: d?.intendedUse[0],
+        readiness: d?.readiness,
+        requirements: d?.requirements,
+        risks: d?.risks,
+        plans: d?.plans,
+        protocols: d?.protocols,
+        executions: d?.executions,
+        defects: d?.defects,
+        limitations: body.approvedLimitations || null,
+      };
+    await approve(
+      req,
+      p,
+      'FINAL',
+      p.id,
+      p.revision,
+      body.approvalRole,
+      `Authenticated ${body.outcome} decision for exact EPOCH version ${p.production_version}`,
+      'EPOCH_VALIDATION_FINAL_APPROVE',
+      body.comments
+    );
+    const required = body.outcome === 'APPROVED_WITH_LIMITATIONS' ? 4 : 3;
+    const approvals = Number(
+      (
+        await query(
+          `SELECT count(DISTINCT approval_role) n FROM qms_epoch_validation_approvals
+    WHERE package_id=$1 AND record_type='FINAL' AND record_revision=$2 AND status='VALID' AND decision='APPROVED'`,
+          [p.id, p.revision]
+        )
+      )[0].n
+    );
+    if (approvals >= required && body.outcome.startsWith('APPROVED')) {
+      await tx(async (q) => {
+        await q(
+          `INSERT INTO qms_epoch_validation_snapshots
       (package_id,snapshot_type,package_revision,snapshot,checksum,created_by_user_id)
       VALUES($1,'FINAL_APPROVAL',$2,$3::jsonb,$4,$5) ON CONFLICT DO NOTHING`,
-      [p.id,p.revision,JSON.stringify(snap),checksum(snap),actor(req).id]);
-      await q(`UPDATE qms_epoch_validation_packages SET status=$1,locked_at=now(),actual_completion_date=current_date,
-        updated_at=now() WHERE id=$2`,[body.outcome,p.id]);});
-  } else if(!body.outcome.startsWith('APPROVED')) await query(`UPDATE qms_epoch_validation_packages SET status=$1 WHERE id=$2`,
-    [body.outcome==='RETURNED_FOR_CORRECTION'?'CORRECTIONS_REQUIRED':'REJECTED',p.id]);
-  res.json({approvalCount:approvals,required,locked:approvals>=required&&body.outcome.startsWith('APPROVED')});
-});
-router.post('/:id/reopen',requirePermission('EPOCH_VALIDATION_REOPEN'),async(req,res)=>{
-  const id=uuid.parse(req.params.id),p=await getPackage(id);if(!p)return res.status(404).json({error:'VALIDATION_PACKAGE_NOT_FOUND'});
-  const body=z.object({reason:z.string().min(20)}).parse(req.body);const a=actor(req);
-  const snapshot=(await query(`SELECT * FROM qms_epoch_validation_snapshots WHERE package_id=$1 AND snapshot_type='FINAL_APPROVAL' ORDER BY created_at DESC LIMIT 1`,[id]))[0];
-  if(!snapshot)return res.status(409).json({error:'APPROVED_SNAPSHOT_REQUIRED'});
-  await tx(async q=>{await invalidateApprovals(id,`Controlled reopening: ${body.reason}`,q);
-    await q(`UPDATE qms_epoch_validation_packages SET status='CORRECTIONS_REQUIRED',locked_at=NULL,revision=revision+1,
-      updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3`,[a.id,a.name,id]);
-    await logEvent(req,p,'PACKAGE','PACKAGE_REOPENED',{reason:body.reason,next:{preservedSnapshot:snapshot.id}},q);});
-  res.json(await getPackage(id));
-});
+          [
+            p.id,
+            p.revision,
+            JSON.stringify(snap),
+            checksum(snap),
+            actor(req).id,
+          ]
+        );
+        await q(
+          `UPDATE qms_epoch_validation_packages SET status=$1,locked_at=now(),actual_completion_date=current_date,
+        updated_at=now() WHERE id=$2`,
+          [body.outcome, p.id]
+        );
+      });
+    } else if (!body.outcome.startsWith('APPROVED'))
+      await query(
+        `UPDATE qms_epoch_validation_packages SET status=$1 WHERE id=$2`,
+        [
+          body.outcome === 'RETURNED_FOR_CORRECTION'
+            ? 'CORRECTIONS_REQUIRED'
+            : 'REJECTED',
+          p.id,
+        ]
+      );
+    res.json({
+      approvalCount: approvals,
+      required,
+      locked: approvals >= required && body.outcome.startsWith('APPROVED'),
+    });
+  }
+);
+router.post(
+  '/:id/reopen',
+  requirePermission('EPOCH_VALIDATION_REOPEN'),
+  async (req, res) => {
+    const id = uuid.parse(req.params.id),
+      p = await getPackage(id);
+    if (!p)
+      return res.status(404).json({ error: 'VALIDATION_PACKAGE_NOT_FOUND' });
+    const body = z.object({ reason: z.string().min(20) }).parse(req.body);
+    const a = actor(req);
+    const snapshot = (
+      await query(
+        `SELECT * FROM qms_epoch_validation_snapshots WHERE package_id=$1 AND snapshot_type='FINAL_APPROVAL' ORDER BY created_at DESC LIMIT 1`,
+        [id]
+      )
+    )[0];
+    if (!snapshot)
+      return res.status(409).json({ error: 'APPROVED_SNAPSHOT_REQUIRED' });
+    await tx(async (q) => {
+      await invalidateApprovals(id, `Controlled reopening: ${body.reason}`, q);
+      await q(
+        `UPDATE qms_epoch_validation_packages SET status='CORRECTIONS_REQUIRED',locked_at=NULL,revision=revision+1,
+      updated_by_user_id=$1,updated_by_display_name=$2,updated_at=now() WHERE id=$3`,
+        [a.id, a.name, id]
+      );
+      await logEvent(
+        req,
+        p,
+        'PACKAGE',
+        'PACKAGE_REOPENED',
+        { reason: body.reason, next: { preservedSnapshot: snapshot.id } },
+        q
+      );
+    });
+    res.json(await getPackage(id));
+  }
+);
 
-router.get('/:id/export',requirePermission('EPOCH_VALIDATION_EXPORT'),async(req,res)=>{
-  const id=uuid.parse(req.params.id),d=await detail(id);if(!d)return res.status(404).send('Validation package not found');
-  const view=z.enum(['validation-plan','requirements-matrix','risk-register','test-protocols','test-executions','defects','summary','complete-package']).catch('complete-package').parse(req.query.view);
-  const approved=['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS'].includes(d.package.status);
-  const mark=approved?'CONTROLLED EPOCH SOFTWARE VALIDATION RECORD':'DRAFT - NOT APPROVED FOR INTENDED USE';
-  const esc=(v:unknown)=>String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]!));
-  const table=(title:string,records:any[],fields:string[])=>`<h2>${esc(title)}</h2><table><thead><tr>${fields.map(f=>`<th>${esc(f.replaceAll('_',' '))}</th>`).join('')}</tr></thead><tbody>${records.map(x=>`<tr>${fields.map(f=>`<td>${esc(x[f])}</td>`).join('')}</tr>`).join('')}</tbody></table>`;
-  const sections:Record<string,string>={
-    'validation-plan':table('Validation Plan',d.plans,['revision','status','purpose','scope','included_modules','excluded_modules','acceptance_criteria']),
-    'requirements-matrix':table('Requirements Traceability Matrix',d.requirements,['requirement_id','module','category','statement','criticality','validation_method','status']),
-    'risk-register':table('Risk Register',d.risks,['risk_id','module','failure_mode','potential_effect','initial_risk_rating','residual_risk','status']),
-    'test-protocols':table('Test Protocol Package',d.protocols,['test_id','title','module','criticality','revision','status']),
-    'test-executions':table('Test Execution Report',d.executions,['execution_id','protocol_revision','tester_display_name','overall_result','review_decision','started_at','ended_at']),
-    defects:table('Validation Defect Report',d.defects,['defect_number','module','severity','description','status','retest_required']),
-    summary:`<h2>Validation Summary</h2><pre>${esc(JSON.stringify(d.readiness,null,2))}</pre>`,
-    'complete-package':'',
-  };
-  const body=view==='complete-package'?Object.entries(sections).filter(([k])=>k!=='complete-package').map(([,v])=>v).join(''):sections[view];
-  res.type('html').send(`<!doctype html><html><head><meta charset="utf-8"><title>${esc(d.package.package_number)}</title>
+router.get(
+  '/:id/export',
+  requirePermission('EPOCH_VALIDATION_EXPORT'),
+  async (req, res) => {
+    const id = uuid.parse(req.params.id),
+      d = await detail(id);
+    if (!d) return res.status(404).send('Validation package not found');
+    const view = z
+      .enum([
+        'validation-plan',
+        'requirements-matrix',
+        'risk-register',
+        'test-protocols',
+        'test-executions',
+        'defects',
+        'summary',
+        'complete-package',
+      ])
+      .catch('complete-package')
+      .parse(req.query.view);
+    const approved = [
+      'APPROVED_FOR_INTENDED_USE',
+      'APPROVED_WITH_LIMITATIONS',
+    ].includes(d.package.status);
+    const mark = approved
+      ? 'CONTROLLED EPOCH SOFTWARE VALIDATION RECORD'
+      : 'DRAFT - NOT APPROVED FOR INTENDED USE';
+    const esc = (v: unknown) =>
+      String(v ?? '').replace(
+        /[&<>"']/g,
+        (c) =>
+          ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+          })[c]!
+      );
+    const table = (title: string, records: any[], fields: string[]) =>
+      `<h2>${esc(title)}</h2><table><thead><tr>${fields.map((f) => `<th>${esc(f.replaceAll('_', ' '))}</th>`).join('')}</tr></thead><tbody>${records.map((x) => `<tr>${fields.map((f) => `<td>${esc(x[f])}</td>`).join('')}</tr>`).join('')}</tbody></table>`;
+    const sections: Record<string, string> = {
+      'validation-plan': table('Validation Plan', d.plans, [
+        'revision',
+        'status',
+        'purpose',
+        'scope',
+        'included_modules',
+        'excluded_modules',
+        'acceptance_criteria',
+      ]),
+      'requirements-matrix': table(
+        'Requirements Traceability Matrix',
+        d.requirements,
+        [
+          'requirement_id',
+          'module',
+          'category',
+          'statement',
+          'criticality',
+          'validation_method',
+          'status',
+        ]
+      ),
+      'risk-register': table('Risk Register', d.risks, [
+        'risk_id',
+        'module',
+        'failure_mode',
+        'potential_effect',
+        'initial_risk_rating',
+        'residual_risk',
+        'status',
+      ]),
+      'test-protocols': table('Test Protocol Package', d.protocols, [
+        'test_id',
+        'title',
+        'module',
+        'criticality',
+        'revision',
+        'status',
+      ]),
+      'test-executions': table('Test Execution Report', d.executions, [
+        'execution_id',
+        'protocol_revision',
+        'tester_display_name',
+        'overall_result',
+        'review_decision',
+        'started_at',
+        'ended_at',
+      ]),
+      defects: table('Validation Defect Report', d.defects, [
+        'defect_number',
+        'module',
+        'severity',
+        'description',
+        'status',
+        'retest_required',
+      ]),
+      summary: `<h2>Validation Summary</h2><pre>${esc(JSON.stringify(d.readiness, null, 2))}</pre>`,
+      'complete-package': '',
+    };
+    const body =
+      view === 'complete-package'
+        ? Object.entries(sections)
+            .filter(([k]) => k !== 'complete-package')
+            .map(([, v]) => v)
+            .join('')
+        : sections[view];
+    res.type('html')
+      .send(`<!doctype html><html><head><meta charset="utf-8"><title>${esc(d.package.package_number)}</title>
   <style>body{font:12px Arial;margin:32px;color:#172033}header{border-bottom:3px solid #214d74}h1,h2{color:#173f63}table{border-collapse:collapse;width:100%;margin:12px 0 24px}th,td{border:1px solid #bbb;padding:6px;text-align:left;vertical-align:top}th{background:#edf4f8}.mark{font-weight:bold;padding:8px;border:2px solid #173f63}</style></head>
   <body><header><div class="mark">${mark}</div><h1>${esc(d.package.package_number)} - ${esc(d.package.title)}</h1>
-  <p>Exact EPOCH version: ${esc(d.package.production_version)} | Commit/release: ${esc(d.package.commit_or_release_identifier||'Not recorded')}</p></header>${body}
+  <p>Exact EPOCH version: ${esc(d.package.production_version)} | Commit/release: ${esc(d.package.commit_or_release_identifier || 'Not recorded')}</p></header>${body}
   <p>Attachment contents are excluded. Controlled evidence references remain available in EPOCH.</p></body></html>`);
-});
+  }
+);
 
-export async function getAuditReadinessValidationStatus(assessmentId:string){
-  const assessment=(await query('SELECT id,epoch_version FROM qms_audit_readiness_assessments WHERE id=$1',[assessmentId]))[0];
-  if(!assessment)return null;
-  const p=(await query(`SELECT * FROM qms_epoch_validation_packages WHERE audit_readiness_assessment_id=$1
-    ORDER BY CASE WHEN status IN ('APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS') THEN 0 ELSE 1 END,updated_at DESC LIMIT 1`,[assessmentId]))[0];
-  if(!p)return {state:'NOT_VALIDATED',message:'Not validated - create or link an EPOCH Software Validation Package.',package:null,complete:false,blockers:['No linked validation package']};
-  const c=await counts(p.id),r=calculateReadiness(c);
-  const review=(await query(`SELECT * FROM qms_epoch_validation_periodic_reviews WHERE package_id=$1 AND status='APPROVED' ORDER BY review_date DESC LIMIT 1`,[p.id]))[0];
-  const periodicCurrent=Boolean(review)&&new Date(review.next_review_date)>=new Date(new Date().toISOString().slice(0,10));
-  const versionMatches=p.production_version===assessment.epoch_version;
-  const approved=['APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS'].includes(p.status);
-  const blockers=[...r.blockers,...(!approved?['Linked package is not approved for intended use']:[]),
-    ...(!versionMatches?['Approved EPOCH version does not match the assessment']:[]),
-    ...(!periodicCurrent?['Periodic review is missing or overdue']:[])];
-  return {state:blockers.length?'BLOCKED':'COMPLETE',message:blockers.length?blockers.join('; '):'EPOCH intended-use validation is current.',
-    package:{id:p.id,packageNumber:p.package_number,status:p.status,productionVersion:p.production_version},
-    assessmentVersion:assessment.epoch_version,versionMatches,periodicReviewCurrent:periodicCurrent,
-    complete:blockers.length===0,blockers,readiness:{...c,...r}};
+export async function getAuditReadinessValidationStatus(assessmentId: string) {
+  const assessment = (
+    await query(
+      'SELECT id,epoch_version FROM qms_audit_readiness_assessments WHERE id=$1',
+      [assessmentId]
+    )
+  )[0];
+  if (!assessment) return null;
+  const p = (
+    await query(
+      `SELECT * FROM qms_epoch_validation_packages WHERE audit_readiness_assessment_id=$1
+    ORDER BY CASE WHEN status IN ('APPROVED_FOR_INTENDED_USE','APPROVED_WITH_LIMITATIONS') THEN 0 ELSE 1 END,updated_at DESC LIMIT 1`,
+      [assessmentId]
+    )
+  )[0];
+  if (!p)
+    return {
+      state: 'NOT_VALIDATED',
+      message:
+        'Not validated - create or link an EPOCH Software Validation Package.',
+      package: null,
+      complete: false,
+      blockers: ['No linked validation package'],
+    };
+  const c = await counts(p.id),
+    r = calculateReadiness(c);
+  const review = (
+    await query(
+      `SELECT * FROM qms_epoch_validation_periodic_reviews WHERE package_id=$1 AND status='APPROVED' ORDER BY review_date DESC LIMIT 1`,
+      [p.id]
+    )
+  )[0];
+  const periodicCurrent =
+    Boolean(review) &&
+    new Date(review.next_review_date) >=
+      new Date(new Date().toISOString().slice(0, 10));
+  const versionMatches = p.production_version === assessment.epoch_version;
+  const approved = [
+    'APPROVED_FOR_INTENDED_USE',
+    'APPROVED_WITH_LIMITATIONS',
+  ].includes(p.status);
+  const blockers = [
+    ...r.blockers,
+    ...(!approved ? ['Linked package is not approved for intended use'] : []),
+    ...(!versionMatches
+      ? ['Approved EPOCH version does not match the assessment']
+      : []),
+    ...(!periodicCurrent ? ['Periodic review is missing or overdue'] : []),
+  ];
+  return {
+    state: blockers.length ? 'BLOCKED' : 'COMPLETE',
+    message: blockers.length
+      ? blockers.join('; ')
+      : 'EPOCH intended-use validation is current.',
+    package: {
+      id: p.id,
+      packageNumber: p.package_number,
+      status: p.status,
+      productionVersion: p.production_version,
+    },
+    assessmentVersion: assessment.epoch_version,
+    versionMatches,
+    periodicReviewCurrent: periodicCurrent,
+    complete: blockers.length === 0,
+    blockers,
+    readiness: { ...c, ...r },
+  };
 }
 
 export default router;

--- a/server/src/services/epochSoftwareValidation.ts
+++ b/server/src/services/epochSoftwareValidation.ts
@@ -4,7 +4,7 @@ export const VALIDATION_STATUSES = [
   'DRAFT', 'PLANNING', 'READY_FOR_APPROVAL', 'PLAN_APPROVED', 'TESTING',
   'TESTING_BLOCKED', 'CORRECTIONS_REQUIRED', 'RETESTING',
   'READY_FOR_FINAL_REVIEW', 'APPROVED_FOR_INTENDED_USE',
-  'APPROVED_WITH_LIMITATIONS', 'REJECTED', 'SUPERSEDED', 'CANCELLED',
+  'APPROVED_WITH_LIMITATIONS', 'REJECTED', 'SUPERSEDED', 'CANCELLED', 'VOID_DUPLICATE',
 ] as const;
 
 export type ValidationStatus = typeof VALIDATION_STATUSES[number];
@@ -27,6 +27,7 @@ export const LEGAL_TRANSITIONS: Record<ValidationStatus, readonly ValidationStat
   REJECTED: ['PLANNING', 'CANCELLED'],
   SUPERSEDED: [],
   CANCELLED: [],
+  VOID_DUPLICATE: [],
 };
 
 export function canTransition(from: ValidationStatus, to: ValidationStatus) {

--- a/server/src/services/epochSoftwareValidation.ts
+++ b/server/src/services/epochSoftwareValidation.ts
@@ -1,26 +1,51 @@
 import crypto from 'crypto';
 
 export const VALIDATION_STATUSES = [
-  'DRAFT', 'PLANNING', 'READY_FOR_APPROVAL', 'PLAN_APPROVED', 'TESTING',
-  'TESTING_BLOCKED', 'CORRECTIONS_REQUIRED', 'RETESTING',
-  'READY_FOR_FINAL_REVIEW', 'APPROVED_FOR_INTENDED_USE',
-  'APPROVED_WITH_LIMITATIONS', 'REJECTED', 'SUPERSEDED', 'CANCELLED', 'VOID_DUPLICATE',
+  'DRAFT',
+  'PLANNING',
+  'READY_FOR_APPROVAL',
+  'PLAN_APPROVED',
+  'TESTING',
+  'TESTING_BLOCKED',
+  'CORRECTIONS_REQUIRED',
+  'RETESTING',
+  'READY_FOR_FINAL_REVIEW',
+  'APPROVED_FOR_INTENDED_USE',
+  'APPROVED_WITH_LIMITATIONS',
+  'REJECTED',
+  'SUPERSEDED',
+  'CANCELLED',
+  'VOID_DUPLICATE',
 ] as const;
 
-export type ValidationStatus = typeof VALIDATION_STATUSES[number];
+export type ValidationStatus = (typeof VALIDATION_STATUSES)[number];
 
-export const LEGAL_TRANSITIONS: Record<ValidationStatus, readonly ValidationStatus[]> = {
+export const LEGAL_TRANSITIONS: Record<
+  ValidationStatus,
+  readonly ValidationStatus[]
+> = {
   DRAFT: ['PLANNING', 'CANCELLED'],
   PLANNING: ['READY_FOR_APPROVAL', 'CANCELLED'],
   READY_FOR_APPROVAL: ['PLAN_APPROVED', 'PLANNING', 'REJECTED'],
   PLAN_APPROVED: ['TESTING', 'CORRECTIONS_REQUIRED', 'CANCELLED'],
-  TESTING: ['TESTING_BLOCKED', 'CORRECTIONS_REQUIRED', 'RETESTING', 'READY_FOR_FINAL_REVIEW'],
+  TESTING: [
+    'TESTING_BLOCKED',
+    'CORRECTIONS_REQUIRED',
+    'RETESTING',
+    'READY_FOR_FINAL_REVIEW',
+  ],
   TESTING_BLOCKED: ['TESTING', 'CORRECTIONS_REQUIRED', 'CANCELLED'],
   CORRECTIONS_REQUIRED: ['RETESTING', 'PLANNING', 'CANCELLED'],
-  RETESTING: ['TESTING_BLOCKED', 'CORRECTIONS_REQUIRED', 'READY_FOR_FINAL_REVIEW'],
+  RETESTING: [
+    'TESTING_BLOCKED',
+    'CORRECTIONS_REQUIRED',
+    'READY_FOR_FINAL_REVIEW',
+  ],
   READY_FOR_FINAL_REVIEW: [
-    'APPROVED_FOR_INTENDED_USE', 'APPROVED_WITH_LIMITATIONS',
-    'CORRECTIONS_REQUIRED', 'REJECTED',
+    'APPROVED_FOR_INTENDED_USE',
+    'APPROVED_WITH_LIMITATIONS',
+    'CORRECTIONS_REQUIRED',
+    'REJECTED',
   ],
   APPROVED_FOR_INTENDED_USE: ['SUPERSEDED'],
   APPROVED_WITH_LIMITATIONS: ['SUPERSEDED'],
@@ -37,11 +62,13 @@ export function canTransition(from: ValidationStatus, to: ValidationStatus) {
 export type StepResult = { required?: boolean; status: string };
 
 export function deriveExecutionResult(steps: StepResult[]) {
-  const required = steps.filter(step => step.required !== false);
-  if (!required.length || required.some(step => step.status === 'NOT_RUN')) return 'NOT_RUN';
-  if (required.some(step => step.status === 'FAILED')) return 'FAILED';
-  if (required.some(step => step.status === 'BLOCKED')) return 'BLOCKED';
-  if (required.some(step => step.status === 'IN_PROGRESS')) return 'IN_PROGRESS';
+  const required = steps.filter((step) => step.required !== false);
+  if (!required.length || required.some((step) => step.status === 'NOT_RUN'))
+    return 'NOT_RUN';
+  if (required.some((step) => step.status === 'FAILED')) return 'FAILED';
+  if (required.some((step) => step.status === 'BLOCKED')) return 'BLOCKED';
+  if (required.some((step) => step.status === 'IN_PROGRESS'))
+    return 'IN_PROGRESS';
   return 'PASSED';
 }
 
@@ -68,53 +95,85 @@ export type ReadinessCounts = {
 
 export function calculateReadiness(counts: ReadinessCounts) {
   const blockers: string[] = [];
-  if (!counts.intendedUseApproved) blockers.push('Intended Use is not approved');
-  if (!counts.requirementsBaselineApproved) blockers.push('Requirements baseline is not approved');
-  if (!counts.riskAssessmentApproved) blockers.push('Risk assessment is not approved');
-  if (!counts.validationPlanApproved) blockers.push('Validation Plan is not approved');
-  if (counts.criticalRequirementsTested < counts.criticalRequirements) blockers.push('Critical requirements remain untested');
-  if (counts.criticalTestsPassed < counts.criticalTests) blockers.push('Critical tests have not all passed');
-  if (counts.openCriticalDefects > 0) blockers.push('Critical validation defects remain open');
-  if (counts.openHighDefects > counts.acceptedHighDefects) blockers.push('High validation defects remain unaccepted');
-  if (counts.passedRetests < counts.requiredRetests) blockers.push('Required retests have not passed');
+  if (!counts.intendedUseApproved)
+    blockers.push('Intended Use is not approved');
+  if (!counts.requirementsBaselineApproved)
+    blockers.push('Requirements baseline is not approved');
+  if (!counts.riskAssessmentApproved)
+    blockers.push('Risk assessment is not approved');
+  if (!counts.validationPlanApproved)
+    blockers.push('Validation Plan is not approved');
+  if (counts.criticalRequirementsTested < counts.criticalRequirements)
+    blockers.push('Critical requirements remain untested');
+  if (counts.criticalTestsPassed < counts.criticalTests)
+    blockers.push('Critical tests have not all passed');
+  if (counts.openCriticalDefects > 0)
+    blockers.push('Critical validation defects remain open');
+  if (counts.openHighDefects > counts.acceptedHighDefects)
+    blockers.push('High validation defects remain unaccepted');
+  if (counts.passedRetests < counts.requiredRetests)
+    blockers.push('Required retests have not passed');
   if (!counts.backupPassed) blockers.push('Backup verification has not passed');
   if (!counts.restorePassed) blockers.push('Restore testing has not passed');
   if (!counts.outageDrillPassed) blockers.push('Outage drill has not passed');
-  if (!counts.approvalsCurrent) blockers.push('Required approvals are missing or stale');
-  if (!counts.exactProductionVersionIdentified) blockers.push('Exact production version is not identified');
+  if (!counts.approvalsCurrent)
+    blockers.push('Required approvals are missing or stale');
+  if (!counts.exactProductionVersionIdentified)
+    blockers.push('Exact production version is not identified');
   return { ready: blockers.length === 0, blockers };
 }
 
 export function checksum(value: unknown) {
-  return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(value))
+    .digest('hex');
 }
 
 const PLACEHOLDER_NOTES = /^(?:n\/?a|none|test|tbd)$/i;
 const FULL_SHA = /^[0-9a-f]{40}$/i;
-const RELEASE_TAG = /^(?:v|release[-_/])?[0-9]+\.[0-9]+(?:\.[0-9]+)?(?:[-+][0-9a-z.-]+)?$/i;
+const RELEASE_TAG =
+  /^(?:v|release[-_/])?[0-9]+\.[0-9]+(?:\.[0-9]+)?(?:[-+][0-9a-z.-]+)?$/i;
 const DEPLOYMENT_ID = /^(?=.*\d)(?=.*[-_:])[a-z0-9][a-z0-9._:/-]{7,}$/i;
 const PR_ONLY = /^(?:merged\s+)?pull\s+request\s+#?\d+$/i;
 
 export function productionIdentifierStatus(value: unknown) {
-  const identifier=String(value??'').trim();
-  if(!identifier)return {valid:false,code:'PRODUCTION_IDENTIFIER_MISSING'};
-  if(PR_ONLY.test(identifier)||/^#?\d+$/.test(identifier))
-    return {valid:false,code:'PRODUCTION_IDENTIFIER_AMBIGUOUS'};
-  return {valid:FULL_SHA.test(identifier)||RELEASE_TAG.test(identifier)||DEPLOYMENT_ID.test(identifier),
-    code:'PRODUCTION_IDENTIFIER_INVALID'};
+  const identifier = String(value ?? '').trim();
+  if (!identifier)
+    return { valid: false, code: 'PRODUCTION_IDENTIFIER_MISSING' };
+  if (PR_ONLY.test(identifier) || /^#?\d+$/.test(identifier))
+    return { valid: false, code: 'PRODUCTION_IDENTIFIER_AMBIGUOUS' };
+  return {
+    valid:
+      FULL_SHA.test(identifier) ||
+      RELEASE_TAG.test(identifier) ||
+      DEPLOYMENT_ID.test(identifier),
+    code: 'PRODUCTION_IDENTIFIER_INVALID',
+  };
 }
 
 export function hasMeaningfulNotes(value: unknown) {
-  const notes=String(value??'').trim();
-  return notes.length>=20&&!PLACEHOLDER_NOTES.test(notes);
+  const notes = String(value ?? '').trim();
+  return notes.length >= 20 && !PLACEHOLDER_NOTES.test(notes);
 }
 
 export type PackageReadinessItem = {
-  key:string;label:string;state:'COMPLETE'|'MISSING'|'REQUIRES_CONFIRMATION'|'NOT_APPLICABLE';
-  field:string;message?:string;
+  key: string;
+  label: string;
+  state: 'COMPLETE' | 'MISSING' | 'REQUIRES_CONFIRMATION' | 'NOT_APPLICABLE';
+  field: string;
+  message?: string;
 };
 
-export function packageReadinessBlockers(items:PackageReadinessItem[]) {
-  return items.filter(item=>item.state==='MISSING'||item.state==='REQUIRES_CONFIRMATION')
-    .map(item=>({field:item.field,code:`${item.key}_INCOMPLETE`,message:item.message||`${item.label} is incomplete.`}));
+export function packageReadinessBlockers(items: PackageReadinessItem[]) {
+  return items
+    .filter(
+      (item) =>
+        item.state === 'MISSING' || item.state === 'REQUIRES_CONFIRMATION'
+    )
+    .map((item) => ({
+      field: item.field,
+      code: `${item.key}_INCOMPLETE`,
+      message: item.message || `${item.label} is incomplete.`,
+    }));
 }


### PR DESCRIPTION
## What changed

- Added a synchronous client submission guard, pending-state button disablement, `Creating package…` feedback, and one authoritative form submit path.
- Added a unique idempotency key per deliberate package-create action and disabled React Query mutation retries.
- Added durable, user- and operation-scoped server idempotency with payload hashing and serialized same-key handling.
- Preserved sequence-backed package numbering inside the create transaction.
- Added an authorized, reasoned, audited `VOID_DUPLICATE` disposition that retains history and locks voided drafts from execution, approval, and release paths.

## Root cause

The create dialog had one form-submit path, not competing button and form handlers. A rapid repeat native submit could enter twice before React rerendered `create.isPending`; the server accepted both because package creation had no idempotency key or durable duplicate-request guard.

## Migration

`0242_epoch_validation_create_idempotency.sql` adds the durable create-request table and extends the validation package status constraint with `VOID_DUPLICATE`. It is additive, retains all existing records, and is registered in both safe and critical boot migration lists.

## Validation

- Focused client validation/readiness tests: 6 passed.
- Focused server validation/readiness/idempotency architecture and rule tests: 20 passed.
- Affected TypeScript/TSX syntax transforms: passed.
- `git diff --check` and staged diff check: passed.
- Full TypeScript check: attempted twice; the bounded run timed out, and the longer run exhausted the 4 GB Node heap.
- Focused lint/format command: existing compact legacy files produce repository-wide Prettier findings; the two new test files were formatted.

## Production data and browser boundary

No production validation record was created, changed, deleted, merged, renumbered, or voided. The authenticated production page currently displayed no validation packages, so ESV-2026-0006 and ESV-2026-0007 could not be compared from that read-only session. End-to-end double-click verification of this unpublished change remains a post-deployment/local-runnable-environment check.
