### PR TITLE
Make migration 0253 safe on clean and replayed databases

### DIFF
--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -269,7 +269,7 @@ jobs:
           server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
           --reporter=verbose
 
-      - name: Run EPOCH software validation regressions
+      - name: Run EPOCH validation server regressions
         run: >-
           npx vitest run
           --config vitest.config.server.ts
@@ -280,6 +280,7 @@ jobs:
           server/__tests__/epochSoftwareValidationReadinessArchitecture.test.ts
           server/__tests__/epochSoftwareValidationRules.test.ts
           server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+          server/__tests__/epochValidationResponsibilityDecision.test.ts
           --reporter=verbose
 
       - name: Run isolated PostgreSQL certification
@@ -358,19 +359,6 @@ jobs:
           client/src/__tests__/P2V2ShippingProjectCloseout.component.test.tsx
           client/src/__tests__/P2V2PilotControlCenter.component.test.tsx
           client/src/__tests__/DesignProjectConfigurationWorkspace.component.test.tsx
-          --reporter=verbose
-
-      - name: Run EPOCH validation server regressions
-        run: >-
-          npx vitest run
-          --config vitest.config.server.ts
-          server/__tests__/epochSoftwareValidationArchitecture.test.ts
-          server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
-          server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
-          server/__tests__/epochSoftwareValidationReadinessArchitecture.test.ts
-          server/__tests__/epochSoftwareValidationRules.test.ts
-          server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
-          server/__tests__/epochValidationResponsibilityDecision.test.ts
           --reporter=verbose
 
       - name: Run EPOCH validation component regressions

--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -360,6 +360,28 @@ jobs:
           client/src/__tests__/DesignProjectConfigurationWorkspace.component.test.tsx
           --reporter=verbose
 
+      - name: Run EPOCH validation server regressions
+        run: >-
+          npx vitest run
+          --config vitest.config.server.ts
+          server/__tests__/epochSoftwareValidationArchitecture.test.ts
+          server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+          server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
+          server/__tests__/epochSoftwareValidationReadinessArchitecture.test.ts
+          server/__tests__/epochSoftwareValidationRules.test.ts
+          server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+          server/__tests__/epochValidationResponsibilityDecision.test.ts
+          --reporter=verbose
+
+      - name: Run EPOCH validation component regressions
+        run: >-
+          npx vitest run
+          --config vitest.config.client.ts
+          client/src/__tests__/epochSoftwareValidationCreate.component.test.tsx
+          client/src/__tests__/epochSoftwareValidationReadiness.component.test.tsx
+          client/src/__tests__/epochSoftwareValidationWizardPhase1.component.test.tsx
+          --reporter=verbose
+
   synthetic-pilot-certification:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/migrations/0253_void_duplicate_epoch_validation_packages.sql
+++ b/migrations/0253_void_duplicate_epoch_validation_packages.sql
@@ -7,6 +7,8 @@
 --   ALREADY_COMPLETED - all targets are already void with audit evidence.
 --   EXACT_SAFE_CLEANUP- all thirteen untouched drafts match the sole retained
 --                       authoritative package and contain no authored content.
+--   MIXED_RECOVERY    - exact evidence-backed voids are preserved while the
+--                       remaining untouched drafts are dispositioned.
 --   AMBIGUOUS_STOP    - every other state fails before mutation.
 --
 -- The anonymous block is one transaction. The advisory lock serializes this
@@ -61,50 +63,9 @@ BEGIN
       candidate_count;
   END IF;
 
-  IF void_count = 13 THEN
-    SELECT count(*) INTO completed_event_count
-    FROM qms_epoch_validation_packages p
-    WHERE p.package_number = ANY(target_numbers)
-      AND EXISTS (
-        SELECT 1
-        FROM qms_epoch_validation_events e
-        WHERE e.package_id = p.id
-          AND e.action = 'PACKAGE_VOIDED_DUPLICATE'
-          AND e.actor_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
-          AND e.actor_role = 'SYSTEM_MAINTENANCE'
-      );
-
-    IF completed_event_count <> cardinality(target_numbers) OR EXISTS (
-      SELECT 1
-      FROM qms_epoch_validation_packages p
-      WHERE p.package_number = ANY(target_numbers)
-        AND (
-          p.locked_at IS NULL
-          OR p.updated_by_display_name <> 'migration 0253 (user-authorized duplicate cleanup)'
-          OR p.revision < 2
-          OR p.row_version < 2
-          OR 1 <> (
-            SELECT count(*)
-            FROM qms_epoch_validation_events e
-            WHERE e.package_id = p.id
-              AND e.action = 'PACKAGE_VOIDED_DUPLICATE'
-              AND e.actor_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
-              AND e.actor_role = 'SYSTEM_MAINTENANCE'
-          )
-        )
-    ) THEN
-      RAISE EXCEPTION
-        '0253 state AMBIGUOUS_STOP: all targets are VOID_DUPLICATE but only % retain exact duplicate-void migration evidence',
-        completed_event_count;
-    END IF;
-
-    RAISE NOTICE '0253 state ALREADY_COMPLETED: all duplicate dispositions and audit evidence already exist';
-    RETURN;
-  END IF;
-
-  IF draft_count <> 13 OR void_count <> 0 THEN
+  IF draft_count + void_count <> cardinality(target_numbers) THEN
     RAISE EXCEPTION
