### PR TITLE
Fix migration 0253 certification assertion

### DIFF
--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -269,6 +269,19 @@ jobs:
           server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
           --reporter=verbose
 
+      - name: Run EPOCH software validation regressions
+        run: >-
+          npx vitest run
+          --config vitest.config.server.ts
+          --no-file-parallelism
+          server/__tests__/epochSoftwareValidationArchitecture.test.ts
+          server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+          server/__tests__/epochSoftwareValidationIdempotencyArchitecture.test.ts
+          server/__tests__/epochSoftwareValidationReadinessArchitecture.test.ts
+          server/__tests__/epochSoftwareValidationRules.test.ts
+          server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+          --reporter=verbose
+
       - name: Run isolated PostgreSQL certification
         env:
           P2_V2_PRODUCTION_LAUNCH_ENABLED: 'true'

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
@@ -18,14 +18,25 @@ const safeBoot = fs.readFileSync(
 
 describe('EPOCH validation duplicate cleanup', () => {
   it('preserves 0001 and classifies empty, complete, safe, and ambiguous states', () => {
+    const expectedTargets = Array.from(
+      { length: 13 },
+      (_, index) => `'ESV-2026-${String(index + 2).padStart(4, '0')}'`
+    );
+    const targetArray = migration.match(
+      /target_numbers\s+constant\s+text\[\]\s*:=\s*ARRAY\[([\s\S]*?)\];/
+    );
+
     expect(migration).toContain("package_number = 'ESV-2026-0001'");
-    expect(migration).toContain(
-      "'ESV-2026-0002', 'ESV-2026-0003', 'ESV-2026-0004'"
+    expect(targetArray).not.toBeNull();
+    expect(targetArray?.[1].match(/'ESV-2026-\d{4}'/g)).toEqual(
+      expectedTargets
     );
     expect(migration).not.toContain('package_number BETWEEN');
     expect(migration).toContain('package_number = ANY(target_numbers)');
     expect(migration).toContain('candidate_count = 0');
-    expect(migration).toContain('candidate_count <> 13');
+    expect(migration).toMatch(
+      /candidate_count\s*<>\s*cardinality\s*\(\s*target_numbers\s*\)/
+    );
     expect(migration).toContain('NOTHING_TO_DO');
     expect(migration).toContain('ALREADY_COMPLETED');
     expect(migration).toContain('EXACT_SAFE_CLEANUP');


### PR DESCRIPTION
## Summary

- replace the stale migration-0253 architecture assertion with a structural cardinality check
- verify all thirteen authorized package numbers are present exactly in the SQL allowlist
- add the dedicated six-file EPOCH validation regression gate to the existing PostgreSQL certification workflow

## Scope

This is a certification-only correction following merged PR #1641. It does not change migration SQL or runtime behavior.

Changed files:

- `.github/workflows/p2-v2-postgres-certification.yml`
- `server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts`

No production access, deployment configuration, feature flag, migration 0254, PR #1631 work, or P2 handoff code is included.

## Root cause

The merged SQL correctly guards the explicit target allowlist with `candidate_count <> cardinality(target_numbers)`, but the architecture test still expected the older hard-coded spelling `candidate_count <> 13`.

The corrected test extracts the declared array, compares its thirteen exact package-number literals to the authorized set, and uses a whitespace-tolerant structural regex for the cardinality invariant.

## Validation

- exact six-file EPOCH validation suite: 6 files, 32/32 tests passed
- scoped ESLint: passed
- exact-lockfile Prettier: passed
- `git diff --check`: passed

PostgreSQL 16.4, safe-boot replay, schema idempotency, TypeScript baseline comparison, and full workflow gates must remain green before this draft is promoted or merged.
