### PR TITLE
Fix post-merge Design Project certification formatting

### DIFF
--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -428,8 +428,9 @@ export async function runSafeBootMigrations() {
   if (process.env.SAFE_BOOT_MIGRATIONS_ONLY === 'true') return;
 
   try {
-    const { logCriticalSchemaHealth } =
-      await import('../../utils/schemaHealth');
+    const { logCriticalSchemaHealth } = await import(
+      '../../utils/schemaHealth'
+    );
     await logCriticalSchemaHealth();
   } catch (caughtSchemaHealthErr: unknown) {
     const schemaHealthErr = caughtSchemaHealthErr as MigrationError;
@@ -440,8 +441,9 @@ export async function runSafeBootMigrations() {
   }
 
   try {
-    const { migrateVendorDocumentUrls } =
-      await import('../../src/routes/vendors');
+    const { migrateVendorDocumentUrls } = await import(
+      '../../src/routes/vendors'
+    );
     await migrateVendorDocumentUrls();
   } catch (caughtVendorMigrErr: unknown) {
     const vendorMigrErr = caughtVendorMigrErr as MigrationError;

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -2332,20 +2332,30 @@ router.post('/', async (req, res) => {
       ...(customerNameSnapshot ? { customerNameSnapshot } : {}),
     };
 
-    const project = workflowVersion === 'p2_v2'
-      ? await db.transaction(async (tx) => {
-          const [created] = await tx.insert(projects).values(projectData).returning();
-          await initializeV2Workflow(created.id, {
-            id: req.user?.id,
-            username: req.user?.username,
-            displayName: req.user?.username,
-            role: req.user?.role,
-          }, tx);
-          return created;
-        })
-      : await storage.createProject(projectData);
+    const project =
+      workflowVersion === 'p2_v2'
+        ? await db.transaction(async (tx) => {
+            const [created] = await tx
+              .insert(projects)
+              .values(projectData)
+              .returning();
+            await initializeV2Workflow(
+              created.id,
+              {
+                id: req.user?.id,
+                username: req.user?.username,
+                displayName: req.user?.username,
+                role: req.user?.role,
+              },
+              tx
+            );
+            return created;
+          })
+        : await storage.createProject(projectData);
 
-    for (const stepType of workflowVersion === 'legacy_v1' ? PROJECT_STEP_TYPES : []) {
+    for (const stepType of workflowVersion === 'legacy_v1'
+      ? PROJECT_STEP_TYPES
+      : []) {
       const isQuoteStep = stepType.type === 'quote';
       await storage.createProjectStep({
         projectId: project.id,


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1627. PR #1627 was merged while its final P2 V2 certification job was still failing. The schema, migration, PostgreSQL, synthetic-pilot, and TypeScript corrections were included in the merge; this PR carries the one post-merge commit that did not reach `main`.

## Changes

- Restore repository-native formatting for the two dynamic imports in `runSafeBootMigrations.ts`.
- Format the existing P2 V2 project-creation transaction block in `projects.ts`.

There are no logic, schema, migration, database, or production-enforcement changes.

## Evidence

On the final PR #1627 run:
- Part Specification Sheet PostgreSQL certification passed.
- P2 V2 synthetic-pilot certification passed.
- Bounded TypeScript certification completed without the former `engineeringChangeRequests` diagnostics.
- The remaining failure was only 15 Prettier diagnostics: 2 in the migration runner and 13 in the project-creation block. This diff directly applies those requested formatting changes.

Local `git diff --check` passes. The borrowed local dependency tree uses a different Prettier version, so GitHub Actions remains the authoritative formatter check.