### PR TITLE
Align P2 production and scheduling counts

### DIFF
--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -10,6 +10,10 @@ import {
   isHistoricalP2Unit,
   p2PendingUnitDeficit,
 } from '../src/lib/p2SchedulingReconciliation';
+import {
+  countDistinctP2PendingUnits,
+  isP2PhysicalProjectWorkOrder,
+} from '../src/lib/p2ControlCenterReconciliation';
 
 describe('P2 shipment and scheduling reconciliation', () => {
   it('treats a durable non-void packing slip as shipment evidence', () => {
@@ -66,6 +70,21 @@ describe('P2 shipment and scheduling reconciliation', () => {
     expect(p2PendingUnitDeficit(90, 81, 0)).toBe(9);
     expect(p2PendingUnitDeficit(90, 81, 9)).toBe(0);
     expect(p2PendingUnitDeficit(90, 81, 12)).toBe(0);
+  });
+
+  it('reports the distinct pending units that are actually exposed to Scheduling', () => {
+    expect(countDistinctP2PendingUnits([
+      { id: 'pending-1', serialNumber: 'ROC-1', status: 'ACTIVE', currentDepartment: 'Pending Layup' },
+      { id: 'duplicate', serialNumber: 'ROC-1', status: 'ACTIVE', currentDepartment: 'Pending Layup' },
+      { id: 'pending-2', serialNumber: 'ROC-2', status: 'ACTIVE', currentDepartment: '' },
+      { id: 'active', serialNumber: 'ROC-3', status: 'ACTIVE', currentDepartment: 'Oven/Cure' },
+    ])).toBe(2);
+  });
+
+  it('keeps WAD context out of the physical serialized production queue', () => {
+    expect(isP2PhysicalProjectWorkOrder({ workOrderNumber: 'WAD-PRJ002-702823' })).toBe(false);
+    expect(isP2PhysicalProjectWorkOrder({ workOrderNumber: 'WO-100', wadStatus: 'READY' })).toBe(false);
+    expect(isP2PhysicalProjectWorkOrder({ workOrderNumber: 'WO-100' })).toBe(true);
   });
 
   it('counts shipped, finalization, active, and scheduled units once by serial', () => {

--- a/server/src/lib/p2ControlCenterReconciliation.ts
+++ b/server/src/lib/p2ControlCenterReconciliation.ts
@@ -1,0 +1,26 @@
+import type { P2SerializedUnitLedgerRow } from './p2SerializedUnitLedger';
+
+const normalized = (value: unknown) => String(value ?? '').trim().toUpperCase();
+
+export function countDistinctP2PendingUnits(
+  rows: readonly P2SerializedUnitLedgerRow[],
+): number {
+  const identities = new Set<string>();
+  for (const row of rows) {
+    if (normalized(row.status) !== 'ACTIVE') continue;
+    const department = normalized(row.currentDepartment ?? row.current_department);
+    if (department !== '' && department !== 'PENDING LAYUP') continue;
+    const serial = normalized(row.serialNumber ?? row.serial_number);
+    const id = String(row.id ?? '').trim().toLowerCase();
+    if (serial || id) identities.add(serial || `ID:${id}`);
+  }
+  return identities.size;
+}
+
+export function isP2PhysicalProjectWorkOrder(row: {
+  workOrderNumber?: unknown;
+  wadStatus?: unknown;
+}): boolean {
+  return !normalized(row.workOrderNumber).startsWith('WAD-')
+    && normalized(row.wadStatus) === '';
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -29,6 +29,10 @@ import {
   countDistinctP2DemandUnits,
   p2PendingUnitDeficit,
 } from '../lib/p2SchedulingReconciliation';
+import {
+  countDistinctP2PendingUnits,
+  isP2PhysicalProjectWorkOrder,
+} from '../lib/p2ControlCenterReconciliation';
 import { softAuth, authenticateToken, sessionAwareAuth, requireAdminOrOwner } from '../../middleware/auth';
 import { computeEffectivePriority, getEffectivePriorityScore } from '../../../shared/utils/computeEffectivePriority';
 import employeesRoutes from './employees';
@@ -4912,7 +4916,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         const completedItems = ledger.shipped;
         const scheduledItems = ledger.scheduled;
         const inProductionItems = ledger.activeProduction;
-        const pendingItems = ledger.missing;
+        const pendingSerializedItems = countDistinctP2PendingUnits(poItems);
+        const pendingItems = pendingSerializedItems > 0
+          ? Math.min(ledger.missing, pendingSerializedItems)
+          : ledger.missing;
         
         const rawStatus = normalizeP2Status(po.status) || 'OPEN';
 
@@ -4933,7 +4940,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           scheduledItems,
           inProductionItems,
           productionPipelineItems: ledger.productionPipeline,
-          missingItems: ledger.missing,
+          missingItems: pendingItems,
           scrappedItems,
           pendingItems,
           hasBOMsNeeded: !po.bomConfigured,
@@ -5560,6 +5567,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         return (!key || !serializedPoItemKeys.has(key)) && !isComplete;
       });
       const activeLegacyProjectProductionRows = legacyProjectProductionRows.filter((row: any) => {
+        if (!isP2PhysicalProjectWorkOrder(row)) return false;
         const key = row.poId && row.poItemId ? `${row.poId}:${row.poItemId}` : null;
         const normalizedStatus = String(row.status || '').toUpperCase();
         return (!key || !serializedPoItemKeys.has(key))


### PR DESCRIPTION
## What changed

- Exclude WAD/project work orders from the physical P2 serialized production queue.
- Count distinct active Pending Layup identities that are actually exposed by Scheduling.
- Once pending identities exist, cap the status card's available-to-schedule count to those distinct schedulable units.
- Add focused regression coverage for WAD exclusion, pending deduplication, and department eligibility.

## Root cause

The Production queue combined physical serialized units with project WAD work orders. That caused WAD-PRJ002-702823 / traveler TRV-2026-000579 to appear as a second Rock West manufactured item even though it is workflow context, not a physical serial.

Separately, the status card continued showing the ledger's unresolved arithmetic remainder of nine after Scheduling exposed only five active Pending Layup identities. The two surfaces therefore described different actionable quantities.

## User impact

- The non-physical Project WO row is removed from the serialized Production queue.
- PO014332-RA's available-to-schedule status reflects the same five distinct pending identities shown in Production Scheduling.

## Data and audit safety

This is read-only reconciliation and display filtering. It does not delete or rewrite the WAD, traveler, production, shipment, packing-slip, scrap, nonconformance, or audit records. The WAD remains available as context on the real serialized unit and through PM Control.

## Validation

- live screenshots confirmed the extra Project WO row and the status 9 versus Scheduling 5 mismatch
- `git diff --cached --check`: passed before commit
- focused Vitest suites: unavailable because repository dependency installation timed out without producing a Vitest binary