### PR TITLE
Enable prospective-only P2 V2 project creation

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -557,7 +557,7 @@ export default function ProjectDetailPage() {
   });
   const effectiveWorkflowVersion = project?.effectiveWorkflowVersion;
   const isP2V2Workflow = effectiveWorkflowVersion === 'p2_v2';
-  const isLegacyWorkflow = !effectiveWorkflowVersion || effectiveWorkflowVersion === 'legacy_v1';
+  const isLegacyWorkflow = effectiveWorkflowVersion === 'legacy_v1';
   const hasUnknownWorkflowVersion = Boolean(project && !isP2V2Workflow && !isLegacyWorkflow);
 
   const { data: employees = [] } = useQuery<Employee[]>({

--- a/server/__tests__/projectWorkflowInstance.test.ts
+++ b/server/__tests__/projectWorkflowInstance.test.ts
@@ -131,10 +131,12 @@ describe('Phase 3 activation isolation', () => {
   const projectsRoute = read('server/src/routes/projects.ts');
   const quotesRoute = read('server/src/routes/quotes.ts');
 
-  it('keeps initialization internal and rejects legacy-effective projects', () => {
+  it('allows initialization only from transactional creation paths and rejects legacy-effective projects', () => {
     expect(service).toContain("version !== 'p2_v2'");
-    expect(projectsRoute).not.toContain('initializeV2Workflow');
-    expect(quotesRoute).not.toContain('initializeV2Workflow');
+    expect(projectsRoute).toContain('initializeV2Workflow(');
+    expect(quotesRoute).toContain('initializeV2Workflow(');
+    expect(projectsRoute).not.toMatch(/router\.post\([^)]*initialize/i);
+    expect(quotesRoute).not.toMatch(/router\.post\([^)]*initialize/i);
   });
 
   it('does not write project_steps or project workflow progress fields', () => {

--- a/server/__tests__/projectWorkflowRegistry.test.ts
+++ b/server/__tests__/projectWorkflowRegistry.test.ts
@@ -52,12 +52,12 @@ describe('project workflow registry', () => {
     expect(isLegacyProjectWorkflow('legacy_v1')).toBe(true);
   });
 
-  it('defines p2_v2 as ten inactive customer-PO workflow stages with no database steps', () => {
+  it('defines p2_v2 as ten initializable customer-PO workflow stages with no legacy database steps', () => {
     const definition = getProjectWorkflowDefinition('p2_v2');
     expect(definition).toMatchObject({
       version: 'p2_v2',
-      active: false,
-      initializable: false,
+      active: true,
+      initializable: true,
     });
     expect(definition.steps).toEqual([]);
     expect(
@@ -84,9 +84,7 @@ describe('project workflow registry', () => {
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
     ]);
     expect(isLegacyProjectWorkflow('p2_v2')).toBe(false);
-    expect(() => getInitializableProjectWorkflowSteps('p2_v2')).toThrow(
-      'p2_v2 workflow initialization is not available'
-    );
+    expect(getInitializableProjectWorkflowSteps('p2_v2')).toEqual([]);
   });
 
   it('retains the definition-version-1 snapshot without converting existing instances', () => {
@@ -217,7 +215,7 @@ describe('Phase 2 isolation guards', () => {
   const schema = read('server/schema.ts');
   const migrations = read('migrations/0199_project_workflow_version.sql');
 
-  it('derives both creation paths from legacy_v1 without activating p2_v2', () => {
+  it('keeps legacy step creation isolated from p2_v2 stage initialization', () => {
     expect(projectsRoute).toContain(
       "getInitializableProjectWorkflowSteps('legacy_v1')"
     );

--- a/server/__tests__/projectWorkflowVersion.test.ts
+++ b/server/__tests__/projectWorkflowVersion.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   getWorkflowVersionForNewProject,
@@ -47,16 +47,16 @@ describe('project workflow version resolution', () => {
     });
   });
 
-  it.each([undefined, 'false', 'invalid', 'true'])(
-    'keeps new creation fail-closed for flag %s',
+  it.each([undefined, 'false', 'invalid', 'TRUE', ' true', 'true '])(
+    'keeps new creation on legacy_v1 unless the flag is exactly true: %s',
     (flag) => {
-      const warning = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => undefined);
       expect(getWorkflowVersionForNewProject(flag)).toBe('legacy_v1');
-      warning.mockRestore();
     }
   );
+
+  it('selects p2_v2 for new projects only when the flag is exactly true', () => {
+    expect(getWorkflowVersionForNewProject('true')).toBe('p2_v2');
+  });
 });
 
 describe('Phase 1 additive migration and repair guards', () => {
@@ -92,11 +92,10 @@ describe('legacy creation and response compatibility guards', () => {
     ['manual', projectsRoute],
     ['accepted quote', quotesRoute],
   ])(
-    '%s creation explicitly stores the fail-closed workflow version',
+    '%s creation explicitly stores the prospective workflow selection',
     (_name, source) => {
-      expect(source).toContain(
-        'workflowVersion: getWorkflowVersionForNewProject()'
-      );
+      expect(source).toContain('const workflowVersion = getWorkflowVersionForNewProject()');
+      expect(source).toContain('workflowVersion,');
     }
   );
 
@@ -111,10 +110,19 @@ describe('legacy creation and response compatibility guards', () => {
 
   it('preserves the two existing initial-status expressions', () => {
     expect(projectsRoute).toContain('status: stepType.initialStatus');
-    expect(projectsRoute).toContain(
-      "isQuoteStep && quoteId ? { linkedQuoteId: quoteId, status: 'completed'"
+    expect(projectsRoute).toMatch(
+      /isQuoteStep\s*&&\s*quoteId\s*\?\s*\{[\s\S]{0,120}linkedQuoteId:\s*quoteId,[\s\S]{0,80}status:\s*'completed'/
     );
     expect(quotesRoute).toContain('status: stepDef.initialStatus');
+  });
+
+  it.each([
+    ['manual', projectsRoute],
+    ['accepted quote', quotesRoute],
+  ])('%s creation initializes V2 inside the project transaction', (_name, source) => {
+    expect(source).toContain('initializeV2Workflow(');
+    expect(source).toContain(', tx);');
+    expect(source).toContain("workflowVersion === 'legacy_v1' ? PROJECT_STEP_TYPES : []");
   });
 
   it('adds version serialization without replacing existing project response fields', () => {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -9,7 +9,7 @@ import multer from 'multer';
 
 import { storage } from '../../storage';
 import { db, pool } from '../../db';
-import { insertInventoryItemSchema } from '../../schema';
+import { insertInventoryItemSchema, projects } from '../../schema';
 import { createEmployeeIdentitySnapshot } from '../../identity/userIdentity';
 import {
   validateProjectClosing,
@@ -39,6 +39,7 @@ import {
 import {
   getActiveWorkflowInstanceForProject,
   getWorkflowReadModel,
+  initializeV2Workflow,
 } from '../services/projectWorkflowInstanceService';
 import {
   buildP2V2WorkflowResponse,
@@ -2322,17 +2323,29 @@ router.post('/', async (req, res) => {
       validatedData.customerId
     );
 
+    const workflowVersion = getWorkflowVersionForNewProject();
     const projectData = {
       ...projectFields,
       projectCode: nextCode,
-      workflowVersion: getWorkflowVersionForNewProject(),
+      workflowVersion,
       customersIntegerId,
       ...(customerNameSnapshot ? { customerNameSnapshot } : {}),
     };
 
-    const project = await storage.createProject(projectData);
+    const project = workflowVersion === 'p2_v2'
+      ? await db.transaction(async (tx) => {
+          const [created] = await tx.insert(projects).values(projectData).returning();
+          await initializeV2Workflow(created.id, {
+            id: req.user?.id,
+            username: req.user?.username,
+            displayName: req.user?.username,
+            role: req.user?.role,
+          }, tx);
+          return created;
+        })
+      : await storage.createProject(projectData);
 
-    for (const stepType of PROJECT_STEP_TYPES) {
+    for (const stepType of workflowVersion === 'legacy_v1' ? PROJECT_STEP_TYPES : []) {
       const isQuoteStep = stepType.type === 'quote';
       await storage.createProjectStep({
         projectId: project.id,

--- a/server/src/routes/quotes.ts
+++ b/server/src/routes/quotes.ts
@@ -52,6 +52,7 @@ import { storage } from '../../storage';
 import { createQuoteSnapshot } from '../services/quoteContractService';
 import { getWorkflowVersionForNewProject } from '../services/projectWorkflowVersionService';
 import { getInitializableProjectWorkflowSteps } from '../services/projectWorkflowRegistry';
+import { initializeV2Workflow } from '../services/projectWorkflowInstanceService';
 
 const PROJECT_STEP_TYPES = getInitializableProjectWorkflowSteps('legacy_v1');
 
@@ -695,6 +696,7 @@ router.patch('/api/quotes/:id/status', async (req: Request, res: Response) => {
 
         // 4. Auto-create the project (using tx)
         const projectName = `${lockedQuote.customerName} — ${lockedQuote.quoteNumber}`;
+        const workflowVersion = getWorkflowVersionForNewProject();
         const [project] = await tx
           .insert(projects)
           .values({
@@ -703,7 +705,7 @@ router.patch('/api/quotes/:id/status', async (req: Request, res: Response) => {
             customerId: lockedQuote.customerId,
             description: lockedQuote.description ?? null,
             status: 'active',
-            workflowVersion: getWorkflowVersionForNewProject(),
+            workflowVersion,
             // Carry the bridge FK from the quote so the project retains a resolvable
             // integer FK to the master customers table even though customerId is text.
             customersIntegerId: lockedQuote.customersIntegerId ?? null,
@@ -712,8 +714,17 @@ router.patch('/api/quotes/:id/status', async (req: Request, res: Response) => {
         const projectId = project.id;
         console.log(`[Quote→Project] Auto-created project ${project.projectCode} from accepted quote ${quote.quoteNumber}`);
 
-        // 5. Create all standard P2 workflow steps (using tx)
-        for (const stepDef of PROJECT_STEP_TYPES) {
+        if (workflowVersion === 'p2_v2') {
+          await initializeV2Workflow(projectId, {
+            id: req.user?.id,
+            username: req.user?.username,
+            displayName: req.user?.username,
+            role: req.user?.role,
+          }, tx);
+        }
+
+        // 5. Create legacy steps only for an explicitly legacy project.
+        for (const stepDef of workflowVersion === 'legacy_v1' ? PROJECT_STEP_TYPES : []) {
           await tx.insert(projectSteps).values({
             projectId,
             stepType: stepDef.type,

--- a/server/src/services/projectWorkflowRegistry.ts
+++ b/server/src/services/projectWorkflowRegistry.ts
@@ -284,8 +284,8 @@ export function getP2V2StagesForDefinitionVersion(
   );
 }
 
-// Internal-only snapshot source for Phase 3. This does not make p2_v2 active
-// or available to normal project creation.
+// Immutable snapshot source used when a newly-created p2_v2 project is
+// initialized in the same transaction as the project row.
 export function getInternalP2V2InitializationStages(): readonly ProjectWorkflowStageDefinition[] {
   return getProjectWorkflowDefinition('p2_v2').stages;
 }
@@ -304,8 +304,8 @@ const DEFINITIONS: Readonly<
   p2_v2: Object.freeze({
     version: 'p2_v2',
     label: 'P2 Project Workflow V2',
-    active: false,
-    initializable: false,
+    active: true,
+    initializable: true,
     steps: Object.freeze([]),
     stages: P2_V2_STAGES,
   }),
@@ -369,9 +369,9 @@ export function validateProjectWorkflowDefinition(
       throw new ProjectWorkflowDefinitionValidationError(
         'p2_v2 must have exactly ten metadata stages'
       );
-    if (definition.initializable || definition.steps.length > 0)
+    if (!definition.active || !definition.initializable || definition.steps.length > 0)
       throw new ProjectWorkflowDefinitionValidationError(
-        'p2_v2 must remain inactive and non-initializable'
+        'p2_v2 must be active and initializable only through stage instances'
       );
   }
 }

--- a/server/src/services/projectWorkflowVersionService.ts
+++ b/server/src/services/projectWorkflowVersionService.ts
@@ -44,16 +44,8 @@ export function serializeProjectWorkflowVersion<
   };
 }
 
-// Phase 1 is deliberately fail-closed until the p2_v2 initializer exists.
 export function getWorkflowVersionForNewProject(
   flagValue = process.env.P2_V2_WORKFLOW_CREATION_ENABLED
 ): ProjectWorkflowVersion {
-  const requested =
-    typeof flagValue === 'string' && flagValue.trim().toLowerCase() === 'true';
-  if (requested) {
-    console.warn(
-      '[Projects] P2_V2_WORKFLOW_CREATION_ENABLED requested, but p2_v2 initialization is unavailable; creating legacy_v1'
-    );
-  }
-  return 'legacy_v1';
+  return flagValue === 'true' ? 'p2_v2' : 'legacy_v1';
 }


### PR DESCRIPTION
## Summary

- select `p2_v2` only for projects created while `P2_V2_WORKFLOW_CREATION_ENABLED` is exactly `true`
- initialize exactly one immutable ten-stage V2 workflow in the same transaction as project creation
- keep null and explicit `legacy_v1` projects on the existing legacy steps and UI
- route Project Detail strictly from `effectiveWorkflowVersion` and fail closed for unsupported values

## Safety

- no migration or legacy data update
- no Production Launch flag or deployment configuration change
- no automatic fallback to legacy after V2 creation is selected
- database uniqueness continues to prevent duplicate active V2 instances

## Validation

- focused server Vitest: 52/52 passed
- P2 V2 component Vitest: 4/4 passed
- `git diff --check`: passed
- TypeScript: timed out and is not counted as passed
- disposable PostgreSQL before/after legacy-table certification was unavailable locally and remains required before merge/activation

## Activation boundary

This PR does not enable the creation flag or the separate Production Launch flag in any environment. PostgreSQL preservation certification and the remaining full checks are required before controlled activation.