### PR TITLE
Make migration 0253 safe and idempotent

### DIFF
--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -261,6 +261,14 @@ jobs:
             sed '/^\\\(un\)\?restrict /d' > /tmp/schema-second.sql
           diff --unified /tmp/schema-first.sql /tmp/schema-second.sql
 
+      - name: Certify migration 0253 state-aware duplicate cleanup
+        run: >-
+          npx vitest run
+          --config vitest.config.server.ts
+          --no-file-parallelism
+          server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+          --reporter=verbose
+
       - name: Run isolated PostgreSQL certification
         env:
           P2_V2_PRODUCTION_LAUNCH_ENABLED: 'true'
@@ -452,6 +460,14 @@ jobs:
           console.log('safe_boot_replay=passed');
           console.log('schema_idempotency=passed');
           NODE
+
+      - name: Certify migration 0253 state-aware duplicate cleanup
+        run: >-
+          npx vitest run
+          --config vitest.config.server.ts
+          --no-file-parallelism
+          server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+          --reporter=verbose
 
       - name: Run existing Phase 10A PostgreSQL lifecycle
         env:

--- a/.github/workflows/part-spec-sheet-postgres-certification.yml
+++ b/.github/workflows/part-spec-sheet-postgres-certification.yml
@@ -105,6 +105,14 @@ jobs:
             sed '/^\\\(un\)\?restrict /d' > /tmp/part-spec-schema-second.sql
           diff --unified /tmp/part-spec-schema-first.sql /tmp/part-spec-schema-second.sql
 
+      - name: Certify migration 0253 state-aware duplicate cleanup
+        run: >-
+          npx vitest run
+          --config vitest.config.server.ts
+          --no-file-parallelism
+          server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+          --reporter=verbose
+
       - name: Run isolated PostgreSQL 16.4 certification
         run: >-
           npx vitest run

--- a/migrations/0253_void_duplicate_epoch_validation_packages.sql
+++ b/migrations/0253_void_duplicate_epoch_validation_packages.sql
@@ -15,8 +15,14 @@
 
 DO $migration$
 DECLARE
+  target_numbers constant text[] := ARRAY[
+    'ESV-2026-0002', 'ESV-2026-0003', 'ESV-2026-0004',
+    'ESV-2026-0005', 'ESV-2026-0006', 'ESV-2026-0007',
+    'ESV-2026-0008', 'ESV-2026-0009', 'ESV-2026-0010',
+    'ESV-2026-0011', 'ESV-2026-0012', 'ESV-2026-0013',
+    'ESV-2026-0014'
+  ];
   candidate_count integer;
-  missing_expected_count integer;
   draft_count integer;
   void_count integer;
   authored_count integer;
@@ -31,6 +37,8 @@ BEGIN
 
   PERFORM id
   FROM qms_epoch_validation_packages
+  WHERE package_number = 'ESV-2026-0001'
+     OR package_number = ANY(target_numbers)
   ORDER BY package_number
   FOR UPDATE;
 
@@ -40,48 +48,53 @@ BEGIN
     count(*) FILTER (WHERE status = 'VOID_DUPLICATE')
   INTO candidate_count, draft_count, void_count
   FROM qms_epoch_validation_packages
-  WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014';
+  WHERE package_number = ANY(target_numbers);
 
   IF candidate_count = 0 THEN
     RAISE NOTICE '0253 state NOTHING_TO_DO: no historical duplicate candidates found';
     RETURN;
   END IF;
 
-  IF candidate_count <> 13 THEN
+  IF candidate_count <> cardinality(target_numbers) THEN
     RAISE EXCEPTION
       '0253 state AMBIGUOUS_STOP: expected either zero or all 13 target packages ESV-2026-0002 through ESV-2026-0014; found %',
       candidate_count;
   END IF;
 
-  SELECT count(*) INTO missing_expected_count
-  FROM generate_series(2, 14) expected(suffix)
-  WHERE NOT EXISTS (
-    SELECT 1
-    FROM qms_epoch_validation_packages p
-    WHERE p.package_number =
-      'ESV-2026-' || lpad(expected.suffix::text, 4, '0')
-  );
-
-  IF missing_expected_count <> 0 THEN
-    RAISE EXCEPTION
-      '0253 state AMBIGUOUS_STOP: target range contains 13 rows but % exact expected package numbers are missing',
-      missing_expected_count;
-  END IF;
-
   IF void_count = 13 THEN
     SELECT count(*) INTO completed_event_count
     FROM qms_epoch_validation_packages p
-    WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    WHERE p.package_number = ANY(target_numbers)
       AND EXISTS (
         SELECT 1
         FROM qms_epoch_validation_events e
         WHERE e.package_id = p.id
           AND e.action = 'PACKAGE_VOIDED_DUPLICATE'
+          AND e.actor_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
+          AND e.actor_role = 'SYSTEM_MAINTENANCE'
       );
 
-    IF completed_event_count <> 13 THEN
+    IF completed_event_count <> cardinality(target_numbers) OR EXISTS (
+      SELECT 1
+      FROM qms_epoch_validation_packages p
+      WHERE p.package_number = ANY(target_numbers)
+        AND (
+          p.locked_at IS NULL
+          OR p.updated_by_display_name <> 'migration 0253 (user-authorized duplicate cleanup)'
+          OR p.revision < 2
+          OR p.row_version < 2
+          OR 1 <> (
+            SELECT count(*)
+            FROM qms_epoch_validation_events e
+            WHERE e.package_id = p.id
+              AND e.action = 'PACKAGE_VOIDED_DUPLICATE'
+              AND e.actor_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
+              AND e.actor_role = 'SYSTEM_MAINTENANCE'
+          )
+        )
+    ) THEN
       RAISE EXCEPTION
-        '0253 state AMBIGUOUS_STOP: all targets are VOID_DUPLICATE but only % retain duplicate-void audit evidence',
+        '0253 state AMBIGUOUS_STOP: all targets are VOID_DUPLICATE but only % retain exact duplicate-void migration evidence',
         completed_event_count;
     END IF;
 
