### PR TITLE
Fix EPOCH validation creation response handling

### DIFF
--- a/client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
+++ b/client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
@@ -44,4 +44,39 @@ describe('EPOCH software validation create submission', () => {
     expect(compact).toContain('if(!body[field]?.trim())deletebody[field]');
     expect(compact).toContain('create.mutate({body,idempotencyKey,})');
   });
+
+  it('uses the parsed API helper result exactly once', () => {
+    expect(compact).toContain(
+      "returnrequestJson<Package>('/api/qms/epoch-software-validation',{"
+    );
+    expect(source).not.toContain('.json()');
+  });
+
+  it('treats a successful create as successful and opens the package', () => {
+    expect(source).toContain('Controlled draft created successfully.');
+    expect(compact).toContain('setCreateOpen(false)');
+    expect(compact).toContain('setSelected(p.id)');
+    expect(compact).toContain(
+      "qc.invalidateQueries({queryKey:['/api/qms/epoch-software-validation']},{throwOnError:true})"
+    );
+  });
+
+  it('reserves the idempotency guard and offers refresh after uncertain UI recovery', () => {
+    expect(source).toContain(
+      'The draft was created, but EPOCH could not refresh the screen. Refresh the package list before trying again.'
+    );
+    expect(source).toContain('Refresh package list');
+    expect(compact).toContain('setCreateRecovery(p)');
+    expect(compact).toContain('disabled={Boolean(createRecovery)}');
+    expect(compact).not.toContain(
+      'catch{createSubmission.current=null;setCreateRecovery(p)'
+    );
+  });
+
+  it('only reports create failure from the request error path', () => {
+    expect(source).toContain("title: 'Package was not created'");
+    expect(compact).toContain(
+      'onError:(e:Error)=>{createSubmission.current=null;'
+    );
+  });
 });

