### PR TITLE
Allow validation package creation with blank optional fields

### DIFF
--- a/client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
+++ b/client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
@@ -23,7 +23,7 @@ describe('EPOCH software validation create submission', () => {
     expect(compact).toContain('createSubmission.current=idempotencyKey;');
     expect(
       compact.indexOf('createSubmission.current=idempotencyKey;')
-    ).toBeLessThan(compact.indexOf('create.mutate({body:'));
+    ).toBeLessThan(compact.indexOf('create.mutate({body,'));
   });
 
   it('uses a fresh key per deliberate action and disables the pending submit', () => {
@@ -37,5 +37,11 @@ describe('EPOCH software validation create submission', () => {
     );
     expect(compact).toContain("'Creatingpackage\\u2026'");
     expect(compact).toContain('setSelected(p.id)');
+  });
+
+  it('omits blank optional values before creating a package', () => {
+    expect(compact).toContain("'productionDeploymentDate'");
+    expect(compact).toContain('if(!body[field]?.trim())deletebody[field]');
+    expect(compact).toContain('create.mutate({body,idempotencyKey,})');
   });
 });

--- a/client/src/pages/EpochSoftwareValidationPage.tsx
+++ b/client/src/pages/EpochSoftwareValidationPage.tsx
@@ -211,12 +211,22 @@ export default function EpochSoftwareValidationPage() {
   const submitCreate = (form: HTMLFormElement) => {
     if (createSubmission.current) return;
     const idempotencyKey = crypto.randomUUID();
+    const body = Object.fromEntries(new FormData(form).entries()) as Record<
+      string,
+      string
+    >;
+    for (const field of [
+      'commitOrReleaseIdentifier',
+      'productionDeploymentDate',
+      'previousApprovedPackageId',
+      'auditReadinessAssessmentId',
+      'notes',
+    ]) {
+      if (!body[field]?.trim()) delete body[field];
+    }
     createSubmission.current = idempotencyKey;
     create.mutate({
-      body: Object.fromEntries(new FormData(form).entries()) as Record<
-        string,
-        string
-      >,
+      body,
       idempotencyKey,
     });
   };

--- a/server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
@@ -25,6 +25,13 @@ describe('EPOCH validation package create idempotency architecture', () => {
     expect(migration).toContain('request_hash text NOT NULL');
   });
 
+  it('accepts omitted or blank optional create identifiers and dates', () => {
+    expect(route).toContain("value === '' ? undefined : value");
+    expect(route).toContain('productionDeploymentDate: optionalCreateDate');
+    expect(route).toContain('previousApprovedPackageId: optionalCreateUuid');
+    expect(route).toContain('auditReadinessAssessmentId: optionalCreateUuid');
+  });
+
   it('serializes same-key requests before allocating a package number', () => {
     const lock = route.indexOf('idempotency_key=$2 FOR UPDATE');
     const allocation = route.indexOf(

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -121,6 +121,15 @@ async function editable(req: Request, res: any) {
   return p;
 }
 
+const optionalCreateDate = z.preprocess(
+  (value) => (value === '' ? undefined : value),
+  z.string().date().optional()
+);
+const optionalCreateUuid = z.preprocess(
+  (value) => (value === '' ? undefined : value),
+  z.string().uuid().optional()
+);
+
 const createSchema = z.object({
   title: z.string().min(3).max(240),
   systemName: z.string().min(1).default('EPOCH'),
@@ -137,7 +146,7 @@ const createSchema = z.object({
   ]),
   productionVersion: z.string().min(1),
   commitOrReleaseIdentifier: z.string().max(240).optional(),
-  productionDeploymentDate: z.string().date().optional(),
+  productionDeploymentDate: optionalCreateDate,
   validationEnvironment: z.string().min(1),
   productionEnvironmentReference: z.string().min(1),
   databaseProvider: z.string().min(1),
@@ -148,8 +157,8 @@ const createSchema = z.object({
   plannedStartDate: z.string().date(),
   plannedCompletionDate: z.string().date(),
   reasonForValidation: z.string().min(3),
-  previousApprovedPackageId: z.string().uuid().optional(),
-  auditReadinessAssessmentId: z.string().uuid().optional(),
+  previousApprovedPackageId: optionalCreateUuid,
+  auditReadinessAssessmentId: optionalCreateUuid,
   notes: z.string().max(20000).optional(),
 });
 router.get(


### PR DESCRIPTION
## Summary

- omit blank optional fields from the EPOCH validation package create payload
- defensively normalize blank optional dates and UUIDs at the POST schema boundary
- add focused client and server regression coverage

## Root cause

The create form labels the production deployment date as optional, but native `FormData` submitted an empty string when it was left blank. The server schema accepted either a valid date or an omitted field, so the empty string caused `400 VALIDATION_ERROR` and prevented draft package creation.

## Impact

Users can create a validation package without filling optional deployment metadata. Required create fields, readiness gates, idempotency, authorization, execution, approval, and release controls remain unchanged. No production records are modified.

## Validation

- focused client validation tests: 7/7 passed
- focused server validation tests: 11/11 passed
- affected-file ESLint: zero errors; 25 pre-existing `no-explicit-any` warnings
- Prettier check: passed
- `git diff --check`: passed
- deployed `/api/boot-status`: ready, database healthy, routes ready, schema migrations complete

Authenticated browser submission was not performed because the available browser session had no session token.