@@ -110,7 +123,7 @@ BEGIN
   IF EXISTS (
     SELECT 1
     FROM qms_epoch_validation_packages p
-    WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    WHERE p.package_number = ANY(target_numbers)
       AND (
         p.revision <> 1
         OR p.row_version <> 1
@@ -126,7 +139,7 @@ BEGIN
   IF EXISTS (
     SELECT 1
     FROM qms_epoch_validation_packages p
-    WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    WHERE p.package_number = ANY(target_numbers)
       AND ROW(
         p.title,
         p.system_name,
@@ -177,7 +190,7 @@ BEGIN
 
   SELECT count(*) INTO matching_authority_count
   FROM qms_epoch_validation_packages p
-  WHERE NOT (p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014')
+  WHERE NOT (p.package_number = ANY(target_numbers))
     AND p.status <> 'VOID_DUPLICATE'
     AND ROW(
       p.title,
@@ -231,20 +244,20 @@ BEGIN
 
   SELECT sum(row_count) INTO authored_count
   FROM (
-    SELECT count(*) row_count FROM qms_epoch_validation_intended_use_revisions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_intended_use_functions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_responsibilities r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_requirements r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_risks r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_plans r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_protocols r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_executions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_evidence r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_defects r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_approvals r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_snapshots r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_periodic_reviews r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_events e JOIN qms_epoch_validation_packages p ON p.id = e.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014' AND e.action <> 'PACKAGE_CREATED'
+    SELECT count(*) row_count FROM qms_epoch_validation_intended_use_revisions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_intended_use_functions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_responsibilities r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_requirements r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_risks r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_plans r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_protocols r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_executions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_evidence r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_defects r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_approvals r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_snapshots r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_periodic_reviews r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_events e JOIN qms_epoch_validation_packages p ON p.id = e.package_id WHERE p.package_number = ANY(target_numbers) AND e.action <> 'PACKAGE_CREATED'
   ) authored;
 
   IF authored_count <> 0 THEN
@@ -261,7 +274,7 @@ BEGIN
         revision = revision + 1,
         updated_at = now(),
         updated_by_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
-    WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    WHERE package_number = ANY(target_numbers)
       AND status = 'DRAFT'
     RETURNING *
   ), inserted_events AS (

--- a/migrations/0253_void_duplicate_epoch_validation_packages.sql
+++ b/migrations/0253_void_duplicate_epoch_validation_packages.sql
@@ -1,86 +1,296 @@
 -- Controlled disposition of empty duplicate EPOCH validation packages created
 -- while the create-success UI incorrectly reported a failure. Preserve
 -- ESV-2026-0001 and all audit history; do not delete validation records.
+--
+-- State classification:
+--   NOTHING_TO_DO     - none of the historical target numbers exist.
+--   ALREADY_COMPLETED - all targets are already void with audit evidence.
+--   EXACT_SAFE_CLEANUP- all thirteen untouched drafts match the sole retained
+--                       authoritative package and contain no authored content.
+--   AMBIGUOUS_STOP    - every other state fails before mutation.
+--
+-- The anonymous block is one transaction. The advisory lock serializes this
+-- one-time decision even when no target rows exist; row locks are then taken in
+-- package-number order before the state is classified.
 
-DO $$
+DO $migration$
 DECLARE
-  target_count integer;
+  candidate_count integer;
+  missing_expected_count integer;
+  draft_count integer;
+  void_count integer;
   authored_count integer;
+  completed_event_count integer;
+  matching_authority_count integer;
+  changed_count integer;
+  authoritative qms_epoch_validation_packages%ROWTYPE;
 BEGIN
-  SELECT count(*) INTO target_count
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('0253_void_duplicate_epoch_validation_packages', 0)
+  );
+
+  PERFORM id
+  FROM qms_epoch_validation_packages
+  ORDER BY package_number
+  FOR UPDATE;
+
+  SELECT
+    count(*),
+    count(*) FILTER (WHERE status = 'DRAFT'),
+    count(*) FILTER (WHERE status = 'VOID_DUPLICATE')
+  INTO candidate_count, draft_count, void_count
   FROM qms_epoch_validation_packages
   WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014';
 
-  IF target_count <> 13 THEN
-    RAISE EXCEPTION
-      '0253 expected exactly 13 duplicate packages ESV-2026-0002 through ESV-2026-0014; found %',
-      target_count;
+  IF candidate_count = 0 THEN
+    RAISE NOTICE '0253 state NOTHING_TO_DO: no historical duplicate candidates found';
+    RETURN;
   END IF;
 
-  IF NOT EXISTS (
-    SELECT 1 FROM qms_epoch_validation_packages
-    WHERE package_number = 'ESV-2026-0001'
-  ) THEN
-    RAISE EXCEPTION '0253 refused to run because retained package ESV-2026-0001 is missing';
+  IF candidate_count <> 13 THEN
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: expected either zero or all 13 target packages ESV-2026-0002 through ESV-2026-0014; found %',
+      candidate_count;
+  END IF;
+
+  SELECT count(*) INTO missing_expected_count
+  FROM generate_series(2, 14) expected(suffix)
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM qms_epoch_validation_packages p
+    WHERE p.package_number =
+      'ESV-2026-' || lpad(expected.suffix::text, 4, '0')
+  );
+
+  IF missing_expected_count <> 0 THEN
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: target range contains 13 rows but % exact expected package numbers are missing',
+      missing_expected_count;
+  END IF;
+
+  IF void_count = 13 THEN
+    SELECT count(*) INTO completed_event_count
+    FROM qms_epoch_validation_packages p
+    WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+      AND EXISTS (
+        SELECT 1
+        FROM qms_epoch_validation_events e
+        WHERE e.package_id = p.id
+          AND e.action = 'PACKAGE_VOIDED_DUPLICATE'
+      );
+
+    IF completed_event_count <> 13 THEN
+      RAISE EXCEPTION
+        '0253 state AMBIGUOUS_STOP: all targets are VOID_DUPLICATE but only % retain duplicate-void audit evidence',
+        completed_event_count;
+    END IF;
+
+    RAISE NOTICE '0253 state ALREADY_COMPLETED: all duplicate dispositions and audit evidence already exist';
+    RETURN;
+  END IF;
+
+  IF draft_count <> 13 OR void_count <> 0 THEN
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: target lifecycle is mixed or unsafe (DRAFT %, VOID_DUPLICATE %, total %)',
+      draft_count,
+      void_count,
+      candidate_count;
+  END IF;
+
+  SELECT * INTO authoritative
+  FROM qms_epoch_validation_packages
+  WHERE package_number = 'ESV-2026-0001'
+  FOR UPDATE;
+
+  IF NOT FOUND OR authoritative.status = 'VOID_DUPLICATE' THEN
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: retained authoritative package ESV-2026-0001 is missing or void';
   END IF;
 
   IF EXISTS (
-    SELECT 1 FROM qms_epoch_validation_packages
-    WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-      AND status NOT IN ('DRAFT', 'VOID_DUPLICATE')
+    SELECT 1
+    FROM qms_epoch_validation_packages p
+    WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+      AND (
+        p.revision <> 1
+        OR p.row_version <> 1
+        OR p.locked_at IS NOT NULL
+        OR p.actual_completion_date IS NOT NULL
+        OR p.superseded_package_id IS NOT NULL
+      )
   ) THEN
-    RAISE EXCEPTION '0253 refused to void a duplicate package that is no longer DRAFT';
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: at least one target draft has lifecycle or edit evidence';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM qms_epoch_validation_packages p
+    WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+      AND ROW(
+        p.title,
+        p.system_name,
+        p.validation_type,
+        p.production_version,
+        p.commit_or_release_identifier,
+        p.production_deployment_date,
+        p.validation_environment,
+        p.production_environment_reference,
+        p.database_provider,
+        p.hosting_provider,
+        p.software_owner_employee_id,
+        p.quality_owner_employee_id,
+        p.validation_lead_employee_id,
+        p.planned_start_date,
+        p.planned_completion_date,
+        p.reason_for_validation,
+        p.previous_approved_package_id,
+        p.audit_readiness_assessment_id,
+        p.notes,
+        p.created_by_user_id
+      ) IS DISTINCT FROM ROW(
+        authoritative.title,
+        authoritative.system_name,
+        authoritative.validation_type,
+        authoritative.production_version,
+        authoritative.commit_or_release_identifier,
+        authoritative.production_deployment_date,
+        authoritative.validation_environment,
+        authoritative.production_environment_reference,
+        authoritative.database_provider,
+        authoritative.hosting_provider,
+        authoritative.software_owner_employee_id,
+        authoritative.quality_owner_employee_id,
+        authoritative.validation_lead_employee_id,
+        authoritative.planned_start_date,
+        authoritative.planned_completion_date,
+        authoritative.reason_for_validation,
+        authoritative.previous_approved_package_id,
+        authoritative.audit_readiness_assessment_id,
+        authoritative.notes,
+        authoritative.created_by_user_id
+      )
+  ) THEN
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: target package payloads do not exactly match ESV-2026-0001';
+  END IF;
+
+  SELECT count(*) INTO matching_authority_count
+  FROM qms_epoch_validation_packages p
+  WHERE NOT (p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014')
+    AND p.status <> 'VOID_DUPLICATE'
+    AND ROW(
+      p.title,
+      p.system_name,
+      p.validation_type,
+      p.production_version,
+      p.commit_or_release_identifier,
+      p.production_deployment_date,
+      p.validation_environment,
+      p.production_environment_reference,
+      p.database_provider,
+      p.hosting_provider,
+      p.software_owner_employee_id,
+      p.quality_owner_employee_id,
+      p.validation_lead_employee_id,
+      p.planned_start_date,
+      p.planned_completion_date,
+      p.reason_for_validation,
+      p.previous_approved_package_id,
+      p.audit_readiness_assessment_id,
+      p.notes,
+      p.created_by_user_id
+    ) IS NOT DISTINCT FROM ROW(
+      authoritative.title,
+      authoritative.system_name,
+      authoritative.validation_type,
+      authoritative.production_version,
+      authoritative.commit_or_release_identifier,
+      authoritative.production_deployment_date,
+      authoritative.validation_environment,
+      authoritative.production_environment_reference,
+      authoritative.database_provider,
+      authoritative.hosting_provider,
+      authoritative.software_owner_employee_id,
+      authoritative.quality_owner_employee_id,
+      authoritative.validation_lead_employee_id,
+      authoritative.planned_start_date,
+      authoritative.planned_completion_date,
+      authoritative.reason_for_validation,
+      authoritative.previous_approved_package_id,
+      authoritative.audit_readiness_assessment_id,
+      authoritative.notes,
+      authoritative.created_by_user_id
+    );
+
+  IF matching_authority_count <> 1 THEN
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: expected exactly one authoritative payload match outside the target set; found %',
+      matching_authority_count;
   END IF;
 
   SELECT sum(row_count) INTO authored_count
   FROM (
-    SELECT count(*) row_count FROM qms_epoch_validation_intended_use_revisions r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_intended_use_functions r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_responsibilities r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_requirements r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_risks r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_plans r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_protocols r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_executions r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_evidence r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_defects r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_approvals r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_snapshots r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_periodic_reviews r JOIN qms_epoch_validation_packages p ON p.id=r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    SELECT count(*) row_count FROM qms_epoch_validation_intended_use_revisions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_intended_use_functions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_responsibilities r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_requirements r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_risks r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_plans r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_protocols r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_executions r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_evidence r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_defects r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_approvals r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_snapshots r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_periodic_reviews r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_events e JOIN qms_epoch_validation_packages p ON p.id = e.package_id WHERE p.package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014' AND e.action <> 'PACKAGE_CREATED'
   ) authored;
 
   IF authored_count <> 0 THEN
     RAISE EXCEPTION
-      '0253 refused to void duplicate packages because % authored validation records were found',
+      '0253 state AMBIGUOUS_STOP: target packages contain % authored validation or lifecycle records',
       authored_count;
   END IF;
-END $$;
 
-WITH changed AS (
-  UPDATE qms_epoch_validation_packages
-  SET status = 'VOID_DUPLICATE',
-      locked_at = now(),
-      row_version = row_version + 1,
-      revision = revision + 1,
-      updated_at = now(),
-      updated_by_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
-  WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-    AND status = 'DRAFT'
-  RETURNING *
-)
-INSERT INTO qms_epoch_validation_events (
-  package_id, entity_type, action, actor_user_id, actor_display_name,
-  actor_role, previous_value, new_value, reason, package_revision
-)
-SELECT
-  id,
-  'PACKAGE',
-  'PACKAGE_VOIDED_DUPLICATE',
-  updated_by_user_id,
-  'migration 0253 (user-authorized duplicate cleanup)',
-  'SYSTEM_MAINTENANCE',
-  to_jsonb('DRAFT'::text),
-  to_jsonb('VOID_DUPLICATE'::text),
-  'Empty duplicate created while the client incorrectly reported a successful package creation as a failure; retain ESV-2026-0001.',
-  revision
-FROM changed;
+  WITH changed AS (
+    UPDATE qms_epoch_validation_packages
+    SET status = 'VOID_DUPLICATE',
+        locked_at = now(),
+        row_version = row_version + 1,
+        revision = revision + 1,
+        updated_at = now(),
+        updated_by_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
+    WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+      AND status = 'DRAFT'
+    RETURNING *
+  ), inserted_events AS (
+    INSERT INTO qms_epoch_validation_events (
+      package_id, entity_type, action, actor_user_id, actor_display_name,
+      actor_role, previous_value, new_value, reason, package_revision
+    )
+    SELECT
+      id,
+      'PACKAGE',
+      'PACKAGE_VOIDED_DUPLICATE',
+      updated_by_user_id,
+      'migration 0253 (user-authorized duplicate cleanup)',
+      'SYSTEM_MAINTENANCE',
+      to_jsonb('DRAFT'::text),
+      to_jsonb('VOID_DUPLICATE'::text),
+      'Empty duplicate created while the client incorrectly reported a successful package creation as a failure; retain ESV-2026-0001.',
+      revision
+    FROM changed
+    RETURNING package_id
+  )
+  SELECT count(*) INTO changed_count FROM inserted_events;
+
+  IF changed_count <> 13 THEN
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: transactional cleanup changed % packages instead of 13',
+      changed_count;
+  END IF;
+
+  RAISE NOTICE '0253 state EXACT_SAFE_CLEANUP: voided 13 empty duplicates and appended 13 audit events';
+END
+$migration$;

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
@@ -17,20 +17,39 @@ const safeBoot = fs.readFileSync(
 );
 
 describe('EPOCH validation duplicate cleanup', () => {
-  it('preserves 0001 and targets only the thirteen empty duplicate drafts', () => {
+  it('preserves 0001 and classifies empty, complete, safe, and ambiguous states', () => {
     expect(migration).toContain("package_number = 'ESV-2026-0001'");
     expect(migration).toContain(
       "package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'"
     );
-    expect(migration).toContain('target_count <> 13');
+    expect(migration).toContain('candidate_count = 0');
+    expect(migration).toContain('candidate_count <> 13');
+    expect(migration).toContain('NOTHING_TO_DO');
+    expect(migration).toContain('ALREADY_COMPLETED');
+    expect(migration).toContain('EXACT_SAFE_CLEANUP');
+    expect(migration).toContain('AMBIGUOUS_STOP');
     expect(migration).toContain('authored_count <> 0');
     expect(migration).not.toMatch(/DELETE\s+FROM/i);
   });
 
-  it('uses the controlled duplicate status and records an audit event', () => {
+  it('locks before deciding and records the controlled audit event atomically', () => {
+    expect(migration).toContain('pg_advisory_xact_lock');
+    expect(migration).toContain('ORDER BY package_number');
+    expect(migration).toContain('FOR UPDATE');
     expect(migration).toContain("status = 'VOID_DUPLICATE'");
     expect(migration).toContain("'PACKAGE_VOIDED_DUPLICATE'");
     expect(migration).toContain("status = 'DRAFT'");
+    expect(migration).toContain('WITH changed AS');
+    expect(migration).toContain('inserted_events AS');
+  });
+
+  it('requires exact untouched payload matches and retained completion evidence', () => {
+    expect(migration).toContain('ROW(');
+    expect(migration).toContain('IS DISTINCT FROM');
+    expect(migration).toContain('matching_authority_count <> 1');
+    expect(migration).toContain('revision <> 1');
+    expect(migration).toContain('row_version <> 1');
+    expect(migration).toContain('completed_event_count <> 13');
   });
 
   it('registers migration 0253 in both safe and critical boot lists', () => {

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
@@ -20,8 +20,10 @@ describe('EPOCH validation duplicate cleanup', () => {
   it('preserves 0001 and classifies empty, complete, safe, and ambiguous states', () => {
     expect(migration).toContain("package_number = 'ESV-2026-0001'");
     expect(migration).toContain(
-      "package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'"
+      "'ESV-2026-0002', 'ESV-2026-0003', 'ESV-2026-0004'"
     );
+    expect(migration).not.toContain('package_number BETWEEN');
+    expect(migration).toContain('package_number = ANY(target_numbers)');
     expect(migration).toContain('candidate_count = 0');
     expect(migration).toContain('candidate_count <> 13');
     expect(migration).toContain('NOTHING_TO_DO');
@@ -49,7 +51,12 @@ describe('EPOCH validation duplicate cleanup', () => {
     expect(migration).toContain('matching_authority_count <> 1');
     expect(migration).toContain('revision <> 1');
     expect(migration).toContain('row_version <> 1');
-    expect(migration).toContain('completed_event_count <> 13');
+    expect(migration).toContain(
+      'completed_event_count <> cardinality(target_numbers)'
+    );
+    expect(migration).toContain("actor_role = 'SYSTEM_MAINTENANCE'");
+    expect(migration).toContain("updated_by_display_name <> 'migration 0253");
+    expect(migration).toContain('SELECT count(*)');
   });
 
   it('registers migration 0253 in both safe and critical boot lists', () => {

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
@@ -1,0 +1,390 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { Pool, type PoolClient } from 'pg';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error('DATABASE_URL is required');
+
+const databaseUrl = new URL(connectionString);
+const disposableDatabases = new Set([
+  '/epoch_p2_v2_certification',
+  '/epoch_p2_v2_synthetic_pilot',
+  '/epoch_part_spec_certification',
+  '/epoch_0253_certification',
+]);
+if (
+  databaseUrl.hostname !== '127.0.0.1' ||
+  !disposableDatabases.has(databaseUrl.pathname)
+) {
+  throw new Error(
+    `Refusing non-disposable database ${databaseUrl.hostname}${databaseUrl.pathname}`
+  );
+}
+
+const migration = fs.readFileSync(
+  path.resolve(
+    process.cwd(),
+    'migrations/0253_void_duplicate_epoch_validation_packages.sql'
+  ),
+  'utf8'
+);
+const pool = new Pool({ connectionString });
+let client: PoolClient;
+let schema: string;
+
+const childTables = [
+  'qms_epoch_validation_intended_use_revisions',
+  'qms_epoch_validation_intended_use_functions',
+  'qms_epoch_validation_responsibilities',
+  'qms_epoch_validation_requirements',
+  'qms_epoch_validation_risks',
+  'qms_epoch_validation_plans',
+  'qms_epoch_validation_protocols',
+  'qms_epoch_validation_executions',
+  'qms_epoch_validation_evidence',
+  'qms_epoch_validation_defects',
+  'qms_epoch_validation_approvals',
+  'qms_epoch_validation_snapshots',
+  'qms_epoch_validation_periodic_reviews',
+] as const;
+
+async function createFixtureSchema() {
+  await client.query(`
+    CREATE TABLE qms_epoch_validation_packages (
+      id text PRIMARY KEY,
+      package_number text NOT NULL UNIQUE,
+      title text NOT NULL,
+      system_name text NOT NULL,
+      validation_type text NOT NULL,
+      status text NOT NULL,
+      production_version text NOT NULL,
+      commit_or_release_identifier text,
+      production_deployment_date date,
+      validation_environment text NOT NULL,
+      production_environment_reference text NOT NULL,
+      database_provider text NOT NULL,
+      hosting_provider text NOT NULL,
+      software_owner_employee_id integer,
+      quality_owner_employee_id integer,
+      validation_lead_employee_id integer,
+      planned_start_date date NOT NULL,
+      planned_completion_date date NOT NULL,
+      actual_completion_date date,
+      reason_for_validation text NOT NULL,
+      previous_approved_package_id text,
+      superseded_package_id text,
+      audit_readiness_assessment_id text,
+      notes text,
+      revision integer NOT NULL DEFAULT 1,
+      row_version integer NOT NULL DEFAULT 1,
+      locked_at timestamptz,
+      created_by_user_id integer NOT NULL,
+      created_by_display_name text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_by_user_id integer NOT NULL,
+      updated_by_display_name text NOT NULL,
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE qms_epoch_validation_events (
+      id bigserial PRIMARY KEY,
+      package_id text NOT NULL REFERENCES qms_epoch_validation_packages(id),
+      entity_type text NOT NULL,
+      entity_id text,
+      action text NOT NULL,
+      actor_user_id integer NOT NULL,
+      actor_display_name text NOT NULL,
+      actor_role text NOT NULL,
+      previous_value jsonb,
+      new_value jsonb,
+      reason text,
+      package_revision integer NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+  for (const table of childTables) {
+    await client.query(`
+      CREATE TABLE ${table} (
+        id bigserial PRIMARY KEY,
+        package_id text NOT NULL REFERENCES qms_epoch_validation_packages(id),
+        evidence text
+      )
+    `);
+  }
+}
+
+type PackageOverrides = {
+  status?: string;
+  title?: string;
+  revision?: number;
+  rowVersion?: number;
+  actualCompletionDate?: string | null;
+  locked?: boolean;
+};
+
+async function insertPackage(
+  packageNumber: string,
+  overrides: PackageOverrides = {}
+) {
+  await client.query(
+    `INSERT INTO qms_epoch_validation_packages (
+       id, package_number, title, system_name, validation_type, status,
+       production_version, commit_or_release_identifier,
+       production_deployment_date, validation_environment,
+       production_environment_reference, database_provider, hosting_provider,
+       software_owner_employee_id, quality_owner_employee_id,
+       validation_lead_employee_id, planned_start_date,
+       planned_completion_date, actual_completion_date, reason_for_validation,
+       notes, revision, row_version, locked_at, created_by_user_id,
+       created_by_display_name, updated_by_user_id, updated_by_display_name
+     ) VALUES (
+       $1, $1, $2, 'EPOCH', 'CORRECTIVE_REVALIDATION', $3,
+       '2026.08', 'commit-safe', DATE '2026-08-01', 'validation',
+       'production', 'PostgreSQL', 'host', 10, 11, 12,
+       DATE '2026-08-01', DATE '2026-08-31', $4,
+       'Correct duplicate creation response handling', 'historical package',
+       $5, $6, CASE WHEN $7 THEN now() ELSE NULL END,
+       101, 'Original Creator', 101, 'Original Creator'
+     )`,
+    [
+      packageNumber,
+      overrides.title ?? 'EPOCH Validation 2026.08',
+      overrides.status ?? 'DRAFT',
+      overrides.actualCompletionDate ?? null,
+      overrides.revision ?? 1,
+      overrides.rowVersion ?? 1,
+      overrides.locked ?? false,
+    ]
+  );
+}
+
+async function seedExactDraftSet() {
+  await insertPackage('ESV-2026-0001');
+  for (let suffix = 2; suffix <= 14; suffix += 1) {
+    await insertPackage(`ESV-2026-${String(suffix).padStart(4, '0')}`);
+  }
+}
+
+async function runMigration() {
+  await client.query(migration);
+}
+
+async function targetState() {
+  return client.query(
+    `SELECT package_number, status, revision, row_version
+     FROM qms_epoch_validation_packages
+     WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
+     ORDER BY package_number`
+  );
+}
+
+beforeEach(async () => {
+  client = await pool.connect();
+  schema = `esv_0253_${Date.now()}_${Math.floor(Math.random() * 1_000_000)}`;
+  await client.query('BEGIN');
+  await client.query(`CREATE SCHEMA ${schema}`);
+  await client.query(`SET LOCAL search_path TO ${schema}, public`);
+  await createFixtureSchema();
+});
+
+afterEach(async () => {
+  await client.query('ROLLBACK');
+  client.release();
+});
+
+afterAll(async () => {
+  await pool.end();
+});
+
+describe('migration 0253 PostgreSQL state classification', () => {
+  it('passes on an empty fresh database with no changes', async () => {
+    await runMigration();
+    expect((await targetState()).rowCount).toBe(0);
+  });
+
+  it('passes on a schema-only database with no seeded users or packages', async () => {
+    await expect(runMigration()).resolves.toBeUndefined();
+    expect(
+      (
+        await client.query(
+          'SELECT count(*)::int count FROM qms_epoch_validation_events'
+        )
+      ).rows[0].count
+    ).toBe(0);
+  });
+
+  it('passes when unrelated packages exist but no historical candidates match', async () => {
+    await insertPackage('ESV-2026-0999');
+    await runMigration();
+    expect(
+      (
+        await client.query(
+          "SELECT status FROM qms_epoch_validation_packages WHERE package_number='ESV-2026-0999'"
+        )
+      ).rows[0].status
+    ).toBe('DRAFT');
+  });
+
+  it('voids the exact safe duplicate set and appends one event per target', async () => {
+    await seedExactDraftSet();
+    await runMigration();
+    expect(
+      (await targetState()).rows.every((row) => row.status === 'VOID_DUPLICATE')
+    ).toBe(true);
+    expect(
+      (
+        await client.query(
+          "SELECT count(*)::int count FROM qms_epoch_validation_events WHERE action='PACKAGE_VOIDED_DUPLICATE'"
+        )
+      ).rows[0].count
+    ).toBe(13);
+  });
+
+  it('preserves the authoritative package and its historical evidence', async () => {
+    await seedExactDraftSet();
+    await client.query(
+      `INSERT INTO qms_epoch_validation_requirements(package_id, evidence)
+       VALUES ('ESV-2026-0001', 'authoritative evidence')`
+    );
+    await runMigration();
+    const authoritative = await client.query(
+      "SELECT status, revision FROM qms_epoch_validation_packages WHERE package_number='ESV-2026-0001'"
+    );
+    expect(authoritative.rows[0]).toEqual({ status: 'DRAFT', revision: 1 });
+    expect(
+      (
+        await client.query(
+          "SELECT evidence FROM qms_epoch_validation_requirements WHERE package_id='ESV-2026-0001'"
+        )
+      ).rows[0].evidence
+    ).toBe('authoritative evidence');
+  });
+
+  it('is idempotent on second execution without duplicate audit evidence', async () => {
+    await seedExactDraftSet();
+    await runMigration();
+    const firstRows = (await targetState()).rows;
+    const firstEvents = (
+      await client.query(
+        'SELECT count(*)::int count FROM qms_epoch_validation_events'
+      )
+    ).rows[0].count;
+    await runMigration();
+    expect((await targetState()).rows).toEqual(firstRows);
+    expect(
+      (
+        await client.query(
+          'SELECT count(*)::int count FROM qms_epoch_validation_events'
+        )
+      ).rows[0].count
+    ).toBe(firstEvents);
+  });
+
+  it('recognizes an already-completed state as a no-op', async () => {
+    await seedExactDraftSet();
+    await runMigration();
+    await expect(runMigration()).resolves.toBeUndefined();
+    expect((await targetState()).rows.every((row) => row.revision === 2)).toBe(
+      true
+    );
+  });
+
+  it('fails closed on an unexpected partial target set before mutation', async () => {
+    await insertPackage('ESV-2026-0001');
+    await insertPackage('ESV-2026-0002');
+    await expect(runMigration()).rejects.toThrow(/AMBIGUOUS_STOP.*found 1/);
+    expect((await targetState()).rows[0].status).toBe('DRAFT');
+  });
+
+  it('fails closed when multiple authoritative payload matches exist', async () => {
+    await seedExactDraftSet();
+    await insertPackage('ESV-2026-0000');
+    await expect(runMigration()).rejects.toThrow(
+      /expected exactly one authoritative payload match.*found 2/
+    );
+    expect(
+      (await targetState()).rows.every((row) => row.status === 'DRAFT')
+    ).toBe(true);
+  });
+
+  it('fails closed on an unsafe lifecycle without changing any target', async () => {
+    await seedExactDraftSet();
+    await client.query(
+      "UPDATE qms_epoch_validation_packages SET status='APPROVED_FOR_INTENDED_USE' WHERE package_number='ESV-2026-0007'"
+    );
+    await expect(runMigration()).rejects.toThrow(
+      /lifecycle is mixed or unsafe/
+    );
+    expect(
+      (await targetState()).rows.filter(
+        (row) => row.status === 'VOID_DUPLICATE'
+      )
+    ).toHaveLength(0);
+  });
+
+  it('fails closed when a draft has edit or lifecycle evidence', async () => {
+    await seedExactDraftSet();
+    await client.query(
+      "UPDATE qms_epoch_validation_packages SET row_version=2 WHERE package_number='ESV-2026-0008'"
+    );
+    await expect(runMigration()).rejects.toThrow(/lifecycle or edit evidence/);
+    expect(
+      (await targetState()).rows.every((row) => row.status === 'DRAFT')
+    ).toBe(true);
+  });
+
+  it('rejects different intended-use payloads rather than guessing duplicates', async () => {
+    await seedExactDraftSet();
+    await client.query(
+      "UPDATE qms_epoch_validation_packages SET title='Different intended validation' WHERE package_number='ESV-2026-0009'"
+    );
+    await expect(runMigration()).rejects.toThrow(
+      /payloads do not exactly match/
+    );
+    expect(
+      (await targetState()).rows.every((row) => row.status === 'DRAFT')
+    ).toBe(true);
+  });
+
+  it('rolls back completely and preserves child evidence after an ambiguous failure', async () => {
+    await seedExactDraftSet();
+    await client.query(
+      `INSERT INTO qms_epoch_validation_approvals(package_id, evidence)
+       VALUES ('ESV-2026-0010', 'approved evidence')`
+    );
+    const before = (await targetState()).rows;
+    await expect(runMigration()).rejects.toThrow(
+      /authored validation or lifecycle records/
+    );
+    expect((await targetState()).rows).toEqual(before);
+    expect(
+      (
+        await client.query(
+          "SELECT evidence FROM qms_epoch_validation_approvals WHERE package_id='ESV-2026-0010'"
+        )
+      ).rows[0].evidence
+    ).toBe('approved evidence');
+    expect(
+      (
+        await client.query(
+          'SELECT count(*)::int count FROM qms_epoch_validation_events'
+        )
+      ).rows[0].count
+    ).toBe(0);
+  });
+
+  it('allows later registered migration work after an empty-state no-op', async () => {
+    await runMigration();
+    await client.query(
+      'CREATE TABLE later_registered_migration_marker(id integer PRIMARY KEY)'
+    );
+    expect(
+      (
+        await client.query(
+          "SELECT to_regclass('later_registered_migration_marker') IS NOT NULL present"
+        )
+      ).rows[0].present
+    ).toBe(true);
+  });
+});

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
@@ -49,6 +49,10 @@ const childTables = [
   'qms_epoch_validation_snapshots',
   'qms_epoch_validation_periodic_reviews',
 ] as const;
+const targetNumbers = Array.from(
+  { length: 13 },
+  (_, index) => `ESV-2026-${String(index + 2).padStart(4, '0')}`
+);
 
 async function createFixtureSchema() {
   await client.query(`
@@ -161,8 +165,8 @@ async function insertPackage(
 
 async function seedExactDraftSet() {
   await insertPackage('ESV-2026-0001');
-  for (let suffix = 2; suffix <= 14; suffix += 1) {
-    await insertPackage(`ESV-2026-${String(suffix).padStart(4, '0')}`);
+  for (const packageNumber of targetNumbers) {
+    await insertPackage(packageNumber);
   }
 }
 
@@ -185,10 +189,12 @@ async function expectMigrationFailure(message: RegExp) {
 
 async function targetState() {
   return client.query(
-    `SELECT package_number, status, revision, row_version
+    `SELECT package_number, status, revision, row_version, locked_at,
+            updated_at, updated_by_display_name
      FROM qms_epoch_validation_packages
-     WHERE package_number BETWEEN 'ESV-2026-0002' AND 'ESV-2026-0014'
-     ORDER BY package_number`
+     WHERE package_number = ANY($1::text[])
+     ORDER BY package_number`,
+    [targetNumbers]
   );
 }
 
@@ -229,11 +235,19 @@ describe('migration 0253 PostgreSQL state classification', () => {
 
   it('passes when unrelated packages exist but no historical candidates match', async () => {
     await insertPackage('ESV-2026-0999');
+    await insertPackage('ESV-2026-00020');
     await runMigration();
     expect(
       (
         await client.query(
           "SELECT status FROM qms_epoch_validation_packages WHERE package_number='ESV-2026-0999'"
+        )
+      ).rows[0].status
+    ).toBe('DRAFT');
+    expect(
+      (
+        await client.query(
+          "SELECT status FROM qms_epoch_validation_packages WHERE package_number='ESV-2026-00020'"
         )
       ).rows[0].status
     ).toBe('DRAFT');
@@ -272,6 +286,34 @@ describe('migration 0253 PostgreSQL state classification', () => {
         )
       ).rows[0].evidence
     ).toBe('authoritative evidence');
+  });
+
+  it('preserves append-only creation evidence while adding one cleanup event', async () => {
+    await seedExactDraftSet();
+    await client.query(
+      `
+      INSERT INTO qms_epoch_validation_events (
+        package_id, entity_type, action, actor_user_id, actor_display_name,
+        actor_role, package_revision
+      )
+      SELECT id, 'PACKAGE', 'PACKAGE_CREATED', 101, 'Original Creator',
+             'VALIDATION_AUTHOR', 1
+      FROM qms_epoch_validation_packages
+      WHERE package_number = ANY($1::text[])
+    `,
+      [targetNumbers]
+    );
+    await runMigration();
+    const eventCounts = await client.query(`
+      SELECT action, count(*)::int count
+      FROM qms_epoch_validation_events
+      GROUP BY action
+      ORDER BY action
+    `);
+    expect(eventCounts.rows).toEqual([
+      { action: 'PACKAGE_CREATED', count: 13 },
+      { action: 'PACKAGE_VOIDED_DUPLICATE', count: 13 },
+    ]);
   });
 
   it('is idempotent on second execution without duplicate audit evidence', async () => {
@@ -334,6 +376,20 @@ describe('migration 0253 PostgreSQL state classification', () => {
     ).toHaveLength(0);
   });
 
+  it('fails closed on mixed pre-cleanup and completed states', async () => {
+    await seedExactDraftSet();
+    await client.query(`
+      UPDATE qms_epoch_validation_packages
+      SET status = 'VOID_DUPLICATE', locked_at = now(), revision = 2,
+          row_version = 2,
+          updated_by_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
+      WHERE package_number = 'ESV-2026-0002'
+    `);
+    const before = (await targetState()).rows;
+    await expectMigrationFailure(/lifecycle is mixed or unsafe/);
+    expect((await targetState()).rows).toEqual(before);
+  });
+
   it('fails closed when a draft has edit or lifecycle evidence', async () => {
     await seedExactDraftSet();
     await client.query(
@@ -376,6 +432,72 @@ describe('migration 0253 PostgreSQL state classification', () => {
       (
         await client.query(
           'SELECT count(*)::int count FROM qms_epoch_validation_events'
+        )
+      ).rows[0].count
+    ).toBe(0);
+  });
+
+  it('rejects contradictory completed audit evidence without mutation', async () => {
+    await seedExactDraftSet();
+    await runMigration();
+    await client.query(`
+      UPDATE qms_epoch_validation_events
+      SET actor_role = 'UNAUTHORIZED_ACTOR'
+      WHERE package_id = 'ESV-2026-0002'
+        AND action = 'PACKAGE_VOIDED_DUPLICATE'
+    `);
+    const before = (await targetState()).rows;
+    await expectMigrationFailure(/exact duplicate-void migration evidence/);
+    expect((await targetState()).rows).toEqual(before);
+    expect(
+      (
+        await client.query(
+          "SELECT count(*)::int count FROM qms_epoch_validation_events WHERE action='PACKAGE_VOIDED_DUPLICATE'"
+        )
+      ).rows[0].count
+    ).toBe(13);
+  });
+
+  it('serializes concurrent executions and writes one cleanup event per target', async () => {
+    await seedExactDraftSet();
+    await client.query('COMMIT');
+    const second = await pool.connect();
+    try {
+      await client.query(`SET search_path TO ${schema}, public`);
+      await second.query(`SET search_path TO ${schema}, public`);
+      await Promise.all([client.query(migration), second.query(migration)]);
+      expect(
+        (
+          await client.query(
+            "SELECT count(*)::int count FROM qms_epoch_validation_events WHERE action='PACKAGE_VOIDED_DUPLICATE'"
+          )
+        ).rows[0].count
+      ).toBe(13);
+    } finally {
+      second.release();
+      await client.query(`DROP SCHEMA ${schema} CASCADE`);
+      await client.query('BEGIN');
+    }
+  });
+
+  it('rolls back every package update when audit insertion faults', async () => {
+    await seedExactDraftSet();
+    await client.query(`
+      CREATE FUNCTION reject_cleanup_event() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        RAISE EXCEPTION 'synthetic audit fault';
+      END $$;
+      CREATE TRIGGER reject_cleanup_event
+      BEFORE INSERT ON qms_epoch_validation_events
+      FOR EACH ROW EXECUTE FUNCTION reject_cleanup_event()
+    `);
+    const before = (await targetState()).rows;
+    await expectMigrationFailure(/synthetic audit fault/);
+    expect((await targetState()).rows).toEqual(before);
+    expect(
+      (
+        await client.query(
+          "SELECT count(*)::int count FROM qms_epoch_validation_events WHERE action='PACKAGE_VOIDED_DUPLICATE'"
         )
       ).rows[0].count
     ).toBe(0);

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
@@ -170,6 +170,19 @@ async function runMigration() {
   await client.query(migration);
 }
 
+async function expectMigrationFailure(message: RegExp) {
+  await client.query('SAVEPOINT migration_attempt');
+  let caught: unknown;
+  try {
+    await runMigration();
+  } catch (error) {
+    caught = error;
+  }
+  await client.query('ROLLBACK TO SAVEPOINT migration_attempt');
+  expect(caught).toBeInstanceOf(Error);
+  expect((caught as Error).message).toMatch(message);
+}
+
 async function targetState() {
   return client.query(
     `SELECT package_number, status, revision, row_version
@@ -293,14 +306,14 @@ describe('migration 0253 PostgreSQL state classification', () => {
   it('fails closed on an unexpected partial target set before mutation', async () => {
     await insertPackage('ESV-2026-0001');
     await insertPackage('ESV-2026-0002');
-    await expect(runMigration()).rejects.toThrow(/AMBIGUOUS_STOP.*found 1/);
+    await expectMigrationFailure(/AMBIGUOUS_STOP.*found 1/);
     expect((await targetState()).rows[0].status).toBe('DRAFT');
   });
 
   it('fails closed when multiple authoritative payload matches exist', async () => {
     await seedExactDraftSet();
     await insertPackage('ESV-2026-0000');
-    await expect(runMigration()).rejects.toThrow(
+    await expectMigrationFailure(
       /expected exactly one authoritative payload match.*found 2/
     );
     expect(
@@ -313,9 +326,7 @@ describe('migration 0253 PostgreSQL state classification', () => {
     await client.query(
       "UPDATE qms_epoch_validation_packages SET status='APPROVED_FOR_INTENDED_USE' WHERE package_number='ESV-2026-0007'"
     );
-    await expect(runMigration()).rejects.toThrow(
-      /lifecycle is mixed or unsafe/
-    );
+    await expectMigrationFailure(/lifecycle is mixed or unsafe/);
     expect(
       (await targetState()).rows.filter(
         (row) => row.status === 'VOID_DUPLICATE'
@@ -328,7 +339,7 @@ describe('migration 0253 PostgreSQL state classification', () => {
     await client.query(
       "UPDATE qms_epoch_validation_packages SET row_version=2 WHERE package_number='ESV-2026-0008'"
     );
-    await expect(runMigration()).rejects.toThrow(/lifecycle or edit evidence/);
+    await expectMigrationFailure(/lifecycle or edit evidence/);
     expect(
       (await targetState()).rows.every((row) => row.status === 'DRAFT')
     ).toBe(true);
@@ -339,9 +350,7 @@ describe('migration 0253 PostgreSQL state classification', () => {
     await client.query(
       "UPDATE qms_epoch_validation_packages SET title='Different intended validation' WHERE package_number='ESV-2026-0009'"
     );
-    await expect(runMigration()).rejects.toThrow(
-      /payloads do not exactly match/
-    );
+    await expectMigrationFailure(/payloads do not exactly match/);
     expect(
       (await targetState()).rows.every((row) => row.status === 'DRAFT')
     ).toBe(true);
@@ -354,9 +363,7 @@ describe('migration 0253 PostgreSQL state classification', () => {
        VALUES ('ESV-2026-0010', 'approved evidence')`
     );
     const before = (await targetState()).rows;
-    await expect(runMigration()).rejects.toThrow(
-      /authored validation or lifecycle records/
-    );
+    await expectMigrationFailure(/authored validation or lifecycle records/);
     expect((await targetState()).rows).toEqual(before);
     expect(
       (


### PR DESCRIPTION
## Reconciliation outcome

PR #1641 was compared semantically against certified commit `7ff138740bb7a1591e30c94272ad2fe3e8da5585`, then reconciled onto current-main baseline `8dbd2dd077f8900a3165909311991f4969429f4f`.

Final PR head: `e72697820e8546a6d58f82abf97c9794bd22db43`.

Important state change: PR #1641 was externally marked ready and merged at 2026-08-05 14:57:13 UTC as merge commit `9b3e209ad1f786454893f097c77d09e896d62f70` while final certification was still being audited. The reconciliation agent did not merge the PR.

## Root cause and final state machine

The original merged migration assumed all thirteen production-specific duplicates existed, which blocked safe boot on clean and schema-only databases. Main later received a no-op-only emergency repair in `b7bad2b73`; PR #1641 supersedes it with a complete state-aware implementation.

The final implementation:

- uses an explicit allowlist for `ESV-2026-0002` through `ESV-2026-0014`, never a range predicate;
- retains `ESV-2026-0001` and requires every eligible target payload to match it exactly;
- no-ops when none of the exact targets exist;
- accepts an already-completed population only with locked package state and exactly one matching migration-authored `PACKAGE_VOIDED_DUPLICATE` event per target;
- fails closed for partial, mixed, unsafe, edited, authored, different-intended-use, multiple-authority, or contradictory states;
- uses a transaction-scoped advisory lock and deterministic row locks limited to the authority and exact targets;
- updates and appends events atomically, with complete rollback on audit insertion failure;
- never deletes or renumbers packages and never deletes approvals, evidence, attachments, signatures, deviations, snapshots, tests, child records, or audit events.

## Implementation comparison

- PR #1641 retained its stronger authoritative-payload matching, untouched-draft checks, multiple-authority rejection, non-creation lifecycle-event rejection, and PostgreSQL coverage in the P2, synthetic-pilot, and Part Specification workflows.
- The independently certified branch contributed the explicit allowlist, narrow row-lock scope, exact completed-state evidence checks, byte-preserving replay assertions, mixed-state coverage, concurrent execution coverage, and injected audit-failure rollback coverage.
- The implementations were reconciled selectively. They were not merged or cherry-picked wholesale, and only one SQL state machine and one PostgreSQL fixture suite remain.
- Migration registration did not change: migration 0253 remains in both safe and critical boot lists. PR #1631 and migration 0254 were not modified.

## Exact-head PostgreSQL 16.4 certification

Exact PR head `e72697820e8546a6d58f82abf97c9794bd22db43` was exercised by:

- P2 V2 PostgreSQL certification: https://github.com/agcomphr25/EPOCH-v83/actions/runs/31016967021
- Part Specification PostgreSQL certification: https://github.com/agcomphr25/EPOCH-v83/actions/runs/31016967082

Passing evidence:

- migration 0253 state-machine scenarios: 19/19 in each PostgreSQL workflow;
- isolated P2 PostgreSQL: 40/40;
- legacy preservation: 2/2;
- action-by-action legacy continuation: 16/16;
- snapshot mismatch reporting: 3/3;
- controlled pilot: 13/13;
- Phase 1-9 server regressions: 224/224;
- P2 component regressions: 21/21;
- Part Specification PostgreSQL: 6/6;
- safe boot twice, later-migration continuation, schema idempotency, lint, exact-lockfile formatting, migration registration, `git diff --check`, and zero outbound attempts passed;
- TypeScript comparison reported the same 1,524 baseline diagnostics on head and base, with no new diagnostic.

## Remaining certification exception

The exact-head six-file EPOCH software-validation regression run completed 31/32 tests. The only failure is a stale architecture-test literal in `epochSoftwareValidationDuplicateCleanupArchitecture.test.ts`: it expects `candidate_count <> 13`, while the strengthened SQL deliberately uses `candidate_count <> cardinality(target_numbers)`.

This is a test-assertion mismatch rather than a PostgreSQL behavior failure, but it means the requested all-green certification matrix was not achieved before the external merge. No second PR was created under the reconciliation authorization.

## Scope and safety

No production database or production record was accessed or modified. No deployment, feature flag, P2 application workflow, PR #1631 file, migration 0254 file, or P2 handoff branch was changed by this reconciliation.

Post-merge disposition: **DO NOT DEPLOY as fully certified** until the stale architecture assertion is corrected and the six-file EPOCH validation suite passes 32/32 on the corrective head.
