### PR TITLE
Add guided EPOCH validation wizard Phase 1

### DIFF
--- a/client/src/__tests__/epochSoftwareValidationWizardPhase1.component.test.tsx
+++ b/client/src/__tests__/epochSoftwareValidationWizardPhase1.component.test.tsx
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+const wizard = fs.readFileSync(
+  path.resolve(
+    import.meta.dirname,
+    '../components/qms/EpochValidationWizard.tsx'
+  ),
+  'utf8'
+);
+const page = fs.readFileSync(
+  path.resolve(import.meta.dirname, '../pages/EpochSoftwareValidationPage.tsx'),
+  'utf8'
+);
+const compact = wizard.replace(/\s+/g, '');
+
+describe('EPOCH software validation wizard Phase 1 UI', () => {
+  it('replaces the selected-package view with the guided wizard', () => {
+    expect(page).toContain('import { EpochValidationWizard }');
+    expect(page).toContain('<EpochValidationWizard');
+    expect(page).toContain('employees={employees.data || []}');
+  });
+
+  it('shows all nine steps while keeping later phases visibly unavailable', () => {
+    for (const step of [
+      'Setup',
+      'Intended Use',
+      'Responsibilities',
+      'Risk Review',
+      'Test Plan',
+      'Perform Tests',
+      'Resolve Issues',
+      'Review & Approve',
+      'Auditor Package',
+    ]) {
+      expect(wizard).toContain(`'${step}'`);
+    }
+    expect(wizard).toContain('Not available yet');
+    expect(compact).toContain('constavailable=index<3');
+    expect(compact).toContain('disabled={!available}');
+  });
+
+  it('provides the package dashboard, progress, next action, and safe navigation', () => {
+    expect(wizard).toContain('Overall completion');
+    expect(wizard).toContain('Incomplete items');
+    expect(wizard).toContain('Next required action');
+    expect(wizard).toContain('beforeunload');
+    expect(wizard).toContain(
+      'You have unsaved changes. Leave this step without saving?'
+    );
+    expect(wizard).toContain('Save and exit');
+    expect(wizard).toContain('aria-label="Validation wizard steps"');
+  });
+
+  it('supports plain-language setup with advanced technical details', () => {
+    expect(wizard).toContain('Why are we validating EPOCH?');
+    expect(wizard).toContain('Advanced technical details');
+    expect(wizard).toContain(
+      'Exact production commit SHA, release tag, or deployment ID'
+    );
+    expect(compact).toContain("method:'PATCH'");
+    expect(wizard).toContain('/wizard/setup');
+    expect(wizard).toContain('Controlled draft saved');
+  });
+
+  it('captures per-function intended use and failure effects as a draft revision', () => {
+    expect(wizard).toContain('EPOCH functions in scope');
+    expect(wizard).toContain('How does the company use this function?');
+    expect(wizard).toContain('What could happen if it did not work correctly?');
+    expect(wizard).toContain('Critical to product quality');
+    expect(wizard).toContain(
+      'Explain why this function is not used for an approved QMS purpose.'
+    );
+    expect(wizard).toContain('Intended Use revision saved as DRAFT');
+    expect(wizard).toContain('functions: Object.values(functions)');
+  });
+
+  it('assigns active employees and exposes personal acceptance', () => {
+    expect(wizard).toContain('Search active employees');
+    expect(wizard).toContain('Additional testers');
+    expect(wizard).toContain('Final approving authority');
+    expect(wizard).toContain('Accept responsibility');
+    expect(wizard).toContain('/api/auth/session');
+    expect(compact).toContain("method:'PUT'");
+    expect(wizard).toContain('/accept');
+  });
+
+  it('uses the parsed shared API response without a second parse', () => {
+    expect(wizard).toContain('apiRequest(url, options) as Promise<T>');
+    expect(wizard).not.toContain('.json()');
+  });
+});

