### PR TITLE
Phase 2: Design Project configuration workspace

### DIFF
--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -262,6 +262,7 @@ jobs:
         run: >-
           npx vitest run
           --config vitest.config.server.ts
+          --no-file-parallelism
           server/__tests__/p2V2PostgresCertification.test.ts
           server/__tests__/designProjectConfigurationSecurityPostgres.test.ts
           --reporter=verbose

--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -258,10 +258,12 @@ jobs:
       - name: Run isolated PostgreSQL certification
         env:
           P2_V2_PRODUCTION_LAUNCH_ENABLED: 'true'
+          DESIGN_PROJECT_CONFIGURATION_POSTGRES_CERTIFICATION: isolated_test
         run: >-
           npx vitest run
           --config vitest.config.server.ts
           server/__tests__/p2V2PostgresCertification.test.ts
+          server/__tests__/designProjectConfigurationSecurityPostgres.test.ts
           --reporter=verbose
 
       - name: Run controlled pilot PostgreSQL certification
@@ -300,6 +302,7 @@ jobs:
           client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
           client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
           client/src/__tests__/P2V2PilotControlCenter.component.test.tsx
+          client/src/__tests__/DesignProjectConfigurationWorkspace.component.test.tsx
           --reporter=verbose
 
   synthetic-pilot-certification:
@@ -457,6 +460,7 @@ jobs:
           client/src/__tests__/P2V2QualityProductRelease.component.test.tsx
           client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
           client/src/__tests__/P2V2PilotControlCenter.component.test.tsx
+          client/src/__tests__/DesignProjectConfigurationWorkspace.component.test.tsx
           --reporter=verbose
 
       - name: Prove zero outbound attempts

--- a/client/src/__tests__/DesignProjectConfigurationWorkspace.component.test.tsx
+++ b/client/src/__tests__/DesignProjectConfigurationWorkspace.component.test.tsx
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '../features/design-control/DesignProjectConfigurationWorkspace.tsx'
+  ),
+  'utf8'
+);
+
+describe('Design Project configuration item creation', () => {
+  it('submits the item and optional parent relationship in one request', () => {
+    expect(source).toContain(
+      'parentConfigurationItemId: itemForm.parentId || null'
+    );
+    expect(source).toContain('quantity: itemForm.parentId');
+    expect(source).toContain('unitOfMeasure: itemForm.parentId');
+    expect(source).toContain('setSelectedItemId(created.item.id)');
+    expect(source).not.toMatch(
+      /if \(created && itemForm\.parentId\)[\s\S]{0,300}configuration\/relationships/
+    );
+  });
+});

--- a/client/src/features/design-control/DesignProjectConfigurationWorkspace.tsx
+++ b/client/src/features/design-control/DesignProjectConfigurationWorkspace.tsx
@@ -296,22 +296,16 @@ export function DesignProjectConfigurationWorkspace({
             : itemForm.itemType === 'MANUFACTURED_PART'
               ? 'MAKE'
               : 'UNDETERMINED',
+        parentConfigurationItemId: itemForm.parentId || null,
+        quantity: itemForm.parentId ? Number(itemForm.quantity) : undefined,
+        unitOfMeasure: itemForm.parentId ? itemForm.unitOfMeasure : undefined,
+        sortOrder: itemForm.parentId
+          ? (childrenByParent.get(itemForm.parentId)?.length ?? 0)
+          : undefined,
       }
     );
