### PR TITLE
Fix EPOCH validation wizard save and assignment acceptance

### DIFF
--- a/client/src/__tests__/epochSoftwareValidationWizardPhase1.component.test.tsx
+++ b/client/src/__tests__/epochSoftwareValidationWizardPhase1.component.test.tsx
@@ -52,6 +52,11 @@ describe('EPOCH software validation wizard Phase 1 UI', () => {
     );
     expect(wizard).toContain('Save and exit');
     expect(wizard).toContain('aria-label="Validation wizard steps"');
+    expect(wizard).toContain('form.requestSubmit(submitter)');
+    expect(wizard).toContain("toast({ title: 'Draft saved successfully.' })");
+    expect(wizard).toContain('if (!dirty)');
+    expect(wizard).toContain('submissionGuard.current');
+    expect(wizard.match(/id=\{stepFormId\([123]\)\}/g)).toHaveLength(3);
   });
 
   it('supports plain-language setup with advanced technical details', () => {
@@ -84,7 +89,9 @@ describe('EPOCH software validation wizard Phase 1 UI', () => {
     expect(wizard).toContain('Accept responsibility');
     expect(wizard).toContain('/api/auth/session');
     expect(compact).toContain("method:'PUT'");
-    expect(wizard).toContain('/accept');
+    expect(wizard).toContain('/decision');
+    expect(wizard).toContain('Reason required to decline');
+    expect(wizard).toContain("decision: 'DECLINED'");
   });
 
   it('uses the parsed shared API response without a second parse', () => {

--- a/client/src/components/qms/EpochValidationWizard.tsx
+++ b/client/src/components/qms/EpochValidationWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   AlertTriangle,
@@ -104,6 +104,14 @@ type Props = {
   employees: Employee[];
   onBack: () => void;
 };
+
+type SaveIntent = 'continue' | 'exit';
+const stepFormId = (step: number) => `epoch-validation-step-${step}`;
+const submittedIntent = (event: FormEvent<HTMLFormElement>) =>
+  ((event.nativeEvent as SubmitEvent).submitter as HTMLButtonElement | null)
+    ?.value === 'exit'
+    ? 'exit'
+    : 'continue';
 
 const requestJson = <T,>(
   url: string,
@@ -225,6 +233,7 @@ export function EpochValidationWizard({ detail, employees, onBack }: Props) {
   const firstIncomplete = !setupComplete ? 1 : !intendedComplete ? 2 : 3;
   const [currentStep, setCurrentStep] = useState(firstIncomplete);
   const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
   const implementedComplete = [
     setupComplete,
     intendedComplete,
@@ -275,6 +284,38 @@ export function EpochValidationWizard({ detail, employees, onBack }: Props) {
       return;
     setDirty(false);
     setCurrentStep(step);
+  };
+  const finishSave = async (intent: SaveIntent, nextStep?: number) => {
+    setDirty(false);
+    let refreshed = true;
+    try {
+      await refresh();
+    } catch {
+      refreshed = false;
+      toast({
+        title: 'Draft saved, but the screen could not be refreshed.',
+        description: 'Reopen the package to continue with current data.',
+        variant: 'destructive',
+      });
+    }
+    if (intent === 'exit') {
+      toast({ title: 'Draft saved successfully.' });
+      onBack();
+    } else if (refreshed && nextStep) setCurrentStep(nextStep);
+  };
+  const submitCurrentStep = (intent: SaveIntent) => {
+    if (saving) return;
+    if (!dirty) {
+      if (intent === 'exit') onBack();
+      else if (currentStep < 3) setCurrentStep(currentStep + 1);
+      return;
+    }
+    const form = document.getElementById(stepFormId(currentStep));
+    const submitter = form?.querySelector<HTMLButtonElement>(
+      `button[type="submit"][value="${intent}"]`
+    );
+    if (form instanceof HTMLFormElement && submitter)
+      form.requestSubmit(submitter);
   };
 
   const nextAction = !setupComplete
@@ -381,22 +422,16 @@ export function EpochValidationWizard({ detail, employees, onBack }: Props) {
             <SetupStep
               detail={detail}
               onDirty={() => setDirty(true)}
-              onSaved={async () => {
-                setDirty(false);
-                await refresh();
-                setCurrentStep(2);
-              }}
+              onSavingChange={setSaving}
+              onSaved={(intent) => finishSave(intent, 2)}
             />
           )}
           {currentStep === 2 && (
             <IntendedUseStep
               detail={detail}
               onDirty={() => setDirty(true)}
-              onSaved={async () => {
-                setDirty(false);
-                await refresh();
-                setCurrentStep(3);
-              }}
+              onSavingChange={setSaving}
+              onSaved={(intent) => finishSave(intent, 3)}
             />
           )}
           {currentStep === 3 && (
@@ -404,10 +439,8 @@ export function EpochValidationWizard({ detail, employees, onBack }: Props) {
               detail={detail}
               employees={activeEmployees}
               onDirty={() => setDirty(true)}
-              onSaved={async () => {
-                setDirty(false);
-                await refresh();
-              }}
+              onSavingChange={setSaving}
+              onSaved={(intent) => finishSave(intent)}
             />
           )}
           {currentStep > 3 && <UnavailableStep step={currentStep} />}
@@ -417,7 +450,7 @@ export function EpochValidationWizard({ detail, employees, onBack }: Props) {
       <div className="sticky bottom-0 flex flex-wrap items-center justify-between gap-3 border-t bg-background/95 py-3 backdrop-blur">
         <Button
           variant="outline"
-          disabled={currentStep === 1}
+          disabled={currentStep === 1 || saving}
           onClick={() => navigate(currentStep - 1)}
         >
           <ChevronLeft className="mr-2 h-4 w-4" /> Previous
@@ -428,22 +461,14 @@ export function EpochValidationWizard({ detail, employees, onBack }: Props) {
         <div className="flex gap-2">
           <Button
             variant="outline"
-            onClick={() => {
-              if (dirty) {
-                toast({
-                  title: 'Save this step before exiting',
-                  variant: 'destructive',
-                });
-                return;
-              }
-              onBack();
-            }}
+            disabled={saving}
+            onClick={() => submitCurrentStep('exit')}
           >
-            Save and exit
+            {saving ? 'Saving…' : 'Save and exit'}
           </Button>
           <Button
-            disabled={currentStep >= 3}
-            onClick={() => navigate(currentStep + 1)}
+            disabled={currentStep >= 3 || saving}
+            onClick={() => submitCurrentStep('continue')}
           >
             Continue <ChevronRight className="ml-2 h-4 w-4" />
           </Button>
@@ -456,14 +481,18 @@ export function EpochValidationWizard({ detail, employees, onBack }: Props) {
 function SetupStep({
   detail,
   onDirty,
+  onSavingChange,
   onSaved,
 }: {
   detail: Detail;
   onDirty: () => void;
-  onSaved: () => Promise<void>;
+  onSavingChange: (saving: boolean) => void;
+  onSaved: (intent: SaveIntent) => Promise<void>;
 }) {
   const p = detail.package;
   const { toast } = useToast();
+  const submissionGuard = useRef(false);
+  const saveIntent = useRef<SaveIntent>('continue');
   const save = useMutation({
     mutationFn: (body: Record<string, unknown>) =>
       requestJson(`/api/qms/epoch-software-validation/${p.id}/wizard/setup`, {
@@ -471,8 +500,9 @@ function SetupStep({
         body,
       }),
     onSuccess: async () => {
-      toast({ title: 'Controlled draft saved' });
-      await onSaved();
+      if (saveIntent.current === 'continue')
+        toast({ title: 'Controlled draft saved' });
+      await onSaved(saveIntent.current);
     },
     onError: (error: Error) =>
       toast({
@@ -480,6 +510,10 @@ function SetupStep({
         description: error.message,
         variant: 'destructive',
       }),
+    onSettled: () => {
+      submissionGuard.current = false;
+      onSavingChange(false);
+    },
   });
   const technicalMissing =
     !p.commit_or_release_identifier || !p.production_deployment_date;
@@ -501,10 +535,15 @@ function SetupStep({
           </div>
         )}
         <form
+          id={stepFormId(1)}
           className="grid gap-4 md:grid-cols-2"
           onChange={onDirty}
           onSubmit={(event) => {
             event.preventDefault();
+            if (submissionGuard.current) return;
+            submissionGuard.current = true;
+            saveIntent.current = submittedIntent(event);
+            onSavingChange(true);
             const form = new FormData(event.currentTarget);
             save.mutate({
               rowVersion: p.row_version,
@@ -637,11 +676,17 @@ function SetupStep({
             </div>
           </details>
           <div className="md:col-span-2 flex justify-end">
-            <Button type="submit" disabled={save.isPending}>
+            <Button
+              type="submit"
+              name="saveIntent"
+              value="continue"
+              disabled={save.isPending}
+            >
               {save.isPending
                 ? 'Saving…'
                 : 'Save controlled draft and continue'}
             </Button>
+            <button type="submit" name="saveIntent" value="exit" hidden />
           </div>
         </form>
       </CardContent>
@@ -652,15 +697,19 @@ function SetupStep({
 function IntendedUseStep({
   detail,
   onDirty,
+  onSavingChange,
   onSaved,
 }: {
   detail: Detail;
   onDirty: () => void;
-  onSaved: () => Promise<void>;
+  onSavingChange: (saving: boolean) => void;
+  onSaved: (intent: SaveIntent) => Promise<void>;
 }) {
   const p = detail.package;
   const prior = detail.intendedUse[0] || {};
   const { toast } = useToast();
+  const submissionGuard = useRef(false);
+  const saveIntent = useRef<SaveIntent>('continue');
   const [functions, setFunctions] = useState<Record<string, FunctionSelection>>(
     Object.fromEntries(
       detail.intendedUseFunctions.map((item) => [item.function_key, item])
@@ -673,8 +722,9 @@ function IntendedUseStep({
         body,
       }),
     onSuccess: async () => {
-      toast({ title: 'Intended Use revision saved as DRAFT' });
-      await onSaved();
+      if (saveIntent.current === 'continue')
+        toast({ title: 'Intended Use revision saved as DRAFT' });
+      await onSaved(saveIntent.current);
     },
     onError: (error: Error) =>
       toast({
@@ -682,6 +732,10 @@ function IntendedUseStep({
         description: error.message,
         variant: 'destructive',
       }),
+    onSettled: () => {
+      submissionGuard.current = false;
+      onSavingChange(false);
+    },
   });
   const updateFunction = (key: string, patch: Partial<FunctionSelection>) => {
     onDirty();
@@ -712,10 +766,15 @@ function IntendedUseStep({
       </CardHeader>
       <CardContent>
         <form
+          id={stepFormId(2)}
           className="space-y-5"
           onChange={onDirty}
           onSubmit={(event) => {
             event.preventDefault();
+            if (submissionGuard.current) return;
+            submissionGuard.current = true;
+            saveIntent.current = submittedIntent(event);
+            onSavingChange(true);
             const form = new FormData(event.currentTarget);
             save.mutate({
               systemName: p.system_name,
@@ -930,10 +989,13 @@ function IntendedUseStep({
           <div className="flex justify-end">
             <Button
               type="submit"
+              name="saveIntent"
+              value="continue"
               disabled={save.isPending || !Object.keys(functions).length}
             >
               {save.isPending ? 'Saving…' : 'Save Intended Use and continue'}
             </Button>
+            <button type="submit" name="saveIntent" value="exit" hidden />
           </div>
         </form>
       </CardContent>
@@ -945,15 +1007,22 @@ function ResponsibilitiesStep({
   detail,
   employees,
   onDirty,
+  onSavingChange,
   onSaved,
 }: {
   detail: Detail;
   employees: Employee[];
   onDirty: () => void;
-  onSaved: () => Promise<void>;
+  onSavingChange: (saving: boolean) => void;
+  onSaved: (intent: SaveIntent) => Promise<void>;
 }) {
   const p = detail.package;
   const { toast } = useToast();
+  const submissionGuard = useRef(false);
+  const saveIntent = useRef<SaveIntent>('continue');
+  const [declineReasons, setDeclineReasons] = useState<Record<string, string>>(
+    {}
+  );
   const currentUser = useQuery<{ employeeId?: number | null }>({
     queryKey: ['/api/auth/session'],
     queryFn: () => requestJson('/api/auth/session'),
@@ -976,11 +1045,12 @@ function ResponsibilitiesStep({
         }
       ),
     onSuccess: async () => {
-      toast({
-        title: 'Responsibilities saved',
-        description: 'New assignments are awaiting acceptance.',
-      });
-      await onSaved();
+      if (saveIntent.current === 'continue')
+        toast({
+          title: 'Responsibilities saved',
+          description: 'New assignments are awaiting acceptance.',
+        });
+      await onSaved(saveIntent.current);
     },
     onError: (error: Error) =>
       toast({
@@ -988,20 +1058,33 @@ function ResponsibilitiesStep({
         description: error.message,
         variant: 'destructive',
       }),
+    onSettled: () => {
+      submissionGuard.current = false;
+      onSavingChange(false);
+    },
   });
-  const accept = useMutation({
-    mutationFn: (assignmentId: string) =>
+  const decide = useMutation({
+    mutationFn: (input: {
+      assignmentId: string;
+      decision: 'ACCEPTED' | 'DECLINED';
+      reason?: string;
+    }) =>
       requestJson(
-        `/api/qms/epoch-software-validation/${p.id}/responsibilities/${assignmentId}/accept`,
-        { method: 'POST', body: {} }
+        `/api/qms/epoch-software-validation/${p.id}/responsibilities/${input.assignmentId}/decision`,
+        { method: 'POST', body: input }
       ),
-    onSuccess: async () => {
-      toast({ title: 'Responsibility accepted' });
-      await onSaved();
+    onSuccess: async (_result, input) => {
+      toast({
+        title:
+          input.decision === 'ACCEPTED'
+            ? 'Responsibility accepted'
+            : 'Responsibility declined',
+      });
+      await onSaved('continue');
     },
     onError: (error: Error) =>
       toast({
-        title: 'Acceptance blocked',
+        title: 'Responsibility decision blocked',
         description: error.message,
         variant: 'destructive',
       }),
@@ -1025,115 +1108,179 @@ function ResponsibilitiesStep({
           assignee must accept with their own identity.
         </p>
       </CardHeader>
-      <CardContent className="space-y-5">
-        {responsibilityDefinitions.map((definition) => {
-          const assigned = assignments.filter(
-            (item) => item.role === definition.role
-          );
-          const records = detail.responsibilities.filter(
-            (item) => item.responsibility_role === definition.role
-          );
-          return (
-            <div key={definition.role} className="rounded-md border p-4">
-              <div className="mb-3">
-                <h3 className="font-medium">{definition.label}</h3>
-                <p className="text-sm text-muted-foreground">
-                  {definition.help}
-                </p>
-              </div>
-              <EmployeeSearch
-                employees={employees.filter(
-                  (employee) =>
-                    definition.multiple ||
-                    !assignments.some(
+      <CardContent>
+        <form
+          id={stepFormId(3)}
+          className="space-y-5"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (submissionGuard.current) return;
+            submissionGuard.current = true;
+            saveIntent.current = submittedIntent(event);
+            onSavingChange(true);
+            save.mutate();
+          }}
+        >
+          {responsibilityDefinitions.map((definition) => {
+            const assigned = assignments.filter(
+              (item) => item.role === definition.role
+            );
+            const records = detail.responsibilities.filter(
+              (item) => item.responsibility_role === definition.role
+            );
+            return (
+              <div key={definition.role} className="rounded-md border p-4">
+                <div className="mb-3">
+                  <h3 className="font-medium">{definition.label}</h3>
+                  <p className="text-sm text-muted-foreground">
+                    {definition.help}
+                  </p>
+                </div>
+                <EmployeeSearch
+                  employees={employees.filter(
+                    (employee) =>
+                      definition.multiple ||
+                      !assignments.some(
+                        (item) =>
+                          item.role === definition.role &&
+                          item.employeeId === employee.id
+                      )
+                  )}
+                  value={
+                    definition.multiple ? undefined : assigned[0]?.employeeId
+                  }
+                  onSelect={(employeeId) => {
+                    if (definition.multiple) {
+                      if (!employeeId) return;
+                      onDirty();
+                      setAssignments((current) => [
+                        ...current,
+                        { role: definition.role, employeeId },
+                      ]);
+                    } else setSingle(definition.role, employeeId);
+                  }}
+                />
+                <div className="mt-3 space-y-2">
+                  {assigned.map((assignment) => {
+                    const employee = employees.find(
+                      (item) => item.id === assignment.employeeId
+                    );
+                    const record = records.find(
                       (item) =>
-                        item.role === definition.role &&
-                        item.employeeId === employee.id
-                    )
-                )}
-                value={
-                  definition.multiple ? undefined : assigned[0]?.employeeId
-                }
-                onSelect={(employeeId) => {
-                  if (definition.multiple) {
-                    if (!employeeId) return;
-                    onDirty();
-                    setAssignments((current) => [
-                      ...current,
-                      { role: definition.role, employeeId },
-                    ]);
-                  } else setSingle(definition.role, employeeId);
-                }}
-              />
-              <div className="mt-3 space-y-2">
-                {assigned.map((assignment) => {
-                  const employee = employees.find(
-                    (item) => item.id === assignment.employeeId
-                  );
-                  const record = records.find(
-                    (item) => Number(item.employee_id) === assignment.employeeId
-                  );
-                  return (
-                    <div
-                      key={`${definition.role}-${assignment.employeeId}`}
-                      className="flex flex-wrap items-center justify-between gap-2 rounded bg-muted p-2 text-sm"
-                    >
-                      <span>
-                        {employee?.name || `Employee ${assignment.employeeId}`}
-                      </span>
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline">
-                          {record
-                            ? pretty(record.assignment_status)
-                            : 'Unsaved'}
-                        </Badge>
-                        {record?.assignment_status === 'AWAITING_ACCEPTANCE' &&
-                          Number(currentUser.data?.employeeId) ===
-                            assignment.employeeId && (
-                            <Button
-                              size="sm"
-                              type="button"
-                              disabled={accept.isPending}
-                              onClick={() => accept.mutate(record.id)}
-                            >
-                              Accept responsibility
-                            </Button>
-                          )}
-                        <Button
-                          size="sm"
-                          type="button"
-                          variant="ghost"
-                          onClick={() => {
-                            onDirty();
-                            setAssignments((current) =>
-                              current.filter(
-                                (item) =>
-                                  !(
-                                    item.role === definition.role &&
-                                    item.employeeId === assignment.employeeId
-                                  )
-                              )
-                            );
-                          }}
-                        >
-                          Remove
-                        </Button>
+                        Number(item.employee_id) === assignment.employeeId
+                    );
+                    return (
+                      <div
+                        key={`${definition.role}-${assignment.employeeId}`}
+                        className="flex flex-wrap items-center justify-between gap-2 rounded bg-muted p-2 text-sm"
+                      >
+                        <span>
+                          {employee?.name ||
+                            `Employee ${assignment.employeeId}`}
+                        </span>
+                        <div className="flex items-center gap-2">
+                          <Badge variant="outline">
+                            {record
+                              ? pretty(record.assignment_status)
+                              : 'Unsaved'}
+                          </Badge>
+                          {record?.assignment_status ===
+                            'AWAITING_ACCEPTANCE' &&
+                            Number(currentUser.data?.employeeId) ===
+                              assignment.employeeId && (
+                              <Button
+                                size="sm"
+                                type="button"
+                                disabled={decide.isPending}
+                                onClick={() =>
+                                  decide.mutate({
+                                    assignmentId: record.id,
+                                    decision: 'ACCEPTED',
+                                  })
+                                }
+                              >
+                                Accept responsibility
+                              </Button>
+                            )}
+                          {record?.assignment_status ===
+                            'AWAITING_ACCEPTANCE' &&
+                            Number(currentUser.data?.employeeId) ===
+                              assignment.employeeId && (
+                              <div className="flex items-center gap-2">
+                                <Input
+                                  aria-label={`Reason for declining ${definition.label}`}
+                                  placeholder="Reason required to decline"
+                                  value={declineReasons[record.id] || ''}
+                                  onChange={(event) =>
+                                    setDeclineReasons((current) => ({
+                                      ...current,
+                                      [record.id]: event.target.value,
+                                    }))
+                                  }
+                                />
+                                <Button
+                                  size="sm"
+                                  type="button"
+                                  variant="outline"
+                                  disabled={
+                                    decide.isPending ||
+                                    (declineReasons[record.id] || '').trim()
+                                      .length < 10
+                                  }
+                                  onClick={() =>
+                                    decide.mutate({
+                                      assignmentId: record.id,
+                                      decision: 'DECLINED',
+                                      reason: declineReasons[record.id],
+                                    })
+                                  }
+                                >
+                                  Decline
+                                </Button>
+                              </div>
+                            )}
+                          <Button
+                            size="sm"
+                            type="button"
+                            variant="ghost"
+                            onClick={() => {
+                              onDirty();
+                              setAssignments((current) =>
+                                current.filter(
+                                  (item) =>
+                                    !(
+                                      item.role === definition.role &&
+                                      item.employeeId === assignment.employeeId
+                                    )
+                                )
+                              );
+                            }}
+                          >
+                            Remove
+                          </Button>
+                        </div>
                       </div>
-                    </div>
-                  );
-                })}
-                {!assigned.length && (
-                  <p className="text-sm text-amber-700">Missing</p>
-                )}
+                    );
+                  })}
+                  {!assigned.length && (
+                    <p className="text-sm text-amber-700">Missing</p>
+                  )}
+                </div>
               </div>
-            </div>
-          );
-        })}
-        <div className="flex justify-end">
-          <Button onClick={() => save.mutate()} disabled={save.isPending}>
-            {save.isPending ? 'Saving…' : 'Save responsibilities'}
-          </Button>
-        </div>
+            );
+          })}
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              name="saveIntent"
+              value="continue"
+              disabled={save.isPending}
+            >
+              {save.isPending ? 'Saving…' : 'Save responsibilities'}
+            </Button>
+            <button type="submit" name="saveIntent" value="exit" hidden />
+          </div>
+        </form>
       </CardContent>
     </Card>
   );

--- a/client/src/components/qms/EpochValidationWizard.tsx
+++ b/client/src/components/qms/EpochValidationWizard.tsx
@@ -311,9 +311,12 @@ export function EpochValidationWizard({ detail, employees, onBack }: Props) {
       return;
     }
     const form = document.getElementById(stepFormId(currentStep));
-    const submitter = form?.querySelector<HTMLButtonElement>(
-      `button[type="submit"][value="${intent}"]`
-    );
+    const selector = `button[type="submit"][value="${intent}"]`;
+    const submitter =
+      form?.querySelector<HTMLButtonElement>(selector) ||
+      document.querySelector<HTMLButtonElement>(
+        `${selector}[form="${stepFormId(currentStep)}"]`
+      );
     if (form instanceof HTMLFormElement && submitter)
       form.requestSubmit(submitter);
   };
@@ -1108,10 +1111,9 @@ function ResponsibilitiesStep({
           assignee must accept with their own identity.
         </p>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-5">
         <form
           id={stepFormId(3)}
-          className="space-y-5"
           onSubmit={(event) => {
             event.preventDefault();
             if (submissionGuard.current) return;
@@ -1120,167 +1122,169 @@ function ResponsibilitiesStep({
             onSavingChange(true);
             save.mutate();
           }}
-        >
-          {responsibilityDefinitions.map((definition) => {
-            const assigned = assignments.filter(
-              (item) => item.role === definition.role
-            );
-            const records = detail.responsibilities.filter(
-              (item) => item.responsibility_role === definition.role
-            );
-            return (
-              <div key={definition.role} className="rounded-md border p-4">
-                <div className="mb-3">
-                  <h3 className="font-medium">{definition.label}</h3>
-                  <p className="text-sm text-muted-foreground">
-                    {definition.help}
-                  </p>
-                </div>
-                <EmployeeSearch
-                  employees={employees.filter(
-                    (employee) =>
-                      definition.multiple ||
-                      !assignments.some(
-                        (item) =>
-                          item.role === definition.role &&
-                          item.employeeId === employee.id
-                      )
-                  )}
-                  value={
-                    definition.multiple ? undefined : assigned[0]?.employeeId
-                  }
-                  onSelect={(employeeId) => {
-                    if (definition.multiple) {
-                      if (!employeeId) return;
-                      onDirty();
-                      setAssignments((current) => [
-                        ...current,
-                        { role: definition.role, employeeId },
-                      ]);
-                    } else setSingle(definition.role, employeeId);
-                  }}
-                />
-                <div className="mt-3 space-y-2">
-                  {assigned.map((assignment) => {
-                    const employee = employees.find(
-                      (item) => item.id === assignment.employeeId
-                    );
-                    const record = records.find(
+        />
+        {responsibilityDefinitions.map((definition) => {
+          const assigned = assignments.filter(
+            (item) => item.role === definition.role
+          );
+          const records = detail.responsibilities.filter(
+            (item) => item.responsibility_role === definition.role
+          );
+          return (
+            <div key={definition.role} className="rounded-md border p-4">
+              <div className="mb-3">
+                <h3 className="font-medium">{definition.label}</h3>
+                <p className="text-sm text-muted-foreground">
+                  {definition.help}
+                </p>
+              </div>
+              <EmployeeSearch
+                employees={employees.filter(
+                  (employee) =>
+                    definition.multiple ||
+                    !assignments.some(
                       (item) =>
-                        Number(item.employee_id) === assignment.employeeId
-                    );
-                    return (
-                      <div
-                        key={`${definition.role}-${assignment.employeeId}`}
-                        className="flex flex-wrap items-center justify-between gap-2 rounded bg-muted p-2 text-sm"
-                      >
-                        <span>
-                          {employee?.name ||
-                            `Employee ${assignment.employeeId}`}
-                        </span>
-                        <div className="flex items-center gap-2">
-                          <Badge variant="outline">
-                            {record
-                              ? pretty(record.assignment_status)
-                              : 'Unsaved'}
-                          </Badge>
-                          {record?.assignment_status ===
-                            'AWAITING_ACCEPTANCE' &&
-                            Number(currentUser.data?.employeeId) ===
-                              assignment.employeeId && (
+                        item.role === definition.role &&
+                        item.employeeId === employee.id
+                    )
+                )}
+                value={
+                  definition.multiple ? undefined : assigned[0]?.employeeId
+                }
+                onSelect={(employeeId) => {
+                  if (definition.multiple) {
+                    if (!employeeId) return;
+                    onDirty();
+                    setAssignments((current) => [
+                      ...current,
+                      { role: definition.role, employeeId },
+                    ]);
+                  } else setSingle(definition.role, employeeId);
+                }}
+              />
+              <div className="mt-3 space-y-2">
+                {assigned.map((assignment) => {
+                  const employee = employees.find(
+                    (item) => item.id === assignment.employeeId
+                  );
+                  const record = records.find(
+                    (item) => Number(item.employee_id) === assignment.employeeId
+                  );
+                  return (
+                    <div
+                      key={`${definition.role}-${assignment.employeeId}`}
+                      className="flex flex-wrap items-center justify-between gap-2 rounded bg-muted p-2 text-sm"
+                    >
+                      <span>
+                        {employee?.name || `Employee ${assignment.employeeId}`}
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline">
+                          {record
+                            ? pretty(record.assignment_status)
+                            : 'Unsaved'}
+                        </Badge>
+                        {record?.assignment_status === 'AWAITING_ACCEPTANCE' &&
+                          Number(currentUser.data?.employeeId) ===
+                            assignment.employeeId && (
+                            <Button
+                              size="sm"
+                              type="button"
+                              disabled={decide.isPending}
+                              onClick={() =>
+                                decide.mutate({
+                                  assignmentId: record.id,
+                                  decision: 'ACCEPTED',
+                                })
+                              }
+                            >
+                              Accept responsibility
+                            </Button>
+                          )}
+                        {record?.assignment_status === 'AWAITING_ACCEPTANCE' &&
+                          Number(currentUser.data?.employeeId) ===
+                            assignment.employeeId && (
+                            <div className="flex items-center gap-2">
+                              <Input
+                                aria-label={`Reason for declining ${definition.label}`}
+                                placeholder="Reason required to decline"
+                                value={declineReasons[record.id] || ''}
+                                onChange={(event) =>
+                                  setDeclineReasons((current) => ({
+                                    ...current,
+                                    [record.id]: event.target.value,
+                                  }))
+                                }
+                              />
                               <Button
                                 size="sm"
                                 type="button"
-                                disabled={decide.isPending}
+                                variant="outline"
+                                disabled={
+                                  decide.isPending ||
+                                  (declineReasons[record.id] || '').trim()
+                                    .length < 10
+                                }
                                 onClick={() =>
                                   decide.mutate({
                                     assignmentId: record.id,
-                                    decision: 'ACCEPTED',
+                                    decision: 'DECLINED',
+                                    reason: declineReasons[record.id],
                                   })
                                 }
                               >
-                                Accept responsibility
+                                Decline
                               </Button>
-                            )}
-                          {record?.assignment_status ===
-                            'AWAITING_ACCEPTANCE' &&
-                            Number(currentUser.data?.employeeId) ===
-                              assignment.employeeId && (
-                              <div className="flex items-center gap-2">
-                                <Input
-                                  aria-label={`Reason for declining ${definition.label}`}
-                                  placeholder="Reason required to decline"
-                                  value={declineReasons[record.id] || ''}
-                                  onChange={(event) =>
-                                    setDeclineReasons((current) => ({
-                                      ...current,
-                                      [record.id]: event.target.value,
-                                    }))
-                                  }
-                                />
-                                <Button
-                                  size="sm"
-                                  type="button"
-                                  variant="outline"
-                                  disabled={
-                                    decide.isPending ||
-                                    (declineReasons[record.id] || '').trim()
-                                      .length < 10
-                                  }
-                                  onClick={() =>
-                                    decide.mutate({
-                                      assignmentId: record.id,
-                                      decision: 'DECLINED',
-                                      reason: declineReasons[record.id],
-                                    })
-                                  }
-                                >
-                                  Decline
-                                </Button>
-                              </div>
-                            )}
-                          <Button
-                            size="sm"
-                            type="button"
-                            variant="ghost"
-                            onClick={() => {
-                              onDirty();
-                              setAssignments((current) =>
-                                current.filter(
-                                  (item) =>
-                                    !(
-                                      item.role === definition.role &&
-                                      item.employeeId === assignment.employeeId
-                                    )
-                                )
-                              );
-                            }}
-                          >
-                            Remove
-                          </Button>
-                        </div>
+                            </div>
+                          )}
+                        <Button
+                          size="sm"
+                          type="button"
+                          variant="ghost"
+                          onClick={() => {
+                            onDirty();
+                            setAssignments((current) =>
+                              current.filter(
+                                (item) =>
+                                  !(
+                                    item.role === definition.role &&
+                                    item.employeeId === assignment.employeeId
+                                  )
+                              )
+                            );
+                          }}
+                        >
+                          Remove
+                        </Button>
                       </div>
-                    );
-                  })}
-                  {!assigned.length && (
-                    <p className="text-sm text-amber-700">Missing</p>
-                  )}
-                </div>
+                    </div>
+                  );
+                })}
+                {!assigned.length && (
+                  <p className="text-sm text-amber-700">Missing</p>
+                )}
               </div>
-            );
-          })}
-          <div className="flex justify-end">
-            <Button
-              type="submit"
-              name="saveIntent"
-              value="continue"
-              disabled={save.isPending}
-            >
-              {save.isPending ? 'Saving…' : 'Save responsibilities'}
-            </Button>
-            <button type="submit" name="saveIntent" value="exit" hidden />
-          </div>
-        </form>
+            </div>
+          );
+        })}
+        <div className="flex justify-end">
+          <Button
+            type="submit"
+            form={stepFormId(3)}
+            name="saveIntent"
+            value="continue"
+            disabled={save.isPending}
+          >
+            {save.isPending ? 'Saving…' : 'Save responsibilities'}
+          </Button>
+          <button
+            type="submit"
+            form={stepFormId(3)}
+            name="saveIntent"
+            value="exit"
+            hidden
+          />
+        </div>
       </CardContent>
     </Card>
   );

--- a/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
@@ -6,6 +6,9 @@ import { describe, expect, it } from 'vitest';
 const root = path.resolve(import.meta.dirname, '../..');
 const read = (file: string) => fs.readFileSync(path.join(root, file), 'utf8');
 const route = read('server/src/routes/epochSoftwareValidation.ts');
+const decisionService = read(
+  'server/src/services/epochValidationResponsibilityDecision.ts'
+);
 const compactRoute = route.replace(/\s+/g, '');
 const migration = read('migrations/0250_epoch_validation_wizard_phase1.sql');
 const safeBoot = read('server/scripts/migrations/runSafeBootMigrations.ts');
@@ -48,12 +51,15 @@ describe('EPOCH validation wizard Phase 1 architecture', () => {
     );
     expect(route).toContain('WHERE id=ANY($1::int[]) AND is_active=true');
     expect(route).toContain("assignment_status='SUPERSEDED'");
-    expect(route).toContain('ASSIGNEE_ACCEPTANCE_REQUIRED');
+    expect(decisionService).toContain('ASSIGNEE_DECISION_REQUIRED');
     expect(route).toContain(
       'if (previousKeys.has(`${assignment.role}:${assignment.employeeId}`))'
     );
     expect(route).toContain("'RESPONSIBILITIES_ASSIGNED'");
     expect(route).toContain("'RESPONSIBILITY_ACCEPTED'");
+    expect(route).toContain("'RESPONSIBILITY_DECLINED'");
+    expect(route).toContain('responsibilityDecisionIdentityError');
+    expect(route).toContain('authenticatedEmployeeId');
   });
 
   it('requires edit authorization and optimistic locking for Phase 1 changes', () => {
@@ -64,6 +70,20 @@ describe('EPOCH validation wizard Phase 1 architecture', () => {
     expect(route).toContain('WHERE id=$14 AND row_version=$15 RETURNING *');
     expect(route).toContain("error: 'STALE_RECORD'");
     expect(route).toContain("'WIZARD_SETUP_SAVED'");
+    const assignmentRoute = compactRoute.slice(
+      compactRoute.indexOf("router.put('/:id/responsibilities'"),
+      compactRoute.indexOf('asyncfunctiondecideResponsibility')
+    );
+    const decisionRoute = compactRoute.slice(
+      compactRoute.indexOf('asyncfunctiondecideResponsibility'),
+      compactRoute.indexOf('constintendedUseSchema')
+    );
+    expect(assignmentRoute).toContain(
+      "requirePermission('EPOCH_VALIDATION_EDIT')"
+    );
+    expect(decisionRoute).not.toContain(
+      "requirePermission('EPOCH_VALIDATION_EDIT')"
+    );
   });
 
   it('registers migration 0250 in both safe and critical boot lists', () => {

--- a/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
@@ -60,6 +60,9 @@ describe('EPOCH validation wizard Phase 1 architecture', () => {
     expect(route).toContain("'RESPONSIBILITY_DECLINED'");
     expect(route).toContain('responsibilityDecisionIdentityError');
     expect(route).toContain('authenticatedEmployeeId');
+    expect(route).toContain('WHERE id=$1 FOR SHARE');
+    expect(route).toContain('packageRevision: packageRow.revision');
+    expect(route).toContain('productionVersion: packageRow.production_version');
   });
 
   it('requires edit authorization and optimistic locking for Phase 1 changes', () => {

--- a/server/__tests__/epochValidationResponsibilityDecision.test.ts
+++ b/server/__tests__/epochValidationResponsibilityDecision.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  responsibilityDecisionIdentityError,
+  responsibilityDecisionSchema,
+} from '../src/services/epochValidationResponsibilityDecision';
+
+const identity = {
+  authenticatedUserId: 7,
+  authenticatedEmployeeId: 42,
+  employeeActive: true,
+  activeUserCount: 1,
+  assignedEmployeeId: 42,
+};
+
+describe('EPOCH validation responsibility decisions', () => {
+  it('allows the active, unambiguous assignee without an edit capability', () => {
+    expect(responsibilityDecisionIdentityError(identity)).toBeNull();
+  });
+
+  it('fails closed for another employee, an inactive identity, or ambiguity', () => {
+    expect(
+      responsibilityDecisionIdentityError({
+        ...identity,
+        assignedEmployeeId: 99,
+      })
+    ).toBe('ASSIGNEE_DECISION_REQUIRED');
+    expect(
+      responsibilityDecisionIdentityError({
+        ...identity,
+        employeeActive: false,
+      })
+    ).toBe('ACTIVE_EMPLOYEE_IDENTITY_REQUIRED');
+    expect(
+      responsibilityDecisionIdentityError({ ...identity, activeUserCount: 2 })
+    ).toBe('UNAMBIGUOUS_EMPLOYEE_IDENTITY_REQUIRED');
+  });
+
+  it('requires a meaningful reason for decline', () => {
+    expect(
+      responsibilityDecisionSchema.safeParse({ decision: 'DECLINED' }).success
+    ).toBe(false);
+    expect(
+      responsibilityDecisionSchema.safeParse({
+        decision: 'DECLINED',
+        reason: 'Responsibility belongs to another department.',
+      }).success
+    ).toBe(true);
+    expect(
+      responsibilityDecisionSchema.safeParse({ decision: 'ACCEPTED' }).success
+    ).toBe(true);
+  });
+});

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -1177,6 +1177,15 @@ async function decideResponsibility(
   );
   const a = actor(req);
   const result = await tx(async (q) => {
+    const packageRow = (
+      await q(
+        `SELECT * FROM qms_epoch_validation_packages
+         WHERE id=$1 FOR SHARE`,
+        [p.id]
+      )
+    )[0];
+    if (!packageRow || isLocked(packageRow))
+      return { packageLocked: true as const };
     const identity = (
       await q(
         `SELECT u.id AS user_id,u.employee_id,e.is_active AS employee_active
@@ -1232,7 +1241,7 @@ async function decideResponsibility(
     )[0];
     await logEvent(
       req,
-      p,
+      packageRow,
       'RESPONSIBILITY',
       body.decision === 'ACCEPTED'
         ? 'RESPONSIBILITY_ACCEPTED'
@@ -1247,7 +1256,8 @@ async function decideResponsibility(
           authenticatedEmployeeId: Number(identity.employee_id),
           decision: body.decision,
           decidedAt: updated.decided_at,
-          packageRevision: p.revision,
+          packageRevision: packageRow.revision,
+          productionVersion: packageRow.production_version,
         },
         reason: body.reason,
       },
@@ -1257,6 +1267,8 @@ async function decideResponsibility(
   });
   if ('missing' in result)
     return res.status(404).json({ error: 'RESPONSIBILITY_NOT_FOUND' });
+  if ('packageLocked' in result)
+    return res.status(409).json({ error: 'VALIDATION_PACKAGE_LOCKED' });
   if ('identityError' in result)
     return res.status(403).json({ error: result.identityError });
   if ('conflict' in result)

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -18,6 +18,10 @@ import {
   type ReadinessCounts,
   type ValidationStatus,
 } from '../services/epochSoftwareValidation';
+import {
+  responsibilityDecisionIdentityError,
+  responsibilityDecisionSchema,
+} from '../services/epochValidationResponsibilityDecision';
 
 const router = Router();
 router.use(authenticateToken);
@@ -1160,54 +1164,113 @@ router.put(
   }
 );
 
-router.post(
-  '/:id/responsibilities/:assignmentId/accept',
-  requirePermission('EPOCH_VALIDATION_EDIT'),
-  async (req, res) => {
-    const p = await editable(req, res);
-    if (!p) return;
-    const assignmentId = uuid.parse(req.params.assignmentId),
-      a = actor(req),
-      employeeId = Number((req.user as any)?.employeeId || 0);
-    if (!employeeId)
-      return res.status(403).json({ error: 'EMPLOYEE_IDENTITY_REQUIRED' });
-    const accepted = await tx(async (q) => {
-      const assignment = (
+async function decideResponsibility(
+  req: Request,
+  res: any,
+  forcedDecision?: 'ACCEPTED'
+) {
+  const p = await editable(req, res);
+  if (!p) return;
+  const assignmentId = uuid.parse(req.params.assignmentId);
+  const body = responsibilityDecisionSchema.parse(
+    forcedDecision ? { decision: forcedDecision } : req.body
+  );
+  const a = actor(req);
+  const result = await tx(async (q) => {
+    const identity = (
+      await q(
+        `SELECT u.id AS user_id,u.employee_id,e.is_active AS employee_active
+           FROM users u JOIN employees e ON e.id=u.employee_id
+           WHERE u.id=$1 AND u.is_active=true FOR SHARE OF u,e`,
+        [a.id]
+      )
+    )[0];
+    if (!identity) return { identityError: 'EMPLOYEE_IDENTITY_REQUIRED' };
+    const activeUserCount = Number(
+      (
         await q(
-          `SELECT * FROM qms_epoch_validation_responsibilities
-           WHERE id=$1 AND package_id=$2 AND active=true FOR UPDATE`,
-          [assignmentId, p.id]
+          `SELECT count(*)::int AS count FROM users
+             WHERE employee_id=$1 AND is_active=true`,
+          [identity.employee_id]
         )
-      )[0];
-      if (!assignment) return { missing: true as const };
-      if (Number(assignment.employee_id) !== employeeId)
-        return { forbidden: true as const };
-      if (assignment.assignment_status === 'ACCEPTED')
-        return { assignment, replay: true as const };
-      const updated = (
-        await q(
-          `UPDATE qms_epoch_validation_responsibilities SET
-           assignment_status='ACCEPTED',accepted_by_user_id=$1,accepted_by_display_name=$2,accepted_at=now()
-           WHERE id=$3 RETURNING *`,
-          [a.id, a.name, assignment.id]
-        )
-      )[0];
-      await logEvent(
-        req,
-        p,
-        'RESPONSIBILITY',
-        'RESPONSIBILITY_ACCEPTED',
-        { entityId: updated.id, previous: assignment, next: updated },
-        q
-      );
-      return { assignment: updated };
+      )[0].count
+    );
+    const assignment = (
+      await q(
+        `SELECT r.*,e.is_active AS employee_active
+           FROM qms_epoch_validation_responsibilities r
+           JOIN employees e ON e.id=r.employee_id
+           WHERE r.id=$1 AND r.package_id=$2 AND r.active=true FOR UPDATE OF r,e`,
+        [assignmentId, p.id]
+      )
+    )[0];
+    if (!assignment) return { missing: true as const };
+    const identityError = responsibilityDecisionIdentityError({
+      authenticatedUserId: a.id,
+      authenticatedEmployeeId: Number(identity.employee_id),
+      employeeActive:
+        Boolean(identity.employee_active) &&
+        Boolean(assignment.employee_active),
+      activeUserCount,
+      assignedEmployeeId: Number(assignment.employee_id),
     });
-    if ('missing' in accepted)
-      return res.status(404).json({ error: 'RESPONSIBILITY_NOT_FOUND' });
-    if ('forbidden' in accepted)
-      return res.status(403).json({ error: 'ASSIGNEE_ACCEPTANCE_REQUIRED' });
-    res.json(accepted.assignment);
-  }
+    if (identityError) return { identityError };
+    if (assignment.assignment_status === body.decision)
+      return { assignment, replay: true as const };
+    if (assignment.assignment_status !== 'AWAITING_ACCEPTANCE')
+      return { conflict: true as const };
+    const updated = (
+      await q(
+        `UPDATE qms_epoch_validation_responsibilities SET
+           assignment_status=$1,
+           accepted_by_user_id=CASE WHEN $1='ACCEPTED' THEN $2 ELSE NULL END,
+           accepted_by_display_name=CASE WHEN $1='ACCEPTED' THEN $3 ELSE NULL END,
+           accepted_at=CASE WHEN $1='ACCEPTED' THEN now() ELSE NULL END
+           WHERE id=$4 RETURNING *,clock_timestamp() AS decided_at`,
+        [body.decision, a.id, a.name, assignment.id]
+      )
+    )[0];
+    await logEvent(
+      req,
+      p,
+      'RESPONSIBILITY',
+      body.decision === 'ACCEPTED'
+        ? 'RESPONSIBILITY_ACCEPTED'
+        : 'RESPONSIBILITY_DECLINED',
+      {
+        entityId: updated.id,
+        previous: assignment,
+        next: {
+          assignmentId: updated.id,
+          assignedEmployeeId: Number(updated.employee_id),
+          authenticatedUserId: a.id,
+          authenticatedEmployeeId: Number(identity.employee_id),
+          decision: body.decision,
+          decidedAt: updated.decided_at,
+          packageRevision: p.revision,
+        },
+        reason: body.reason,
+      },
+      q
+    );
+    return { assignment: updated };
+  });
+  if ('missing' in result)
+    return res.status(404).json({ error: 'RESPONSIBILITY_NOT_FOUND' });
+  if ('identityError' in result)
+    return res.status(403).json({ error: result.identityError });
+  if ('conflict' in result)
+    return res
+      .status(409)
+      .json({ error: 'RESPONSIBILITY_DECISION_ALREADY_RECORDED' });
+  res.json(result.assignment);
+}
+
+router.post('/:id/responsibilities/:assignmentId/decision', (req, res) =>
+  decideResponsibility(req, res)
+);
+router.post('/:id/responsibilities/:assignmentId/accept', (req, res) =>
+  decideResponsibility(req, res, 'ACCEPTED')
 );
 
 const intendedUseSchema = z.object({

--- a/server/src/services/epochValidationResponsibilityDecision.ts
+++ b/server/src/services/epochValidationResponsibilityDecision.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const responsibilityDecisionSchema = z
+  .object({
+    decision: z.enum(['ACCEPTED', 'DECLINED']),
+    reason: z.string().trim().max(2000).optional(),
+  })
+  .superRefine((value, context) => {
+    if (value.decision === 'DECLINED' && (value.reason?.length || 0) < 10)
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['reason'],
+        message: 'A meaningful reason is required to decline.',
+      });
+  });
+
+export type ResponsibilityDecisionIdentity = {
+  authenticatedUserId: number;
+  authenticatedEmployeeId: number | null;
+  employeeActive: boolean;
+  activeUserCount: number;
+  assignedEmployeeId: number;
+};
+
+export function responsibilityDecisionIdentityError(
+  identity: ResponsibilityDecisionIdentity
+) {
+  if (!identity.authenticatedEmployeeId) return 'EMPLOYEE_IDENTITY_REQUIRED';
+  if (!identity.employeeActive) return 'ACTIVE_EMPLOYEE_IDENTITY_REQUIRED';
+  if (identity.activeUserCount !== 1)
+    return 'UNAMBIGUOUS_EMPLOYEE_IDENTITY_REQUIRED';
+  if (identity.authenticatedEmployeeId !== identity.assignedEmployeeId)
+    return 'ASSIGNEE_DECISION_REQUIRED';
+  return null;
+}


### PR DESCRIPTION
## Summary
- make **Save and exit** submit the current Setup, Intended Use, or Responsibilities form through the same controlled mutation used by the step action
- prevent duplicate step writes, preserve DRAFT/error behavior, and avoid writes when the current step is clean
- allow only the active, unambiguous assigned employee to accept or decline a responsibility without requiring broad `EPOCH_VALIDATION_EDIT`
- require a decline reason and retain immutable decision audit data while preserving reassignment history

## Verification
- Focused Software Validation client tests: **18/18 passed**
- Focused Software Validation server tests: **30/30 passed**
- Focused authorization tests: included above, **3/3 passed**
- Focused ESLint: passed (errors only / `--quiet`)
- Focused Prettier: passed
- Bounded TypeScript check for the new decision service: passed
- Full TypeScript graph: unavailable locally; default heap exhausted and CI-sized 6 GB run timed out after 5 minutes without diagnostics
- Migration safety: **8 static tests passed**; **8 DB-backed tests unavailable** because `DATABASE_URL` is not configured
- `git diff --check`: passed

## Scope controls
- no migration added or changed; migration `0250` is untouched
- no Phase 2 workflow added
- no production record changed, including `ESV-2026-0013`
- existing package-creation idempotency, DRAFT controls, readiness, execution, approval, release, and audit gates remain intact

## Browser verification
Not run locally because no authenticated/running EPOCH browser session was available. The PR remains draft for CI and environment-backed review.