### PR TITLE
Fix EPOCH validation package opening and duplicate cleanup

### DIFF
--- a/migrations/0253_void_duplicate_epoch_validation_packages.sql
+++ b/migrations/0253_void_duplicate_epoch_validation_packages.sql
@@ -1,0 +1,86 @@
+-- Controlled disposition of empty duplicate EPOCH validation packages created
+-- while the create-success UI incorrectly reported a failure. Preserve
+-- ESV-2026-0001 and all audit history; do not delete validation records.
+
+DO $$
+DECLARE
+  target_count integer;
+  authored_count integer;
+BEGIN
+  SELECT count(*) INTO target_count
+  FROM qms_epoch_validation_packages
+  WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014';
+
+  IF target_count <> 13 THEN
+    RAISE EXCEPTION
+      '0253 expected exactly 13 duplicate packages ESV-2026-0002 through ESV-2026-0014; found %',
+      target_count;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM qms_epoch_validation_packages
+    WHERE package_number = 'ESV-2026-0001'
+  ) THEN
+    RAISE EXCEPTION '0253 refused to run because retained package ESV-2026-0001 is missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM qms_epoch_validation_packages
+    WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+      AND status NOT IN ('DRAFT', 'VOID_DUPLICATE')
+  ) THEN
+    RAISE EXCEPTION '0253 refused to void a duplicate package that is no longer DRAFT';
+  END IF;
+
+  SELECT sum(row_count) INTO authored_count
+  FROM (
+    SELECT count(*) row_count FROM qms_epoch_validation_intended_use_revisions r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_intended_use_functions r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_responsibilities r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_requirements r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_risks r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_plans r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_protocols r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_executions r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_evidence r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_defects r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_approvals r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_snapshots r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_periodic_reviews r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+  ) authored;
+
+  IF authored_count <> 0 THEN
+    RAISE EXCEPTION
+      '0253 refused to void duplicate packages because % authored validation records were found',
+      authored_count;
+  END IF;
+END $$;
+
+WITH changed AS (
+  UPDATE qms_epoch_validation_packages
+  SET status = 'VOID_DUPLICATE',
+      locked_at = now(),
+      row_version = row_version + 1,
+      revision = revision + 1,
+      updated_at = now(),
+      updated_by_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
+  WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    AND status = 'DRAFT'
+  RETURNING *
+)
+INSERT INTO qms_epoch_validation_events (
+  package_id, entity_type, action, actor_user_id, actor_display_name,
+  actor_role, previous_value, new_value, reason, package_revision
+)
+SELECT
+  id,
+  'PACKAGE',
+  'PACKAGE_VOIDED_DUPLICATE',
+  updated_by_user_id,
+  'migration 0253 (user-authorized duplicate cleanup)',
+  'SYSTEM_MAINTENANCE',
+  to_jsonb('DRAFT'::text),
+  to_jsonb('VOID_DUPLICATE'::text),
+  'Empty duplicate created while the client incorrectly reported a successful package creation as a failure; retain ESV-2026-0001.',
+  revision
+FROM changed;

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const migration = fs.readFileSync(
+  path.join(
+    root,
+    'migrations/0253_void_duplicate_epoch_validation_packages.sql'
+  ),
+  'utf8'
+);
+const safeBoot = fs.readFileSync(
+  path.join(root, 'server/scripts/migrations/runSafeBootMigrations.ts'),
+  'utf8'
+);
+
+describe('EPOCH validation duplicate cleanup', () => {
+  it('preserves 0001 and targets only the thirteen empty duplicate drafts', () => {
+    expect(migration).toContain("package_number = 'ESV-2026-0001'");
+    expect(migration).toContain(
+      "package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'"
+    );
+    expect(migration).toContain('target_count <> 13');
+    expect(migration).toContain('authored_count <> 0');
+    expect(migration).not.toMatch(/DELETE\s+FROM/i);
+  });
+
+  it('uses the controlled duplicate status and records an audit event', () => {
+    expect(migration).toContain("status = 'VOID_DUPLICATE'");
+    expect(migration).toContain("'PACKAGE_VOIDED_DUPLICATE'");
+    expect(migration).toContain("status = 'DRAFT'");
+  });
+
+  it('registers migration 0253 in both safe and critical boot lists', () => {
+    expect(
+      safeBoot.match(/0253_void_duplicate_epoch_validation_packages\.sql/g)
+        ?.length
+    ).toBe(2);
+  });
+});