--- a/client/src/pages/EpochSoftwareValidationPage.tsx
+++ b/client/src/pages/EpochSoftwareValidationPage.tsx
@@ -43,6 +43,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Textarea } from '@/components/ui/textarea';
+import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/hooks/use-toast';
 
 type Package = {
@@ -73,6 +74,11 @@ type Package = {
   execution_count?: number;
   open_defect_count?: number;
 };
+
+const requestJson = <T,>(
+  url: string,
+  options?: Parameters<typeof apiRequest>[1]
+) => apiRequest(url, options) as Promise<T>;
 type Detail = {
   package: Package;
   intendedUse: any[];
@@ -151,53 +157,94 @@ export default function EpochSoftwareValidationPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [auditor, setAuditor] = useState(false);
   const [activeSection, setActiveSection] = useState('01');
+  const [createRecovery, setCreateRecovery] = useState<Package>();
   const createSubmission = useRef<string | null>(null);
   const qc = useQueryClient(),
     { toast } = useToast();
   const list = useQuery<Package[]>({
     queryKey: ['/api/qms/epoch-software-validation'],
-    queryFn: async () =>
-      (await apiRequest('/api/qms/epoch-software-validation')).json(),
+    queryFn: () => requestJson<Package[]>('/api/qms/epoch-software-validation'),
   });
   const detail = useQuery<Detail>({
     queryKey: ['/api/qms/epoch-software-validation', selected],
     enabled: Boolean(selected),
-    queryFn: async () =>
-      (
-        await apiRequest(`/api/qms/epoch-software-validation/${selected}`)
-      ).json(),
+    queryFn: () =>
+      requestJson<Detail>(`/api/qms/epoch-software-validation/${selected}`),
   });
   const employees = useQuery<Employee[]>({
     queryKey: ['/api/employees'],
-    queryFn: async () => (await apiRequest('/api/employees')).json(),
+    queryFn: () => requestJson<Employee[]>('/api/employees'),
   });
   const assessments = useQuery<Assessment[]>({
     queryKey: ['/api/qms/as9100-audit-readiness'],
-    queryFn: async () =>
-      (await apiRequest('/api/qms/as9100-audit-readiness')).json(),
+    queryFn: () => requestJson<Assessment[]>('/api/qms/as9100-audit-readiness'),
   });
+  const refreshCreatedPackage = async (created: Package) => {
+    try {
+      await qc.invalidateQueries(
+        { queryKey: ['/api/qms/epoch-software-validation'] },
+        { throwOnError: true }
+      );
+      setSelected(created.id);
+      setCreateRecovery(undefined);
+      createSubmission.current = null;
+      toast({
+        title: 'Package list refreshed',
+        description: `${created.package_number} is open.`,
+      });
+    } catch (error) {
+      toast({
+        title: 'Package list refresh failed',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Refresh the package list before trying again.',
+        variant: 'destructive',
+      });
+    }
+  };
   const create = useMutation({
     retry: false,
     mutationFn: async (input: {
       body: Record<string, string>;
       idempotencyKey: string;
     }) => {
-      return (
-        await apiRequest('/api/qms/epoch-software-validation', {
-          method: 'POST',
-          body: input.body,
-          headers: { 'Idempotency-Key': input.idempotencyKey },
-        })
-      ).json();
-    },
-    onSuccess: (p: Package) => {
-      qc.invalidateQueries({
-        queryKey: ['/api/qms/epoch-software-validation'],
+      return requestJson<Package>('/api/qms/epoch-software-validation', {
+        method: 'POST',
+        body: input.body,
+        headers: { 'Idempotency-Key': input.idempotencyKey },
       });
-      createSubmission.current = null;
+    },
+    onSuccess: async (p: Package) => {
       setCreateOpen(false);
       setSelected(p.id);
-      toast({ title: `${p.package_number} created` });
+      toast({
+        title: 'Controlled draft created successfully.',
+        description: p.package_number,
+      });
+      try {
+        await qc.invalidateQueries(
+          { queryKey: ['/api/qms/epoch-software-validation'] },
+          { throwOnError: true }
+        );
+        createSubmission.current = null;
+      } catch {
+        setCreateRecovery(p);
+        toast({
+          title: 'Draft created; refresh needed',
+          description:
+            'The draft was created, but EPOCH could not refresh the screen. Refresh the package list before trying again.',
+          variant: 'destructive',
+          action: (
+            <ToastAction
+              altText="Refresh package list"
+              onClick={() => void refreshCreatedPackage(p)}
+            >
+              Refresh package list
+            </ToastAction>
+          ),
+        });
+      }
     },
     onError: (e: Error) => {
       createSubmission.current = null;
@@ -242,8 +289,9 @@ export default function EpochSoftwareValidationPage() {
           return value && value !== 'NONE' ? Number(value) : null;
         };
       const assessment = f.get('auditReadinessAssessmentId');
-      return (
-        await apiRequest(`/api/qms/epoch-software-validation/${selected}`, {
+      return requestJson<Package>(
+        `/api/qms/epoch-software-validation/${selected}`,
+        {
           method: 'PATCH',
           body: {
             rowVersion: detail.data!.package.row_version,
@@ -264,8 +312,8 @@ export default function EpochSoftwareValidationPage() {
                 : String(assessment),
             notes: f.get('notes') || null,
           },
-        })
-      ).json();
+        }
+      );
     },
     onSuccess: () => {
       refresh();
@@ -281,12 +329,10 @@ export default function EpochSoftwareValidationPage() {
   });
   const confirm = useMutation({
     mutationFn: async (kind: 'deployment-date' | 'environment-separation') =>
-      (
-        await apiRequest(
-          `/api/qms/epoch-software-validation/${selected}/confirm-${kind}`,
-          { method: 'POST', body: {} }
-        )
-      ).json(),
+      requestJson<Package>(
+        `/api/qms/epoch-software-validation/${selected}/confirm-${kind}`,
+        { method: 'POST', body: {} }
+      ),
     onSuccess: () => {
       refresh();
       toast({ title: 'Authenticated confirmation recorded' });
@@ -675,7 +721,7 @@ export default function EpochSoftwareValidationPage() {
         </div>
         <Dialog open={createOpen} onOpenChange={setCreateOpen}>
           <DialogTrigger asChild>
-            <Button>
+            <Button disabled={Boolean(createRecovery)}>
               <Plus className="mr-2 h-4 w-4" />
               New validation package
             </Button>
@@ -791,6 +837,27 @@ export default function EpochSoftwareValidationPage() {
           </DialogContent>
         </Dialog>
       </div>
+      {createRecovery && (
+        <Card className="border-amber-300">
+          <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-6">
+            <div>
+              <p className="font-medium">
+                {createRecovery.package_number} was created.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Refresh the package list before creating another package.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void refreshCreatedPackage(createRecovery)}
+            >
+              Refresh package list
+            </Button>
+          </CardContent>
+        </Card>
+      )}
       <Card>
         <CardContent className="pt-6 text-sm text-muted-foreground">
           This workflow does not assert that AS9100 requires a commercial ERP or


### PR DESCRIPTION
## Summary

- use the shared `apiRequest` helper according to its parsed-response contract throughout the EPOCH Software Validation page
- treat a successful package POST as successful, close the dialog, select the returned package, show its number, and refresh the list
- preserve the idempotency guard and provide a safe `Refresh package list` recovery path if post-create screen refresh fails
- retain blank optional-field normalization, double-click protection, readiness gates, authorization, and controlled DRAFT behavior

## Root cause

`apiRequest` already parses successful JSON responses and returns the parsed value. The create mutation called `.json()` on the returned package object, producing `(intermediate value).json is not a function` after the server had already created the record. React Query then routed that client-side parsing error through `onError`, causing the false `Package was not created` toast.

## Validation

- focused Software Validation client tests: 11/11 passed
- focused Software Validation server tests: 11/11 passed
- affected-entry TypeScript check: passed
- full repository TypeScript check: unavailable after exhausting both 2 GB and 4 GB Node heap limits without diagnostics
- focused ESLint: zero errors; 14 pre-existing `no-explicit-any` warnings
- focused Prettier: passed
- `git diff --check`: passed

## Browser validation

The deployed site was reachable and boot-ready, but the available browser session had no authenticated session token. No production create request was sent. ESV-2026-0013 was not modified, deleted, or recreated.