-    if (created && itemForm.parentId)
-      await mutate(
-        `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/relationships`,
-        'POST',
-        {
-          parentConfigurationItemId: itemForm.parentId,
-          childConfigurationItemId: created.id,
-          quantity: Number(itemForm.quantity),
-          unitOfMeasure: itemForm.unitOfMeasure,
-          sortOrder: childrenByParent.get(itemForm.parentId)?.length ?? 0,
-        }
-      );
     if (created) {
-      setSelectedItemId(created.id);
+      setSelectedItemId(created.item.id);
       setItemForm({
         configurationItemNumber: '',
         partNumber: '',

--- a/client/src/features/design-control/DesignProjectConfigurationWorkspace.tsx
+++ b/client/src/features/design-control/DesignProjectConfigurationWorkspace.tsx
@@ -1,0 +1,1217 @@
+import { useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  Plus,
+  Search,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { usePermissions } from '@/hooks/usePermissions';
+
+type ItemType =
+  | 'PRODUCT'
+  | 'ASSEMBLY'
+  | 'SUBASSEMBLY'
+  | 'MANUFACTURED_PART'
+  | 'PURCHASED_COMPONENT'
+  | 'TOOLING'
+  | 'SOFTWARE';
+interface ConfigurationItem {
+  id: string;
+  configurationItemNumber: string;
+  partNumber: string;
+  title: string;
+  itemType: ItemType;
+  makeBuyDesignation: string;
+  designResponsibility?: string | null;
+  inventoryItemId?: number | null;
+  lifecycleStatus: string;
+}
+interface Relationship {
+  id: string;
+  parentConfigurationItemId: string;
+  childConfigurationItemId: string;
+  quantity: string;
+  unitOfMeasure: string;
+  sortOrder: number;
+}
+interface Revision {
+  id: string;
+  configurationItemId: string;
+  revisionIdentifier: string;
+  revisionSequence: number;
+  lifecycleState: string;
+  changeSummary: string;
+  effectivityStart?: string | null;
+  effectivityEnd?: string | null;
+  sourceEcrId?: string | null;
+  sourceEcnId?: string | null;
+}
+interface CoverageEntry {
+  role: string;
+  status: string;
+  applicability?: {
+    id: string;
+    decision: string;
+    justification?: string;
+    approvalStatus: string;
+  } | null;
+  artifact?: {
+    sourceModule: string;
+    sourceRecordId: string;
+    artifactNumber: string;
+    revisionSnapshot: string;
+  } | null;
+}
+interface Summary {
+  established: boolean;
+  message?: string;
+  workspace?: { configurationStatus: string };
+  authoritativeDesignControl?: {
+    id: string;
+    title?: string;
+    status?: string;
+  } | null;
+  currentEngineeringRelease?: {
+    release_revision: string;
+    release_status: string;
+  } | null;
+  parts?: Array<{
+    item: ConfigurationItem;
+    currentRevision: Revision | null;
+    coverage: CoverageEntry[];
+  }>;
+  totals?: Record<string, number | boolean>;
+}
+
+const steps = [
+  {
+    title: 'Product Structure',
+    help: 'Build the product, its assemblies, and the components that belong beneath them.',
+  },
+  {
+    title: 'Parts and Revisions',
+    help: 'Identify the current controlled revision and proposed effectivity for each part.',
+  },
+  {
+    title: 'Make/Buy Decisions',
+    help: 'Assign whether each part is manufactured here or purchased, and who owns the design.',
+  },
+  {
+    title: 'Documentation Requirements',
+    help: 'Decide which manufacturing and quality records each part requires.',
+  },
+  {
+    title: 'Coverage Review',
+    help: 'Review authoritative evidence links and resolve missing or pending coverage.',
+  },
+];
+const labels: Record<string, string> = {
+  DRAWING_CAD: 'Drawing / CAD',
+  BOM: 'BOM',
+  ROUTING: 'Routing',
+  TRAVELER: 'Traveler',
+  WORK_INSTRUCTION: 'Work instructions',
+  INSPECTION_PLAN: 'Inspection plan',
+  TEST_PROCEDURE: 'Test procedure',
+  MATERIAL_SPECIFICATION: 'Material specification',
+  TOOLING_FIXTURE: 'Tooling / fixtures',
+  CNC_PROGRAM: 'CNC program',
+  SUPPLIER_REQUIREMENT: 'Supplier requirements',
+  TRAINING_CERTIFICATION: 'Training / certification',
+  PACKAGING_SHIPPING: 'Packaging / shipping',
+};
+
+async function requestJson(
+  path: string,
+  init?: { method?: string; body?: string; headers?: Record<string, string> }
+) {
+  const response = await fetch(path, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok)
+    throw new Error(payload.message ?? payload.error ?? 'Request failed');
+  return payload;
+}
+
+export function DesignProjectConfigurationWorkspace({
+  projectId,
+  projectName,
+  designControlReadiness,
+}: {
+  projectId: string;
+  projectName: string;
+  designControlReadiness: string;
+}) {
+  const queryClient = useQueryClient();
+  const { can } = usePermissions();
+  const canEdit = can('design.configuration.edit');
+  const canApprove = can('design.configuration.applicability.approve');
+  const [step, setStep] = useState(0);
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [notice, setNotice] = useState('');
+  const [itemForm, setItemForm] = useState({
+    configurationItemNumber: '',
+    partNumber: '',
+    title: '',
+    itemType: 'MANUFACTURED_PART' as ItemType,
+    parentId: '',
+    quantity: '1',
+    unitOfMeasure: 'EA',
+    inventoryItemId: '',
+  });
+  const [revisionForm, setRevisionForm] = useState({
+    revisionIdentifier: '',
+    changeSummary: '',
+    predecessorRevisionId: '',
+    effectivityStart: '',
+    effectivityEnd: '',
+    sourceEcrId: '',
+    sourceEcnId: '',
+  });
+
+  const summaryQuery = useQuery<Summary>({
+    queryKey: ['/api/rd-projects', projectId, 'configuration', 'summary'],
+    queryFn: () =>
+      requestJson(
+        `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/summary`
+      ),
+    retry: false,
+  });
+  const treeQuery = useQuery<{
+    items: ConfigurationItem[];
+    relationships: Relationship[];
+    revisions: Revision[];
+  }>({
+    queryKey: ['/api/rd-projects', projectId, 'configuration', 'tree'],
+    queryFn: () =>
+      requestJson(
+        `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/tree`
+      ),
+    enabled: summaryQuery.data?.established === true,
+    retry: false,
+  });
+  const summary = summaryQuery.data;
+  const items = treeQuery.data?.items ?? [];
+  const relationships = useMemo(
+    () => treeQuery.data?.relationships ?? [],
+    [treeQuery.data?.relationships]
+  );
+  const revisions = treeQuery.data?.revisions ?? [];
+  const selectedItem =
+    items.find((item) => item.id === selectedItemId) ?? items[0] ?? null;
+  const selectedCoverage = summary?.parts?.find(
+    (part) => part.item.id === selectedItem?.id
+  );
+  const childrenByParent = useMemo(() => {
+    const map = new Map<string, Relationship[]>();
+    for (const relation of relationships)
+      map.set(
+        relation.parentConfigurationItemId,
+        [...(map.get(relation.parentConfigurationItemId) ?? []), relation].sort(
+          (a, b) => a.sortOrder - b.sortOrder
+        )
+      );
+    return map;
+  }, [relationships]);
+  const childIds = new Set(
+    relationships.map((relation) => relation.childConfigurationItemId)
+  );
+  const roots = items.filter((item) => !childIds.has(item.id));
+
+  async function refresh() {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ['/api/rd-projects', projectId, 'configuration', 'summary'],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ['/api/rd-projects', projectId, 'configuration', 'tree'],
+      }),
+    ]);
+  }
+  async function mutate(path: string, method: string, body?: unknown) {
+    setNotice('');
+    try {
+      const result = await requestJson(path, {
+        method,
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+      await refresh();
+      setNotice('Draft saved.');
+      return result;
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'Unable to save');
+      return null;
+    }
+  }
+  async function activate() {
+    await mutate(
+      `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/activate`,
+      'POST',
+      {}
+    );
+  }
+  async function createItem() {
+    const created = await mutate(
+      `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/items`,
+      'POST',
+      {
+        configurationItemNumber: itemForm.configurationItemNumber,
+        partNumber: itemForm.partNumber,
+        title: itemForm.title,
+        itemType: itemForm.itemType,
+        inventoryItemId: itemForm.inventoryItemId
+          ? Number(itemForm.inventoryItemId)
+          : null,
+        makeBuyDesignation:
+          itemForm.itemType === 'PURCHASED_COMPONENT'
+            ? 'BUY'
+            : itemForm.itemType === 'MANUFACTURED_PART'
+              ? 'MAKE'
+              : 'UNDETERMINED',
+      }
+    );
+    if (created && itemForm.parentId)
+      await mutate(
+        `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/relationships`,
+        'POST',
+        {
+          parentConfigurationItemId: itemForm.parentId,
+          childConfigurationItemId: created.id,
+          quantity: Number(itemForm.quantity),
+          unitOfMeasure: itemForm.unitOfMeasure,
+          sortOrder: childrenByParent.get(itemForm.parentId)?.length ?? 0,
+        }
+      );
+    if (created) {
+      setSelectedItemId(created.id);
+      setItemForm({
+        configurationItemNumber: '',
+        partNumber: '',
+        title: '',
+        itemType: 'MANUFACTURED_PART',
+        parentId: '',
+        quantity: '1',
+        unitOfMeasure: 'EA',
+        inventoryItemId: '',
+      });
+    }
+  }
+  async function updateItem(fields: Partial<ConfigurationItem>) {
+    if (selectedItem)
+      await mutate(
+        `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/items/${selectedItem.id}`,
+        'PATCH',
+        fields
+      );
+  }
+  async function createRevision() {
+    if (!selectedItem) return;
+    await mutate(
+      `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/items/${selectedItem.id}/revisions`,
+      'POST',
+      Object.fromEntries(
+        Object.entries(revisionForm).map(([key, value]) => [key, value || null])
+      )
+    );
+    setRevisionForm({
+      revisionIdentifier: '',
+      changeSummary: '',
+      predecessorRevisionId: '',
+      effectivityStart: '',
+      effectivityEnd: '',
+      sourceEcrId: '',
+      sourceEcnId: '',
+    });
+  }
+  async function setRequirement(
+    role: string,
+    decision: string,
+    justification?: string
+  ) {
+    if (selectedItem)
+      await mutate(
+        `/api/rd-projects/${encodeURIComponent(projectId)}/configuration/items/${selectedItem.id}/applicability/${role}`,
+        'PUT',
+        { decision, justification: justification || null }
+      );
+  }
+
+  function TreeNode({
+    item,
+    depth = 0,
+  }: {
+    item: ConfigurationItem;
+    depth?: number;
+  }) {
+    const relations = childrenByParent.get(item.id) ?? [];
+    const isOpen = expanded.has(item.id);
+    const matches =
+      !search ||
+      `${item.partNumber} ${item.title}`
+        .toLowerCase()
+        .includes(search.toLowerCase());
+    const descendantMatches = relations.some((relation) => {
+      const child = items.find(
+        (candidate) => candidate.id === relation.childConfigurationItemId
+      );
+      return (
+        child &&
+        `${child.partNumber} ${child.title}`
+          .toLowerCase()
+          .includes(search.toLowerCase())
+      );
+    });
+    if (!matches && !descendantMatches) return null;
+    return (
+      <div>
+        <button
+          className={`flex w-full items-center gap-2 rounded px-2 py-2 text-left text-sm hover:bg-muted ${selectedItem?.id === item.id ? 'bg-blue-50 ring-1 ring-blue-200' : ''}`}
+          style={{ paddingLeft: 8 + depth * 18 }}
+          onClick={() => setSelectedItemId(item.id)}
+        >
+          <span
+            onClick={(event) => {
+              event.stopPropagation();
+              setExpanded((current) => {
+                const next = new Set(current);
+                next.has(item.id) ? next.delete(item.id) : next.add(item.id);
+                return next;
+              });
+            }}
+          >
+            {relations.length ? (
+              isOpen ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )
+            ) : (
+              <span className="inline-block w-4" />
+            )}
+          </span>
+          <span className="font-medium">{item.partNumber}</span>
+          <span className="truncate text-muted-foreground">{item.title}</span>
+          <Badge variant="outline" className="ml-auto">
+            {item.itemType.replaceAll('_', ' ')}
+          </Badge>
+        </button>
+        {(isOpen || Boolean(search)) &&
+          relations.map((relation) => {
+            const child = items.find(
+              (candidate) => candidate.id === relation.childConfigurationItemId
+            );
+            return child ? (
+              <TreeNode key={relation.id} item={child} depth={depth + 1} />
+            ) : null;
+          })}
+      </div>
+    );
+  }
+
+  if (summaryQuery.isLoading)
+    return (
+      <Card>
+        <CardContent className="py-8">
+          Loading controlled configuration…
+        </CardContent>
+      </Card>
+    );
+  if (!summary?.established)
+    return (
+      <Card className="border-amber-200">
+        <CardHeader>
+          <CardTitle>Part &amp; Assembly Configuration</CardTitle>
+          <CardDescription>
+            {summary?.message ??
+              'Configuration has not been established for this legacy project.'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Starting is explicit and audited. It does not create inferred links,
+            alter production, or enable release blocking.
+          </p>
+          {canEdit && (
+            <Button onClick={activate}>Start Controlled Configuration</Button>
+          )}
+        </CardContent>
+      </Card>
+    );
+
+  const totals = summary.totals ?? {};
+  return (
+    <div className="space-y-4" data-testid={`configuration-step-${step + 1}`}>
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <CardTitle>Part &amp; Assembly Configuration</CardTitle>
+              <CardDescription>
+                {projectId} · {projectName}
+              </CardDescription>
+            </div>
+            <Badge>{summary.workspace?.configurationStatus ?? 'DRAFT'}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-5">
+          <div>
+            <p className="text-xs text-muted-foreground">Engineering release</p>
+            <p className="font-medium">
+              {summary.currentEngineeringRelease
+                ? `Revision ${summary.currentEngineeringRelease.release_revision} · ${summary.currentEngineeringRelease.release_status}`
+                : 'No current release'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">
+              Authoritative Design Control
+            </p>
+            <p className="font-medium">
+              {summary.authoritativeDesignControl?.title ?? 'Not initialized'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">
+              Design Control readiness
+            </p>
+            <p className="font-medium">
+              {designControlReadiness.replaceAll('_', ' ')}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">
+              Configuration coverage
+            </p>
+            <Progress
+              className="mt-2"
+              value={Number(totals.completenessPercentage ?? 0)}
+            />
+            <p className="mt-1 text-xs">
+              {String(totals.completenessPercentage ?? 0)}% informational only
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">
+              Production enforcement
+            </p>
+            <p className="font-medium text-emerald-700">Disabled in Phase 2</p>
+          </div>
+        </CardContent>
+      </Card>
+      <div className="grid gap-2 md:grid-cols-5">
+        {steps.map((entry, index) => (
+          <button
+            key={entry.title}
+            onClick={() => setStep(index)}
+            className={`rounded-lg border p-3 text-left ${step === index ? 'border-blue-500 bg-blue-50' : 'bg-card'}`}
+          >
+            <span className="text-xs text-muted-foreground">
+              Step {index + 1}
+            </span>
+            <p className="font-medium">{entry.title}</p>
+          </button>
+        ))}
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>{steps[step].title}</CardTitle>
+          <CardDescription>{steps[step].help}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {step === 0 && (
+            <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+              <div className="space-y-3">
+                <div className="relative">
+                  <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    className="pl-9"
+                    placeholder="Search part number or name"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                  />
+                </div>
+                <div className="max-h-[520px] overflow-auto rounded border p-2">
+                  {roots.length ? (
+                    roots.map((item) => <TreeNode key={item.id} item={item} />)
+                  ) : (
+                    <p className="p-6 text-center text-sm text-muted-foreground">
+                      Add the top-level product to begin the structure.
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="space-y-3 rounded border p-4">
+                <h3 className="font-semibold">
+                  <Plus className="mr-2 inline h-4 w-4" />
+                  Add product structure item
+                </h3>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Label>
+                    Configuration number
+                    <Input
+                      value={itemForm.configurationItemNumber}
+                      onChange={(e) =>
+                        setItemForm({
+                          ...itemForm,
+                          configurationItemNumber: e.target.value,
+                        })
+                      }
+                    />
+                  </Label>
+                  <Label>
+                    Part number
+                    <Input
+                      value={itemForm.partNumber}
+                      onChange={(e) =>
+                        setItemForm({ ...itemForm, partNumber: e.target.value })
+                      }
+                    />
+                  </Label>
+                </div>
+                <Label>
+                  Part name
+                  <Input
+                    value={itemForm.title}
+                    onChange={(e) =>
+                      setItemForm({ ...itemForm, title: e.target.value })
+                    }
+                  />
+                </Label>
+                <Label>
+                  Type
+                  <Select
+                    value={itemForm.itemType}
+                    onValueChange={(value: ItemType) =>
+                      setItemForm({ ...itemForm, itemType: value })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[
+                        'PRODUCT',
+                        'ASSEMBLY',
+                        'SUBASSEMBLY',
+                        'MANUFACTURED_PART',
+                        'PURCHASED_COMPONENT',
+                        'TOOLING',
+                        'SOFTWARE',
+                      ].map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {type.replaceAll('_', ' ')}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Label>
+                <Label>
+                  Parent assembly
+                  <Select
+                    value={itemForm.parentId || 'root'}
+                    onValueChange={(value) =>
+                      setItemForm({
+                        ...itemForm,
+                        parentId: value === 'root' ? '' : value,
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="root">Top level</SelectItem>
+                      {items
+                        .filter((item) =>
+                          ['PRODUCT', 'ASSEMBLY', 'SUBASSEMBLY'].includes(
+                            item.itemType
+                          )
+                        )
+                        .map((item) => (
+                          <SelectItem key={item.id} value={item.id}>
+                            {item.partNumber} — {item.title}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                </Label>
+                <div className="grid grid-cols-3 gap-2">
+                  <Label>
+                    Quantity
+                    <Input
+                      type="number"
+                      min="0.000001"
+                      value={itemForm.quantity}
+                      onChange={(e) =>
+                        setItemForm({ ...itemForm, quantity: e.target.value })
+                      }
+                    />
+                  </Label>
+                  <Label>
+                    Unit
+                    <Input
+                      value={itemForm.unitOfMeasure}
+                      onChange={(e) =>
+                        setItemForm({
+                          ...itemForm,
+                          unitOfMeasure: e.target.value,
+                        })
+                      }
+                    />
+                  </Label>
+                  <Label>
+                    Inventory ID
+                    <Input
+                      type="number"
+                      value={itemForm.inventoryItemId}
+                      onChange={(e) =>
+                        setItemForm({
+                          ...itemForm,
+                          inventoryItemId: e.target.value,
+                        })
+                      }
+                    />
+                  </Label>
+                </div>
+                <Button
+                  disabled={
+                    !canEdit ||
+                    !itemForm.partNumber ||
+                    !itemForm.title ||
+                    !itemForm.configurationItemNumber
+                  }
+                  onClick={createItem}
+                >
+                  Add item
+                </Button>
+              </div>
+            </div>
+          )}
+          {step === 1 && (
+            <div className="grid gap-4 lg:grid-cols-[1fr_1.2fr]">
+              <PartList
+                items={items}
+                selectedId={selectedItem?.id}
+                onSelect={setSelectedItemId}
+              />
+              <div className="space-y-4 rounded border p-4">
+                {selectedItem ? (
+                  <>
+                    <div>
+                      <h3 className="font-semibold">
+                        {selectedItem.partNumber} — {selectedItem.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        {selectedItem.itemType.replaceAll('_', ' ')} ·{' '}
+                        {selectedItem.lifecycleStatus}
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      {revisions
+                        .filter(
+                          (revision) =>
+                            revision.configurationItemId === selectedItem.id
+                        )
+                        .sort((a, b) => b.revisionSequence - a.revisionSequence)
+                        .map((revision) => (
+                          <div key={revision.id} className="rounded border p-3">
+                            <div className="flex justify-between">
+                              <span className="font-medium">
+                                Revision {revision.revisionIdentifier}
+                              </span>
+                              <Badge variant="outline">
+                                {revision.lifecycleState}
+                              </Badge>
+                            </div>
+                            <p className="text-sm text-muted-foreground">
+                              {revision.changeSummary}
+                            </p>
+                          </div>
+                        ))}
+                    </div>
+                    <h4 className="font-medium">Create draft revision</h4>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <Label>
+                        Revision
+                        <Input
+                          value={revisionForm.revisionIdentifier}
+                          onChange={(e) =>
+                            setRevisionForm({
+                              ...revisionForm,
+                              revisionIdentifier: e.target.value,
+                            })
+                          }
+                        />
+                      </Label>
+                      <Label>
+                        Predecessor
+                        <Select
+                          value={revisionForm.predecessorRevisionId || 'none'}
+                          onValueChange={(value) =>
+                            setRevisionForm({
+                              ...revisionForm,
+                              predecessorRevisionId:
+                                value === 'none' ? '' : value,
+                            })
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="none">
+                              Initial revision
+                            </SelectItem>
+                            {revisions
+                              .filter(
+                                (revision) =>
+                                  revision.configurationItemId ===
+                                  selectedItem.id
+                              )
+                              .map((revision) => (
+                                <SelectItem
+                                  key={revision.id}
+                                  value={revision.id}
+                                >
+                                  {revision.revisionIdentifier} (
+                                  {revision.lifecycleState})
+                                </SelectItem>
+                              ))}
+                          </SelectContent>
+                        </Select>
+                      </Label>
+                    </div>
+                    <Label>
+                      Change summary
+                      <Textarea
+                        value={revisionForm.changeSummary}
+                        onChange={(e) =>
+                          setRevisionForm({
+                            ...revisionForm,
+                            changeSummary: e.target.value,
+                          })
+                        }
+                      />
+                    </Label>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <Label>
+                        Proposed effectivity start
+                        <Input
+                          value={revisionForm.effectivityStart}
+                          onChange={(e) =>
+                            setRevisionForm({
+                              ...revisionForm,
+                              effectivityStart: e.target.value,
+                            })
+                          }
+                        />
+                      </Label>
+                      <Label>
+                        Proposed effectivity end
+                        <Input
+                          value={revisionForm.effectivityEnd}
+                          onChange={(e) =>
+                            setRevisionForm({
+                              ...revisionForm,
+                              effectivityEnd: e.target.value,
+                            })
+                          }
+                        />
+                      </Label>
+                      <Label>
+                        ECR ID
+                        <Input
+                          value={revisionForm.sourceEcrId}
+                          onChange={(e) =>
+                            setRevisionForm({
+                              ...revisionForm,
+                              sourceEcrId: e.target.value,
+                            })
+                          }
+                        />
+                      </Label>
+                      <Label>
+                        ECN ID
+                        <Input
+                          value={revisionForm.sourceEcnId}
+                          onChange={(e) =>
+                            setRevisionForm({
+                              ...revisionForm,
+                              sourceEcnId: e.target.value,
+                            })
+                          }
+                        />
+                      </Label>
+                    </div>
+                    <Button
+                      disabled={
+                        !canEdit ||
+                        !revisionForm.revisionIdentifier ||
+                        !revisionForm.changeSummary
+                      }
+                      onClick={createRevision}
+                    >
+                      Create draft revision
+                    </Button>
+                  </>
+                ) : (
+                  <p>Select a part.</p>
+                )}
+              </div>
+            </div>
+          )}
+          {step === 2 && (
+            <div className="grid gap-4 lg:grid-cols-[1fr_1.2fr]">
+              <PartList
+                items={items}
+                selectedId={selectedItem?.id}
+                onSelect={setSelectedItemId}
+              />
+              <div className="space-y-4 rounded border p-4">
+                {selectedItem ? (
+                  <>
+                    <h3 className="font-semibold">
+                      {selectedItem.partNumber} — {selectedItem.title}
+                    </h3>
+                    <Label>
+                      Make / buy decision
+                      <Select
+                        value={selectedItem.makeBuyDesignation}
+                        disabled={!canEdit}
+                        onValueChange={(value) =>
+                          updateItem({ makeBuyDesignation: value })
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="MAKE">
+                            Make — manufactured here
+                          </SelectItem>
+                          <SelectItem value="BUY">
+                            Buy — purchased component
+                          </SelectItem>
+                          <SelectItem value="UNDETERMINED">
+                            Decision needed
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </Label>
+                    <Label>
+                      Design responsibility
+                      <Input
+                        disabled={!canEdit}
+                        defaultValue={selectedItem.designResponsibility ?? ''}
+                        onBlur={(event) =>
+                          updateItem({
+                            designResponsibility: event.target.value,
+                          })
+                        }
+                        placeholder="Engineering owner, supplier, or team"
+                      />
+                    </Label>
+                    <Label>
+                      Linked inventory item
+                      <Input
+                        disabled={!canEdit}
+                        type="number"
+                        defaultValue={selectedItem.inventoryItemId ?? ''}
+                        onBlur={(event) =>
+                          updateItem({
+                            inventoryItemId: event.target.value
+                              ? Number(event.target.value)
+                              : null,
+                          })
+                        }
+                        placeholder="Inventory item ID (optional)"
+                      />
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      Save Draft occurs when a field changes. Inventory linkage
+                      is explicit; no part-number match is used.
+                    </p>
+                  </>
+                ) : (
+                  <p>Select a part.</p>
+                )}
+              </div>
+            </div>
+          )}
+          {step === 3 && (
+            <div className="grid gap-4 lg:grid-cols-[1fr_1.4fr]">
+              <PartList
+                items={items.filter((item) =>
+                  ['MANUFACTURED_PART', 'PURCHASED_COMPONENT'].includes(
+                    item.itemType
+                  )
+                )}
+                selectedId={selectedItem?.id}
+                onSelect={setSelectedItemId}
+              />
+              <div className="space-y-2">
+                {selectedCoverage?.coverage.map((entry) => (
+                  <RequirementRow
+                    key={entry.role}
+                    entry={entry}
+                    canEdit={canEdit}
+                    canApprove={canApprove}
+                    onSet={(decision, justification) =>
+                      setRequirement(entry.role, decision, justification)
+                    }
+                    onSubmit={() =>
+                      entry.applicability &&
+                      mutate(
+                        `/api/rd-projects/${projectId}/configuration/applicability/${entry.applicability.id}/submit`,
+                        'POST',
+                        {}
+                      )
+                    }
+                    onApprove={() =>
+                      entry.applicability &&
+                      mutate(
+                        `/api/rd-projects/${projectId}/configuration/applicability/${entry.applicability.id}/approve`,
+                        'POST',
+                        {}
+                      )
+                    }
+                  />
+                )) ?? (
+                  <p className="text-sm text-muted-foreground">
+                    Select a manufactured part or purchased component.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+          {step === 4 && (
+            <div className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <Metric
+                  label="Configuration items"
+                  value={totals.totalConfigurationItems}
+                />
+                <Metric
+                  label="Parts missing revisions"
+                  value={totals.partsMissingRevisions}
+                />
+                <Metric
+                  label="Pending N/A approvals"
+                  value={totals.pendingNotApplicableApprovals}
+                />
+                <Metric
+                  label="Completeness"
+                  value={`${totals.completenessPercentage ?? 0}%`}
+                />
+              </div>
+              {summary.parts?.map((part) => (
+                <Card key={part.item.id}>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">
+                      {part.item.partNumber} — {part.item.title}
+                    </CardTitle>
+                    <CardDescription>
+                      Revision{' '}
+                      {part.currentRevision?.revisionIdentifier ?? 'missing'} ·
+                      evaluated separately for this part
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="flex flex-wrap gap-2">
+                    {part.coverage.map((entry) => (
+                      <Badge
+                        key={entry.role}
+                        variant={
+                          entry.status === 'Missing' ||
+                          entry.status.includes('Required')
+                            ? 'destructive'
+                            : 'outline'
+                        }
+                      >
+                        {labels[entry.role]}: {entry.status}
+                        {entry.artifact && (
+                          <a
+                            className="ml-1"
+                            href={`/${entry.artifact.sourceModule}/${entry.artifact.sourceRecordId}`}
+                          >
+                            <ExternalLink className="inline h-3 w-3" />
+                          </a>
+                        )}
+                      </Badge>
+                    ))}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      {notice && (
+        <p role="status" className="text-sm">
+          {notice}
+        </p>
+      )}
+      <div className="flex flex-wrap justify-between gap-2">
+        <Button
+          variant="outline"
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        >
+          Return to project
+        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={refresh}>
+            Save Draft
+          </Button>
+          {step > 0 && (
+            <Button variant="outline" onClick={() => setStep(step - 1)}>
+              Back
+            </Button>
+          )}
+          {step < steps.length - 1 && (
+            <Button onClick={() => setStep(step + 1)}>
+              Next: {steps[step + 1].title}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PartList({
+  items,
+  selectedId,
+  onSelect,
+}: {
+  items: ConfigurationItem[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <div className="max-h-[520px] space-y-1 overflow-auto rounded border p-2">
+      {items.map((item) => (
+        <button
+          key={item.id}
+          onClick={() => onSelect(item.id)}
+          className={`w-full rounded p-3 text-left hover:bg-muted ${selectedId === item.id ? 'bg-blue-50 ring-1 ring-blue-200' : ''}`}
+        >
+          <span className="font-medium">{item.partNumber}</span>
+          <span className="ml-2 text-sm text-muted-foreground">
+            {item.title}
+          </span>
+          <Badge variant="outline" className="float-right">
+            {item.makeBuyDesignation}
+          </Badge>
+        </button>
+      ))}
+    </div>
+  );
+}
+function Metric({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div className="rounded border p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-semibold">{String(value ?? 0)}</p>
+    </div>
+  );
+}
+function RequirementRow({
+  entry,
+  canEdit,
+  canApprove,
+  onSet,
+  onSubmit,
+  onApprove,
+}: {
+  entry: CoverageEntry;
+  canEdit: boolean;
+  canApprove: boolean;
+  onSet: (decision: string, justification?: string) => void;
+  onSubmit: () => void;
+  onApprove: () => void;
+}) {
+  const [justification, setJustification] = useState(
+    entry.applicability?.justification ?? ''
+  );
+  return (
+    <div className="rounded border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="font-medium">{labels[entry.role] ?? entry.role}</p>
+          <p className="text-xs text-muted-foreground">
+            Coverage: {entry.status}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canEdit}
+            onClick={() => onSet('REQUIRED')}
+          >
+            Required
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canEdit}
+            onClick={() => onSet('OPTIONAL')}
+          >
+            Optional
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canEdit || !justification.trim()}
+            onClick={() => onSet('NOT_APPLICABLE', justification)}
+          >
+            Not Applicable
+          </Button>
+          {entry.applicability?.approvalStatus === 'DRAFT' && (
+            <Button size="sm" disabled={!canEdit} onClick={onSubmit}>
+              Submit approval
+            </Button>
+          )}
+          {entry.applicability?.approvalStatus === 'PENDING' && (
+            <Button size="sm" disabled={!canApprove} onClick={onApprove}>
+              Approve N/A
+            </Button>
+          )}
+        </div>
+      </div>
+      <Input
+        className="mt-2"
+        value={justification}
+        onChange={(e) => setJustification(e.target.value)}
+        placeholder="Justification required for Not Applicable"
+      />
+    </div>
+  );
+}

--- a/client/src/pages/RDProjectsPage.tsx
+++ b/client/src/pages/RDProjectsPage.tsx
@@ -51,6 +51,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { DesignHistoryFilePanel } from '@/components/design-control/DesignHistoryFilePanel';
 import { DesignControlWorkspace } from '@/features/design-control/DesignControlWorkspace';
+import { DesignProjectConfigurationWorkspace } from '@/features/design-control/DesignProjectConfigurationWorkspace';
 
 interface EmployeeOption {
   id: number;
@@ -1661,7 +1662,7 @@ export default function RDProjectsPage() {
                 </CardHeader>
                 <CardContent>
                   <Tabs value={activeProjectTab} onValueChange={changeProjectTab} className="space-y-4">
-                    <TabsList className="grid h-auto w-full grid-cols-2 md:grid-cols-4 xl:grid-cols-12">
+                    <TabsList className="grid h-auto w-full grid-cols-2 md:grid-cols-4 xl:grid-cols-13">
                       <TabsTrigger value="overview">Overview</TabsTrigger>
                       <TabsTrigger value="requirements">Requirements</TabsTrigger>
                       <TabsTrigger value="risks">Risks</TabsTrigger>
@@ -1677,6 +1678,9 @@ export default function RDProjectsPage() {
                       </TabsTrigger>
                       <TabsTrigger value="engineering-release">
                         Engineering Release
+                      </TabsTrigger>
+                      <TabsTrigger value="configuration">
+                        Part &amp; Assembly Configuration
                       </TabsTrigger>
                     </TabsList>
 
@@ -2581,6 +2585,13 @@ export default function RDProjectsPage() {
                           )}
                         </CardContent>
                       </Card>
+                    </TabsContent>
+                    <TabsContent value="configuration" className="space-y-4">
+                      <DesignProjectConfigurationWorkspace
+                        projectId={selectedProject.id}
+                        projectName={selectedProject.projectName}
+                        designControlReadiness={selectedDesignControlPayload?.state ?? 'NOT_INITIALIZED'}
+                      />
                     </TabsContent>
                   </Tabs>
                 </CardContent>

--- a/client/src/pages/RDProjectsPage.tsx
+++ b/client/src/pages/RDProjectsPage.tsx
@@ -200,8 +200,18 @@ interface EngineeringReleasePreview {
   finalDesignReviewStatus: string;
   engineeringChangeStatus: string;
   manufacturingEvidenceStatus: string;
-  requiredApprovals: Array<{ role: string; approved: boolean; approvedBy?: string | null; approvedAt?: string | null }>;
-  completedApprovals: Array<{ role: string; approved: boolean; approvedBy?: string | null; approvedAt?: string | null }>;
+  requiredApprovals: Array<{
+    role: string;
+    approved: boolean;
+    approvedBy?: string | null;
+    approvedAt?: string | null;
+  }>;
+  completedApprovals: Array<{
+    role: string;
+    approved: boolean;
+    approvedBy?: string | null;
+    approvedAt?: string | null;
+  }>;
   missingEvidence: string[];
   baselineItems: Array<{
     baselineCategory: string;
@@ -670,8 +680,11 @@ function getPartsForProject(
 ) {
   if (!project) return [];
   const attachedRecords = getDraftRecordsForProject(project, records);
-  const lines = attachedRecords.flatMap((draft) =>
-    (draft.partsRequestLines?.length ? draft.partsRequestLines : draft.lines) ?? []
+  const lines = attachedRecords.flatMap(
+    (draft) =>
+      (draft.partsRequestLines?.length
+        ? draft.partsRequestLines
+        : draft.lines) ?? []
   );
 
   if (lines.length === 0)
@@ -695,7 +708,10 @@ function getPartsForProject(
   });
 }
 
-function getBomRecordsForProject(project: RDProject | null, records: DraftBomRecord[]) {
+function getBomRecordsForProject(
+  project: RDProject | null,
+  records: DraftBomRecord[]
+) {
   if (!project) return [];
   return getDraftRecordsForProject(project, records).flatMap((draft) => {
     const savedBoms = draft.savedDraftBoms ?? [];
@@ -710,7 +726,10 @@ function getBomRecordsForProject(project: RDProject | null, records: DraftBomRec
   });
 }
 
-function getLaborLinesForProject(project: RDProject | null, records: DraftBomRecord[]) {
+function getLaborLinesForProject(
+  project: RDProject | null,
+  records: DraftBomRecord[]
+) {
   if (!project) return [];
   return getDraftRecordsForProject(project, records).flatMap((draft) =>
     (draft.laborEstimateLines ?? []).map((line) => ({
@@ -721,7 +740,9 @@ function getLaborLinesForProject(project: RDProject | null, records: DraftBomRec
 }
 
 function laborLineHours(line: DraftLaborEstimateLine) {
-  return asNumber(line.hoursPerPart) * Math.max(1, asNumber(line.quantityPerPo));
+  return (
+    asNumber(line.hoursPerPart) * Math.max(1, asNumber(line.quantityPerPo))
+  );
 }
 
 function laborLineTotal(line: DraftLaborEstimateLine) {
@@ -887,13 +908,22 @@ export default function RDProjectsPage() {
   const [localProjects, setLocalProjects] = useState<RDProject[]>(() =>
     readJsonStorage(R_AND_D_PROJECT_STORAGE_KEY, [])
   );
-  const [isCreatingDesignControlRecord, setIsCreatingDesignControlRecord] = useState(false);
+  const [isCreatingDesignControlRecord, setIsCreatingDesignControlRecord] =
+    useState(false);
   const [isReleaseDialogOpen, setIsReleaseDialogOpen] = useState(false);
-  const [isSubmittingEngineeringRelease, setIsSubmittingEngineeringRelease] = useState(false);
-  const [isGeneratingEngineeringPackage, setIsGeneratingEngineeringPackage] = useState(false);
-  const [engineeringReleaseError, setEngineeringReleaseError] = useState<string | null>(null);
-  const [engineeringPackageError, setEngineeringPackageError] = useState<string | null>(null);
-  const [localImportState, setLocalImportState] = useState<Record<string, string>>({});
+  const [isSubmittingEngineeringRelease, setIsSubmittingEngineeringRelease] =
+    useState(false);
+  const [isGeneratingEngineeringPackage, setIsGeneratingEngineeringPackage] =
+    useState(false);
+  const [engineeringReleaseError, setEngineeringReleaseError] = useState<
+    string | null
+  >(null);
+  const [engineeringPackageError, setEngineeringPackageError] = useState<
+    string | null
+  >(null);
+  const [localImportState, setLocalImportState] = useState<
+    Record<string, string>
+  >({});
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
     () => new URLSearchParams(window.location.search).get('projectId')
   );
@@ -907,7 +937,9 @@ export default function RDProjectsPage() {
     'draft-tabs': 'outputs',
   };
   const initialProjectTab =
-    rdTabAliases[new URLSearchParams(window.location.search).get('tab') ?? 'overview'] ??
+    rdTabAliases[
+      new URLSearchParams(window.location.search).get('tab') ?? 'overview'
+    ] ??
     new URLSearchParams(window.location.search).get('tab') ??
     'overview';
   const [activeProjectTab, setActiveProjectTab] = useState(initialProjectTab);
@@ -915,7 +947,9 @@ export default function RDProjectsPage() {
   const projects = sharedProjects;
   const localOnlyProjects = useMemo(() => {
     const serverIds = new Set(sharedProjects.map((project) => project.id));
-    return localProjects.filter((project) => project.id && !serverIds.has(project.id));
+    return localProjects.filter(
+      (project) => project.id && !serverIds.has(project.id)
+    );
   }, [localProjects, sharedProjects]);
   const draftRecords = useMemo(
     () => mergeDraftRecords(localDraftRecords, sharedDraftRecords),
@@ -977,11 +1011,24 @@ export default function RDProjectsPage() {
     enabled: Boolean(selectedProject?.id),
     retry: false,
     queryFn: async () => {
-      if (!selectedProject?.id) return { state: 'NOT_INITIALIZED', authoritativeRecord: null, records: [] };
-      const response = await fetch(`/api/rd-projects/${encodeURIComponent(selectedProject.id)}/design-control`, {
-        credentials: 'include',
-      });
-      if (!response.ok) return { state: 'NOT_INITIALIZED', authoritativeRecord: null, records: [] };
+      if (!selectedProject?.id)
+        return {
+          state: 'NOT_INITIALIZED',
+          authoritativeRecord: null,
+          records: [],
+        };
+      const response = await fetch(
+        `/api/rd-projects/${encodeURIComponent(selectedProject.id)}/design-control`,
+        {
+          credentials: 'include',
+        }
+      );
+      if (!response.ok)
+        return {
+          state: 'NOT_INITIALIZED',
+          authoritativeRecord: null,
+          records: [],
+        };
       const payload = await response.json();
       return {
         state: payload.state,
@@ -990,38 +1037,55 @@ export default function RDProjectsPage() {
       };
     },
   });
-  const selectedDesignControlRecords = selectedDesignControlPayload?.records ?? [];
-  const activeDesignControlRecord = selectedDesignControlPayload?.authoritativeRecord ?? null;
+  const selectedDesignControlRecords =
+    selectedDesignControlPayload?.records ?? [];
+  const activeDesignControlRecord =
+    selectedDesignControlPayload?.authoritativeRecord ?? null;
   const {
     data: engineeringReleasePayload,
     isLoading: isLoadingEngineeringReleasePreview,
   } = useQuery<{ preview: EngineeringReleasePreview } | null>({
-    queryKey: ['/api/qms/design-control', activeDesignControlRecord?.id, 'engineering-release-preview'],
+    queryKey: [
+      '/api/qms/design-control',
+      activeDesignControlRecord?.id,
+      'engineering-release-preview',
+    ],
     enabled: Boolean(activeDesignControlRecord?.id),
     retry: false,
     queryFn: async () => {
       if (!activeDesignControlRecord?.id) return null;
-      const response = await fetch(`/api/qms/design-control/${activeDesignControlRecord.id}/engineering-release-preview`, {
-        credentials: 'include',
-      });
+      const response = await fetch(
+        `/api/qms/design-control/${activeDesignControlRecord.id}/engineering-release-preview`,
+        {
+          credentials: 'include',
+        }
+      );
       if (!response.ok) return null;
       return response.json();
     },
   });
   const engineeringReleasePreview = engineeringReleasePayload?.preview ?? null;
-  const releasedEngineeringReleaseId = engineeringReleasePreview?.existingRelease?.id ?? null;
+  const releasedEngineeringReleaseId =
+    engineeringReleasePreview?.existingRelease?.id ?? null;
   const {
     data: engineeringPackagePayload,
     isLoading: isLoadingEngineeringPackagePreview,
   } = useQuery<{ preview: EngineeringPackagePreview } | null>({
-    queryKey: ['/api/engineering-releases', releasedEngineeringReleaseId, 'package-preview'],
+    queryKey: [
+      '/api/engineering-releases',
+      releasedEngineeringReleaseId,
+      'package-preview',
+    ],
     enabled: Boolean(releasedEngineeringReleaseId),
     retry: false,
     queryFn: async () => {
       if (!releasedEngineeringReleaseId) return null;
-      const response = await fetch(`/api/engineering-releases/${releasedEngineeringReleaseId}/package-preview`, {
-        credentials: 'include',
-      });
+      const response = await fetch(
+        `/api/engineering-releases/${releasedEngineeringReleaseId}/package-preview`,
+        {
+          credentials: 'include',
+        }
+      );
       if (!response.ok) return null;
       return response.json();
     },
@@ -1124,24 +1188,33 @@ export default function RDProjectsPage() {
       existingDraft?.projectType !== 'R_AND_D' ||
       existingDraft?.projectId !== project.id
     ) {
-      setLocalDraftRecords((current) => mergeDraftRecords(current, [linkedDraft]));
+      setLocalDraftRecords((current) =>
+        mergeDraftRecords(current, [linkedDraft])
+      );
       queryClient.setQueryData<DraftBomRecord[]>(
         ['/api/draft-bom-drafts'],
         (current = []) => mergeDraftRecords(current, [linkedDraft])
       );
       saveSharedDraftRecord(linkedDraft)
         .then(() => {
-          queryClient.invalidateQueries({ queryKey: ['/api/draft-bom-drafts'] });
+          queryClient.invalidateQueries({
+            queryKey: ['/api/draft-bom-drafts'],
+          });
         })
         .catch((error) => {
-          console.error('Failed to attach Draft Builder handoff to R&D project:', error);
+          console.error(
+            'Failed to attach Draft Builder handoff to R&D project:',
+            error
+          );
         });
     }
 
     if (project.deletedDraftTabIds?.includes(draftId)) {
       persistProject({
         ...project,
-        deletedDraftTabIds: project.deletedDraftTabIds.filter((id) => id !== draftId),
+        deletedDraftTabIds: project.deletedDraftTabIds.filter(
+          (id) => id !== draftId
+        ),
       });
     }
   }, [draftRecords, location, projects, queryClient]);
@@ -1274,13 +1347,17 @@ export default function RDProjectsPage() {
   const openProjectFolder = (projectId: string, tab = activeProjectTab) => {
     setSelectedProjectId(projectId);
     setActiveProjectTab(tab);
-    setLocation(`/design/rd-projects?projectId=${encodeURIComponent(projectId)}&tab=${encodeURIComponent(tab)}`);
+    setLocation(
+      `/design/rd-projects?projectId=${encodeURIComponent(projectId)}&tab=${encodeURIComponent(tab)}`
+    );
   };
 
   const changeProjectTab = (tab: string) => {
     setActiveProjectTab(tab);
     if (selectedProject?.id) {
-      setLocation(`/design/rd-projects?projectId=${encodeURIComponent(selectedProject.id)}&tab=${encodeURIComponent(tab)}`);
+      setLocation(
+        `/design/rd-projects?projectId=${encodeURIComponent(selectedProject.id)}&tab=${encodeURIComponent(tab)}`
+      );
     }
   };
 
@@ -1297,14 +1374,17 @@ export default function RDProjectsPage() {
     if (!selectedProject) return;
     setIsCreatingDesignControlRecord(true);
     try {
-      const response = await fetch(`/api/rd-projects/${encodeURIComponent(selectedProject.id)}/design-control/initialize`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          title: `${selectedProject.projectName} Design Control`,
-        }),
-      });
+      const response = await fetch(
+        `/api/rd-projects/${encodeURIComponent(selectedProject.id)}/design-control/initialize`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: `${selectedProject.projectName} Design Control`,
+          }),
+        }
+      );
 
       if (!response.ok) {
         throw new Error('Failed to create design control record');
@@ -1316,10 +1396,19 @@ export default function RDProjectsPage() {
           queryKey: ['/api/rd-projects', selectedProject.id, 'design-control'],
         }),
         queryClient.invalidateQueries({
-          queryKey: ['/api/qms/design-control', 'rd-project', selectedProject.id],
+          queryKey: [
+            '/api/qms/design-control',
+            'rd-project',
+            selectedProject.id,
+          ],
         }),
       ]);
-      setLocation(designControlUrl(selectedProject, payload.resolution?.authoritativeRecord?.id));
+      setLocation(
+        designControlUrl(
+          selectedProject,
+          payload.resolution?.authoritativeRecord?.id
+        )
+      );
     } catch (error) {
       console.error('Failed to create R&D design control record:', error);
     } finally {
@@ -1328,8 +1417,16 @@ export default function RDProjectsPage() {
   };
 
   const importLocalProject = async (project: RDProject) => {
-    if (!window.confirm(`Import the browser-local project "${project.projectName}" to the shared server project list? Existing server projects will not be overwritten.`)) return;
-    setLocalImportState((current) => ({ ...current, [project.id]: 'importing' }));
+    if (
+      !window.confirm(
+        `Import the browser-local project "${project.projectName}" to the shared server project list? Existing server projects will not be overwritten.`
+      )
+    )
+      return;
+    setLocalImportState((current) => ({
+      ...current,
+      [project.id]: 'importing',
+    }));
     try {
       const response = await fetch('/api/rd-projects/reconcile-local', {
         method: 'POST',
@@ -1343,13 +1440,22 @@ export default function RDProjectsPage() {
       });
       const payload = await response.json().catch(() => ({}));
       if (!response.ok) {
-        setLocalImportState((current) => ({ ...current, [project.id]: payload.outcome ?? 'failed' }));
+        setLocalImportState((current) => ({
+          ...current,
+          [project.id]: payload.outcome ?? 'failed',
+        }));
         return;
       }
-      setLocalImportState((current) => ({ ...current, [project.id]: 'imported' }));
+      setLocalImportState((current) => ({
+        ...current,
+        [project.id]: 'imported',
+      }));
       await queryClient.invalidateQueries({ queryKey: ['/api/rd-projects'] });
     } catch {
-      setLocalImportState((current) => ({ ...current, [project.id]: 'failed' }));
+      setLocalImportState((current) => ({
+        ...current,
+        [project.id]: 'failed',
+      }));
     }
   };
 
@@ -1358,26 +1464,45 @@ export default function RDProjectsPage() {
     setIsSubmittingEngineeringRelease(true);
     setEngineeringReleaseError(null);
     try {
-      const response = await fetch(`/api/qms/design-control/${activeDesignControlRecord.id}/engineering-release`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          effectiveDate: engineeringReleasePreview?.effectiveDate,
-        }),
-      });
+      const response = await fetch(
+        `/api/qms/design-control/${activeDesignControlRecord.id}/engineering-release`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            effectiveDate: engineeringReleasePreview?.effectiveDate,
+          }),
+        }
+      );
       const payload = await response.json().catch(() => ({}));
       if (!response.ok) {
-        throw new Error(payload.message || 'Engineering Release Gate is not ready.');
+        throw new Error(
+          payload.message || 'Engineering Release Gate is not ready.'
+        );
       }
       setIsReleaseDialogOpen(false);
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['/api/qms/design-control', 'rd-project', selectedProject?.id] }),
-        queryClient.invalidateQueries({ queryKey: ['/api/qms/design-control', activeDesignControlRecord.id, 'engineering-release-preview'] }),
+        queryClient.invalidateQueries({
+          queryKey: [
+            '/api/qms/design-control',
+            'rd-project',
+            selectedProject?.id,
+          ],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [
+            '/api/qms/design-control',
+            activeDesignControlRecord.id,
+            'engineering-release-preview',
+          ],
+        }),
         queryClient.invalidateQueries({ queryKey: ['/api/rd-projects'] }),
       ]);
     } catch (error: any) {
-      setEngineeringReleaseError(error.message || 'Failed to release engineering baseline.');
+      setEngineeringReleaseError(
+        error.message || 'Failed to release engineering baseline.'
+      );
     } finally {
       setIsSubmittingEngineeringRelease(false);
     }
@@ -1388,21 +1513,34 @@ export default function RDProjectsPage() {
     setIsGeneratingEngineeringPackage(true);
     setEngineeringPackageError(null);
     try {
-      const response = await fetch(`/api/engineering-releases/${releasedEngineeringReleaseId}/generate-package`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
+      const response = await fetch(
+        `/api/engineering-releases/${releasedEngineeringReleaseId}/generate-package`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
       const payload = await response.json().catch(() => ({}));
       if (!response.ok) {
-        const missingItems = Array.isArray(payload.missingItems) ? ` ${payload.missingItems.join('; ')}` : '';
-        throw new Error(`${payload.message || 'Engineering Package is not ready.'}${missingItems}`);
+        const missingItems = Array.isArray(payload.missingItems)
+          ? ` ${payload.missingItems.join('; ')}`
+          : '';
+        throw new Error(
+          `${payload.message || 'Engineering Package is not ready.'}${missingItems}`
+        );
       }
       await queryClient.invalidateQueries({
-        queryKey: ['/api/engineering-releases', releasedEngineeringReleaseId, 'package-preview'],
+        queryKey: [
+          '/api/engineering-releases',
+          releasedEngineeringReleaseId,
+          'package-preview',
+        ],
       });
     } catch (error: any) {
-      setEngineeringPackageError(error.message || 'Failed to generate Engineering Package.');
+      setEngineeringPackageError(
+        error.message || 'Failed to generate Engineering Package.'
+      );
     } finally {
       setIsGeneratingEngineeringPackage(false);
     }
@@ -1438,31 +1576,48 @@ export default function RDProjectsPage() {
                 Browser-local project data needs review
               </CardTitle>
               <CardDescription className="text-amber-800">
-                These legacy records remain in this browser but are not shared server projects. They are excluded from normal project selection until reviewed and imported.
+                These legacy records remain in this browser but are not shared
+                server projects. They are excluded from normal project selection
+                until reviewed and imported.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
               {localOnlyProjects.map((project) => (
-                <div key={project.id} className="flex flex-col gap-3 rounded-md border border-amber-200 bg-white p-3 sm:flex-row sm:items-center sm:justify-between">
+                <div
+                  key={project.id}
+                  className="flex flex-col gap-3 rounded-md border border-amber-200 bg-white p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
                   <div>
                     <p className="font-medium">{project.projectName}</p>
                     <p className="mt-1 text-sm text-muted-foreground">
-                      Owner: {project.owner || 'Unassigned'} · Status: {project.status} · Draft tabs: {project.draftTabIds.length}
+                      Owner: {project.owner || 'Unassigned'} · Status:{' '}
+                      {project.status} · Draft tabs:{' '}
+                      {project.draftTabIds.length}
                     </p>
                     {project.description && (
-                      <p className="mt-1 max-w-3xl text-sm text-muted-foreground">{project.description}</p>
+                      <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+                        {project.description}
+                      </p>
                     )}
                     <p className="text-xs text-muted-foreground">
-                      Local ID {project.id} · {localImportState[project.id] ?? 'local only'}
+                      Local ID {project.id} ·{' '}
+                      {localImportState[project.id] ?? 'local only'}
                     </p>
                   </div>
                   <Button
                     type="button"
                     variant="outline"
-                    disabled={localImportState[project.id] === 'importing' || localImportState[project.id] === 'imported'}
+                    disabled={
+                      localImportState[project.id] === 'importing' ||
+                      localImportState[project.id] === 'imported'
+                    }
                     onClick={() => importLocalProject(project)}
                   >
-                    {localImportState[project.id] === 'importing' ? 'Checking…' : localImportState[project.id] === 'imported' ? 'Imported' : 'Review and import'}
+                    {localImportState[project.id] === 'importing'
+                      ? 'Checking…'
+                      : localImportState[project.id] === 'imported'
+                        ? 'Imported'
+                        : 'Review and import'}
                   </Button>
                 </div>
               ))}
@@ -1661,14 +1816,22 @@ export default function RDProjectsPage() {
                   )}
                 </CardHeader>
                 <CardContent>
-                  <Tabs value={activeProjectTab} onValueChange={changeProjectTab} className="space-y-4">
+                  <Tabs
+                    value={activeProjectTab}
+                    onValueChange={changeProjectTab}
+                    className="space-y-4"
+                  >
                     <TabsList className="grid h-auto w-full grid-cols-2 md:grid-cols-4 xl:grid-cols-13">
                       <TabsTrigger value="overview">Overview</TabsTrigger>
-                      <TabsTrigger value="requirements">Requirements</TabsTrigger>
+                      <TabsTrigger value="requirements">
+                        Requirements
+                      </TabsTrigger>
                       <TabsTrigger value="risks">Risks</TabsTrigger>
                       <TabsTrigger value="outputs">Design Outputs</TabsTrigger>
                       <TabsTrigger value="prototype">Prototype</TabsTrigger>
-                      <TabsTrigger value="verification">Verification</TabsTrigger>
+                      <TabsTrigger value="verification">
+                        Verification
+                      </TabsTrigger>
                       <TabsTrigger value="validation">Validation</TabsTrigger>
                       <TabsTrigger value="reviews">Design Reviews</TabsTrigger>
                       <TabsTrigger value="changes">Changes</TabsTrigger>
@@ -1804,11 +1967,18 @@ export default function RDProjectsPage() {
                     <TabsContent value="requirements" className="space-y-4">
                       <Card>
                         <CardHeader>
-                          <CardTitle className="text-base">Requirements</CardTitle>
-                          <CardDescription>Customer, regulatory, performance, material, inspection, and test requirements owned by this R&amp;D project.</CardDescription>
+                          <CardTitle className="text-base">
+                            Requirements
+                          </CardTitle>
+                          <CardDescription>
+                            Customer, regulatory, performance, material,
+                            inspection, and test requirements owned by this
+                            R&amp;D project.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
-                          Design Control evaluates completeness; the R&amp;D project owns the requirement set.
+                          Design Control evaluates completeness; the R&amp;D
+                          project owns the requirement set.
                         </CardContent>
                       </Card>
                     </TabsContent>
@@ -1817,10 +1987,14 @@ export default function RDProjectsPage() {
                       <Card>
                         <CardHeader>
                           <CardTitle className="text-base">Risks</CardTitle>
-                          <CardDescription>Design risk assessment and mitigation closure for the selected R&amp;D project.</CardDescription>
+                          <CardDescription>
+                            Design risk assessment and mitigation closure for
+                            the selected R&amp;D project.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
-                          Open high risks block Engineering Release until dispositioned.
+                          Open high risks block Engineering Release until
+                          dispositioned.
                         </CardContent>
                       </Card>
                     </TabsContent>
@@ -1828,21 +2002,38 @@ export default function RDProjectsPage() {
                     <TabsContent value="outputs" className="space-y-4">
                       <Card>
                         <CardHeader>
-                          <CardTitle className="text-base">Design Outputs</CardTitle>
-                          <CardDescription>Draft Builder tabs, BOM records, CAD/drawing references, and output package evidence.</CardDescription>
+                          <CardTitle className="text-base">
+                            Design Outputs
+                          </CardTitle>
+                          <CardDescription>
+                            Draft Builder tabs, BOM records, CAD/drawing
+                            references, and output package evidence.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="grid gap-3 md:grid-cols-3">
                           <div className="rounded-md border bg-white p-3">
-                            <p className="text-xs text-muted-foreground">Linked draft tabs</p>
-                            <p className="text-lg font-semibold">{selectedDraftTabs.length}</p>
+                            <p className="text-xs text-muted-foreground">
+                              Linked draft tabs
+                            </p>
+                            <p className="text-lg font-semibold">
+                              {selectedDraftTabs.length}
+                            </p>
                           </div>
                           <div className="rounded-md border bg-white p-3">
-                            <p className="text-xs text-muted-foreground">BOM records</p>
-                            <p className="text-lg font-semibold">{selectedBomRecords.length}</p>
+                            <p className="text-xs text-muted-foreground">
+                              BOM records
+                            </p>
+                            <p className="text-lg font-semibold">
+                              {selectedBomRecords.length}
+                            </p>
                           </div>
                           <div className="rounded-md border bg-white p-3">
-                            <p className="text-xs text-muted-foreground">Parts</p>
-                            <p className="text-lg font-semibold">{selectedParts.length}</p>
+                            <p className="text-xs text-muted-foreground">
+                              Parts
+                            </p>
+                            <p className="text-lg font-semibold">
+                              {selectedParts.length}
+                            </p>
                           </div>
                         </CardContent>
                       </Card>
@@ -1852,10 +2043,14 @@ export default function RDProjectsPage() {
                       <Card>
                         <CardHeader>
                           <CardTitle className="text-base">Prototype</CardTitle>
-                          <CardDescription>Prototype build identity, build notes, lots, deviations, and evidence attachments.</CardDescription>
+                          <CardDescription>
+                            Prototype build identity, build notes, lots,
+                            deviations, and evidence attachments.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
-                          The Engineering Release preview pulls the prototype identifier from the linked Design Control workflow.
+                          The Engineering Release preview pulls the prototype
+                          identifier from the linked Design Control workflow.
                         </CardContent>
                       </Card>
                     </TabsContent>
@@ -1863,11 +2058,16 @@ export default function RDProjectsPage() {
                     <TabsContent value="verification" className="space-y-4">
                       <Card>
                         <CardHeader>
-                          <CardTitle className="text-base">Verification</CardTitle>
-                          <CardDescription>Evidence that design outputs meet design inputs.</CardDescription>
+                          <CardTitle className="text-base">
+                            Verification
+                          </CardTitle>
+                          <CardDescription>
+                            Evidence that design outputs meet design inputs.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
-                          Verification must be complete before Engineering Release.
+                          Verification must be complete before Engineering
+                          Release.
                         </CardContent>
                       </Card>
                     </TabsContent>
@@ -1875,11 +2075,17 @@ export default function RDProjectsPage() {
                     <TabsContent value="validation" className="space-y-4">
                       <Card>
                         <CardHeader>
-                          <CardTitle className="text-base">Validation</CardTitle>
-                          <CardDescription>Evidence that the product meets intended use and customer mission.</CardDescription>
+                          <CardTitle className="text-base">
+                            Validation
+                          </CardTitle>
+                          <CardDescription>
+                            Evidence that the product meets intended use and
+                            customer mission.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
-                          Validation must be complete before Engineering Release.
+                          Validation must be complete before Engineering
+                          Release.
                         </CardContent>
                       </Card>
                     </TabsContent>
@@ -1887,8 +2093,13 @@ export default function RDProjectsPage() {
                     <TabsContent value="reviews" className="space-y-4">
                       <Card>
                         <CardHeader>
-                          <CardTitle className="text-base">Design Reviews</CardTitle>
-                          <CardDescription>Concept, requirements, and final design review status.</CardDescription>
+                          <CardTitle className="text-base">
+                            Design Reviews
+                          </CardTitle>
+                          <CardDescription>
+                            Concept, requirements, and final design review
+                            status.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
                           Approved final design review is required for release.
@@ -1899,11 +2110,17 @@ export default function RDProjectsPage() {
                     <TabsContent value="changes" className="space-y-4">
                       <Card>
                         <CardHeader>
-                          <CardTitle className="text-base">Engineering Changes</CardTitle>
-                          <CardDescription>Open changes and future revision work for this design.</CardDescription>
+                          <CardTitle className="text-base">
+                            Engineering Changes
+                          </CardTitle>
+                          <CardDescription>
+                            Open changes and future revision work for this
+                            design.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
-                          Changes to released design data require Engineering Change and do not alter the locked baseline.
+                          Changes to released design data require Engineering
+                          Change and do not alter the locked baseline.
                         </CardContent>
                       </Card>
                     </TabsContent>
@@ -1911,11 +2128,17 @@ export default function RDProjectsPage() {
                     <TabsContent value="dhf" className="space-y-4">
                       <Card>
                         <CardHeader>
-                          <CardTitle className="text-base">Design History File</CardTitle>
-                          <CardDescription>Release-ready design evidence retained by R&amp;D project and Design Control record.</CardDescription>
+                          <CardTitle className="text-base">
+                            Design History File
+                          </CardTitle>
+                          <CardDescription>
+                            Release-ready design evidence retained by R&amp;D
+                            project and Design Control record.
+                          </CardDescription>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
-                          Engineering Release freezes a reproducible baseline snapshot for the DHF.
+                          Engineering Release freezes a reproducible baseline
+                          snapshot for the DHF.
                         </CardContent>
                       </Card>
                     </TabsContent>
@@ -1979,35 +2202,52 @@ export default function RDProjectsPage() {
                       {selectedBomRecords.length === 0 ? (
                         <Card>
                           <CardContent className="py-8 text-center text-sm text-muted-foreground">
-                            Push a Draft Builder BOM wizard tab or attach a draft with saved BOMs to populate this folder tab.
+                            Push a Draft Builder BOM wizard tab or attach a
+                            draft with saved BOMs to populate this folder tab.
                           </CardContent>
                         </Card>
                       ) : (
                         <div className="grid gap-3 md:grid-cols-2">
-                          {selectedBomRecords.map((bom: DraftPartBom & { sourceDraftName?: string }) => {
-                            const rootPart = bom.parts?.[0] ?? bom.rootPart;
-                            const components = rootPart?.bomItems ?? bom.rootPart?.bomItems ?? [];
-                            return (
-                              <Card key={bom.id}>
-                                <CardHeader>
-                                  <CardTitle className="flex items-center gap-2 text-base">
-                                    <Boxes className="h-4 w-4 text-cyan-700" />
-                                    {bom.name}
-                                  </CardTitle>
-                                  <CardDescription>
-                                    {bom.sourceDraftName || 'Draft Builder'} {bom.revision ? `- ${bom.revision}` : ''}
-                                  </CardDescription>
-                                </CardHeader>
-                                <CardContent className="space-y-3 text-sm">
-                                  <div className="rounded-md border bg-white p-3">
-                                    <p className="font-mono text-xs text-muted-foreground">{rootPart?.partNumber || 'No root part'}</p>
-                                    <p className="font-medium">{rootPart?.description || 'No description'}</p>
-                                  </div>
-                                  <Badge variant="outline">{components.length} component{components.length === 1 ? '' : 's'}</Badge>
-                                </CardContent>
-                              </Card>
-                            );
-                          })}
+                          {selectedBomRecords.map(
+                            (
+                              bom: DraftPartBom & { sourceDraftName?: string }
+                            ) => {
+                              const rootPart = bom.parts?.[0] ?? bom.rootPart;
+                              const components =
+                                rootPart?.bomItems ??
+                                bom.rootPart?.bomItems ??
+                                [];
+                              return (
+                                <Card key={bom.id}>
+                                  <CardHeader>
+                                    <CardTitle className="flex items-center gap-2 text-base">
+                                      <Boxes className="h-4 w-4 text-cyan-700" />
+                                      {bom.name}
+                                    </CardTitle>
+                                    <CardDescription>
+                                      {bom.sourceDraftName || 'Draft Builder'}{' '}
+                                      {bom.revision ? `- ${bom.revision}` : ''}
+                                    </CardDescription>
+                                  </CardHeader>
+                                  <CardContent className="space-y-3 text-sm">
+                                    <div className="rounded-md border bg-white p-3">
+                                      <p className="font-mono text-xs text-muted-foreground">
+                                        {rootPart?.partNumber || 'No root part'}
+                                      </p>
+                                      <p className="font-medium">
+                                        {rootPart?.description ||
+                                          'No description'}
+                                      </p>
+                                    </div>
+                                    <Badge variant="outline">
+                                      {components.length} component
+                                      {components.length === 1 ? '' : 's'}
+                                    </Badge>
+                                  </CardContent>
+                                </Card>
+                              );
+                            }
+                          )}
                         </div>
                       )}
                     </TabsContent>
@@ -2070,46 +2310,101 @@ export default function RDProjectsPage() {
                     <TabsContent value="labor" className="space-y-4">
                       <div className="grid gap-3 md:grid-cols-3">
                         <div className="rounded-md border bg-white p-3">
-                          <p className="text-xs text-muted-foreground">Estimate Lines</p>
-                          <p className="text-lg font-semibold">{selectedLaborLines.length}</p>
+                          <p className="text-xs text-muted-foreground">
+                            Estimate Lines
+                          </p>
+                          <p className="text-lg font-semibold">
+                            {selectedLaborLines.length}
+                          </p>
                         </div>
                         <div className="rounded-md border bg-white p-3">
-                          <p className="text-xs text-muted-foreground">Estimated Hours</p>
-                          <p className="text-lg font-semibold">{selectedLaborHours.toLocaleString(undefined, { maximumFractionDigits: 2 })}</p>
+                          <p className="text-xs text-muted-foreground">
+                            Estimated Hours
+                          </p>
+                          <p className="text-lg font-semibold">
+                            {selectedLaborHours.toLocaleString(undefined, {
+                              maximumFractionDigits: 2,
+                            })}
+                          </p>
                         </div>
                         <div className="rounded-md border bg-white p-3">
-                          <p className="text-xs text-muted-foreground">Estimated Labor</p>
-                          <p className="text-lg font-semibold">{selectedLaborTotal.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}</p>
+                          <p className="text-xs text-muted-foreground">
+                            Estimated Labor
+                          </p>
+                          <p className="text-lg font-semibold">
+                            {selectedLaborTotal.toLocaleString(undefined, {
+                              style: 'currency',
+                              currency: 'USD',
+                            })}
+                          </p>
                         </div>
                       </div>
                       {selectedLaborLines.length === 0 ? (
                         <Card>
                           <CardContent className="py-8 text-center text-sm text-muted-foreground">
-                            Push a Draft Direct Labor Estimate from Draft Builder to populate this folder tab.
+                            Push a Draft Direct Labor Estimate from Draft
+                            Builder to populate this folder tab.
                           </CardContent>
                         </Card>
                       ) : (
                         <div className="space-y-2">
-                          {selectedLaborLines.map((line: DraftLaborEstimateLine & { sourceDraftName?: string }) => (
-                            <div key={line.id ?? `${line.employeeRole}-${line.sourceDraftName}`} className="grid gap-3 rounded-md border bg-white p-3 md:grid-cols-5">
-                              <div className="md:col-span-2">
-                                <p className="font-medium">{line.employeeRole || 'Unassigned role'}</p>
-                                <p className="text-xs text-muted-foreground">{line.sourceDraftName || 'Draft Builder'}</p>
+                          {selectedLaborLines.map(
+                            (
+                              line: DraftLaborEstimateLine & {
+                                sourceDraftName?: string;
+                              }
+                            ) => (
+                              <div
+                                key={
+                                  line.id ??
+                                  `${line.employeeRole}-${line.sourceDraftName}`
+                                }
+                                className="grid gap-3 rounded-md border bg-white p-3 md:grid-cols-5"
+                              >
+                                <div className="md:col-span-2">
+                                  <p className="font-medium">
+                                    {line.employeeRole || 'Unassigned role'}
+                                  </p>
+                                  <p className="text-xs text-muted-foreground">
+                                    {line.sourceDraftName || 'Draft Builder'}
+                                  </p>
+                                </div>
+                                <div>
+                                  <p className="text-xs text-muted-foreground">
+                                    Hours / Part
+                                  </p>
+                                  <p className="font-medium">
+                                    {asNumber(line.hoursPerPart).toLocaleString(
+                                      undefined,
+                                      { maximumFractionDigits: 2 }
+                                    )}
+                                  </p>
+                                </div>
+                                <div>
+                                  <p className="text-xs text-muted-foreground">
+                                    Qty / PO
+                                  </p>
+                                  <p className="font-medium">
+                                    {Math.max(
+                                      1,
+                                      asNumber(line.quantityPerPo)
+                                    ).toLocaleString()}
+                                  </p>
+                                </div>
+                                <div>
+                                  <p className="text-xs text-muted-foreground">
+                                    Ext Labor
+                                  </p>
+                                  <p className="font-medium">
+                                    {laborLineTotal(line).toLocaleString(
+                                      undefined,
+                                      { style: 'currency', currency: 'USD' }
+                                    )}
+                                  </p>
+                                </div>
                               </div>
-                              <div>
-                                <p className="text-xs text-muted-foreground">Hours / Part</p>
-                                <p className="font-medium">{asNumber(line.hoursPerPart).toLocaleString(undefined, { maximumFractionDigits: 2 })}</p>
-                              </div>
-                              <div>
-                                <p className="text-xs text-muted-foreground">Qty / PO</p>
-                                <p className="font-medium">{Math.max(1, asNumber(line.quantityPerPo)).toLocaleString()}</p>
-                              </div>
-                              <div>
-                                <p className="text-xs text-muted-foreground">Ext Labor</p>
-                                <p className="font-medium">{laborLineTotal(line).toLocaleString(undefined, { style: 'currency', currency: 'USD' })}</p>
-                              </div>
-                            </div>
-                          ))}
+                            )
+                          )}
                         </div>
                       )}
                     </TabsContent>
@@ -2123,25 +2418,37 @@ export default function RDProjectsPage() {
                               Design Control
                             </CardTitle>
                             <CardDescription>
-                              Design-control records linked to this R&amp;D project only.
+                              Design-control records linked to this R&amp;D
+                              project only.
                             </CardDescription>
                           </div>
                           <Button
                             className="gap-2 self-start"
                             onClick={createDesignControlRecordForProject}
-                            disabled={isCreatingDesignControlRecord || selectedDesignControlRecords.length > 0}
+                            disabled={
+                              isCreatingDesignControlRecord ||
+                              selectedDesignControlRecords.length > 0
+                            }
                           >
                             <Plus className="h-4 w-4" />
-                            {isCreatingDesignControlRecord ? 'Creating...' : 'Create Design Control'}
+                            {isCreatingDesignControlRecord
+                              ? 'Creating...'
+                              : 'Create Design Control'}
                           </Button>
                         </CardHeader>
                         <CardContent className="space-y-3">
                           <div className="rounded-md border bg-white px-3 py-2 text-sm text-muted-foreground">
-                            When this design is released, its R&amp;D data can become the source package for a manufactured inventory item. That released item can later be selected from P2 when a PO is received.
+                            When this design is released, its R&amp;D data can
+                            become the source package for a manufactured
+                            inventory item. That released item can later be
+                            selected from P2 when a PO is received.
                           </div>
-                          {selectedDesignControlPayload?.state === 'RECONCILIATION_REQUIRED' && (
+                          {selectedDesignControlPayload?.state ===
+                            'RECONCILIATION_REQUIRED' && (
                             <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                              Multiple historical Design Control records require an administrator to designate authority. No record was selected automatically.
+                              Multiple historical Design Control records require
+                              an administrator to designate authority. No record
+                              was selected automatically.
                             </div>
                           )}
                           {isLoadingDesignControlRecords ? (
@@ -2150,7 +2457,8 @@ export default function RDProjectsPage() {
                             </div>
                           ) : selectedDesignControlRecords.length === 0 ? (
                             <div className="flex flex-col items-start gap-3 rounded-md border bg-white px-3 py-4 text-sm text-muted-foreground">
-                              No design-control record is linked to this R&amp;D project yet.
+                              No design-control record is linked to this R&amp;D
+                              project yet.
                               <Button
                                 variant="outline"
                                 size="sm"
@@ -2165,18 +2473,22 @@ export default function RDProjectsPage() {
                           ) : (
                             <div className="grid gap-3 md:grid-cols-2">
                               {selectedDesignControlRecords.map((record) => (
-                                <div key={record.id} className="rounded-md border bg-white px-3 py-3">
+                                <div
+                                  key={record.id}
+                                  className="rounded-md border bg-white px-3 py-3"
+                                >
                                   <div className="flex items-start justify-between gap-3">
                                     <div className="min-w-0">
                                       <p className="truncate text-sm font-medium text-slate-950">
                                         {record.title}
                                       </p>
                                       <p className="mt-1 text-xs text-muted-foreground">
-                                        {record.authorityStatus === 'authoritative'
+                                        {record.authorityStatus ===
+                                        'authoritative'
                                           ? 'Authoritative Design Control'
                                           : record.releasedAt
-                                          ? 'Released design control'
-                                          : `Status: ${record.status} · Authority: ${record.authorityStatus ?? 'legacy'}`}
+                                            ? 'Released design control'
+                                            : `Status: ${record.status} · Authority: ${record.authorityStatus ?? 'legacy'}`}
                                       </p>
                                     </div>
                                     <Badge variant="outline">
@@ -2188,7 +2500,14 @@ export default function RDProjectsPage() {
                                       variant="outline"
                                       size="sm"
                                       className="gap-2"
-                                      onClick={() => setLocation(designControlUrl(selectedProject, record.id))}
+                                      onClick={() =>
+                                        setLocation(
+                                          designControlUrl(
+                                            selectedProject,
+                                            record.id
+                                          )
+                                        )
+                                      }
                                     >
                                       <ExternalLink className="h-4 w-4" />
                                       Open
@@ -2202,7 +2521,10 @@ export default function RDProjectsPage() {
                       </Card>
                     </TabsContent>
 
-                    <TabsContent value="engineering-release" className="space-y-4">
+                    <TabsContent
+                      value="engineering-release"
+                      className="space-y-4"
+                    >
                       {activeDesignControlRecord && (
                         <DesignControlWorkspace
                           projectId={selectedProject.id}
@@ -2219,12 +2541,19 @@ export default function RDProjectsPage() {
                               Engineering Release Gate
                             </CardTitle>
                             <CardDescription>
-                              Freeze the approved R&amp;D design baseline before manufactured inventory item creation.
+                              Freeze the approved R&amp;D design baseline before
+                              manufactured inventory item creation.
                             </CardDescription>
                           </div>
                           <Button
                             className="gap-2 self-start"
-                            disabled={!engineeringReleasePreview?.ready || isSubmittingEngineeringRelease || Boolean(engineeringReleasePreview?.existingRelease)}
+                            disabled={
+                              !engineeringReleasePreview?.ready ||
+                              isSubmittingEngineeringRelease ||
+                              Boolean(
+                                engineeringReleasePreview?.existingRelease
+                              )
+                            }
                             onClick={() => setIsReleaseDialogOpen(true)}
                           >
                             <PackageCheck className="h-4 w-4" />
@@ -2234,7 +2563,8 @@ export default function RDProjectsPage() {
                         <CardContent className="space-y-4">
                           {!activeDesignControlRecord ? (
                             <div className="flex flex-col items-start gap-3 rounded-md border bg-white px-3 py-4 text-sm text-muted-foreground">
-                              Create a linked Design Control record before releasing an engineering baseline.
+                              Create a linked Design Control record before
+                              releasing an engineering baseline.
                               <Button
                                 variant="outline"
                                 size="sm"
@@ -2254,76 +2584,163 @@ export default function RDProjectsPage() {
                             <>
                               <div className="grid gap-3 md:grid-cols-4">
                                 <div className="rounded-md border bg-white p-3">
-                                  <p className="text-xs text-muted-foreground">Release readiness</p>
+                                  <p className="text-xs text-muted-foreground">
+                                    Release readiness
+                                  </p>
                                   <Badge
                                     variant="outline"
-                                    className={engineeringReleasePreview.ready ? 'mt-2 border-emerald-300 bg-emerald-50 text-emerald-700' : 'mt-2 border-amber-300 bg-amber-50 text-amber-800'}
+                                    className={
+                                      engineeringReleasePreview.ready
+                                        ? 'mt-2 border-emerald-300 bg-emerald-50 text-emerald-700'
+                                        : 'mt-2 border-amber-300 bg-amber-50 text-amber-800'
+                                    }
                                   >
-                                    {engineeringReleasePreview.ready ? 'Ready' : 'Blocked'}
+                                    {engineeringReleasePreview.ready
+                                      ? 'Ready'
+                                      : 'Blocked'}
                                   </Badge>
                                 </div>
                                 <div className="rounded-md border bg-white p-3">
-                                  <p className="text-xs text-muted-foreground">Release number</p>
-                                  <p className="mt-1 text-lg font-semibold">{engineeringReleasePreview.proposedReleaseNumber}</p>
+                                  <p className="text-xs text-muted-foreground">
+                                    Release number
+                                  </p>
+                                  <p className="mt-1 text-lg font-semibold">
+                                    {
+                                      engineeringReleasePreview.proposedReleaseNumber
+                                    }
+                                  </p>
                                 </div>
                                 <div className="rounded-md border bg-white p-3">
-                                  <p className="text-xs text-muted-foreground">Release revision</p>
-                                  <p className="mt-1 text-lg font-semibold">{engineeringReleasePreview.proposedReleaseRevision}</p>
+                                  <p className="text-xs text-muted-foreground">
+                                    Release revision
+                                  </p>
+                                  <p className="mt-1 text-lg font-semibold">
+                                    {
+                                      engineeringReleasePreview.proposedReleaseRevision
+                                    }
+                                  </p>
                                 </div>
                                 <div className="rounded-md border bg-white p-3">
-                                  <p className="text-xs text-muted-foreground">Effective date</p>
-                                  <p className="mt-1 text-lg font-semibold">{engineeringReleasePreview.effectiveDate}</p>
+                                  <p className="text-xs text-muted-foreground">
+                                    Effective date
+                                  </p>
+                                  <p className="mt-1 text-lg font-semibold">
+                                    {engineeringReleasePreview.effectiveDate}
+                                  </p>
                                 </div>
                                 <div className="rounded-md border bg-white p-3">
-                                  <p className="text-xs text-muted-foreground">Manufacturing evidence</p>
-                                  <p className="mt-1 text-lg font-semibold">{engineeringReleasePreview.manufacturingEvidenceStatus}</p>
+                                  <p className="text-xs text-muted-foreground">
+                                    Manufacturing evidence
+                                  </p>
+                                  <p className="mt-1 text-lg font-semibold">
+                                    {
+                                      engineeringReleasePreview.manufacturingEvidenceStatus
+                                    }
+                                  </p>
                                 </div>
                               </div>
 
                               {engineeringReleasePreview.existingRelease && (
                                 <div className="space-y-3 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
                                   <div>
-                                    <div className="text-base font-semibold">Engineering Release</div>
+                                    <div className="text-base font-semibold">
+                                      Engineering Release
+                                    </div>
                                     <div className="text-emerald-800">
-                                      Released by {engineeringReleasePreview.existingRelease.releasedBy || 'system'} on {engineeringReleasePreview.existingRelease.releasedAt || 'recorded release date'}
+                                      Released by{' '}
+                                      {engineeringReleasePreview.existingRelease
+                                        .releasedBy || 'system'}{' '}
+                                      on{' '}
+                                      {engineeringReleasePreview.existingRelease
+                                        .releasedAt || 'recorded release date'}
                                     </div>
                                   </div>
                                   <div className="grid gap-3 md:grid-cols-3">
                                     <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                      <p className="text-xs text-muted-foreground">Status</p>
+                                      <p className="text-xs text-muted-foreground">
+                                        Status
+                                      </p>
                                       <p className="font-semibold">Released</p>
                                     </div>
                                     <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                      <p className="text-xs text-muted-foreground">Release Number</p>
-                                      <p className="font-semibold">{engineeringReleasePreview.existingRelease.releaseNumber}</p>
+                                      <p className="text-xs text-muted-foreground">
+                                        Release Number
+                                      </p>
+                                      <p className="font-semibold">
+                                        {
+                                          engineeringReleasePreview
+                                            .existingRelease.releaseNumber
+                                        }
+                                      </p>
                                     </div>
                                     <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                      <p className="text-xs text-muted-foreground">Revision</p>
-                                      <p className="font-semibold">{engineeringReleasePreview.existingRelease.releaseRevision}</p>
+                                      <p className="text-xs text-muted-foreground">
+                                        Revision
+                                      </p>
+                                      <p className="font-semibold">
+                                        {
+                                          engineeringReleasePreview
+                                            .existingRelease.releaseRevision
+                                        }
+                                      </p>
                                     </div>
                                     <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                      <p className="text-xs text-muted-foreground">Baseline</p>
+                                      <p className="text-xs text-muted-foreground">
+                                        Baseline
+                                      </p>
                                       <p className="font-semibold">Locked</p>
                                     </div>
                                     <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                      <p className="text-xs text-muted-foreground">Manufactured Item</p>
-                                      <p className="font-semibold">Pending creation</p>
+                                      <p className="text-xs text-muted-foreground">
+                                        Manufactured Item
+                                      </p>
+                                      <p className="font-semibold">
+                                        Pending creation
+                                      </p>
                                     </div>
                                     <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                      <p className="text-xs text-muted-foreground">Manufacturing</p>
-                                      <p className="font-semibold">Baseline ready</p>
+                                      <p className="text-xs text-muted-foreground">
+                                        Manufacturing
+                                      </p>
+                                      <p className="font-semibold">
+                                        Baseline ready
+                                      </p>
                                     </div>
                                   </div>
                                   <div className="flex flex-wrap gap-2">
-                                    <Badge variant="outline" className="border-emerald-300 bg-white text-emerald-700">Available after item creation for Quote</Badge>
-                                    <Badge variant="outline" className="border-emerald-300 bg-white text-emerald-700">Available after item creation for Future PO</Badge>
-                                    <Badge variant="outline" className="border-emerald-300 bg-white text-emerald-700">Ready for Manufacturing setup</Badge>
+                                    <Badge
+                                      variant="outline"
+                                      className="border-emerald-300 bg-white text-emerald-700"
+                                    >
+                                      Available after item creation for Quote
+                                    </Badge>
+                                    <Badge
+                                      variant="outline"
+                                      className="border-emerald-300 bg-white text-emerald-700"
+                                    >
+                                      Available after item creation for Future
+                                      PO
+                                    </Badge>
+                                    <Badge
+                                      variant="outline"
+                                      className="border-emerald-300 bg-white text-emerald-700"
+                                    >
+                                      Ready for Manufacturing setup
+                                    </Badge>
                                   </div>
-                                  <Button variant="outline" size="sm" className="gap-2" disabled>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="gap-2"
+                                    disabled
+                                  >
                                     <ExternalLink className="h-4 w-4" />
                                     Open Inventory Item
                                   </Button>
-                                  <div className="font-medium">Next action: Create Manufactured Inventory Item</div>
+                                  <div className="font-medium">
+                                    Next action: Create Manufactured Inventory
+                                    Item
+                                  </div>
                                 </div>
                               )}
 
@@ -2343,20 +2760,28 @@ export default function RDProjectsPage() {
                                         Engineering Package
                                       </CardTitle>
                                       <CardDescription>
-                                        Locked Technical Data Package used as the engineering source for future manufactured inventory items.
+                                        Locked Technical Data Package used as
+                                        the engineering source for future
+                                        manufactured inventory items.
                                       </CardDescription>
                                     </div>
                                     <Button
                                       className="gap-2 self-start"
                                       disabled={
                                         !engineeringPackagePreview?.ready ||
-                                        Boolean(engineeringPackagePreview?.existingPackage) ||
+                                        Boolean(
+                                          engineeringPackagePreview?.existingPackage
+                                        ) ||
                                         isGeneratingEngineeringPackage
                                       }
-                                      onClick={generateEngineeringPackageForRelease}
+                                      onClick={
+                                        generateEngineeringPackageForRelease
+                                      }
                                     >
                                       <ShieldCheck className="h-4 w-4" />
-                                      {isGeneratingEngineeringPackage ? 'Generating...' : 'Generate Package'}
+                                      {isGeneratingEngineeringPackage
+                                        ? 'Generating...'
+                                        : 'Generate Package'}
                                     </Button>
                                   </CardHeader>
                                   <CardContent className="space-y-4">
@@ -2368,26 +2793,58 @@ export default function RDProjectsPage() {
                                       <>
                                         <div className="grid gap-3 md:grid-cols-4">
                                           <div className="rounded-md border bg-white p-3">
-                                            <p className="text-xs text-muted-foreground">Status</p>
+                                            <p className="text-xs text-muted-foreground">
+                                              Status
+                                            </p>
                                             <p className="mt-1 font-semibold">
-                                              {engineeringPackagePreview.existingPackage?.packageStatus ?? engineeringPackagePreview.packageCompleteness.status}
+                                              {engineeringPackagePreview
+                                                .existingPackage
+                                                ?.packageStatus ??
+                                                engineeringPackagePreview
+                                                  .packageCompleteness.status}
                                             </p>
                                           </div>
                                           <div className="rounded-md border bg-white p-3">
-                                            <p className="text-xs text-muted-foreground">Revision</p>
+                                            <p className="text-xs text-muted-foreground">
+                                              Revision
+                                            </p>
                                             <p className="mt-1 font-semibold">
-                                              {engineeringPackagePreview.existingPackage?.packageRevision ?? engineeringReleasePreview.existingRelease.releaseRevision}
+                                              {engineeringPackagePreview
+                                                .existingPackage
+                                                ?.packageRevision ??
+                                                engineeringReleasePreview
+                                                  .existingRelease
+                                                  .releaseRevision}
                                             </p>
                                           </div>
                                           <div className="rounded-md border bg-white p-3">
-                                            <p className="text-xs text-muted-foreground">Contents</p>
+                                            <p className="text-xs text-muted-foreground">
+                                              Contents
+                                            </p>
                                             <p className="mt-1 font-semibold">
-                                              {engineeringPackagePreview.packageCompleteness.presentRequiredCount}/{engineeringPackagePreview.packageCompleteness.requiredCount} required
+                                              {
+                                                engineeringPackagePreview
+                                                  .packageCompleteness
+                                                  .presentRequiredCount
+                                              }
+                                              /
+                                              {
+                                                engineeringPackagePreview
+                                                  .packageCompleteness
+                                                  .requiredCount
+                                              }{' '}
+                                              required
                                             </p>
                                           </div>
                                           <div className="rounded-md border bg-white p-3">
-                                            <p className="text-xs text-muted-foreground">BOM revision</p>
-                                            <p className="mt-1 font-semibold">{engineeringPackagePreview.bomSummary.revision || 'Not captured'}</p>
+                                            <p className="text-xs text-muted-foreground">
+                                              BOM revision
+                                            </p>
+                                            <p className="mt-1 font-semibold">
+                                              {engineeringPackagePreview
+                                                .bomSummary.revision ||
+                                                'Not captured'}
+                                            </p>
                                           </div>
                                         </div>
 
@@ -2395,26 +2852,61 @@ export default function RDProjectsPage() {
                                           <div className="space-y-3 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
                                             <div className="grid gap-3 md:grid-cols-4">
                                               <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                                <p className="text-xs text-muted-foreground">Package Number</p>
-                                                <p className="font-semibold">{engineeringPackagePreview.existingPackage.packageNumber}</p>
+                                                <p className="text-xs text-muted-foreground">
+                                                  Package Number
+                                                </p>
+                                                <p className="font-semibold">
+                                                  {
+                                                    engineeringPackagePreview
+                                                      .existingPackage
+                                                      .packageNumber
+                                                  }
+                                                </p>
                                               </div>
                                               <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                                <p className="text-xs text-muted-foreground">Revision</p>
-                                                <p className="font-semibold">{engineeringPackagePreview.existingPackage.packageRevision}</p>
+                                                <p className="text-xs text-muted-foreground">
+                                                  Revision
+                                                </p>
+                                                <p className="font-semibold">
+                                                  {
+                                                    engineeringPackagePreview
+                                                      .existingPackage
+                                                      .packageRevision
+                                                  }
+                                                </p>
                                               </div>
                                               <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                                <p className="text-xs text-muted-foreground">Created By</p>
-                                                <p className="font-semibold">{engineeringPackagePreview.existingPackage.lockedBy || 'system'}</p>
+                                                <p className="text-xs text-muted-foreground">
+                                                  Created By
+                                                </p>
+                                                <p className="font-semibold">
+                                                  {engineeringPackagePreview
+                                                    .existingPackage.lockedBy ||
+                                                    'system'}
+                                                </p>
                                               </div>
                                               <div className="rounded-md border border-emerald-200 bg-white p-3">
-                                                <p className="text-xs text-muted-foreground">Package Status</p>
-                                                <p className="font-semibold">Locked</p>
+                                                <p className="text-xs text-muted-foreground">
+                                                  Package Status
+                                                </p>
+                                                <p className="font-semibold">
+                                                  Locked
+                                                </p>
                                               </div>
                                             </div>
                                             <div className="text-emerald-800">
-                                              Created {engineeringPackagePreview.existingPackage.lockedAt || 'at recorded package time'}.
+                                              Created{' '}
+                                              {engineeringPackagePreview
+                                                .existingPackage.lockedAt ||
+                                                'at recorded package time'}
+                                              .
                                             </div>
-                                            <Button variant="outline" size="sm" className="gap-2" disabled>
+                                            <Button
+                                              variant="outline"
+                                              size="sm"
+                                              className="gap-2"
+                                              disabled
+                                            >
                                               <ExternalLink className="h-4 w-4" />
                                               Open Package
                                             </Button>
@@ -2427,11 +2919,24 @@ export default function RDProjectsPage() {
                                           </div>
                                         )}
 
-                                        {(engineeringPackagePreview.missingEngineeringDocuments.length > 0 || engineeringPackagePreview.missingControlledRecords.length > 0) && (
+                                        {(engineeringPackagePreview
+                                          .missingEngineeringDocuments.length >
+                                          0 ||
+                                          engineeringPackagePreview
+                                            .missingControlledRecords.length >
+                                            0) && (
                                           <div className="space-y-2">
-                                            <div className="text-sm font-medium">Missing Items</div>
-                                            {[...engineeringPackagePreview.missingEngineeringDocuments, ...engineeringPackagePreview.missingControlledRecords].map((item) => (
-                                              <div key={item} className="flex items-start gap-2 rounded-md border bg-white px-3 py-2 text-sm">
+                                            <div className="text-sm font-medium">
+                                              Missing Items
+                                            </div>
+                                            {[
+                                              ...engineeringPackagePreview.missingEngineeringDocuments,
+                                              ...engineeringPackagePreview.missingControlledRecords,
+                                            ].map((item) => (
+                                              <div
+                                                key={item}
+                                                className="flex items-start gap-2 rounded-md border bg-white px-3 py-2 text-sm"
+                                              >
                                                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
                                                 <span>{item}</span>
                                               </div>
@@ -2440,29 +2945,46 @@ export default function RDProjectsPage() {
                                         )}
 
                                         <div className="grid gap-2 md:grid-cols-2">
-                                          {engineeringPackagePreview.contents.slice(0, 12).map((item) => (
-                                            <div key={item.category} className="rounded-md border bg-white px-3 py-2 text-sm">
-                                              <div className="flex items-start justify-between gap-3">
-                                                <div>
-                                                  <div className="font-medium">{item.label}</div>
-                                                  <div className="text-xs text-muted-foreground">
-                                                    {item.sourceRevision ? `Revision ${item.sourceRevision}` : item.sourceRecordId || 'Reference pending'}
+                                          {engineeringPackagePreview.contents
+                                            .slice(0, 12)
+                                            .map((item) => (
+                                              <div
+                                                key={item.category}
+                                                className="rounded-md border bg-white px-3 py-2 text-sm"
+                                              >
+                                                <div className="flex items-start justify-between gap-3">
+                                                  <div>
+                                                    <div className="font-medium">
+                                                      {item.label}
+                                                    </div>
+                                                    <div className="text-xs text-muted-foreground">
+                                                      {item.sourceRevision
+                                                        ? `Revision ${item.sourceRevision}`
+                                                        : item.sourceRecordId ||
+                                                          'Reference pending'}
+                                                    </div>
                                                   </div>
+                                                  <Badge
+                                                    variant="outline"
+                                                    className={
+                                                      item.present
+                                                        ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+                                                        : 'border-amber-300 bg-amber-50 text-amber-800'
+                                                    }
+                                                  >
+                                                    {item.present
+                                                      ? 'Referenced'
+                                                      : 'Missing'}
+                                                  </Badge>
                                                 </div>
-                                                <Badge
-                                                  variant="outline"
-                                                  className={item.present ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-amber-300 bg-amber-50 text-amber-800'}
-                                                >
-                                                  {item.present ? 'Referenced' : 'Missing'}
-                                                </Badge>
                                               </div>
-                                            </div>
-                                          ))}
+                                            ))}
                                         </div>
                                       </>
                                     ) : (
                                       <div className="rounded-md border bg-white px-3 py-4 text-sm text-muted-foreground">
-                                        Engineering Package preview is unavailable for this release.
+                                        Engineering Package preview is
+                                        unavailable for this release.
                                       </div>
                                     )}
                                   </CardContent>
@@ -2475,18 +2997,29 @@ export default function RDProjectsPage() {
                                 </div>
                               )}
 
-                              {engineeringReleasePreview.missingEvidence.length > 0 && (
+                              {engineeringReleasePreview.missingEvidence
+                                .length > 0 && (
                                 <div className="space-y-2">
-                                  <div className="text-sm font-medium">Blocked items</div>
-                                  {engineeringReleasePreview.missingEvidence.slice(0, 12).map((item) => (
-                                    <div key={item} className="flex items-start gap-2 rounded-md border bg-white px-3 py-2 text-sm">
-                                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
-                                      <span>{item}</span>
-                                    </div>
-                                  ))}
-                                  {engineeringReleasePreview.missingEvidence.length > 12 && (
+                                  <div className="text-sm font-medium">
+                                    Blocked items
+                                  </div>
+                                  {engineeringReleasePreview.missingEvidence
+                                    .slice(0, 12)
+                                    .map((item) => (
+                                      <div
+                                        key={item}
+                                        className="flex items-start gap-2 rounded-md border bg-white px-3 py-2 text-sm"
+                                      >
+                                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+                                        <span>{item}</span>
+                                      </div>
+                                    ))}
+                                  {engineeringReleasePreview.missingEvidence
+                                    .length > 12 && (
                                     <p className="text-sm text-muted-foreground">
-                                      {engineeringReleasePreview.missingEvidence.length - 12} additional item(s) remain.
+                                      {engineeringReleasePreview.missingEvidence
+                                        .length - 12}{' '}
+                                      additional item(s) remain.
                                     </p>
                                   )}
                                 </div>
@@ -2495,92 +3028,170 @@ export default function RDProjectsPage() {
                               <div className="grid gap-4 lg:grid-cols-2">
                                 <Card>
                                   <CardHeader>
-                                    <CardTitle className="text-base">Baseline Preview</CardTitle>
+                                    <CardTitle className="text-base">
+                                      Baseline Preview
+                                    </CardTitle>
                                     <CardDescription>
-                                      Immutable snapshots that will be locked by Engineering Release.
+                                      Immutable snapshots that will be locked by
+                                      Engineering Release.
                                     </CardDescription>
                                   </CardHeader>
                                   <CardContent className="space-y-2">
-                                    {engineeringReleasePreview.baselineItems.slice(0, 10).map((item) => (
-                                      <div key={`${item.baselineCategory}-${item.sourceRecordId ?? item.sourceModule}`} className="rounded-md border bg-white px-3 py-2 text-sm">
-                                        <div className="flex items-start justify-between gap-3">
-                                          <div>
-                                            <div className="font-medium">{item.baselineCategory}</div>
-                                            <div className="text-xs text-muted-foreground">{item.sourceModule || 'Source module pending'}</div>
+                                    {engineeringReleasePreview.baselineItems
+                                      .slice(0, 10)
+                                      .map((item) => (
+                                        <div
+                                          key={`${item.baselineCategory}-${item.sourceRecordId ?? item.sourceModule}`}
+                                          className="rounded-md border bg-white px-3 py-2 text-sm"
+                                        >
+                                          <div className="flex items-start justify-between gap-3">
+                                            <div>
+                                              <div className="font-medium">
+                                                {item.baselineCategory}
+                                              </div>
+                                              <div className="text-xs text-muted-foreground">
+                                                {item.sourceModule ||
+                                                  'Source module pending'}
+                                              </div>
+                                            </div>
+                                            <Badge variant="outline">
+                                              {item.sourceStatus || 'snapshot'}
+                                            </Badge>
                                           </div>
-                                          <Badge variant="outline">{item.sourceStatus || 'snapshot'}</Badge>
+                                          {(item.sourceRevision ||
+                                            item.sourceRecordId) && (
+                                            <p className="mt-1 text-xs text-muted-foreground">
+                                              {item.sourceRevision
+                                                ? `Revision ${item.sourceRevision}`
+                                                : 'No revision'}
+                                              {item.sourceRecordId
+                                                ? ` · ${item.sourceRecordId}`
+                                                : ''}
+                                            </p>
+                                          )}
                                         </div>
-                                        {(item.sourceRevision || item.sourceRecordId) && (
-                                          <p className="mt-1 text-xs text-muted-foreground">
-                                            {item.sourceRevision ? `Revision ${item.sourceRevision}` : 'No revision'}{item.sourceRecordId ? ` · ${item.sourceRecordId}` : ''}
-                                          </p>
-                                        )}
-                                      </div>
-                                    ))}
+                                      ))}
                                   </CardContent>
                                 </Card>
 
                                 <Card>
                                   <CardHeader>
-                                    <CardTitle className="text-base">Approval Status</CardTitle>
+                                    <CardTitle className="text-base">
+                                      Approval Status
+                                    </CardTitle>
                                     <CardDescription>
-                                      Required approvals for Engineering Release.
+                                      Required approvals for Engineering
+                                      Release.
                                     </CardDescription>
                                   </CardHeader>
                                   <CardContent className="space-y-2">
-                                    {engineeringReleasePreview.requiredApprovals.map((approval) => (
-                                      <div key={approval.role} className="flex items-center justify-between rounded-md border bg-white px-3 py-2 text-sm">
-                                        <span>{approval.role}</span>
-                                        <Badge
-                                          variant="outline"
-                                          className={approval.approved ? 'border-emerald-300 bg-emerald-50 text-emerald-700' : 'border-amber-300 bg-amber-50 text-amber-800'}
+                                    {engineeringReleasePreview.requiredApprovals.map(
+                                      (approval) => (
+                                        <div
+                                          key={approval.role}
+                                          className="flex items-center justify-between rounded-md border bg-white px-3 py-2 text-sm"
                                         >
-                                          {approval.approved ? 'Approved' : 'Missing'}
-                                        </Badge>
-                                      </div>
-                                    ))}
+                                          <span>{approval.role}</span>
+                                          <Badge
+                                            variant="outline"
+                                            className={
+                                              approval.approved
+                                                ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+                                                : 'border-amber-300 bg-amber-50 text-amber-800'
+                                            }
+                                          >
+                                            {approval.approved
+                                              ? 'Approved'
+                                              : 'Missing'}
+                                          </Badge>
+                                        </div>
+                                      )
+                                    )}
                                     <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-                                      Verification: {engineeringReleasePreview.verificationStatus} · Validation: {engineeringReleasePreview.validationStatus} · Review: {engineeringReleasePreview.finalDesignReviewStatus} · Changes: {engineeringReleasePreview.engineeringChangeStatus}
+                                      Verification:{' '}
+                                      {
+                                        engineeringReleasePreview.verificationStatus
+                                      }{' '}
+                                      · Validation:{' '}
+                                      {
+                                        engineeringReleasePreview.validationStatus
+                                      }{' '}
+                                      · Review:{' '}
+                                      {
+                                        engineeringReleasePreview.finalDesignReviewStatus
+                                      }{' '}
+                                      · Changes:{' '}
+                                      {
+                                        engineeringReleasePreview.engineeringChangeStatus
+                                      }
                                     </div>
                                   </CardContent>
                                 </Card>
                               </div>
 
-                              {engineeringReleasePreview.releaseHistory.length > 0 && (
+                              {engineeringReleasePreview.releaseHistory.length >
+                                0 && (
                                 <Card>
                                   <CardHeader>
-                                    <CardTitle className="text-base">Release History</CardTitle>
-                                    <CardDescription>Engineering releases previously created for this R&amp;D design.</CardDescription>
+                                    <CardTitle className="text-base">
+                                      Release History
+                                    </CardTitle>
+                                    <CardDescription>
+                                      Engineering releases previously created
+                                      for this R&amp;D design.
+                                    </CardDescription>
                                   </CardHeader>
                                   <CardContent className="space-y-2">
-                                    {engineeringReleasePreview.releaseHistory.map((release) => (
-                                      <div key={release.id} className="flex items-center justify-between rounded-md border bg-white px-3 py-2 text-sm">
-                                        <div>
-                                          <div className="font-medium">{release.releaseNumber}</div>
-                                          <div className="text-xs text-muted-foreground">Revision {release.releaseRevision} · {release.releasedAt || 'released'}</div>
+                                    {engineeringReleasePreview.releaseHistory.map(
+                                      (release) => (
+                                        <div
+                                          key={release.id}
+                                          className="flex items-center justify-between rounded-md border bg-white px-3 py-2 text-sm"
+                                        >
+                                          <div>
+                                            <div className="font-medium">
+                                              {release.releaseNumber}
+                                            </div>
+                                            <div className="text-xs text-muted-foreground">
+                                              Revision {release.releaseRevision}{' '}
+                                              ·{' '}
+                                              {release.releasedAt || 'released'}
+                                            </div>
+                                          </div>
+                                          <Badge variant="outline">
+                                            {release.releaseStatus}
+                                          </Badge>
                                         </div>
-                                        <Badge variant="outline">{release.releaseStatus}</Badge>
-                                      </div>
-                                    ))}
+                                      )
+                                    )}
                                   </CardContent>
                                 </Card>
                               )}
 
-                              {engineeringReleasePreview.changedSinceReleaseWarnings.length > 0 && (
+                              {engineeringReleasePreview
+                                .changedSinceReleaseWarnings.length > 0 && (
                                 <div className="space-y-2">
-                                  <div className="text-sm font-medium">Changed since release</div>
-                                  {engineeringReleasePreview.changedSinceReleaseWarnings.map((warning) => (
-                                    <div key={warning} className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                                      <span>{warning}</span>
-                                    </div>
-                                  ))}
+                                  <div className="text-sm font-medium">
+                                    Changed since release
+                                  </div>
+                                  {engineeringReleasePreview.changedSinceReleaseWarnings.map(
+                                    (warning) => (
+                                      <div
+                                        key={warning}
+                                        className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+                                      >
+                                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                                        <span>{warning}</span>
+                                      </div>
+                                    )
+                                  )}
                                 </div>
                               )}
                             </>
                           ) : (
                             <div className="rounded-md border bg-white px-3 py-4 text-sm text-muted-foreground">
-                              Engineering release preview is unavailable for this design control record.
+                              Engineering release preview is unavailable for
+                              this design control record.
                             </div>
                           )}
                         </CardContent>
@@ -2590,7 +3201,10 @@ export default function RDProjectsPage() {
                       <DesignProjectConfigurationWorkspace
                         projectId={selectedProject.id}
                         projectName={selectedProject.projectName}
-                        designControlReadiness={selectedDesignControlPayload?.state ?? 'NOT_INITIALIZED'}
+                        designControlReadiness={
+                          selectedDesignControlPayload?.state ??
+                          'NOT_INITIALIZED'
+                        }
                       />
                     </TabsContent>
                   </Tabs>
@@ -2600,7 +3214,10 @@ export default function RDProjectsPage() {
           </div>
         )}
 
-        <Dialog open={isReleaseDialogOpen} onOpenChange={setIsReleaseDialogOpen}>
+        <Dialog
+          open={isReleaseDialogOpen}
+          onOpenChange={setIsReleaseDialogOpen}
+        >
           <DialogContent className="max-h-[85vh] max-w-2xl overflow-hidden flex flex-col">
             <DialogHeader className="flex-shrink-0">
               <DialogTitle>Release Engineering Baseline</DialogTitle>
@@ -2608,41 +3225,73 @@ export default function RDProjectsPage() {
             {engineeringReleasePreview && selectedProject && (
               <div className="min-h-0 flex-1 space-y-3 overflow-y-auto py-2 pr-2 text-sm">
                 <div className="rounded-md border bg-white p-3">
-                  <div className="font-medium">{selectedProject.projectName}</div>
-                  <div className="text-muted-foreground">{engineeringReleasePreview.productName}</div>
+                  <div className="font-medium">
+                    {selectedProject.projectName}
+                  </div>
+                  <div className="text-muted-foreground">
+                    {engineeringReleasePreview.productName}
+                  </div>
                 </div>
                 <div className="grid gap-3 md:grid-cols-2">
                   <div className="rounded-md border bg-white p-3">
-                    <p className="text-xs text-muted-foreground">Release number</p>
-                    <p className="font-medium">{engineeringReleasePreview.proposedReleaseNumber}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Release number
+                    </p>
+                    <p className="font-medium">
+                      {engineeringReleasePreview.proposedReleaseNumber}
+                    </p>
                   </div>
                   <div className="rounded-md border bg-white p-3">
-                    <p className="text-xs text-muted-foreground">Release revision</p>
-                    <p className="font-medium">{engineeringReleasePreview.proposedReleaseRevision}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Release revision
+                    </p>
+                    <p className="font-medium">
+                      {engineeringReleasePreview.proposedReleaseRevision}
+                    </p>
                   </div>
                   <div className="rounded-md border bg-white p-3">
-                    <p className="text-xs text-muted-foreground">Effective date</p>
-                    <p className="font-medium">{engineeringReleasePreview.effectiveDate}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Effective date
+                    </p>
+                    <p className="font-medium">
+                      {engineeringReleasePreview.effectiveDate}
+                    </p>
                   </div>
                   <div className="rounded-md border bg-white p-3">
-                    <p className="text-xs text-muted-foreground">BOM revision</p>
-                    <p className="font-medium">{engineeringReleasePreview.bomRevision || 'Not captured'}</p>
+                    <p className="text-xs text-muted-foreground">
+                      BOM revision
+                    </p>
+                    <p className="font-medium">
+                      {engineeringReleasePreview.bomRevision || 'Not captured'}
+                    </p>
                   </div>
                   <div className="rounded-md border bg-white p-3">
-                    <p className="text-xs text-muted-foreground">CAD revision</p>
-                    <p className="font-medium">{engineeringReleasePreview.cadRevision || 'Not captured'}</p>
+                    <p className="text-xs text-muted-foreground">
+                      CAD revision
+                    </p>
+                    <p className="font-medium">
+                      {engineeringReleasePreview.cadRevision || 'Not captured'}
+                    </p>
                   </div>
                   <div className="rounded-md border bg-white p-3">
                     <p className="text-xs text-muted-foreground">Prototype</p>
-                    <p className="font-medium">{engineeringReleasePreview.prototypeIdentifier || 'Not captured'}</p>
+                    <p className="font-medium">
+                      {engineeringReleasePreview.prototypeIdentifier ||
+                        'Not captured'}
+                    </p>
                   </div>
                   <div className="rounded-md border bg-white p-3">
                     <p className="text-xs text-muted-foreground">V&amp;V</p>
-                    <p className="font-medium">{engineeringReleasePreview.verificationStatus} / {engineeringReleasePreview.validationStatus}</p>
+                    <p className="font-medium">
+                      {engineeringReleasePreview.verificationStatus} /{' '}
+                      {engineeringReleasePreview.validationStatus}
+                    </p>
                   </div>
                 </div>
                 <div className="rounded-md border bg-white p-3">
-                  <p className="text-xs text-muted-foreground">Drawing revisions</p>
+                  <p className="text-xs text-muted-foreground">
+                    Drawing revisions
+                  </p>
                   <p className="font-medium">
                     {engineeringReleasePreview.drawingRevisions.length > 0
                       ? engineeringReleasePreview.drawingRevisions.join(', ')
@@ -2652,26 +3301,37 @@ export default function RDProjectsPage() {
                 <div className="rounded-md border bg-white p-3">
                   <p className="text-xs text-muted-foreground">Approvers</p>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {engineeringReleasePreview.requiredApprovals.map((approval) => (
-                      <Badge key={approval.role} variant="outline">
-                        {approval.role}: {approval.approved ? 'Approved' : 'Missing'}
-                      </Badge>
-                    ))}
+                    {engineeringReleasePreview.requiredApprovals.map(
+                      (approval) => (
+                        <Badge key={approval.role} variant="outline">
+                          {approval.role}:{' '}
+                          {approval.approved ? 'Approved' : 'Missing'}
+                        </Badge>
+                      )
+                    )}
                   </div>
                 </div>
               </div>
             )}
             <DialogFooter className="flex-shrink-0">
-              <Button variant="outline" onClick={() => setIsReleaseDialogOpen(false)}>
+              <Button
+                variant="outline"
+                onClick={() => setIsReleaseDialogOpen(false)}
+              >
                 Cancel
               </Button>
               <Button
                 className="gap-2"
                 onClick={submitEngineeringReleaseForProject}
-                disabled={isSubmittingEngineeringRelease || !engineeringReleasePreview?.ready}
+                disabled={
+                  isSubmittingEngineeringRelease ||
+                  !engineeringReleasePreview?.ready
+                }
               >
                 <PackageCheck className="h-4 w-4" />
-                {isSubmittingEngineeringRelease ? 'Releasing...' : 'Release Engineering Baseline'}
+                {isSubmittingEngineeringRelease
+                  ? 'Releasing...'
+                  : 'Release Engineering Baseline'}
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/migrations/0251_design_project_configuration_workspace.sql
+++ b/migrations/0251_design_project_configuration_workspace.sql
@@ -13,6 +13,20 @@ CREATE TABLE IF NOT EXISTS design_project_configuration_workspaces (
 CREATE INDEX IF NOT EXISTS design_project_configuration_workspaces_status_idx
   ON design_project_configuration_workspaces(configuration_status);
 
+-- 0248 originally declared these only inside CREATE TABLE IF NOT EXISTS.
+-- Repair schema-push-first databases where the tables already existed and the
+-- table-level declarations were therefore skipped.
+CREATE UNIQUE INDEX IF NOT EXISTS design_project_configuration_items_project_number_unique
+  ON design_project_configuration_items(rd_project_id, configuration_item_number);
+
+CREATE UNIQUE INDEX IF NOT EXISTS design_project_configuration_relationship_unique
+  ON design_project_configuration_item_relationships(
+    parent_configuration_item_id,
+    child_configuration_item_id,
+    effectivity_start,
+    effectivity_end
+  );
+
 ALTER TABLE design_project_document_applicability
   ADD COLUMN IF NOT EXISTS approval_status text NOT NULL DEFAULT 'NOT_REQUIRED';
 

--- a/migrations/0251_design_project_configuration_workspace.sql
+++ b/migrations/0251_design_project_configuration_workspace.sql
@@ -1,0 +1,33 @@
+-- Phase 2 explicit activation state for the Design Project configuration workspace.
+-- Existing projects remain untouched until an authorized user starts configuration.
+CREATE TABLE IF NOT EXISTS design_project_configuration_workspaces (
+  rd_project_id text PRIMARY KEY REFERENCES rd_projects(id) ON DELETE RESTRICT,
+  configuration_status text NOT NULL DEFAULT 'DRAFT'
+    CHECK (configuration_status IN ('DRAFT', 'IN_REVIEW', 'COMPLETE')),
+  activated_by_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  activated_by_snapshot jsonb NOT NULL,
+  activated_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS design_project_configuration_workspaces_status_idx
+  ON design_project_configuration_workspaces(configuration_status);
+
+ALTER TABLE design_project_document_applicability
+  ADD COLUMN IF NOT EXISTS approval_status text NOT NULL DEFAULT 'NOT_REQUIRED';
+
+ALTER TABLE design_project_document_applicability
+  DROP CONSTRAINT IF EXISTS design_project_document_applicability_na_check;
+
+ALTER TABLE design_project_document_applicability
+  DROP CONSTRAINT IF EXISTS design_project_document_applicability_approval_status_check;
+
+ALTER TABLE design_project_document_applicability
+  ADD CONSTRAINT design_project_document_applicability_approval_status_check CHECK (
+    approval_status IN ('NOT_REQUIRED', 'DRAFT', 'PENDING', 'APPROVED')
+    AND (decision <> 'NOT_APPLICABLE' OR nullif(btrim(justification), '') IS NOT NULL)
+    AND (approval_status <> 'APPROVED' OR (
+      decision = 'NOT_APPLICABLE' AND approved_by_user_id IS NOT NULL
+      AND approved_by_snapshot IS NOT NULL AND approved_at IS NOT NULL
+    ))
+  );

--- a/server/__tests__/designControlSchemaHardening.test.ts
+++ b/server/__tests__/designControlSchemaHardening.test.ts
@@ -60,9 +60,12 @@ function readMigrations() {
 }
 
 function captureNames(pattern: RegExp) {
-  return readMigrations().flatMap(({ file, content }) => (
-    Array.from(content.matchAll(pattern)).map((match) => ({ file, name: match[1] }))
-  ));
+  return readMigrations().flatMap(({ file, content }) =>
+    Array.from(content.matchAll(pattern)).map((match) => ({
+      file,
+      name: match[1],
+    }))
+  );
 }
 
 describe('Design Control schema hardening', () => {
@@ -78,7 +81,11 @@ describe('Design Control schema hardening', () => {
   });
 
   it('covers every required Design Control and Engineering Package table in migrations', () => {
-    const tables = new Set(captureNames(/CREATE TABLE IF NOT EXISTS\s+([a-z_]+)/gi).map((entry) => entry.name));
+    const tables = new Set(
+      captureNames(/CREATE TABLE IF NOT EXISTS\s+([a-z_]+)/gi).map(
+        (entry) => entry.name
+      )
+    );
 
     for (const table of requiredDesignControlTables) {
       expect(tables.has(table)).toBe(true);
@@ -94,7 +101,9 @@ describe('Design Control schema hardening', () => {
         acc[entry.name] = (acc[entry.name] ?? 0) + 1;
         return acc;
       }, {});
-      expect(Object.entries(counts).filter(([, count]) => count > 1)).toEqual([]);
+      expect(Object.entries(counts).filter(([, count]) => count > 1)).toEqual(
+        []
+      );
     }
   });
 
@@ -113,7 +122,9 @@ describe('Design Control schema hardening', () => {
   it('returns a structured readiness payload when schema is missing', async () => {
     const client = {
       execute: async () => {
-        const error = new Error('relation "design_control_records" does not exist') as Error & { code: string };
+        const error = new Error(
+          'relation "design_control_records" does not exist'
+        ) as Error & { code: string };
         error.code = '42P01';
         throw error;
       },
@@ -125,7 +136,7 @@ describe('Design Control schema hardening', () => {
     });
 
     const payload = designControlSchemaNotReadyPayload(
-      new DesignControlSchemaNotReadyError(['design_control_records']),
+      new DesignControlSchemaNotReadyError(['design_control_records'])
     );
 
     expect(payload).toEqual({
@@ -155,7 +166,8 @@ describe('Design Control schema hardening', () => {
             { column_name: 'record_version' },
           ];
         }
-        if (callNumber === requiredDesignControlTables.length + 2) return [{ present: 1 }];
+        if (callNumber === requiredDesignControlTables.length + 2)
+          return [{ present: 1 }];
         if (callNumber === requiredDesignControlTables.length + 3) {
           return [
             { conname: 'design_control_records_authority_status_check' },
@@ -174,7 +186,10 @@ describe('Design Control schema hardening', () => {
         }
         if (callNumber === requiredDesignControlTables.length + 5) {
           return [
-            { object_name: 'design_control_step_content_versions_step_version_unique' },
+            {
+              object_name:
+                'design_control_step_content_versions_step_version_unique',
+            },
             { object_name: 'design_control_step_approvals_valid_slot_unique' },
             { object_name: 'prevent_design_control_step_version_delete' },
             { object_name: 'prevent_design_control_step_approval_delete' },
@@ -184,7 +199,9 @@ describe('Design Control schema hardening', () => {
       },
     };
 
-    await expect(assertDesignControlSchemaReady(client)).resolves.toBeUndefined();
+    await expect(
+      assertDesignControlSchemaReady(client)
+    ).resolves.toBeUndefined();
     expect(calls).toHaveLength(requiredDesignControlTables.length + 5);
   });
 
@@ -193,7 +210,7 @@ describe('Design Control schema hardening', () => {
     delete process.env.FORCE_DATABASE_URL;
 
     await expect(runSafeBootMigrations()).rejects.toThrow(
-      'Missing required database environment variable: FORCE_DATABASE_URL or DATABASE_URL',
+      'Missing required database environment variable: FORCE_DATABASE_URL or DATABASE_URL'
     );
   });
 });

--- a/server/__tests__/designControlSchemaHardening.test.ts
+++ b/server/__tests__/designControlSchemaHardening.test.ts
@@ -30,6 +30,8 @@ const migrationFiles = [
   'migrations/0192_engineering_packages.sql',
   'migrations/0207_design_control_authority_foundation.sql',
   'migrations/0208_design_control_authenticated_approvals.sql',
+  'migrations/0248_design_project_manufacturing_configuration.sql',
+  'migrations/0251_design_project_configuration_workspace.sql',
 ];
 
 const originalDatabaseUrl = process.env.DATABASE_URL;

--- a/server/__tests__/designProjectConfigurationSecurityPostgres.test.ts
+++ b/server/__tests__/designProjectConfigurationSecurityPostgres.test.ts
@@ -1,0 +1,350 @@
+import express from 'express';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../middleware/requirePermission', () => ({
+  requirePermission: () => (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
+}));
+
+import { getDatabaseTargetInfo, pgPool } from '../db';
+import rdProjectRoutes from '../src/routes/rdProjects';
+
+const projectA = 'phase2-security-project-a';
+const projectB = 'phase2-security-project-b';
+const parentA = '10000000-0000-4000-8000-000000000001';
+const parentB = '10000000-0000-4000-8000-000000000002';
+const itemA = '10000000-0000-4000-8000-000000000003';
+const relationshipA = '20000000-0000-4000-8000-000000000001';
+const applicabilityDraft = '30000000-0000-4000-8000-000000000001';
+const applicabilityPending = '30000000-0000-4000-8000-000000000002';
+let actorUserId = 0;
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => {
+  (
+    req as express.Request & {
+      user: { id: number; username: string; role: string };
+    }
+  ).user = {
+    id: actorUserId,
+    username: 'phase2-certifier',
+    role: 'ADMIN',
+  };
+  next();
+});
+app.use('/api/rd-projects', rdProjectRoutes);
+
+async function countPart(partNumber: string) {
+  const result = await pgPool.query(
+    'SELECT count(*)::int AS count FROM design_project_configuration_items WHERE part_number = $1',
+    [partNumber]
+  );
+  return result.rows[0].count as number;
+}
+
+describe('Design Project configuration PostgreSQL ownership and atomicity', () => {
+  beforeAll(async () => {
+    const target = getDatabaseTargetInfo();
+    if (
+      process.env.DESIGN_PROJECT_CONFIGURATION_POSTGRES_CERTIFICATION !==
+        'isolated_test' ||
+      target.host !== '127.0.0.1' ||
+      target.database !== 'epoch_p2_v2_certification'
+    ) {
+      throw new Error(
+        `Disposable Design Project certification boundary rejected: ${target.redactedUrl ?? 'unknown'}`
+      );
+    }
+
+    const actor = await pgPool.query(
+      `INSERT INTO users (username, password_hash, role)
+       VALUES ('phase2-configuration-certifier', 'not-a-login-secret', 'ADMIN')
+       RETURNING id`
+    );
+    actorUserId = actor.rows[0].id;
+
+    await pgPool.query(
+      `INSERT INTO rd_projects (id, project_name) VALUES ($1, 'Phase 2 Security A'), ($2, 'Phase 2 Security B')`,
+      [projectA, projectB]
+    );
+    await pgPool.query(
+      `INSERT INTO design_project_configuration_workspaces
+        (rd_project_id, activated_by_snapshot) VALUES ($1, '{}'::jsonb), ($2, '{}'::jsonb)`,
+      [projectA, projectB]
+    );
+    await pgPool.query(
+      `INSERT INTO design_project_configuration_items
+        (id, rd_project_id, configuration_item_number, part_number, title, item_type, created_by_snapshot)
+       VALUES
+        ($1, $2, 'A-PARENT', 'A-PARENT', 'Project A Parent', 'ASSEMBLY', '{}'::jsonb),
+        ($3, $4, 'B-PARENT', 'B-PARENT', 'Project B Parent', 'ASSEMBLY', '{}'::jsonb),
+        ($5, $2, 'A-ITEM', 'A-ITEM', 'Project A Item', 'MANUFACTURED_PART', '{}'::jsonb)`,
+      [parentA, projectA, parentB, projectB, itemA]
+    );
+    await pgPool.query(
+      `INSERT INTO design_project_configuration_item_relationships
+        (id, rd_project_id, parent_configuration_item_id, child_configuration_item_id, quantity, unit_of_measure, created_by_snapshot)
+       VALUES ($1, $2, $3, $4, 1, 'EA', '{}'::jsonb)`,
+      [relationshipA, projectA, parentA, itemA]
+    );
+    await pgPool.query(
+      `INSERT INTO design_project_document_applicability
+        (id, configuration_item_id, requirement_role, decision, justification, approval_status, created_by_snapshot)
+       VALUES
+        ($1, $2, 'ROUTING', 'NOT_APPLICABLE', 'Routing is not used.', 'DRAFT', '{}'::jsonb),
+        ($3, $2, 'WORK_INSTRUCTION', 'NOT_APPLICABLE', 'No work instruction is required.', 'PENDING', '{}'::jsonb)`,
+      [applicabilityDraft, itemA, applicabilityPending]
+    );
+    await pgPool.query(`
+      CREATE OR REPLACE FUNCTION phase2_reject_relationship() RETURNS trigger AS $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM design_project_configuration_items
+          WHERE id = NEW.child_configuration_item_id AND part_number = 'FAIL-REL'
+        ) THEN
+          RAISE EXCEPTION 'synthetic relationship failure';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+      CREATE TRIGGER phase2_reject_relationship_trigger
+      BEFORE INSERT ON design_project_configuration_item_relationships
+      FOR EACH ROW EXECUTE FUNCTION phase2_reject_relationship();
+    `);
+  });
+
+  afterAll(async () => {
+    await pgPool.query(
+      'DROP TRIGGER IF EXISTS phase2_reject_relationship_trigger ON design_project_configuration_item_relationships'
+    );
+    await pgPool.query('DROP FUNCTION IF EXISTS phase2_reject_relationship()');
+    await pgPool.query(
+      `DELETE FROM design_project_document_applicability
+       WHERE configuration_item_id IN (
+         SELECT id FROM design_project_configuration_items WHERE rd_project_id = ANY($1::text[])
+       )`,
+      [[projectA, projectB]]
+    );
+    await pgPool.query(
+      'DELETE FROM design_project_part_revisions WHERE configuration_item_id IN (SELECT id FROM design_project_configuration_items WHERE rd_project_id = ANY($1::text[]))',
+      [[projectA, projectB]]
+    );
+    await pgPool.query(
+      'DELETE FROM design_project_configuration_item_relationships WHERE rd_project_id = ANY($1::text[])',
+      [[projectA, projectB]]
+    );
+    await pgPool.query(
+      'DELETE FROM design_project_configuration_items WHERE rd_project_id = ANY($1::text[])',
+      [[projectA, projectB]]
+    );
+    await pgPool.query(
+      'DELETE FROM design_project_configuration_workspaces WHERE rd_project_id = ANY($1::text[])',
+      [[projectA, projectB]]
+    );
+    await pgPool.query('DELETE FROM rd_projects WHERE id = ANY($1::text[])', [
+      [projectA, projectB],
+    ]);
+    await pgPool.query('DELETE FROM users WHERE id = $1', [actorUserId]);
+  });
+
+  it('does not submit Project A applicability through Project B', async () => {
+    const response = await request(app).post(
+      `/api/rd-projects/${projectB}/configuration/applicability/${applicabilityDraft}/submit`
+    );
+    expect(response.status).toBe(404);
+    const state = await pgPool.query(
+      'SELECT approval_status FROM design_project_document_applicability WHERE id = $1',
+      [applicabilityDraft]
+    );
+    expect(state.rows[0].approval_status).toBe('DRAFT');
+  });
+
+  it('does not approve Project A applicability through Project B', async () => {
+    const response = await request(app).post(
+      `/api/rd-projects/${projectB}/configuration/applicability/${applicabilityPending}/approve`
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it('does not edit a Project A item through Project B', async () => {
+    const response = await request(app)
+      .patch(`/api/rd-projects/${projectB}/configuration/items/${itemA}`)
+      .send({ title: 'Unauthorized title' });
+    expect(response.status).toBe(404);
+  });
+
+  it('does not change or delete a Project A relationship through Project B', async () => {
+    const changed = await request(app)
+      .patch(
+        `/api/rd-projects/${projectB}/configuration/relationships/${relationshipA}`
+      )
+      .send({ quantity: 2 });
+    const removed = await request(app).delete(
+      `/api/rd-projects/${projectB}/configuration/relationships/${relationshipA}`
+    );
+    expect(changed.status).toBe(404);
+    expect(removed.status).toBe(404);
+  });
+
+  it('does not reorder a Project A relationship through Project B', async () => {
+    const response = await request(app)
+      .put(`/api/rd-projects/${projectB}/configuration/relationships/reorder`)
+      .send({
+        parentConfigurationItemId: parentA,
+        relationshipIds: [relationshipA],
+      });
+    expect(response.status).toBe(409);
+  });
+
+  it('does not create a revision for another project item', async () => {
+    const response = await request(app)
+      .post(
+        `/api/rd-projects/${projectB}/configuration/items/${itemA}/revisions`
+      )
+      .send({
+        revisionIdentifier: 'X',
+        changeSummary: 'Unauthorized revision',
+      });
+    expect(response.status).toBe(409);
+  });
+
+  it('does not expose another project item coverage', async () => {
+    const response = await request(app).get(
+      `/api/rd-projects/${projectB}/configuration/items/${itemA}/coverage`
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it('creates an item and parent relationship atomically', async () => {
+    const response = await request(app)
+      .post(`/api/rd-projects/${projectA}/configuration/items`)
+      .send({
+        configurationItemNumber: 'ATOMIC-OK',
+        partNumber: 'ATOMIC-OK',
+        title: 'Atomic child',
+        itemType: 'MANUFACTURED_PART',
+        parentConfigurationItemId: parentA,
+        quantity: 2,
+        unitOfMeasure: 'EA',
+      });
+    expect(response.status).toBe(201);
+    expect(response.body.item.partNumber).toBe('ATOMIC-OK');
+    expect(response.body.relationship.parentConfigurationItemId).toBe(parentA);
+    const evidence = await pgPool.query(
+      `SELECT i.created_by_user_id AS item_actor, r.created_by_user_id AS relationship_actor
+       FROM design_project_configuration_items i
+       JOIN design_project_configuration_item_relationships r
+         ON r.child_configuration_item_id = i.id
+       WHERE i.part_number = 'ATOMIC-OK'`
+    );
+    expect(evidence.rows[0]).toEqual({
+      item_actor: actorUserId,
+      relationship_actor: actorUserId,
+    });
+  });
+
+  it('preserves standalone top-level item creation', async () => {
+    const response = await request(app)
+      .post(`/api/rd-projects/${projectA}/configuration/items`)
+      .send({
+        configurationItemNumber: 'TOP-LEVEL',
+        partNumber: 'TOP-LEVEL',
+        title: 'Standalone top-level item',
+        itemType: 'PRODUCT',
+      });
+    expect(response.status).toBe(201);
+    expect(response.body.item.partNumber).toBe('TOP-LEVEL');
+    expect(response.body.relationship).toBeNull();
+  });
+
+  it('leaves no extra item when a uniqueness failure rolls back creation', async () => {
+    const response = await request(app)
+      .post(`/api/rd-projects/${projectA}/configuration/items`)
+      .send({
+        configurationItemNumber: 'ATOMIC-OK',
+        partNumber: 'DUPLICATE-ROLLBACK',
+        title: 'Duplicate configuration number',
+        itemType: 'MANUFACTURED_PART',
+        parentConfigurationItemId: parentA,
+        quantity: 1,
+        unitOfMeasure: 'EA',
+      });
+    expect(response.status).toBe(409);
+    expect(await countPart('DUPLICATE-ROLLBACK')).toBe(0);
+  });
+
+  it('leaves no orphan for an invalid or cross-project parent', async () => {
+    const cases: Array<[string, string]> = [
+      ['INVALID-PARENT', '40000000-0000-4000-8000-000000000001'],
+      ['CROSS-PARENT', parentB],
+    ];
+    for (const [partNumber, parent] of cases) {
+      const response = await request(app)
+        .post(`/api/rd-projects/${projectA}/configuration/items`)
+        .send({
+          configurationItemNumber: partNumber,
+          partNumber,
+          title: partNumber,
+          itemType: 'MANUFACTURED_PART',
+          parentConfigurationItemId: parent,
+          quantity: 1,
+          unitOfMeasure: 'EA',
+        });
+      expect(response.status).toBe(409);
+      expect(await countPart(partNumber)).toBe(0);
+    }
+  });
+
+  it('rolls back the item when relationship insertion fails', async () => {
+    const response = await request(app)
+      .post(`/api/rd-projects/${projectA}/configuration/items`)
+      .send({
+        configurationItemNumber: 'FAIL-REL',
+        partNumber: 'FAIL-REL',
+        title: 'Synthetic rollback child',
+        itemType: 'MANUFACTURED_PART',
+        parentConfigurationItemId: parentA,
+        quantity: 1,
+        unitOfMeasure: 'EA',
+      });
+    expect(response.status).toBe(500);
+    expect(await countPart('FAIL-REL')).toBe(0);
+  });
+
+  it('rejects Not Applicable without justification', async () => {
+    const response = await request(app)
+      .put(
+        `/api/rd-projects/${projectA}/configuration/items/${itemA}/applicability/TEST_PROCEDURE`
+      )
+      .send({ decision: 'NOT_APPLICABLE', justification: '   ' });
+    expect(response.status).toBe(400);
+  });
+
+  it('submits only draft records and approves only pending records', async () => {
+    const resubmit = await request(app).post(
+      `/api/rd-projects/${projectA}/configuration/applicability/${applicabilityPending}/submit`
+    );
+    const earlyApprove = await request(app).post(
+      `/api/rd-projects/${projectA}/configuration/applicability/${applicabilityDraft}/approve`
+    );
+    expect(resubmit.status).toBe(409);
+    expect(earlyApprove.status).toBe(409);
+  });
+
+  it('submits a project-owned draft and then approves only its pending state', async () => {
+    const submitted = await request(app).post(
+      `/api/rd-projects/${projectA}/configuration/applicability/${applicabilityDraft}/submit`
+    );
+    expect(submitted.status).toBe(200);
+    expect(submitted.body.approval_status).toBe('PENDING');
+
+    const approved = await request(app).post(
+      `/api/rd-projects/${projectA}/configuration/applicability/${applicabilityDraft}/approve`
+    );
+    expect(approved.status).toBe(200);
+    expect(approved.body.approval_status).toBe('APPROVED');
+    expect(approved.body.approved_by_user_id).toBe(actorUserId);
+  });
+});

--- a/server/__tests__/designProjectConfigurationSecurityPostgres.test.ts
+++ b/server/__tests__/designProjectConfigurationSecurityPostgres.test.ts
@@ -260,10 +260,20 @@ describe('Design Project configuration PostgreSQL ownership and atomicity', () =
   });
 
   it('leaves no extra item when a uniqueness failure rolls back creation', async () => {
+    const seed = await request(app)
+      .post(`/api/rd-projects/${projectA}/configuration/items`)
+      .send({
+        configurationItemNumber: 'DUPLICATE-CONFIG',
+        partNumber: 'DUPLICATE-SEED',
+        title: 'Duplicate constraint seed',
+        itemType: 'PRODUCT',
+      });
+    expect(seed.status).toBe(201);
+
     const response = await request(app)
       .post(`/api/rd-projects/${projectA}/configuration/items`)
       .send({
-        configurationItemNumber: 'ATOMIC-OK',
+        configurationItemNumber: 'DUPLICATE-CONFIG',
         partNumber: 'DUPLICATE-ROLLBACK',
         title: 'Duplicate configuration number',
         itemType: 'MANUFACTURED_PART',

--- a/server/__tests__/designProjectConfigurationWorkspacePhase2.test.ts
+++ b/server/__tests__/designProjectConfigurationWorkspacePhase2.test.ts
@@ -143,10 +143,32 @@ describe('Design Project configuration workspace Phase 2', () => {
 
   it('uses transactions for multi-record tree mutations', () => {
     expect(routeSource).toMatch(
+      /configuration\/items'[\s\S]{0,500}db\.transaction/
+    );
+    expect(routeSource).toMatch(
       /relationships\/reorder[\s\S]{0,500}db\.transaction/
     );
     expect(routeSource).toMatch(
       /items\/:itemId\/revisions[\s\S]{0,700}db\.transaction/
+    );
+  });
+
+  it('uses one client request for item and parent creation', () => {
+    expect(uiSource).toContain('parentConfigurationItemId: itemForm.parentId');
+    expect(uiSource).not.toMatch(
+      /if \(created && itemForm\.parentId\)[\s\S]{0,300}configuration\/relationships/
+    );
+    expect(uiSource).toContain('setSelectedItemId(created.item.id)');
+  });
+
+  it('project-scopes applicability submit and approval transitions', () => {
+    expect(routeSource.match(/FOR UPDATE OF a/g)).toHaveLength(2);
+    expect(routeSource).toContain(
+      'AND i.rd_project_id = ${req.params.projectId}'
+    );
+    expect(routeSource).toContain("applicability.approval_status !== 'DRAFT'");
+    expect(routeSource).toContain(
+      "applicability.approval_status !== 'PENDING'"
     );
   });
 

--- a/server/__tests__/designProjectConfigurationWorkspacePhase2.test.ts
+++ b/server/__tests__/designProjectConfigurationWorkspacePhase2.test.ts
@@ -87,6 +87,15 @@ describe('Design Project configuration workspace Phase 2', () => {
     );
   });
 
+  it('repairs uniqueness after schema-push-first boot', () => {
+    expect(migrationSource).toContain(
+      'CREATE UNIQUE INDEX IF NOT EXISTS design_project_configuration_items_project_number_unique'
+    );
+    expect(migrationSource).toContain(
+      'CREATE UNIQUE INDEX IF NOT EXISTS design_project_configuration_relationship_unique'
+    );
+  });
+
   it('requires the Engineering or Quality approval capability', () => {
     expect(routeSource).toContain(
       "requirePermission('design.configuration.applicability.approve')"

--- a/server/__tests__/designProjectConfigurationWorkspacePhase2.test.ts
+++ b/server/__tests__/designProjectConfigurationWorkspacePhase2.test.ts
@@ -1,0 +1,164 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(__dirname, '../..');
+const routeSource = fs.readFileSync(
+  path.join(root, 'server/src/routes/rdProjects.ts'),
+  'utf8'
+);
+const uiSource = fs.readFileSync(
+  path.join(
+    root,
+    'client/src/features/design-control/DesignProjectConfigurationWorkspace.tsx'
+  ),
+  'utf8'
+);
+const pageSource = fs.readFileSync(
+  path.join(root, 'client/src/pages/RDProjectsPage.tsx'),
+  'utf8'
+);
+const migrationSource = fs.readFileSync(
+  path.join(root, 'migrations/0251_design_project_configuration_workspace.sql'),
+  'utf8'
+);
+
+describe('Design Project configuration workspace Phase 2', () => {
+  it('renders a recursive multi-level assembly tree', () => {
+    expect(uiSource).toContain(
+      '<TreeNode key={relation.id} item={child} depth={depth + 1} />'
+    );
+  });
+
+  it('offers manufactured and purchased component creation', () => {
+    expect(uiSource).toContain("'MANUFACTURED_PART'");
+    expect(uiSource).toContain("'PURCHASED_COMPONENT'");
+  });
+
+  it('supports explicit existing inventory linkage', () => {
+    expect(uiSource).toContain('inventoryItemId');
+    expect(routeSource).toContain(
+      'inventoryItemId: z.number().int().positive().nullable().optional()'
+    );
+  });
+
+  it('rejects cross-project relationships', () => {
+    expect(routeSource).toContain("return 'CROSS_PROJECT_RELATIONSHIP'");
+  });
+
+  it('rejects relationship cycles', () => {
+    expect(routeSource).toContain("return 'CONFIGURATION_CYCLE'");
+    expect(routeSource).toContain('if (id === parentId) return true');
+  });
+
+  it('protects every mutation with a Phase 1 capability', () => {
+    const editChecks =
+      routeSource.match(
+        /requirePermission\('design\.configuration\.edit'\)/g
+      ) ?? [];
+    expect(editChecks.length).toBeGreaterThanOrEqual(10);
+    expect(routeSource).toContain(
+      "requirePermission('design.configuration.applicability.approve')"
+    );
+  });
+
+  it('creates only draft part revisions', () => {
+    expect(routeSource).toContain("lifecycleState: 'DRAFT'");
+    expect(routeSource).not.toMatch(
+      /router\.(patch|put)\('\/:projectId\/configuration\/.*revisions/
+    );
+  });
+
+  it('does not provide a released-revision edit path', () => {
+    expect(routeSource).not.toContain('/revisions/:revisionId');
+  });
+
+  it('stores applicability per configuration item', () => {
+    expect(routeSource).toContain(
+      'ON CONFLICT (configuration_item_id, requirement_role)'
+    );
+  });
+
+  it('requires justification for Not Applicable', () => {
+    expect(routeSource).toContain('NOT_APPLICABLE_JUSTIFICATION_REQUIRED');
+    expect(migrationSource).toContain(
+      "nullif(btrim(justification), '') IS NOT NULL"
+    );
+  });
+
+  it('requires the Engineering or Quality approval capability', () => {
+    expect(routeSource).toContain(
+      "requirePermission('design.configuration.applicability.approve')"
+    );
+  });
+
+  it('keeps unapproved Not Applicable decisions incomplete', () => {
+    expect(routeSource).toContain('Not Applicable — Approval Required');
+    expect(routeSource).toContain("approvalStatus === 'APPROVED'");
+  });
+
+  it('evaluates coverage separately for each part', () => {
+    expect(routeSource).toMatch(
+      /configurationCoverage\(\s*req\.params\.projectId,\s*req\.params\.itemId\s*\)/
+    );
+    expect(uiSource).toContain('evaluated separately for this part');
+  });
+
+  it('uses authoritative artifact links rather than metadata', () => {
+    expect(routeSource).toContain('designProjectPartRevisionArtifacts');
+    expect(routeSource).not.toMatch(/metadata.*status/i);
+  });
+
+  it('does not infer links from matching part numbers', () => {
+    expect(routeSource).not.toMatch(
+      /part_number\s*=|partNumber\s*===.*artifact/i
+    );
+    expect(uiSource).toContain('no part-number match is used');
+  });
+
+  it('leaves legacy projects unchanged until explicit activation', () => {
+    expect(routeSource).toContain(
+      'Configuration has not been established for this legacy project.'
+    );
+    expect(routeSource).toContain('DESIGN_PROJECT_CONFIGURATION_ACTIVATED');
+  });
+
+  it('keeps the workspace on rd_projects and out of P2', () => {
+    expect(migrationSource).toContain('REFERENCES rd_projects(id)');
+    expect(routeSource).not.toContain('p2_projects');
+  });
+
+  it('marks completeness as informational only', () => {
+    expect(routeSource).toContain('informationalOnly: true');
+    expect(uiSource).toContain('% informational only');
+  });
+
+  it('does not activate a production or Engineering Release gate', () => {
+    expect(routeSource).toContain('productionEnforcementEnabled: false');
+    expect(routeSource).not.toMatch(
+      /engineeringRelease.*(block|gate)|production.*enabled:\s*true/i
+    );
+  });
+
+  it('uses transactions for multi-record tree mutations', () => {
+    expect(routeSource).toMatch(
+      /relationships\/reorder[\s\S]{0,500}db\.transaction/
+    );
+    expect(routeSource).toMatch(
+      /items\/:itemId\/revisions[\s\S]{0,700}db\.transaction/
+    );
+  });
+
+  it('exposes all five guided steps inside the authoritative project page', () => {
+    for (const step of [
+      'Product Structure',
+      'Parts and Revisions',
+      'Make/Buy Decisions',
+      'Documentation Requirements',
+      'Coverage Review',
+    ])
+      expect(uiSource).toContain(step);
+    expect(pageSource).toContain('Part &amp; Assembly Configuration');
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -12481,51 +12481,87 @@ export const controlledDocumentRevisionApprovals = pgTable(
   }
 );
 
-export const controlledDocumentReconciliationPreviews = pgTable('controlled_document_reconciliation_previews', {
-  id: uuid('id').defaultRandom().primaryKey(),
-  previewHash: text('preview_hash').notNull(),
-  policyVersion: text('policy_version').notNull(),
-  selectedDocumentIds: jsonb('selected_document_ids').notNull().default([]),
-  assessmentSnapshot: jsonb('assessment_snapshot').notNull(),
-  actorUserId: integer('actor_user_id').references(() => users.id, { onDelete: 'restrict' }).notNull(),
-  actorSnapshot: jsonb('actor_snapshot').notNull(),
-  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-});
+export const controlledDocumentReconciliationPreviews = pgTable(
+  'controlled_document_reconciliation_previews',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    previewHash: text('preview_hash').notNull(),
+    policyVersion: text('policy_version').notNull(),
+    selectedDocumentIds: jsonb('selected_document_ids').notNull().default([]),
+    assessmentSnapshot: jsonb('assessment_snapshot').notNull(),
+    actorUserId: integer('actor_user_id')
+      .references(() => users.id, { onDelete: 'restrict' })
+      .notNull(),
+    actorSnapshot: jsonb('actor_snapshot').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  }
+);
 
-export const controlledDocumentReconciliationEvents = pgTable('controlled_document_reconciliation_events', {
-  id: uuid('id').defaultRandom().primaryKey(),
-  previewId: uuid('preview_id').references(() => controlledDocumentReconciliationPreviews.id, { onDelete: 'restrict' }),
-  controlledDocumentId: uuid('controlled_document_id').references(() => controlledDocuments.id, { onDelete: 'restrict' }).notNull(),
-  revisionId: uuid('revision_id').references(() => documentVersionHistory.id, { onDelete: 'restrict' }),
-  idempotencyKey: text('idempotency_key').notNull().unique(),
-  eventType: text('event_type').notNull(),
-  provenance: text('provenance').notNull().default('LEGACY_MIGRATION_VERIFIED'),
-  policyVersion: text('policy_version').notNull(),
-  originalSnapshot: jsonb('original_snapshot').notNull(),
-  proposedChanges: jsonb('proposed_changes').notNull(),
-  completedChanges: jsonb('completed_changes').notNull(),
-  actorUserId: integer('actor_user_id').references(() => users.id, { onDelete: 'restrict' }).notNull(),
-  actorSnapshot: jsonb('actor_snapshot').notNull(),
-  reason: text('reason').notNull(),
-  checksum: text('checksum'),
-  fileIdentity: text('file_identity'),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-});
+export const controlledDocumentReconciliationEvents = pgTable(
+  'controlled_document_reconciliation_events',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    previewId: uuid('preview_id').references(
+      () => controlledDocumentReconciliationPreviews.id,
+      { onDelete: 'restrict' }
+    ),
+    controlledDocumentId: uuid('controlled_document_id')
+      .references(() => controlledDocuments.id, { onDelete: 'restrict' })
+      .notNull(),
+    revisionId: uuid('revision_id').references(
+      () => documentVersionHistory.id,
+      { onDelete: 'restrict' }
+    ),
+    idempotencyKey: text('idempotency_key').notNull().unique(),
+    eventType: text('event_type').notNull(),
+    provenance: text('provenance')
+      .notNull()
+      .default('LEGACY_MIGRATION_VERIFIED'),
+    policyVersion: text('policy_version').notNull(),
+    originalSnapshot: jsonb('original_snapshot').notNull(),
+    proposedChanges: jsonb('proposed_changes').notNull(),
+    completedChanges: jsonb('completed_changes').notNull(),
+    actorUserId: integer('actor_user_id')
+      .references(() => users.id, { onDelete: 'restrict' })
+      .notNull(),
+    actorSnapshot: jsonb('actor_snapshot').notNull(),
+    reason: text('reason').notNull(),
+    checksum: text('checksum'),
+    fileIdentity: text('file_identity'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  }
+);
 
-export const controlledDocumentReconciliationEvidence = pgTable('controlled_document_reconciliation_evidence', {
-  id: uuid('id').defaultRandom().primaryKey(),
-  controlledDocumentId: uuid('controlled_document_id').references(() => controlledDocuments.id, { onDelete: 'restrict' }).notNull(),
-  revisionId: uuid('revision_id').references(() => documentVersionHistory.id, { onDelete: 'restrict' }),
-  evidenceType: text('evidence_type').notNull(),
-  evidencePayload: jsonb('evidence_payload').notNull(),
-  immutableFilePath: text('immutable_file_path'),
-  immutableFileChecksum: text('immutable_file_checksum'),
-  actorUserId: integer('actor_user_id').references(() => users.id, { onDelete: 'restrict' }).notNull(),
-  actorSnapshot: jsonb('actor_snapshot').notNull(),
-  reason: text('reason').notNull(),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-});
+export const controlledDocumentReconciliationEvidence = pgTable(
+  'controlled_document_reconciliation_evidence',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    controlledDocumentId: uuid('controlled_document_id')
+      .references(() => controlledDocuments.id, { onDelete: 'restrict' })
+      .notNull(),
+    revisionId: uuid('revision_id').references(
+      () => documentVersionHistory.id,
+      { onDelete: 'restrict' }
+    ),
+    evidenceType: text('evidence_type').notNull(),
+    evidencePayload: jsonb('evidence_payload').notNull(),
+    immutableFilePath: text('immutable_file_path'),
+    immutableFileChecksum: text('immutable_file_checksum'),
+    actorUserId: integer('actor_user_id')
+      .references(() => users.id, { onDelete: 'restrict' })
+      .notNull(),
+    actorSnapshot: jsonb('actor_snapshot').notNull(),
+    reason: text('reason').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  }
+);
 
 export const designControlFormTemplates = pgTable(
   'design_control_form_templates',
@@ -20323,7 +20359,9 @@ export const accountingPeriods = pgTable(
     periodYear: integer('period_year').notNull(),
     periodMonth: integer('period_month').notNull(),
     status: text('status').notNull().default('MIGRATION'), // OPEN | MIGRATION | SOFT_CLOSED | HARD_CLOSED | FINAL_LOCKED
-    paymentEntryGraceBusinessDays: integer('payment_entry_grace_business_days').notNull().default(3),
+    paymentEntryGraceBusinessDays: integer('payment_entry_grace_business_days')
+      .notNull()
+      .default(3),
     hardLockEnforcedAt: timestamp('hard_lock_enforced_at'),
     closedBy: text('closed_by'),
     closedAt: timestamp('closed_at'),
@@ -26021,10 +26059,15 @@ export const designProjectConfigurationWorkspaces = pgTable(
     rdProjectId: text('rd_project_id')
       .primaryKey()
       .references(() => rdProjects.id, { onDelete: 'restrict' }),
-    configurationStatus: text('configuration_status').notNull().default('DRAFT'),
-    activatedByUserId: integer('activated_by_user_id').references(() => users.id, {
-      onDelete: 'restrict',
-    }),
+    configurationStatus: text('configuration_status')
+      .notNull()
+      .default('DRAFT'),
+    activatedByUserId: integer('activated_by_user_id').references(
+      () => users.id,
+      {
+        onDelete: 'restrict',
+      }
+    ),
     activatedBySnapshot: jsonb('activated_by_snapshot')
       .$type<Record<string, unknown>>()
       .notNull(),

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -26015,6 +26015,33 @@ export const engineeringControlledRevisions = pgTable(
 
 // Design Project manufacturing-configuration foundation. These identities are
 // deliberately separate from P2 projects and from part_routings.project_id.
+export const designProjectConfigurationWorkspaces = pgTable(
+  'design_project_configuration_workspaces',
+  {
+    rdProjectId: text('rd_project_id')
+      .primaryKey()
+      .references(() => rdProjects.id, { onDelete: 'restrict' }),
+    configurationStatus: text('configuration_status').notNull().default('DRAFT'),
+    activatedByUserId: integer('activated_by_user_id').references(() => users.id, {
+      onDelete: 'restrict',
+    }),
+    activatedBySnapshot: jsonb('activated_by_snapshot')
+      .$type<Record<string, unknown>>()
+      .notNull(),
+    activatedAt: timestamp('activated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    statusIdx: index('design_project_configuration_workspaces_status_idx').on(
+      table.configurationStatus
+    ),
+  })
+);
+
 export const designProjectConfigurationItems = pgTable(
   'design_project_configuration_items',
   {
@@ -26204,6 +26231,7 @@ export const designProjectDocumentApplicability = pgTable(
     requirementRole: text('requirement_role').notNull(),
     decision: text('decision').notNull().default('REQUIRED'),
     justification: text('justification'),
+    approvalStatus: text('approval_status').notNull().default('NOT_REQUIRED'),
     approvedByUserId: integer('approved_by_user_id').references(
       () => users.id,
       { onDelete: 'restrict' }

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -434,9 +434,8 @@ export async function runSafeBootMigrations() {
   if (process.env.SAFE_BOOT_MIGRATIONS_ONLY === 'true') return;
 
   try {
-    const { logCriticalSchemaHealth } = await import(
-      '../../utils/schemaHealth'
-    );
+    const { logCriticalSchemaHealth } =
+      await import('../../utils/schemaHealth');
     await logCriticalSchemaHealth();
   } catch (caughtSchemaHealthErr: unknown) {
     const schemaHealthErr = caughtSchemaHealthErr as MigrationError;
@@ -447,9 +446,8 @@ export async function runSafeBootMigrations() {
   }
 
   try {
-    const { migrateVendorDocumentUrls } = await import(
-      '../../src/routes/vendors'
-    );
+    const { migrateVendorDocumentUrls } =
+      await import('../../src/routes/vendors');
     await migrateVendorDocumentUrls();
   } catch (caughtVendorMigrErr: unknown) {
     const vendorMigrErr = caughtVendorMigrErr as MigrationError;

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -314,6 +314,7 @@ export const safeMigrationFiles = [
   '0248_design_project_manufacturing_configuration.sql',
   '0249_prior_month_payment_entry_grace.sql',
   '0250_epoch_validation_wizard_phase1.sql',
+  '0251_design_project_configuration_workspace.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -367,6 +368,7 @@ export const criticalMigrationFiles = new Set([
   '0247_retire_duplicate_traveler_roc2600719.sql',
   '0248_design_project_manufacturing_configuration.sql',
   '0249_prior_month_payment_entry_grace.sql',
+  '0251_design_project_configuration_workspace.sql',
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
   '0233a_spec_sheets_base_table.sql',

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -434,8 +434,9 @@ export async function runSafeBootMigrations() {
   if (process.env.SAFE_BOOT_MIGRATIONS_ONLY === 'true') return;
 
   try {
-    const { logCriticalSchemaHealth } =
-      await import('../../utils/schemaHealth');
+    const { logCriticalSchemaHealth } = await import(
+      '../../utils/schemaHealth'
+    );
     await logCriticalSchemaHealth();
   } catch (caughtSchemaHealthErr: unknown) {
     const schemaHealthErr = caughtSchemaHealthErr as MigrationError;
@@ -446,8 +447,9 @@ export async function runSafeBootMigrations() {
   }
 
   try {
-    const { migrateVendorDocumentUrls } =
-      await import('../../src/routes/vendors');
+    const { migrateVendorDocumentUrls } = await import(
+      '../../src/routes/vendors'
+    );
     await migrateVendorDocumentUrls();
   } catch (caughtVendorMigrErr: unknown) {
     const vendorMigrErr = caughtVendorMigrErr as MigrationError;

--- a/server/src/routes/rdProjects.ts
+++ b/server/src/routes/rdProjects.ts
@@ -74,8 +74,24 @@ const relationshipPayloadSchema = z.object({
   sortOrder: z.number().int().min(0).default(0),
 });
 
+const createItemPayloadSchema = itemPayloadSchema.extend({
+  parentConfigurationItemId: z.string().uuid().nullable().optional(),
+  quantity: z.coerce.number().positive().optional(),
+  unitOfMeasure: z.string().trim().min(1).optional(),
+  referenceDesignator: z.string().trim().nullable().optional(),
+  effectivityStart: z.string().trim().nullable().optional(),
+  effectivityEnd: z.string().trim().nullable().optional(),
+  sortOrder: z.number().int().min(0).optional(),
+});
+
 function rowsOf<T>(result: unknown): T[] {
   return (((result as any)?.rows ?? result) || []) as T[];
+}
+
+function errorCode(error: unknown) {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String(error.code)
+    : null;
 }
 
 function requestEvidence(req: Request) {
@@ -771,34 +787,108 @@ router.post(
   requirePermission('design.configuration.edit'),
   async (req, res) => {
     try {
-      const parsed = itemPayloadSchema.parse(req.body);
+      const parsed = createItemPayloadSchema.parse(req.body);
       const evidence = requestEvidence(req);
-      const [workspace] = await db
-        .select()
-        .from(designProjectConfigurationWorkspaces)
-        .where(
-          eq(
-            designProjectConfigurationWorkspaces.rdProjectId,
-            req.params.projectId
+      const created = await db.transaction(async (tx) => {
+        const [workspace] = await tx
+          .select()
+          .from(designProjectConfigurationWorkspaces)
+          .where(
+            eq(
+              designProjectConfigurationWorkspaces.rdProjectId,
+              req.params.projectId
+            )
           )
-        )
-        .limit(1);
-      if (!workspace)
-        return res.status(409).json({ error: 'CONFIGURATION_NOT_ESTABLISHED' });
-      const [item] = await db
-        .insert(designProjectConfigurationItems)
-        .values({
-          rdProjectId: req.params.projectId,
-          ...parsed,
-          createdByUserId: evidence.actor.id,
-          createdBySnapshot: evidence.snapshot,
-        })
-        .returning();
-      res.status(201).json(item);
+          .limit(1);
+        if (!workspace)
+          throw Object.assign(new Error('Configuration not established'), {
+            code: 'CONFIGURATION_NOT_ESTABLISHED',
+          });
+
+        if (parsed.parentConfigurationItemId) {
+          const [parent] = await tx
+            .select({ id: designProjectConfigurationItems.id })
+            .from(designProjectConfigurationItems)
+            .where(
+              and(
+                eq(
+                  designProjectConfigurationItems.id,
+                  parsed.parentConfigurationItemId
+                ),
+                eq(
+                  designProjectConfigurationItems.rdProjectId,
+                  req.params.projectId
+                )
+              )
+            )
+            .limit(1);
+          if (!parent)
+            throw Object.assign(new Error('Parent not found'), {
+              code: 'PARENT_NOT_FOUND',
+            });
+        }
+
+        const {
+          parentConfigurationItemId,
+          quantity,
+          unitOfMeasure,
+          referenceDesignator,
+          effectivityStart,
+          effectivityEnd,
+          sortOrder,
+          ...itemValues
+        } = parsed;
+        const [item] = await tx
+          .insert(designProjectConfigurationItems)
+          .values({
+            rdProjectId: req.params.projectId,
+            ...itemValues,
+            createdByUserId: evidence.actor.id,
+            createdBySnapshot: evidence.snapshot,
+          })
+          .returning();
+
+        let relationship:
+          | typeof designProjectConfigurationItemRelationships.$inferSelect
+          | null = null;
+        if (parentConfigurationItemId) {
+          if (quantity === undefined || !unitOfMeasure)
+            throw Object.assign(new Error('Parent relationship incomplete'), {
+              code: 'PARENT_RELATIONSHIP_REQUIRED_FIELDS',
+            });
+          [relationship] = await tx
+            .insert(designProjectConfigurationItemRelationships)
+            .values({
+              rdProjectId: req.params.projectId,
+              parentConfigurationItemId,
+              childConfigurationItemId: item.id,
+              quantity: String(quantity),
+              unitOfMeasure,
+              referenceDesignator,
+              effectivityStart,
+              effectivityEnd,
+              sortOrder: sortOrder ?? 0,
+              createdByUserId: evidence.actor.id,
+              createdBySnapshot: evidence.snapshot,
+            })
+            .returning();
+        }
+        return { item, relationship };
+      });
+      res.status(201).json(created);
     } catch (error) {
       if (error instanceof z.ZodError)
         return res.status(400).json({ error: error.errors[0]?.message });
-      if ((error as any)?.code === '23505')
+      const code = errorCode(error);
+      if (code === 'CONFIGURATION_NOT_ESTABLISHED')
+        return res.status(409).json({ error: 'CONFIGURATION_NOT_ESTABLISHED' });
+      if (
+        ['PARENT_NOT_FOUND', 'PARENT_RELATIONSHIP_REQUIRED_FIELDS'].includes(
+          code ?? ''
+        )
+      )
+        return res.status(409).json({ error: code });
+      if (code === '23505')
         return res.status(409).json({ error: 'DUPLICATE_CONFIGURATION_ITEM' });
       res.status(500).json({ error: 'Failed to create configuration item' });
     }
@@ -921,7 +1011,7 @@ router.post(
     } catch (error) {
       if (error instanceof z.ZodError)
         return res.status(400).json({ error: error.errors[0]?.message });
-      if ((error as any)?.code === '23505')
+      if (errorCode(error) === '23505')
         return res.status(409).json({ error: 'DUPLICATE_CURRENT_CHILD' });
       res.status(500).json({ error: 'Failed to add relationship' });
     }
@@ -966,9 +1056,15 @@ router.patch(
         .update(designProjectConfigurationItemRelationships)
         .set({ ...parsed, quantity: String(parsed.quantity) })
         .where(
-          eq(
-            designProjectConfigurationItemRelationships.id,
-            req.params.relationshipId
+          and(
+            eq(
+              designProjectConfigurationItemRelationships.id,
+              req.params.relationshipId
+            ),
+            eq(
+              designProjectConfigurationItemRelationships.rdProjectId,
+              req.params.projectId
+            )
           )
         )
         .returning();
@@ -993,6 +1089,26 @@ router.put(
         })
         .parse(req.body);
       await db.transaction(async (tx) => {
+        const [parent] = await tx
+          .select({ id: designProjectConfigurationItems.id })
+          .from(designProjectConfigurationItems)
+          .where(
+            and(
+              eq(
+                designProjectConfigurationItems.id,
+                parsed.parentConfigurationItemId
+              ),
+              eq(
+                designProjectConfigurationItems.rdProjectId,
+                req.params.projectId
+              )
+            )
+          )
+          .limit(1);
+        if (!parent)
+          throw Object.assign(new Error('Invalid reorder scope'), {
+            code: 'INVALID_REORDER_SCOPE',
+          });
         const rows = await tx
           .select()
           .from(designProjectConfigurationItemRelationships)
@@ -1016,17 +1132,31 @@ router.put(
           throw Object.assign(new Error('Invalid reorder scope'), {
             code: 'INVALID_REORDER_SCOPE',
           });
-        for (const [sortOrder, id] of parsed.relationshipIds.entries())
+        for (
+          let sortOrder = 0;
+          sortOrder < parsed.relationshipIds.length;
+          sortOrder += 1
+        ) {
+          const id = parsed.relationshipIds[sortOrder];
           await tx
             .update(designProjectConfigurationItemRelationships)
             .set({ sortOrder })
-            .where(eq(designProjectConfigurationItemRelationships.id, id));
+            .where(
+              and(
+                eq(designProjectConfigurationItemRelationships.id, id),
+                eq(
+                  designProjectConfigurationItemRelationships.rdProjectId,
+                  req.params.projectId
+                )
+              )
+            );
+        }
       });
       res.json({ reordered: parsed.relationshipIds.length });
     } catch (error) {
       if (error instanceof z.ZodError)
         return res.status(400).json({ error: error.errors[0]?.message });
-      if ((error as any)?.code === 'INVALID_REORDER_SCOPE')
+      if (errorCode(error) === 'INVALID_REORDER_SCOPE')
         return res.status(409).json({ error: 'INVALID_REORDER_SCOPE' });
       res.status(500).json({ error: 'Failed to reorder relationships' });
     }
@@ -1142,10 +1272,10 @@ router.post(
         return res.status(400).json({ error: error.errors[0]?.message });
       if (
         ['ITEM_NOT_FOUND', 'PREDECESSOR_NOT_FOUND'].includes(
-          (error as any)?.code
+          errorCode(error) ?? ''
         )
       )
-        return res.status(409).json({ error: (error as any).code });
+        return res.status(409).json({ error: errorCode(error) });
       res.status(500).json({ error: 'Failed to create draft revision' });
     }
   }
@@ -1199,20 +1329,46 @@ router.post(
   '/:projectId/configuration/applicability/:applicabilityId/submit',
   requirePermission('design.configuration.edit'),
   async (req, res) => {
-    const [row] = await db
-      .update(designProjectDocumentApplicability)
-      .set({ approvalStatus: 'PENDING', updatedAt: new Date() })
-      .where(
-        and(
-          eq(designProjectDocumentApplicability.id, req.params.applicabilityId),
-          eq(designProjectDocumentApplicability.decision, 'NOT_APPLICABLE'),
-          eq(designProjectDocumentApplicability.approvalStatus, 'DRAFT')
-        )
+    const outcome = await db.transaction(async (tx) => {
+      const scoped = await tx.execute(sql`
+        SELECT a.id, a.decision, a.approval_status, a.justification
+        FROM design_project_document_applicability a
+        JOIN design_project_configuration_items i ON i.id = a.configuration_item_id
+        WHERE a.id = ${req.params.applicabilityId}
+          AND i.rd_project_id = ${req.params.projectId}
+        FOR UPDATE OF a
+      `);
+      const applicability = rowsOf<{
+        decision: string;
+        approval_status: string;
+        justification: string | null;
+      }>(scoped)[0];
+      if (!applicability) return { status: 'not_found' as const };
+      if (
+        applicability.decision !== 'NOT_APPLICABLE' ||
+        applicability.approval_status !== 'DRAFT' ||
+        !applicability.justification?.trim()
       )
-      .returning();
-    if (!row)
+        return { status: 'not_ready' as const };
+      const result = await tx.execute(sql`
+        UPDATE design_project_document_applicability a
+        SET approval_status = 'PENDING', updated_at = now()
+        FROM design_project_configuration_items i
+        WHERE a.id = ${req.params.applicabilityId}
+          AND a.configuration_item_id = i.id
+          AND i.rd_project_id = ${req.params.projectId}
+          AND a.decision = 'NOT_APPLICABLE'
+          AND a.approval_status = 'DRAFT'
+          AND nullif(btrim(a.justification), '') IS NOT NULL
+        RETURNING a.*
+      `);
+      return { status: 'submitted' as const, row: rowsOf(result)[0] };
+    });
+    if (outcome.status === 'not_found')
+      return res.status(404).json({ error: 'Applicability not found' });
+    if (outcome.status === 'not_ready')
       return res.status(409).json({ error: 'NOT_APPLICABLE_NOT_SUBMITTABLE' });
-    res.json(row);
+    res.json(outcome.row);
   }
 );
 
@@ -1221,19 +1377,41 @@ router.post(
   requirePermission('design.configuration.applicability.approve'),
   async (req, res) => {
     const evidence = requestEvidence(req);
-    const result = await db.execute(sql`
-    UPDATE design_project_document_applicability a SET approval_status = 'APPROVED',
-      approved_by_user_id = ${evidence.actor.id}, approved_by_snapshot = ${JSON.stringify(evidence.snapshot)}::jsonb,
-      approved_at = now(), updated_at = now()
-    FROM design_project_configuration_items i
-    WHERE a.id = ${req.params.applicabilityId} AND a.configuration_item_id = i.id
-      AND i.rd_project_id = ${req.params.projectId} AND a.decision = 'NOT_APPLICABLE'
-      AND a.approval_status = 'PENDING' RETURNING a.*
-  `);
-    const row = rowsOf(result)[0];
-    if (!row)
+    const outcome = await db.transaction(async (tx) => {
+      const scoped = await tx.execute(sql`
+        SELECT a.id, a.decision, a.approval_status, a.justification
+        FROM design_project_document_applicability a
+        JOIN design_project_configuration_items i ON i.id = a.configuration_item_id
+        WHERE a.id = ${req.params.applicabilityId}
+          AND i.rd_project_id = ${req.params.projectId}
+        FOR UPDATE OF a
+      `);
+      const applicability = rowsOf<{
+        decision: string;
+        approval_status: string;
+      }>(scoped)[0];
+      if (!applicability) return { status: 'not_found' as const };
+      if (
+        applicability.decision !== 'NOT_APPLICABLE' ||
+        applicability.approval_status !== 'PENDING'
+      )
+        return { status: 'not_ready' as const };
+      const result = await tx.execute(sql`
+        UPDATE design_project_document_applicability a SET approval_status = 'APPROVED',
+          approved_by_user_id = ${evidence.actor.id}, approved_by_snapshot = ${JSON.stringify(evidence.snapshot)}::jsonb,
+          approved_at = now(), updated_at = now()
+        FROM design_project_configuration_items i
+        WHERE a.id = ${req.params.applicabilityId} AND a.configuration_item_id = i.id
+          AND i.rd_project_id = ${req.params.projectId} AND a.decision = 'NOT_APPLICABLE'
+          AND a.approval_status = 'PENDING' RETURNING a.*
+      `);
+      return { status: 'approved' as const, row: rowsOf(result)[0] };
+    });
+    if (outcome.status === 'not_found')
+      return res.status(404).json({ error: 'Applicability not found' });
+    if (outcome.status === 'not_ready')
       return res.status(409).json({ error: 'NOT_APPLICABLE_NOT_APPROVABLE' });
-    res.json(row);
+    res.json(outcome.row);
   }
 );
 

--- a/server/src/routes/rdProjects.ts
+++ b/server/src/routes/rdProjects.ts
@@ -1,9 +1,17 @@
 import { Router, type Request, type Response } from 'express';
-import { desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from '../../db';
-import { rdProjects } from '../../schema';
+import {
+  designProjectConfigurationItems,
+  designProjectConfigurationItemRelationships,
+  designProjectConfigurationWorkspaces,
+  designProjectDocumentApplicability,
+  designProjectPartRevisionArtifacts,
+  designProjectPartRevisions,
+  rdProjects,
+} from '../../schema';
 import { resolveUserSnapshot } from '../../utils/userSnapshot';
 import { requirePermission } from '../../middleware/requirePermission';
 import {
@@ -12,8 +20,96 @@ import {
   resolveDesignControlAuthority,
 } from '../services/designControlAuthorityService';
 import { recordAuditEvent } from '../services/auditLedgerService';
+import {
+  assertDesignControlSchemaReady,
+  DesignControlSchemaNotReadyError,
+} from '../services/designControlSchemaReadiness';
 
 const router = Router();
+
+const itemTypes = [
+  'PRODUCT',
+  'ASSEMBLY',
+  'SUBASSEMBLY',
+  'MANUFACTURED_PART',
+  'PURCHASED_COMPONENT',
+  'TOOLING',
+  'SOFTWARE',
+] as const;
+const makeBuyValues = ['MAKE', 'BUY', 'UNDETERMINED'] as const;
+const requirementRoles = [
+  'DRAWING_CAD',
+  'BOM',
+  'ROUTING',
+  'TRAVELER',
+  'WORK_INSTRUCTION',
+  'INSPECTION_PLAN',
+  'TEST_PROCEDURE',
+  'MATERIAL_SPECIFICATION',
+  'TOOLING_FIXTURE',
+  'CNC_PROGRAM',
+  'SUPPLIER_REQUIREMENT',
+  'TRAINING_CERTIFICATION',
+  'PACKAGING_SHIPPING',
+] as const;
+
+const itemPayloadSchema = z.object({
+  configurationItemNumber: z.string().trim().min(1),
+  partNumber: z.string().trim().min(1),
+  title: z.string().trim().min(1),
+  itemType: z.enum(itemTypes),
+  makeBuyDesignation: z.enum(makeBuyValues).default('UNDETERMINED'),
+  designResponsibility: z.string().trim().nullable().optional(),
+  inventoryItemId: z.number().int().positive().nullable().optional(),
+});
+
+const relationshipPayloadSchema = z.object({
+  parentConfigurationItemId: z.string().uuid(),
+  childConfigurationItemId: z.string().uuid(),
+  quantity: z.coerce.number().positive(),
+  unitOfMeasure: z.string().trim().min(1),
+  referenceDesignator: z.string().trim().nullable().optional(),
+  effectivityStart: z.string().trim().nullable().optional(),
+  effectivityEnd: z.string().trim().nullable().optional(),
+  sortOrder: z.number().int().min(0).default(0),
+});
+
+function rowsOf<T>(result: unknown): T[] {
+  return (((result as any)?.rows ?? result) || []) as T[];
+}
+
+function requestEvidence(req: Request) {
+  const actor = actorSnapshot(req);
+  return {
+    actor,
+    snapshot: { userId: actor.id, username: actor.username, role: actor.role },
+    metadata: { ipAddress: req.ip, userAgent: req.get('user-agent') ?? null },
+  };
+}
+
+async function ensureConfigurationReady(
+  _req: Request,
+  res: Response,
+  next: () => void
+) {
+  try {
+    await assertDesignControlSchemaReady();
+    next();
+  } catch (error) {
+    if (error instanceof DesignControlSchemaNotReadyError) {
+      return res.status(503).json({
+        error: 'DESIGN_CONTROL_SCHEMA_NOT_READY',
+        missing: error.missingObjects,
+      });
+    }
+    console.error('Design configuration readiness error:', error);
+    return res
+      .status(503)
+      .json({ error: 'DESIGN_CONTROL_SCHEMA_READINESS_FAILED' });
+  }
+}
+
+router.use('/:projectId/configuration', ensureConfigurationReady);
 
 const rdProjectPayloadSchema = z.object({
   id: z.string().trim().min(1),
@@ -75,7 +171,10 @@ function toClientProject(row: typeof rdProjects.$inferSelect) {
 
 router.get('/', async (_req: Request, res: Response) => {
   try {
-    const rows = await db.select().from(rdProjects).orderBy(desc(rdProjects.updatedAt));
+    const rows = await db
+      .select()
+      .from(rdProjects)
+      .orderBy(desc(rdProjects.updatedAt));
     res.json(rows.map(toClientProject));
   } catch (error) {
     console.error('List R&D projects error:', error);
@@ -85,11 +184,18 @@ router.get('/', async (_req: Request, res: Response) => {
 
 router.put('/:id', async (req: Request, res: Response) => {
   try {
-    const parsed = rdProjectPayloadSchema.parse({ ...req.body, id: req.params.id });
+    const parsed = rdProjectPayloadSchema.parse({
+      ...req.body,
+      id: req.params.id,
+    });
     const snapshot = await userSnapshot(req);
     const now = new Date();
 
-    const [existing] = await db.select().from(rdProjects).where(eq(rdProjects.id, parsed.id)).limit(1);
+    const [existing] = await db
+      .select()
+      .from(rdProjects)
+      .where(eq(rdProjects.id, parsed.id))
+      .limit(1);
 
     const [row] = await db
       .insert(rdProjects)
@@ -103,7 +209,8 @@ router.put('/:id', async (req: Request, res: Response) => {
         draftTabIds: parsed.draftTabIds,
         description: parsed.description,
         createdByUserId: existing?.createdByUserId ?? snapshot.userId ?? null,
-        createdByDisplayName: existing?.createdByDisplayName ?? snapshot.displayName ?? 'unknown',
+        createdByDisplayName:
+          existing?.createdByDisplayName ?? snapshot.displayName ?? 'unknown',
         updatedByUserId: snapshot.userId ?? null,
         updatedByDisplayName: snapshot.displayName ?? 'unknown',
         updatedAt: now,
@@ -129,22 +236,32 @@ router.put('/:id', async (req: Request, res: Response) => {
   } catch (error) {
     console.error('Save R&D project error:', error);
     if (error instanceof z.ZodError) {
-      return res.status(400).json({ error: error.errors[0]?.message || 'Invalid R&D project payload' });
+      return res.status(400).json({
+        error: error.errors[0]?.message || 'Invalid R&D project payload',
+      });
     }
     res.status(500).json({ error: 'Failed to save R&D project' });
   }
 });
 
-router.get('/:projectId/design-control', async (req: Request, res: Response) => {
-  try {
-    const resolution = await resolveDesignControlAuthority(req.params.projectId);
-    if (!resolution) return res.status(404).json({ error: 'R&D project not found' });
-    res.json(resolution);
-  } catch (error) {
-    console.error('Resolve project Design Control authority error:', error);
-    res.status(500).json({ error: 'Failed to resolve project Design Control authority' });
+router.get(
+  '/:projectId/design-control',
+  async (req: Request, res: Response) => {
+    try {
+      const resolution = await resolveDesignControlAuthority(
+        req.params.projectId
+      );
+      if (!resolution)
+        return res.status(404).json({ error: 'R&D project not found' });
+      res.json(resolution);
+    } catch (error) {
+      console.error('Resolve project Design Control authority error:', error);
+      res
+        .status(500)
+        .json({ error: 'Failed to resolve project Design Control authority' });
+    }
   }
-});
+);
 
 router.post(
   '/:projectId/design-control/initialize',
@@ -155,26 +272,35 @@ router.post(
         projectId: req.params.projectId,
         title: typeof req.body?.title === 'string' ? req.body.title : undefined,
         actor: actorSnapshot(req),
-        requestMetadata: { ipAddress: req.ip, userAgent: req.get('user-agent') ?? null },
+        requestMetadata: {
+          ipAddress: req.ip,
+          userAgent: req.get('user-agent') ?? null,
+        },
       });
-      if (result.status === 'project_not_found') return res.status(404).json({ error: 'R&D project not found' });
+      if (result.status === 'project_not_found')
+        return res.status(404).json({ error: 'R&D project not found' });
       if (result.status === 'conflict') {
         return res.status(409).json({
           error: 'DESIGN_CONTROL_RECONCILIATION_REQUIRED',
-          message: 'Existing Design Control records require explicit authority reconciliation.',
+          message:
+            'Existing Design Control records require explicit authority reconciliation.',
           resolution: result.resolution,
         });
       }
       res.status(result.status === 'created' ? 201 : 200).json(result);
     } catch (error: any) {
       if (error?.code === '23505') {
-        const resolution = await resolveDesignControlAuthority(req.params.projectId);
+        const resolution = await resolveDesignControlAuthority(
+          req.params.projectId
+        );
         return res.status(200).json({ status: 'existing', resolution });
       }
       console.error('Initialize project Design Control error:', error);
-      res.status(500).json({ error: 'Failed to initialize project Design Control' });
+      res
+        .status(500)
+        .json({ error: 'Failed to initialize project Design Control' });
     }
-  },
+  }
 );
 
 router.post(
@@ -182,99 +308,955 @@ router.post(
   requirePermission('design.control.admin'),
   async (req: Request, res: Response) => {
     try {
-      const parsed = z.object({
-        recordId: z.string().uuid(),
-        reason: z.string().trim().min(1),
-      }).parse(req.body);
+      const parsed = z
+        .object({
+          recordId: z.string().uuid(),
+          reason: z.string().trim().min(1),
+        })
+        .parse(req.body);
       const result = await designateAuthoritativeDesignControl({
         projectId: req.params.projectId,
         recordId: parsed.recordId,
         reason: parsed.reason,
         actor: actorSnapshot(req),
-        requestMetadata: { ipAddress: req.ip, userAgent: req.get('user-agent') ?? null },
+        requestMetadata: {
+          ipAddress: req.ip,
+          userAgent: req.get('user-agent') ?? null,
+        },
       });
-      if (result.status === 'project_not_found') return res.status(404).json({ error: 'R&D project not found' });
+      if (result.status === 'project_not_found')
+        return res.status(404).json({ error: 'R&D project not found' });
       if (result.status === 'record_not_in_project') {
-        return res.status(409).json({ error: 'Selected Design Control record does not belong to this project' });
+        return res.status(409).json({
+          error:
+            'Selected Design Control record does not belong to this project',
+        });
       }
       res.json(result);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: error.errors[0]?.message ?? 'Invalid designation request' });
+        return res.status(400).json({
+          error: error.errors[0]?.message ?? 'Invalid designation request',
+        });
       }
       console.error('Designate project Design Control authority error:', error);
-      res.status(500).json({ error: 'Failed to designate project Design Control authority' });
+      res.status(500).json({
+        error: 'Failed to designate project Design Control authority',
+      });
     }
-  },
+  }
 );
 
-router.post('/reconcile-local', requirePermission('design.control.create'), async (req: Request, res: Response) => {
-  try {
-    const parsed = localReconciliationSchema.parse(req.body);
-    const [sameId] = await db.select().from(rdProjects).where(eq(rdProjects.id, parsed.id)).limit(1);
-    if (sameId) {
-      return res.status(409).json({ outcome: 'server_match', project: toClientProject(sameId) });
-    }
+router.post(
+  '/reconcile-local',
+  requirePermission('design.control.create'),
+  async (req: Request, res: Response) => {
+    try {
+      const parsed = localReconciliationSchema.parse(req.body);
+      const [sameId] = await db
+        .select()
+        .from(rdProjects)
+        .where(eq(rdProjects.id, parsed.id))
+        .limit(1);
+      if (sameId) {
+        return res
+          .status(409)
+          .json({ outcome: 'server_match', project: toClientProject(sameId) });
+      }
 
-    const possibleDuplicates = await db.execute(sql`
+      const possibleDuplicates = await db.execute(sql`
       SELECT id, project_name, owner, status
       FROM rd_projects
       WHERE lower(trim(project_name)) = lower(trim(${parsed.projectName}))
       ORDER BY updated_at DESC
       LIMIT 10
     `);
-    const duplicateRows = (possibleDuplicates as any)?.rows ?? possibleDuplicates;
-    if (Array.isArray(duplicateRows) && duplicateRows.length > 0) {
-      return res.status(409).json({
-        outcome: 'possible_duplicate',
-        message: 'A similarly named server project exists. No automatic merge or overwrite was performed.',
-        possibleDuplicates: duplicateRows,
+      const duplicateRows =
+        (possibleDuplicates as any)?.rows ?? possibleDuplicates;
+      if (Array.isArray(duplicateRows) && duplicateRows.length > 0) {
+        return res.status(409).json({
+          outcome: 'possible_duplicate',
+          message:
+            'A similarly named server project exists. No automatic merge or overwrite was performed.',
+          possibleDuplicates: duplicateRows,
+        });
+      }
+
+      const snapshot = await userSnapshot(req);
+      const created = await db.transaction(async (tx) => {
+        const [row] = await tx
+          .insert(rdProjects)
+          .values({
+            id: parsed.id,
+            projectName: parsed.projectName,
+            owner: parsed.owner,
+            status: parsed.status,
+            signoffRequired: parsed.signoffRequired,
+            signoffUserId: parsed.signoffRequired ? parsed.signoffUserId : '',
+            draftTabIds: parsed.draftTabIds,
+            description: parsed.description,
+            createdByUserId: snapshot.userId,
+            createdByDisplayName: snapshot.displayName,
+            updatedByUserId: snapshot.userId,
+            updatedByDisplayName: snapshot.displayName,
+          })
+          .returning();
+
+        await recordAuditEvent(
+          {
+            eventType: 'RD_PROJECT_IMPORTED_FROM_LOCAL_STORAGE',
+            subjectType: 'rd_project',
+            subjectId: row.id,
+            sourceService: 'rdProjects.route',
+            actor: actorSnapshot(req),
+            ipAddress: req.ip,
+            userAgent: req.get('user-agent') ?? null,
+            reason: 'Reviewed browser-local R&D project import',
+            fieldsChanged: {
+              persistence: {
+                before: 'browser_local',
+                after: 'server_authoritative',
+              },
+            },
+            payload: {
+              projectId: row.id,
+              localStorageKey: parsed.localStorageKey,
+              importedFromLocalStorage: true,
+            },
+          },
+          tx
+        );
+        return row;
+      });
+      res
+        .status(201)
+        .json({ outcome: 'imported', project: toClientProject(created) });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          outcome: 'failed',
+          error: error.errors[0]?.message ?? 'Invalid local project',
+        });
+      }
+      console.error('Reconcile browser-local R&D project error:', error);
+      res.status(500).json({
+        outcome: 'failed',
+        error: 'Failed to import local project; local data was not changed',
       });
     }
-
-    const snapshot = await userSnapshot(req);
-    const created = await db.transaction(async (tx) => {
-      const [row] = await tx.insert(rdProjects).values({
-        id: parsed.id,
-        projectName: parsed.projectName,
-        owner: parsed.owner,
-        status: parsed.status,
-        signoffRequired: parsed.signoffRequired,
-        signoffUserId: parsed.signoffRequired ? parsed.signoffUserId : '',
-        draftTabIds: parsed.draftTabIds,
-        description: parsed.description,
-        createdByUserId: snapshot.userId,
-        createdByDisplayName: snapshot.displayName,
-        updatedByUserId: snapshot.userId,
-        updatedByDisplayName: snapshot.displayName,
-      }).returning();
-
-      await recordAuditEvent({
-        eventType: 'RD_PROJECT_IMPORTED_FROM_LOCAL_STORAGE',
-        subjectType: 'rd_project',
-        subjectId: row.id,
-        sourceService: 'rdProjects.route',
-        actor: actorSnapshot(req),
-        ipAddress: req.ip,
-        userAgent: req.get('user-agent') ?? null,
-        reason: 'Reviewed browser-local R&D project import',
-        fieldsChanged: { persistence: { before: 'browser_local', after: 'server_authoritative' } },
-        payload: {
-          projectId: row.id,
-          localStorageKey: parsed.localStorageKey,
-          importedFromLocalStorage: true,
-        },
-      }, tx);
-      return row;
-    });
-    res.status(201).json({ outcome: 'imported', project: toClientProject(created) });
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return res.status(400).json({ outcome: 'failed', error: error.errors[0]?.message ?? 'Invalid local project' });
-    }
-    console.error('Reconcile browser-local R&D project error:', error);
-    res.status(500).json({ outcome: 'failed', error: 'Failed to import local project; local data was not changed' });
   }
-});
+);
+
+async function projectExists(projectId: string) {
+  const [project] = await db
+    .select({ id: rdProjects.id })
+    .from(rdProjects)
+    .where(eq(rdProjects.id, projectId))
+    .limit(1);
+  return Boolean(project);
+}
+
+async function configurationCoverage(projectId: string, onlyItemId?: string) {
+  const itemRows = await db
+    .select()
+    .from(designProjectConfigurationItems)
+    .where(
+      onlyItemId
+        ? and(
+            eq(designProjectConfigurationItems.rdProjectId, projectId),
+            eq(designProjectConfigurationItems.id, onlyItemId)
+          )
+        : eq(designProjectConfigurationItems.rdProjectId, projectId)
+    );
+  const itemIds = itemRows.map((item) => item.id);
+  const revisions = itemIds.length
+    ? await db
+        .select()
+        .from(designProjectPartRevisions)
+        .where(inArray(designProjectPartRevisions.configurationItemId, itemIds))
+    : [];
+  const revisionIds = revisions.map((revision) => revision.id);
+  const applicability = itemIds.length
+    ? await db
+        .select()
+        .from(designProjectDocumentApplicability)
+        .where(
+          inArray(
+            designProjectDocumentApplicability.configurationItemId,
+            itemIds
+          )
+        )
+    : [];
+  const artifacts = revisionIds.length
+    ? await db
+        .select()
+        .from(designProjectPartRevisionArtifacts)
+        .where(
+          inArray(
+            designProjectPartRevisionArtifacts.partRevisionId,
+            revisionIds
+          )
+        )
+    : [];
+  const currentRevision = new Map<string, (typeof revisions)[number]>();
+  for (const revision of revisions) {
+    const current = currentRevision.get(revision.configurationItemId);
+    if (!current || revision.revisionSequence > current.revisionSequence)
+      currentRevision.set(revision.configurationItemId, revision);
+  }
+  const rolesFor = (itemType: string) =>
+    itemType === 'PURCHASED_COMPONENT'
+      ? [
+          'SUPPLIER_REQUIREMENT',
+          'DRAWING_CAD',
+          'INSPECTION_PLAN',
+          'MATERIAL_SPECIFICATION',
+        ]
+      : [...requirementRoles];
+  const parts = itemRows
+    .filter(
+      (item) =>
+        item.itemType === 'MANUFACTURED_PART' ||
+        item.itemType === 'PURCHASED_COMPONENT'
+    )
+    .map((item) => {
+      const revision = currentRevision.get(item.id);
+      const coverage = rolesFor(item.itemType).map((role) => {
+        const decision = applicability.find(
+          (entry) =>
+            entry.configurationItemId === item.id &&
+            entry.requirementRole === role
+        );
+        const link =
+          revision &&
+          artifacts.find(
+            (entry) =>
+              entry.partRevisionId === revision.id &&
+              entry.artifactRole === role
+          );
+        let status = 'Missing';
+        if (decision?.decision === 'NOT_APPLICABLE') {
+          status =
+            decision.approvalStatus === 'APPROVED'
+              ? 'Not Applicable — Approved'
+              : 'Not Applicable — Approval Required';
+        } else if (link) {
+          status =
+            link.lifecycleStateSnapshot === 'RELEASED'
+              ? 'Released'
+              : link.lifecycleStateSnapshot === 'APPROVED'
+                ? 'Approved'
+                : 'Draft';
+        } else if (decision?.approvalStatus === 'PENDING')
+          status = 'Awaiting Approval';
+        return {
+          role,
+          status,
+          applicability: decision ?? null,
+          artifact: link ?? null,
+        };
+      });
+      return {
+        item,
+        currentRevision: revision ?? null,
+        coverage,
+        complete: coverage.filter((entry) =>
+          [
+            'Released',
+            'Approved',
+            'Complete',
+            'Not Applicable — Approved',
+          ].includes(entry.status)
+        ).length,
+      };
+    });
+  const totalRequirements = parts.reduce(
+    (sum, part) => sum + part.coverage.length,
+    0
+  );
+  const completeRequirements = parts.reduce(
+    (sum, part) => sum + part.complete,
+    0
+  );
+  return {
+    parts,
+    totals: {
+      totalConfigurationItems: itemRows.length,
+      totalManufacturedParts: itemRows.filter(
+        (item) => item.itemType === 'MANUFACTURED_PART'
+      ).length,
+      totalPurchasedComponents: itemRows.filter(
+        (item) => item.itemType === 'PURCHASED_COMPONENT'
+      ).length,
+      partsMissingRevisions: parts.filter((part) => !part.currentRevision)
+        .length,
+      partsMissingRoutings: parts.filter(
+        (part) =>
+          part.item.itemType === 'MANUFACTURED_PART' &&
+          part.coverage.some(
+            (entry) => entry.role === 'ROUTING' && entry.status === 'Missing'
+          )
+      ).length,
+      partsMissingWorkInstructions: parts.filter(
+        (part) =>
+          part.item.itemType === 'MANUFACTURED_PART' &&
+          part.coverage.some(
+            (entry) =>
+              entry.role === 'WORK_INSTRUCTION' && entry.status === 'Missing'
+          )
+      ).length,
+      partsMissingInspectionPlans: parts.filter((part) =>
+        part.coverage.some(
+          (entry) =>
+            entry.role === 'INSPECTION_PLAN' && entry.status === 'Missing'
+        )
+      ).length,
+      pendingNotApplicableApprovals: parts.reduce(
+        (sum, part) =>
+          sum +
+          part.coverage.filter(
+            (entry) => entry.status === 'Not Applicable — Approval Required'
+          ).length,
+        0
+      ),
+      completenessPercentage: totalRequirements
+        ? Math.round((completeRequirements / totalRequirements) * 100)
+        : 0,
+      informationalOnly: true,
+      productionEnforcementEnabled: false,
+    },
+  };
+}
+
+router.get(
+  '/:projectId/configuration/summary',
+  requirePermission('design.configuration.view'),
+  async (req, res) => {
+    try {
+      if (!(await projectExists(req.params.projectId)))
+        return res.status(404).json({ error: 'R&D project not found' });
+      const [workspace] = await db
+        .select()
+        .from(designProjectConfigurationWorkspaces)
+        .where(
+          eq(
+            designProjectConfigurationWorkspaces.rdProjectId,
+            req.params.projectId
+          )
+        )
+        .limit(1);
+      if (!workspace)
+        return res.json({
+          established: false,
+          message:
+            'Configuration has not been established for this legacy project.',
+          productionEnforcementEnabled: false,
+        });
+      const [coverage, designControl, releaseResult] = await Promise.all([
+        configurationCoverage(req.params.projectId),
+        resolveDesignControlAuthority(req.params.projectId),
+        db.execute(
+          sql`SELECT release_revision, release_status, released_at FROM engineering_releases WHERE rd_project_id = ${req.params.projectId} ORDER BY released_at DESC NULLS LAST, created_at DESC LIMIT 1`
+        ),
+      ]);
+      res.json({
+        established: true,
+        workspace,
+        authoritativeDesignControl: designControl?.authoritativeRecord ?? null,
+        currentEngineeringRelease: rowsOf(releaseResult)[0] ?? null,
+        ...coverage,
+      });
+    } catch (error) {
+      console.error('Configuration summary error:', error);
+      res.status(500).json({ error: 'Failed to load configuration summary' });
+    }
+  }
+);
+
+router.post(
+  '/:projectId/configuration/activate',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    try {
+      if (!(await projectExists(req.params.projectId)))
+        return res.status(404).json({ error: 'R&D project not found' });
+      const evidence = requestEvidence(req);
+      const workspace = await db.transaction(async (tx) => {
+        const [row] = await tx
+          .insert(designProjectConfigurationWorkspaces)
+          .values({
+            rdProjectId: req.params.projectId,
+            activatedByUserId: evidence.actor.id,
+            activatedBySnapshot: evidence.snapshot,
+          })
+          .onConflictDoNothing()
+          .returning();
+        const [resolved] = row
+          ? [row]
+          : await tx
+              .select()
+              .from(designProjectConfigurationWorkspaces)
+              .where(
+                eq(
+                  designProjectConfigurationWorkspaces.rdProjectId,
+                  req.params.projectId
+                )
+              )
+              .limit(1);
+        if (row)
+          await recordAuditEvent(
+            {
+              eventType: 'DESIGN_PROJECT_CONFIGURATION_ACTIVATED',
+              subjectType: 'rd_project',
+              subjectId: req.params.projectId,
+              sourceService: 'rdProjects.configuration',
+              actor: evidence.actor,
+              ...evidence.metadata,
+              payload: { productionEnforcementEnabled: false },
+            },
+            tx
+          );
+        return { workspace: resolved, created: Boolean(row) };
+      });
+      res.status(workspace.created ? 201 : 200).json({
+        workspace: workspace.workspace,
+        alreadyEstablished: !workspace.created,
+        productionEnforcementEnabled: false,
+      });
+    } catch (error) {
+      console.error('Activate configuration error:', error);
+      res
+        .status(500)
+        .json({ error: 'Failed to start controlled configuration' });
+    }
+  }
+);
+
+router.get(
+  '/:projectId/configuration/tree',
+  requirePermission('design.configuration.view'),
+  async (req, res) => {
+    const items = await db
+      .select()
+      .from(designProjectConfigurationItems)
+      .where(
+        eq(designProjectConfigurationItems.rdProjectId, req.params.projectId)
+      );
+    const relationships = await db
+      .select()
+      .from(designProjectConfigurationItemRelationships)
+      .where(
+        eq(
+          designProjectConfigurationItemRelationships.rdProjectId,
+          req.params.projectId
+        )
+      );
+    const revisions = items.length
+      ? await db
+          .select()
+          .from(designProjectPartRevisions)
+          .where(
+            inArray(
+              designProjectPartRevisions.configurationItemId,
+              items.map((item) => item.id)
+            )
+          )
+      : [];
+    res.json({ items, relationships, revisions });
+  }
+);
+
+router.post(
+  '/:projectId/configuration/items',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    try {
+      const parsed = itemPayloadSchema.parse(req.body);
+      const evidence = requestEvidence(req);
+      const [workspace] = await db
+        .select()
+        .from(designProjectConfigurationWorkspaces)
+        .where(
+          eq(
+            designProjectConfigurationWorkspaces.rdProjectId,
+            req.params.projectId
+          )
+        )
+        .limit(1);
+      if (!workspace)
+        return res.status(409).json({ error: 'CONFIGURATION_NOT_ESTABLISHED' });
+      const [item] = await db
+        .insert(designProjectConfigurationItems)
+        .values({
+          rdProjectId: req.params.projectId,
+          ...parsed,
+          createdByUserId: evidence.actor.id,
+          createdBySnapshot: evidence.snapshot,
+        })
+        .returning();
+      res.status(201).json(item);
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return res.status(400).json({ error: error.errors[0]?.message });
+      if ((error as any)?.code === '23505')
+        return res.status(409).json({ error: 'DUPLICATE_CONFIGURATION_ITEM' });
+      res.status(500).json({ error: 'Failed to create configuration item' });
+    }
+  }
+);
+
+router.patch(
+  '/:projectId/configuration/items/:itemId',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    try {
+      const parsed = itemPayloadSchema.partial().parse(req.body);
+      const [item] = await db
+        .update(designProjectConfigurationItems)
+        .set({ ...parsed, updatedAt: new Date() })
+        .where(
+          and(
+            eq(designProjectConfigurationItems.id, req.params.itemId),
+            eq(
+              designProjectConfigurationItems.rdProjectId,
+              req.params.projectId
+            )
+          )
+        )
+        .returning();
+      if (!item)
+        return res.status(404).json({ error: 'Configuration item not found' });
+      res.json(item);
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return res.status(400).json({ error: error.errors[0]?.message });
+      res.status(500).json({ error: 'Failed to update configuration item' });
+    }
+  }
+);
+
+async function createsCycle(
+  projectId: string,
+  parentId: string,
+  childId: string,
+  excludedRelationshipId?: string
+) {
+  if (parentId === childId) return true;
+  const edges = await db
+    .select()
+    .from(designProjectConfigurationItemRelationships)
+    .where(
+      eq(designProjectConfigurationItemRelationships.rdProjectId, projectId)
+    );
+  const children = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (edge.id === excludedRelationshipId) continue;
+    children.set(edge.parentConfigurationItemId, [
+      ...(children.get(edge.parentConfigurationItemId) ?? []),
+      edge.childConfigurationItemId,
+    ]);
+  }
+  const pending = [childId];
+  const seen = new Set<string>();
+  while (pending.length) {
+    const id = pending.pop()!;
+    if (id === parentId) return true;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    pending.push(...(children.get(id) ?? []));
+  }
+  return false;
+}
+
+async function validateRelationship(
+  projectId: string,
+  payload: z.infer<typeof relationshipPayloadSchema>,
+  excludedRelationshipId?: string
+) {
+  const items = await db
+    .select({ id: designProjectConfigurationItems.id })
+    .from(designProjectConfigurationItems)
+    .where(
+      and(
+        eq(designProjectConfigurationItems.rdProjectId, projectId),
+        inArray(designProjectConfigurationItems.id, [
+          payload.parentConfigurationItemId,
+          payload.childConfigurationItemId,
+        ])
+      )
+    );
+  if (items.length !== 2) return 'CROSS_PROJECT_RELATIONSHIP';
+  if (
+    await createsCycle(
+      projectId,
+      payload.parentConfigurationItemId,
+      payload.childConfigurationItemId,
+      excludedRelationshipId
+    )
+  )
+    return 'CONFIGURATION_CYCLE';
+  return null;
+}
+
+router.post(
+  '/:projectId/configuration/relationships',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    try {
+      const parsed = relationshipPayloadSchema.parse(req.body);
+      const invalid = await validateRelationship(req.params.projectId, parsed);
+      if (invalid) return res.status(409).json({ error: invalid });
+      const evidence = requestEvidence(req);
+      const [relationship] = await db
+        .insert(designProjectConfigurationItemRelationships)
+        .values({
+          rdProjectId: req.params.projectId,
+          ...parsed,
+          quantity: String(parsed.quantity),
+          createdByUserId: evidence.actor.id,
+          createdBySnapshot: evidence.snapshot,
+        })
+        .returning();
+      res.status(201).json(relationship);
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return res.status(400).json({ error: error.errors[0]?.message });
+      if ((error as any)?.code === '23505')
+        return res.status(409).json({ error: 'DUPLICATE_CURRENT_CHILD' });
+      res.status(500).json({ error: 'Failed to add relationship' });
+    }
+  }
+);
+
+router.patch(
+  '/:projectId/configuration/relationships/:relationshipId',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    try {
+      const existing = await db
+        .select()
+        .from(designProjectConfigurationItemRelationships)
+        .where(
+          and(
+            eq(
+              designProjectConfigurationItemRelationships.id,
+              req.params.relationshipId
+            ),
+            eq(
+              designProjectConfigurationItemRelationships.rdProjectId,
+              req.params.projectId
+            )
+          )
+        )
+        .limit(1);
+      if (!existing[0])
+        return res.status(404).json({ error: 'Relationship not found' });
+      const parsed = relationshipPayloadSchema.parse({
+        ...existing[0],
+        ...req.body,
+        quantity: req.body.quantity ?? existing[0].quantity,
+      });
+      const invalid = await validateRelationship(
+        req.params.projectId,
+        parsed,
+        req.params.relationshipId
+      );
+      if (invalid) return res.status(409).json({ error: invalid });
+      const [relationship] = await db
+        .update(designProjectConfigurationItemRelationships)
+        .set({ ...parsed, quantity: String(parsed.quantity) })
+        .where(
+          eq(
+            designProjectConfigurationItemRelationships.id,
+            req.params.relationshipId
+          )
+        )
+        .returning();
+      res.json(relationship);
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return res.status(400).json({ error: error.errors[0]?.message });
+      res.status(500).json({ error: 'Failed to update relationship' });
+    }
+  }
+);
+
+router.put(
+  '/:projectId/configuration/relationships/reorder',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    try {
+      const parsed = z
+        .object({
+          parentConfigurationItemId: z.string().uuid(),
+          relationshipIds: z.array(z.string().uuid()).min(1),
+        })
+        .parse(req.body);
+      await db.transaction(async (tx) => {
+        const rows = await tx
+          .select()
+          .from(designProjectConfigurationItemRelationships)
+          .where(
+            and(
+              eq(
+                designProjectConfigurationItemRelationships.rdProjectId,
+                req.params.projectId
+              ),
+              eq(
+                designProjectConfigurationItemRelationships.parentConfigurationItemId,
+                parsed.parentConfigurationItemId
+              ),
+              inArray(
+                designProjectConfigurationItemRelationships.id,
+                parsed.relationshipIds
+              )
+            )
+          );
+        if (rows.length !== parsed.relationshipIds.length)
+          throw Object.assign(new Error('Invalid reorder scope'), {
+            code: 'INVALID_REORDER_SCOPE',
+          });
+        for (const [sortOrder, id] of parsed.relationshipIds.entries())
+          await tx
+            .update(designProjectConfigurationItemRelationships)
+            .set({ sortOrder })
+            .where(eq(designProjectConfigurationItemRelationships.id, id));
+      });
+      res.json({ reordered: parsed.relationshipIds.length });
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return res.status(400).json({ error: error.errors[0]?.message });
+      if ((error as any)?.code === 'INVALID_REORDER_SCOPE')
+        return res.status(409).json({ error: 'INVALID_REORDER_SCOPE' });
+      res.status(500).json({ error: 'Failed to reorder relationships' });
+    }
+  }
+);
+
+router.delete(
+  '/:projectId/configuration/relationships/:relationshipId',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    const [removed] = await db
+      .delete(designProjectConfigurationItemRelationships)
+      .where(
+        and(
+          eq(
+            designProjectConfigurationItemRelationships.id,
+            req.params.relationshipId
+          ),
+          eq(
+            designProjectConfigurationItemRelationships.rdProjectId,
+            req.params.projectId
+          )
+        )
+      )
+      .returning();
+    if (!removed)
+      return res.status(404).json({ error: 'Relationship not found' });
+    res.json({ removed: true });
+  }
+);
+
+router.post(
+  '/:projectId/configuration/items/:itemId/revisions',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    try {
+      const parsed = z
+        .object({
+          revisionIdentifier: z.string().trim().min(1),
+          changeSummary: z.string().trim().min(1),
+          predecessorRevisionId: z.string().uuid().nullable().optional(),
+          effectivityStart: z.string().trim().nullable().optional(),
+          effectivityEnd: z.string().trim().nullable().optional(),
+          sourceEcrId: z.string().uuid().nullable().optional(),
+          sourceEcnId: z.string().uuid().nullable().optional(),
+        })
+        .parse(req.body);
+      const evidence = requestEvidence(req);
+      const revision = await db.transaction(async (tx) => {
+        const [item] = await tx
+          .select()
+          .from(designProjectConfigurationItems)
+          .where(
+            and(
+              eq(designProjectConfigurationItems.id, req.params.itemId),
+              eq(
+                designProjectConfigurationItems.rdProjectId,
+                req.params.projectId
+              )
+            )
+          )
+          .limit(1);
+        if (!item)
+          throw Object.assign(new Error('Item not found'), {
+            code: 'ITEM_NOT_FOUND',
+          });
+        await tx.execute(
+          sql`SELECT id FROM design_project_configuration_items WHERE id = ${item.id} FOR UPDATE`
+        );
+        if (parsed.predecessorRevisionId) {
+          const [predecessor] = await tx
+            .select()
+            .from(designProjectPartRevisions)
+            .where(
+              and(
+                eq(designProjectPartRevisions.id, parsed.predecessorRevisionId),
+                eq(designProjectPartRevisions.configurationItemId, item.id)
+              )
+            )
+            .limit(1);
+          if (!predecessor)
+            throw Object.assign(new Error('Predecessor not found'), {
+              code: 'PREDECESSOR_NOT_FOUND',
+            });
+        }
+        const sequenceRows = await tx.execute(
+          sql`SELECT COALESCE(MAX(revision_sequence), 0)::int AS value FROM design_project_part_revisions WHERE configuration_item_id = ${item.id}`
+        );
+        const revisionSequence =
+          Number(rowsOf<{ value: number }>(sequenceRows)[0]?.value ?? 0) + 1;
+        const [created] = await tx
+          .insert(designProjectPartRevisions)
+          .values({
+            configurationItemId: item.id,
+            revisionIdentifier: parsed.revisionIdentifier,
+            revisionSequence,
+            lifecycleState: 'DRAFT',
+            changeSummary: parsed.changeSummary,
+            predecessorRevisionId: parsed.predecessorRevisionId,
+            effectivityStart: parsed.effectivityStart,
+            effectivityEnd: parsed.effectivityEnd,
+            sourceEcrId: parsed.sourceEcrId,
+            sourceEcnId: parsed.sourceEcnId,
+            createdByUserId: evidence.actor.id,
+            createdBySnapshot: evidence.snapshot,
+          })
+          .returning();
+        return created;
+      });
+      res.status(201).json(revision);
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return res.status(400).json({ error: error.errors[0]?.message });
+      if (
+        ['ITEM_NOT_FOUND', 'PREDECESSOR_NOT_FOUND'].includes(
+          (error as any)?.code
+        )
+      )
+        return res.status(409).json({ error: (error as any).code });
+      res.status(500).json({ error: 'Failed to create draft revision' });
+    }
+  }
+);
+
+router.put(
+  '/:projectId/configuration/items/:itemId/applicability/:role',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    try {
+      const role = z.enum(requirementRoles).parse(req.params.role);
+      const parsed = z
+        .object({
+          decision: z.enum(['REQUIRED', 'OPTIONAL', 'NOT_APPLICABLE']),
+          justification: z.string().trim().nullable().optional(),
+        })
+        .parse(req.body);
+      if (parsed.decision === 'NOT_APPLICABLE' && !parsed.justification)
+        return res
+          .status(400)
+          .json({ error: 'NOT_APPLICABLE_JUSTIFICATION_REQUIRED' });
+      const evidence = requestEvidence(req);
+      const approvalStatus =
+        parsed.decision === 'NOT_APPLICABLE' ? 'DRAFT' : 'NOT_REQUIRED';
+      const result = await db.execute(sql`
+      INSERT INTO design_project_document_applicability
+        (configuration_item_id, requirement_role, decision, justification, approval_status, created_by_user_id, created_by_snapshot)
+      SELECT id, ${role}, ${parsed.decision}, ${parsed.justification ?? null}, ${approvalStatus}, ${evidence.actor.id}, ${JSON.stringify(evidence.snapshot)}::jsonb
+      FROM design_project_configuration_items WHERE id = ${req.params.itemId} AND rd_project_id = ${req.params.projectId}
+      ON CONFLICT (configuration_item_id, requirement_role) WHERE configuration_item_id IS NOT NULL
+      DO UPDATE SET decision = EXCLUDED.decision, justification = EXCLUDED.justification,
+        approval_status = EXCLUDED.approval_status, approved_by_user_id = NULL,
+        approved_by_snapshot = NULL, approved_at = NULL, updated_at = now()
+      RETURNING *
+    `);
+      const row = rowsOf(result)[0];
+      if (!row)
+        return res.status(404).json({ error: 'Configuration item not found' });
+      res.json(row);
+    } catch (error) {
+      if (error instanceof z.ZodError)
+        return res.status(400).json({ error: error.errors[0]?.message });
+      res
+        .status(500)
+        .json({ error: 'Failed to set documentation requirement' });
+    }
+  }
+);
+
+router.post(
+  '/:projectId/configuration/applicability/:applicabilityId/submit',
+  requirePermission('design.configuration.edit'),
+  async (req, res) => {
+    const [row] = await db
+      .update(designProjectDocumentApplicability)
+      .set({ approvalStatus: 'PENDING', updatedAt: new Date() })
+      .where(
+        and(
+          eq(designProjectDocumentApplicability.id, req.params.applicabilityId),
+          eq(designProjectDocumentApplicability.decision, 'NOT_APPLICABLE'),
+          eq(designProjectDocumentApplicability.approvalStatus, 'DRAFT')
+        )
+      )
+      .returning();
+    if (!row)
+      return res.status(409).json({ error: 'NOT_APPLICABLE_NOT_SUBMITTABLE' });
+    res.json(row);
+  }
+);
+
+router.post(
+  '/:projectId/configuration/applicability/:applicabilityId/approve',
+  requirePermission('design.configuration.applicability.approve'),
+  async (req, res) => {
+    const evidence = requestEvidence(req);
+    const result = await db.execute(sql`
+    UPDATE design_project_document_applicability a SET approval_status = 'APPROVED',
+      approved_by_user_id = ${evidence.actor.id}, approved_by_snapshot = ${JSON.stringify(evidence.snapshot)}::jsonb,
+      approved_at = now(), updated_at = now()
+    FROM design_project_configuration_items i
+    WHERE a.id = ${req.params.applicabilityId} AND a.configuration_item_id = i.id
+      AND i.rd_project_id = ${req.params.projectId} AND a.decision = 'NOT_APPLICABLE'
+      AND a.approval_status = 'PENDING' RETURNING a.*
+  `);
+    const row = rowsOf(result)[0];
+    if (!row)
+      return res.status(409).json({ error: 'NOT_APPLICABLE_NOT_APPROVABLE' });
+    res.json(row);
+  }
+);
+
+router.get(
+  '/:projectId/configuration/items/:itemId/coverage',
+  requirePermission('design.configuration.view'),
+  async (req, res) => {
+    const coverage = await configurationCoverage(
+      req.params.projectId,
+      req.params.itemId
+    );
+    if (!coverage.parts[0])
+      return res.status(404).json({ error: 'Part not found' });
+    res.json(coverage.parts[0]);
+  }
+);
+
+router.get(
+  '/:projectId/configuration/coverage',
+  requirePermission('design.configuration.view'),
+  async (req, res) => {
+    res.json(await configurationCoverage(req.params.projectId));
+  }
+);
 
 export default router;

--- a/server/src/routes/rdProjects.ts
+++ b/server/src/routes/rdProjects.ts
@@ -85,7 +85,16 @@ const createItemPayloadSchema = itemPayloadSchema.extend({
 });
 
 function rowsOf<T>(result: unknown): T[] {
-  return (((result as any)?.rows ?? result) || []) as T[];
+  if (Array.isArray(result)) return result as T[];
+  if (
+    result &&
+    typeof result === 'object' &&
+    'rows' in result &&
+    Array.isArray(result.rows)
+  ) {
+    return result.rows as T[];
+  }
+  return [];
 }
 
 function errorCode(error: unknown) {
@@ -143,8 +152,20 @@ const localReconciliationSchema = rdProjectPayloadSchema.extend({
   localStorageKey: z.string().trim().min(1),
 });
 
+type AuthenticatedUser = {
+  id?: number | null;
+  username?: string | null;
+  email?: string | null;
+  displayName?: string | null;
+  role?: string | null;
+};
+
+function authenticatedUser(req: Request): AuthenticatedUser | undefined {
+  return (req as Request & { user?: AuthenticatedUser }).user;
+}
+
 function actorSnapshot(req: Request) {
-  const user = (req as any).user;
+  const user = authenticatedUser(req);
   return {
     id: typeof user?.id === 'number' ? user.id : null,
     username: user?.username ?? user?.email ?? user?.displayName ?? 'unknown',
@@ -153,7 +174,7 @@ function actorSnapshot(req: Request) {
 }
 
 async function userSnapshot(req: Request) {
-  const user = (req as any).user;
+  const user = authenticatedUser(req);
   if (!user) return { userId: null, displayName: 'unknown' };
   if (!user.id) {
     return {
@@ -304,8 +325,8 @@ router.post(
         });
       }
       res.status(result.status === 'created' ? 201 : 200).json(result);
-    } catch (error: any) {
-      if (error?.code === '23505') {
+    } catch (error: unknown) {
+      if (errorCode(error) === '23505') {
         const resolution = await resolveDesignControlAuthority(
           req.params.projectId
         );
@@ -387,8 +408,7 @@ router.post(
       ORDER BY updated_at DESC
       LIMIT 10
     `);
-      const duplicateRows =
-        (possibleDuplicates as any)?.rows ?? possibleDuplicates;
+      const duplicateRows = rowsOf<Record<string, unknown>>(possibleDuplicates);
       if (Array.isArray(duplicateRows) && duplicateRows.length > 0) {
         return res.status(409).json({
           outcome: 'possible_duplicate',

--- a/server/src/services/designControlSchemaReadiness.ts
+++ b/server/src/services/designControlSchemaReadiness.ts
@@ -10,6 +10,7 @@ export const requiredDesignControlMigrations = [
   '0207_design_control_authority_foundation.sql',
   '0208_design_control_authenticated_approvals.sql',
   '0248_design_project_manufacturing_configuration.sql',
+  '0251_design_project_configuration_workspace.sql',
 ] as const;
 
 export const requiredDesignControlTables = [
@@ -39,6 +40,7 @@ export const requiredDesignControlTables = [
   'routing_operation_work_instruction_revisions',
   'design_project_configuration_reconciliation_queue',
   'design_project_configuration_reconciliation_events',
+  'design_project_configuration_workspaces',
 ] as const;
 
 type ReadinessClient = Pick<typeof db, 'execute'>;


### PR DESCRIPTION
## Summary
- Adds **Part & Assembly Configuration** directly to the authoritative `/design/rd-projects` workspace.
- Provides the five guided steps: Product Structure, Parts and Revisions, Make/Buy Decisions, Documentation Requirements, and Coverage Review.
- Adds capability-protected APIs for explicit activation, tree reads and mutations, draft revisions, applicability submission/approval, and per-part/project coverage.
- Uses only authoritative Phase 1 artifact links for coverage; filenames, metadata, URLs, titles, and part-number matches never satisfy coverage.

## Base and head
- Starting SHA (`origin/main` after corrective refresh): `d807967b0475c363930b90178e49caffbfe57f60`
- Ending SHA: `d0105a88eabf15598640004d20602c4876908edc`
- PR #1627 merge `d099ee48fb190012ce57744b70a89dd63c21c2a6`: contained in starting SHA.
- PR #1629 merge `7ac241f2bb17dd0f8a60c7dec4999b51e76abcc1`: contained in starting SHA.
- Phase 1 migration on main: `0248_design_project_manufacturing_configuration.sql`.
- Phase 2 migration: `0251_design_project_configuration_workspace.sql` (renumbered after final refresh found main's `0250_epoch_validation_wizard_phase1.sql`).

## API and authorization
Reads require `design.configuration.view`. Configuration activation, item/relationship mutations, draft revision creation, and applicability submission require `design.configuration.edit`. Not Applicable approval requires `design.configuration.applicability.approve`. Schema readiness fails closed with 503 responses. Multi-record reorder and revision allocation use transactions, and relationships reject cross-project links and cycles.

## Validation
- Focused Phase 2 + schema-readiness Vitest: **28/28 passed**.
- Targeted ESLint for the new component, route, and focused tests: **passed**.
- Formatting for new/changed implementation files: **passed**.
- `git diff --check`: **passed**.
- Full TypeScript: **not certified**. A 2 GB run OOMed; an 8 GB full run timed out after 244 seconds. A focused compile reached existing repository errors in `RDProjectsPage`, shared `schema.ts`, permission middleware, audit service, and Design Control authority service; it reported no new Phase 2 component-specific diagnostic.
- PostgreSQL certification: **not run** because no positively identified disposable database was available. No production, shared development, or staging database was contacted.
- Browser workflow/screenshots: **not available**. The in-app browser blocked the local preview URL, and starting the real app safely requires an identified disposable database. No screenshot was fabricated and no unknown environment was used.

## Legacy and production safety
Existing Design Projects are unchanged until an authorized user explicitly selects **Start Controlled Configuration**. No configuration tree, relationship, inventory link, routing, document, traveler, BOM, P2 project, or production record is inferred or backfilled. P2 behavior is untouched. Configuration completeness is informational only; Engineering Release and production enforcement remain disabled.

## Exact Phase 3 recommendation
After migration 0251 is certified on a disposable PostgreSQL database and the complete five-step authenticated browser workflow is captured, add an opt-in configuration-review gate for newly activated Design Projects only. Phase 3 should require approved applicability plus authoritative released artifact links before Engineering Release, preserve an administrator-audited exception path, keep all legacy projects unenforced until explicit reconciliation, and still avoid any automatic production backfill or part-number-based linking.
## Corrective hardening
- Original P2 certification failure was PR-caused: exact-main TypeScript comparison found one new TS2802 diagnostic from `relationshipIds.entries()` in `rdProjects.ts`. The indexed loop removes that diagnostic.
- Applicability submission and approval now lock and scope the record through its configuration item to the URL `rd_project`; cross-project IDs return 404 while invalid same-project lifecycle state returns 409.
- Item creation accepts an optional parent relationship and inserts item plus relationship in one server transaction. Invalid/cross-project parents, uniqueness conflicts, and relationship failures roll back without an orphan.
- Relationship update/delete/reorder, item update, draft revision, applicability upsert, and part coverage all prove project ownership.
- Added disposable PostgreSQL route certification for cross-project denial, lifecycle transitions, authenticated actor evidence, and rollback behavior; wired into the existing P2 certification workflow.
- Added a component contract test proving the client uses one create request.
- Production and Engineering Release enforcement remain disabled.