--- a/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
@@ -63,6 +63,8 @@ describe('EPOCH validation wizard Phase 1 architecture', () => {
     expect(route).toContain('WHERE id=$1 FOR SHARE');
     expect(route).toContain('packageRevision: packageRow.revision');
     expect(route).toContain('productionVersion: packageRow.production_version');
+    expect(route).toContain('e.job_title AS position');
+    expect(route).not.toContain('e.position');
   });
 
   it('requires edit authorization and optimistic locking for Phase 1 changes', () => {
@@ -87,6 +89,11 @@ describe('EPOCH validation wizard Phase 1 architecture', () => {
     expect(decisionRoute).not.toContain(
       "requirePermission('EPOCH_VALIDATION_EDIT')"
     );
+  });
+
+  it('keeps controlled duplicate dispositions out of the active package list', () => {
+    expect(route).toContain("WHERE p.status<>'VOID_DUPLICATE'");
+    expect(route).toContain("'PACKAGE_VOIDED_DUPLICATE'");
   });
 
   it('registers migration 0250 in both safe and critical boot lists', () => {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -316,6 +316,7 @@ export const safeMigrationFiles = [
   '0250_epoch_validation_wizard_phase1.sql',
   '0251_design_project_configuration_workspace.sql',
   '0252_potential_order_duplicate_reviews.sql',
+  '0253_void_duplicate_epoch_validation_packages.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -371,6 +372,7 @@ export const criticalMigrationFiles = new Set([
   '0249_prior_month_payment_entry_grace.sql',
   '0251_design_project_configuration_workspace.sql',
   '0252_potential_order_duplicate_reviews.sql',
+  '0253_void_duplicate_epoch_validation_packages.sql',
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
   '0233a_spec_sheets_base_table.sql',

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -174,7 +174,9 @@ router.get(
     (SELECT count(*)::int FROM qms_epoch_validation_requirements r WHERE r.package_id=p.id) requirement_count,
     (SELECT count(*)::int FROM qms_epoch_validation_executions e WHERE e.package_id=p.id) execution_count,
     (SELECT count(*)::int FROM qms_epoch_validation_defects d WHERE d.package_id=p.id AND d.status NOT IN ('CLOSED','CANCELLED')) open_defect_count
-    FROM qms_epoch_validation_packages p ORDER BY p.created_at DESC`)
+    FROM qms_epoch_validation_packages p
+    WHERE p.status<>'VOID_DUPLICATE'
+    ORDER BY p.created_at DESC`)
     );
   }
 );
@@ -789,7 +791,7 @@ async function detail(packageId: string) {
       [packageId]
     ),
     query(
-      `SELECT r.*,e.name employee_name,e.department,e.position
+      `SELECT r.*,e.name employee_name,e.department,e.job_title AS position
        FROM qms_epoch_validation_responsibilities r
        JOIN employees e ON e.id=r.employee_id
        WHERE r.package_id=$1 AND r.active=true


### PR DESCRIPTION
## Summary
- fix validation detail loading by selecting the real employee job_title column and preserving the client-facing position alias
- disposition only empty duplicate packages ESV-2026-0002 through ESV-2026-0014 while retaining ESV-2026-0001 and audit history
- hide controlled VOID_DUPLICATE records from the active package list

## Safety
- migration 0253 is idempotent and fail-closed
- it aborts unless all 13 exact duplicates exist, remain DRAFT/VOID_DUPLICATE, and have no authored validation section records
- no validation package or audit record is deleted

## Checks
- TypeScript syntax check passed for the affected route
- focused Prettier check passed
- git diff --check passed
- merge-tree check against current origin/main passed
- focused Vitest/ESLint could not run locally because dependencies are unavailable and registry access is blocked; CI is required