### PR TITLE
Align P2 Scheduling with the status ledger

### DIFF
--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -55,6 +55,15 @@ describe('P2 shipment and scheduling reconciliation', () => {
     ], new Set())).toBe(1);
   });
 
+  it('uses the status ledger rules when allocating scheduling demand', () => {
+    expect(countDistinctP2DemandUnits([
+      { id: 'inventory-history', serialNumber: 'S-001', status: 'COMPLETED', currentDepartment: 'Inventory' },
+      { id: 'active', serialNumber: 'S-002', status: 'ACTIVE', currentDepartment: 'Oven/Cure' },
+      { id: 'scheduled', serialNumber: 'S-003', status: 'ACTIVE', currentDepartment: 'Layup' },
+      { id: 'pending', serialNumber: 'S-004', status: 'ACTIVE', currentDepartment: 'Pending Layup' },
+    ], new Set())).toBe(2);
+  });
+
   it('creates pending capacity for duplicate historical serialized rows', () => {
     const generated = countDistinctP2SerializedUnits([
       { id: 'original', serialNumber: 'ROC2600001', status: 'ACTIVE', currentDepartment: 'Layup' },

--- a/server/src/lib/p2SchedulingReconciliation.ts
+++ b/server/src/lib/p2SchedulingReconciliation.ts
@@ -1,4 +1,8 @@
-import type { P2SerializedUnitLedgerRow } from './p2SerializedUnitLedger';
+import {
+  buildP2SerializedUnitLedger,
+  countP2LedgerAccountedUnits,
+  type P2SerializedUnitLedgerRow,
+} from './p2SerializedUnitLedger';
 
 const normalized = (value: unknown) => String(value ?? '').trim().toUpperCase();
 
@@ -39,29 +43,12 @@ export function p2UnitConsumesOrderedDemand(
   row: P2SerializedUnitLedgerRow,
   shippedItemIds: ReadonlySet<string>,
 ): boolean {
-  const id = String(row.id ?? '').trim().toLowerCase();
-  if (id && shippedItemIds.has(id)) return true;
-  if (isHistoricalP2Unit(row)) return false;
-  if (row.finalizedAt ?? row.finalized_at) return true;
-
-  const status = normalized(row.status);
-  if (['COMPLETE', 'COMPLETED', 'CLOSED'].includes(status)) return true;
-  if (status !== 'ACTIVE') return false;
-
-  const department = normalized(row.currentDepartment ?? row.current_department);
-  return department !== '' && department !== 'PENDING LAYUP';
+  return buildP2SerializedUnitLedger(1, [row], shippedItemIds).accounted > 0;
 }
 
 export function countDistinctP2DemandUnits(
   rows: readonly P2SerializedUnitLedgerRow[],
   shippedItemIds: ReadonlySet<string>,
 ): number {
-  const identities = new Set<string>();
-  for (const row of rows) {
-    if (!p2UnitConsumesOrderedDemand(row, shippedItemIds)) continue;
-    const serial = normalized(row.serialNumber ?? row.serial_number);
-    const id = String(row.id ?? '').trim().toLowerCase();
-    if (serial || id) identities.add(serial || `ID:${id}`);
-  }
-  return identities.size;
+  return countP2LedgerAccountedUnits(rows, shippedItemIds);
 }

--- a/server/src/lib/p2SerializedUnitLedger.ts
+++ b/server/src/lib/p2SerializedUnitLedger.ts
@@ -75,20 +75,15 @@ const classify = (
   return null;
 };
 
-export function buildP2SerializedUnitLedger(
-  orderedQuantity: number,
+const bucketP2SerializedUnits = (
   rows: readonly P2SerializedUnitLedgerRow[],
-  shippedSerializedItemIds: Iterable<string>,
-): P2SerializedUnitLedger {
-  const total = Math.max(0, Math.trunc(Number(orderedQuantity) || 0));
+  shippedItemIds: Iterable<string>,
+) => {
   const shippedIds = new Set(
-    Array.from(shippedSerializedItemIds, (id) => String(id).trim().toLowerCase())
+    Array.from(shippedItemIds, (id) => String(id).trim().toLowerCase())
       .filter(Boolean),
   );
   const bucketBySerial = new Map<string, P2SerializedUnitBucket>();
-
-  // A serial can have historical duplicate rows. Evaluate every row and retain
-  // only the highest-precedence legitimate state for that physical unit.
   const precedence: Record<P2SerializedUnitBucket, number> = {
     shipped: 4,
     finalization: 3,
@@ -97,7 +92,7 @@ export function buildP2SerializedUnitLedger(
   };
   for (const row of rows) {
     const serial = serialKey(row);
-    if (!serial) continue; // excludes nonserialized/quantity-only ghost rows
+    if (!serial) continue;
     const bucket = classify(row, shippedIds);
     if (!bucket) continue;
     const existing = bucketBySerial.get(serial);
@@ -105,6 +100,25 @@ export function buildP2SerializedUnitLedger(
       bucketBySerial.set(serial, bucket);
     }
   }
+  return bucketBySerial;
+};
+
+export function countP2LedgerAccountedUnits(
+  rows: readonly P2SerializedUnitLedgerRow[],
+  shippedItemIds: Iterable<string>,
+): number {
+  return bucketP2SerializedUnits(rows, shippedItemIds).size;
+}
+
+export function buildP2SerializedUnitLedger(
+  orderedQuantity: number,
+  rows: readonly P2SerializedUnitLedgerRow[],
+  shippedSerializedItemIds: Iterable<string>,
+): P2SerializedUnitLedger {
+  const total = Math.max(0, Math.trunc(Number(orderedQuantity) || 0));
+  // A serial can have historical duplicate rows. Evaluate every row and retain
+  // only the highest-precedence legitimate state for that physical unit.
+  const bucketBySerial = bucketP2SerializedUnits(rows, shippedSerializedItemIds);
 
   const counts = {
     shipped: 0,


### PR DESCRIPTION
## What changed

- moved serialized-unit bucketing into a shared ledger helper
- made Scheduling use the same accounted-unit classification as the P2 status card
- stopped completed/closed inventory history from consuming scheduling capacity when the authoritative ledger excludes it
- added regression coverage for active, scheduled, pending, and historical inventory states

## Root cause

The status card and Scheduling used different definitions of consumed PO demand. The status ledger excludes completed inventory history unless it has valid shipment or finalization evidence, while Scheduling counted any `COMPLETE`, `COMPLETED`, or `CLOSED` serialized row. For PO014332-RA, that made the status card report four available units while Scheduling calculated that all 390 units were already consumed and returned no row.

## Impact

Both surfaces now use the same mutually exclusive serialized-unit ledger. The four-unit gap on PO014332-RA can be generated as pending serials and exposed on the Schedule tab without changing existing PO, shipment, scrap, or audit records.

## Validation

- verified the deployed mismatch live: status reports four available while Scheduling returns no PO014332-RA row
- `git diff --check` passed
- focused Vitest was unavailable because the isolated worktree does not contain `node_modules/.bin/vitest.cmd`
