### PR TITLE
Show scheduled P2 serials in production

### DIFF
--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   countDistinctP2PendingUnits,
   isP2PhysicalProjectWorkOrder,
+  p2PhysicalSerializedIdentity,
 } from '../src/lib/p2ControlCenterReconciliation';
 
 describe('P2 shipment and scheduling reconciliation', () => {
@@ -85,6 +86,13 @@ describe('P2 shipment and scheduling reconciliation', () => {
     expect(isP2PhysicalProjectWorkOrder({ workOrderNumber: 'WAD-PRJ002-702823' })).toBe(false);
     expect(isP2PhysicalProjectWorkOrder({ workOrderNumber: 'WO-100', wadStatus: 'READY' })).toBe(false);
     expect(isP2PhysicalProjectWorkOrder({ workOrderNumber: 'WO-100' })).toBe(true);
+  });
+
+  it('deduplicates visible production rows by physical serial identity', () => {
+    expect(p2PhysicalSerializedIdentity({ id: 'one', serialNumber: ' roc2601001 ' }))
+      .toBe('ROC2601001');
+    expect(p2PhysicalSerializedIdentity({ id: 'fallback', serialNumber: null }))
+      .toBe('ID:fallback');
   });
 
   it('counts shipped, finalization, active, and scheduled units once by serial', () => {

--- a/server/src/lib/p2ControlCenterReconciliation.ts
+++ b/server/src/lib/p2ControlCenterReconciliation.ts
@@ -24,3 +24,9 @@ export function isP2PhysicalProjectWorkOrder(row: {
   return !normalized(row.workOrderNumber).startsWith('WAD-')
     && normalized(row.wadStatus) === '';
 }
+
+export function p2PhysicalSerializedIdentity(row: P2SerializedUnitLedgerRow): string {
+  const serial = normalized(row.serialNumber ?? row.serial_number);
+  const id = String(row.id ?? '').trim().toLowerCase();
+  return serial || (id ? `ID:${id}` : '');
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -32,6 +32,7 @@ import {
 import {
   countDistinctP2PendingUnits,
   isP2PhysicalProjectWorkOrder,
+  p2PhysicalSerializedIdentity,
 } from '../lib/p2ControlCenterReconciliation';
 import { softAuth, authenticateToken, sessionAwareAuth, requireAdminOrOwner } from '../../middleware/auth';
 import { computeEffectivePriority, getEffectivePriorityScore } from '../../../shared/utils/computeEffectivePriority';
@@ -5253,62 +5254,16 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       }
       const visibleStatuses = new Set(['ACTIVE']);
       const activeSerializedItems = (allItems || []).filter((item: any) => visibleStatuses.has(item.status));
-      const poItemQuantityRows = await optionalP2Rows(
-        'PO item quantity',
-        dbPool.query(
-          `SELECT
-             poi.id AS "poItemId",
-             poi.quantity AS "orderedQuantity"
-           FROM p2_purchase_order_items poi
-           JOIN p2_purchase_orders po ON po.id = poi.po_id
-           WHERE COALESCE(UPPER(po.status), '') NOT IN ('COMPLETED', 'CANCELED', 'CANCELLED', 'CLOSED')`
-        )
-      );
-      const orderedQuantityByPoItemId = new Map<number, number>(
-        poItemQuantityRows.map((row: any) => [
-          Number(row.poItemId),
-          Math.max(0, Number(row.orderedQuantity) || 0),
-        ])
-      );
-      const isPastLayupQueueStage = (item: any) => {
-        const dept = normalizeP2ControlDepartment(item.currentDepartment);
-        return dept !== '' && dept !== 'Pending Layup' && dept !== 'Layup';
-      };
-      const consumedPastLayupByPoItemId = new Map<number, number>();
-      for (const item of allItems || []) {
-        const poItemId = Number(item.poItemId ?? item.po_item_id);
-        if (!Number.isFinite(poItemId)) continue;
-
-        if (item.status === 'COMPLETED' || (item.status === 'ACTIVE' && isPastLayupQueueStage(item))) {
-          consumedPastLayupByPoItemId.set(
-            poItemId,
-            (consumedPastLayupByPoItemId.get(poItemId) ?? 0) + 1
-          );
-        }
-      }
-      const layupShownByPoItemId = new Map<number, number>();
+      const shownPhysicalIdentities = new Set<string>();
       const items = activeSerializedItems.filter((item: any) => {
         const dept = normalizeP2ControlDepartment(item.currentDepartment);
         if (dept === '' || dept === 'Pending Layup') {
           return false;
         }
 
-        const poItemId = Number(item.poItemId ?? item.po_item_id);
-        const orderedQuantity = orderedQuantityByPoItemId.get(poItemId);
-        if (!orderedQuantity || dept !== 'Layup') {
-          return true;
-        }
-
-        const remainingLayupCapacity = Math.max(
-          0,
-          orderedQuantity - (consumedPastLayupByPoItemId.get(poItemId) ?? 0)
-        );
-        const shownForLine = layupShownByPoItemId.get(poItemId) ?? 0;
-        if (shownForLine >= remainingLayupCapacity) {
-          return false;
-        }
-
-        layupShownByPoItemId.set(poItemId, shownForLine + 1);
+        const identity = p2PhysicalSerializedIdentity(item);
+        if (!identity || shownPhysicalIdentities.has(identity)) return false;
+        shownPhysicalIdentities.add(identity);
         return true;
       });
       const legacyProductionRows: any[] = [];


### PR DESCRIPTION
## What changed

- Remove the raw historical per-line capacity cap from the P2 Production queue.
- Show each distinct active physical serialized identity after it leaves Pending Layup.
- Deduplicate active queue rows by normalized production serial, with item ID fallback.
- Add regression coverage for physical queue identity normalization.

## Root cause

The scheduling write correctly moved five PO014332-RA serialized items out of Pending Layup. The Production queue then calculated Layup visibility from raw historical rows attached to the PO line. Those historical rows exhausted the line's apparent capacity before the five newly scheduled serials were rendered, so they were hidden and their barcode actions were inaccessible.

## User impact

The five scheduled serialized units now appear in their routed Production department (Layup when Layup is the routing start) and can be selected for barcode printing. Historical duplicate active rows remain collapsed by physical serial identity.

## Data and audit safety

This is a read-only queue reconciliation change. It does not rewrite scheduled items, production history, travelers, shipments, packing slips, scrap, nonconformance, or audit records.

## Validation

- `git diff --cached --check`: passed before commit
- focused Vitest suites: unavailable because repository dependency installation timed out without producing a Vitest binary