### PR TITLE
Expose prior-revision P2 pending serials in Scheduling

### DIFF
--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -14,6 +14,7 @@ import {
   countDistinctP2PendingUnits,
   isP2PhysicalProjectWorkOrder,
   p2PhysicalSerializedIdentity,
+  takeP2PriorRevisionPendingForLine,
 } from '../src/lib/p2ControlCenterReconciliation';
 
 describe('P2 shipment and scheduling reconciliation', () => {
@@ -80,6 +81,31 @@ describe('P2 shipment and scheduling reconciliation', () => {
       { id: 'pending-2', serialNumber: 'ROC-2', status: 'ACTIVE', currentDepartment: '' },
       { id: 'active', serialNumber: 'ROC-3', status: 'ACTIVE', currentDepartment: 'Oven/Cure' },
     ])).toBe(2);
+  });
+
+  it('exposes prior-revision pending serials on the current line without exceeding capacity', () => {
+    const priorRevisionPending = ['old-1', 'old-2', 'old-3', 'old-4'];
+    const exhaustedLine = takeP2PriorRevisionPendingForLine(
+      [],
+      priorRevisionPending,
+      0,
+    );
+    expect(exhaustedLine.pendingItems).toEqual([]);
+    expect(exhaustedLine.remainingPriorRevisionPending).toEqual(priorRevisionPending);
+
+    const currentLine = takeP2PriorRevisionPendingForLine(
+      ['current-1'],
+      exhaustedLine.remainingPriorRevisionPending,
+      5,
+    );
+    expect(currentLine.pendingItems).toEqual([
+      'current-1',
+      'old-1',
+      'old-2',
+      'old-3',
+      'old-4',
+    ]);
+    expect(currentLine.remainingPriorRevisionPending).toEqual([]);
   });
 
   it('keeps WAD context out of the physical serialized production queue', () => {

--- a/server/src/lib/p2ControlCenterReconciliation.ts
+++ b/server/src/lib/p2ControlCenterReconciliation.ts
@@ -30,3 +30,19 @@ export function p2PhysicalSerializedIdentity(row: P2SerializedUnitLedgerRow): st
   const id = String(row.id ?? '').trim().toLowerCase();
   return serial || (id ? `ID:${id}` : '');
 }
+
+export function takeP2PriorRevisionPendingForLine<T>(
+  currentPending: readonly T[],
+  priorRevisionPending: readonly T[],
+  earlyStageCapacity: number,
+): { pendingItems: T[]; remainingPriorRevisionPending: T[] } {
+  const availableCapacity = Math.max(
+    0,
+    Math.floor(Number(earlyStageCapacity) || 0) - currentPending.length,
+  );
+  const adopted = priorRevisionPending.slice(0, availableCapacity);
+  return {
+    pendingItems: [...currentPending, ...adopted],
+    remainingPriorRevisionPending: priorRevisionPending.slice(adopted.length),
+  };
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -33,6 +33,7 @@ import {
   countDistinctP2PendingUnits,
   isP2PhysicalProjectWorkOrder,
   p2PhysicalSerializedIdentity,
+  takeP2PriorRevisionPendingForLine,
 } from '../lib/p2ControlCenterReconciliation';
 import { softAuth, authenticateToken, sessionAwareAuth, requireAdminOrOwner } from '../../middleware/auth';
 import { computeEffectivePriority, getEffectivePriorityScore } from '../../../shared/utils/computeEffectivePriority';
@@ -5039,9 +5040,32 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       );
 
       const serializedByPoItemId = new Map<number, any[]>();
+      const priorRevisionPendingByPoAndPart = new Map<string, any[]>();
       for (const item of serializedItems as any[]) {
         const poItemId = Number(item.poItemId);
-        if (!poItemById.has(poItemId)) continue;
+        if (!poItemById.has(poItemId)) {
+          const status = String(item.status ?? '').trim().toUpperCase();
+          const department = String(
+            item.currentDepartment ?? item.current_department ?? ''
+          ).trim().toUpperCase();
+          const sourcePoId = Number(item.poId ?? item.po_id);
+          const partKey = normalizeP2ControlPartKey(
+            item.partNumber ?? item.part_number
+          );
+          if (
+            status === 'ACTIVE'
+            && (department === '' || department === 'PENDING LAYUP')
+            && Number.isFinite(sourcePoId)
+            && partKey
+          ) {
+            const poolKey = `${displayPoIdForPoId(sourcePoId)}:${partKey}`;
+            if (!priorRevisionPendingByPoAndPart.has(poolKey)) {
+              priorRevisionPendingByPoAndPart.set(poolKey, []);
+            }
+            priorRevisionPendingByPoAndPart.get(poolKey)!.push(item);
+          }
+          continue;
+        }
         if (!serializedByPoItemId.has(poItemId)) {
           serializedByPoItemId.set(poItemId, []);
         }
@@ -5098,6 +5122,21 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           const dept = String(s.currentDepartment || '').trim();
           return dept === '' || dept === 'Pending Layup';
         });
+
+        const priorRevisionPoolKey = `${displayPoIdForPoId(Number(poItem.poId))}:${normalizeP2ControlPartKey(poItem.partNumber)}`;
+        const priorRevisionPending = (
+          priorRevisionPendingByPoAndPart.get(priorRevisionPoolKey) ?? []
+        ).sort(sortBySequence);
+        const pooledPending = takeP2PriorRevisionPendingForLine(
+          pendingItems,
+          priorRevisionPending,
+          earlyStageCapacity,
+        );
+        pendingItems = pooledPending.pendingItems.sort(sortBySequence);
+        priorRevisionPendingByPoAndPart.set(
+          priorRevisionPoolKey,
+          pooledPending.remainingPriorRevisionPending,
+        );
 
         const pendingDeficit = p2PendingUnitDeficit(
           orderedQuantity,


### PR DESCRIPTION
## What changed

- retain active Pending Layup serials whose original PO item belongs to an earlier revision of the same PO family
- pool those serials by current PO revision and exact part number
- expose them through the current line only up to that line's remaining scheduling capacity
- preserve the original serialized-item IDs and historical PO ownership when scheduling
- add regression coverage for four prior-revision serials flowing past exhausted duplicate lines

## Root cause

The P2 status ledger counts serialized units across the PO revision family, but the Scheduling endpoint discarded every serialized row whose `poItemId` was not present among current-revision PO items. That made four valid pending units count on the status card while remaining invisible on the Schedule tab.

## Impact

The four PO014332-RA units can appear on the Schedule tab and be scheduled without rewriting historical audit relationships or generating replacement serial records.

## Validation

- `git diff --check` passed
- focused Vitest suite was not run because this isolated worktree does not contain `node_modules/.bin/vitest.cmd`