-      '0253 state AMBIGUOUS_STOP: target lifecycle is mixed or unsafe (DRAFT %, VOID_DUPLICATE %, total %)',
+      '0253 state AMBIGUOUS_STOP: target lifecycle is unsafe (DRAFT %, VOID_DUPLICATE %, total %)',
       draft_count,
       void_count,
       candidate_count;
@@ -120,10 +81,64 @@ BEGIN
       '0253 state AMBIGUOUS_STOP: retained authoritative package ESV-2026-0001 is missing or void';
   END IF;
 
+  SELECT count(*) INTO completed_event_count
+  FROM qms_epoch_validation_packages p
+  WHERE p.package_number = ANY(target_numbers)
+    AND p.status = 'VOID_DUPLICATE'
+    AND EXISTS (
+      SELECT 1
+      FROM qms_epoch_validation_events e
+      WHERE e.package_id = p.id
+        AND e.action = 'PACKAGE_VOIDED_DUPLICATE'
+        AND e.actor_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
+        AND e.actor_role = 'SYSTEM_MAINTENANCE'
+    );
+
+  IF completed_event_count <> void_count OR EXISTS (
+    SELECT 1
+    FROM qms_epoch_validation_packages p
+    WHERE p.package_number = ANY(target_numbers)
+      AND (
+        (p.status = 'VOID_DUPLICATE' AND (
+          p.locked_at IS NULL
+          OR p.updated_by_display_name <> 'migration 0253 (user-authorized duplicate cleanup)'
+          OR p.revision < 2
+          OR p.row_version < 2
+          OR 1 <> (
+            SELECT count(*)
+            FROM qms_epoch_validation_events e
+            WHERE e.package_id = p.id
+              AND e.action = 'PACKAGE_VOIDED_DUPLICATE'
+              AND e.actor_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
+              AND e.actor_role = 'SYSTEM_MAINTENANCE'
+          )
+        ))
+        OR (p.status = 'DRAFT' AND EXISTS (
+          SELECT 1
+          FROM qms_epoch_validation_events e
+          WHERE e.package_id = p.id
+            AND e.action = 'PACKAGE_VOIDED_DUPLICATE'
+            AND e.actor_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
+            AND e.actor_role = 'SYSTEM_MAINTENANCE'
+        ))
+      )
+  ) THEN
+    RAISE EXCEPTION
+      '0253 state AMBIGUOUS_STOP: % void targets exist but only % retain exact duplicate-void migration evidence',
+      void_count,
+      completed_event_count;
+  END IF;
+
+  IF void_count = cardinality(target_numbers) THEN
+    RAISE NOTICE '0253 state ALREADY_COMPLETED: all duplicate dispositions and audit evidence already exist';
+    RETURN;
+  END IF;
+
   IF EXISTS (
     SELECT 1
     FROM qms_epoch_validation_packages p
     WHERE p.package_number = ANY(target_numbers)
+      AND p.status = 'DRAFT'
       AND (
         p.revision <> 1
         OR p.row_version <> 1
@@ -257,7 +272,7 @@ BEGIN
     UNION ALL SELECT count(*) FROM qms_epoch_validation_approvals r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
     UNION ALL SELECT count(*) FROM qms_epoch_validation_snapshots r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
     UNION ALL SELECT count(*) FROM qms_epoch_validation_periodic_reviews r JOIN qms_epoch_validation_packages p ON p.id = r.package_id WHERE p.package_number = ANY(target_numbers)
-    UNION ALL SELECT count(*) FROM qms_epoch_validation_events e JOIN qms_epoch_validation_packages p ON p.id = e.package_id WHERE p.package_number = ANY(target_numbers) AND e.action <> 'PACKAGE_CREATED'
+    UNION ALL SELECT count(*) FROM qms_epoch_validation_events e JOIN qms_epoch_validation_packages p ON p.id = e.package_id WHERE p.package_number = ANY(target_numbers) AND e.action <> 'PACKAGE_CREATED' AND NOT (e.action = 'PACKAGE_VOIDED_DUPLICATE' AND e.actor_display_name = 'migration 0253 (user-authorized duplicate cleanup)' AND e.actor_role = 'SYSTEM_MAINTENANCE')
   ) authored;
 
   IF authored_count <> 0 THEN
@@ -298,12 +313,15 @@ BEGIN
   )
   SELECT count(*) INTO changed_count FROM inserted_events;
 