--- a/client/src/components/qms/EpochValidationWizard.tsx
+++ b/client/src/components/qms/EpochValidationWizard.tsx
@@ -1,0 +1,1307 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  CircleDashed,
+  Lock,
+  Search,
+  Users,
+} from 'lucide-react';
+
+import { apiRequest } from '@/lib/queryClient';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+
+type Employee = {
+  id: number;
+  name: string;
+  department?: string;
+  position?: string;
+  is_active?: boolean;
+};
+
+type PackageRecord = Record<string, any> & {
+  id: string;
+  package_number: string;
+  title: string;
+  status: string;
+  system_name: string;
+  production_version: string;
+  validation_type: string;
+  planned_start_date: string;
+  planned_completion_date: string;
+  reason_for_validation: string;
+  row_version: number;
+};
+
+type FunctionSelection = {
+  function_key: string;
+  usage_status: 'USED_FOR_QMS' | 'NOT_USED_FOR_QMS';
+  use_description?: string | null;
+  failure_effect?: string | null;
+  critical_to_qms: boolean;
+  not_used_explanation?: string | null;
+};
+
+type Responsibility = {
+  id: string;
+  responsibility_role: ResponsibilityRole;
+  employee_id: number;
+  employee_name: string;
+  assignment_status: string;
+  accepted_at?: string | null;
+};
+
+type ResponsibilityRole =
+  | 'SOFTWARE_OWNER'
+  | 'QUALITY_REVIEWER'
+  | 'VALIDATION_COORDINATOR'
+  | 'ADDITIONAL_TESTER'
+  | 'FINAL_APPROVING_AUTHORITY';
+
+type Detail = Record<string, any> & {
+  package: PackageRecord;
+  intendedUse: Array<Record<string, any>>;
+  intendedUseFunctions: FunctionSelection[];
+  responsibilities: Responsibility[];
+  packageReadiness: {
+    executionReady: boolean;
+    blockers: string[];
+    items: Array<{
+      key: string;
+      label: string;
+      state: string;
+      message?: string;
+    }>;
+  };
+  readiness: Record<string, any>;
+  risks: Array<Record<string, any>>;
+  protocols: Array<Record<string, any>>;
+  executions: Array<Record<string, any>>;
+  defects: Array<Record<string, any>>;
+};
+
+type Props = {
+  detail: Detail;
+  employees: Employee[];
+  onBack: () => void;
+};
+
+const requestJson = <T,>(
+  url: string,
+  options?: Parameters<typeof apiRequest>[1]
+) => apiRequest(url, options) as Promise<T>;
+
+const steps = [
+  ['1', 'Setup', 'Define why this validation is being performed.'],
+  ['2', 'Intended Use', 'Document the approved QMS uses in plain language.'],
+  [
+    '3',
+    'Responsibilities',
+    'Assign accountable employees and obtain acceptance.',
+  ],
+  ['4', 'Risk Review', 'Review risks generated from intended uses.'],
+  ['5', 'Test Plan', 'Prepare and approve objective validation tests.'],
+  ['6', 'Perform Tests', 'Execute approved tests and retain evidence.'],
+  ['7', 'Resolve Issues', 'Control failures, deviations, and retesting.'],
+  [
+    '8',
+    'Review & Approve',
+    'Confirm readiness and record authorized decisions.',
+  ],
+  ['9', 'Auditor Package', 'Preview and print the retained evidence package.'],
+] as const;
+
+const epochFunctions = [
+  'User login and account access',
+  'Employee permissions and authorization',
+  'Electronic approvals',
+  'Audit history',
+  'Controlled documents',
+  'Receiving',
+  'Inventory',
+  'Material lot traceability and genealogy',
+  'Work orders',
+  'Routing',
+  'Travelers',
+  'Inspection and testing',
+  'Final product release',
+  'Nonconformance and corrective action',
+  'Training and employee qualifications',
+  'Design Control',
+  'Engineering release and change control',
+  'Record searching, retrieval, and export',
+  'Backup, restoration, and outage continuity',
+] as const;
+
+const responsibilityDefinitions: Array<{
+  role: ResponsibilityRole;
+  label: string;
+  help: string;
+  multiple?: boolean;
+}> = [
+  {
+    role: 'SOFTWARE_OWNER',
+    label: 'Software owner',
+    help: 'Accountable for the EPOCH system and technical coordination.',
+  },
+  {
+    role: 'QUALITY_REVIEWER',
+    label: 'Quality reviewer',
+    help: 'Reviews QMS scope, risks, evidence, and validation conclusions.',
+  },
+  {
+    role: 'VALIDATION_COORDINATOR',
+    label: 'Validation coordinator',
+    help: 'Coordinates the package, schedule, tests, and missing evidence.',
+  },
+  {
+    role: 'ADDITIONAL_TESTER',
+    label: 'Additional testers',
+    help: 'Employees assigned to perform approved validation tests.',
+    multiple: true,
+  },
+  {
+    role: 'FINAL_APPROVING_AUTHORITY',
+    label: 'Final approving authority',
+    help: 'Authorized person responsible for the final validation decision.',
+  },
+];
+
+const pretty = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+export function EpochValidationWizard({ detail, employees, onBack }: Props) {
+  const p = detail.package;
+  const qc = useQueryClient();
+  const { toast } = useToast();
+  const activeEmployees = useMemo(
+    () => employees.filter((employee) => employee.is_active !== false),
+    [employees]
+  );
+  const setupComplete = Boolean(
+    p.title &&
+    p.reason_for_validation &&
+    p.planned_start_date &&
+    p.planned_completion_date
+  );
+  const intendedComplete = Boolean(
+    detail.intendedUse.length && detail.intendedUseFunctions.length
+  );
+  const requiredRoles: ResponsibilityRole[] = [
+    'SOFTWARE_OWNER',
+    'QUALITY_REVIEWER',
+    'VALIDATION_COORDINATOR',
+    'FINAL_APPROVING_AUTHORITY',
+  ];
+  const responsibilitiesComplete = requiredRoles.every((role) =>
+    detail.responsibilities.some(
+      (item) =>
+        item.responsibility_role === role &&
+        item.assignment_status === 'ACCEPTED'
+    )
+  );
+  const firstIncomplete = !setupComplete ? 1 : !intendedComplete ? 2 : 3;
+  const [currentStep, setCurrentStep] = useState(firstIncomplete);
+  const [dirty, setDirty] = useState(false);
+  const implementedComplete = [
+    setupComplete,
+    intendedComplete,
+    responsibilitiesComplete,
+  ];
+  const completion = Math.round(
+    (implementedComplete.filter(Boolean).length / steps.length) * 100
+  );
+  const missingCount =
+    Number(!setupComplete) +
+    Number(!intendedComplete) +
+    requiredRoles.filter(
+      (role) =>
+        !detail.responsibilities.some(
+          (item) =>
+            item.responsibility_role === role &&
+            item.assignment_status === 'ACCEPTED'
+        )
+    ).length;
+
+  useEffect(() => {
+    const warn = (event: BeforeUnloadEvent) => {
+      if (!dirty) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', warn);
+    return () => window.removeEventListener('beforeunload', warn);
+  }, [dirty]);
+
+  const refresh = async () => {
+    await Promise.all([
+      qc.invalidateQueries({
+        queryKey: ['/api/qms/epoch-software-validation', p.id],
+      }),
+      qc.invalidateQueries({
+        queryKey: ['/api/qms/epoch-software-validation'],
+      }),
+    ]);
+  };
+  const navigate = (step: number) => {
+    if (
+      dirty &&
+      !window.confirm(
+        'You have unsaved changes. Leave this step without saving?'
+      )
+    )
+      return;
+    setDirty(false);
+    setCurrentStep(step);
+  };
+
+  const nextAction = !setupComplete
+    ? 'Complete Setup'
+    : !intendedComplete
+      ? 'Complete Intended Use'
+      : !responsibilitiesComplete
+        ? 'Assign and accept required responsibilities'
+        : 'Phase 1 complete — Risk Review will be added in Phase 2';
+
+  return (
+    <div className="container mx-auto space-y-5 p-4 lg:p-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <Button variant="ghost" className="px-0" onClick={onBack}>
+            <ArrowLeft className="mr-2 h-4 w-4" /> Validation packages
+          </Button>
+          <h1 className="text-2xl font-bold">
+            {p.package_number} · {p.title}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Objective evidence that EPOCH is suitable for the
+            organization&apos;s approved QMS and manufacturing intended uses.
+          </p>
+        </div>
+        <Badge variant={p.status === 'DRAFT' ? 'outline' : 'default'}>
+          {pretty(p.status)}
+        </Badge>
+      </header>
+
+      <Card>
+        <CardContent className="grid gap-4 pt-6 sm:grid-cols-2 lg:grid-cols-4">
+          <Summary
+            label="Current step"
+            value={`${currentStep}. ${steps[currentStep - 1][1]}`}
+          />
+          <Summary label="Overall completion" value={`${completion}%`} />
+          <Summary label="Incomplete items" value={String(missingCount)} />
+          <Summary
+            label="Planned completion"
+            value={p.planned_completion_date || 'Not entered'}
+          />
+          <div className="sm:col-span-2 lg:col-span-4">
+            <div className="mb-2 flex justify-between text-sm">
+              <span>Phase 1 workflow progress</span>
+              <span>{completion}%</span>
+            </div>
+            <Progress value={completion} />
+          </div>
+          <div className="rounded-md bg-muted p-3 sm:col-span-2 lg:col-span-4">
+            <span className="font-medium">Next required action: </span>
+            {nextAction}
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-5 lg:grid-cols-[300px_1fr]">
+        <nav aria-label="Validation wizard steps">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Validation workflow</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {steps.map(([number, title, help], index) => {
+                const available = index < 3;
+                const done = implementedComplete[index] || false;
+                return (
+                  <button
+                    key={number}
+                    type="button"
+                    disabled={!available}
+                    aria-current={
+                      currentStep === index + 1 ? 'step' : undefined
+                    }
+                    onClick={() => navigate(index + 1)}
+                    className={`w-full rounded-md border p-3 text-left ${
+                      currentStep === index + 1
+                        ? 'border-primary bg-primary/5'
+                        : 'hover:bg-muted'
+                    } disabled:cursor-not-allowed disabled:opacity-60`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium">
+                        {number}. {title}
+                      </span>
+                      {done ? (
+                        <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                      ) : available ? (
+                        <CircleDashed className="h-4 w-4 text-amber-600" />
+                      ) : (
+                        <Badge variant="outline">Not available yet</Badge>
+                      )}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{help}</p>
+                  </button>
+                );
+              })}
+            </CardContent>
+          </Card>
+        </nav>
+
+        <main>
+          {currentStep === 1 && (
+            <SetupStep
+              detail={detail}
+              onDirty={() => setDirty(true)}
+              onSaved={async () => {
+                setDirty(false);
+                await refresh();
+                setCurrentStep(2);
+              }}
+            />
+          )}
+          {currentStep === 2 && (
+            <IntendedUseStep
+              detail={detail}
+              onDirty={() => setDirty(true)}
+              onSaved={async () => {
+                setDirty(false);
+                await refresh();
+                setCurrentStep(3);
+              }}
+            />
+          )}
+          {currentStep === 3 && (
+            <ResponsibilitiesStep
+              detail={detail}
+              employees={activeEmployees}
+              onDirty={() => setDirty(true)}
+              onSaved={async () => {
+                setDirty(false);
+                await refresh();
+              }}
+            />
+          )}
+          {currentStep > 3 && <UnavailableStep step={currentStep} />}
+        </main>
+      </div>
+
+      <div className="sticky bottom-0 flex flex-wrap items-center justify-between gap-3 border-t bg-background/95 py-3 backdrop-blur">
+        <Button
+          variant="outline"
+          disabled={currentStep === 1}
+          onClick={() => navigate(currentStep - 1)}
+        >
+          <ChevronLeft className="mr-2 h-4 w-4" /> Previous
+        </Button>
+        <div className="text-sm text-muted-foreground">
+          {dirty ? 'Unsaved changes' : 'All changes saved'}
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => {
+              if (dirty) {
+                toast({
+                  title: 'Save this step before exiting',
+                  variant: 'destructive',
+                });
+                return;
+              }
+              onBack();
+            }}
+          >
+            Save and exit
+          </Button>
+          <Button
+            disabled={currentStep >= 3}
+            onClick={() => navigate(currentStep + 1)}
+          >
+            Continue <ChevronRight className="ml-2 h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SetupStep({
+  detail,
+  onDirty,
+  onSaved,
+}: {
+  detail: Detail;
+  onDirty: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const p = detail.package;
+  const { toast } = useToast();
+  const save = useMutation({
+    mutationFn: (body: Record<string, unknown>) =>
+      requestJson(`/api/qms/epoch-software-validation/${p.id}/wizard/setup`, {
+        method: 'PATCH',
+        body,
+      }),
+    onSuccess: async () => {
+      toast({ title: 'Controlled draft saved' });
+      await onSaved();
+    },
+    onError: (error: Error) =>
+      toast({
+        title: 'Setup could not be saved',
+        description: error.message,
+        variant: 'destructive',
+      }),
+  });
+  const technicalMissing =
+    !p.commit_or_release_identifier || !p.production_deployment_date;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>1. Setup</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Start with the purpose and schedule. An incomplete package remains a
+          controlled DRAFT.
+        </p>
+      </CardHeader>
+      <CardContent>
+        {technicalMissing && (
+          <div className="mb-4 flex gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            Technical deployment information still needs confirmation before
+            testing.
+          </div>
+        )}
+        <form
+          className="grid gap-4 md:grid-cols-2"
+          onChange={onDirty}
+          onSubmit={(event) => {
+            event.preventDefault();
+            const form = new FormData(event.currentTarget);
+            save.mutate({
+              rowVersion: p.row_version,
+              title: form.get('title'),
+              reasonForValidation: form.get('reasonForValidation'),
+              validationType: form.get('validationType'),
+              plannedStartDate: form.get('plannedStartDate'),
+              plannedCompletionDate: form.get('plannedCompletionDate'),
+              commitOrReleaseIdentifier:
+                form.get('commitOrReleaseIdentifier') || null,
+              productionDeploymentDate:
+                form.get('productionDeploymentDate') || null,
+              validationEnvironment: form.get('validationEnvironment'),
+              productionEnvironmentReference: form.get(
+                'productionEnvironmentReference'
+              ),
+              environmentDifferences:
+                form.get('environmentDifferences') || null,
+            });
+          }}
+        >
+          <Field
+            name="title"
+            label="Validation title"
+            defaultValue={p.title}
+            required
+          />
+          <SelectField
+            name="validationType"
+            label="Validation type"
+            defaultValue={p.validation_type}
+            options={[
+              'INITIAL_INTENDED_USE',
+              'MAJOR_RELEASE',
+              'CRITICAL_CHANGE',
+              'DATABASE_MIGRATION',
+              'SECURITY_ACCESS_CONTROL',
+              'BACKUP_RECOVERY',
+              'PERIODIC_REVIEW',
+              'PRE_AUDIT_REVALIDATION',
+              'CORRECTIVE_REVALIDATION',
+            ]}
+          />
+          <div className="md:col-span-2">
+            <Label htmlFor="reasonForValidation">
+              Why are we validating EPOCH?
+            </Label>
+            <Textarea
+              id="reasonForValidation"
+              name="reasonForValidation"
+              defaultValue={p.reason_for_validation}
+              placeholder="Example: Validate the production release used for controlled receiving, traceability, approvals, and record retrieval."
+              required
+            />
+          </div>
+          <Field
+            name="plannedStartDate"
+            label="Planned start date"
+            type="date"
+            defaultValue={p.planned_start_date?.slice(0, 10)}
+            required
+          />
+          <Field
+            name="plannedCompletionDate"
+            label="Planned completion date"
+            type="date"
+            defaultValue={p.planned_completion_date?.slice(0, 10)}
+            required
+          />
+          <div className="rounded-md bg-muted p-3 text-sm md:col-span-2">
+            <div className="grid gap-2 sm:grid-cols-2">
+              <span>
+                <strong>System:</strong> {p.system_name}
+              </span>
+              <span>
+                <strong>Package:</strong> {p.package_number}
+              </span>
+              <span>
+                <strong>Creator:</strong> {p.created_by_display_name}
+              </span>
+              <span>
+                <strong>Created:</strong> {p.created_at?.slice(0, 10)}
+              </span>
+              <span>
+                <strong>Hosting:</strong> {p.hosting_provider}
+              </span>
+              <span>
+                <strong>Database:</strong> {p.database_provider}
+              </span>
+            </div>
+          </div>
+          <details className="rounded-md border p-4 md:col-span-2">
+            <summary className="cursor-pointer font-medium">
+              Advanced technical details
+            </summary>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <Field
+                name="commitOrReleaseIdentifier"
+                label="Exact production commit SHA, release tag, or deployment ID"
+                defaultValue={p.commit_or_release_identifier || ''}
+              />
+              <Field
+                name="productionDeploymentDate"
+                label="Production deployment date"
+                type="date"
+                defaultValue={p.production_deployment_date?.slice(0, 10) || ''}
+              />
+              <Field
+                name="validationEnvironment"
+                label="Validation environment"
+                defaultValue={p.validation_environment}
+                required
+              />
+              <Field
+                name="productionEnvironmentReference"
+                label="Production environment"
+                defaultValue={p.production_environment_reference}
+                required
+              />
+              <div className="md:col-span-2">
+                <Label htmlFor="environmentDifferences">
+                  Environment differences
+                </Label>
+                <Textarea
+                  id="environmentDifferences"
+                  name="environmentDifferences"
+                  defaultValue={p.environment_differences || ''}
+                />
+              </div>
+            </div>
+          </details>
+          <div className="md:col-span-2 flex justify-end">
+            <Button type="submit" disabled={save.isPending}>
+              {save.isPending
+                ? 'Saving…'
+                : 'Save controlled draft and continue'}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function IntendedUseStep({
+  detail,
+  onDirty,
+  onSaved,
+}: {
+  detail: Detail;
+  onDirty: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const p = detail.package;
+  const prior = detail.intendedUse[0] || {};
+  const { toast } = useToast();
+  const [functions, setFunctions] = useState<Record<string, FunctionSelection>>(
+    Object.fromEntries(
+      detail.intendedUseFunctions.map((item) => [item.function_key, item])
+    )
+  );
+  const save = useMutation({
+    mutationFn: (body: Record<string, unknown>) =>
+      requestJson(`/api/qms/epoch-software-validation/${p.id}/intended-use`, {
+        method: 'POST',
+        body,
+      }),
+    onSuccess: async () => {
+      toast({ title: 'Intended Use revision saved as DRAFT' });
+      await onSaved();
+    },
+    onError: (error: Error) =>
+      toast({
+        title: 'Intended Use could not be saved',
+        description: error.message,
+        variant: 'destructive',
+      }),
+  });
+  const updateFunction = (key: string, patch: Partial<FunctionSelection>) => {
+    onDirty();
+    setFunctions((current) => {
+      const existing = current[key];
+      return {
+        ...current,
+        [key]: {
+          ...existing,
+          ...patch,
+          function_key: existing?.function_key ?? key,
+          usage_status:
+            patch.usage_status ?? existing?.usage_status ?? 'USED_FOR_QMS',
+          critical_to_qms:
+            patch.critical_to_qms ?? existing?.critical_to_qms ?? false,
+        },
+      };
+    });
+  };
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>2. Intended Use</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Select only uses reviewed by the organization. Suggestions are not
+          evidence until a user saves them.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <form
+          className="space-y-5"
+          onChange={onDirty}
+          onSubmit={(event) => {
+            event.preventDefault();
+            const form = new FormData(event.currentTarget);
+            save.mutate({
+              systemName: p.system_name,
+              epochVersion: p.production_version,
+              productionEnvironment: p.production_environment_reference,
+              softwareOwnerEmployeeId:
+                p.software_owner_employee_id || undefined,
+              qualityOwnerEmployeeId: p.quality_owner_employee_id || undefined,
+              hostingProvider: p.hosting_provider,
+              databaseProvider: p.database_provider,
+              intendedUseStatement: form.get('intendedUseStatement'),
+              qmsProcessesSupported: Object.keys(functions).join(', '),
+              officialRecordsControlled: form.get('officialRecordsControlled'),
+              userGroupsDepartments: form.get('userGroupsDepartments'),
+              dataRetentionResponsibilities: form.get(
+                'dataRetentionResponsibilities'
+              ),
+              backupResponsibilities: form.get('backupResponsibilities'),
+              outsideProcessesRecords:
+                form.get('outsideProcessesRecords') || undefined,
+              interfacesDependencies:
+                form.get('interfacesDependencies') || undefined,
+              customerContractualRequirements:
+                form.get('customerContractualRequirements') || undefined,
+              complianceConsiderations:
+                form.get('complianceConsiderations') || undefined,
+              knownLimitations: form.get('knownLimitations') || undefined,
+              excludedFunctionality:
+                form.get('excludedFunctionality') || undefined,
+              functions: Object.values(functions).map((item) => ({
+                functionKey: item.function_key,
+                usageStatus: item.usage_status,
+                useDescription: item.use_description || undefined,
+                failureEffect: item.failure_effect || undefined,
+                criticalToQms: item.critical_to_qms,
+                notUsedExplanation: item.not_used_explanation || undefined,
+              })),
+            });
+          }}
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <TextField
+              name="intendedUseStatement"
+              label="How does the organization use EPOCH overall?"
+              defaultValue={prior.intended_use_statement}
+              placeholder="Describe the approved QMS and manufacturing purpose in plain language."
+              required
+            />
+            <TextField
+              name="officialRecordsControlled"
+              label="Which official records are controlled in EPOCH?"
+              defaultValue={prior.official_records_controlled}
+              required
+            />
+            <TextField
+              name="userGroupsDepartments"
+              label="Which employee groups use these functions?"
+              defaultValue={prior.user_groups_departments}
+              required
+            />
+            <TextField
+              name="dataRetentionResponsibilities"
+              label="Who is responsible for record retention and retrieval?"
+              defaultValue={prior.data_retention_responsibilities}
+              required
+            />
+            <TextField
+              name="backupResponsibilities"
+              label="Who is responsible for backup and restoration?"
+              defaultValue={prior.backup_responsibilities}
+              required
+            />
+          </div>
+          <div className="space-y-3">
+            <h3 className="font-semibold">EPOCH functions in scope</h3>
+            {epochFunctions.map((label) => {
+              const selected = functions[label];
+              return (
+                <div key={label} className="rounded-md border p-4">
+                  <div className="flex items-start gap-3">
+                    <Checkbox
+                      id={`function-${label}`}
+                      checked={Boolean(selected)}
+                      onCheckedChange={(checked) => {
+                        onDirty();
+                        if (!checked) {
+                          setFunctions((current) => {
+                            const next = { ...current };
+                            delete next[label];
+                            return next;
+                          });
+                          return;
+                        }
+                        updateFunction(label, {});
+                      }}
+                    />
+                    <Label
+                      htmlFor={`function-${label}`}
+                      className="font-medium"
+                    >
+                      {label}
+                    </Label>
+                  </div>
+                  {selected && (
+                    <div className="mt-4 grid gap-4 md:grid-cols-2">
+                      <Select
+                        value={selected.usage_status}
+                        onValueChange={(value) =>
+                          updateFunction(label, {
+                            usage_status:
+                              value as FunctionSelection['usage_status'],
+                          })
+                        }
+                      >
+                        <SelectTrigger aria-label={`${label} usage status`}>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="USED_FOR_QMS">
+                            Used for an approved QMS purpose
+                          </SelectItem>
+                          <SelectItem value="NOT_USED_FOR_QMS">
+                            Not used for an approved QMS purpose
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      {selected.usage_status === 'USED_FOR_QMS' ? (
+                        <>
+                          <Textarea
+                            aria-label={`${label}: how the company uses this function`}
+                            placeholder="How does the company use this function?"
+                            value={selected.use_description || ''}
+                            onChange={(event) =>
+                              updateFunction(label, {
+                                use_description: event.target.value,
+                              })
+                            }
+                            required
+                          />
+                          <Textarea
+                            aria-label={`${label}: failure effect`}
+                            placeholder="What could happen if it did not work correctly?"
+                            value={selected.failure_effect || ''}
+                            onChange={(event) =>
+                              updateFunction(label, {
+                                failure_effect: event.target.value,
+                              })
+                            }
+                            required
+                          />
+                          <label className="flex items-center gap-2 text-sm">
+                            <Checkbox
+                              checked={selected.critical_to_qms}
+                              onCheckedChange={(checked) =>
+                                updateFunction(label, {
+                                  critical_to_qms: Boolean(checked),
+                                })
+                              }
+                            />
+                            Critical to product quality, traceability, approval,
+                            or record retention
+                          </label>
+                        </>
+                      ) : (
+                        <Textarea
+                          className="md:col-span-2"
+                          aria-label={`${label}: not used explanation`}
+                          placeholder="Explain why this function is not used for an approved QMS purpose."
+                          value={selected.not_used_explanation || ''}
+                          onChange={(event) =>
+                            updateFunction(label, {
+                              not_used_explanation: event.target.value,
+                            })
+                          }
+                          required
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <details className="rounded-md border p-4">
+            <summary className="cursor-pointer font-medium">
+              Additional scope details
+            </summary>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              {[
+                [
+                  'outsideProcessesRecords',
+                  'Processes or records outside EPOCH',
+                ],
+                ['interfacesDependencies', 'Interfaces and dependencies'],
+                [
+                  'customerContractualRequirements',
+                  'Customer or contractual requirements',
+                ],
+                ['complianceConsiderations', 'Compliance considerations'],
+                ['knownLimitations', 'Known limitations'],
+                ['excludedFunctionality', 'Excluded functionality'],
+              ].map(([name, label]) => (
+                <TextField
+                  key={name}
+                  name={name}
+                  label={label}
+                  defaultValue={prior[snake(name)]}
+                />
+              ))}
+            </div>
+          </details>
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              disabled={save.isPending || !Object.keys(functions).length}
+            >
+              {save.isPending ? 'Saving…' : 'Save Intended Use and continue'}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ResponsibilitiesStep({
+  detail,
+  employees,
+  onDirty,
+  onSaved,
+}: {
+  detail: Detail;
+  employees: Employee[];
+  onDirty: () => void;
+  onSaved: () => Promise<void>;
+}) {
+  const p = detail.package;
+  const { toast } = useToast();
+  const currentUser = useQuery<{ employeeId?: number | null }>({
+    queryKey: ['/api/auth/session'],
+    queryFn: () => requestJson('/api/auth/session'),
+  });
+  const [assignments, setAssignments] = useState<
+    Array<{ role: ResponsibilityRole; employeeId: number }>
+  >(
+    detail.responsibilities.map((item) => ({
+      role: item.responsibility_role,
+      employeeId: Number(item.employee_id),
+    }))
+  );
+  const save = useMutation({
+    mutationFn: () =>
+      requestJson(
+        `/api/qms/epoch-software-validation/${p.id}/responsibilities`,
+        {
+          method: 'PUT',
+          body: { rowVersion: p.row_version, assignments },
+        }
+      ),
+    onSuccess: async () => {
+      toast({
+        title: 'Responsibilities saved',
+        description: 'New assignments are awaiting acceptance.',
+      });
+      await onSaved();
+    },
+    onError: (error: Error) =>
+      toast({
+        title: 'Responsibilities could not be saved',
+        description: error.message,
+        variant: 'destructive',
+      }),
+  });
+  const accept = useMutation({
+    mutationFn: (assignmentId: string) =>
+      requestJson(
+        `/api/qms/epoch-software-validation/${p.id}/responsibilities/${assignmentId}/accept`,
+        { method: 'POST', body: {} }
+      ),
+    onSuccess: async () => {
+      toast({ title: 'Responsibility accepted' });
+      await onSaved();
+    },
+    onError: (error: Error) =>
+      toast({
+        title: 'Acceptance blocked',
+        description: error.message,
+        variant: 'destructive',
+      }),
+  });
+  const setSingle = (role: ResponsibilityRole, employeeId?: number) => {
+    onDirty();
+    setAssignments((current) => [
+      ...current.filter((item) => item.role !== role),
+      ...(employeeId ? [{ role, employeeId }] : []),
+    ]);
+  };
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          3. Responsibilities
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Assign active employees. Assignment does not imply acceptance; each
+          assignee must accept with their own identity.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {responsibilityDefinitions.map((definition) => {
+          const assigned = assignments.filter(
+            (item) => item.role === definition.role
+          );
+          const records = detail.responsibilities.filter(
+            (item) => item.responsibility_role === definition.role
+          );
+          return (
+            <div key={definition.role} className="rounded-md border p-4">
+              <div className="mb-3">
+                <h3 className="font-medium">{definition.label}</h3>
+                <p className="text-sm text-muted-foreground">
+                  {definition.help}
+                </p>
+              </div>
+              <EmployeeSearch
+                employees={employees.filter(
+                  (employee) =>
+                    definition.multiple ||
+                    !assignments.some(
+                      (item) =>
+                        item.role === definition.role &&
+                        item.employeeId === employee.id
+                    )
+                )}
+                value={
+                  definition.multiple ? undefined : assigned[0]?.employeeId
+                }
+                onSelect={(employeeId) => {
+                  if (definition.multiple) {
+                    if (!employeeId) return;
+                    onDirty();
+                    setAssignments((current) => [
+                      ...current,
+                      { role: definition.role, employeeId },
+                    ]);
+                  } else setSingle(definition.role, employeeId);
+                }}
+              />
+              <div className="mt-3 space-y-2">
+                {assigned.map((assignment) => {
+                  const employee = employees.find(
+                    (item) => item.id === assignment.employeeId
+                  );
+                  const record = records.find(
+                    (item) => Number(item.employee_id) === assignment.employeeId
+                  );
+                  return (
+                    <div
+                      key={`${definition.role}-${assignment.employeeId}`}
+                      className="flex flex-wrap items-center justify-between gap-2 rounded bg-muted p-2 text-sm"
+                    >
+                      <span>
+                        {employee?.name || `Employee ${assignment.employeeId}`}
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline">
+                          {record
+                            ? pretty(record.assignment_status)
+                            : 'Unsaved'}
+                        </Badge>
+                        {record?.assignment_status === 'AWAITING_ACCEPTANCE' &&
+                          Number(currentUser.data?.employeeId) ===
+                            assignment.employeeId && (
+                            <Button
+                              size="sm"
+                              type="button"
+                              disabled={accept.isPending}
+                              onClick={() => accept.mutate(record.id)}
+                            >
+                              Accept responsibility
+                            </Button>
+                          )}
+                        <Button
+                          size="sm"
+                          type="button"
+                          variant="ghost"
+                          onClick={() => {
+                            onDirty();
+                            setAssignments((current) =>
+                              current.filter(
+                                (item) =>
+                                  !(
+                                    item.role === definition.role &&
+                                    item.employeeId === assignment.employeeId
+                                  )
+                              )
+                            );
+                          }}
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })}
+                {!assigned.length && (
+                  <p className="text-sm text-amber-700">Missing</p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+        <div className="flex justify-end">
+          <Button onClick={() => save.mutate()} disabled={save.isPending}>
+            {save.isPending ? 'Saving…' : 'Save responsibilities'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmployeeSearch({
+  employees,
+  value,
+  onSelect,
+}: {
+  employees: Employee[];
+  value?: number;
+  onSelect: (employeeId?: number) => void;
+}) {
+  const [search, setSearch] = useState('');
+  const filtered = employees
+    .filter((employee) =>
+      `${employee.name} ${employee.department || ''} ${employee.position || ''}`
+        .toLowerCase()
+        .includes(search.toLowerCase())
+    )
+    .slice(0, 50);
+  return (
+    <div className="grid gap-2 sm:grid-cols-[1fr_1fr]">
+      <div className="relative">
+        <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          aria-label="Search active employees"
+          className="pl-8"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search active employees"
+        />
+      </div>
+      <select
+        aria-label="Select active employee"
+        className="h-10 rounded-md border bg-background px-3 text-sm"
+        value={value || ''}
+        onChange={(event) =>
+          onSelect(event.target.value ? Number(event.target.value) : undefined)
+        }
+      >
+        <option value="">Not assigned</option>
+        {filtered.map((employee) => (
+          <option key={employee.id} value={employee.id}>
+            {employee.name}
+            {employee.department ? ` · ${employee.department}` : ''}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function UnavailableStep({ step }: { step: number }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {step}. {steps[step - 1][1]}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="py-12 text-center">
+        <Lock className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+        <p className="font-medium">Not available yet</p>
+        <p className="mx-auto mt-2 max-w-xl text-sm text-muted-foreground">
+          This controlled step will be delivered in a later reviewable phase.
+          Existing server-side readiness, execution, approval, and release gates
+          remain active and fail closed.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Summary({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function Field({
+  name,
+  label,
+  type = 'text',
+  defaultValue,
+  required,
+}: {
+  name: string;
+  label: string;
+  type?: string;
+  defaultValue?: string;
+  required?: boolean;
+}) {
+  return (
+    <div>
+      <Label htmlFor={name}>{label}</Label>
+      <Input
+        id={name}
+        name={name}
+        type={type}
+        defaultValue={defaultValue}
+        required={required}
+      />
+    </div>
+  );
+}
+
+function TextField({
+  name,
+  label,
+  defaultValue,
+  placeholder,
+  required,
+}: {
+  name: string;
+  label: string;
+  defaultValue?: string;
+  placeholder?: string;
+  required?: boolean;
+}) {
+  return (
+    <div>
+      <Label htmlFor={name}>{label}</Label>
+      <Textarea
+        id={name}
+        name={name}
+        defaultValue={defaultValue}
+        placeholder={placeholder}
+        required={required}
+      />
+    </div>
+  );
+}
+
+function SelectField({
+  name,
+  label,
+  defaultValue,
+  options,
+}: {
+  name: string;
+  label: string;
+  defaultValue: string;
+  options: string[];
+}) {
+  return (
+    <div>
+      <Label htmlFor={name}>{label}</Label>
+      <select
+        id={name}
+        name={name}
+        defaultValue={defaultValue}
+        className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {pretty(option)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function snake(value: string) {
+  return value.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}

--- a/client/src/pages/EpochSoftwareValidationPage.tsx
+++ b/client/src/pages/EpochSoftwareValidationPage.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 
 import { apiRequest } from '@/lib/queryClient';
+import { EpochValidationWizard } from '@/components/qms/EpochValidationWizard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -69,6 +70,7 @@ type Package = {
   environment_separation_confirmed?: boolean;
   planned_start_date: string;
   planned_completion_date: string;
+  reason_for_validation: string;
   locked_at?: string;
   requirement_count?: number;
   execution_count?: number;
@@ -82,6 +84,8 @@ const requestJson = <T,>(
 type Detail = {
   package: Package;
   intendedUse: any[];
+  intendedUseFunctions: any[];
+  responsibilities: any[];
   requirements: any[];
   risks: any[];
   plans: any[];
@@ -367,6 +371,17 @@ export default function EpochSoftwareValidationPage() {
     if (d.periodicReviews.length) complete++;
     return complete * 10;
   }, [detail.data]);
+
+  if (selected && detail.data) {
+    return (
+      <EpochValidationWizard
+        key={`${detail.data.package.id}-${detail.data.package.row_version}`}
+        detail={detail.data}
+        employees={employees.data || []}
+        onBack={() => setSelected(undefined)}
+      />
+    );
+  }
 
   if (selected && detail.data) {
     const d = detail.data,

--- a/migrations/0250_epoch_validation_wizard_phase1.sql
+++ b/migrations/0250_epoch_validation_wizard_phase1.sql
@@ -1,0 +1,58 @@
+-- Phase 1 guided EPOCH validation workflow.
+-- Additive only: existing packages and intended-use revisions are not rewritten.
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_intended_use_functions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  intended_use_revision_id uuid NOT NULL REFERENCES qms_epoch_validation_intended_use_revisions(id) ON DELETE RESTRICT,
+  function_key text NOT NULL,
+  usage_status text NOT NULL CHECK (usage_status IN ('USED_FOR_QMS','NOT_USED_FOR_QMS')),
+  use_description text,
+  failure_effect text,
+  critical_to_qms boolean NOT NULL DEFAULT false,
+  not_used_explanation text,
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT qms_esv_intended_function_complete CHECK (
+    (usage_status='USED_FOR_QMS' AND nullif(trim(use_description),'') IS NOT NULL AND nullif(trim(failure_effect),'') IS NOT NULL)
+    OR
+    (usage_status='NOT_USED_FOR_QMS' AND nullif(trim(not_used_explanation),'') IS NOT NULL)
+  ),
+  CONSTRAINT qms_esv_intended_function_revision_unique UNIQUE(intended_use_revision_id,function_key)
+);
+
+CREATE INDEX IF NOT EXISTS qms_esv_intended_function_package_idx
+  ON qms_epoch_validation_intended_use_functions(package_id,intended_use_revision_id);
+
+CREATE TABLE IF NOT EXISTS qms_epoch_validation_responsibilities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id uuid NOT NULL REFERENCES qms_epoch_validation_packages(id) ON DELETE RESTRICT,
+  responsibility_role text NOT NULL CHECK (responsibility_role IN
+    ('SOFTWARE_OWNER','QUALITY_REVIEWER','VALIDATION_COORDINATOR','ADDITIONAL_TESTER','FINAL_APPROVING_AUTHORITY')),
+  employee_id integer NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+  assignment_status text NOT NULL DEFAULT 'AWAITING_ACCEPTANCE' CHECK (assignment_status IN
+    ('AWAITING_ACCEPTANCE','ACCEPTED','DECLINED','SUPERSEDED')),
+  assigned_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  assigned_by_display_name text NOT NULL,
+  assigned_at timestamptz NOT NULL DEFAULT now(),
+  accepted_by_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  accepted_by_display_name text,
+  accepted_at timestamptz,
+  superseded_at timestamptz,
+  active boolean NOT NULL DEFAULT true,
+  CONSTRAINT qms_esv_responsibility_acceptance_consistent CHECK (
+    (assignment_status='ACCEPTED' AND accepted_by_user_id IS NOT NULL AND accepted_at IS NOT NULL)
+    OR assignment_status<>'ACCEPTED'
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS qms_esv_responsibility_active_employee_unique
+  ON qms_epoch_validation_responsibilities(package_id,responsibility_role,employee_id)
+  WHERE active;
+
+CREATE UNIQUE INDEX IF NOT EXISTS qms_esv_responsibility_active_single_role
+  ON qms_epoch_validation_responsibilities(package_id,responsibility_role)
+  WHERE active AND responsibility_role<>'ADDITIONAL_TESTER';
+
+CREATE INDEX IF NOT EXISTS qms_esv_responsibility_package_idx
+  ON qms_epoch_validation_responsibilities(package_id,active,responsibility_role);

--- a/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
@@ -1,0 +1,81 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
+const route = read('server/src/routes/epochSoftwareValidation.ts');
+const compactRoute = route.replace(/\s+/g, '');
+const migration = read('migrations/0250_epoch_validation_wizard_phase1.sql');
+const safeBoot = read('server/scripts/migrations/runSafeBootMigrations.ts');
+
+describe('EPOCH validation wizard Phase 1 architecture', () => {
+  it('adds revision-linked intended-use functions without rewriting existing records', () => {
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS qms_epoch_validation_intended_use_functions'
+    );
+    expect(migration).toContain(
+      'intended_use_revision_id uuid NOT NULL REFERENCES qms_epoch_validation_intended_use_revisions(id)'
+    );
+    expect(migration).toContain('qms_esv_intended_function_complete');
+    expect(migration).not.toMatch(/UPDATE\s+qms_epoch_validation_packages/i);
+    expect(migration).not.toMatch(
+      /INSERT\s+INTO\s+qms_epoch_validation_packages/i
+    );
+  });
+
+  it('keeps structured intended-use persistence in the revision transaction', () => {
+    const intendedUse = compactRoute.slice(
+      compactRoute.indexOf("router.post('/:id/intended-use'"),
+      compactRoute.indexOf("router.post('/:id/requirements'")
+    );
+    expect(intendedUse).toContain('constrecord=awaittx(async(q)=>');
+    expect(intendedUse).toContain(
+      'INSERTINTOqms_epoch_validation_intended_use_functions'
+    );
+    expect(intendedUse).toContain('intended_use_revision_id');
+    expect(route).toContain('.default([])');
+  });
+
+  it('stores responsibilities as auditable assignments with employee acceptance', () => {
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS qms_epoch_validation_responsibilities'
+    );
+    expect(migration).toContain("'FINAL_APPROVING_AUTHORITY'");
+    expect(migration).toContain(
+      "'AWAITING_ACCEPTANCE','ACCEPTED','DECLINED','SUPERSEDED'"
+    );
+    expect(route).toContain('WHERE id=ANY($1::int[]) AND is_active=true');
+    expect(route).toContain("assignment_status='SUPERSEDED'");
+    expect(route).toContain('ASSIGNEE_ACCEPTANCE_REQUIRED');
+    expect(route).toContain(
+      'if (previousKeys.has(`${assignment.role}:${assignment.employeeId}`))'
+    );
+    expect(route).toContain("'RESPONSIBILITIES_ASSIGNED'");
+    expect(route).toContain("'RESPONSIBILITY_ACCEPTED'");
+  });
+
+  it('requires edit authorization and optimistic locking for Phase 1 changes', () => {
+    expect(route).toContain("'/:id/wizard/setup'");
+    expect(
+      route.match(/requirePermission\('EPOCH_VALIDATION_EDIT'\)/g)?.length
+    ).toBeGreaterThan(3);
+    expect(route).toContain('WHERE id=$14 AND row_version=$15 RETURNING *');
+    expect(route).toContain("error: 'STALE_RECORD'");
+    expect(route).toContain("'WIZARD_SETUP_SAVED'");
+  });
+
+  it('registers migration 0250 in both safe and critical boot lists', () => {
+    expect(
+      safeBoot.match(/0250_epoch_validation_wizard_phase1\.sql/g)?.length
+    ).toBe(2);
+  });
+
+  it('retains existing execution, approval, and release gates', () => {
+    expect(route).toContain('PACKAGE_EXECUTION_READINESS_BLOCKED');
+    expect(route).toContain('FORMAL_TEST_EXECUTION_NOT_ALLOWED');
+    expect(route).toContain('PACKAGE_FINAL_READINESS_BLOCKED');
+    expect(route).toContain('invalidateApprovals');
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -27884,3 +27884,75 @@ export const operatorAuthSessions = pgTable(
 export type OperatorAuthSession = typeof operatorAuthSessions.$inferSelect;
 export type InsertOperatorAuthSession =
   typeof operatorAuthSessions.$inferInsert;
+
+// Guided EPOCH Software Validation Phase 1 child records. Existing validation
+// package and intended-use tables remain managed by their established raw-SQL
+// service; these additive tables provide structured wizard data and acceptance.
+export const qmsEpochValidationIntendedUseFunctions = pgTable(
+  'qms_epoch_validation_intended_use_functions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    packageId: uuid('package_id').notNull(),
+    intendedUseRevisionId: uuid('intended_use_revision_id').notNull(),
+    functionKey: text('function_key').notNull(),
+    usageStatus: text('usage_status').notNull(),
+    useDescription: text('use_description'),
+    failureEffect: text('failure_effect'),
+    criticalToQms: boolean('critical_to_qms').notNull().default(false),
+    notUsedExplanation: text('not_used_explanation'),
+    createdByUserId: integer('created_by_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    packageIdx: index('qms_esv_intended_function_package_idx').on(
+      table.packageId,
+      table.intendedUseRevisionId
+    ),
+    revisionFunctionUnique: uniqueIndex(
+      'qms_esv_intended_function_revision_unique'
+    ).on(table.intendedUseRevisionId, table.functionKey),
+  })
+);
+
+export const qmsEpochValidationResponsibilities = pgTable(
+  'qms_epoch_validation_responsibilities',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    packageId: uuid('package_id').notNull(),
+    responsibilityRole: text('responsibility_role').notNull(),
+    employeeId: integer('employee_id')
+      .notNull()
+      .references(() => employees.id, { onDelete: 'restrict' }),
+    assignmentStatus: text('assignment_status')
+      .notNull()
+      .default('AWAITING_ACCEPTANCE'),
+    assignedByUserId: integer('assigned_by_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    assignedByDisplayName: text('assigned_by_display_name').notNull(),
+    assignedAt: timestamp('assigned_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    acceptedByUserId: integer('accepted_by_user_id').references(
+      () => users.id,
+      {
+        onDelete: 'restrict',
+      }
+    ),
+    acceptedByDisplayName: text('accepted_by_display_name'),
+    acceptedAt: timestamp('accepted_at', { withTimezone: true }),
+    supersededAt: timestamp('superseded_at', { withTimezone: true }),
+    active: boolean('active').notNull().default(true),
+  },
+  (table) => ({
+    packageIdx: index('qms_esv_responsibility_package_idx').on(
+      table.packageId,
+      table.active,
+      table.responsibilityRole
+    ),
+  })
+);

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -313,6 +313,7 @@ export const safeMigrationFiles = [
   '0247_retire_duplicate_traveler_roc2600719.sql',
   '0248_design_project_manufacturing_configuration.sql',
   '0249_prior_month_payment_entry_grace.sql',
+  '0250_epoch_validation_wizard_phase1.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -376,6 +377,7 @@ export const criticalMigrationFiles = new Set([
   '0241_rom_builder_approval_authority.sql',
   '0242_epoch_validation_create_idempotency.sql',
   '0245_controlled_document_legacy_reconciliation.sql',
+  '0250_epoch_validation_wizard_phase1.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -761,6 +761,8 @@ async function detail(packageId: string) {
   if (!p) return null;
   const [
     intendedUse,
+    intendedUseFunctions,
+    responsibilities,
     requirements,
     risks,
     plans,
@@ -773,6 +775,21 @@ async function detail(packageId: string) {
   ] = await Promise.all([
     query(
       'SELECT * FROM qms_epoch_validation_intended_use_revisions WHERE package_id=$1 ORDER BY revision DESC',
+      [packageId]
+    ),
+    query(
+      `SELECT f.* FROM qms_epoch_validation_intended_use_functions f
+       JOIN qms_epoch_validation_intended_use_revisions u ON u.id=f.intended_use_revision_id
+       WHERE f.package_id=$1 AND u.approval_status<>'SUPERSEDED'
+       ORDER BY f.function_key`,
+      [packageId]
+    ),
+    query(
+      `SELECT r.*,e.name employee_name,e.department,e.position
+       FROM qms_epoch_validation_responsibilities r
+       JOIN employees e ON e.id=r.employee_id
+       WHERE r.package_id=$1 AND r.active=true
+       ORDER BY r.responsibility_role,e.name`,
       [packageId]
     ),
     query(
@@ -818,6 +835,8 @@ async function detail(packageId: string) {
   return {
     package: p,
     intendedUse,
+    intendedUseFunctions,
+    responsibilities,
     requirements,
     risks,
     plans,
@@ -924,6 +943,273 @@ router.post(
   }
 );
 
+const wizardSetupSchema = z.object({
+  rowVersion: z.number().int().positive(),
+  title: z.string().min(3).max(240),
+  reasonForValidation: z.string().min(3).max(10000),
+  validationType: z.enum([
+    'INITIAL_INTENDED_USE',
+    'MAJOR_RELEASE',
+    'CRITICAL_CHANGE',
+    'DATABASE_MIGRATION',
+    'SECURITY_ACCESS_CONTROL',
+    'BACKUP_RECOVERY',
+    'PERIODIC_REVIEW',
+    'PRE_AUDIT_REVALIDATION',
+    'CORRECTIVE_REVALIDATION',
+  ]),
+  plannedStartDate: z.string().date(),
+  plannedCompletionDate: z.string().date(),
+  commitOrReleaseIdentifier: z.string().max(240).nullable().optional(),
+  productionDeploymentDate: z.string().date().nullable().optional(),
+  validationEnvironment: z.string().min(1),
+  productionEnvironmentReference: z.string().min(1),
+  environmentDifferences: z.string().max(10000).nullable().optional(),
+});
+
+router.patch(
+  '/:id/wizard/setup',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const v = wizardSetupSchema.parse(req.body),
+      a = actor(req),
+      technicalChanged =
+        v.commitOrReleaseIdentifier !== p.commit_or_release_identifier ||
+        v.productionDeploymentDate !== p.production_deployment_date ||
+        v.environmentDifferences !== p.environment_differences;
+    const updated = (
+      await query(
+        `UPDATE qms_epoch_validation_packages SET
+         title=$1,reason_for_validation=$2,validation_type=$3,
+         planned_start_date=$4::date,planned_completion_date=$5::date,
+         commit_or_release_identifier=$6,production_deployment_date=$7::date,
+         validation_environment=$8,production_environment_reference=$9,environment_differences=$10,
+         deployment_date_confirmed=CASE WHEN $11 THEN false ELSE deployment_date_confirmed END,
+         deployment_date_confirmed_by_user_id=CASE WHEN $11 THEN NULL ELSE deployment_date_confirmed_by_user_id END,
+         deployment_date_confirmed_by_display_name=CASE WHEN $11 THEN NULL ELSE deployment_date_confirmed_by_display_name END,
+         deployment_date_confirmed_at=CASE WHEN $11 THEN NULL ELSE deployment_date_confirmed_at END,
+         environment_separation_confirmed=CASE WHEN $11 THEN false ELSE environment_separation_confirmed END,
+         environment_separation_confirmed_by_user_id=CASE WHEN $11 THEN NULL ELSE environment_separation_confirmed_by_user_id END,
+         environment_separation_confirmed_by_display_name=CASE WHEN $11 THEN NULL ELSE environment_separation_confirmed_by_display_name END,
+         environment_separation_confirmed_at=CASE WHEN $11 THEN NULL ELSE environment_separation_confirmed_at END,
+         row_version=row_version+1,revision=revision+1,
+         updated_by_user_id=$12,updated_by_display_name=$13,updated_at=now()
+         WHERE id=$14 AND row_version=$15 RETURNING *`,
+        [
+          v.title,
+          v.reasonForValidation,
+          v.validationType,
+          v.plannedStartDate,
+          v.plannedCompletionDate,
+          v.commitOrReleaseIdentifier ?? null,
+          v.productionDeploymentDate ?? null,
+          v.validationEnvironment,
+          v.productionEnvironmentReference,
+          v.environmentDifferences ?? null,
+          technicalChanged,
+          a.id,
+          a.name,
+          p.id,
+          v.rowVersion,
+        ]
+      )
+    )[0];
+    if (!updated) return res.status(409).json({ error: 'STALE_RECORD' });
+    await invalidateApprovals(p.id, 'Wizard setup changed');
+    await logEvent(req, updated, 'PACKAGE', 'WIZARD_SETUP_SAVED', {
+      previous: p,
+      next: updated,
+    });
+    res.json({ package: updated, readiness: await packageReadiness(updated) });
+  }
+);
+
+const responsibilityRole = z.enum([
+  'SOFTWARE_OWNER',
+  'QUALITY_REVIEWER',
+  'VALIDATION_COORDINATOR',
+  'ADDITIONAL_TESTER',
+  'FINAL_APPROVING_AUTHORITY',
+]);
+const responsibilitySchema = z.object({
+  rowVersion: z.number().int().positive(),
+  assignments: z.array(
+    z.object({
+      role: responsibilityRole,
+      employeeId: z.number().int().positive(),
+    })
+  ),
+});
+
+router.put(
+  '/:id/responsibilities',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const body = responsibilitySchema.parse(req.body),
+      a = actor(req);
+    const singularRoles = [
+      'SOFTWARE_OWNER',
+      'QUALITY_REVIEWER',
+      'VALIDATION_COORDINATOR',
+      'FINAL_APPROVING_AUTHORITY',
+    ] as const;
+    for (const role of singularRoles) {
+      if (body.assignments.filter((item) => item.role === role).length > 1)
+        return res.status(400).json({
+          error: 'RESPONSIBILITY_ROLE_MUST_BE_SINGULAR',
+          role,
+        });
+    }
+    const uniqueAssignments = new Set(
+      body.assignments.map((item) => `${item.role}:${item.employeeId}`)
+    );
+    if (uniqueAssignments.size !== body.assignments.length)
+      return res
+        .status(400)
+        .json({ error: 'DUPLICATE_RESPONSIBILITY_ASSIGNMENT' });
+    const employeeIds = Array.from(
+      new Set(body.assignments.map((x) => x.employeeId))
+    );
+    if (employeeIds.length) {
+      const active = await query(
+        `SELECT id FROM employees WHERE id=ANY($1::int[]) AND is_active=true`,
+        [employeeIds]
+      );
+      if (active.length !== employeeIds.length)
+        return res.status(409).json({ error: 'INACTIVE_EMPLOYEE_ASSIGNMENT' });
+    }
+    const updated = await tx(async (q) => {
+      const locked = (
+        await q(
+          `SELECT * FROM qms_epoch_validation_packages WHERE id=$1 AND row_version=$2 FOR UPDATE`,
+          [p.id, body.rowVersion]
+        )
+      )[0];
+      if (!locked) return null;
+      const previous = await q(
+        `SELECT * FROM qms_epoch_validation_responsibilities WHERE package_id=$1 AND active=true`,
+        [p.id]
+      );
+      const desiredKeys = new Set(
+        body.assignments.map((item) => `${item.role}:${item.employeeId}`)
+      );
+      const previousKeys = new Set(
+        previous.map(
+          (item) => `${item.responsibility_role}:${item.employee_id}`
+        )
+      );
+      const removedIds = previous
+        .filter(
+          (item) =>
+            !desiredKeys.has(`${item.responsibility_role}:${item.employee_id}`)
+        )
+        .map((item) => item.id);
+      if (removedIds.length)
+        await q(
+          `UPDATE qms_epoch_validation_responsibilities
+           SET active=false,assignment_status='SUPERSEDED',superseded_at=now()
+           WHERE package_id=$1 AND id=ANY($2::uuid[]) AND active=true`,
+          [p.id, removedIds]
+        );
+      for (const assignment of body.assignments) {
+        if (previousKeys.has(`${assignment.role}:${assignment.employeeId}`))
+          continue;
+        await q(
+          `INSERT INTO qms_epoch_validation_responsibilities
+          (package_id,responsibility_role,employee_id,assigned_by_user_id,assigned_by_display_name)
+          VALUES($1,$2,$3,$4,$5)`,
+          [p.id, assignment.role, assignment.employeeId, a.id, a.name]
+        );
+      }
+      const assigned = (role: string) =>
+        body.assignments.find((item) => item.role === role)?.employeeId || null;
+      const packageRow = (
+        await q(
+          `UPDATE qms_epoch_validation_packages SET
+           software_owner_employee_id=$1,quality_owner_employee_id=$2,validation_lead_employee_id=$3,
+           row_version=row_version+1,revision=revision+1,
+           updated_by_user_id=$4,updated_by_display_name=$5,updated_at=now()
+           WHERE id=$6 RETURNING *`,
+          [
+            assigned('SOFTWARE_OWNER'),
+            assigned('QUALITY_REVIEWER'),
+            assigned('VALIDATION_COORDINATOR'),
+            a.id,
+            a.name,
+            p.id,
+          ]
+        )
+      )[0];
+      await invalidateApprovals(p.id, 'Validation responsibilities changed', q);
+      await logEvent(
+        req,
+        packageRow,
+        'RESPONSIBILITY',
+        'RESPONSIBILITIES_ASSIGNED',
+        { previous, next: body.assignments },
+        q
+      );
+      return packageRow;
+    });
+    if (!updated) return res.status(409).json({ error: 'STALE_RECORD' });
+    res.json(await detail(updated.id));
+  }
+);
+
+router.post(
+  '/:id/responsibilities/:assignmentId/accept',
+  requirePermission('EPOCH_VALIDATION_EDIT'),
+  async (req, res) => {
+    const p = await editable(req, res);
+    if (!p) return;
+    const assignmentId = uuid.parse(req.params.assignmentId),
+      a = actor(req),
+      employeeId = Number((req.user as any)?.employeeId || 0);
+    if (!employeeId)
+      return res.status(403).json({ error: 'EMPLOYEE_IDENTITY_REQUIRED' });
+    const accepted = await tx(async (q) => {
+      const assignment = (
+        await q(
+          `SELECT * FROM qms_epoch_validation_responsibilities
+           WHERE id=$1 AND package_id=$2 AND active=true FOR UPDATE`,
+          [assignmentId, p.id]
+        )
+      )[0];
+      if (!assignment) return { missing: true as const };
+      if (Number(assignment.employee_id) !== employeeId)
+        return { forbidden: true as const };
+      if (assignment.assignment_status === 'ACCEPTED')
+        return { assignment, replay: true as const };
+      const updated = (
+        await q(
+          `UPDATE qms_epoch_validation_responsibilities SET
+           assignment_status='ACCEPTED',accepted_by_user_id=$1,accepted_by_display_name=$2,accepted_at=now()
+           WHERE id=$3 RETURNING *`,
+          [a.id, a.name, assignment.id]
+        )
+      )[0];
+      await logEvent(
+        req,
+        p,
+        'RESPONSIBILITY',
+        'RESPONSIBILITY_ACCEPTED',
+        { entityId: updated.id, previous: assignment, next: updated },
+        q
+      );
+      return { assignment: updated };
+    });
+    if ('missing' in accepted)
+      return res.status(404).json({ error: 'RESPONSIBILITY_NOT_FOUND' });
+    if ('forbidden' in accepted)
+      return res.status(403).json({ error: 'ASSIGNEE_ACCEPTANCE_REQUIRED' });
+    res.json(accepted.assignment);
+  }
+);
+
 const intendedUseSchema = z.object({
   systemName: z.string().min(1),
   epochVersion: z.string().min(1),
@@ -944,6 +1230,38 @@ const intendedUseSchema = z.object({
   excludedFunctionality: z.string().optional(),
   dataRetentionResponsibilities: z.string().min(1),
   backupResponsibilities: z.string().min(1),
+  functions: z
+    .array(
+      z
+        .object({
+          functionKey: z.string().min(1).max(120),
+          usageStatus: z.enum(['USED_FOR_QMS', 'NOT_USED_FOR_QMS']),
+          useDescription: z.string().max(5000).optional(),
+          failureEffect: z.string().max(5000).optional(),
+          criticalToQms: z.boolean().default(false),
+          notUsedExplanation: z.string().max(5000).optional(),
+        })
+        .superRefine((value, ctx) => {
+          if (
+            value.usageStatus === 'USED_FOR_QMS' &&
+            (!value.useDescription?.trim() || !value.failureEffect?.trim())
+          )
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message:
+                'Selected functions require a use description and failure effect.',
+            });
+          if (
+            value.usageStatus === 'NOT_USED_FOR_QMS' &&
+            !value.notUsedExplanation?.trim()
+          )
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Not-used functions require an explanation.',
+            });
+        })
+    )
+    .default([]),
 });
 router.post(
   '/:id/intended-use',
@@ -1005,6 +1323,25 @@ router.post(
           ]
         )
       )[0];
+      for (const selectedFunction of v.functions) {
+        await q(
+          `INSERT INTO qms_epoch_validation_intended_use_functions
+          (package_id,intended_use_revision_id,function_key,usage_status,use_description,failure_effect,
+           critical_to_qms,not_used_explanation,created_by_user_id)
+          VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+          [
+            p.id,
+            x.id,
+            selectedFunction.functionKey,
+            selectedFunction.usageStatus,
+            selectedFunction.useDescription?.trim() || null,
+            selectedFunction.failureEffect?.trim() || null,
+            selectedFunction.criticalToQms,
+            selectedFunction.notUsedExplanation?.trim() || null,
+            a.id,
+          ]
+        );
+      }
       await invalidateApprovals(p.id, 'Intended Use revised', q);
       await logEvent(
         req,


### PR DESCRIPTION
## Summary

- replace the selected-package read-only view with a guided nine-step validation workflow shell
- implement Phase 1 Setup, Intended Use, and Responsibilities steps; keep later phases visible and disabled
- persist structured intended-use functions by revision and auditable employee responsibility assignments/acceptance
- preserve existing controlled-draft creation, idempotency, readiness, execution, approval, release, authorization, and audit gates
- register additive migration `0250_epoch_validation_wizard_phase1.sql` in safe and critical boot lists

## Data safety

- additive schema only; no backfill or rewriting of existing packages
- existing validation records are not deleted or modified by the migration
- unchanged accepted responsibility assignments remain accepted when assignments are re-saved

## Verification

- client validation tests: 18 passed
- server validation tests: 27 passed
- focused client TypeScript check: passed
- error-only focused ESLint (excluding `server/schema.ts` pre-existing errors): passed
- focused Prettier check: passed
- `git diff --check`: passed

## Known verification limits

- repository-wide TypeScript checking exceeded both 2 GB and 4 GB Node heaps; the narrowed affected client check passed, while the broader graph also contains existing unrelated errors
- `server/schema.ts` focused ESLint is blocked by pre-existing `import/order` and undefined `SupplySourceDashboard` errors
- no authenticated browser/database walkthrough was performed locally; CI and review-environment verification remain required