-  IF changed_count <> 13 THEN
+  IF changed_count <> draft_count THEN
     RAISE EXCEPTION
-      '0253 state AMBIGUOUS_STOP: transactional cleanup changed % packages instead of 13',
-      changed_count;
+      '0253 state AMBIGUOUS_STOP: transactional cleanup changed % packages instead of %',
+      changed_count,
+      draft_count;
   END IF;
 
-  RAISE NOTICE '0253 state EXACT_SAFE_CLEANUP: voided 13 empty duplicates and appended 13 audit events';
+  RAISE NOTICE '0253 state MIXED_RECOVERY: preserved % completed dispositions and voided % remaining empty duplicates',
+    void_count,
+    changed_count;
 END
 $migration$;

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
@@ -15,6 +15,10 @@ const safeBoot = fs.readFileSync(
   path.join(root, 'server/scripts/migrations/runSafeBootMigrations.ts'),
   'utf8'
 );
+const certification = fs.readFileSync(
+  path.join(root, '.github/workflows/p2-v2-postgres-certification.yml'),
+  'utf8'
+);
 
 describe('EPOCH validation duplicate cleanup', () => {
   it('preserves 0001 and classifies empty, complete, safe, and ambiguous states', () => {
@@ -40,6 +44,7 @@ describe('EPOCH validation duplicate cleanup', () => {
     expect(migration).toContain('NOTHING_TO_DO');
     expect(migration).toContain('ALREADY_COMPLETED');
     expect(migration).toContain('EXACT_SAFE_CLEANUP');
+    expect(migration).toContain('MIXED_RECOVERY');
     expect(migration).toContain('AMBIGUOUS_STOP');
     expect(migration).toContain('authored_count <> 0');
     expect(migration).not.toMatch(/DELETE\s+FROM/i);
@@ -62,9 +67,7 @@ describe('EPOCH validation duplicate cleanup', () => {
     expect(migration).toContain('matching_authority_count <> 1');
     expect(migration).toContain('revision <> 1');
     expect(migration).toContain('row_version <> 1');
-    expect(migration).toContain(
-      'completed_event_count <> cardinality(target_numbers)'
-    );
+    expect(migration).toContain('completed_event_count <> void_count');
     expect(migration).toContain("actor_role = 'SYSTEM_MAINTENANCE'");
     expect(migration).toContain("updated_by_display_name <> 'migration 0253");
     expect(migration).toContain('SELECT count(*)');
@@ -75,5 +78,17 @@ describe('EPOCH validation duplicate cleanup', () => {
       safeBoot.match(/0253_void_duplicate_epoch_validation_packages\.sql/g)
         ?.length
     ).toBe(2);
+  });
+
+  it('keeps the migration matrix and validation regressions in certification', () => {
+    expect(certification).toContain(
+      'epochSoftwareValidationDuplicateCleanupPostgres.test.ts'
+    );
+    expect(certification).toContain(
+      'epochSoftwareValidationIdempotencyArchitecture.test.ts'
+    );
+    expect(certification).toContain(
+      'epochSoftwareValidationCreate.component.test.tsx'
+    );
   });
 });

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
@@ -368,7 +368,9 @@ describe('migration 0253 PostgreSQL state classification', () => {
     await client.query(
       "UPDATE qms_epoch_validation_packages SET status='APPROVED_FOR_INTENDED_USE' WHERE package_number='ESV-2026-0007'"
     );
-    await expectMigrationFailure(/lifecycle is mixed or unsafe/);
+    await expectMigrationFailure(
+      /state AMBIGUOUS_STOP: target lifecycle is unsafe/
+    );
     expect(
       (await targetState()).rows.filter(
         (row) => row.status === 'VOID_DUPLICATE'

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
@@ -376,7 +376,7 @@ describe('migration 0253 PostgreSQL state classification', () => {
     ).toHaveLength(0);
   });
 
-  it('fails closed on mixed pre-cleanup and completed states', async () => {
+  it('completes a mixed exact set and writes events only for remaining drafts', async () => {
     await seedExactDraftSet();
     await client.query(`
       UPDATE qms_epoch_validation_packages
@@ -385,8 +385,48 @@ describe('migration 0253 PostgreSQL state classification', () => {
           updated_by_display_name = 'migration 0253 (user-authorized duplicate cleanup)'
       WHERE package_number = 'ESV-2026-0002'
     `);
+    await client.query(`
+      INSERT INTO qms_epoch_validation_events (
+        package_id, entity_type, action, actor_user_id, actor_display_name,
+        actor_role, previous_value, new_value, reason, package_revision
+      ) VALUES (
+        'ESV-2026-0002', 'PACKAGE', 'PACKAGE_VOIDED_DUPLICATE', 101,
+        'migration 0253 (user-authorized duplicate cleanup)',
+        'SYSTEM_MAINTENANCE', '"DRAFT"', '"VOID_DUPLICATE"',
+        'authorized cleanup', 2
+      )
+    `);
+    const existing = (
+      await client.query(
+        "SELECT updated_at FROM qms_epoch_validation_packages WHERE package_number='ESV-2026-0002'"
+      )
+    ).rows[0];
+    await runMigration();
+    expect(
+      (await targetState()).rows.every((row) => row.status === 'VOID_DUPLICATE')
+    ).toBe(true);
+    expect(
+      (
+        await client.query(
+          "SELECT count(*)::int count FROM qms_epoch_validation_events WHERE action='PACKAGE_VOIDED_DUPLICATE'"
+        )
+      ).rows[0].count
+    ).toBe(13);
+    expect(
+      (
+        await client.query(
+          "SELECT updated_at FROM qms_epoch_validation_packages WHERE package_number='ESV-2026-0002'"
+        )
+      ).rows[0]
+    ).toEqual(existing);
+  });
+
+  it('fails closed when all targets exist without retained 0001', async () => {
+    for (const packageNumber of targetNumbers) {
+      await insertPackage(packageNumber);
+    }
     const before = (await targetState()).rows;
-    await expectMigrationFailure(/lifecycle is mixed or unsafe/);
+    await expectMigrationFailure(/retained authoritative package.*missing/);
     expect((await targetState()).rows).toEqual(before);
   });
 
@@ -436,6 +476,24 @@ describe('migration 0253 PostgreSQL state classification', () => {
       ).rows[0].count
     ).toBe(0);
   });
+
+  it.each(childTables)(
+    'fails closed and rolls back authored content in %s',
+    async (table) => {
+      await seedExactDraftSet();
+      await client.query(
+        `INSERT INTO ${table}(package_id, evidence) VALUES ($1, 'authored')`,
+        ['ESV-2026-0002']
+      );
+      const before = (await targetState()).rows;
+      await expectMigrationFailure(/authored validation or lifecycle records/);
+      expect((await targetState()).rows).toEqual(before);
+      expect(
+        (await client.query(`SELECT count(*)::int count FROM ${table}`)).rows[0]
+          .count
+      ).toBe(1);
+    }
+  );
 
   it('rejects contradictory completed audit evidence without mutation', async () => {
     await seedExactDraftSet();


### PR DESCRIPTION
## Root cause
Migration 0253 is a universal critical safe-boot migration but required all 13 production-only duplicate package identities on every database. Clean, schema-push-first, and disposable databases therefore failed before certification could begin.

## Correction
- no-op only when none of the exact target identities exist
- retain fail-closed behavior for partial or ambiguous target populations
- preserve the retained ESV-2026-0001 requirement when all targets exist
- preserve authored-content and lifecycle guards
- support exact all-DRAFT, all-VOID_DUPLICATE, and evidence-backed mixed states
- update only DRAFT targets and append exactly one event per changed package
- add disposable PostgreSQL state-machine coverage and run it in P2 certification

## Safety
No records are deleted. No packages are fabricated. No production or shared database was accessed. Migration 0253 remains registered as a critical safe-boot migration and no runner bypass or environment condition was added.

## Validation
CI is required for PostgreSQL 16.4, npm-ci TypeScript, ESLint, Prettier, safe-boot, schema idempotency, P2, Design Project Configuration, synthetic-pilot, and EPOCH validation regressions. The PR remains draft until those checks are reviewed.