### PR TITLE
Add gated atomic controlled-document approval and release

### DIFF
--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -44,9 +44,15 @@ on:
       - 'server/src/routes/projectShippingCloseout.ts'
       - 'server/src/routes/projects.ts'
       - 'server/src/routes/travelers.ts'
+      - 'server/src/routes/controlledDocuments.ts'
+      - 'server/src/services/controlledDocumentLifecycleService.ts'
+      - 'server/src/services/controlledDocumentPhase2Gate.ts'
+      - 'server/src/services/controlledDocumentSchemaReadiness.ts'
       - 'server/src/routes/workOrders.ts'
       - 'server/storage.ts'
       - 'server/__tests__/p2V2PostgresCertification.test.ts'
+      - 'server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts'
+      - 'server/__tests__/controlledDocumentPhase2Postgres.test.ts'
       - 'server/__tests__/p2V2LegacyPreservationPostgres.test.ts'
       - 'server/__tests__/p2V2PilotPostgresCertification.test.ts'
       - 'server/__tests__/projectWorkflowVersion.test.ts'
@@ -294,6 +300,15 @@ jobs:
           --config vitest.config.server.ts
           --no-file-parallelism
           server/__tests__/epochSoftwareValidationDuplicateCleanupPostgres.test.ts
+          --reporter=verbose
+
+      - name: Certify controlled-document Phase 2 atomicity and concurrency
+        run: >-
+          npx vitest run
+          --config vitest.config.server.ts
+          --no-file-parallelism
+          server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
+          server/__tests__/controlledDocumentPhase2Postgres.test.ts
           --reporter=verbose
 
       - name: Run EPOCH validation server regressions

--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -431,8 +431,10 @@ export default function MasterDocumentRegister() {
   });
 
   const getStatusBadge = (doc: ControlledDocument) => {
+    /* eslint-disable prettier/prettier -- Linux CI and Windows disagree on this union layout. */
     const compatibilityStatus = (doc as any).compatibilityStatus as
       string | undefined;
+    /* eslint-enable prettier/prettier */
     if (compatibilityStatus === 'Released and Verified') {
       return <Badge className="bg-emerald-700">Released and Verified</Badge>;
     }

--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -45,7 +45,10 @@ import {
   Printer,
   RefreshCw,
 } from 'lucide-react';
-import type { ControlledDocument, DocumentVersionHistory } from '@shared/schema';
+import type {
+  ControlledDocument,
+  DocumentVersionHistory,
+} from '@shared/schema';
 import { apiRequest, queryClient } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -110,7 +113,8 @@ const DEPARTMENT_CODE_PREFIXES: Record<string, string> = {
   Purchasing: 'PO',
 };
 
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const codePrefixForDepartment = (department: string) => {
   const mapped = DEPARTMENT_CODE_PREFIXES[department];
@@ -125,7 +129,8 @@ const codePrefixForDepartment = (department: string) => {
 };
 
 const codeTokenForDocumentType = (documentType: string) =>
-  DOCUMENT_TYPE_OPTIONS.find((option) => option.value === documentType)?.codeToken || documentType;
+  DOCUMENT_TYPE_OPTIONS.find((option) => option.value === documentType)
+    ?.codeToken || documentType;
 
 const generateDocumentNumber = (
   documents: ControlledDocument[],
@@ -190,8 +195,18 @@ type DesignControlTemplateView = {
 };
 
 type DesignControlTemplateReconciliationView = {
-  conflicts: Array<{ id: string; templateKey: string; conflictType: string; details: Record<string, unknown> }>;
-  legacyTemplates: Array<{ id: string; templateName: string; templateType: string; reason: string }>;
+  conflicts: Array<{
+    id: string;
+    templateKey: string;
+    conflictType: string;
+    details: Record<string, unknown>;
+  }>;
+  legacyTemplates: Array<{
+    id: string;
+    templateName: string;
+    templateType: string;
+    reason: string;
+  }>;
 };
 
 export default function MasterDocumentRegister() {
@@ -207,7 +222,8 @@ export default function MasterDocumentRegister() {
   const [isHistoryDialogOpen, setIsHistoryDialogOpen] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [csvFile, setCsvFile] = useState<File | null>(null);
-  const [selectedDocument, setSelectedDocument] = useState<ControlledDocument | null>(null);
+  const [selectedDocument, setSelectedDocument] =
+    useState<ControlledDocument | null>(null);
   const [createNewVersion, setCreateNewVersion] = useState(false);
   const [newDocumentDepartment, setNewDocumentDepartment] = useState('');
   const [newDocumentType, setNewDocumentType] = useState('');
@@ -220,7 +236,9 @@ export default function MasterDocumentRegister() {
   const [stepUpError, setStepUpError] = useState<string | null>(null);
   const [isStepUpOpen, setIsStepUpOpen] = useState(false);
   const [isStepUpSubmitting, setIsStepUpSubmitting] = useState(false);
-  const [openingDocumentId, setOpeningDocumentId] = useState<string | null>(null);
+  const [openingDocumentId, setOpeningDocumentId] = useState<string | null>(
+    null
+  );
   const { toast } = useToast();
 
   // Fetch controlled documents
@@ -228,29 +246,38 @@ export default function MasterDocumentRegister() {
     queryKey: ['/api/controlled-documents'],
   });
 
-  const { data: designControlTemplates = [], isLoading: areDesignTemplatesLoading } = useQuery<DesignControlTemplateView[]>({
+  const {
+    data: designControlTemplates = [],
+    isLoading: areDesignTemplatesLoading,
+  } = useQuery<DesignControlTemplateView[]>({
     queryKey: ['/api/design-control-form-templates'],
   });
-  const { data: designTemplateReconciliation } = useQuery<DesignControlTemplateReconciliationView>({
-    queryKey: ['/api/design-control-form-templates/reconciliation'],
-  });
+  const { data: designTemplateReconciliation } =
+    useQuery<DesignControlTemplateReconciliationView>({
+      queryKey: ['/api/design-control-form-templates/reconciliation'],
+    });
 
   // Fetch current user session for role-based access
   const { data: session } = useQuery<{ username: string; role: string }>({
     queryKey: ['/api/auth/session'],
   });
-  /* eslint-disable prettier/prettier */
-  const { data: phase2Availability } = useQuery<{ enabled: boolean }>({ queryKey: ['/api/controlled-documents/phase2/availability'] });
+  const { data: phase2Availability } = useQuery<{ enabled: boolean }>({
+    queryKey: ['/api/controlled-documents/phase2/availability'],
+  });
   const phase2Enabled = phase2Availability?.enabled === true;
-  /* eslint-enable prettier/prettier */
 
-  const { data: versionHistory = [], isLoading: isHistoryLoading } = useQuery<DocumentVersionHistory[]>({
+  const { data: versionHistory = [], isLoading: isHistoryLoading } = useQuery<
+    DocumentVersionHistory[]
+  >({
     queryKey: ['/api/controlled-documents', selectedDocument?.id, 'versions'],
     enabled: isHistoryDialogOpen && Boolean(selectedDocument?.id),
     queryFn: async () => {
-      const response = await fetch(`/api/controlled-documents/${selectedDocument?.id}/versions`, {
-        credentials: 'include',
-      });
+      const response = await fetch(
+        `/api/controlled-documents/${selectedDocument?.id}/versions`,
+        {
+          credentials: 'include',
+        }
+      );
       if (!response.ok) throw new Error('Failed to fetch version history');
       return response.json();
     },
@@ -267,49 +294,63 @@ export default function MasterDocumentRegister() {
       body?: Record<string, unknown>;
       method?: 'POST';
     }) => {
-      const response = await fetch(`/api/design-control-form-templates${input.path}`, {
-        method: input.method ?? 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(input.body ?? {}),
-      });
+      const response = await fetch(
+        `/api/design-control-form-templates${input.path}`,
+        {
+          method: input.method ?? 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input.body ?? {}),
+        }
+      );
       const payload = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(payload.message || payload.error || 'Template operation failed');
+      if (!response.ok)
+        throw new Error(
+          payload.message || payload.error || 'Template operation failed'
+        );
       return payload;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/design-control-form-templates'] });
-      queryClient.invalidateQueries({ queryKey: ['/api/design-control-form-templates/reconciliation'] });
-      queryClient.invalidateQueries({ queryKey: ['/api/controlled-documents'] });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/design-control-form-templates'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/design-control-form-templates/reconciliation'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/controlled-documents'],
+      });
       toast({ title: 'Design Control template updated' });
     },
-    onError: (error: Error) => toast({
-      title: 'Design Control template action failed',
-      description: error.message,
-      variant: 'destructive',
-    }),
+    onError: (error: Error) =>
+      toast({
+        title: 'Design Control template action failed',
+        description: error.message,
+        variant: 'destructive',
+      }),
   });
 
   const runDesignTemplateAction = (
     template: DesignControlTemplateView,
     revision: DesignControlTemplateRevisionView,
-    action: 'submit' | 'decision' | 'release' | 'obsolete',
+    action: 'submit' | 'decision' | 'release' | 'obsolete'
   ) => {
     const reason = window.prompt(`Reason for ${action}:`);
     if (!reason?.trim()) return;
     designTemplateMutation.mutate({
       path: `/${template.templateKey}/revisions/${revision.id}/${action}`,
-      body: action === 'decision' ? { reason, decision: 'APPROVED' } : { reason },
+      body:
+        action === 'decision' ? { reason, decision: 'APPROVED' } : { reason },
     });
   };
 
   const createDesignTemplateRevision = (
     template: DesignControlTemplateView,
-    revision: DesignControlTemplateRevisionView,
+    revision: DesignControlTemplateRevisionView
   ) => {
     const documentRevision = window.prompt(
       'New controlled document revision:',
-      nextRevisionVersion(revision.documentRevisionSnapshot),
+      nextRevisionVersion(revision.documentRevisionSnapshot)
     );
     if (!documentRevision?.trim()) return;
     const reason = window.prompt('Material-change reason:');
@@ -326,14 +367,27 @@ export default function MasterDocumentRegister() {
   };
 
   // Get unique departments and types for filters
-  const departments = ['all', ...Array.from(new Set(documents.map((d) => d.department)))];
-  const documentTypes = ['all', ...Array.from(new Set(documents.map((d) => d.documentType)))];
+  const departments = [
+    'all',
+    ...Array.from(new Set(documents.map((d) => d.department))),
+  ];
+  const documentTypes = [
+    'all',
+    ...Array.from(new Set(documents.map((d) => d.documentType))),
+  ];
   const createDepartmentOptions = useMemo(
-    () => Array.from(new Set([...DOCUMENT_DEPARTMENT_OPTIONS, ...documents.map((d) => d.department).filter(Boolean)])),
+    () =>
+      Array.from(
+        new Set([
+          ...DOCUMENT_DEPARTMENT_OPTIONS,
+          ...documents.map((d) => d.department).filter(Boolean),
+        ])
+      ),
     [documents]
   );
   const generatedDocumentNumber = useMemo(
-    () => generateDocumentNumber(documents, newDocumentDepartment, newDocumentType),
+    () =>
+      generateDocumentNumber(documents, newDocumentDepartment, newDocumentType),
     [documents, newDocumentDepartment, newDocumentType]
   );
 
@@ -348,7 +402,9 @@ export default function MasterDocumentRegister() {
     if (!doc.expirationDate || doc.status !== 'approved') return false;
     const today = new Date();
     const expDate = new Date(doc.expirationDate);
-    const daysUntilExpiration = Math.floor((expDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+    const daysUntilExpiration = Math.floor(
+      (expDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+    );
     return daysUntilExpiration > 0 && daysUntilExpiration <= 30;
   };
 
@@ -358,32 +414,44 @@ export default function MasterDocumentRegister() {
       searchQuery === '' ||
       doc.documentName.toLowerCase().includes(searchQuery.toLowerCase()) ||
       doc.documentNumber.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      (doc.description && doc.description.toLowerCase().includes(searchQuery.toLowerCase()));
+      (doc.description &&
+        doc.description.toLowerCase().includes(searchQuery.toLowerCase()));
 
-    const matchesDepartment = departmentFilter === 'all' || doc.department === departmentFilter;
+    const matchesDepartment =
+      departmentFilter === 'all' || doc.department === departmentFilter;
     const matchesType = typeFilter === 'all' || doc.documentType === typeFilter;
     const matchesStatus =
       statusFilter === 'all' ||
       (statusFilter === 'expired'
         ? isExpired(doc)
-        : ((doc as any).lifecycleStatus || doc.status).toLowerCase() === statusFilter.toLowerCase());
+        : ((doc as any).lifecycleStatus || doc.status).toLowerCase() ===
+          statusFilter.toLowerCase());
 
     return matchesSearch && matchesDepartment && matchesType && matchesStatus;
   });
 
   const getStatusBadge = (doc: ControlledDocument) => {
-    const compatibilityStatus = (doc as any).compatibilityStatus as string | undefined;
+    const compatibilityStatus = (doc as any).compatibilityStatus as
+      string | undefined;
     if (compatibilityStatus === 'Released and Verified') {
       return <Badge className="bg-emerald-700">Released and Verified</Badge>;
     }
     if (compatibilityStatus === 'Legacy Approved — Verification Required') {
-      return <Badge variant="outline" className="border-amber-500 text-amber-700">Legacy Approved — Verification Required</Badge>;
+      return (
+        <Badge variant="outline" className="border-amber-500 text-amber-700">
+          Legacy Approved — Verification Required
+        </Badge>
+      );
     }
     if (compatibilityStatus === 'File Reconciliation Required') {
       return <Badge variant="destructive">File Reconciliation Required</Badge>;
     }
     if (compatibilityStatus === 'Awaiting Approval') {
-      return <Badge variant="outline" className="border-blue-500 text-blue-700">Awaiting Approval</Badge>;
+      return (
+        <Badge variant="outline" className="border-blue-500 text-blue-700">
+          Awaiting Approval
+        </Badge>
+      );
     }
 
     if (isExpired(doc)) {
@@ -397,19 +465,29 @@ export default function MasterDocumentRegister() {
 
     if (isExpiringSoon(doc)) {
       return (
-        <Badge variant="outline" className="flex items-center gap-1 border-yellow-500 text-yellow-700">
+        <Badge
+          variant="outline"
+          className="flex items-center gap-1 border-yellow-500 text-yellow-700"
+        >
           <Clock className="h-3 w-3" />
           Expiring Soon
         </Badge>
       );
     }
 
-    /* eslint-disable prettier/prettier */
     const lifecycle = doc.lifecycleStatus || doc.status?.toUpperCase();
-    if (phase2Enabled && lifecycle === 'DRAFT') return <Badge variant="outline" className="border-blue-500 text-blue-700">Registered — awaiting approval</Badge>;
-    if (phase2Enabled && lifecycle === 'REJECTED') return <Badge variant="destructive">Rejected — correction required</Badge>;
-    if (phase2Enabled && ['IN_REVIEW', 'APPROVED'].includes(lifecycle)) return <Badge variant="outline">Historical/legacy — retained</Badge>;
-    /* eslint-enable prettier/prettier */
+    if (phase2Enabled && lifecycle === 'DRAFT')
+      return (
+        <Badge variant="outline" className="border-blue-500 text-blue-700">
+          Registered — awaiting approval
+        </Badge>
+      );
+    if (phase2Enabled && lifecycle === 'REJECTED')
+      return (
+        <Badge variant="destructive">Rejected — correction required</Badge>
+      );
+    if (phase2Enabled && ['IN_REVIEW', 'APPROVED'].includes(lifecycle))
+      return <Badge variant="outline">Historical/legacy — retained</Badge>;
     switch (lifecycle) {
       case 'RELEASED':
         return <Badge className="bg-emerald-700">Released</Badge>;
@@ -420,19 +498,29 @@ export default function MasterDocumentRegister() {
       case 'VOID':
         return <Badge variant="secondary">Void</Badge>;
       case 'IN_REVIEW':
-        return <Badge variant="outline" className="border-blue-500 text-blue-700">In Review</Badge>;
+        return (
+          <Badge variant="outline" className="border-blue-500 text-blue-700">
+            In Review
+          </Badge>
+        );
       case 'APPROVED':
       case 'approved':
       case 'approved':
         return (
-          <Badge variant="default" className="flex items-center gap-1 bg-green-600">
+          <Badge
+            variant="default"
+            className="flex items-center gap-1 bg-green-600"
+          >
             <CheckCircle className="h-3 w-3" />
             Approved
           </Badge>
         );
       case 'pending':
         return (
-          <Badge variant="outline" className="flex items-center gap-1 border-blue-500 text-blue-700">
+          <Badge
+            variant="outline"
+            className="flex items-center gap-1 border-blue-500 text-blue-700"
+          >
             <Clock className="h-3 w-3" />
             Pending
           </Badge>
@@ -458,7 +546,9 @@ export default function MasterDocumentRegister() {
   const formatVersionDisplay = (doc: ControlledDocument) => {
     const versionDate = (doc as any).versionDate;
     if (!versionDate) return `Version ${doc.currentVersion}`;
-    const date = String(versionDate).includes('T') ? new Date(versionDate) : new Date(`${versionDate}T00:00:00`);
+    const date = String(versionDate).includes('T')
+      ? new Date(versionDate)
+      : new Date(`${versionDate}T00:00:00`);
     if (Number.isNaN(date.getTime())) return `Version ${doc.currentVersion}`;
     return `Version ${doc.currentVersion} ${date.toLocaleDateString('en-US', {
       month: '2-digit',
@@ -481,19 +571,29 @@ export default function MasterDocumentRegister() {
   };
 
   const getAuthHeaders = (): Record<string, string> => {
-    const storedToken = localStorage.getItem('sessionToken') || localStorage.getItem('jwtToken');
+    const storedToken =
+      localStorage.getItem('sessionToken') || localStorage.getItem('jwtToken');
     return storedToken ? { Authorization: `Bearer ${storedToken}` } : {};
   };
 
-  const getFilenameFromDisposition = (disposition: string | null, fallback: string) => {
+  const getFilenameFromDisposition = (
+    disposition: string | null,
+    fallback: string
+  ) => {
     if (!disposition) return fallback;
     const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
-    if (utf8Match?.[1]) return decodeURIComponent(utf8Match[1].replace(/"/g, ''));
+    if (utf8Match?.[1])
+      return decodeURIComponent(utf8Match[1].replace(/"/g, ''));
     const filenameMatch = disposition.match(/filename="?([^"]+)"?/i);
     return filenameMatch?.[1] || fallback;
   };
 
-  const openDocumentBlob = (blob: Blob, filename: string, mode: 'view' | 'download', targetWindow?: Window | null) => {
+  const openDocumentBlob = (
+    blob: Blob,
+    filename: string,
+    mode: 'view' | 'download',
+    targetWindow?: Window | null
+  ) => {
     const blobUrl = URL.createObjectURL(blob);
     if (mode === 'view') {
       if (targetWindow) {
@@ -518,17 +618,19 @@ export default function MasterDocumentRegister() {
     doc: ControlledDocument,
     mode: 'view' | 'download',
     targetWindowOverride?: Window | null,
-    apiPathOverride?: string,
+    apiPathOverride?: string
   ) => {
-    const path = apiPathOverride || `/api/controlled-documents/${doc.id}/${mode}`;
+    const path =
+      apiPathOverride || `/api/controlled-documents/${doc.id}/${mode}`;
     const targetWindow =
-      targetWindowOverride ?? (mode === 'view'
-        ? window.open('', '_blank')
-        : null);
+      targetWindowOverride ??
+      (mode === 'view' ? window.open('', '_blank') : null);
 
     if (targetWindow) {
       targetWindow.opener = null;
-      targetWindow.document.write('<p style="font-family: sans-serif; padding: 1rem;">Loading document...</p>');
+      targetWindow.document.write(
+        '<p style="font-family: sans-serif; padding: 1rem;">Loading document...</p>'
+      );
     }
 
     try {
@@ -555,7 +657,9 @@ export default function MasterDocumentRegister() {
         }
 
         targetWindow?.close();
-        throw new Error(errorData?.message || errorData?.error || `Failed to ${mode} document`);
+        throw new Error(
+          errorData?.message || errorData?.error || `Failed to ${mode} document`
+        );
       }
 
       const blob = await response.blob();
@@ -583,8 +687,17 @@ export default function MasterDocumentRegister() {
         headers: getAuthHeaders(),
       });
       const payload = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(payload.message || payload.error || 'Failed to generate legacy audit report');
-      const blobUrl = URL.createObjectURL(new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' }));
+      if (!response.ok)
+        throw new Error(
+          payload.message ||
+            payload.error ||
+            'Failed to generate legacy audit report'
+        );
+      const blobUrl = URL.createObjectURL(
+        new Blob([JSON.stringify(payload, null, 2)], {
+          type: 'application/json',
+        })
+      );
       const link = document.createElement('a');
       link.href = blobUrl;
       link.download = `controlled-document-legacy-audit-${new Date().toISOString().slice(0, 10)}.json`;
@@ -593,11 +706,17 @@ export default function MasterDocumentRegister() {
       document.body.removeChild(link);
       URL.revokeObjectURL(blobUrl);
     } catch (error: any) {
-      toast({ title: 'Unable to generate audit report', description: error.message, variant: 'destructive' });
+      toast({
+        title: 'Unable to generate audit report',
+        description: error.message,
+        variant: 'destructive',
+      });
     }
   };
 
-  const handleStepUpSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleStepUpSubmit = async (
+    event: React.FormEvent<HTMLFormElement>
+  ) => {
     event.preventDefault();
     if (!pendingDocumentAccess) return;
     if (!stepUpPassword.trim()) {
@@ -614,7 +733,9 @@ export default function MasterDocumentRegister() {
           : null;
       if (targetWindow) {
         targetWindow.opener = null;
-        targetWindow.document.write('<p style="font-family: sans-serif; padding: 1rem;">Verifying credentials...</p>');
+        targetWindow.document.write(
+          '<p style="font-family: sans-serif; padding: 1rem;">Verifying credentials...</p>'
+        );
       }
 
       const response = await fetch('/api/auth/step-up', {
@@ -642,7 +763,12 @@ export default function MasterDocumentRegister() {
       setIsStepUpOpen(false);
       setPendingDocumentAccess(null);
       setStepUpPassword('');
-      await openDocumentFile(access.doc, access.mode, targetWindow, access.apiPath);
+      await openDocumentFile(
+        access.doc,
+        access.mode,
+        targetWindow,
+        access.apiPath
+      );
     } catch (error: any) {
       setStepUpError(error.message || 'Credential verification failed');
     } finally {
@@ -659,7 +785,9 @@ export default function MasterDocumentRegister() {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/controlled-documents'] });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/controlled-documents'],
+      });
       setIsCreateDialogOpen(false);
       setSelectedFile(null);
       setNewDocumentDepartment('');
@@ -692,14 +820,27 @@ export default function MasterDocumentRegister() {
 
   // Update document mutation
   const updateDocumentMutation = useMutation({
-    mutationFn: async ({ id, formData, revise }: { id: string; formData: FormData; revise: boolean }) => {
-      return await apiRequest(`/api/controlled-documents/${id}${revise ? '/revise' : ''}`, {
-        method: revise ? 'POST' : 'PUT',
-        body: formData,
-      });
+    mutationFn: async ({
+      id,
+      formData,
+      revise,
+    }: {
+      id: string;
+      formData: FormData;
+      revise: boolean;
+    }) => {
+      return await apiRequest(
+        `/api/controlled-documents/${id}${revise ? '/revise' : ''}`,
+        {
+          method: revise ? 'POST' : 'PUT',
+          body: formData,
+        }
+      );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/controlled-documents'] });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/controlled-documents'],
+      });
       setIsEditDialogOpen(false);
       setSelectedDocument(null);
       setSelectedFile(null);
@@ -736,10 +877,19 @@ export default function MasterDocumentRegister() {
     const formData = new FormData(formElement);
 
     if (createNewVersion) {
-      formData.append('revisionValue', nextRevisionVersion(selectedDocument.currentVersion));
-      formData.append('reason', String(formData.get('changeDescription') || ''));
+      formData.append(
+        'revisionValue',
+        nextRevisionVersion(selectedDocument.currentVersion)
+      );
+      formData.append(
+        'reason',
+        String(formData.get('changeDescription') || '')
+      );
       if ((selectedDocument as any).currentRevisionId) {
-        formData.append('currentRevisionId', (selectedDocument as any).currentRevisionId);
+        formData.append(
+          'currentRevisionId',
+          (selectedDocument as any).currentRevisionId
+        );
       }
     }
 
@@ -747,32 +897,53 @@ export default function MasterDocumentRegister() {
       formData.append('file', selectedFile);
     }
 
-    updateDocumentMutation.mutate({ id: selectedDocument.id, formData, revise: createNewVersion });
+    updateDocumentMutation.mutate({
+      id: selectedDocument.id,
+      formData,
+      revise: createNewVersion,
+    });
   };
 
   // Approve document mutation
-  /* eslint-disable prettier/prettier */
   const approveDocumentMutation = useMutation({
-    mutationFn: async ({ id, effectiveDate }: { id: string; effectiveDate: string }) => {
-      return await apiRequest(`/api/controlled-documents/${id}/${phase2Enabled ? 'approve-and-release' : 'decision'}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...(phase2Enabled ? { 'Idempotency-Key': crypto.randomUUID() } : {}) },
-        body: JSON.stringify({
-          revisionId: (selectedDocument as any)?.currentRevisionId,
-          decision: 'APPROVED',
-          comment: `Approved with effective date ${effectiveDate}`,
-          reason: `Approved and released with effective date ${effectiveDate}`,
-          effectiveDate,
-        }),
-      });
+    mutationFn: async ({
+      id,
+      effectiveDate,
+    }: {
+      id: string;
+      effectiveDate: string;
+    }) => {
+      return await apiRequest(
+        `/api/controlled-documents/${id}/${phase2Enabled ? 'approve-and-release' : 'decision'}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(phase2Enabled
+              ? { 'Idempotency-Key': crypto.randomUUID() }
+              : {}),
+          },
+          body: JSON.stringify({
+            revisionId: (selectedDocument as any)?.currentRevisionId,
+            decision: 'APPROVED',
+            comment: `Approved with effective date ${effectiveDate}`,
+            reason: `Approved and released with effective date ${effectiveDate}`,
+            effectiveDate,
+          }),
+        }
+      );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/controlled-documents'] });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/controlled-documents'],
+      });
       setIsApproveDialogOpen(false);
       setSelectedDocument(null);
       toast({
         title: 'Success',
-        description: phase2Enabled ? 'Document approved and released successfully' : 'Document approved successfully',
+        description: phase2Enabled
+          ? 'Document approved and released successfully'
+          : 'Document approved successfully',
       });
     },
     onError: (error: any) => {
@@ -783,7 +954,6 @@ export default function MasterDocumentRegister() {
       });
     },
   });
-  /* eslint-enable prettier/prettier */
 
   const handleApproveDocument = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -796,9 +966,14 @@ export default function MasterDocumentRegister() {
     approveDocumentMutation.mutate({ id: selectedDocument.id, effectiveDate });
   };
 
-  /* eslint-disable prettier/prettier */
   const lifecycleMutation = useMutation({
-    mutationFn: async ({ doc, action }: { doc: ControlledDocument; action: 'submit' | 'release' | 'reject' | 'obsolete' | 'void' }) => {
+    mutationFn: async ({
+      doc,
+      action,
+    }: {
+      doc: ControlledDocument;
+      action: 'submit' | 'release' | 'reject' | 'obsolete' | 'void';
+    }) => {
       const reason = window.prompt(`Reason for ${action}`);
       if (!reason?.trim()) throw new Error('A transition reason is required');
       return apiRequest(`/api/controlled-documents/${doc.id}/${action}`, {
@@ -809,14 +984,17 @@ export default function MasterDocumentRegister() {
         },
       });
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['/api/controlled-documents'] }),
-    onError: (error: any) => toast({
-      title: 'Document lifecycle action failed',
-      description: error.message,
-      variant: 'destructive',
-    }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ['/api/controlled-documents'],
+      }),
+    onError: (error: any) =>
+      toast({
+        title: 'Document lifecycle action failed',
+        description: error.message,
+        variant: 'destructive',
+      }),
   });
-  /* eslint-enable prettier/prettier */
 
   // CSV Import mutation
   const importCsvMutation = useMutation({
@@ -830,7 +1008,9 @@ export default function MasterDocumentRegister() {
       });
     },
     onSuccess: (data: any) => {
-      queryClient.invalidateQueries({ queryKey: ['/api/controlled-documents'] });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/controlled-documents'],
+      });
       setIsImportDialogOpen(false);
       setCsvFile(null);
       const results = data.results;
@@ -902,27 +1082,27 @@ export default function MasterDocumentRegister() {
               <ControlledDocumentReconciliationWorkspace />
               {canCreateEdit && (
                 <>
-                <Button
-                  variant="outline"
-                  className="flex items-center gap-2"
-                  data-testid="button-import-csv"
-                  onClick={() => setIsImportDialogOpen(true)}
-                >
-                  <Upload className="h-4 w-4" />
-                  Import CSV
-                </Button>
-                <Button
-                  className="flex items-center gap-2"
-                  data-testid="button-create-document"
-                  onClick={() => {
-                    setNewDocumentDepartment('');
-                    setNewDocumentType('');
-                    setIsCreateDialogOpen(true);
-                  }}
-                >
-                  <Plus className="h-4 w-4" />
-                  New Document
-                </Button>
+                  <Button
+                    variant="outline"
+                    className="flex items-center gap-2"
+                    data-testid="button-import-csv"
+                    onClick={() => setIsImportDialogOpen(true)}
+                  >
+                    <Upload className="h-4 w-4" />
+                    Import CSV
+                  </Button>
+                  <Button
+                    className="flex items-center gap-2"
+                    data-testid="button-create-document"
+                    onClick={() => {
+                      setNewDocumentDepartment('');
+                      setNewDocumentType('');
+                      setIsCreateDialogOpen(true);
+                    }}
+                  >
+                    <Plus className="h-4 w-4" />
+                    New Document
+                  </Button>
                 </>
               )}
             </div>
@@ -952,7 +1132,10 @@ export default function MasterDocumentRegister() {
               </div>
 
               {/* Department Filter */}
-              <Select value={departmentFilter} onValueChange={setDepartmentFilter}>
+              <Select
+                value={departmentFilter}
+                onValueChange={setDepartmentFilter}
+              >
                 <SelectTrigger data-testid="select-department-filter">
                   <SelectValue placeholder="All Departments" />
                 </SelectTrigger>
@@ -1003,10 +1186,13 @@ export default function MasterDocumentRegister() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between gap-4">
             <div>
-              <CardTitle className="text-lg">Design Control Form Templates</CardTitle>
+              <CardTitle className="text-lg">
+                Design Control Form Templates
+              </CardTitle>
               <p className="text-sm text-muted-foreground mt-1">
-                Exact template-definition revisions linked to independently controlled MDR documents.
-                Project form entry begins in Phase 5 and is not available here.
+                Exact template-definition revisions linked to independently
+                controlled MDR documents. Project form entry begins in Phase 5
+                and is not available here.
               </p>
             </div>
             {can('documents.template.create') && (
@@ -1021,21 +1207,32 @@ export default function MasterDocumentRegister() {
             )}
           </CardHeader>
           <CardContent>
-            {Boolean(designTemplateReconciliation?.conflicts.length || designTemplateReconciliation?.legacyTemplates.length) && (
+            {Boolean(
+              designTemplateReconciliation?.conflicts.length ||
+              designTemplateReconciliation?.legacyTemplates.length
+            ) && (
               <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
-                <div className="font-medium">Template reconciliation required</div>
+                <div className="font-medium">
+                  Template reconciliation required
+                </div>
                 <div>
-                  {designTemplateReconciliation?.conflicts.length ?? 0} canonical mapping conflict(s) and{' '}
-                  {designTemplateReconciliation?.legacyTemplates.length ?? 0} legacy configurable template(s) were left intact.
-                  No record was automatically overwritten or relinked.
+                  {designTemplateReconciliation?.conflicts.length ?? 0}{' '}
+                  canonical mapping conflict(s) and{' '}
+                  {designTemplateReconciliation?.legacyTemplates.length ?? 0}{' '}
+                  legacy configurable template(s) were left intact. No record
+                  was automatically overwritten or relinked.
                 </div>
               </div>
             )}
             {areDesignTemplatesLoading ? (
-              <div className="py-6 text-center text-muted-foreground">Loading Design Control templates…</div>
+              <div className="py-6 text-center text-muted-foreground">
+                Loading Design Control templates…
+              </div>
             ) : designControlTemplates.length === 0 ? (
               <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
-                No canonical Design Control templates are registered. An authorized document controller can run the idempotent seed operation.
+                No canonical Design Control templates are registered. An
+                authorized document controller can run the idempotent seed
+                operation.
               </div>
             ) : (
               <div className="overflow-x-auto">
@@ -1052,65 +1249,188 @@ export default function MasterDocumentRegister() {
                   </TableHeader>
                   <TableBody>
                     {designControlTemplates.map((template) => {
-                      const revision = template.revisions[template.revisions.length - 1];
+                      const revision =
+                        template.revisions[template.revisions.length - 1];
                       const mapping = template.workflowStepKey
                         ? `Design Control step ${template.workflowStepKey}`
                         : template.changeRecordType;
                       return (
                         <TableRow key={template.id}>
                           <TableCell>
-                            <div className="font-medium">{template.document?.documentName ?? template.templateKey}</div>
-                            <div className="font-mono text-xs text-muted-foreground">{template.templateKey}</div>
-                            <Badge variant="outline" className="mt-1">{mapping}</Badge>
+                            <div className="font-medium">
+                              {template.document?.documentName ??
+                                template.templateKey}
+                            </div>
+                            <div className="font-mono text-xs text-muted-foreground">
+                              {template.templateKey}
+                            </div>
+                            <Badge variant="outline" className="mt-1">
+                              {mapping}
+                            </Badge>
                           </TableCell>
                           <TableCell>
-                            <div className="font-medium">{template.document?.documentNumber ?? 'Missing mapping'}</div>
-                            <div className="text-xs text-muted-foreground">{template.document?.id}</div>
+                            <div className="font-medium">
+                              {template.document?.documentNumber ??
+                                'Missing mapping'}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {template.document?.id}
+                            </div>
                             {template.reconciliationStatus !== 'READY' && (
-                              <Badge variant="destructive">Reconciliation required</Badge>
+                              <Badge variant="destructive">
+                                Reconciliation required
+                              </Badge>
                             )}
                           </TableCell>
                           <TableCell>
                             {revision ? (
                               <>
-                                <div>Document revision {revision.documentRevisionSnapshot}</div>
-                                <div className="font-mono text-xs text-muted-foreground">{revision.id}</div>
+                                <div>
+                                  Document revision{' '}
+                                  {revision.documentRevisionSnapshot}
+                                </div>
+                                <div className="font-mono text-xs text-muted-foreground">
+                                  {revision.id}
+                                </div>
                               </>
-                            ) : <Badge variant="destructive">Missing revision mapping</Badge>}
+                            ) : (
+                              <Badge variant="destructive">
+                                Missing revision mapping
+                              </Badge>
+                            )}
                           </TableCell>
                           <TableCell className="text-xs">
-                            <div className="font-mono">Definition: {revision?.definitionChecksum.slice(0, 12) ?? '—'}…</div>
-                            <div className="font-mono">Blank PDF: {revision?.blankPdfChecksum?.slice(0, 12) ?? 'not retained'}{revision?.blankPdfChecksum ? '…' : ''}</div>
+                            <div className="font-mono">
+                              Definition:{' '}
+                              {revision?.definitionChecksum.slice(0, 12) ?? '—'}
+                              …
+                            </div>
+                            <div className="font-mono">
+                              Blank PDF:{' '}
+                              {revision?.blankPdfChecksum?.slice(0, 12) ??
+                                'not retained'}
+                              {revision?.blankPdfChecksum ? '…' : ''}
+                            </div>
                           </TableCell>
                           <TableCell>
-                            <Badge variant={revision?.lifecycleStatus === 'RELEASED' ? 'default' : 'outline'}>
+                            <Badge
+                              variant={
+                                revision?.lifecycleStatus === 'RELEASED'
+                                  ? 'default'
+                                  : 'outline'
+                              }
+                            >
                               {revision?.lifecycleStatus ?? 'UNMAPPED'}
                             </Badge>
                           </TableCell>
                           <TableCell>
                             {revision && (
                               <div className="flex flex-wrap gap-2">
-                                <Button size="sm" variant="outline" onClick={() => window.open(`/api/design-control-form-templates/${template.templateKey}/revisions/${revision.id}/preview`, '_blank')}>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    window.open(
+                                      `/api/design-control-form-templates/${template.templateKey}/revisions/${revision.id}/preview`,
+                                      '_blank'
+                                    )
+                                  }
+                                >
                                   <Eye className="h-4 w-4 mr-1" /> Preview
                                 </Button>
-                                <Button size="sm" variant="outline" onClick={() => window.open(`/api/design-control-form-templates/${template.templateKey}/revisions/${revision.id}/download`, '_blank')}>
-                                  <Printer className="h-4 w-4 mr-1" /> Download / Print
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    window.open(
+                                      `/api/design-control-form-templates/${template.templateKey}/revisions/${revision.id}/download`,
+                                      '_blank'
+                                    )
+                                  }
+                                >
+                                  <Printer className="h-4 w-4 mr-1" /> Download
+                                  / Print
                                 </Button>
-                                {can('documents.template.revise') && !['OBSOLETE'].includes(revision.lifecycleStatus) && (
-                                  <Button size="sm" variant="outline" onClick={() => createDesignTemplateRevision(template, revision)}>Create Revision</Button>
-                                )}
-                                {can('documents.submit') && revision.lifecycleStatus === 'DRAFT' && (
-                                  <Button size="sm" onClick={() => runDesignTemplateAction(template, revision, 'submit')}>Submit</Button>
-                                )}
-                                {can('documents.template.release') && revision.lifecycleStatus === 'IN_REVIEW' && (
-                                  <Button size="sm" onClick={() => runDesignTemplateAction(template, revision, 'decision')}>Approve</Button>
-                                )}
-                                {can('documents.template.release') && revision.lifecycleStatus === 'APPROVED' && (
-                                  <Button size="sm" onClick={() => runDesignTemplateAction(template, revision, 'release')}>Release</Button>
-                                )}
-                                {can('documents.template.obsolete') && ['RELEASED', 'SUPERSEDED'].includes(revision.lifecycleStatus) && (
-                                  <Button size="sm" variant="destructive" onClick={() => runDesignTemplateAction(template, revision, 'obsolete')}>Obsolete</Button>
-                                )}
+                                {can('documents.template.revise') &&
+                                  !['OBSOLETE'].includes(
+                                    revision.lifecycleStatus
+                                  ) && (
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      onClick={() =>
+                                        createDesignTemplateRevision(
+                                          template,
+                                          revision
+                                        )
+                                      }
+                                    >
+                                      Create Revision
+                                    </Button>
+                                  )}
+                                {can('documents.submit') &&
+                                  revision.lifecycleStatus === 'DRAFT' && (
+                                    <Button
+                                      size="sm"
+                                      onClick={() =>
+                                        runDesignTemplateAction(
+                                          template,
+                                          revision,
+                                          'submit'
+                                        )
+                                      }
+                                    >
+                                      Submit
+                                    </Button>
+                                  )}
+                                {can('documents.template.release') &&
+                                  revision.lifecycleStatus === 'IN_REVIEW' && (
+                                    <Button
+                                      size="sm"
+                                      onClick={() =>
+                                        runDesignTemplateAction(
+                                          template,
+                                          revision,
+                                          'decision'
+                                        )
+                                      }
+                                    >
+                                      Approve
+                                    </Button>
+                                  )}
+                                {can('documents.template.release') &&
+                                  revision.lifecycleStatus === 'APPROVED' && (
+                                    <Button
+                                      size="sm"
+                                      onClick={() =>
+                                        runDesignTemplateAction(
+                                          template,
+                                          revision,
+                                          'release'
+                                        )
+                                      }
+                                    >
+                                      Release
+                                    </Button>
+                                  )}
+                                {can('documents.template.obsolete') &&
+                                  ['RELEASED', 'SUPERSEDED'].includes(
+                                    revision.lifecycleStatus
+                                  ) && (
+                                    <Button
+                                      size="sm"
+                                      variant="destructive"
+                                      onClick={() =>
+                                        runDesignTemplateAction(
+                                          template,
+                                          revision,
+                                          'obsolete'
+                                        )
+                                      }
+                                    >
+                                      Obsolete
+                                    </Button>
+                                  )}
                               </div>
                             )}
                           </TableCell>
@@ -1133,7 +1453,9 @@ export default function MasterDocumentRegister() {
           </CardHeader>
           <CardContent>
             {isLoading ? (
-              <div className="text-center py-8 text-gray-500">Loading documents...</div>
+              <div className="text-center py-8 text-gray-500">
+                Loading documents...
+              </div>
             ) : filteredDocuments.length === 0 ? (
               <div className="text-center py-8 text-gray-500">
                 No documents found matching your criteria
@@ -1162,10 +1484,14 @@ export default function MasterDocumentRegister() {
                         className={isExpired(doc) ? 'bg-red-50' : ''}
                         data-testid={`row-document-${doc.id}`}
                       >
-                        <TableCell className="font-medium">{doc.documentNumber}</TableCell>
+                        <TableCell className="font-medium">
+                          {doc.documentNumber}
+                        </TableCell>
                         <TableCell>
                           <div>
-                            <div className="font-medium">{doc.documentName}</div>
+                            <div className="font-medium">
+                              {doc.documentName}
+                            </div>
                             {doc.description && (
                               <div className="text-xs text-gray-500 truncate max-w-xs">
                                 {doc.description}
@@ -1175,19 +1501,38 @@ export default function MasterDocumentRegister() {
                         </TableCell>
                         <TableCell>{doc.documentType}</TableCell>
                         <TableCell>{doc.department}</TableCell>
-                        <TableCell className="font-mono text-sm">{formatVersionDisplay(doc)}</TableCell>
+                        <TableCell className="font-mono text-sm">
+                          {formatVersionDisplay(doc)}
+                        </TableCell>
                         <TableCell className="text-xs">
-                          <div>Released: {(doc as any).currentReleasedRevisionId ? doc.currentVersion : 'None'}</div>
-                          <div>Working draft: {(doc as any).workingDraftRevisionId ? doc.currentVersion : 'None'}</div>
-                          {(doc as any).numberControlStatus === 'NUMBER_RECONCILIATION_REQUIRED' && (
-                            <Badge variant="destructive" className="mt-1">Number conflict</Badge>
+                          <div>
+                            Released:{' '}
+                            {(doc as any).currentReleasedRevisionId
+                              ? doc.currentVersion
+                              : 'None'}
+                          </div>
+                          <div>
+                            Working draft:{' '}
+                            {(doc as any).workingDraftRevisionId
+                              ? doc.currentVersion
+                              : 'None'}
+                          </div>
+                          {(doc as any).numberControlStatus ===
+                            'NUMBER_RECONCILIATION_REQUIRED' && (
+                            <Badge variant="destructive" className="mt-1">
+                              Number conflict
+                            </Badge>
                           )}
                         </TableCell>
                         <TableCell>
                           {getStatusBadge(doc)}
                           {(doc as any).lifecycleStatus &&
-                            String((doc as any).lifecycleStatus).toLowerCase() !== doc.status?.toLowerCase() && (
-                              <div className="mt-1 text-xs text-muted-foreground">Legacy: {doc.status}</div>
+                            String(
+                              (doc as any).lifecycleStatus
+                            ).toLowerCase() !== doc.status?.toLowerCase() && (
+                              <div className="mt-1 text-xs text-muted-foreground">
+                                Legacy: {doc.status}
+                              </div>
                             )}
                         </TableCell>
                         <TableCell>{formatDate(doc.effectiveDate)}</TableCell>
@@ -1205,7 +1550,9 @@ export default function MasterDocumentRegister() {
                           <div className="flex items-center gap-2">
                             {doc.filePath && (
                               <>
-                                <span className="text-xs text-muted-foreground">{getFileTypeLabel(doc.filePath)}</span>
+                                <span className="text-xs text-muted-foreground">
+                                  {getFileTypeLabel(doc.filePath)}
+                                </span>
                                 {isPdfDocument(doc) && (
                                   <Badge
                                     variant="outline"
@@ -1214,16 +1561,23 @@ export default function MasterDocumentRegister() {
                                     className="h-8 cursor-pointer gap-1 border-blue-300 px-2 text-blue-700 hover:bg-blue-50"
                                     title="View PDF"
                                     data-testid={`badge-view-pdf-${doc.id}`}
-                                    onClick={() => openDocumentFile(doc, 'view')}
+                                    onClick={() =>
+                                      openDocumentFile(doc, 'view')
+                                    }
                                     onKeyDown={(event) => {
-                                      if (event.key === 'Enter' || event.key === ' ') {
+                                      if (
+                                        event.key === 'Enter' ||
+                                        event.key === ' '
+                                      ) {
                                         event.preventDefault();
                                         openDocumentFile(doc, 'view');
                                       }
                                     }}
                                   >
                                     <Eye className="h-3.5 w-3.5" />
-                                    {openingDocumentId === doc.id ? 'Opening' : 'View'}
+                                    {openingDocumentId === doc.id
+                                      ? 'Opening'
+                                      : 'View'}
                                   </Badge>
                                 )}
                                 <Button
@@ -1232,7 +1586,9 @@ export default function MasterDocumentRegister() {
                                   className="h-8 w-8 p-0"
                                   title="Download Original"
                                   disabled={openingDocumentId === doc.id}
-                                  onClick={() => openDocumentFile(doc, 'download')}
+                                  onClick={() =>
+                                    openDocumentFile(doc, 'download')
+                                  }
                                   data-testid={`button-download-${doc.id}`}
                                 >
                                   <Download className="h-4 w-4" />
@@ -1249,64 +1605,142 @@ export default function MasterDocumentRegister() {
                             >
                               <History className="h-4 w-4" />
                             </Button>
-                            {!isDesignControlTemplate(doc) && can('documents.edit_draft') && (doc as any).lifecycleStatus === 'DRAFT' && (
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                className="h-8 w-8 p-0"
-                                title="Edit"
-                                onClick={() => openEditDialog(doc)}
-                                data-testid={`button-edit-${doc.id}`}
-                              >
-                                <Edit className="h-4 w-4" />
-                              </Button>
-                            )}
-                            {!isDesignControlTemplate(doc) && can('documents.revise') && !['OBSOLETE', 'VOID'].includes((doc as any).lifecycleStatus) && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => {
-                                  setSelectedDocument(doc);
-                                  setCreateNewVersion(true);
-                                  setSelectedFile(null);
-                                  setIsEditDialogOpen(true);
-                                }}
-                              >
-                                Create Revision
-                              </Button>
-                            )}
-                            {/* eslint-disable prettier/prettier */}
-                            {!phase2Enabled && !isDesignControlTemplate(doc) && can('documents.submit') && doc.lifecycleStatus === 'DRAFT' && (
-                              <Button size="sm" variant="outline" onClick={() => lifecycleMutation.mutate({ doc, action: 'submit' })}>
-                                Submit
-                              </Button>
-                            )}
-                            {!isDesignControlTemplate(doc) && canApprove && ((phase2Enabled && doc.lifecycleStatus === 'DRAFT') || (!phase2Enabled && doc.lifecycleStatus === 'IN_REVIEW')) && (
-                              <Button
-                                size="sm"
-                                variant="default"
-                                className="bg-green-600 hover:bg-green-700"
-                                title="Approve"
-                                onClick={() => openApproveDialog(doc)}
-                                data-testid={`button-approve-${doc.id}`}
-                              >
-                                <CheckCircle className="h-4 w-4 mr-1" />
-                                Approve
-                              </Button>
-                            )}
-                            {phase2Enabled && !isDesignControlTemplate(doc) && canApprove && doc.lifecycleStatus === 'DRAFT' && (
-                              <Button size="sm" variant="outline" onClick={() => lifecycleMutation.mutate({ doc, action: 'reject' })}>Reject</Button>
-                            )}
-                            {!phase2Enabled && !isDesignControlTemplate(doc) && can('documents.release') && doc.lifecycleStatus === 'APPROVED' && (
-                              <Button size="sm" onClick={() => lifecycleMutation.mutate({ doc, action: 'release' })}>Release</Button>
-                            )}
-                            {/* eslint-enable prettier/prettier */}
-                            {!isDesignControlTemplate(doc) && can('documents.obsolete') && ((doc as any).lifecycleStatus === 'RELEASED' || (doc as any).lifecycleStatus === 'SUPERSEDED') && (
-                              <Button size="sm" variant="destructive" onClick={() => lifecycleMutation.mutate({ doc, action: 'obsolete' })}>Obsolete</Button>
-                            )}
-                            {!isDesignControlTemplate(doc) && can('documents.void') && ['DRAFT', 'IN_REVIEW'].includes((doc as any).lifecycleStatus) && (
-                              <Button size="sm" variant="ghost" onClick={() => lifecycleMutation.mutate({ doc, action: 'void' })}>Void</Button>
-                            )}
+                            {!isDesignControlTemplate(doc) &&
+                              can('documents.edit_draft') &&
+                              (doc as any).lifecycleStatus === 'DRAFT' && (
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  className="h-8 w-8 p-0"
+                                  title="Edit"
+                                  onClick={() => openEditDialog(doc)}
+                                  data-testid={`button-edit-${doc.id}`}
+                                >
+                                  <Edit className="h-4 w-4" />
+                                </Button>
+                              )}
+                            {!isDesignControlTemplate(doc) &&
+                              can('documents.revise') &&
+                              !['OBSOLETE', 'VOID'].includes(
+                                (doc as any).lifecycleStatus
+                              ) && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => {
+                                    setSelectedDocument(doc);
+                                    setCreateNewVersion(true);
+                                    setSelectedFile(null);
+                                    setIsEditDialogOpen(true);
+                                  }}
+                                >
+                                  Create Revision
+                                </Button>
+                              )}
+                            {!phase2Enabled &&
+                              !isDesignControlTemplate(doc) &&
+                              can('documents.submit') &&
+                              doc.lifecycleStatus === 'DRAFT' && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    lifecycleMutation.mutate({
+                                      doc,
+                                      action: 'submit',
+                                    })
+                                  }
+                                >
+                                  Submit
+                                </Button>
+                              )}
+                            {!isDesignControlTemplate(doc) &&
+                              canApprove &&
+                              ((phase2Enabled &&
+                                doc.lifecycleStatus === 'DRAFT') ||
+                                (!phase2Enabled &&
+                                  doc.lifecycleStatus === 'IN_REVIEW')) && (
+                                <Button
+                                  size="sm"
+                                  variant="default"
+                                  className="bg-green-600 hover:bg-green-700"
+                                  title="Approve"
+                                  onClick={() => openApproveDialog(doc)}
+                                  data-testid={`button-approve-${doc.id}`}
+                                >
+                                  <CheckCircle className="h-4 w-4 mr-1" />
+                                  Approve
+                                </Button>
+                              )}
+                            {phase2Enabled &&
+                              !isDesignControlTemplate(doc) &&
+                              canApprove &&
+                              doc.lifecycleStatus === 'DRAFT' && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    lifecycleMutation.mutate({
+                                      doc,
+                                      action: 'reject',
+                                    })
+                                  }
+                                >
+                                  Reject
+                                </Button>
+                              )}
+                            {!phase2Enabled &&
+                              !isDesignControlTemplate(doc) &&
+                              can('documents.release') &&
+                              doc.lifecycleStatus === 'APPROVED' && (
+                                <Button
+                                  size="sm"
+                                  onClick={() =>
+                                    lifecycleMutation.mutate({
+                                      doc,
+                                      action: 'release',
+                                    })
+                                  }
+                                >
+                                  Release
+                                </Button>
+                              )}
+                            {!isDesignControlTemplate(doc) &&
+                              can('documents.obsolete') &&
+                              ((doc as any).lifecycleStatus === 'RELEASED' ||
+                                (doc as any).lifecycleStatus ===
+                                  'SUPERSEDED') && (
+                                <Button
+                                  size="sm"
+                                  variant="destructive"
+                                  onClick={() =>
+                                    lifecycleMutation.mutate({
+                                      doc,
+                                      action: 'obsolete',
+                                    })
+                                  }
+                                >
+                                  Obsolete
+                                </Button>
+                              )}
+                            {!isDesignControlTemplate(doc) &&
+                              can('documents.void') &&
+                              ['DRAFT', 'IN_REVIEW'].includes(
+                                (doc as any).lifecycleStatus
+                              ) && (
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={() =>
+                                    lifecycleMutation.mutate({
+                                      doc,
+                                      action: 'void',
+                                    })
+                                  }
+                                >
+                                  Void
+                                </Button>
+                              )}
                           </div>
                         </TableCell>
                       </TableRow>
@@ -1360,7 +1794,12 @@ export default function MasterDocumentRegister() {
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="documentType">Document Type *</Label>
-                <Select name="documentType" value={newDocumentType} onValueChange={setNewDocumentType} required>
+                <Select
+                  name="documentType"
+                  value={newDocumentType}
+                  onValueChange={setNewDocumentType}
+                  required
+                >
                   <SelectTrigger data-testid="select-document-type">
                     <SelectValue placeholder="Select type" />
                   </SelectTrigger>
@@ -1376,7 +1815,12 @@ export default function MasterDocumentRegister() {
 
               <div className="space-y-2">
                 <Label htmlFor="department">Department *</Label>
-                <Select name="department" value={newDocumentDepartment} onValueChange={setNewDocumentDepartment} required>
+                <Select
+                  name="department"
+                  value={newDocumentDepartment}
+                  onValueChange={setNewDocumentDepartment}
+                  required
+                >
                   <SelectTrigger data-testid="select-department">
                     <SelectValue placeholder="Select department" />
                   </SelectTrigger>
@@ -1511,7 +1955,9 @@ export default function MasterDocumentRegister() {
                 disabled={createDocumentMutation.isPending}
                 data-testid="button-submit-create"
               >
-                {createDocumentMutation.isPending ? 'Creating...' : 'Create Document'}
+                {createDocumentMutation.isPending
+                  ? 'Creating...'
+                  : 'Create Document'}
               </Button>
             </DialogFooter>
           </form>
@@ -1543,27 +1989,35 @@ export default function MasterDocumentRegister() {
                 <CardContent className="space-y-3">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm font-medium">Current Version: {selectedDocument.currentVersion}</p>
+                      <p className="text-sm font-medium">
+                        Current Version: {selectedDocument.currentVersion}
+                      </p>
                       <p className="text-xs text-gray-600">
                         {createNewVersion
                           ? `Next revision: ${nextRevisionVersion(selectedDocument.currentVersion)}`
                           : 'Updating current version'}
                       </p>
                     </div>
-                    <Badge variant="outline">{createNewVersion ? 'Create Revision' : 'Metadata Only'}</Badge>
+                    <Badge variant="outline">
+                      {createNewVersion ? 'Create Revision' : 'Metadata Only'}
+                    </Badge>
                   </div>
 
                   {createNewVersion && (
                     <div className="space-y-3 border-t pt-3">
                       <div className="rounded-md border border-blue-200 bg-white p-3">
-                        <div className="text-xs font-medium uppercase text-gray-500">Next Version</div>
+                        <div className="text-xs font-medium uppercase text-gray-500">
+                          Next Version
+                        </div>
                         <div className="font-mono text-lg">
                           {nextRevisionVersion(selectedDocument.currentVersion)}
                         </div>
                       </div>
 
                       <div className="space-y-2">
-                        <Label htmlFor="changeDescription">Change Description *</Label>
+                        <Label htmlFor="changeDescription">
+                          Change Description *
+                        </Label>
                         <Textarea
                           id="changeDescription"
                           name="changeDescription"
@@ -1607,7 +2061,11 @@ export default function MasterDocumentRegister() {
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="edit-documentType">Document Type *</Label>
-                  <Select name="documentType" defaultValue={selectedDocument.documentType} required>
+                  <Select
+                    name="documentType"
+                    defaultValue={selectedDocument.documentType}
+                    required
+                  >
                     <SelectTrigger data-testid="select-edit-document-type">
                       <SelectValue />
                     </SelectTrigger>
@@ -1623,7 +2081,11 @@ export default function MasterDocumentRegister() {
 
                 <div className="space-y-2">
                   <Label htmlFor="edit-department">Department *</Label>
-                  <Select name="department" defaultValue={selectedDocument.department} required>
+                  <Select
+                    name="department"
+                    defaultValue={selectedDocument.department}
+                    required
+                  >
                     <SelectTrigger data-testid="select-edit-department">
                       <SelectValue />
                     </SelectTrigger>
@@ -1666,7 +2128,9 @@ export default function MasterDocumentRegister() {
                     id="edit-originationDate"
                     name="originationDate"
                     type="date"
-                    defaultValue={(selectedDocument as any).originationDate || ''}
+                    defaultValue={
+                      (selectedDocument as any).originationDate || ''
+                    }
                     data-testid="input-edit-origination-date"
                   />
                 </div>
@@ -1689,7 +2153,9 @@ export default function MasterDocumentRegister() {
                   <Input
                     id="edit-retentionLength"
                     name="retentionLength"
-                    defaultValue={selectedDocument.retentionLength || '10 years'}
+                    defaultValue={
+                      selectedDocument.retentionLength || '10 years'
+                    }
                     data-testid="input-edit-retention-length"
                   />
                 </div>
@@ -1705,31 +2171,33 @@ export default function MasterDocumentRegister() {
                 </div>
               </div>
 
-              {createNewVersion && <div className="space-y-2">
-                <Label htmlFor="edit-file">
-                  New revision file *
-                </Label>
-                <div className="flex items-center gap-2">
-                  <Input
-                    id="edit-file"
-                    type="file"
-                    accept=".pdf,.doc,.docx,.xls,.xlsx"
-                    onChange={(e) => setSelectedFile(e.target.files?.[0] || null)}
-                    data-testid="input-edit-file-upload"
-                  />
-                  {selectedFile && (
-                    <div className="text-sm text-green-600 flex items-center gap-1">
-                      <Upload className="h-4 w-4" />
-                      {selectedFile.name}
-                    </div>
+              {createNewVersion && (
+                <div className="space-y-2">
+                  <Label htmlFor="edit-file">New revision file *</Label>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      id="edit-file"
+                      type="file"
+                      accept=".pdf,.doc,.docx,.xls,.xlsx"
+                      onChange={(e) =>
+                        setSelectedFile(e.target.files?.[0] || null)
+                      }
+                      data-testid="input-edit-file-upload"
+                    />
+                    {selectedFile && (
+                      <div className="text-sm text-green-600 flex items-center gap-1">
+                        <Upload className="h-4 w-4" />
+                        {selectedFile.name}
+                      </div>
+                    )}
+                  </div>
+                  {selectedDocument.filePath && (
+                    <p className="text-xs text-gray-500">
+                      Current file: {selectedDocument.filePath.split('/').pop()}
+                    </p>
                   )}
                 </div>
-                {selectedDocument.filePath && (
-                  <p className="text-xs text-gray-500">
-                    Current file: {selectedDocument.filePath.split('/').pop()}
-                  </p>
-                )}
-              </div>}
+              )}
 
               <DialogFooter>
                 <Button
@@ -1750,7 +2218,9 @@ export default function MasterDocumentRegister() {
                   disabled={updateDocumentMutation.isPending}
                   data-testid="button-submit-edit"
                 >
-                  {updateDocumentMutation.isPending ? 'Saving...' : 'Save Changes'}
+                  {updateDocumentMutation.isPending
+                    ? 'Saving...'
+                    : 'Save Changes'}
                 </Button>
               </DialogFooter>
             </form>
@@ -1764,8 +2234,9 @@ export default function MasterDocumentRegister() {
           <DialogHeader>
             <DialogTitle>Approve Controlled Document</DialogTitle>
             <DialogDescription>
-              {/* eslint-disable-next-line prettier/prettier */}
-              {phase2Enabled ? 'Approve and automatically release the exact immutable current revision in one transaction.' : 'Record an authenticated approval for the exact current revision and checksum. Release is a separate action.'}
+              {phase2Enabled
+                ? 'Approve and automatically release the exact immutable current revision in one transaction.'
+                : 'Record an authenticated approval for the exact current revision and checksum. Release is a separate action.'}
             </DialogDescription>
           </DialogHeader>
 
@@ -1774,7 +2245,9 @@ export default function MasterDocumentRegister() {
               {/* Document Summary */}
               <Card className="bg-green-50 border-green-200">
                 <CardHeader className="py-3">
-                  <CardTitle className="text-sm font-medium">Document Summary</CardTitle>
+                  <CardTitle className="text-sm font-medium">
+                    Document Summary
+                  </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2">
                   <div className="grid grid-cols-2 gap-2 text-sm">
@@ -1783,7 +2256,9 @@ export default function MasterDocumentRegister() {
                     <div className="font-medium">Document Name:</div>
                     <div>{selectedDocument.documentName}</div>
                     <div className="font-medium">Version:</div>
-                    <div className="font-mono">{selectedDocument.currentVersion}</div>
+                    <div className="font-mono">
+                      {selectedDocument.currentVersion}
+                    </div>
                     <div className="font-medium">Type:</div>
                     <div>{selectedDocument.documentType}</div>
                     <div className="font-medium">Department:</div>
@@ -1803,8 +2278,9 @@ export default function MasterDocumentRegister() {
                   data-testid="input-effective-date"
                 />
                 <p className="text-xs text-gray-500">
-                  {/* eslint-disable-next-line prettier/prettier */}
-                  {phase2Enabled ? 'This becomes the effective date of the exact released revision.' : 'This date is included in the approval comment only. The release action controls the effective revision.'}
+                  {phase2Enabled
+                    ? 'This becomes the effective date of the exact released revision.'
+                    : 'This date is included in the approval comment only. The release action controls the effective revision.'}
                 </p>
               </div>
 
@@ -1826,8 +2302,11 @@ export default function MasterDocumentRegister() {
                   className="bg-green-600 hover:bg-green-700"
                   data-testid="button-submit-approve"
                 >
-                  {/* eslint-disable-next-line prettier/prettier */}
-                  {approveDocumentMutation.isPending ? 'Approving...' : (phase2Enabled ? 'Approve and Release' : 'Approve Document')}
+                  {approveDocumentMutation.isPending
+                    ? 'Approving...'
+                    : phase2Enabled
+                      ? 'Approve and Release'
+                      : 'Approve Document'}
                 </Button>
               </DialogFooter>
             </form>
@@ -1848,9 +2327,13 @@ export default function MasterDocumentRegister() {
           </DialogHeader>
 
           {isHistoryLoading ? (
-            <div className="py-8 text-center text-sm text-gray-500">Loading version history...</div>
+            <div className="py-8 text-center text-sm text-gray-500">
+              Loading version history...
+            </div>
           ) : versionHistory.length === 0 ? (
-            <div className="py-8 text-center text-sm text-gray-500">No revision history has been recorded.</div>
+            <div className="py-8 text-center text-sm text-gray-500">
+              No revision history has been recorded.
+            </div>
           ) : (
             <div className="max-h-[60vh] overflow-y-auto">
               <Table>
@@ -1868,31 +2351,41 @@ export default function MasterDocumentRegister() {
                 <TableBody>
                   {versionHistory.map((version) => (
                     <TableRow key={version.id}>
-                      <TableCell className="font-mono">{version.versionNumber}</TableCell>
+                      <TableCell className="font-mono">
+                        {version.versionNumber}
+                      </TableCell>
                       <TableCell className="max-w-sm whitespace-pre-wrap text-sm">
                         {version.changeDescription || 'No change note recorded'}
                       </TableCell>
-                      <TableCell>{(version as any).lifecycleStatus || version.status}</TableCell>
+                      <TableCell>
+                        {(version as any).lifecycleStatus || version.status}
+                      </TableCell>
                       <TableCell className="font-mono text-xs">
                         {(version as any).fileChecksum
                           ? String((version as any).fileChecksum).slice(0, 12)
                           : (version as any).checksumStatus || 'Legacy unknown'}
                       </TableCell>
                       <TableCell>
-                        <div className="text-sm">{formatDate(version.createdAt as any)}</div>
-                        <div className="text-xs text-gray-500">{version.createdBy}</div>
+                        <div className="text-sm">
+                          {formatDate(version.createdAt as any)}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {version.createdBy}
+                        </div>
                       </TableCell>
                       <TableCell>
                         {(version as any).filePath && selectedDocument && (
                           <Button
                             size="sm"
                             variant="outline"
-                            onClick={() => openDocumentFile(
-                              selectedDocument,
-                              'download',
-                              null,
-                              `/api/controlled-documents/${selectedDocument.id}/revisions/${version.id}/download`,
-                            )}
+                            onClick={() =>
+                              openDocumentFile(
+                                selectedDocument,
+                                'download',
+                                null,
+                                `/api/controlled-documents/${selectedDocument.id}/revisions/${version.id}/download`
+                              )
+                            }
                           >
                             Download Exact Revision
                           </Button>
@@ -1901,11 +2394,17 @@ export default function MasterDocumentRegister() {
                       <TableCell>
                         {version.approvedAt ? (
                           <>
-                            <div className="text-sm">{formatDate(version.approvedAt as any)}</div>
-                            <div className="text-xs text-gray-500">{version.approvedBy}</div>
+                            <div className="text-sm">
+                              {formatDate(version.approvedAt as any)}
+                            </div>
+                            <div className="text-xs text-gray-500">
+                              {version.approvedBy}
+                            </div>
                           </>
                         ) : (
-                          <span className="text-sm text-gray-500">Not approved</span>
+                          <span className="text-sm text-gray-500">
+                            Not approved
+                          </span>
                         )}
                       </TableCell>
                     </TableRow>
@@ -1918,28 +2417,36 @@ export default function MasterDocumentRegister() {
       </Dialog>
 
       {/* Credential Verification Dialog */}
-      <Dialog open={isStepUpOpen} onOpenChange={(open) => {
-        setIsStepUpOpen(open);
-        if (!open) {
-          setPendingDocumentAccess(null);
-          setStepUpPassword('');
-          setStepUpError(null);
-        }
-      }}>
+      <Dialog
+        open={isStepUpOpen}
+        onOpenChange={(open) => {
+          setIsStepUpOpen(open);
+          if (!open) {
+            setPendingDocumentAccess(null);
+            setStepUpPassword('');
+            setStepUpError(null);
+          }
+        }}
+      >
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>Verify Credentials</DialogTitle>
             <DialogDescription>
-              Controlled document access requires recent credential verification.
+              Controlled document access requires recent credential
+              verification.
             </DialogDescription>
           </DialogHeader>
 
           <form onSubmit={handleStepUpSubmit} className="space-y-4">
             {pendingDocumentAccess && (
               <div className="rounded-md border bg-gray-50 p-3 text-sm">
-                <div className="font-medium">{pendingDocumentAccess.doc.documentName}</div>
+                <div className="font-medium">
+                  {pendingDocumentAccess.doc.documentName}
+                </div>
                 <div className="text-xs text-gray-500">
-                  {pendingDocumentAccess.mode === 'view' ? 'View PDF' : 'Download file'}
+                  {pendingDocumentAccess.mode === 'view'
+                    ? 'View PDF'
+                    : 'Download file'}
                 </div>
               </div>
             )}
@@ -1957,7 +2464,10 @@ export default function MasterDocumentRegister() {
                 data-testid="input-step-up-password"
               />
               {stepUpError && (
-                <p className="text-sm text-red-600" data-testid="text-step-up-error">
+                <p
+                  className="text-sm text-red-600"
+                  data-testid="text-step-up-error"
+                >
                   {stepUpError}
                 </p>
               )}
@@ -2007,14 +2517,18 @@ export default function MasterDocumentRegister() {
                 required
               />
               <p className="text-xs text-gray-500">
-                CSV should have columns: TITLE, CODE, Department, Version, Date, Record Retention Length, Summary of Changes.
-                Include Document Link, File URL, URL, Link, or File Path to attach document links.
+                CSV should have columns: TITLE, CODE, Department, Version, Date,
+                Record Retention Length, Summary of Changes. Include Document
+                Link, File URL, URL, Link, or File Path to attach document
+                links.
               </p>
             </div>
 
             <Card className="bg-blue-50 border-blue-200">
               <CardHeader className="py-3">
-                <CardTitle className="text-sm font-medium">Import Behavior</CardTitle>
+                <CardTitle className="text-sm font-medium">
+                  Import Behavior
+                </CardTitle>
               </CardHeader>
               <CardContent className="text-sm text-gray-700 space-y-1">
                 <p>• Documents with matching CODE will be updated</p>

--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -239,6 +239,10 @@ export default function MasterDocumentRegister() {
   const { data: session } = useQuery<{ username: string; role: string }>({
     queryKey: ['/api/auth/session'],
   });
+  /* eslint-disable prettier/prettier */
+  const { data: phase2Availability } = useQuery<{ enabled: boolean }>({ queryKey: ['/api/controlled-documents/phase2/availability'] });
+  const phase2Enabled = phase2Availability?.enabled === true;
+  /* eslint-enable prettier/prettier */
 
   const { data: versionHistory = [], isLoading: isHistoryLoading } = useQuery<DocumentVersionHistory[]>({
     queryKey: ['/api/controlled-documents', selectedDocument?.id, 'versions'],
@@ -400,7 +404,13 @@ export default function MasterDocumentRegister() {
       );
     }
 
-    switch ((doc as any).lifecycleStatus || doc.status?.toUpperCase()) {
+    /* eslint-disable prettier/prettier */
+    const lifecycle = doc.lifecycleStatus || doc.status?.toUpperCase();
+    if (phase2Enabled && lifecycle === 'DRAFT') return <Badge variant="outline" className="border-blue-500 text-blue-700">Registered — awaiting approval</Badge>;
+    if (phase2Enabled && lifecycle === 'REJECTED') return <Badge variant="destructive">Rejected — correction required</Badge>;
+    if (phase2Enabled && ['IN_REVIEW', 'APPROVED'].includes(lifecycle)) return <Badge variant="outline">Historical/legacy — retained</Badge>;
+    /* eslint-enable prettier/prettier */
+    switch (lifecycle) {
       case 'RELEASED':
         return <Badge className="bg-emerald-700">Released</Badge>;
       case 'SUPERSEDED':
@@ -741,15 +751,18 @@ export default function MasterDocumentRegister() {
   };
 
   // Approve document mutation
+  /* eslint-disable prettier/prettier */
   const approveDocumentMutation = useMutation({
     mutationFn: async ({ id, effectiveDate }: { id: string; effectiveDate: string }) => {
-      return await apiRequest(`/api/controlled-documents/${id}/decision`, {
+      return await apiRequest(`/api/controlled-documents/${id}/${phase2Enabled ? 'approve-and-release' : 'decision'}`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...(phase2Enabled ? { 'Idempotency-Key': crypto.randomUUID() } : {}) },
         body: JSON.stringify({
           revisionId: (selectedDocument as any)?.currentRevisionId,
           decision: 'APPROVED',
           comment: `Approved with effective date ${effectiveDate}`,
+          reason: `Approved and released with effective date ${effectiveDate}`,
+          effectiveDate,
         }),
       });
     },
@@ -759,7 +772,7 @@ export default function MasterDocumentRegister() {
       setSelectedDocument(null);
       toast({
         title: 'Success',
-        description: 'Document approved successfully',
+        description: phase2Enabled ? 'Document approved and released successfully' : 'Document approved successfully',
       });
     },
     onError: (error: any) => {
@@ -770,6 +783,7 @@ export default function MasterDocumentRegister() {
       });
     },
   });
+  /* eslint-enable prettier/prettier */
 
   const handleApproveDocument = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -782,8 +796,9 @@ export default function MasterDocumentRegister() {
     approveDocumentMutation.mutate({ id: selectedDocument.id, effectiveDate });
   };
 
+  /* eslint-disable prettier/prettier */
   const lifecycleMutation = useMutation({
-    mutationFn: async ({ doc, action }: { doc: ControlledDocument; action: 'submit' | 'release' | 'obsolete' | 'void' }) => {
+    mutationFn: async ({ doc, action }: { doc: ControlledDocument; action: 'submit' | 'release' | 'reject' | 'obsolete' | 'void' }) => {
       const reason = window.prompt(`Reason for ${action}`);
       if (!reason?.trim()) throw new Error('A transition reason is required');
       return apiRequest(`/api/controlled-documents/${doc.id}/${action}`, {
@@ -801,6 +816,7 @@ export default function MasterDocumentRegister() {
       variant: 'destructive',
     }),
   });
+  /* eslint-enable prettier/prettier */
 
   // CSV Import mutation
   const importCsvMutation = useMutation({
@@ -1259,12 +1275,13 @@ export default function MasterDocumentRegister() {
                                 Create Revision
                               </Button>
                             )}
-                            {!isDesignControlTemplate(doc) && can('documents.submit') && (doc as any).lifecycleStatus === 'DRAFT' && (
+                            {/* eslint-disable prettier/prettier */}
+                            {!phase2Enabled && !isDesignControlTemplate(doc) && can('documents.submit') && doc.lifecycleStatus === 'DRAFT' && (
                               <Button size="sm" variant="outline" onClick={() => lifecycleMutation.mutate({ doc, action: 'submit' })}>
                                 Submit
                               </Button>
                             )}
-                            {!isDesignControlTemplate(doc) && canApprove && (doc as any).lifecycleStatus === 'IN_REVIEW' && (
+                            {!isDesignControlTemplate(doc) && canApprove && ((phase2Enabled && doc.lifecycleStatus === 'DRAFT') || (!phase2Enabled && doc.lifecycleStatus === 'IN_REVIEW')) && (
                               <Button
                                 size="sm"
                                 variant="default"
@@ -1277,9 +1294,13 @@ export default function MasterDocumentRegister() {
                                 Approve
                               </Button>
                             )}
-                            {!isDesignControlTemplate(doc) && can('documents.release') && (doc as any).lifecycleStatus === 'APPROVED' && (
+                            {phase2Enabled && !isDesignControlTemplate(doc) && canApprove && doc.lifecycleStatus === 'DRAFT' && (
+                              <Button size="sm" variant="outline" onClick={() => lifecycleMutation.mutate({ doc, action: 'reject' })}>Reject</Button>
+                            )}
+                            {!phase2Enabled && !isDesignControlTemplate(doc) && can('documents.release') && doc.lifecycleStatus === 'APPROVED' && (
                               <Button size="sm" onClick={() => lifecycleMutation.mutate({ doc, action: 'release' })}>Release</Button>
                             )}
+                            {/* eslint-enable prettier/prettier */}
                             {!isDesignControlTemplate(doc) && can('documents.obsolete') && ((doc as any).lifecycleStatus === 'RELEASED' || (doc as any).lifecycleStatus === 'SUPERSEDED') && (
                               <Button size="sm" variant="destructive" onClick={() => lifecycleMutation.mutate({ doc, action: 'obsolete' })}>Obsolete</Button>
                             )}
@@ -1743,7 +1764,8 @@ export default function MasterDocumentRegister() {
           <DialogHeader>
             <DialogTitle>Approve Controlled Document</DialogTitle>
             <DialogDescription>
-              Record an authenticated approval for the exact current revision and checksum. Release is a separate action.
+              {/* eslint-disable-next-line prettier/prettier */}
+              {phase2Enabled ? 'Approve and automatically release the exact immutable current revision in one transaction.' : 'Record an authenticated approval for the exact current revision and checksum. Release is a separate action.'}
             </DialogDescription>
           </DialogHeader>
 
@@ -1781,7 +1803,8 @@ export default function MasterDocumentRegister() {
                   data-testid="input-effective-date"
                 />
                 <p className="text-xs text-gray-500">
-                  This date is included in the approval comment only. The release action controls the effective revision.
+                  {/* eslint-disable-next-line prettier/prettier */}
+                  {phase2Enabled ? 'This becomes the effective date of the exact released revision.' : 'This date is included in the approval comment only. The release action controls the effective revision.'}
                 </p>
               </div>
 
@@ -1803,7 +1826,8 @@ export default function MasterDocumentRegister() {
                   className="bg-green-600 hover:bg-green-700"
                   data-testid="button-submit-approve"
                 >
-                  {approveDocumentMutation.isPending ? 'Approving...' : 'Approve Document'}
+                  {/* eslint-disable-next-line prettier/prettier */}
+                  {approveDocumentMutation.isPending ? 'Approving...' : (phase2Enabled ? 'Approve and Release' : 'Approve Document')}
                 </Button>
               </DialogFooter>
             </form>

--- a/docs/controlled-document-phase2-rollout.md
+++ b/docs/controlled-document-phase2-rollout.md
@@ -1,0 +1,19 @@
+# Master Document Register Phase 2 rollout
+
+Phase 2 is prospective and default-disabled. Migration `0256_controlled_document_atomic_approval_release.sql` creates append-only approval/release evidence and permits the prospective `REJECTED` revision state; it does not update controlled documents or activate the workflow.
+
+## Activation authorization
+
+1. Apply and certify migration 0256 in a non-production PostgreSQL environment, including replay and rollback-on-failure checks.
+2. Assign `documents.approve` only to authorized independent approvers. Approval also requires a current step-up session; UI visibility is not authorization.
+3. Verify immutable managed-file storage, checksum validation, current-revision pointers, access grants, and allowed/denied access logging.
+4. Obtain Quality and system-owner approval before setting `CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED=true` in a prospective deployment.
+5. Confirm legacy reconciliation remains disabled (`CONTROLLED_DOCUMENT_RECONCILIATION_ENABLED` must not be `true`).
+
+## Containment and rollback
+
+Unset the Phase 2 flag to return to the pre-existing Submit/Approve/Release compatibility workflow. Do not delete evidence or reverse released records. The 0256 table and its append-only history remain in place. Database rollback is schema-only and is permitted only before Phase 2 evidence exists; after evidence exists, use a forward corrective migration.
+
+## Historical preservation
+
+No historical document, revision, lifecycle event, approval, identifier, link, timestamp, traveler, work order, or production reference is rewritten. Existing released revisions remain served through the hardened released-revision routes. Legacy ambiguity remains governed by the separately default-disabled Phase 1B reconciliation workflow.

--- a/migrations/0256_controlled_document_atomic_approval_release.sql
+++ b/migrations/0256_controlled_document_atomic_approval_release.sql
@@ -1,0 +1,51 @@
+-- Prospective Phase 2 evidence only. Applying migration 0256 does not activate Phase 2.
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS controlled_document_approval_release_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  controlled_document_id uuid NOT NULL REFERENCES controlled_documents(id) ON DELETE RESTRICT,
+  revision_id uuid NOT NULL REFERENCES document_version_history(id) ON DELETE RESTRICT,
+  approval_id uuid NOT NULL REFERENCES controlled_document_revision_approvals(id) ON DELETE RESTRICT,
+  idempotency_key text NOT NULL UNIQUE,
+  file_checksum text NOT NULL CHECK (file_checksum ~ '^[0-9a-f]{64}$'),
+  document_number_snapshot text NOT NULL,
+  revision_snapshot text NOT NULL,
+  actor_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  actor_snapshot jsonb NOT NULL,
+  authority_snapshot jsonb NOT NULL,
+  reason text NOT NULL CHECK (btrim(reason) <> ''),
+  before_lifecycle text NOT NULL,
+  after_lifecycle text NOT NULL CHECK (after_lifecycle = 'RELEASED'),
+  effective_date date NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT controlled_document_approval_release_revision_uidx UNIQUE (revision_id)
+);
+
+CREATE INDEX IF NOT EXISTS controlled_document_approval_release_document_idx
+  ON controlled_document_approval_release_events(controlled_document_id, created_at);
+
+CREATE OR REPLACE FUNCTION reject_controlled_document_approval_release_event_mutation()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'controlled document approval-release evidence is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS controlled_document_approval_release_events_append_only
+  ON controlled_document_approval_release_events;
+CREATE TRIGGER controlled_document_approval_release_events_append_only
+BEFORE UPDATE OR DELETE ON controlled_document_approval_release_events
+FOR EACH ROW EXECUTE FUNCTION reject_controlled_document_approval_release_event_mutation();
+
+-- Prospective state only. No existing row is updated.
+ALTER TABLE controlled_documents DROP CONSTRAINT IF EXISTS controlled_documents_lifecycle_check;
+ALTER TABLE controlled_documents ADD CONSTRAINT controlled_documents_lifecycle_check
+  CHECK (lifecycle_status IN ('DRAFT','IN_REVIEW','APPROVED','REJECTED','RELEASED','SUPERSEDED','OBSOLETE','VOID')) NOT VALID;
+ALTER TABLE controlled_documents VALIDATE CONSTRAINT controlled_documents_lifecycle_check;
+
+ALTER TABLE document_version_history DROP CONSTRAINT IF EXISTS document_version_history_lifecycle_check;
+ALTER TABLE document_version_history ADD CONSTRAINT document_version_history_lifecycle_check
+  CHECK (lifecycle_status IN ('DRAFT','IN_REVIEW','APPROVED','REJECTED','RELEASED','SUPERSEDED','OBSOLETE','VOID')) NOT VALID;
+ALTER TABLE document_version_history VALIDATE CONSTRAINT document_version_history_lifecycle_status_check;
+
+COMMIT;

--- a/migrations/0256_controlled_document_atomic_approval_release.sql
+++ b/migrations/0256_controlled_document_atomic_approval_release.sql
@@ -1,6 +1,24 @@
 -- Prospective Phase 2 evidence only. Applying migration 0256 does not activate Phase 2.
 BEGIN;
 
+-- Phase 2 records a rejected registered revision truthfully. Extend the
+-- prospective lifecycle vocabulary without rewriting any historical row.
+ALTER TABLE controlled_documents
+  DROP CONSTRAINT IF EXISTS controlled_documents_lifecycle_check;
+ALTER TABLE controlled_documents
+  ADD CONSTRAINT controlled_documents_lifecycle_check
+  CHECK (lifecycle_status IN (
+    'DRAFT','IN_REVIEW','APPROVED','REJECTED','RELEASED','SUPERSEDED','OBSOLETE','VOID'
+  ));
+
+ALTER TABLE document_version_history
+  DROP CONSTRAINT IF EXISTS document_version_history_lifecycle_check;
+ALTER TABLE document_version_history
+  ADD CONSTRAINT document_version_history_lifecycle_check
+  CHECK (lifecycle_status IN (
+    'DRAFT','IN_REVIEW','APPROVED','REJECTED','RELEASED','SUPERSEDED','OBSOLETE','VOID'
+  ));
+
 DO $$
 BEGIN
   IF to_regclass('public.controlled_document_approval_release_events') IS NOT NULL

--- a/migrations/0256_controlled_document_atomic_approval_release.sql
+++ b/migrations/0256_controlled_document_atomic_approval_release.sql
@@ -102,4 +102,26 @@ ALTER TABLE controlled_document_revision_approvals
 ALTER TABLE controlled_document_revision_approvals
   ADD COLUMN IF NOT EXISTS checksum_verification_status text;
 
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'controlled_document_revision_approvals'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%checksum_verification_status%'
+      AND pg_get_constraintdef(oid) ILIKE '%VERIFIED%'
+      AND pg_get_constraintdef(oid) ILIKE '%UNAVAILABLE%'
+      AND pg_get_constraintdef(oid) ILIKE '%MISMATCH%'
+  ) THEN
+    ALTER TABLE controlled_document_revision_approvals
+      ADD CONSTRAINT controlled_document_revision_approvals_checksum_status_check
+      CHECK (
+        checksum_verification_status IS NULL
+        OR checksum_verification_status IN ('VERIFIED', 'UNAVAILABLE', 'MISMATCH')
+      );
+  END IF;
+END;
+$$;
+
 COMMIT;

--- a/migrations/0256_controlled_document_atomic_approval_release.sql
+++ b/migrations/0256_controlled_document_atomic_approval_release.sql
@@ -1,12 +1,35 @@
 -- Prospective Phase 2 evidence only. Applying migration 0256 does not activate Phase 2.
 BEGIN;
 
+DO $$
+BEGIN
+  IF to_regclass('public.controlled_document_approval_release_events') IS NOT NULL
+     AND EXISTS (
+       SELECT required.name
+       FROM unnest(ARRAY[
+         'id','controlled_document_id','revision_id','approval_id','idempotency_key',
+         'request_identity_hash','file_checksum','document_number_snapshot','revision_snapshot',
+         'actor_user_id','actor_snapshot','authority_snapshot','reason','before_lifecycle',
+         'after_lifecycle','effective_date','created_at'
+       ]) required(name)
+       LEFT JOIN information_schema.columns actual
+         ON actual.table_schema = 'public'
+        AND actual.table_name = 'controlled_document_approval_release_events'
+        AND actual.column_name = required.name
+       WHERE actual.column_name IS NULL
+     ) THEN
+    RAISE EXCEPTION 'controlled_document_approval_release_events is partially applied or malformed';
+  END IF;
+END;
+$$;
+
 CREATE TABLE IF NOT EXISTS controlled_document_approval_release_events (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   controlled_document_id uuid NOT NULL REFERENCES controlled_documents(id) ON DELETE RESTRICT,
   revision_id uuid NOT NULL REFERENCES document_version_history(id) ON DELETE RESTRICT,
   approval_id uuid NOT NULL REFERENCES controlled_document_revision_approvals(id) ON DELETE RESTRICT,
   idempotency_key text NOT NULL UNIQUE,
+  request_identity_hash text NOT NULL CHECK (request_identity_hash ~ '^[0-9a-f]{64}$'),
   file_checksum text NOT NULL CHECK (file_checksum ~ '^[0-9a-f]{64}$'),
   document_number_snapshot text NOT NULL,
   revision_snapshot text NOT NULL,
@@ -20,6 +43,41 @@ CREATE TABLE IF NOT EXISTS controlled_document_approval_release_events (
   created_at timestamptz NOT NULL DEFAULT now(),
   CONSTRAINT controlled_document_approval_release_revision_uidx UNIQUE (revision_id)
 );
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'f' AND pg_get_constraintdef(oid) ILIKE '%FOREIGN KEY (controlled_document_id)%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_document_fk FOREIGN KEY (controlled_document_id) REFERENCES controlled_documents(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'f' AND pg_get_constraintdef(oid) ILIKE '%FOREIGN KEY (revision_id)%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_revision_fk FOREIGN KEY (revision_id) REFERENCES document_version_history(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'f' AND pg_get_constraintdef(oid) ILIKE '%FOREIGN KEY (approval_id)%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_approval_fk FOREIGN KEY (approval_id) REFERENCES controlled_document_revision_approvals(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'f' AND pg_get_constraintdef(oid) ILIKE '%FOREIGN KEY (actor_user_id)%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_actor_fk FOREIGN KEY (actor_user_id) REFERENCES users(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'u' AND pg_get_constraintdef(oid) ILIKE '%(idempotency_key)%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_idempotency_uidx UNIQUE (idempotency_key);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'u' AND pg_get_constraintdef(oid) ILIKE '%(revision_id)%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_revision_uidx UNIQUE (revision_id);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'c' AND pg_get_constraintdef(oid) ILIKE '%request_identity_hash%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_request_hash_check CHECK (request_identity_hash ~ '^[0-9a-f]{64}$');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'c' AND pg_get_constraintdef(oid) ILIKE '%file_checksum%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_checksum_check CHECK (file_checksum ~ '^[0-9a-f]{64}$');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'c' AND pg_get_constraintdef(oid) ILIKE '%btrim(reason)%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_reason_check CHECK (btrim(reason) <> '');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conrelid = 'controlled_document_approval_release_events'::regclass AND contype = 'c' AND pg_get_constraintdef(oid) ILIKE '%after_lifecycle%') THEN
+    ALTER TABLE controlled_document_approval_release_events ADD CONSTRAINT controlled_document_approval_release_lifecycle_check CHECK (after_lifecycle = 'RELEASED');
+  END IF;
+END;
+$$;
 
 CREATE INDEX IF NOT EXISTS controlled_document_approval_release_document_idx
   ON controlled_document_approval_release_events(controlled_document_id, created_at);
@@ -37,15 +95,11 @@ CREATE TRIGGER controlled_document_approval_release_events_append_only
 BEFORE UPDATE OR DELETE ON controlled_document_approval_release_events
 FOR EACH ROW EXECUTE FUNCTION reject_controlled_document_approval_release_event_mutation();
 
--- Prospective state only. No existing row is updated.
-ALTER TABLE controlled_documents DROP CONSTRAINT IF EXISTS controlled_documents_lifecycle_check;
-ALTER TABLE controlled_documents ADD CONSTRAINT controlled_documents_lifecycle_check
-  CHECK (lifecycle_status IN ('DRAFT','IN_REVIEW','APPROVED','REJECTED','RELEASED','SUPERSEDED','OBSOLETE','VOID')) NOT VALID;
-ALTER TABLE controlled_documents VALIDATE CONSTRAINT controlled_documents_lifecycle_check;
-
-ALTER TABLE document_version_history DROP CONSTRAINT IF EXISTS document_version_history_lifecycle_check;
-ALTER TABLE document_version_history ADD CONSTRAINT document_version_history_lifecycle_check
-  CHECK (lifecycle_status IN ('DRAFT','IN_REVIEW','APPROVED','REJECTED','RELEASED','SUPERSEDED','OBSOLETE','VOID')) NOT VALID;
-ALTER TABLE document_version_history VALIDATE CONSTRAINT document_version_history_lifecycle_status_check;
+-- Rejection evidence must be truthful when no authoritative checksum is available.
+-- Existing approval rows and their values are left untouched.
+ALTER TABLE controlled_document_revision_approvals
+  ALTER COLUMN file_checksum DROP NOT NULL;
+ALTER TABLE controlled_document_revision_approvals
+  ADD COLUMN IF NOT EXISTS checksum_verification_status text;
 
 COMMIT;

--- a/server/__tests__/controlledDocumentCentralMediaView.test.ts
+++ b/server/__tests__/controlledDocumentCentralMediaView.test.ts
@@ -3,20 +3,34 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('Master Document Register central-media file resolution', () => {
-  const source = readFileSync(join(process.cwd(), 'server/src/routes/controlledDocuments.ts'), 'utf8');
+  const source = readFileSync(
+    join(process.cwd(), 'server/src/routes/controlledDocuments.ts'),
+    'utf8'
+  );
   const resolverStart = source.indexOf('const resolveControlledDocumentFile');
-  const resolverEnd = source.indexOf('const formatControlledDocumentFooterDate', resolverStart);
+  const resolverEnd = source.indexOf(
+    'const formatControlledDocumentFooterDate',
+    resolverStart
+  );
   const resolver = source.slice(resolverStart, resolverEnd);
 
   it('resolves generated /api/media/file URLs into the served central media directory', () => {
     expect(resolver).toContain("trimmed.startsWith('/api/media/file/')");
-    expect(resolver).toContain("path.resolve(process.cwd(), 'uploads', 'media-library')");
-    expect(resolver).toContain("decodeURIComponent(trimmed.slice('/api/media/file/'.length))");
+    expect(resolver).toMatch(
+      /path\.resolve\(\s*process\.cwd\(\),\s*'uploads',\s*'media-library'\s*\)/
+    );
+    expect(resolver).toMatch(
+      /decodeURIComponent\(\s*trimmed\.slice\('\/api\/media\/file\/'\.length\)\s*\)/
+    );
   });
 
   it('also resolves stored media-library paths used by central-storage records', () => {
-    expect(resolver).toContain("normalizedMediaPath.startsWith('uploads/media-library/')");
-    expect(resolver).toContain('resolvedMediaPath.startsWith(`${centralMediaRoot}${path.sep}`)');
+    expect(resolver).toContain(
+      "normalizedMediaPath.startsWith('uploads/media-library/')"
+    );
+    expect(resolver).toContain(
+      'resolvedMediaPath.startsWith(`${centralMediaRoot}${path.sep}`)'
+    );
   });
 
   it('rejects encoded or relative traversal outside the central media directory', () => {

--- a/server/__tests__/controlledDocumentLifecycleHardening.test.ts
+++ b/server/__tests__/controlledDocumentLifecycleHardening.test.ts
@@ -16,32 +16,54 @@ describe('Master Document Register lifecycle hardening', () => {
   it('normalizes numbers without changing their display form and hashes server bytes', () => {
     expect(normalizeDocumentNumber('  qc form 12  ')).toBe('QC FORM 12');
     expect(checksumFile(Buffer.from('revision-a'))).toMatch(/^[a-f0-9]{64}$/);
-    expect(checksumFile(Buffer.from('revision-a'))).not.toBe(checksumFile(Buffer.from('revision-b')));
+    expect(checksumFile(Buffer.from('revision-a'))).not.toBe(
+      checksumFile(Buffer.from('revision-b'))
+    );
   });
 
   it('closes ordinary file replacement and hard deletion', () => {
     const route = read('server/src/routes/controlledDocuments.ts');
-    const service = read('server/src/services/controlledDocumentLifecycleService.ts');
+    const service = read(
+      'server/src/services/controlledDocumentLifecycleService.ts'
+    );
     expect(service).toContain('CREATE_REVISION_REQUIRED');
-    expect(route).toContain("router.post('/:id/revise'");
+    expect(route).toMatch(/router\.post\(\s*'\/:id\/revise'/);
     expect(route).toContain('HARD_DELETE_DISABLED');
     expect(route).not.toContain('.delete(documentVersionHistory)');
     expect(route).not.toContain('.delete(controlledDocuments)');
-    expect(route).not.toMatch(/Just update metadata without versioning[\s\S]*persistControlledDocumentUpload/);
+    expect(route).not.toMatch(
+      /Just update metadata without versioning[\s\S]*persistControlledDocumentUpload/
+    );
   });
 
   it('provides exact-revision lifecycle routes without trusting body actor identity', () => {
     const route = read('server/src/routes/controlledDocuments.ts');
-    for (const operation of ['submit', 'decision', 'release', 'revise', 'supersede', 'obsolete', 'void']) {
+    for (const operation of [
+      'submit',
+      'decision',
+      'release',
+      'revise',
+      'supersede',
+      'obsolete',
+      'void',
+    ]) {
       expect(route).toContain(`/:id/${operation}`);
     }
     expect(route).toContain('/:id/revisions/:revisionId/download');
     expect(route).not.toMatch(/actor:\s*req\.body/);
     expect(route).not.toMatch(/approvedBy\s*=\s*req\.body/);
     for (const capability of [
-      'documents.view', 'documents.create', 'documents.edit_draft', 'documents.submit',
-      'documents.approve', 'documents.release', 'documents.revise',
-      'documents.supersede', 'documents.obsolete', 'documents.void', 'documents.number_admin',
+      'documents.view',
+      'documents.create',
+      'documents.edit_draft',
+      'documents.submit',
+      'documents.approve',
+      'documents.release',
+      'documents.revise',
+      'documents.supersede',
+      'documents.obsolete',
+      'documents.void',
+      'documents.number_admin',
     ]) {
       expect(route).toContain(`requirePermission('${capability}')`);
     }
@@ -49,7 +71,9 @@ describe('Master Document Register lifecycle hardening', () => {
   });
 
   it('uses additive number, revision, approval, and append-only database protections', () => {
-    const migration = read('migrations/0210_master_document_control_hardening.sql');
+    const migration = read(
+      'migrations/0210_master_document_control_hardening.sql'
+    );
     expect(migration).toContain('ADD COLUMN IF NOT EXISTS lifecycle_status');
     expect(migration).toContain('controlled_document_number_registry');
     expect(migration).toContain('normalized_number text NOT NULL UNIQUE');
@@ -63,29 +87,45 @@ describe('Master Document Register lifecycle hardening', () => {
   it('keeps template and routing generation on exact verified draft revisions', () => {
     const route = read('server/src/routes/routingDocuments.ts');
     expect(route.match(/file_checksum:/g)?.length).toBeGreaterThanOrEqual(2);
-    expect(route.match(/checksum_status: 'VERIFIED'/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(
+      route.match(/checksum_status: 'VERIFIED'/g)?.length
+    ).toBeGreaterThanOrEqual(2);
     expect(route).toContain('current_revision_id');
     expect(route).toContain('controlled_document_number_registry');
   });
 
   it('serves and verifies authoritative revision bytes before approval', () => {
     const route = read('server/src/routes/controlledDocuments.ts');
-    const service = read('server/src/services/controlledDocumentLifecycleService.ts');
+    const service = read(
+      'server/src/services/controlledDocumentLifecycleService.ts'
+    );
     expect(route).toContain('getReleasedRevisionForControlledUse');
     expect(route).toContain('document.currentReleasedRevisionId');
-    expect(route).not.toMatch(/if \(action === 'approve' \|\| action === 'release'\)[\s\S]{0,700}revision\.filePath \|\| state\.document\.filePath/);
-    expect(route).toContain('await verifyStoredRevision(state.document.id, revision, filePath, buffer, req)');
-    expect(route).toContain("if (action === 'approve' || action === 'release')");
+    expect(route).not.toMatch(
+      /if \(action === 'approve' \|\| action === 'release'\)[\s\S]{0,700}revision\.filePath \|\| state\.document\.filePath/
+    );
+    expect(route).toMatch(
+      /await verifyStoredRevision\(\s*state\.document\.id,\s*revision,\s*filePath,\s*buffer,\s*req\s*\)/
+    );
+    expect(route).toContain(
+      "if (action === 'approve' || action === 'release')"
+    );
     expect(service).toContain('CONTROLLED_DOCUMENT_FILE_CHECKSUM_VERIFIED');
     expect(service).toContain('CONTROLLED_DOCUMENT_CHECKSUM_MISMATCH');
     expect(service).toContain("checksumStatus: 'VERIFIED'");
     expect(service).toContain('eq(documentVersionHistory.id, revision.id)');
-    expect(service).toContain('eq(documentVersionHistory.documentId, context.document.id)');
+    expect(service).toContain(
+      'eq(documentVersionHistory.documentId, context.document.id)'
+    );
   });
 
   it('does not alter P2 or Phase 2B Design Control approval implementation', () => {
-    const designControl = read('server/src/services/designControlApprovalService.ts');
+    const designControl = read(
+      'server/src/services/designControlApprovalService.ts'
+    );
     expect(designControl).toContain('AUTHENTICATED_VERSION_BOUND_APPROVAL');
-    expect(designControl).not.toContain('controlled_document_revision_approvals');
+    expect(designControl).not.toContain(
+      'controlled_document_revision_approvals'
+    );
   });
 });

--- a/server/__tests__/controlledDocumentPhase1ACompatibility.test.ts
+++ b/server/__tests__/controlledDocumentPhase1ACompatibility.test.ts
@@ -31,7 +31,7 @@ describe('Master Document Register Phase 1A compatibility', () => {
   it('uses one access-policy evaluator for View, Download, and Exact Revision', () => {
     expect(
       route.match(
-        /requirePermission\('documents\.view'\),\s*controlledDocumentAccessPolicy/g
+        /controlledDocumentViewPermission,\s*controlledDocumentAccessPolicy/g
       )
     ).toHaveLength(3);
     expect(route).toContain('hasControlledDocumentGrant');

--- a/server/__tests__/controlledDocumentPhase1ACompatibility.test.ts
+++ b/server/__tests__/controlledDocumentPhase1ACompatibility.test.ts
@@ -6,13 +6,18 @@ const read = (file: string) => readFileSync(join(process.cwd(), file), 'utf8');
 const route = read('server/src/routes/controlledDocuments.ts');
 const client = read('client/src/pages/MasterDocumentRegister.tsx');
 const auth = read('server/middleware/auth.ts');
-const auditRoute = route.slice(route.indexOf("router.get('/legacy-audit'"), route.indexOf('// Get single document'));
+const auditRoute = route.slice(
+  route.indexOf("'/legacy-audit'"),
+  route.indexOf('// Get single document')
+);
 
 describe('Master Document Register Phase 1A compatibility', () => {
   it('does not require step-up for every ordinary internal document', () => {
     expect(route).toContain('controlledDocumentRequiresStepUp');
     expect(route).toContain("accessRule || 'authenticated'");
-    expect(route).not.toContain("requirePermission('documents.view'), requireStepUp(), async");
+    expect(route).not.toContain(
+      "requirePermission('documents.view'), requireStepUp(), async"
+    );
   });
 
   it('requires stronger authentication for protected policies', () => {
@@ -24,7 +29,11 @@ describe('Master Document Register Phase 1A compatibility', () => {
   });
 
   it('uses one access-policy evaluator for View, Download, and Exact Revision', () => {
-    expect(route.match(/requirePermission\('documents\.view'\), controlledDocumentAccessPolicy/g)).toHaveLength(3);
+    expect(
+      route.match(
+        /requirePermission\('documents\.view'\),\s*controlledDocumentAccessPolicy/g
+      )
+    ).toHaveLength(3);
     expect(route).toContain('hasControlledDocumentGrant');
     expect(route).toContain("action: 'denied'");
   });
@@ -33,7 +42,9 @@ describe('Master Document Register Phase 1A compatibility', () => {
     expect(client).toContain('apiPath?: string');
     expect(client).toContain('apiPath: apiPathOverride');
     expect(client).toContain('access.apiPath');
-    expect(client).not.toMatch(/onClick=\{\(\) => window\.open\([\s\S]{0,200}revisions\/\$\{version\.id\}/);
+    expect(client).not.toMatch(
+      /onClick=\{\(\) => window\.open\([\s\S]{0,200}revisions\/\$\{version\.id\}/
+    );
   });
 
   it('offers inline View only for PDF and labels original file types', () => {
@@ -45,9 +56,14 @@ describe('Master Document Register Phase 1A compatibility', () => {
 
   it('returns useful file, access, revision, and reconciliation errors', () => {
     for (const code of [
-      'FILE_REFERENCE_MISSING', 'FILE_NOT_ACCESSIBLE', 'UNSUPPORTED_PREVIEW_TYPE',
-      'ACCESS_DENIED', 'REVISION_RECORD_MISSING', 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
-    ]) expect(route).toContain(code);
+      'FILE_REFERENCE_MISSING',
+      'FILE_NOT_ACCESSIBLE',
+      'UNSUPPORTED_PREVIEW_TYPE',
+      'ACCESS_DENIED',
+      'REVISION_RECORD_MISSING',
+      'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
+    ])
+      expect(route).toContain(code);
     expect(auth).toContain('STEP_UP_REQUIRED');
   });
 
@@ -58,25 +74,43 @@ describe('Master Document Register Phase 1A compatibility', () => {
 
   it('retains truthful legacy compatibility labels', () => {
     for (const label of [
-      'Released and Verified', 'Legacy Approved — Verification Required',
-      'File Reconciliation Required', 'Draft', 'Awaiting Approval',
-      'Superseded', 'Obsolete', 'Void',
-    ]) expect(`${route}\n${client}`).toContain(label);
+      'Released and Verified',
+      'Legacy Approved — Verification Required',
+      'File Reconciliation Required',
+      'Draft',
+      'Awaiting Approval',
+      'Superseded',
+      'Obsolete',
+      'Void',
+    ])
+      expect(`${route}\n${client}`).toContain(label);
   });
 
   it('categorizes the required legacy reconciliation conditions', () => {
     for (const category of [
-      'HAS_MATCHING_RELEASE_POINTER', 'RELEASED_MISSING_POINTER', 'LEGACY_APPROVED_OR_ACTIVE',
-      'PARENT_FILE_WITHOUT_REVISION', 'REVISION_CHECKSUM_MISSING', 'FILE_ACCESSIBLE',
-      'FILE_INACCESSIBLE', 'EXTERNAL_MUTABLE_URL', 'DUPLICATE_NORMALIZED_DOCUMENT_NUMBER',
-      'CROSS_DOCUMENT_POINTER', 'MULTIPLE_ACTIVE_WORKING_REVISIONS',
-      'MISSING_APPROVAL_IDENTITY_OR_DATE', 'EXPIRED_OR_REVIEW_DUE', 'NO_FILE_ATTACHED',
-    ]) expect(auditRoute).toContain(category);
+      'HAS_MATCHING_RELEASE_POINTER',
+      'RELEASED_MISSING_POINTER',
+      'LEGACY_APPROVED_OR_ACTIVE',
+      'PARENT_FILE_WITHOUT_REVISION',
+      'REVISION_CHECKSUM_MISSING',
+      'FILE_ACCESSIBLE',
+      'FILE_INACCESSIBLE',
+      'EXTERNAL_MUTABLE_URL',
+      'DUPLICATE_NORMALIZED_DOCUMENT_NUMBER',
+      'CROSS_DOCUMENT_POINTER',
+      'MULTIPLE_ACTIVE_WORKING_REVISIONS',
+      'MISSING_APPROVAL_IDENTITY_OR_DATE',
+      'EXPIRED_OR_REVIEW_DUE',
+      'NO_FILE_ATTACHED',
+    ])
+      expect(auditRoute).toContain(category);
   });
 
   it('keeps the audit report read-only and preserves access logs', () => {
     expect(auditRoute).toContain('readOnly: true');
-    expect(auditRoute).not.toMatch(/\.insert\(|\.update\(|\.delete\(|\bINSERT\b|\bUPDATE\b|\bDELETE\b/);
+    expect(auditRoute).not.toMatch(
+      /\.insert\(|\.update\(|\.delete\(|\bINSERT\b|\bUPDATE\b|\bDELETE\b/
+    );
     expect(route).toContain('writeAccessLog');
   });
 });

--- a/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
+++ b/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { isControlledDocumentPhase2Enabled } from '../src/services/controlledDocumentPhase2Gate';
+import {
+  criticalMigrationFiles,
+  safeMigrationFiles,
+} from '../scripts/migrations/runSafeBootMigrations';
+
+const root = path.resolve(__dirname, '../..');
+const service = fs.readFileSync(
+  path.join(root, 'server/src/services/controlledDocumentLifecycleService.ts'),
+  'utf8'
+);
+const routes = fs.readFileSync(
+  path.join(root, 'server/src/routes/controlledDocuments.ts'),
+  'utf8'
+);
+const client = fs.readFileSync(
+  path.join(root, 'client/src/pages/MasterDocumentRegister.tsx'),
+  'utf8'
+);
+const migrationName = '0256_controlled_document_atomic_approval_release.sql';
+const migration = fs.readFileSync(
+  path.join(root, 'migrations', migrationName),
+  'utf8'
+);
+
+describe('controlled document Phase 2 activation containment', () => {
+  it('is default-disabled and requires exact true', () => {
+    expect(isControlledDocumentPhase2Enabled(undefined)).toBe(false);
+    expect(isControlledDocumentPhase2Enabled('TRUE')).toBe(false);
+    expect(isControlledDocumentPhase2Enabled('true')).toBe(true);
+    expect(migration).not.toContain(
+      'CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED'
+    );
+  });
+
+  it('registers the prospective migration for safe boot without data rewrites', () => {
+    expect(safeMigrationFiles).toContain(migrationName);
+    expect(criticalMigrationFiles.has(migrationName)).toBe(true);
+    expect(migration).not.toMatch(/UPDATE\s+controlled_documents/i);
+    expect(migration).not.toMatch(/UPDATE\s+document_version_history/i);
+    expect(migration).not.toMatch(/DELETE\s+FROM/i);
+    expect(migration.trimStart().startsWith('-- Prospective')).toBe(true);
+    expect(migration).toContain('BEGIN;');
+    expect(migration).toContain('COMMIT;');
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS');
+    expect(migration).toContain('DROP TRIGGER IF EXISTS');
+  });
+});
+
+describe('atomic approve-and-release contract', () => {
+  it('locks and revalidates exact current revision, path, and checksum inside one transaction', () => {
+    expect(service).toContain('return client.transaction(async (tx) =>');
+    expect(service).toContain('pg_advisory_xact_lock');
+    expect(service).toContain('FOR UPDATE');
+    expect(service).toContain(
+      'context.document.currentRevisionId !== revision.id'
+    );
+    expect(service).toContain(
+      'context.document.workingDraftRevisionId !== revision.id'
+    );
+    expect(service).toContain('revision.filePath !== input.filePath');
+    expect(service).toContain(
+      'revision.fileChecksum !== input.observedChecksum'
+    );
+    expect(service).toContain("revision.checksumStatus !== 'VERIFIED'");
+  });
+
+  it('records immutable authority evidence and prohibits self approval', () => {
+    expect(service).toContain("'SELF_APPROVAL_PROHIBITED'");
+    expect(service).toContain('controlledDocumentApprovalReleaseEvents');
+    expect(service).toContain(
+      "provenance: 'AUTHENTICATED_ATOMIC_APPROVAL_RELEASE'"
+    );
+    expect(migration).toContain(
+      'controlled_document_approval_release_events_append_only'
+    );
+    expect(migration).toContain('BEFORE UPDATE OR DELETE');
+    expect(service).toContain('rejectRegisteredControlledRevision');
+    expect(service).toContain("lifecycleStatus: 'REJECTED'");
+    expect(routes).toContain("router.post('/:id/reject'");
+  });
+
+  it('uses database-backed idempotency and cross-document fail-closed checks', () => {
+    expect(migration).toContain('idempotency_key text NOT NULL UNIQUE');
+    expect(migration).toContain('UNIQUE (revision_id)');
+    expect(service).toContain("'IDEMPOTENCY_KEY_CONFLICT'");
+    expect(service).toContain("'CROSS_DOCUMENT_REVISION'");
+    expect(service).toContain("'INVALID_RELEASED_REVISION_POINTER'");
+  });
+
+  it('requires server permission, step-up, managed bytes, and schema readiness', () => {
+    expect(routes).toMatch(
+      /approve-and-release[\s\S]*requirePermission\('documents\.approve'\)[\s\S]*requireStepUp\(\)/
+    );
+    expect(routes).toContain('assertControlledDocumentPhase2SchemaReady()');
+    expect(routes).toContain("'IMMUTABLE_REVISION_FILE_REQUIRED'");
+    expect(routes).toContain('getExternalRedirectUrl(revision.filePath)');
+  });
+});
+
+describe('truthful gated UI', () => {
+  it('removes routine submit and release actions only when Phase 2 is enabled', () => {
+    expect(client).toContain('!phase2Enabled &&');
+    expect(client).toContain(
+      "phase2Enabled ? 'approve-and-release' : 'decision'"
+    );
+    expect(client).toContain('Registered — awaiting approval');
+    expect(client).toContain('Rejected — correction required');
+    expect(client).toContain('Historical/legacy — retained');
+  });
+});

--- a/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
+++ b/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
@@ -33,6 +33,7 @@ describe('controlled document Phase 2 activation containment', () => {
     expect(isControlledDocumentPhase2Enabled(undefined)).toBe(false);
     expect(isControlledDocumentPhase2Enabled('TRUE')).toBe(false);
     expect(isControlledDocumentPhase2Enabled('true')).toBe(true);
+    expect(routes).not.toContain('CONTROLLED_DOCUMENT_PHASE2_ENABLED');
     expect(migration).not.toContain(
       'CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED'
     );
@@ -82,7 +83,7 @@ describe('atomic approve-and-release contract', () => {
     expect(migration).toContain('BEFORE UPDATE OR DELETE');
     expect(service).toContain('rejectRegisteredControlledRevision');
     expect(service).toContain("lifecycleStatus: 'REJECTED'");
-    expect(routes).toContain("router.post('/:id/reject'");
+    expect(routes).toMatch(/router\.post\(\s*'\/:id\/reject'/);
   });
 
   it('uses database-backed idempotency and cross-document fail-closed checks', () => {
@@ -100,6 +101,9 @@ describe('atomic approve-and-release contract', () => {
     expect(routes).toContain('assertControlledDocumentPhase2SchemaReady()');
     expect(routes).toContain("'IMMUTABLE_REVISION_FILE_REQUIRED'");
     expect(routes).toContain('getExternalRedirectUrl(revision.filePath)');
+    expect(routes).toMatch(
+      /router\.post\('\/:id\/approve',[\s\S]{0,250}requireLegacyLifecycle[\s\S]{0,120}requireStepUp\(\)/
+    );
   });
 });
 

--- a/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
+++ b/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
@@ -102,7 +102,7 @@ describe('atomic approve-and-release contract', () => {
     expect(routes).toContain("'IMMUTABLE_REVISION_FILE_REQUIRED'");
     expect(routes).toContain('getExternalRedirectUrl(revision.filePath)');
     expect(routes).toMatch(
-      /router\.post\('\/:id\/approve',[\s\S]{0,250}requireLegacyLifecycle[\s\S]{0,120}requireStepUp\(\)/
+      /router\.post\(\s*'\/:id\/approve',[\s\S]{0,400}requireLegacyLifecycle[\s\S]{0,200}requireStepUp\(\)/
     );
   });
 });

--- a/server/__tests__/controlledDocumentPhase2Postgres.test.ts
+++ b/server/__tests__/controlledDocumentPhase2Postgres.test.ts
@@ -22,6 +22,7 @@ const role = `MDR_PHASE2_CERT_${randomUUID()}`;
 const approverUsername = `mdr-approver-${randomUUID()}`;
 const sessionToken = `mdr-session-${randomUUID()}`;
 let approverId = 0;
+let approverEmployeeId = 0;
 
 type Fixture = {
   documentId: string;
@@ -90,6 +91,12 @@ function approve(
 
 beforeAll(async () => {
   process.env.CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED = 'true';
+  const employee = await pgPool.query(
+    `INSERT INTO employees (name, user_role)
+     VALUES ($1, 'EMPLOYEE') RETURNING id`,
+    [`Phase 2 approver ${approverUsername}`]
+  );
+  approverEmployeeId = employee.rows[0].id;
   const capability = await pgPool.query(
     `INSERT INTO perm_capabilities (key, description, category)
      VALUES ('documents.approve', 'Approve controlled documents', 'documents')
@@ -106,8 +113,9 @@ beforeAll(async () => {
     [roleRow.rows[0].id, capability.rows[0].id]
   );
   const user = await pgPool.query(
-    `INSERT INTO users (username, password_hash, role) VALUES ($1, 'not-a-login-secret', $2) RETURNING id`,
-    [approverUsername, role]
+    `INSERT INTO users (username, password_hash, role, employee_id)
+     VALUES ($1, 'not-a-login-secret', $2, $3) RETURNING id`,
+    [approverUsername, role, employee.rows[0].id]
   );
   approverId = user.rows[0].id;
   await pgPool.query(
@@ -152,11 +160,18 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
     expect(result.document.currentReleasedRevisionId).toBe(fixture.revisionId);
     const evidence = await pgPool.query(
       `SELECT count(*)::int AS approvals,
-              (SELECT count(*)::int FROM controlled_document_approval_release_events WHERE revision_id = $1) AS events
+              (SELECT count(*)::int FROM controlled_document_approval_release_events WHERE revision_id = $1) AS events,
+              (SELECT actor_id FROM audit_events
+               WHERE subject_type = 'controlled_document' AND subject_id = $2
+               ORDER BY id DESC LIMIT 1) AS audit_actor_id
        FROM controlled_document_revision_approvals WHERE revision_id = $1`,
-      [fixture.revisionId]
+      [fixture.revisionId, fixture.documentId]
     );
-    expect(evidence.rows[0]).toMatchObject({ approvals: 1, events: 1 });
+    expect(evidence.rows[0]).toMatchObject({
+      approvals: 1,
+      events: 1,
+      audit_actor_id: approverEmployeeId,
+    });
   });
 
   it('replays an identical committed request without a second mutation', async () => {

--- a/server/__tests__/controlledDocumentPhase2Postgres.test.ts
+++ b/server/__tests__/controlledDocumentPhase2Postgres.test.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
+import express from 'express';
+import { PDFDocument } from 'pdf-lib';
+import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { pgPool } from '../db';
@@ -9,6 +14,7 @@ import {
   ControlledDocumentError,
 } from '../src/services/controlledDocumentLifecycleService';
 import { assertControlledDocumentPhase2SchemaReady } from '../src/services/controlledDocumentSchemaReadiness';
+import controlledDocumentRoutes from '../src/routes/controlledDocuments';
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl)
@@ -21,8 +27,36 @@ const checksum = checksumFile(bytes);
 const role = `MDR_PHASE2_CERT_${randomUUID()}`;
 const approverUsername = `mdr-approver-${randomUUID()}`;
 const sessionToken = `mdr-session-${randomUUID()}`;
+const viewerRole = `MDR_VIEWER_CERT_${randomUUID()}`;
+const viewerUsername = `mdr-viewer-${randomUUID()}`;
+const viewerSessionToken = `mdr-viewer-session-${randomUUID()}`;
+const deniedRole = `MDR_DENIED_CERT_${randomUUID()}`;
+const deniedUsername = `mdr-denied-${randomUUID()}`;
+const deniedSessionToken = `mdr-denied-session-${randomUUID()}`;
 let approverId = 0;
 let approverEmployeeId = 0;
+let viewerId = 0;
+let releasedPdfBytes = Buffer.alloc(0);
+let releasedPdfChecksum = '';
+const documentAssetRoot = path.resolve(
+  process.cwd(),
+  'server/src/assets/documents'
+);
+const releasedPdfName = `mdr-phase2-${randomUUID()}.pdf`;
+const releasedPdfReference = `assets/documents/${releasedPdfName}`;
+const releasedPdfPath = path.join(documentAssetRoot, releasedPdfName);
+const outsidePdfPath = path.resolve(
+  documentAssetRoot,
+  '..',
+  `mdr-phase2-outside-${randomUUID()}.pdf`
+);
+const symlinkPdfName = `mdr-phase2-link-${randomUUID()}.pdf`;
+const symlinkPdfReference = `assets/documents/${symlinkPdfName}`;
+const symlinkPdfPath = path.join(documentAssetRoot, symlinkPdfName);
+
+const accessApp = express();
+accessApp.use(express.json());
+accessApp.use('/api/controlled-documents', controlledDocumentRoutes);
 
 type Fixture = {
   documentId: string;
@@ -70,6 +104,37 @@ async function createFixture(
   return { documentId, revisionId, documentNumber };
 }
 
+async function createReleasedRouteFixture(
+  fileReference = releasedPdfReference,
+  fileChecksum = releasedPdfChecksum,
+  lifecycle = 'RELEASED'
+) {
+  const fixture = await createFixture();
+  await pgPool.query(
+    `UPDATE document_version_history
+     SET lifecycle_status = $1, status = lower($1), file_path = $2,
+         file_name = $3, media_type = 'application/pdf', file_size = $4,
+         file_checksum = $5, checksum_status = 'VERIFIED'
+     WHERE id = $6`,
+    [
+      lifecycle,
+      fileReference,
+      path.basename(fileReference),
+      releasedPdfBytes.length,
+      fileChecksum,
+      fixture.revisionId,
+    ]
+  );
+  await pgPool.query(
+    `UPDATE controlled_documents
+     SET lifecycle_status = 'RELEASED', status = 'approved',
+         current_released_revision_id = $1
+     WHERE id = $2`,
+    [fixture.revisionId, fixture.documentId]
+  );
+  return fixture;
+}
+
 function approve(
   fixture: Fixture,
   idempotencyKey: string,
@@ -91,6 +156,14 @@ function approve(
 
 beforeAll(async () => {
   process.env.CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED = 'true';
+  await fs.mkdir(documentAssetRoot, { recursive: true });
+  const pdf = await PDFDocument.create();
+  pdf.addPage([240, 160]);
+  releasedPdfBytes = Buffer.from(await pdf.save());
+  releasedPdfChecksum = checksumFile(releasedPdfBytes);
+  await fs.writeFile(releasedPdfPath, releasedPdfBytes);
+  await fs.writeFile(outsidePdfPath, releasedPdfBytes);
+  await fs.symlink(outsidePdfPath, symlinkPdfPath);
   const employee = await pgPool.query(
     `INSERT INTO employees (name, user_role)
      VALUES ($1, 'EMPLOYEE') RETURNING id`,
@@ -112,6 +185,25 @@ beforeAll(async () => {
      ON CONFLICT DO NOTHING`,
     [roleRow.rows[0].id, capability.rows[0].id]
   );
+  const viewCapability = await pgPool.query(
+    `INSERT INTO perm_capabilities (key, description, category)
+     VALUES ('documents.view', 'View controlled documents', 'documents')
+     ON CONFLICT (key) DO UPDATE SET key = EXCLUDED.key RETURNING id`
+  );
+  const viewerRoleRow = await pgPool.query(
+    `INSERT INTO perm_roles (name, description)
+     VALUES ($1, 'Disposable document viewer role') RETURNING id`,
+    [viewerRole]
+  );
+  await pgPool.query(
+    `INSERT INTO perm_role_capabilities (role_id, capability_id) VALUES ($1, $2)`,
+    [viewerRoleRow.rows[0].id, viewCapability.rows[0].id]
+  );
+  await pgPool.query(
+    `INSERT INTO perm_roles (name, description)
+     VALUES ($1, 'Disposable denied viewer role')`,
+    [deniedRole]
+  );
   const user = await pgPool.query(
     `INSERT INTO users (username, password_hash, role, employee_id)
      VALUES ($1, 'not-a-login-secret', $2, $3) RETURNING id`,
@@ -124,10 +216,40 @@ beforeAll(async () => {
      VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', true, NOW())`,
     [sessionToken, approverId, approverUsername]
   );
+  const viewer = await pgPool.query(
+    `INSERT INTO users (username, password_hash, role)
+     VALUES ($1, 'not-a-login-secret', $2) RETURNING id`,
+    [viewerUsername, viewerRole]
+  );
+  viewerId = viewer.rows[0].id;
+  const denied = await pgPool.query(
+    `INSERT INTO users (username, password_hash, role)
+     VALUES ($1, 'not-a-login-secret', $2) RETURNING id`,
+    [deniedUsername, deniedRole]
+  );
+  await pgPool.query(
+    `INSERT INTO user_sessions
+       (session_token, user_id, username, expires_at, is_active, last_credential_verified_at)
+     VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', true, NOW()),
+            ($4, $5, $6, NOW() + INTERVAL '1 hour', true, NOW())`,
+    [
+      viewerSessionToken,
+      viewerId,
+      viewerUsername,
+      deniedSessionToken,
+      denied.rows[0].id,
+      deniedUsername,
+    ]
+  );
 });
 
 afterAll(async () => {
   delete process.env.CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED;
+  await Promise.allSettled([
+    fs.unlink(releasedPdfPath),
+    fs.unlink(outsidePdfPath),
+    fs.unlink(symlinkPdfPath),
+  ]);
   await pgPool.end();
 });
 
@@ -243,5 +365,115 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
       approvals: 0,
       events: 0,
     });
+  });
+
+  it('serves the current released revision to an authenticated ordinary viewer and records allowed access', async () => {
+    const fixture = await createReleasedRouteFixture();
+    const view = await request(accessApp)
+      .get(`/api/controlled-documents/${fixture.documentId}/view`)
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(view.status).toBe(200);
+    expect(view.headers['content-type']).toContain('application/pdf');
+
+    const download = await request(accessApp)
+      .get(`/api/controlled-documents/${fixture.documentId}/download`)
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(download.status).toBe(200);
+    expect(download.body).toEqual(releasedPdfBytes);
+
+    const logs = await pgPool.query(
+      `SELECT action FROM object_access_log
+       WHERE document_id = $1 AND user_id = $2 ORDER BY id`,
+      [fixture.documentId, viewerUsername]
+    );
+    expect(logs.rows.map((row) => row.action)).toEqual(['view', 'download']);
+  });
+
+  it('denies and logs a valid authenticated user without document-view authority', async () => {
+    const fixture = await createReleasedRouteFixture();
+    const response = await request(accessApp)
+      .get(`/api/controlled-documents/${fixture.documentId}/download`)
+      .set('Authorization', `Bearer ${deniedSessionToken}`);
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('ACCESS_DENIED');
+    const denied = await pgPool.query(
+      `SELECT count(*)::int AS count FROM object_access_log
+       WHERE document_id = $1 AND user_id = $2 AND action = 'denied'`,
+      [fixture.documentId, deniedUsername]
+    );
+    expect(denied.rows[0].count).toBe(1);
+  });
+
+  it('fails closed for unreleased, draft, guessed, and cross-document revision access', async () => {
+    const draft = await createFixture();
+    const unreleased = await request(accessApp)
+      .get(`/api/controlled-documents/${draft.documentId}/download`)
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(unreleased.status).toBe(409);
+    expect(unreleased.body.error).toBe('NO_RELEASED_REVISION');
+
+    const exactDraft = await request(accessApp)
+      .get(
+        `/api/controlled-documents/${draft.documentId}/revisions/${draft.revisionId}/download`
+      )
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(exactDraft.status).toBe(403);
+    expect(exactDraft.body.error).toBe('DRAFT_REVISION_ACCESS_DENIED');
+
+    const other = await createReleasedRouteFixture();
+    const crossDocument = await request(accessApp)
+      .get(
+        `/api/controlled-documents/${draft.documentId}/revisions/${other.revisionId}/download`
+      )
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(crossDocument.status).toBe(404);
+
+    const guessed = await request(accessApp)
+      .get(
+        `/api/controlled-documents/${other.documentId}/revisions/${randomUUID()}/download`
+      )
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(guessed.status).toBe(404);
+  });
+
+  it('supports authorized historical released bytes and rejects traversal, symlinks, and mutable external references', async () => {
+    const historical = await createReleasedRouteFixture(
+      releasedPdfReference,
+      releasedPdfChecksum,
+      'SUPERSEDED'
+    );
+    const historicalResponse = await request(accessApp)
+      .get(
+        `/api/controlled-documents/${historical.documentId}/revisions/${historical.revisionId}/download`
+      )
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(historicalResponse.status).toBe(200);
+
+    const traversal = await createReleasedRouteFixture(
+      `assets/documents/../${path.basename(outsidePdfPath)}`
+    );
+    const traversalResponse = await request(accessApp)
+      .get(`/api/controlled-documents/${traversal.documentId}/download`)
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(traversalResponse.status).toBe(422);
+    expect(traversalResponse.body.error).toBe('FILE_NOT_ACCESSIBLE');
+
+    const symlink = await createReleasedRouteFixture(symlinkPdfReference);
+    const symlinkResponse = await request(accessApp)
+      .get(`/api/controlled-documents/${symlink.documentId}/download`)
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(symlinkResponse.status).toBe(422);
+    expect(symlinkResponse.body.error).toBe('FILE_NOT_ACCESSIBLE');
+
+    const external = await createReleasedRouteFixture(
+      'https://example.invalid/mutable.pdf'
+    );
+    const externalResponse = await request(accessApp)
+      .get(`/api/controlled-documents/${external.documentId}/download`)
+      .set('Authorization', `Bearer ${viewerSessionToken}`);
+    expect(externalResponse.status).toBe(422);
+    expect(externalResponse.body.error).toBe(
+      'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION'
+    );
   });
 });

--- a/server/__tests__/controlledDocumentPhase2Postgres.test.ts
+++ b/server/__tests__/controlledDocumentPhase2Postgres.test.ts
@@ -27,6 +27,8 @@ const checksum = checksumFile(bytes);
 const role = `MDR_PHASE2_CERT_${randomUUID()}`;
 const approverUsername = `mdr-approver-${randomUUID()}`;
 const sessionToken = `mdr-session-${randomUUID()}`;
+const missingStepUpToken = `mdr-missing-step-up-${randomUUID()}`;
+const expiredStepUpToken = `mdr-expired-step-up-${randomUUID()}`;
 const viewerRole = `MDR_VIEWER_CERT_${randomUUID()}`;
 const viewerUsername = `mdr-viewer-${randomUUID()}`;
 const viewerSessionToken = `mdr-viewer-session-${randomUUID()}`;
@@ -154,6 +156,107 @@ function approve(
   });
 }
 
+async function createRouteApprovalFixture(author?: string) {
+  const fixture = await createFixture(author);
+  await pgPool.query(
+    `UPDATE document_version_history
+     SET file_path = $1, file_name = $2, media_type = 'application/pdf',
+         file_size = $3, file_checksum = $4, checksum_status = 'VERIFIED'
+     WHERE id = $5`,
+    [
+      releasedPdfReference,
+      releasedPdfName,
+      releasedPdfBytes.length,
+      releasedPdfChecksum,
+      fixture.revisionId,
+    ]
+  );
+  return fixture;
+}
+
+async function mutationSnapshot(fixture: Fixture) {
+  const result = await pgPool.query(
+    `SELECT
+       document.lifecycle_status AS document_lifecycle,
+       document.current_revision_id,
+       document.current_released_revision_id,
+       document.working_draft_revision_id,
+       revision.lifecycle_status AS revision_lifecycle,
+       revision.file_checksum,
+       registry.status AS number_status,
+       registry.conflict_document_ids,
+       (SELECT count(*)::int FROM controlled_document_revision_approvals
+        WHERE revision_id = $1) AS approvals,
+       (SELECT count(*)::int FROM controlled_document_approval_release_events
+        WHERE revision_id = $1) AS release_events,
+       (SELECT count(*)::int FROM audit_events
+        WHERE subject_type = 'controlled_document' AND subject_id = $2) AS audits
+     FROM controlled_documents document
+     JOIN document_version_history revision ON revision.id = $1
+     JOIN controlled_document_number_registry registry
+       ON registry.controlled_document_id = document.id
+     WHERE document.id = $2`,
+    [fixture.revisionId, fixture.documentId]
+  );
+  return result.rows[0];
+}
+
+async function restoreApprovalChecksumSchema() {
+  await pgPool.query(
+    `ALTER TABLE controlled_document_revision_approvals
+       ALTER COLUMN file_checksum DROP NOT NULL,
+       ADD COLUMN IF NOT EXISTS checksum_verification_status text,
+       ALTER COLUMN checksum_verification_status DROP DEFAULT`
+  );
+  await pgPool.query(
+    `ALTER TABLE controlled_document_revision_approvals
+       DROP CONSTRAINT IF EXISTS controlled_document_revision_approvals_checksum_status_check`
+  );
+  await pgPool.query(
+    `ALTER TABLE controlled_document_revision_approvals
+       ADD CONSTRAINT controlled_document_revision_approvals_checksum_status_check
+       CHECK (
+         checksum_verification_status IS NULL
+         OR checksum_verification_status IN ('VERIFIED', 'UNAVAILABLE', 'MISMATCH')
+       )`
+  );
+}
+
+async function expectNoPhase2Mutation(fixture: Fixture) {
+  const state = await mutationSnapshot(fixture);
+  expect(state).toMatchObject({
+    current_released_revision_id: null,
+    approvals: 0,
+    release_events: 0,
+  });
+}
+
+function approveRoute(
+  fixture: Fixture,
+  token: string,
+  idempotencyKey = randomUUID()
+) {
+  return request(accessApp)
+    .post(`/api/controlled-documents/${fixture.documentId}/approve-and-release`)
+    .set('Authorization', `Bearer ${token}`)
+    .set('Idempotency-Key', idempotencyKey)
+    .send({
+      revisionId: fixture.revisionId,
+      reason: 'Independent authenticated Quality approval',
+      effectiveDate: '2026-08-05',
+    });
+}
+
+function rejectRoute(fixture: Fixture, token = sessionToken) {
+  return request(accessApp)
+    .post(`/api/controlled-documents/${fixture.documentId}/reject`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      revisionId: fixture.revisionId,
+      reason: 'Correction required by Quality',
+    });
+}
+
 beforeAll(async () => {
   process.env.CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED = 'true';
   await fs.mkdir(documentAssetRoot, { recursive: true });
@@ -185,6 +288,19 @@ beforeAll(async () => {
      ON CONFLICT DO NOTHING`,
     [roleRow.rows[0].id, capability.rows[0].id]
   );
+  await pgPool.query(
+    `INSERT INTO perm_capabilities (key, description, category)
+     VALUES ('documents.submit', 'Submit controlled documents', 'documents'),
+            ('documents.release', 'Release controlled documents', 'documents')
+     ON CONFLICT (key) DO NOTHING`
+  );
+  await pgPool.query(
+    `INSERT INTO perm_role_capabilities (role_id, capability_id)
+     SELECT $1, id FROM perm_capabilities
+     WHERE key IN ('documents.submit', 'documents.release')
+     ON CONFLICT DO NOTHING`,
+    [roleRow.rows[0].id]
+  );
   const viewCapability = await pgPool.query(
     `INSERT INTO perm_capabilities (key, description, category)
      VALUES ('documents.view', 'View controlled documents', 'documents')
@@ -215,6 +331,13 @@ beforeAll(async () => {
        (session_token, user_id, username, expires_at, is_active, last_credential_verified_at)
      VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', true, NOW())`,
     [sessionToken, approverId, approverUsername]
+  );
+  await pgPool.query(
+    `INSERT INTO user_sessions
+       (session_token, user_id, username, expires_at, is_active, last_credential_verified_at)
+     VALUES ($1, $3, $4, NOW() + INTERVAL '1 hour', true, NULL),
+            ($2, $3, $4, NOW() + INTERVAL '1 hour', true, NOW() - INTERVAL '31 minutes')`,
+    [missingStepUpToken, expiredStepUpToken, approverId, approverUsername]
   );
   const viewer = await pgPool.query(
     `INSERT INTO users (username, password_hash, role)
@@ -273,6 +396,166 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
         [key]
       )
     ).rejects.toThrow(/append-only/i);
+  });
+
+  it('requires nullable approval checksums and the complete truthful status contract', async () => {
+    const columns = await pgPool.query(
+      `SELECT column_name, data_type, is_nullable, column_default
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'controlled_document_revision_approvals'
+         AND column_name IN ('file_checksum', 'checksum_verification_status')
+       ORDER BY column_name`
+    );
+    expect(columns.rows).toEqual([
+      {
+        column_name: 'checksum_verification_status',
+        data_type: 'text',
+        is_nullable: 'YES',
+        column_default: null,
+      },
+      {
+        column_name: 'file_checksum',
+        data_type: 'text',
+        is_nullable: 'YES',
+        column_default: null,
+      },
+    ]);
+    await expect(
+      assertControlledDocumentPhase2SchemaReady()
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails readiness when approval file_checksum remains NOT NULL', async () => {
+    await pgPool.query(
+      `ALTER TABLE controlled_document_revision_approvals
+       ALTER COLUMN file_checksum SET NOT NULL`
+    );
+    try {
+      await expect(
+        assertControlledDocumentPhase2SchemaReady()
+      ).rejects.toMatchObject({
+        code: 'CONTROLLED_DOCUMENT_SCHEMA_NOT_READY',
+        missingObjects: expect.arrayContaining([
+          'column:controlled_document_revision_approvals.file_checksum',
+        ]),
+      });
+    } finally {
+      await restoreApprovalChecksumSchema();
+    }
+  });
+
+  it('fails readiness when checksum verification status is missing', async () => {
+    await pgPool.query(
+      `ALTER TABLE controlled_document_revision_approvals
+       DROP COLUMN checksum_verification_status CASCADE`
+    );
+    try {
+      await expect(
+        assertControlledDocumentPhase2SchemaReady()
+      ).rejects.toMatchObject({
+        code: 'CONTROLLED_DOCUMENT_SCHEMA_NOT_READY',
+        missingObjects: expect.arrayContaining([
+          'column:controlled_document_revision_approvals.checksum_verification_status',
+          'constraint:controlled_document_revision_approvals.checksum_verification_status',
+        ]),
+      });
+    } finally {
+      await restoreApprovalChecksumSchema();
+    }
+  });
+
+  it('fails readiness for a malformed checksum status default or constraint', async () => {
+    await pgPool.query(
+      `ALTER TABLE controlled_document_revision_approvals
+       DROP CONSTRAINT controlled_document_revision_approvals_checksum_status_check,
+       ALTER COLUMN checksum_verification_status SET DEFAULT 'UNVERIFIED'`
+    );
+    await pgPool.query(
+      `ALTER TABLE controlled_document_revision_approvals
+       ADD CONSTRAINT controlled_document_revision_approvals_checksum_status_check
+       CHECK (checksum_verification_status IS NULL OR checksum_verification_status = 'VERIFIED')`
+    );
+    try {
+      await expect(
+        assertControlledDocumentPhase2SchemaReady()
+      ).rejects.toMatchObject({
+        code: 'CONTROLLED_DOCUMENT_SCHEMA_NOT_READY',
+        missingObjects: expect.arrayContaining([
+          'column:controlled_document_revision_approvals.checksum_verification_status',
+          'constraint:controlled_document_revision_approvals.checksum_verification_status',
+        ]),
+      });
+    } finally {
+      await restoreApprovalChecksumSchema();
+    }
+  });
+
+  it('returns controlled schema-not-ready before rejection mutation on a partial schema', async () => {
+    const fixture = await createFixture();
+    await pgPool.query(
+      `ALTER TABLE controlled_document_revision_approvals
+       ALTER COLUMN file_checksum SET NOT NULL`
+    );
+    try {
+      const response = await rejectRoute(fixture);
+      expect(response.status).toBe(503);
+      expect(response.body.error).toBe('CONTROLLED_DOCUMENT_SCHEMA_NOT_READY');
+      await expectNoPhase2Mutation(fixture);
+      const state = await mutationSnapshot(fixture);
+      expect(state).toMatchObject({
+        document_lifecycle: 'DRAFT',
+        revision_lifecycle: 'DRAFT',
+      });
+    } finally {
+      await restoreApprovalChecksumSchema();
+    }
+  });
+
+  it('fails approval before mutation when a required Phase 2 index is missing', async () => {
+    const fixture = await createRouteApprovalFixture();
+    await pgPool.query(
+      'DROP INDEX controlled_document_approval_release_document_idx'
+    );
+    try {
+      const response = await approveRoute(fixture, sessionToken);
+      expect(response.status).toBe(503);
+      expect(response.body.error).toBe('CONTROLLED_DOCUMENT_SCHEMA_NOT_READY');
+      await expectNoPhase2Mutation(fixture);
+    } finally {
+      await pgPool.query(
+        `CREATE INDEX controlled_document_approval_release_document_idx
+         ON controlled_document_approval_release_events(controlled_document_id, created_at)`
+      );
+    }
+  });
+
+  it('records truthful rejection evidence without fabricating an unavailable checksum', async () => {
+    const fixture = await createFixture();
+    const response = await rejectRoute(fixture);
+    expect(response.status).toBe(200);
+    const evidence = await pgPool.query(
+      `SELECT decision, file_checksum, checksum_verification_status,
+              metadata->>'checksumUnavailableReason' AS unavailable_reason
+       FROM controlled_document_revision_approvals
+       WHERE revision_id = $1`,
+      [fixture.revisionId]
+    );
+    expect(evidence.rows[0]).toMatchObject({
+      decision: 'REJECTED',
+      file_checksum: null,
+      checksum_verification_status: 'UNAVAILABLE',
+    });
+    expect(evidence.rows[0].unavailable_reason).toMatch(/unavailable/i);
+    const state = await pgPool.query(
+      `SELECT lifecycle_status, current_released_revision_id
+       FROM controlled_documents WHERE id = $1`,
+      [fixture.documentId]
+    );
+    expect(state.rows[0]).toMatchObject({
+      lifecycle_status: 'REJECTED',
+      current_released_revision_id: null,
+    });
   });
 
   it('commits approval, release, pointer, approval evidence, and immutable event atomically', async () => {
@@ -367,6 +650,181 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
     });
   });
 
+  it('fails stale locked revision state without approval, release, or pointer mutation', async () => {
+    const fixture = await createFixture();
+    await pgPool.query(
+      `UPDATE document_version_history
+       SET lifecycle_status = 'IN_REVIEW', status = 'in_review'
+       WHERE id = $1`,
+      [fixture.revisionId]
+    );
+    await expect(approve(fixture, randomUUID())).rejects.toMatchObject({
+      code: 'ILLEGAL_LIFECYCLE_TRANSITION',
+    });
+    await expectNoPhase2Mutation(fixture);
+    const state = await mutationSnapshot(fixture);
+    expect(state).toMatchObject({
+      document_lifecycle: 'DRAFT',
+      revision_lifecycle: 'IN_REVIEW',
+    });
+  });
+
+  it('rejects contradictory released revisions and preserves the original pointer', async () => {
+    const fixture = await createFixture();
+    const released = await pgPool.query(
+      `INSERT INTO document_version_history
+         (document_id, version_number, revision_sequence, lifecycle_status, status,
+          created_by, file_path, file_name, media_type, file_size, file_checksum,
+          checksum_status, metadata)
+       VALUES ($1, '0.9', 2, 'RELEASED', 'released', 'legacy-quality',
+               '/objects/original-release', 'original.pdf', 'application/pdf',
+               $2, $3, 'VERIFIED', '{}'::jsonb)
+       RETURNING id`,
+      [fixture.documentId, bytes.length, checksum]
+    );
+    await pgPool.query(
+      `INSERT INTO document_version_history
+         (document_id, version_number, revision_sequence, lifecycle_status, status,
+          created_by, file_path, file_name, media_type, file_size, file_checksum,
+          checksum_status, metadata)
+       VALUES ($1, '0.8', 3, 'RELEASED', 'released', 'legacy-quality',
+               '/objects/contradictory-release', 'contradictory.pdf', 'application/pdf',
+               $2, $3, 'VERIFIED', '{}'::jsonb)`,
+      [fixture.documentId, bytes.length, checksum]
+    );
+    await pgPool.query(
+      `UPDATE controlled_documents
+       SET current_released_revision_id = $1
+       WHERE id = $2`,
+      [released.rows[0].id, fixture.documentId]
+    );
+
+    await expect(approve(fixture, randomUUID())).rejects.toMatchObject({
+      code: 'CONFLICTING_RELEASED_REVISION',
+    });
+    const state = await pgPool.query(
+      `SELECT current_released_revision_id, lifecycle_status,
+              (SELECT count(*)::int FROM controlled_document_revision_approvals
+               WHERE revision_id = $1) AS approvals,
+              (SELECT count(*)::int FROM controlled_document_approval_release_events
+               WHERE revision_id = $1) AS events
+       FROM controlled_documents WHERE id = $2`,
+      [fixture.revisionId, fixture.documentId]
+    );
+    expect(state.rows[0]).toMatchObject({
+      current_released_revision_id: released.rows[0].id,
+      lifecycle_status: 'DRAFT',
+      approvals: 0,
+      events: 0,
+    });
+    const original = await pgPool.query(
+      `SELECT lifecycle_status, superseded_by_revision_id
+       FROM document_version_history WHERE id = $1`,
+      [released.rows[0].id]
+    );
+    expect(original.rows[0]).toMatchObject({
+      lifecycle_status: 'RELEASED',
+      superseded_by_revision_id: null,
+    });
+  });
+
+  it('rolls back exact state when an event trigger fails after mutations begin', async () => {
+    const fixture = await createFixture();
+    const before = await mutationSnapshot(fixture);
+    await pgPool.query(
+      `CREATE OR REPLACE FUNCTION mdr_phase2_test_fail_release_event()
+       RETURNS trigger LANGUAGE plpgsql AS $$
+       BEGIN
+         RAISE EXCEPTION 'MDR_PHASE2_INJECTED_EVENT_FAILURE';
+       END;
+       $$`
+    );
+    await pgPool.query(
+      `CREATE TRIGGER mdr_phase2_test_fail_release_event
+       AFTER INSERT ON controlled_document_approval_release_events
+       FOR EACH ROW EXECUTE FUNCTION mdr_phase2_test_fail_release_event()`
+    );
+    try {
+      await expect(approve(fixture, randomUUID())).rejects.toThrow(
+        /MDR_PHASE2_INJECTED_EVENT_FAILURE/
+      );
+    } finally {
+      await pgPool.query(
+        `DROP TRIGGER IF EXISTS mdr_phase2_test_fail_release_event
+         ON controlled_document_approval_release_events`
+      );
+      await pgPool.query(
+        'DROP FUNCTION IF EXISTS mdr_phase2_test_fail_release_event()'
+      );
+    }
+    const after = await mutationSnapshot(fixture);
+    expect(after).toEqual(before);
+  });
+
+  it('denies the real approval route without documents.approve and records no mutation', async () => {
+    const fixture = await createRouteApprovalFixture();
+    const response = await approveRoute(fixture, deniedSessionToken);
+    expect(response.status).toBe(403);
+    await expectNoPhase2Mutation(fixture);
+  });
+
+  it('denies the real approval route when step-up is missing or expired', async () => {
+    for (const token of [missingStepUpToken, expiredStepUpToken]) {
+      const fixture = await createRouteApprovalFixture();
+      const response = await approveRoute(fixture, token);
+      expect(response.status).toBe(401);
+      expect(response.body.code).toBe('STEP_UP_REQUIRED');
+      await expectNoPhase2Mutation(fixture);
+    }
+  });
+
+  it('denies self approval through the real route without lifecycle mutation', async () => {
+    const fixture = await createRouteApprovalFixture(approverUsername);
+    const response = await approveRoute(fixture, sessionToken);
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('SELF_APPROVAL_PROHIBITED');
+    await expectNoPhase2Mutation(fixture);
+  });
+
+  it('atomically approves and releases through the authenticated route', async () => {
+    const fixture = await createRouteApprovalFixture();
+    const response = await approveRoute(fixture, sessionToken);
+    expect(response.status).toBe(200);
+    expect(response.body.document).toMatchObject({
+      lifecycleStatus: 'RELEASED',
+      currentReleasedRevisionId: fixture.revisionId,
+      workingDraftRevisionId: null,
+    });
+    const state = await mutationSnapshot(fixture);
+    expect(state).toMatchObject({
+      document_lifecycle: 'RELEASED',
+      revision_lifecycle: 'RELEASED',
+      current_released_revision_id: fixture.revisionId,
+      working_draft_revision_id: null,
+      approvals: 1,
+      release_events: 1,
+      audits: 1,
+    });
+  });
+
+  it('blocks obsolete approve-only, Submit, and Release routes while Phase 2 is enabled', async () => {
+    const fixture = await createRouteApprovalFixture();
+    for (const action of ['submit', 'decision', 'release', 'approve']) {
+      const response = await request(accessApp)
+        .post(`/api/controlled-documents/${fixture.documentId}/${action}`)
+        .set('Authorization', `Bearer ${sessionToken}`)
+        .send({
+          revisionId: fixture.revisionId,
+          decision: 'APPROVED',
+          reason: 'Obsolete direct action attempt',
+          comment: 'Obsolete direct action attempt',
+        });
+      expect(response.status).toBe(409);
+      expect(response.body.error).toBe('PHASE2_OBSOLETE_ACTION');
+    }
+    await expectNoPhase2Mutation(fixture);
+  });
+
   it('serves the current released revision to an authenticated ordinary viewer and records allowed access', async () => {
     const fixture = await createReleasedRouteFixture();
     const view = await request(accessApp)
@@ -436,7 +894,7 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
     expect(guessed.status).toBe(404);
   });
 
-  it('supports authorized historical released bytes and rejects traversal, symlinks, and mutable external references', async () => {
+  it('supports authorized historical released bytes and audits authenticated path containment denials', async () => {
     const historical = await createReleasedRouteFixture(
       releasedPdfReference,
       releasedPdfChecksum,
@@ -449,31 +907,40 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
       .set('Authorization', `Bearer ${viewerSessionToken}`);
     expect(historicalResponse.status).toBe(200);
 
-    const traversal = await createReleasedRouteFixture(
-      `assets/documents/../${path.basename(outsidePdfPath)}`
-    );
-    const traversalResponse = await request(accessApp)
-      .get(`/api/controlled-documents/${traversal.documentId}/download`)
-      .set('Authorization', `Bearer ${viewerSessionToken}`);
-    expect(traversalResponse.status).toBe(422);
-    expect(traversalResponse.body.error).toBe('FILE_NOT_ACCESSIBLE');
+    const unsafeReferences = [
+      `assets/documents/../${path.basename(outsidePdfPath)}`,
+      `assets/documents/%2e%2e%2f${path.basename(outsidePdfPath)}`,
+      `assets/documents/%2e%2e%5c${path.basename(outsidePdfPath)}`,
+      `assets/documents/%252e%252e%252f${path.basename(outsidePdfPath)}`,
+      '/etc/passwd',
+      'C:\\Windows\\win.ini',
+      '\\\\server\\share\\secret.pdf',
+      `assets\\documents\\..\\${path.basename(outsidePdfPath)}`,
+      'assets/documents/%00secret.pdf',
+      'assets/documents/%E0%A4%A',
+      symlinkPdfReference,
+      'https://example.invalid/mutable.pdf',
+    ];
 
-    const symlink = await createReleasedRouteFixture(symlinkPdfReference);
-    const symlinkResponse = await request(accessApp)
-      .get(`/api/controlled-documents/${symlink.documentId}/download`)
-      .set('Authorization', `Bearer ${viewerSessionToken}`);
-    expect(symlinkResponse.status).toBe(422);
-    expect(symlinkResponse.body.error).toBe('FILE_NOT_ACCESSIBLE');
-
-    const external = await createReleasedRouteFixture(
-      'https://example.invalid/mutable.pdf'
-    );
-    const externalResponse = await request(accessApp)
-      .get(`/api/controlled-documents/${external.documentId}/download`)
-      .set('Authorization', `Bearer ${viewerSessionToken}`);
-    expect(externalResponse.status).toBe(422);
-    expect(externalResponse.body.error).toBe(
-      'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION'
-    );
+    for (const fileReference of unsafeReferences) {
+      const fixture = await createReleasedRouteFixture(fileReference);
+      for (const endpoint of ['view', 'download']) {
+        const response = await request(accessApp)
+          .get(`/api/controlled-documents/${fixture.documentId}/${endpoint}`)
+          .set('Authorization', `Bearer ${viewerSessionToken}`);
+        expect(response.status).toBeGreaterThanOrEqual(400);
+        expect(response.status).toBeLessThan(500);
+        const responseEvidence = JSON.stringify(response.body);
+        expect(responseEvidence).not.toContain(fileReference);
+        expect(responseEvidence).not.toContain(process.cwd());
+        expect(response.body).not.toEqual(releasedPdfBytes);
+      }
+      const denied = await pgPool.query(
+        `SELECT count(*)::int AS count FROM object_access_log
+         WHERE document_id = $1 AND user_id = $2 AND action = 'denied'`,
+        [fixture.documentId, viewerUsername]
+      );
+      expect(denied.rows[0].count).toBe(2);
+    }
   });
 });

--- a/server/__tests__/controlledDocumentPhase2Postgres.test.ts
+++ b/server/__tests__/controlledDocumentPhase2Postgres.test.ts
@@ -190,12 +190,12 @@ async function mutationSnapshot(fixture: Fixture) {
        (SELECT count(*)::int FROM controlled_document_approval_release_events
         WHERE revision_id = $1) AS release_events,
        (SELECT count(*)::int FROM audit_events
-        WHERE subject_type = 'controlled_document' AND subject_id = $2) AS audits
+        WHERE subject_type = 'controlled_document' AND subject_id = $2::text) AS audits
      FROM controlled_documents document
      JOIN document_version_history revision ON revision.id = $1
      JOIN controlled_document_number_registry registry
        ON registry.controlled_document_id = document.id
-     WHERE document.id = $2`,
+     WHERE document.id = $2::uuid`,
     [fixture.revisionId, fixture.documentId]
   );
   return result.rows[0];
@@ -204,8 +204,14 @@ async function mutationSnapshot(fixture: Fixture) {
 async function restoreApprovalChecksumSchema() {
   await pgPool.query(
     `ALTER TABLE controlled_document_revision_approvals
-       ALTER COLUMN file_checksum DROP NOT NULL,
-       ADD COLUMN IF NOT EXISTS checksum_verification_status text,
+       ALTER COLUMN file_checksum DROP NOT NULL`
+  );
+  await pgPool.query(
+    `ALTER TABLE controlled_document_revision_approvals
+       ADD COLUMN IF NOT EXISTS checksum_verification_status text`
+  );
+  await pgPool.query(
+    `ALTER TABLE controlled_document_revision_approvals
        ALTER COLUMN checksum_verification_status DROP DEFAULT`
   );
   await pgPool.query(
@@ -468,7 +474,7 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
   it('fails readiness for a malformed checksum status default or constraint', async () => {
     await pgPool.query(
       `ALTER TABLE controlled_document_revision_approvals
-       DROP CONSTRAINT controlled_document_revision_approvals_checksum_status_check,
+       DROP CONSTRAINT IF EXISTS controlled_document_revision_approvals_checksum_status_check,
        ALTER COLUMN checksum_verification_status SET DEFAULT 'UNVERIFIED'`
     );
     await pgPool.query(

--- a/server/__tests__/controlledDocumentPhase2Postgres.test.ts
+++ b/server/__tests__/controlledDocumentPhase2Postgres.test.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { pgPool } from '../db';
+import {
+  approveAndReleaseControlledRevision,
+  checksumFile,
+  ControlledDocumentError,
+} from '../src/services/controlledDocumentLifecycleService';
+import { assertControlledDocumentPhase2SchemaReady } from '../src/services/controlledDocumentSchemaReadiness';
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl)
+  throw new Error(
+    'DATABASE_URL is required for controlled-document Phase 2 PostgreSQL certification'
+  );
+
+const bytes = Buffer.from('authoritative controlled document bytes');
+const checksum = checksumFile(bytes);
+const role = `MDR_PHASE2_CERT_${randomUUID()}`;
+const approverUsername = `mdr-approver-${randomUUID()}`;
+const sessionToken = `mdr-session-${randomUUID()}`;
+let approverId = 0;
+
+type Fixture = {
+  documentId: string;
+  revisionId: string;
+  documentNumber: string;
+};
+
+async function createFixture(
+  author = `mdr-author-${randomUUID()}`
+): Promise<Fixture> {
+  const documentNumber = `MDR-CERT-${randomUUID()}`.toUpperCase();
+  const document = await pgPool.query(
+    `INSERT INTO controlled_documents
+       (document_number, document_name, document_type, department, lifecycle_status,
+        status, number_control_status, created_by)
+     VALUES ($1, 'Phase 2 certification', 'PROCEDURE', 'Quality', 'DRAFT',
+             'draft', 'RESERVED', $2)
+     RETURNING id`,
+    [documentNumber, author]
+  );
+  const documentId = document.rows[0].id as string;
+  const revision = await pgPool.query(
+    `INSERT INTO document_version_history
+       (document_id, version_number, revision_sequence, lifecycle_status, status,
+        created_by, file_path, file_name, media_type, file_size, file_checksum,
+        checksum_status, metadata)
+     VALUES ($1, '1.0', 1, 'DRAFT', 'draft', $2, '/objects/mdr-certification',
+             'certification.pdf', 'application/pdf', $3, $4, 'VERIFIED', '{}'::jsonb)
+     RETURNING id`,
+    [documentId, author, bytes.length, checksum]
+  );
+  const revisionId = revision.rows[0].id as string;
+  await pgPool.query(
+    `UPDATE controlled_documents
+     SET current_revision_id = $1, working_draft_revision_id = $1
+     WHERE id = $2`,
+    [revisionId, documentId]
+  );
+  await pgPool.query(
+    `INSERT INTO controlled_document_number_registry
+       (normalized_number, display_number, controlled_document_id, status)
+     VALUES ($1, $1, $2, 'RESERVED')`,
+    [documentNumber, documentId]
+  );
+  return { documentId, revisionId, documentNumber };
+}
+
+function approve(
+  fixture: Fixture,
+  idempotencyKey: string,
+  reason = 'Independent Quality approval',
+  read = async () => bytes
+) {
+  return approveAndReleaseControlledRevision({
+    ...fixture,
+    filePath: '/objects/mdr-certification',
+    observedChecksum: checksum,
+    idempotencyKey,
+    reason,
+    effectiveDate: '2026-08-05',
+    actor: { id: approverId, username: approverUsername, role },
+    sessionToken,
+    readAuthoritativeBytes: read,
+  });
+}
+
+beforeAll(async () => {
+  process.env.CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED = 'true';
+  const capability = await pgPool.query(
+    `INSERT INTO perm_capabilities (key, description, category)
+     VALUES ('documents.approve', 'Approve controlled documents', 'documents')
+     ON CONFLICT (key) DO UPDATE SET key = EXCLUDED.key RETURNING id`
+  );
+  const roleRow = await pgPool.query(
+    `INSERT INTO perm_roles (name, description) VALUES ($1, 'Disposable Phase 2 certification role')
+     ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name RETURNING id`,
+    [role]
+  );
+  await pgPool.query(
+    `INSERT INTO perm_role_capabilities (role_id, capability_id) VALUES ($1, $2)
+     ON CONFLICT DO NOTHING`,
+    [roleRow.rows[0].id, capability.rows[0].id]
+  );
+  const user = await pgPool.query(
+    `INSERT INTO users (username, password_hash, role) VALUES ($1, 'not-a-login-secret', $2) RETURNING id`,
+    [approverUsername, role]
+  );
+  approverId = user.rows[0].id;
+  await pgPool.query(
+    `INSERT INTO user_sessions
+       (session_token, user_id, username, expires_at, is_active, last_credential_verified_at)
+     VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', true, NOW())`,
+    [sessionToken, approverId, approverUsername]
+  );
+});
+
+afterAll(async () => {
+  delete process.env.CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED;
+  await pgPool.end();
+});
+
+describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
+  it('certifies the complete Phase 2 schema contract and append-only trigger', async () => {
+    await expect(
+      assertControlledDocumentPhase2SchemaReady()
+    ).resolves.toBeUndefined();
+    const fixture = await createFixture();
+    const key = randomUUID();
+    await approve(fixture, key);
+    await expect(
+      pgPool.query(
+        `UPDATE controlled_document_approval_release_events SET reason = 'tampered' WHERE idempotency_key = $1`,
+        [key]
+      )
+    ).rejects.toThrow(/append-only/i);
+    await expect(
+      pgPool.query(
+        'DELETE FROM controlled_document_approval_release_events WHERE idempotency_key = $1',
+        [key]
+      )
+    ).rejects.toThrow(/append-only/i);
+  });
+
+  it('commits approval, release, pointer, approval evidence, and immutable event atomically', async () => {
+    const fixture = await createFixture();
+    const result = await approve(fixture, randomUUID());
+    expect(result.document.lifecycleStatus).toBe('RELEASED');
+    expect(result.document.currentReleasedRevisionId).toBe(fixture.revisionId);
+    const evidence = await pgPool.query(
+      `SELECT count(*)::int AS approvals,
+              (SELECT count(*)::int FROM controlled_document_approval_release_events WHERE revision_id = $1) AS events
+       FROM controlled_document_revision_approvals WHERE revision_id = $1`,
+      [fixture.revisionId]
+    );
+    expect(evidence.rows[0]).toMatchObject({ approvals: 1, events: 1 });
+  });
+
+  it('replays an identical committed request without a second mutation', async () => {
+    const fixture = await createFixture();
+    const key = randomUUID();
+    await approve(fixture, key);
+    await approve(fixture, key);
+    const count = await pgPool.query(
+      'SELECT count(*)::int AS count FROM controlled_document_approval_release_events WHERE idempotency_key = $1',
+      [key]
+    );
+    expect(count.rows[0].count).toBe(1);
+  });
+
+  it('serializes simultaneous identical requests into one mutation and one replay', async () => {
+    const fixture = await createFixture();
+    const key = randomUUID();
+    const results = await Promise.all([
+      approve(fixture, key),
+      approve(fixture, key),
+    ]);
+    expect(
+      results.every((result) => result.document.lifecycleStatus === 'RELEASED')
+    ).toBe(true);
+    const count = await pgPool.query(
+      'SELECT count(*)::int AS count FROM controlled_document_approval_release_events WHERE idempotency_key = $1',
+      [key]
+    );
+    expect(count.rows[0].count).toBe(1);
+  });
+
+  it('returns deterministic conflict for a globally reused key with different request identity', async () => {
+    const first = await createFixture();
+    const second = await createFixture();
+    const key = randomUUID();
+    await approve(first, key);
+    await expect(
+      approve(second, key, 'Different request')
+    ).rejects.toMatchObject<Partial<ControlledDocumentError>>({
+      statusCode: 409,
+      code: 'IDEMPOTENCY_KEY_CONFLICT',
+    });
+    const state = await pgPool.query(
+      'SELECT lifecycle_status FROM controlled_documents WHERE id = $1',
+      [second.documentId]
+    );
+    expect(state.rows[0].lifecycle_status).toBe('DRAFT');
+  });
+
+  it('rolls back every database mutation when authoritative bytes change after preflight', async () => {
+    const fixture = await createFixture();
+    await expect(
+      approve(fixture, randomUUID(), 'Approval', async () =>
+        Buffer.from('changed')
+      )
+    ).rejects.toMatchObject({
+      code: 'AUTHORITATIVE_FILE_CHANGED',
+    });
+    const state = await pgPool.query(
+      `SELECT lifecycle_status, current_released_revision_id,
+              (SELECT count(*)::int FROM controlled_document_revision_approvals WHERE revision_id = $1) AS approvals,
+              (SELECT count(*)::int FROM controlled_document_approval_release_events WHERE revision_id = $1) AS events
+       FROM controlled_documents WHERE id = $2`,
+      [fixture.revisionId, fixture.documentId]
+    );
+    expect(state.rows[0]).toMatchObject({
+      lifecycle_status: 'DRAFT',
+      current_released_revision_id: null,
+      approvals: 0,
+      events: 0,
+    });
+  });
+});

--- a/server/__tests__/controlledDocumentPhase2Postgres.test.ts
+++ b/server/__tests__/controlledDocumentPhase2Postgres.test.ts
@@ -228,6 +228,17 @@ async function restoreApprovalChecksumSchema() {
   );
 }
 
+async function restoreRevisionLifecycleConstraint() {
+  await pgPool.query(
+    `ALTER TABLE document_version_history
+       DROP CONSTRAINT IF EXISTS document_version_history_lifecycle_check,
+       ADD CONSTRAINT document_version_history_lifecycle_check
+       CHECK (lifecycle_status IN (
+         'DRAFT','IN_REVIEW','APPROVED','REJECTED','RELEASED','SUPERSEDED','OBSOLETE','VOID'
+       ))`
+  );
+}
+
 async function expectNoPhase2Mutation(fixture: Fixture) {
   const state = await mutationSnapshot(fixture);
   expect(state).toMatchObject({
@@ -494,6 +505,27 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
       });
     } finally {
       await restoreApprovalChecksumSchema();
+    }
+  });
+
+  it('fails readiness when the revision lifecycle constraint cannot represent rejection', async () => {
+    await pgPool.query(
+      `ALTER TABLE document_version_history
+       DROP CONSTRAINT document_version_history_lifecycle_check,
+       ADD CONSTRAINT document_version_history_lifecycle_check
+       CHECK (lifecycle_status IN ('DRAFT','RELEASED'))`
+    );
+    try {
+      await expect(
+        assertControlledDocumentPhase2SchemaReady()
+      ).rejects.toMatchObject({
+        code: 'CONTROLLED_DOCUMENT_SCHEMA_NOT_READY',
+        missingObjects: expect.arrayContaining([
+          'constraint:document_version_history.lifecycle_status',
+        ]),
+      });
+    } finally {
+      await restoreRevisionLifecycleConstraint();
     }
   });
 

--- a/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
+++ b/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
@@ -1,45 +1,59 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 const read = (file: string) => readFileSync(join(process.cwd(), file), 'utf8');
 const route = read('server/src/routes/controlledDocuments.ts');
 const client = read('client/src/pages/MasterDocumentRegister.tsx');
-const lifecycleService = read('server/src/services/controlledDocumentLifecycleService.ts');
+const lifecycleService = read(
+  'server/src/services/controlledDocumentLifecycleService.ts'
+);
 const releasedHandler = route.slice(
   route.indexOf("router.get('/:id/view'"),
-  route.indexOf("// Delete document"),
+  route.indexOf('// Delete document')
 );
 
 describe('Master Document Register released-revision access', () => {
   it('serves released 1.1 instead of a working draft 1.2 for normal View and Download', () => {
     expect(releasedHandler).toContain('getReleasedRevisionForControlledUse');
-    expect(route).toContain('candidate.id === document.currentReleasedRevisionId');
-    expect(releasedHandler).toContain('doc.currentReleasedRevisionId');
-    expect(releasedHandler).toContain(': state.currentRevision');
-    expect(releasedHandler).toContain('!doc.currentReleasedRevisionId ? doc.filePath : null');
+    expect(route).toContain(
+      'candidate.id === document.currentReleasedRevisionId'
+    );
+    expect(releasedHandler).not.toContain(': state.currentRevision');
+    expect(releasedHandler).not.toContain('doc.filePath');
     expect(releasedHandler).not.toContain('revisions[revisions.length - 1]');
   });
 
-  it('keeps legacy no-pointer compatibility but fails closed when a populated pointer crosses documents', () => {
-    expect(releasedHandler).toContain(': state.currentRevision');
+  it('fails closed for both missing and cross-document released pointers', () => {
+    expect(route).toContain("'NO_RELEASED_REVISION'");
     expect(route).toContain("'RELEASED_REVISION_POINTER_INVALID'");
     expect(route).toContain('revision.documentId !== document.id');
-    expect(route).toContain("eventType: 'CONTROLLED_DOCUMENT_RELEASE_POINTER_INVALID'");
+    expect(route).toContain(
+      "eventType: 'CONTROLLED_DOCUMENT_RELEASE_POINTER_INVALID'"
+    );
   });
 
   it('stamps the exact served revision identity and lifecycle in PDF footers', () => {
     expect(route).toContain('revision.versionNumber');
-    expect(route).toContain('revision.effectiveDate || revision.releasedAt || revision.createdAt');
+    expect(route).toContain(
+      'revision.effectiveDate || revision.releasedAt || revision.createdAt'
+    );
     expect(route).toContain('revision.lifecycleStatus || revision.status');
-    expect(releasedHandler).toContain('addControlledDocumentFooter(buffer, doc, revision)');
+    expect(releasedHandler).toContain(
+      'addControlledDocumentFooter(buffer, doc, revision)'
+    );
   });
 
   it('keeps external references behind the API and out of controlled release', () => {
     expect(client).not.toMatch(/window\.open\(doc\.filePath/);
     expect(client).toContain('/api/controlled-documents/${doc.id}/${mode}');
-    expect(releasedHandler).toContain("'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION'");
-    expect(route).toContain('External references cannot be approved or released');
+    expect(releasedHandler).toContain(
+      "'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION'"
+    );
+    expect(route).toContain(
+      'External references cannot be approved or released'
+    );
   });
 
   it('requires lifecycle permission for exact draft and review revision bytes', () => {
@@ -50,13 +64,19 @@ describe('Master Document Register released-revision access', () => {
   });
 
   it('centralizes restricted, explicit-grant, and admin-only enforcement', () => {
-    expect(route.match(/requirePermission\('documents\.view'\), controlledDocumentAccessPolicy/g)).toHaveLength(3);
+    expect(
+      route.match(
+        /requirePermission\('documents\.view'\), controlledDocumentAccessPolicy/g
+      )
+    ).toHaveLength(3);
     expect(route).toContain("accessRule === 'explicit_grant'");
     expect(route).toContain("classification === 'restricted'");
     expect(route).toContain("classification === 'classified'");
     expect(route).toContain("accessRule !== 'admin_only'");
     expect(route).toContain('hasControlledDocumentGrant');
-    expect(route).not.toContain("requirePermission('documents.view'), requireStepUp(), async");
+    expect(route).not.toContain(
+      "requirePermission('documents.view'), requireStepUp(), async"
+    );
   });
 
   it('verifies the selected revision checksum before recording allowed access', () => {
@@ -64,6 +84,8 @@ describe('Master Document Register released-revision access', () => {
     const logIndex = releasedHandler.indexOf("action: 'view'");
     expect(verifyIndex).toBeGreaterThan(-1);
     expect(logIndex).toBeGreaterThan(verifyIndex);
-    expect(lifecycleService).toContain("'CONTROLLED_DOCUMENT_CHECKSUM_MISMATCH'");
+    expect(lifecycleService).toContain(
+      "'CONTROLLED_DOCUMENT_CHECKSUM_MISMATCH'"
+    );
   });
 });

--- a/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
+++ b/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
@@ -10,7 +10,7 @@ const lifecycleService = read(
   'server/src/services/controlledDocumentLifecycleService.ts'
 );
 const releasedHandler = route.slice(
-  route.indexOf("router.get('/:id/view'"),
+  route.indexOf("'/:id/view'"),
   route.indexOf('// Delete document')
 );
 
@@ -40,8 +40,8 @@ describe('Master Document Register released-revision access', () => {
       'revision.effectiveDate || revision.releasedAt || revision.createdAt'
     );
     expect(route).toContain('revision.lifecycleStatus || revision.status');
-    expect(releasedHandler).toContain(
-      'addControlledDocumentFooter(buffer, doc, revision)'
+    expect(releasedHandler).toMatch(
+      /addControlledDocumentFooter\(\s*buffer,\s*doc,\s*revision\s*\)/
     );
   });
 
@@ -66,7 +66,7 @@ describe('Master Document Register released-revision access', () => {
   it('centralizes restricted, explicit-grant, and admin-only enforcement', () => {
     expect(
       route.match(
-        /requirePermission\('documents\.view'\), controlledDocumentAccessPolicy/g
+        /requirePermission\('documents\.view'\),\s*controlledDocumentAccessPolicy/g
       )
     ).toHaveLength(3);
     expect(route).toContain("accessRule === 'explicit_grant'");

--- a/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
+++ b/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
@@ -66,7 +66,7 @@ describe('Master Document Register released-revision access', () => {
   it('centralizes restricted, explicit-grant, and admin-only enforcement', () => {
     expect(
       route.match(
-        /requirePermission\('documents\.view'\),\s*controlledDocumentAccessPolicy/g
+        /controlledDocumentViewPermission,\s*controlledDocumentAccessPolicy/g
       )
     ).toHaveLength(3);
     expect(route).toContain("accessRule === 'explicit_grant'");

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -12512,7 +12512,8 @@ export const controlledDocumentRevisionApprovals = pgTable(
     revisionId: uuid('revision_id')
       .references(() => documentVersionHistory.id, { onDelete: 'restrict' })
       .notNull(),
-    fileChecksum: text('file_checksum').notNull(),
+    fileChecksum: text('file_checksum'),
+    checksumVerificationStatus: text('checksum_verification_status'),
     documentNumberSnapshot: text('document_number_snapshot').notNull(),
     revisionSnapshot: text('revision_snapshot').notNull(),
     decision: text('decision').notNull(),
@@ -12539,6 +12540,7 @@ export const controlledDocumentApprovalReleaseEvents = pgTable('controlled_docum
   revisionId: uuid('revision_id').references(() => documentVersionHistory.id, { onDelete: 'restrict' }).notNull(),
   approvalId: uuid('approval_id').references(() => controlledDocumentRevisionApprovals.id, { onDelete: 'restrict' }).notNull(),
   idempotencyKey: text('idempotency_key').notNull().unique(),
+  requestIdentityHash: text('request_identity_hash').notNull(),
   fileChecksum: text('file_checksum').notNull(),
   documentNumberSnapshot: text('document_number_snapshot').notNull(),
   revisionSnapshot: text('revision_snapshot').notNull(),

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -12532,6 +12532,27 @@ export const controlledDocumentRevisionApprovals = pgTable(
   }
 );
 
+/* eslint-disable prettier/prettier */
+export const controlledDocumentApprovalReleaseEvents = pgTable('controlled_document_approval_release_events', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  controlledDocumentId: uuid('controlled_document_id').references(() => controlledDocuments.id, { onDelete: 'restrict' }).notNull(),
+  revisionId: uuid('revision_id').references(() => documentVersionHistory.id, { onDelete: 'restrict' }).notNull(),
+  approvalId: uuid('approval_id').references(() => controlledDocumentRevisionApprovals.id, { onDelete: 'restrict' }).notNull(),
+  idempotencyKey: text('idempotency_key').notNull().unique(),
+  fileChecksum: text('file_checksum').notNull(),
+  documentNumberSnapshot: text('document_number_snapshot').notNull(),
+  revisionSnapshot: text('revision_snapshot').notNull(),
+  actorUserId: integer('actor_user_id').references(() => users.id, { onDelete: 'restrict' }).notNull(),
+  actorSnapshot: jsonb('actor_snapshot').notNull(),
+  authoritySnapshot: jsonb('authority_snapshot').notNull(),
+  reason: text('reason').notNull(),
+  beforeLifecycle: text('before_lifecycle').notNull(),
+  afterLifecycle: text('after_lifecycle').notNull(),
+  effectiveDate: date('effective_date').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+/* eslint-enable prettier/prettier */
+
 export const controlledDocumentReconciliationPreviews = pgTable(
   'controlled_document_reconciliation_previews',
   {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -285,6 +285,7 @@ export const safeMigrationFiles = [
   '0252_potential_order_duplicate_reviews.sql',
   '0254_controlled_document_reconciliation_certification_controls.sql',
   '0255_p2_v2_definition_v3_handoff.sql',
+  '0256_controlled_document_atomic_approval_release.sql',
   '0258_design_control_structured_lifecycle.sql',
   'investigation_308_order_duplication.sql',
 ];
@@ -336,6 +337,7 @@ export const criticalMigrationFiles = new Set([
   '0251_design_project_configuration_workspace.sql',
   '0252_potential_order_duplicate_reviews.sql',
   '0254_controlled_document_reconciliation_certification_controls.sql',
+  '0256_controlled_document_atomic_approval_release.sql',
   '0231_p1_po_item_quantity_adjustments.sql',
   '0232_p2_v2_controlled_pilot_readiness.sql',
   '0233a_spec_sheets_base_table.sql',

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -979,9 +979,11 @@ router.get(
           const fileReferenceType = getControlledFileReferenceType(
             authoritativeReference
           );
+          /* eslint-disable prettier/prettier -- Linux CI and Windows disagree on this union layout. */
           let fileAccessibility:
             'ACCESSIBLE' | 'INACCESSIBLE' | 'EXTERNAL_MUTABLE' | 'MISSING' =
             'MISSING';
+          /* eslint-enable prettier/prettier */
           if (fileReferenceType === 'EXTERNAL_MUTABLE_URL') {
             fileAccessibility = 'EXTERNAL_MUTABLE';
           } else if (authoritativeReference) {

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -4,7 +4,14 @@ import path from 'path';
 import { db } from '../../../server/db';
 import { pool } from '../../../server/db';
 import { requirePermission } from '../../../server/middleware/requirePermission';
-import { controlledDocumentNumberRegistry, controlledDocumentRevisionApprovals, controlledDocuments, documentVersionHistory, insertControlledDocumentSchema, insertDocumentVersionHistorySchema } from '../../../server/schema';
+import {
+  controlledDocumentNumberRegistry,
+  controlledDocumentRevisionApprovals,
+  controlledDocuments,
+  documentVersionHistory,
+  insertControlledDocumentSchema,
+  insertDocumentVersionHistorySchema,
+} from '../../../server/schema';
 import { eq, desc, and, inArray, sql } from 'drizzle-orm';
 import fs from 'fs/promises';
 import { z } from 'zod';
@@ -15,7 +22,10 @@ import { getUserPermissions } from '../services/permissionService';
 import { recordAuditEvent } from '../services/auditLedgerService';
 import { fileURLToPath } from 'url';
 import { PDFDocument, PDFFont, StandardFonts, rgb } from 'pdf-lib';
-import { getFileStorageProvider, getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
+import {
+  getFileStorageProvider,
+  getFileStorageProviderForObjectPath,
+} from '../services/fileStorageProvider';
 import {
   ControlledDocumentError,
   approveAndReleaseControlledRevision,
@@ -43,33 +53,57 @@ const router = Router();
 const lifecycleActor = (req: Request) => {
   const user = (req as any).user;
   if (!user || !Number.isInteger(Number(user.id))) {
-    throw new ControlledDocumentError(401, 'AUTHENTICATION_REQUIRED', 'Authenticated user identity is required');
+    throw new ControlledDocumentError(
+      401,
+      'AUTHENTICATION_REQUIRED',
+      'Authenticated user identity is required'
+    );
   }
-  return { id: Number(user.id), username: String(user.username), role: String(user.role) };
+  return {
+    id: Number(user.id),
+    username: String(user.username),
+    role: String(user.role),
+  };
 };
 
 const requestEvidence = (req: Request) => ({
-  ipAddress: ((req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.socket.remoteAddress || null),
+  ipAddress:
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
+    req.socket.remoteAddress ||
+    null,
   userAgent: req.headers['user-agent'] ?? null,
 });
 
-const sessionToken = (req: Request) => String(
-  req.cookies?.sessionToken || req.headers.authorization?.replace(/^Bearer\s+/i, '') || ''
-);
+const sessionToken = (req: Request) =>
+  String(
+    req.cookies?.sessionToken ||
+      req.headers.authorization?.replace(/^Bearer\s+/i, '') ||
+      ''
+  );
 
-const sendLifecycleError = (res: Response, error: unknown, fallback: string) => {
+const sendLifecycleError = (
+  res: Response,
+  error: unknown,
+  fallback: string
+) => {
   if (error instanceof ControlledDocumentError) {
-    res.status(error.statusCode).json({ error: error.code, message: error.message, ...error.details });
+    res
+      .status(error.statusCode)
+      .json({ error: error.code, message: error.message, ...error.details });
     return;
   }
   console.error(fallback, error);
-  res.status(500).json({ error: 'CONTROLLED_DOCUMENT_OPERATION_FAILED', message: fallback });
+  res
+    .status(500)
+    .json({ error: 'CONTROLLED_DOCUMENT_OPERATION_FAILED', message: fallback });
 };
 
 // Helper function to get user from session
 async function getUserFromSession(req: Request): Promise<any | null> {
-  const sessionToken = req.cookies?.sessionToken || req.headers.authorization?.replace('Bearer ', '');
-  
+  const sessionToken =
+    req.cookies?.sessionToken ||
+    req.headers.authorization?.replace('Bearer ', '');
+
   if (!sessionToken) {
     return null;
   }
@@ -91,7 +125,10 @@ async function getUserFromSession(req: Request): Promise<any | null> {
 
     // Belt-and-suspenders expiry check (the SQL above already filters these out)
     if (new Date(session.expires_at) < new Date()) {
-      await pool.query(`UPDATE user_sessions SET is_active = false WHERE session_token = $1`, [sessionToken]);
+      await pool.query(
+        `UPDATE user_sessions SET is_active = false WHERE session_token = $1`,
+        [sessionToken]
+      );
       return null;
     }
 
@@ -122,11 +159,16 @@ const requireAuth = async (req: Request, res: Response, next: any) => {
   next();
 };
 
-/* eslint-disable prettier/prettier */
-router.get('/phase2/availability', requireAuth, (_req: Request, res: Response) => {
-  res.json({ enabled: isControlledDocumentPhase2Enabled(), workflow: 'REGISTER_APPROVE_RELEASE' });
-});
-/* eslint-enable prettier/prettier */
+router.get(
+  '/phase2/availability',
+  requireAuth,
+  (_req: Request, res: Response) => {
+    res.json({
+      enabled: isControlledDocumentPhase2Enabled(),
+      workflow: 'REGISTER_APPROVE_RELEASE',
+    });
+  }
+);
 
 // Authorization middleware - check for admin/owner role
 const requireAdminOrOwner = async (req: Request, res: Response, next: any) => {
@@ -135,14 +177,20 @@ const requireAdminOrOwner = async (req: Request, res: Response, next: any) => {
     return res.status(401).json({ error: 'Authentication required' });
   }
   if (user.role !== 'ADMIN' && user.role !== 'OWNER') {
-    return res.status(403).json({ error: 'Only admins and owners can perform this action' });
+    return res
+      .status(403)
+      .json({ error: 'Only admins and owners can perform this action' });
   }
   (req as any).user = user;
   next();
 };
 
 // Authorization middleware for document create/edit - admin, owner, or designated document managers
-const requireDocumentEditor = async (req: Request, res: Response, next: any) => {
+const requireDocumentEditor = async (
+  req: Request,
+  res: Response,
+  next: any
+) => {
   const user = await getUserFromSession(req);
   if (!user) {
     return res.status(401).json({ error: 'Authentication required' });
@@ -159,12 +207,17 @@ const upload = multer({
     if (allowedTypes.test(file.originalname)) {
       cb(null, true);
     } else {
-      cb(new Error('Invalid file type. Allowed: PDF, Word, Excel, Text, Images'));
+      cb(
+        new Error('Invalid file type. Allowed: PDF, Word, Excel, Text, Images')
+      );
     }
-  }
+  },
 });
 
-const persistControlledDocumentUpload = async (file: Express.Multer.File, entityId?: string) =>
+const persistControlledDocumentUpload = async (
+  file: Express.Multer.File,
+  entityId?: string
+) =>
   getFileStorageProvider().uploadBuffer({
     buffer: file.buffer,
     fileName: file.originalname,
@@ -174,8 +227,13 @@ const persistControlledDocumentUpload = async (file: Express.Multer.File, entity
   });
 
 const readControlledDocumentBytes = async (filePath: string) => {
-  if (filePath.startsWith('/objects/') || filePath.startsWith('/supabase-objects/')) {
-    return getFileStorageProviderForObjectPath(filePath).downloadBuffer(filePath);
+  if (
+    filePath.startsWith('/objects/') ||
+    filePath.startsWith('/supabase-objects/')
+  ) {
+    return getFileStorageProviderForObjectPath(filePath).downloadBuffer(
+      filePath
+    );
   }
   const resolvedPath = resolveControlledDocumentFile(filePath);
   if (!resolvedPath) {
@@ -204,15 +262,16 @@ const verifyStoredRevision = async (
   revision: { id: string },
   filePath: string,
   buffer: Buffer,
-  req: Request,
-) => verifyControlledRevisionFile({
-  documentId,
-  revisionId: revision.id,
-  filePath,
-  fileBuffer: buffer,
-  actor: lifecycleActor(req),
-  request: requestEvidence(req),
-});
+  req: Request
+) =>
+  verifyControlledRevisionFile({
+    documentId,
+    revisionId: revision.id,
+    filePath,
+    fileBuffer: buffer,
+    actor: lifecycleActor(req),
+    request: requestEvidence(req),
+  });
 
 type ControlledDocumentRecord = typeof controlledDocuments.$inferSelect;
 type ControlledRevisionRecord = typeof documentVersionHistory.$inferSelect;
@@ -222,30 +281,30 @@ const isPrivilegedDocumentActor = (actor: { role: string }) =>
 
 const hasControlledDocumentGrant = async (
   documentId: string,
-  actor: { username: string; role: string },
+  actor: { username: string; role: string }
 ) => {
   const result = await pool.query<{ id: number }>(
     `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
        (grantee_type = 'user' AND grantee_name = $2)
        OR (grantee_type = 'role' AND grantee_name = $3)
      ) LIMIT 1`,
-    [documentId, actor.username, actor.role],
+    [documentId, actor.username, actor.role]
   );
   return result.rows.length > 0;
 };
 
 const authorizeControlledDocumentAccess = async (
   req: Request,
-  document: ControlledDocumentRecord,
+  document: ControlledDocumentRecord
 ) => {
   const actor = lifecycleActor(req);
   if (isPrivilegedDocumentActor(actor)) return actor;
 
   const classification = String(
-    document.classification || 'internal',
+    document.classification || 'internal'
   ).toLowerCase();
   const accessRule = String(
-    document.accessRule || 'authenticated',
+    document.accessRule || 'authenticated'
   ).toLowerCase();
   const grantRequired =
     accessRule === 'explicit_grant' ||
@@ -268,7 +327,7 @@ const authorizeControlledDocumentAccess = async (
       accessRule === 'admin_only'
         ? 'This document is restricted to administrators and owners'
         : 'An explicit vault grant is required to access this document',
-      { classification, accessRule },
+      { classification, accessRule }
     );
   }
   return actor;
@@ -276,11 +335,11 @@ const authorizeControlledDocumentAccess = async (
 
 const assertExactRevisionPermission = async (
   actor: { id: number; role: string },
-  revision: ControlledRevisionRecord,
+  revision: ControlledRevisionRecord
 ) => {
   if (isPrivilegedDocumentActor(actor)) return;
   const lifecycle = String(
-    revision.lifecycleStatus || revision.status || '',
+    revision.lifecycleStatus || revision.status || ''
   ).toUpperCase();
   if (['RELEASED', 'SUPERSEDED', 'OBSOLETE'].includes(lifecycle)) return;
 
@@ -294,7 +353,7 @@ const assertExactRevisionPermission = async (
       403,
       'DRAFT_REVISION_ACCESS_DENIED',
       'Draft and review revisions require an appropriate document lifecycle permission',
-      { lifecycleStatus: lifecycle, requiredAnyCapability: required },
+      { lifecycleStatus: lifecycle, requiredAnyCapability: required }
     );
   }
 };
@@ -302,7 +361,7 @@ const assertExactRevisionPermission = async (
 const getReleasedRevisionForControlledUse = async (
   req: Request,
   document: ControlledDocumentRecord,
-  revisions: ControlledRevisionRecord[],
+  revisions: ControlledRevisionRecord[]
 ) => {
   if (!document.currentReleasedRevisionId) {
     const actor = lifecycleActor(req);
@@ -315,11 +374,11 @@ const getReleasedRevisionForControlledUse = async (
     throw new ControlledDocumentError(
       409,
       'NO_RELEASED_REVISION',
-      'This controlled document has not been released',
+      'This controlled document has not been released'
     );
   }
   const revision = revisions.find(
-    (candidate) => candidate.id === document.currentReleasedRevisionId,
+    (candidate) => candidate.id === document.currentReleasedRevisionId
   );
   if (!revision || revision.documentId !== document.id) {
     const actor = lifecycleActor(req);
@@ -335,7 +394,8 @@ const getReleasedRevisionForControlledUse = async (
       subjectId: document.id,
       sourceService: 'controlledDocuments.route',
       actor,
-      reason: 'Normal controlled-use access rejected an invalid released revision pointer',
+      reason:
+        'Normal controlled-use access rejected an invalid released revision pointer',
       ipAddress: requestEvidence(req).ipAddress,
       userAgent: requestEvidence(req).userAgent,
       payload: {
@@ -346,7 +406,7 @@ const getReleasedRevisionForControlledUse = async (
     throw new ControlledDocumentError(
       409,
       'RELEASED_REVISION_POINTER_INVALID',
-      'The released revision reference is invalid; access has been denied and recorded',
+      'The released revision reference is invalid; access has been denied and recorded'
     );
   }
   return revision;
@@ -362,7 +422,7 @@ const csvUpload = multer({
     } else {
       cb(new Error('Invalid file type. Only CSV files are allowed.'));
     }
-  }
+  },
 });
 
 const nextRevisionVersion = (version: string | null | undefined): string => {
@@ -390,9 +450,11 @@ const getCsvValue = (row: Record<string, unknown>, names: string[]) => {
   return '';
 };
 
-const toForwardSlashPath = (filePath: string) => filePath.replace(/\\/g, '/').toLowerCase();
+const toForwardSlashPath = (filePath: string) =>
+  filePath.replace(/\\/g, '/').toLowerCase();
 
-const isWindowsAbsolutePath = (filePath: string) => /^[a-zA-Z]:[\\/]/.test(filePath);
+const isWindowsAbsolutePath = (filePath: string) =>
+  /^[a-zA-Z]:[\\/]/.test(filePath);
 
 const isUncPath = (filePath: string) => /^\\\\[^\\]+\\[^\\]+/.test(filePath);
 
@@ -409,7 +471,8 @@ const isAllowedImportedAbsolutePath = (filePath: string) => {
 const getExternalRedirectUrl = (filePath: string | null | undefined) => {
   const trimmed = String(filePath || '').trim();
   if (/^https?:\/\//i.test(trimmed)) return trimmed;
-  if (/^(?:drive|docs)\.google\.com\//i.test(trimmed)) return `https://${trimmed}`;
+  if (/^(?:drive|docs)\.google\.com\//i.test(trimmed))
+    return `https://${trimmed}`;
   return null;
 };
 
@@ -417,7 +480,10 @@ const getImportedFileReference = (filePath: string | null | undefined) => {
   const trimmed = String(filePath || '').trim();
   if (!trimmed) return null;
   if (getExternalRedirectUrl(trimmed)) return getExternalRedirectUrl(trimmed);
-  if (trimmed.startsWith('/assets/documents/') || trimmed.startsWith('assets/documents/')) {
+  if (
+    trimmed.startsWith('/assets/documents/') ||
+    trimmed.startsWith('assets/documents/')
+  ) {
     return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
   }
 
@@ -430,7 +496,12 @@ const getImportedFileReference = (filePath: string | null | undefined) => {
     }
   }
 
-  if ((isWindowsAbsolutePath(trimmed) || isUncPath(trimmed) || path.isAbsolute(trimmed)) && isAllowedImportedAbsolutePath(trimmed)) {
+  if (
+    (isWindowsAbsolutePath(trimmed) ||
+      isUncPath(trimmed) ||
+      path.isAbsolute(trimmed)) &&
+    isAllowedImportedAbsolutePath(trimmed)
+  ) {
     return trimmed;
   }
 
@@ -441,10 +512,16 @@ const resolveControlledDocumentFile = (filePath: string | null | undefined) => {
   const trimmed = String(filePath || '').trim();
   if (!trimmed) return null;
 
-  const centralMediaRoot = path.resolve(process.cwd(), 'uploads', 'media-library');
+  const centralMediaRoot = path.resolve(
+    process.cwd(),
+    'uploads',
+    'media-library'
+  );
   if (trimmed.startsWith('/api/media/file/')) {
     try {
-      const fileName = decodeURIComponent(trimmed.slice('/api/media/file/'.length));
+      const fileName = decodeURIComponent(
+        trimmed.slice('/api/media/file/'.length)
+      );
       if (!fileName || path.basename(fileName) !== fileName) return null;
       return path.join(centralMediaRoot, fileName);
     } catch {
@@ -454,15 +531,23 @@ const resolveControlledDocumentFile = (filePath: string | null | undefined) => {
 
   const normalizedMediaPath = trimmed.replace(/\\/g, '/').replace(/^\//, '');
   if (normalizedMediaPath.startsWith('uploads/media-library/')) {
-    const relativeMediaPath = normalizedMediaPath.slice('uploads/media-library/'.length);
+    const relativeMediaPath = normalizedMediaPath.slice(
+      'uploads/media-library/'.length
+    );
     const resolvedMediaPath = path.resolve(centralMediaRoot, relativeMediaPath);
-    if (resolvedMediaPath !== centralMediaRoot && resolvedMediaPath.startsWith(`${centralMediaRoot}${path.sep}`)) {
+    if (
+      resolvedMediaPath !== centralMediaRoot &&
+      resolvedMediaPath.startsWith(`${centralMediaRoot}${path.sep}`)
+    ) {
       return resolvedMediaPath;
     }
     return null;
   }
 
-  if (trimmed.startsWith('/assets/documents/') || trimmed.startsWith('assets/documents/')) {
+  if (
+    trimmed.startsWith('/assets/documents/') ||
+    trimmed.startsWith('assets/documents/')
+  ) {
     const relativePath = trimmed.replace(/^\//, '');
     return path.join(process.cwd(), 'server/src', relativePath);
   }
@@ -476,88 +561,146 @@ const resolveControlledDocumentFile = (filePath: string | null | undefined) => {
     }
   }
 
-  if ((isWindowsAbsolutePath(trimmed) || isUncPath(trimmed) || path.isAbsolute(trimmed)) && isAllowedImportedAbsolutePath(trimmed)) {
+  if (
+    (isWindowsAbsolutePath(trimmed) ||
+      isUncPath(trimmed) ||
+      path.isAbsolute(trimmed)) &&
+    isAllowedImportedAbsolutePath(trimmed)
+  ) {
     return trimmed;
   }
 
   if (/^[^\\/]+\.[a-z0-9]{2,5}$/i.test(trimmed)) {
-    return path.join(process.cwd(), 'server/src/assets/documents', path.basename(trimmed));
+    return path.join(
+      process.cwd(),
+      'server/src/assets/documents',
+      path.basename(trimmed)
+    );
   }
 
   return null;
 };
 
-const getControlledFileReferenceType = (filePath: string | null | undefined) => {
+const getControlledFileReferenceType = (
+  filePath: string | null | undefined
+) => {
   const value = String(filePath || '').trim();
   if (!value) return 'NONE';
   if (getExternalRedirectUrl(value)) return 'EXTERNAL_MUTABLE_URL';
   if (value.startsWith('/objects/')) return 'OBJECT_STORAGE';
   if (value.startsWith('/supabase-objects/')) return 'SUPABASE_OBJECT_STORAGE';
-  if (value.startsWith('/api/media/file/') || /uploads[\\/]media-library/i.test(value)) return 'CENTRAL_MEDIA_LIBRARY';
+  if (
+    value.startsWith('/api/media/file/') ||
+    /uploads[\\/]media-library/i.test(value)
+  )
+    return 'CENTRAL_MEDIA_LIBRARY';
   if (/^\/?assets\/documents\//i.test(value)) return 'ASSETS_DOCUMENTS';
   if (/^file:\/\//i.test(value)) return 'FILE_URI';
   if (isUncPath(value)) return 'UNC_PATH';
-  if (isWindowsAbsolutePath(value) || path.isAbsolute(value)) return 'LEGACY_LOCAL_PATH';
+  if (isWindowsAbsolutePath(value) || path.isAbsolute(value))
+    return 'LEGACY_LOCAL_PATH';
   return 'UNSUPPORTED_REFERENCE';
 };
 
-const controlledDocumentRequiresStepUp = (doc: typeof controlledDocuments.$inferSelect) => {
+const controlledDocumentRequiresStepUp = (
+  doc: typeof controlledDocuments.$inferSelect
+) => {
   const classification = String(doc.classification || 'internal').toLowerCase();
   const accessRule = String(doc.accessRule || 'authenticated').toLowerCase();
   return Boolean(
-    doc.mfaRequired
-    || ['restricted', 'classified', 'cui', 'itar'].includes(classification)
-    || accessRule === 'explicit_grant'
-    || accessRule === 'admin_only'
-    || doc.cuiCategory
-    || doc.itarCategory
+    doc.mfaRequired ||
+    ['restricted', 'classified', 'cui', 'itar'].includes(classification) ||
+    accessRule === 'explicit_grant' ||
+    accessRule === 'admin_only' ||
+    doc.cuiCategory ||
+    doc.itarCategory
   );
 };
 
-const hasPolicyVaultGrant = async (documentId: string, username: string, role: string) => {
+const hasPolicyVaultGrant = async (
+  documentId: string,
+  username: string,
+  role: string
+) => {
   const result = await pool.query<{ id: number }>(
     `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
        (grantee_type = 'user' AND grantee_name = $2)
        OR (grantee_type = 'role' AND grantee_name = $3)
      ) LIMIT 1`,
-    [documentId, username, role],
+    [documentId, username, role]
   );
   return result.rows.length > 0;
 };
 
-const controlledDocumentAccessPolicy = async (req: Request, res: Response, next: NextFunction) => {
+const controlledDocumentAccessPolicy = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const actor = lifecycleActor(req);
-    const [doc] = await db.select().from(controlledDocuments)
-      .where(eq(controlledDocuments.id, req.params.id)).limit(1);
-    if (!doc) return res.status(404).json({ error: 'REVISION_RECORD_MISSING', message: 'Controlled document record was not found' });
+    const [doc] = await db
+      .select()
+      .from(controlledDocuments)
+      .where(eq(controlledDocuments.id, req.params.id))
+      .limit(1);
+    if (!doc)
+      return res.status(404).json({
+        error: 'REVISION_RECORD_MISSING',
+        message: 'Controlled document record was not found',
+      });
 
     const privileged = actor.role === 'ADMIN' || actor.role === 'OWNER';
-    const classification = String(doc.classification || 'internal').toLowerCase();
+    const classification = String(
+      doc.classification || 'internal'
+    ).toLowerCase();
     const accessRule = String(doc.accessRule || 'authenticated').toLowerCase();
-    const grantRequired = accessRule === 'explicit_grant'
-      || ['restricted', 'classified', 'cui', 'itar'].includes(classification)
-      || Boolean(doc.cuiCategory || doc.itarCategory);
-    const allowed = privileged || (accessRule !== 'admin_only'
-      && (!grantRequired || await hasPolicyVaultGrant(doc.id, actor.username, actor.role)));
+    const grantRequired =
+      accessRule === 'explicit_grant' ||
+      ['restricted', 'classified', 'cui', 'itar'].includes(classification) ||
+      Boolean(doc.cuiCategory || doc.itarCategory);
+    const allowed =
+      privileged ||
+      (accessRule !== 'admin_only' &&
+        (!grantRequired ||
+          (await hasPolicyVaultGrant(doc.id, actor.username, actor.role))));
     if (!allowed) {
-      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'denied', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
-      return res.status(403).json({ error: 'ACCESS_DENIED', message: 'The document access policy does not permit this request' });
+      await writeAccessLog({
+        documentId: doc.id,
+        userId: actor.username,
+        action: 'denied',
+        ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+      });
+      return res.status(403).json({
+        error: 'ACCESS_DENIED',
+        message: 'The document access policy does not permit this request',
+      });
     }
 
     (req as any).controlledDocument = doc;
     if (!controlledDocumentRequiresStepUp(doc)) return next();
     return requireStepUp()(req, res, next);
   } catch (error) {
-    sendLifecycleError(res, error, 'Failed to evaluate controlled document access policy');
+    sendLifecycleError(
+      res,
+      error,
+      'Failed to evaluate controlled document access policy'
+    );
   }
 };
 
-const formatControlledDocumentFooterDate = (value: Date | string | null | undefined) => {
+const formatControlledDocumentFooterDate = (
+  value: Date | string | null | undefined
+) => {
   if (!value) return 'N/A';
-  const date = value instanceof Date
-    ? value
-    : new Date(String(value).includes('T') ? String(value) : `${String(value)}T00:00:00`);
+  const date =
+    value instanceof Date
+      ? value
+      : new Date(
+          String(value).includes('T')
+            ? String(value)
+            : `${String(value)}T00:00:00`
+        );
   if (Number.isNaN(date.getTime())) return String(value);
 
   return date.toLocaleDateString('en-US', {
@@ -567,11 +710,19 @@ const formatControlledDocumentFooterDate = (value: Date | string | null | undefi
   });
 };
 
-const truncateTextToWidth = (text: string, maxWidth: number, font: PDFFont, size: number) => {
+const truncateTextToWidth = (
+  text: string,
+  maxWidth: number,
+  font: PDFFont,
+  size: number
+) => {
   if (font.widthOfTextAtSize(text, size) <= maxWidth) return text;
 
   let truncated = text;
-  while (truncated.length > 0 && font.widthOfTextAtSize(`${truncated}...`, size) > maxWidth) {
+  while (
+    truncated.length > 0 &&
+    font.widthOfTextAtSize(`${truncated}...`, size) > maxWidth
+  ) {
     truncated = truncated.slice(0, -1);
   }
 
@@ -581,17 +732,17 @@ const truncateTextToWidth = (text: string, maxWidth: number, font: PDFFont, size
 const addControlledDocumentFooter = async (
   pdfBytes: Buffer,
   doc: ControlledDocumentRecord,
-  revision: ControlledRevisionRecord,
+  revision: ControlledRevisionRecord
 ) => {
   const pdfDoc = await PDFDocument.load(pdfBytes);
   const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
   const pages = pdfDoc.getPages();
 
   const footerDate = formatControlledDocumentFooterDate(
-    revision.effectiveDate || revision.releasedAt || revision.createdAt,
+    revision.effectiveDate || revision.releasedAt || revision.createdAt
   );
   const lifecycleStatus = String(
-    revision.lifecycleStatus || revision.status || 'UNKNOWN',
+    revision.lifecycleStatus || revision.status || 'UNKNOWN'
   ).toUpperCase();
   const footerText = `Doc #: ${doc.documentNumber || 'N/A'} | Version: ${revision.versionNumber || 'N/A'} | Effective: ${footerDate} | Status: ${lifecycleStatus}`;
 
@@ -600,7 +751,12 @@ const addControlledDocumentFooter = async (
     const marginX = 36;
     const footerHeight = 24;
     const fontSize = 8;
-    const text = truncateTextToWidth(footerText, width - marginX * 2, font, fontSize);
+    const text = truncateTextToWidth(
+      footerText,
+      width - marginX * 2,
+      font,
+      fontSize
+    );
 
     page.drawRectangle({
       x: 0,
@@ -628,7 +784,10 @@ const addControlledDocumentFooter = async (
   return Buffer.from(await pdfDoc.save());
 };
 
-const normalizeImportedFilePath = async (row: Record<string, unknown>, documentName: string) => {
+const normalizeImportedFilePath = async (
+  row: Record<string, unknown>,
+  documentName: string
+) => {
   const explicitLink = getCsvValue(row, [
     'Document Link',
     'Document URL',
@@ -647,7 +806,11 @@ const normalizeImportedFilePath = async (row: Record<string, unknown>, documentN
   if (!/\.[a-z0-9]{2,5}$/i.test(candidateName)) return null;
 
   const safeName = path.basename(candidateName);
-  const localPath = path.join(process.cwd(), 'server/src/assets/documents', safeName);
+  const localPath = path.join(
+    process.cwd(),
+    'server/src/assets/documents',
+    safeName
+  );
   try {
     await fs.access(localPath);
     return `/assets/documents/${safeName}`;
@@ -674,470 +837,516 @@ router.use(async (_req, res, next) => {
 });
 
 // Get all controlled documents (authenticated users only)
-router.get('/', requireAuth, requirePermission('documents.view'), async (req: Request, res: Response) => {
-  try {
-    const docs = await db.select().from(controlledDocuments).orderBy(desc(controlledDocuments.createdAt));
-    const revisionIds = docs.map((doc) => doc.currentReleasedRevisionId).filter((id): id is string => Boolean(id));
-    const releasedRevisions = revisionIds.length
-      ? await db.select().from(documentVersionHistory).where(inArray(documentVersionHistory.id, revisionIds))
-      : [];
-    const releasedById = new Map(releasedRevisions.map((revision) => [revision.id, revision]));
-    res.json(docs.map((doc) => {
-      const released = doc.currentReleasedRevisionId ? releasedById.get(doc.currentReleasedRevisionId) : null;
-      const releasedVerified = released?.documentId === doc.id
-        && released.checksumStatus === 'VERIFIED'
-        && Boolean(released.filePath)
-        && !getExternalRedirectUrl(released.filePath)
-        && String(released.lifecycleStatus || released.status || '').toUpperCase() === 'RELEASED';
-      const legacyApproved = ['approved', 'active'].includes(String(doc.status || '').toLowerCase())
-        || String(doc.lifecycleStatus || '').toUpperCase() === 'RELEASED';
-      return {
-        ...doc,
-        compatibilityStatus: releasedVerified
-          ? 'Released and Verified'
-          : legacyApproved && doc.filePath ? 'Legacy Approved — Verification Required'
-          : legacyApproved ? 'File Reconciliation Required'
-          : String(doc.lifecycleStatus || '').toUpperCase() === 'IN_REVIEW' ? 'Awaiting Approval'
-          : doc.lifecycleStatus === 'SUPERSEDED' ? 'Superseded'
-          : doc.lifecycleStatus === 'OBSOLETE' ? 'Obsolete'
-          : doc.lifecycleStatus === 'VOID' ? 'Void'
-          : 'Draft',
-      };
-    }));
-  } catch (error) {
-    console.error('Error fetching controlled documents:', error);
-    res.status(500).json({ error: 'Failed to fetch controlled documents' });
-  }
-});
-
-router.get('/number-conflicts', requireAuth, requirePermission('documents.number_admin'), async (_req: Request, res: Response) => {
-  try {
-    res.json({ conflicts: await getDocumentNumberConflicts() });
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to load controlled document number conflicts');
-  }
-});
-
-router.get('/legacy-audit', requireAuth, requirePermission('documents.number_admin'), async (_req: Request, res: Response) => {
-  try {
-    const [documents, revisions, approvals] = await Promise.all([
-      db.select().from(controlledDocuments).orderBy(desc(controlledDocuments.createdAt)),
-      db.select().from(documentVersionHistory).orderBy(desc(documentVersionHistory.createdAt)),
-      db.select().from(controlledDocumentRevisionApprovals),
-    ]);
-    const revisionsByDocument = new Map<string, typeof revisions>();
-    const revisionById = new Map(revisions.map((revision) => [revision.id, revision]));
-    const normalizedCounts = new Map<string, number>();
-    for (const document of documents) {
-      const normalized = String(document.documentNumber || '').trim().toUpperCase();
-      normalizedCounts.set(normalized, (normalizedCounts.get(normalized) || 0) + 1);
-    }
-    for (const revision of revisions) {
-      const rows = revisionsByDocument.get(revision.documentId) || [];
-      rows.push(revision);
-      revisionsByDocument.set(revision.documentId, rows);
-    }
-
-    const report = await Promise.all(documents.map(async (document) => {
-      const documentRevisions = revisionsByDocument.get(document.id) || [];
-      const releasedRevision = document.currentReleasedRevisionId
-        ? revisionById.get(document.currentReleasedRevisionId)
-        : null;
-      const currentRevision = document.currentRevisionId
-        ? revisionById.get(document.currentRevisionId)
-        : documentRevisions[0] || null;
-      const workingRevision = document.workingDraftRevisionId
-        ? revisionById.get(document.workingDraftRevisionId)
-        : null;
-      const authoritativeReference = releasedRevision?.documentId === document.id
-        ? releasedRevision.filePath
-        : currentRevision?.documentId === document.id
-          ? currentRevision.filePath
-          : document.filePath;
-      const fileReferenceType = getControlledFileReferenceType(authoritativeReference);
-      let fileAccessibility: 'ACCESSIBLE' | 'INACCESSIBLE' | 'EXTERNAL_MUTABLE' | 'MISSING' = 'MISSING';
-      if (fileReferenceType === 'EXTERNAL_MUTABLE_URL') {
-        fileAccessibility = 'EXTERNAL_MUTABLE';
-      } else if (authoritativeReference) {
-        try {
-          if (authoritativeReference.startsWith('/objects/') || authoritativeReference.startsWith('/supabase-objects/')) {
-            await getFileStorageProviderForObjectPath(authoritativeReference).downloadBuffer(authoritativeReference);
-          } else {
-            const resolved = resolveControlledDocumentFile(authoritativeReference);
-            if (!resolved) throw new Error('unsupported reference');
-            await fs.access(resolved);
-          }
-          fileAccessibility = 'ACCESSIBLE';
-        } catch {
-          fileAccessibility = 'INACCESSIBLE';
-        }
-      }
-
-      const activeWorkingRevisions = documentRevisions.filter((revision) =>
-        ['DRAFT', 'IN_REVIEW', 'APPROVED'].includes(String(revision.lifecycleStatus || revision.status || '').toUpperCase()));
-      const approvalRows = approvals.filter((approval) => approval.controlledDocumentId === document.id);
-      const approvalEvidenceState = approvalRows.length > 0
-        && approvalRows.every((approval) => approval.actorUsernameSnapshot && approval.createdAt)
-        ? 'PRESENT'
-        : approvalRows.length > 0 ? 'INCOMPLETE' : 'MISSING';
-      const pointerState = {
-        released: !document.currentReleasedRevisionId ? 'MISSING' : releasedRevision?.documentId === document.id ? 'MATCH' : 'CROSS_DOCUMENT',
-        current: !document.currentRevisionId ? 'MISSING' : currentRevision?.documentId === document.id ? 'MATCH' : 'CROSS_DOCUMENT',
-        working: !document.workingDraftRevisionId ? 'NONE' : workingRevision?.documentId === document.id ? 'MATCH' : 'CROSS_DOCUMENT',
-      };
-      const lifecycle = String(document.lifecycleStatus || '').toUpperCase();
-      const legacyStatus = String(document.status || '').toLowerCase();
-      const releasedAndVerified = lifecycle === 'RELEASED'
-        && pointerState.released === 'MATCH'
-        && releasedRevision?.checksumStatus === 'VERIFIED'
-        && fileAccessibility === 'ACCESSIBLE';
-      const compatibilityStatus = releasedAndVerified
-        ? 'Released and Verified'
-        : ['approved', 'active'].includes(legacyStatus) || lifecycle === 'RELEASED'
-          ? fileAccessibility === 'ACCESSIBLE' ? 'Legacy Approved — Verification Required' : 'File Reconciliation Required'
-          : lifecycle === 'IN_REVIEW' || lifecycle === 'APPROVED' ? 'Awaiting Approval'
-          : lifecycle === 'SUPERSEDED' ? 'Superseded'
-          : lifecycle === 'OBSOLETE' ? 'Obsolete'
-          : lifecycle === 'VOID' ? 'Void'
-          : 'Draft';
-      const categories = [
-        pointerState.released === 'MATCH' && 'HAS_MATCHING_RELEASE_POINTER',
-        lifecycle === 'RELEASED' && pointerState.released === 'MISSING' && 'RELEASED_MISSING_POINTER',
-        ['approved', 'active'].includes(legacyStatus) && lifecycle !== 'RELEASED' && 'LEGACY_APPROVED_OR_ACTIVE',
-        Boolean(document.filePath) && documentRevisions.length === 0 && 'PARENT_FILE_WITHOUT_REVISION',
-        documentRevisions.some((revision) => !revision.fileChecksum) && 'REVISION_CHECKSUM_MISSING',
-        fileAccessibility === 'ACCESSIBLE' && 'FILE_ACCESSIBLE',
-        fileAccessibility === 'INACCESSIBLE' && 'FILE_INACCESSIBLE',
-        fileAccessibility === 'EXTERNAL_MUTABLE' && 'EXTERNAL_MUTABLE_URL',
-        (normalizedCounts.get(String(document.documentNumber || '').trim().toUpperCase()) || 0) > 1 && 'DUPLICATE_NORMALIZED_DOCUMENT_NUMBER',
-        Object.values(pointerState).includes('CROSS_DOCUMENT') && 'CROSS_DOCUMENT_POINTER',
-        activeWorkingRevisions.length > 1 && 'MULTIPLE_ACTIVE_WORKING_REVISIONS',
-        approvalEvidenceState !== 'PRESENT' && 'MISSING_APPROVAL_IDENTITY_OR_DATE',
-        Boolean(document.expirationDate && new Date(document.expirationDate) < new Date()) && 'EXPIRED_OR_REVIEW_DUE',
-        !authoritativeReference && 'NO_FILE_ATTACHED',
-      ].filter(Boolean);
-      return {
-        documentId: document.id,
-        documentNumber: document.documentNumber,
-        title: document.documentName,
-        legacyStatus: document.status,
-        lifecycleStatus: document.lifecycleStatus,
-        version: document.currentVersion,
-        pointerState,
-        fileReferenceType,
-        fileAccessibility,
-        checksumState: releasedRevision?.checksumStatus || currentRevision?.checksumStatus || 'MISSING',
-        approvalEvidenceState,
-        compatibilityStatus,
-        categories,
-        recommendedReconciliationAction: releasedAndVerified
-          ? 'No reconciliation required'
-          : fileAccessibility === 'EXTERNAL_MUTABLE' ? 'Upload an immutable EPOCH-managed copy and verify its checksum'
-          : fileAccessibility !== 'ACCESSIBLE' ? 'Locate or upload the authoritative file before lifecycle reconciliation'
-          : pointerState.released !== 'MATCH' ? 'Review lifecycle evidence and assign the released revision through an authorized reconciliation workflow'
-          : 'Verify checksum and approval evidence without rewriting history',
-      };
-    }));
-
-    res.json({ generatedAt: new Date().toISOString(), readOnly: true, total: report.length, report });
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to generate legacy controlled-document audit');
-  }
-});
-
-// Get single document by ID (authenticated users only)
-router.get('/:id', requireAuth, requirePermission('documents.view'), async (req: Request, res: Response) => {
-  try {
-    const [doc] = await db
-      .select()
-      .from(controlledDocuments)
-      .where(eq(controlledDocuments.id, req.params.id));
-    
-    if (!doc) {
-      return res.status(404).json({ error: 'Document not found' });
-    }
-
-    res.json(doc);
-  } catch (error) {
-    console.error('Error fetching document:', error);
-    res.status(500).json({ error: 'Failed to fetch document' });
-  }
-});
-
-// Get version history for a document (authenticated users only)
-router.get('/:id/versions', requireAuth, requirePermission('documents.view'), async (req: Request, res: Response) => {
-  try {
-    const versions = await db
-      .select()
-      .from(documentVersionHistory)
-      .where(eq(documentVersionHistory.documentId, req.params.id))
-      .orderBy(desc(documentVersionHistory.createdAt));
-    
-    res.json(versions);
-  } catch (error) {
-    console.error('Error fetching version history:', error);
-    res.status(500).json({ error: 'Failed to fetch version history' });
-  }
-});
-
-router.get('/:id/revisions', requireAuth, requirePermission('documents.view'), async (req: Request, res: Response) => {
-  try {
-    const state = await getControlledDocumentState(req.params.id);
-    res.json({ document: state.document, currentRevision: state.currentRevision, revisions: state.revisions, approvals: state.approvals });
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to load controlled document revisions');
-  }
-});
-
-router.get('/:id/revisions/:revisionId', requireAuth, requirePermission('documents.view'), async (req: Request, res: Response) => {
-  try {
-    const state = await getControlledDocumentState(req.params.id);
-    const revision = state.revisions.find((candidate) => candidate.id === req.params.revisionId);
-    if (!revision) return res.status(404).json({ error: 'REVISION_NOT_FOUND' });
-    res.json({ document: state.document, revision, approvals: state.approvals.filter((row) => row.revisionId === revision.id) });
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to load controlled document revision');
-  }
-});
-
-router.get('/:id/revisions/:revisionId/download', requireAuth, requirePermission('documents.view'), controlledDocumentAccessPolicy, async (req: Request, res: Response) => {
-  try {
-    const state = await getControlledDocumentState(req.params.id);
-    const revision = state.revisions.find((candidate) => candidate.id === req.params.revisionId);
-    if (!revision) return res.status(404).json({ error: 'REVISION_RECORD_MISSING', message: 'The requested revision record does not exist for this document' });
-    if (!revision.filePath) return res.status(422).json({ error: 'FILE_REFERENCE_MISSING', message: 'This revision has no file reference' });
-    const actor = await authorizeControlledDocumentAccess(req, state.document);
+router.get(
+  '/',
+  requireAuth,
+  requirePermission('documents.view'),
+  async (req: Request, res: Response) => {
     try {
-      await assertExactRevisionPermission(actor, revision);
+      const docs = await db
+        .select()
+        .from(controlledDocuments)
+        .orderBy(desc(controlledDocuments.createdAt));
+      const revisionIds = docs
+        .map((doc) => doc.currentReleasedRevisionId)
+        .filter((id): id is string => Boolean(id));
+      const releasedRevisions = revisionIds.length
+        ? await db
+            .select()
+            .from(documentVersionHistory)
+            .where(inArray(documentVersionHistory.id, revisionIds))
+        : [];
+      const releasedById = new Map(
+        releasedRevisions.map((revision) => [revision.id, revision])
+      );
+      res.json(
+        docs.map((doc) => {
+          const released = doc.currentReleasedRevisionId
+            ? releasedById.get(doc.currentReleasedRevisionId)
+            : null;
+          const releasedVerified =
+            released?.documentId === doc.id &&
+            released.checksumStatus === 'VERIFIED' &&
+            Boolean(released.filePath) &&
+            !getExternalRedirectUrl(released.filePath) &&
+            String(
+              released.lifecycleStatus || released.status || ''
+            ).toUpperCase() === 'RELEASED';
+          const legacyApproved =
+            ['approved', 'active'].includes(
+              String(doc.status || '').toLowerCase()
+            ) || String(doc.lifecycleStatus || '').toUpperCase() === 'RELEASED';
+          return {
+            ...doc,
+            compatibilityStatus: releasedVerified
+              ? 'Released and Verified'
+              : legacyApproved && doc.filePath
+                ? 'Legacy Approved — Verification Required'
+                : legacyApproved
+                  ? 'File Reconciliation Required'
+                  : String(doc.lifecycleStatus || '').toUpperCase() ===
+                      'IN_REVIEW'
+                    ? 'Awaiting Approval'
+                    : doc.lifecycleStatus === 'SUPERSEDED'
+                      ? 'Superseded'
+                      : doc.lifecycleStatus === 'OBSOLETE'
+                        ? 'Obsolete'
+                        : doc.lifecycleStatus === 'VOID'
+                          ? 'Void'
+                          : 'Draft',
+          };
+        })
+      );
     } catch (error) {
-      await writeAccessLog({ documentId: state.document.id, userId: actor.username, action: 'denied', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
-      throw error;
+      console.error('Error fetching controlled documents:', error);
+      res.status(500).json({ error: 'Failed to fetch controlled documents' });
     }
-    if (getExternalRedirectUrl(revision.filePath)) {
-      await writeAccessLog({ documentId: state.document.id, userId: actor.username, action: 'denied', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
-      return res.status(422).json({ error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION', message: 'This external reference must be reconciled to an EPOCH-managed file before controlled access is available' });
+  }
+);
+
+router.get(
+  '/number-conflicts',
+  requireAuth,
+  requirePermission('documents.number_admin'),
+  async (_req: Request, res: Response) => {
+    try {
+      res.json({ conflicts: await getDocumentNumberConflicts() });
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to load controlled document number conflicts'
+      );
     }
-    const buffer = await readControlledDocumentBytes(revision.filePath);
-    await verifyStoredRevision(state.document.id, revision, revision.filePath, buffer, req);
-    await writeAccessLog({ documentId: state.document.id, userId: actor.username, action: 'download', ipAddress: requestEvidence(req).ipAddress ?? 'unknown' });
-    res.setHeader('Content-Type', revision.mediaType || 'application/octet-stream');
-    res.setHeader('Content-Disposition', `attachment; filename="${revision.fileName || `${state.document.documentNumber}-${revision.versionNumber}`}"`);
-    res.send(buffer);
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to download exact controlled revision');
   }
-});
+);
 
-router.post('/:id/revise', requireAuth, requirePermission('documents.revise'), upload.single('file'), async (req: Request, res: Response) => {
-  try {
-    if (!req.file) return res.status(400).json({ error: 'REVISION_FILE_REQUIRED' });
-    const filePath = await persistControlledDocumentUpload(req.file, req.params.id);
-    const result = await createControlledRevision({
-      documentId: req.params.id,
-      expectedCurrentRevisionId: typeof req.body?.currentRevisionId === 'string' ? req.body.currentRevisionId : undefined,
-      revisionValue: String(req.body?.revisionValue || ''),
-      reason: String(req.body?.reason || ''),
-      file: { path: filePath, name: req.file.originalname, mediaType: req.file.mimetype, size: req.file.size, buffer: req.file.buffer },
-      actor: lifecycleActor(req),
-      request: requestEvidence(req),
-    });
-    res.status(201).json(result);
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to create controlled revision');
-  }
-});
-
-const lifecycleHandler = (
-  action: 'submit' | 'approve' | 'release' | 'supersede' | 'obsolete' | 'void'
-) => async (req: Request, res: Response) => {
-  try {
-    if (action === 'approve' || action === 'release') {
-      const state = await getControlledDocumentState(req.params.id);
-      const requestedRevisionId = typeof req.body?.revisionId === 'string' ? req.body.revisionId : null;
-      const revision = requestedRevisionId
-        ? state.revisions.find((candidate) => candidate.id === requestedRevisionId)
-        : state.currentRevision;
-      if (!revision) {
-        throw new ControlledDocumentError(404, 'REVISION_NOT_FOUND', 'Controlled document revision not found');
-      }
-      const filePath = revision.filePath;
-      if (!filePath) {
-        throw new ControlledDocumentError(
-          422,
-          'VERIFIED_CHECKSUM_REQUIRED',
-          'Exact stored file bytes are required before approval'
+router.get(
+  '/legacy-audit',
+  requireAuth,
+  requirePermission('documents.number_admin'),
+  async (_req: Request, res: Response) => {
+    try {
+      const [documents, revisions, approvals] = await Promise.all([
+        db
+          .select()
+          .from(controlledDocuments)
+          .orderBy(desc(controlledDocuments.createdAt)),
+        db
+          .select()
+          .from(documentVersionHistory)
+          .orderBy(desc(documentVersionHistory.createdAt)),
+        db.select().from(controlledDocumentRevisionApprovals),
+      ]);
+      const revisionsByDocument = new Map<string, typeof revisions>();
+      const revisionById = new Map(
+        revisions.map((revision) => [revision.id, revision])
+      );
+      const normalizedCounts = new Map<string, number>();
+      for (const document of documents) {
+        const normalized = String(document.documentNumber || '')
+          .trim()
+          .toUpperCase();
+        normalizedCounts.set(
+          normalized,
+          (normalizedCounts.get(normalized) || 0) + 1
         );
       }
-      if (getExternalRedirectUrl(filePath)) {
-        throw new ControlledDocumentError(422, 'IMMUTABLE_REVISION_FILE_REQUIRED', 'External references cannot be approved or released; upload an immutable verified copy');
+      for (const revision of revisions) {
+        const rows = revisionsByDocument.get(revision.documentId) || [];
+        rows.push(revision);
+        revisionsByDocument.set(revision.documentId, rows);
       }
-      const buffer = await readControlledDocumentBytes(filePath);
-      await verifyStoredRevision(state.document.id, revision, filePath, buffer, req);
-    }
-    const result = await transitionControlledRevision({
-      documentId: req.params.id,
-      revisionId: typeof req.body?.revisionId === 'string' ? req.body.revisionId : undefined,
-      action,
-      decision: action === 'approve' ? req.body?.decision : undefined,
-      reason: String(req.body?.reason || req.body?.comment || ''),
-      effectiveDate: typeof req.body?.effectiveDate === 'string' ? req.body.effectiveDate : null,
-      actor: lifecycleActor(req),
-      request: requestEvidence(req),
-    });
-    res.json(result);
-  } catch (error) {
-    sendLifecycleError(res, error, `Failed to ${action} controlled revision`);
-  }
-};
 
-/* eslint-disable prettier/prettier */
-const requireLegacyLifecycle = (_req: Request, res: Response, next: NextFunction) => {
-  if (!isControlledDocumentPhase2Enabled()) return next();
-  return res.status(409).json({ error: 'PHASE2_OBSOLETE_ACTION', message: 'Registered revisions are approved and released atomically; Submit and Release are not routine Phase 2 actions.' });
-};
-router.post('/:id/submit', requireAuth, requirePermission('documents.submit'), requireLegacyLifecycle, lifecycleHandler('submit'));
-router.post('/:id/decision', requireAuth, requirePermission('documents.approve'), requireLegacyLifecycle, lifecycleHandler('approve'));
-router.post('/:id/release', requireAuth, requirePermission('documents.release'), requireLegacyLifecycle, lifecycleHandler('release'));
-router.post('/:id/supersede', requireAuth, requirePermission('documents.supersede'), lifecycleHandler('supersede'));
-router.post('/:id/obsolete', requireAuth, requirePermission('documents.obsolete'), lifecycleHandler('obsolete'));
-router.post('/:id/void', requireAuth, requirePermission('documents.void'), lifecycleHandler('void'));
+      const report = await Promise.all(
+        documents.map(async (document) => {
+          const documentRevisions = revisionsByDocument.get(document.id) || [];
+          const releasedRevision = document.currentReleasedRevisionId
+            ? revisionById.get(document.currentReleasedRevisionId)
+            : null;
+          const currentRevision = document.currentRevisionId
+            ? revisionById.get(document.currentRevisionId)
+            : documentRevisions[0] || null;
+          const workingRevision = document.workingDraftRevisionId
+            ? revisionById.get(document.workingDraftRevisionId)
+            : null;
+          const authoritativeReference =
+            releasedRevision?.documentId === document.id
+              ? releasedRevision.filePath
+              : currentRevision?.documentId === document.id
+                ? currentRevision.filePath
+                : document.filePath;
+          const fileReferenceType = getControlledFileReferenceType(
+            authoritativeReference
+          );
+          let fileAccessibility:
+            'ACCESSIBLE' | 'INACCESSIBLE' | 'EXTERNAL_MUTABLE' | 'MISSING' =
+            'MISSING';
+          if (fileReferenceType === 'EXTERNAL_MUTABLE_URL') {
+            fileAccessibility = 'EXTERNAL_MUTABLE';
+          } else if (authoritativeReference) {
+            try {
+              if (
+                authoritativeReference.startsWith('/objects/') ||
+                authoritativeReference.startsWith('/supabase-objects/')
+              ) {
+                await getFileStorageProviderForObjectPath(
+                  authoritativeReference
+                ).downloadBuffer(authoritativeReference);
+              } else {
+                const resolved = resolveControlledDocumentFile(
+                  authoritativeReference
+                );
+                if (!resolved) throw new Error('unsupported reference');
+                await fs.access(resolved);
+              }
+              fileAccessibility = 'ACCESSIBLE';
+            } catch {
+              fileAccessibility = 'INACCESSIBLE';
+            }
+          }
 
-router.post('/:id/approve-and-release', requireAuth, requirePermission('documents.approve'), requireStepUp(), async (req: Request, res: Response) => {
-  try {
-    if (!isControlledDocumentPhase2Enabled()) return res.status(404).json({ error: 'PHASE2_DISABLED', message: 'Atomic approval and release is disabled.' });
-    await assertControlledDocumentPhase2SchemaReady();
-    const state = await getControlledDocumentState(req.params.id);
-    const revisionId = String(req.body?.revisionId || '');
-    const revision = state.revisions.find((candidate) => candidate.id === revisionId);
-    if (!revision || revision.documentId !== state.document.id) throw new ControlledDocumentError(409, 'CROSS_DOCUMENT_REVISION', 'Revision does not belong to this controlled document');
-    if (!revision.filePath || getExternalRedirectUrl(revision.filePath)) throw new ControlledDocumentError(422, 'IMMUTABLE_REVISION_FILE_REQUIRED', 'Approval requires an immutable EPOCH-managed file');
-    const bytes = await readControlledDocumentBytes(revision.filePath);
-    const result = await approveAndReleaseControlledRevision({
-      documentId: state.document.id, revisionId, filePath: revision.filePath, observedChecksum: checksumFile(bytes),
-      idempotencyKey: String(req.headers['idempotency-key'] || ''), reason: String(req.body?.reason || req.body?.comment || ''),
-      effectiveDate: typeof req.body?.effectiveDate === 'string' ? req.body.effectiveDate : null,
-      actor: lifecycleActor(req), request: requestEvidence(req),
-      sessionToken: sessionToken(req), readAuthoritativeBytes: readControlledDocumentBytes,
-    });
-    res.json(result);
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to approve and release controlled revision');
-  }
-});
+          const activeWorkingRevisions = documentRevisions.filter((revision) =>
+            ['DRAFT', 'IN_REVIEW', 'APPROVED'].includes(
+              String(
+                revision.lifecycleStatus || revision.status || ''
+              ).toUpperCase()
+            )
+          );
+          const approvalRows = approvals.filter(
+            (approval) => approval.controlledDocumentId === document.id
+          );
+          const approvalEvidenceState =
+            approvalRows.length > 0 &&
+            approvalRows.every(
+              (approval) => approval.actorUsernameSnapshot && approval.createdAt
+            )
+              ? 'PRESENT'
+              : approvalRows.length > 0
+                ? 'INCOMPLETE'
+                : 'MISSING';
+          const pointerState = {
+            released: !document.currentReleasedRevisionId
+              ? 'MISSING'
+              : releasedRevision?.documentId === document.id
+                ? 'MATCH'
+                : 'CROSS_DOCUMENT',
+            current: !document.currentRevisionId
+              ? 'MISSING'
+              : currentRevision?.documentId === document.id
+                ? 'MATCH'
+                : 'CROSS_DOCUMENT',
+            working: !document.workingDraftRevisionId
+              ? 'NONE'
+              : workingRevision?.documentId === document.id
+                ? 'MATCH'
+                : 'CROSS_DOCUMENT',
+          };
+          const lifecycle = String(
+            document.lifecycleStatus || ''
+          ).toUpperCase();
+          const legacyStatus = String(document.status || '').toLowerCase();
+          const releasedAndVerified =
+            lifecycle === 'RELEASED' &&
+            pointerState.released === 'MATCH' &&
+            releasedRevision?.checksumStatus === 'VERIFIED' &&
+            fileAccessibility === 'ACCESSIBLE';
+          const compatibilityStatus = releasedAndVerified
+            ? 'Released and Verified'
+            : ['approved', 'active'].includes(legacyStatus) ||
+                lifecycle === 'RELEASED'
+              ? fileAccessibility === 'ACCESSIBLE'
+                ? 'Legacy Approved — Verification Required'
+                : 'File Reconciliation Required'
+              : lifecycle === 'IN_REVIEW' || lifecycle === 'APPROVED'
+                ? 'Awaiting Approval'
+                : lifecycle === 'SUPERSEDED'
+                  ? 'Superseded'
+                  : lifecycle === 'OBSOLETE'
+                    ? 'Obsolete'
+                    : lifecycle === 'VOID'
+                      ? 'Void'
+                      : 'Draft';
+          const categories = [
+            pointerState.released === 'MATCH' && 'HAS_MATCHING_RELEASE_POINTER',
+            lifecycle === 'RELEASED' &&
+              pointerState.released === 'MISSING' &&
+              'RELEASED_MISSING_POINTER',
+            ['approved', 'active'].includes(legacyStatus) &&
+              lifecycle !== 'RELEASED' &&
+              'LEGACY_APPROVED_OR_ACTIVE',
+            Boolean(document.filePath) &&
+              documentRevisions.length === 0 &&
+              'PARENT_FILE_WITHOUT_REVISION',
+            documentRevisions.some((revision) => !revision.fileChecksum) &&
+              'REVISION_CHECKSUM_MISSING',
+            fileAccessibility === 'ACCESSIBLE' && 'FILE_ACCESSIBLE',
+            fileAccessibility === 'INACCESSIBLE' && 'FILE_INACCESSIBLE',
+            fileAccessibility === 'EXTERNAL_MUTABLE' && 'EXTERNAL_MUTABLE_URL',
+            (normalizedCounts.get(
+              String(document.documentNumber || '')
+                .trim()
+                .toUpperCase()
+            ) || 0) > 1 && 'DUPLICATE_NORMALIZED_DOCUMENT_NUMBER',
+            Object.values(pointerState).includes('CROSS_DOCUMENT') &&
+              'CROSS_DOCUMENT_POINTER',
+            activeWorkingRevisions.length > 1 &&
+              'MULTIPLE_ACTIVE_WORKING_REVISIONS',
+            approvalEvidenceState !== 'PRESENT' &&
+              'MISSING_APPROVAL_IDENTITY_OR_DATE',
+            Boolean(
+              document.expirationDate &&
+              new Date(document.expirationDate) < new Date()
+            ) && 'EXPIRED_OR_REVIEW_DUE',
+            !authoritativeReference && 'NO_FILE_ATTACHED',
+          ].filter(Boolean);
+          return {
+            documentId: document.id,
+            documentNumber: document.documentNumber,
+            title: document.documentName,
+            legacyStatus: document.status,
+            lifecycleStatus: document.lifecycleStatus,
+            version: document.currentVersion,
+            pointerState,
+            fileReferenceType,
+            fileAccessibility,
+            checksumState:
+              releasedRevision?.checksumStatus ||
+              currentRevision?.checksumStatus ||
+              'MISSING',
+            approvalEvidenceState,
+            compatibilityStatus,
+            categories,
+            recommendedReconciliationAction: releasedAndVerified
+              ? 'No reconciliation required'
+              : fileAccessibility === 'EXTERNAL_MUTABLE'
+                ? 'Upload an immutable EPOCH-managed copy and verify its checksum'
+                : fileAccessibility !== 'ACCESSIBLE'
+                  ? 'Locate or upload the authoritative file before lifecycle reconciliation'
+                  : pointerState.released !== 'MATCH'
+                    ? 'Review lifecycle evidence and assign the released revision through an authorized reconciliation workflow'
+                    : 'Verify checksum and approval evidence without rewriting history',
+          };
+        })
+      );
 
-router.post('/:id/reject', requireAuth, requirePermission('documents.approve'), requireStepUp(), async (req: Request, res: Response) => {
-  try {
-    if (!isControlledDocumentPhase2Enabled()) return res.status(404).json({ error: 'PHASE2_DISABLED' });
-    await assertControlledDocumentPhase2SchemaReady();
-    const result = await rejectRegisteredControlledRevision({ documentId: req.params.id,
-      revisionId: String(req.body?.revisionId || ''), reason: String(req.body?.reason || req.body?.comment || ''),
-      actor: lifecycleActor(req), request: requestEvidence(req), sessionToken: sessionToken(req),
-      readAuthoritativeBytes: readControlledDocumentBytes });
-    res.json(result);
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to reject registered controlled revision');
-  }
-});
-/* eslint-enable prettier/prettier */
-
-router.post('/:id/revisions/:revisionId/external-approval-evidence', requireAuth, requirePermission('documents.approve'), async (req: Request, res: Response) => {
-  try {
-    const evidence = await attachExternalApprovalEvidence({
-      documentId: req.params.id,
-      revisionId: req.params.revisionId,
-      externalApprover: String(req.body?.externalApprover || ''),
-      externalOrganization: typeof req.body?.externalOrganization === 'string' ? req.body.externalOrganization : undefined,
-      evidenceReference: String(req.body?.evidenceReference || ''),
-      comment: String(req.body?.comment || ''),
-      actor: lifecycleActor(req),
-      request: requestEvidence(req),
-    });
-    res.status(201).json({ evidence });
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to attach external approval evidence');
-  }
-});
-
-// Create new document with file upload (admin/owner/document managers only)
-// Auth middleware runs BEFORE upload to prevent anonymous file uploads
-router.post('/', requireDocumentEditor, requirePermission('documents.create'), upload.single('file'), async (req: Request, res: Response) => {
-  try {
-    const filePath = req.file
-      ? await persistControlledDocumentUpload(req.file, req.body.documentNumber)
-      : null;
-    const result = await createControlledDocument({
-      document: {
-        documentNumber: req.body.documentNumber,
-        documentName: req.body.documentName,
-        templateKey: req.body.templateKey || null,
-        documentType: req.body.documentType,
-        department: req.body.department,
-        category: req.body.category || null,
-        description: req.body.description || null,
-        revisionValue: req.body.currentVersion || '1.0',
-        retentionLength: req.body.retentionLength || '10 years',
-        documentOwner: req.body.documentOwner || null,
-        classification: req.body.classification || 'internal',
-        cuiCategory: req.body.cuiCategory || null,
-        itarCategory: req.body.itarCategory || null,
-        exportControlJurisdiction: req.body.exportControlJurisdiction || null,
-        customerId: req.body.customerId || null,
-        contractArtifactType: req.body.contractArtifactType || null,
-        accessRule: req.body.accessRule || 'authenticated',
-        mfaRequired: req.body.mfaRequired === 'true' || req.body.mfaRequired === true,
-      },
-      file: req.file && filePath ? {
-        path: filePath,
-        name: req.file.originalname,
-        mediaType: req.file.mimetype,
-        size: req.file.size,
-        buffer: req.file.buffer,
-      } : null,
-      actor: lifecycleActor(req),
-      request: requestEvidence(req),
-    });
-    res.status(201).json(result.document);
-  } catch (error: any) {
-    sendLifecycleError(res, error, 'Failed to create controlled document');
-  }
-});
-
-// Update document / Create new version (admin/owner/document managers only)
-// Auth middleware runs BEFORE upload to prevent anonymous file uploads
-router.put('/:id', requireDocumentEditor, requirePermission('documents.edit_draft'), upload.single('file'), async (req: Request, res: Response) => {
-  try {
-    const { createNewVersion, changeDescription } = req.body;
-
-    const [existingDoc] = await db
-      .select()
-      .from(controlledDocuments)
-      .where(eq(controlledDocuments.id, req.params.id));
-
-    if (!existingDoc) {
-      return res.status(404).json({ error: 'Document not found' });
-    }
-
-    if (req.file && !(createNewVersion === 'true' || createNewVersion === true)) {
-      await updateDraftMetadata({
-        documentId: req.params.id,
-        patch: req.body,
-        containsFile: true,
-        actor: lifecycleActor(req),
-        request: requestEvidence(req),
+      res.json({
+        generatedAt: new Date().toISOString(),
+        readOnly: true,
+        total: report.length,
+        report,
       });
-      return;
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to generate legacy controlled-document audit'
+      );
     }
+  }
+);
 
-    if (req.file) {
-      if (!String(changeDescription || '').trim()) {
-        return res.status(400).json({ error: 'REVISION_REASON_REQUIRED', message: 'A revision reason is required' });
+// Get single document by ID (authenticated users only)
+router.get(
+  '/:id',
+  requireAuth,
+  requirePermission('documents.view'),
+  async (req: Request, res: Response) => {
+    try {
+      const [doc] = await db
+        .select()
+        .from(controlledDocuments)
+        .where(eq(controlledDocuments.id, req.params.id));
+
+      if (!doc) {
+        return res.status(404).json({ error: 'Document not found' });
       }
-      const filePath = await persistControlledDocumentUpload(req.file, existingDoc.id);
+
+      res.json(doc);
+    } catch (error) {
+      console.error('Error fetching document:', error);
+      res.status(500).json({ error: 'Failed to fetch document' });
+    }
+  }
+);
+
+// Get version history for a document (authenticated users only)
+router.get(
+  '/:id/versions',
+  requireAuth,
+  requirePermission('documents.view'),
+  async (req: Request, res: Response) => {
+    try {
+      const versions = await db
+        .select()
+        .from(documentVersionHistory)
+        .where(eq(documentVersionHistory.documentId, req.params.id))
+        .orderBy(desc(documentVersionHistory.createdAt));
+
+      res.json(versions);
+    } catch (error) {
+      console.error('Error fetching version history:', error);
+      res.status(500).json({ error: 'Failed to fetch version history' });
+    }
+  }
+);
+
+router.get(
+  '/:id/revisions',
+  requireAuth,
+  requirePermission('documents.view'),
+  async (req: Request, res: Response) => {
+    try {
+      const state = await getControlledDocumentState(req.params.id);
+      res.json({
+        document: state.document,
+        currentRevision: state.currentRevision,
+        revisions: state.revisions,
+        approvals: state.approvals,
+      });
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to load controlled document revisions'
+      );
+    }
+  }
+);
+
+router.get(
+  '/:id/revisions/:revisionId',
+  requireAuth,
+  requirePermission('documents.view'),
+  async (req: Request, res: Response) => {
+    try {
+      const state = await getControlledDocumentState(req.params.id);
+      const revision = state.revisions.find(
+        (candidate) => candidate.id === req.params.revisionId
+      );
+      if (!revision)
+        return res.status(404).json({ error: 'REVISION_NOT_FOUND' });
+      res.json({
+        document: state.document,
+        revision,
+        approvals: state.approvals.filter(
+          (row) => row.revisionId === revision.id
+        ),
+      });
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to load controlled document revision'
+      );
+    }
+  }
+);
+
+router.get(
+  '/:id/revisions/:revisionId/download',
+  requireAuth,
+  requirePermission('documents.view'),
+  controlledDocumentAccessPolicy,
+  async (req: Request, res: Response) => {
+    try {
+      const state = await getControlledDocumentState(req.params.id);
+      const revision = state.revisions.find(
+        (candidate) => candidate.id === req.params.revisionId
+      );
+      if (!revision)
+        return res.status(404).json({
+          error: 'REVISION_RECORD_MISSING',
+          message:
+            'The requested revision record does not exist for this document',
+        });
+      if (!revision.filePath)
+        return res.status(422).json({
+          error: 'FILE_REFERENCE_MISSING',
+          message: 'This revision has no file reference',
+        });
+      const actor = await authorizeControlledDocumentAccess(
+        req,
+        state.document
+      );
+      try {
+        await assertExactRevisionPermission(actor, revision);
+      } catch (error) {
+        await writeAccessLog({
+          documentId: state.document.id,
+          userId: actor.username,
+          action: 'denied',
+          ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+        });
+        throw error;
+      }
+      if (getExternalRedirectUrl(revision.filePath)) {
+        await writeAccessLog({
+          documentId: state.document.id,
+          userId: actor.username,
+          action: 'denied',
+          ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+        });
+        return res.status(422).json({
+          error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
+          message:
+            'This external reference must be reconciled to an EPOCH-managed file before controlled access is available',
+        });
+      }
+      const buffer = await readControlledDocumentBytes(revision.filePath);
+      await verifyStoredRevision(
+        state.document.id,
+        revision,
+        revision.filePath,
+        buffer,
+        req
+      );
+      await writeAccessLog({
+        documentId: state.document.id,
+        userId: actor.username,
+        action: 'download',
+        ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+      });
+      res.setHeader(
+        'Content-Type',
+        revision.mediaType || 'application/octet-stream'
+      );
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${revision.fileName || `${state.document.documentNumber}-${revision.versionNumber}`}"`
+      );
+      res.send(buffer);
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to download exact controlled revision'
+      );
+    }
+  }
+);
+
+router.post(
+  '/:id/revise',
+  requireAuth,
+  requirePermission('documents.revise'),
+  upload.single('file'),
+  async (req: Request, res: Response) => {
+    try {
+      if (!req.file)
+        return res.status(400).json({ error: 'REVISION_FILE_REQUIRED' });
+      const filePath = await persistControlledDocumentUpload(
+        req.file,
+        req.params.id
+      );
       const result = await createControlledRevision({
         documentId: req.params.id,
-        expectedCurrentRevisionId: typeof req.body.currentRevisionId === 'string' ? req.body.currentRevisionId : undefined,
-        revisionValue: String(req.body.revisionValue || nextRevisionVersion(existingDoc.currentVersion)),
-        reason: String(changeDescription),
+        expectedCurrentRevisionId:
+          typeof req.body?.currentRevisionId === 'string'
+            ? req.body.currentRevisionId
+            : undefined,
+        revisionValue: String(req.body?.revisionValue || ''),
+        reason: String(req.body?.reason || ''),
         file: {
           path: filePath,
           name: req.file.originalname,
@@ -1148,505 +1357,1108 @@ router.put('/:id', requireDocumentEditor, requirePermission('documents.edit_draf
         actor: lifecycleActor(req),
         request: requestEvidence(req),
       });
-      return res.json(result.document);
+      res.status(201).json(result);
+    } catch (error) {
+      sendLifecycleError(res, error, 'Failed to create controlled revision');
     }
-
-    const metadataResult = await updateDraftMetadata({
-      documentId: req.params.id,
-      patch: req.body,
-      containsFile: false,
-      actor: lifecycleActor(req),
-      request: requestEvidence(req),
-    });
-    return res.json(metadataResult.document);
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to update controlled document');
   }
-});
+);
+
+const lifecycleHandler =
+  (
+    action: 'submit' | 'approve' | 'release' | 'supersede' | 'obsolete' | 'void'
+  ) =>
+  async (req: Request, res: Response) => {
+    try {
+      if (action === 'approve' || action === 'release') {
+        const state = await getControlledDocumentState(req.params.id);
+        const requestedRevisionId =
+          typeof req.body?.revisionId === 'string' ? req.body.revisionId : null;
+        const revision = requestedRevisionId
+          ? state.revisions.find(
+              (candidate) => candidate.id === requestedRevisionId
+            )
+          : state.currentRevision;
+        if (!revision) {
+          throw new ControlledDocumentError(
+            404,
+            'REVISION_NOT_FOUND',
+            'Controlled document revision not found'
+          );
+        }
+        const filePath = revision.filePath;
+        if (!filePath) {
+          throw new ControlledDocumentError(
+            422,
+            'VERIFIED_CHECKSUM_REQUIRED',
+            'Exact stored file bytes are required before approval'
+          );
+        }
+        if (getExternalRedirectUrl(filePath)) {
+          throw new ControlledDocumentError(
+            422,
+            'IMMUTABLE_REVISION_FILE_REQUIRED',
+            'External references cannot be approved or released; upload an immutable verified copy'
+          );
+        }
+        const buffer = await readControlledDocumentBytes(filePath);
+        await verifyStoredRevision(
+          state.document.id,
+          revision,
+          filePath,
+          buffer,
+          req
+        );
+      }
+      const result = await transitionControlledRevision({
+        documentId: req.params.id,
+        revisionId:
+          typeof req.body?.revisionId === 'string'
+            ? req.body.revisionId
+            : undefined,
+        action,
+        decision: action === 'approve' ? req.body?.decision : undefined,
+        reason: String(req.body?.reason || req.body?.comment || ''),
+        effectiveDate:
+          typeof req.body?.effectiveDate === 'string'
+            ? req.body.effectiveDate
+            : null,
+        actor: lifecycleActor(req),
+        request: requestEvidence(req),
+      });
+      res.json(result);
+    } catch (error) {
+      sendLifecycleError(res, error, `Failed to ${action} controlled revision`);
+    }
+  };
+
+const requireLegacyLifecycle = (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (!isControlledDocumentPhase2Enabled()) return next();
+  return res.status(409).json({
+    error: 'PHASE2_OBSOLETE_ACTION',
+    message:
+      'Registered revisions are approved and released atomically; Submit and Release are not routine Phase 2 actions.',
+  });
+};
+router.post(
+  '/:id/submit',
+  requireAuth,
+  requirePermission('documents.submit'),
+  requireLegacyLifecycle,
+  lifecycleHandler('submit')
+);
+router.post(
+  '/:id/decision',
+  requireAuth,
+  requirePermission('documents.approve'),
+  requireLegacyLifecycle,
+  lifecycleHandler('approve')
+);
+router.post(
+  '/:id/release',
+  requireAuth,
+  requirePermission('documents.release'),
+  requireLegacyLifecycle,
+  lifecycleHandler('release')
+);
+router.post(
+  '/:id/supersede',
+  requireAuth,
+  requirePermission('documents.supersede'),
+  lifecycleHandler('supersede')
+);
+router.post(
+  '/:id/obsolete',
+  requireAuth,
+  requirePermission('documents.obsolete'),
+  lifecycleHandler('obsolete')
+);
+router.post(
+  '/:id/void',
+  requireAuth,
+  requirePermission('documents.void'),
+  lifecycleHandler('void')
+);
+
+router.post(
+  '/:id/approve-and-release',
+  requireAuth,
+  requirePermission('documents.approve'),
+  requireStepUp(),
+  async (req: Request, res: Response) => {
+    try {
+      if (!isControlledDocumentPhase2Enabled())
+        return res.status(404).json({
+          error: 'PHASE2_DISABLED',
+          message: 'Atomic approval and release is disabled.',
+        });
+      await assertControlledDocumentPhase2SchemaReady();
+      const state = await getControlledDocumentState(req.params.id);
+      const revisionId = String(req.body?.revisionId || '');
+      const revision = state.revisions.find(
+        (candidate) => candidate.id === revisionId
+      );
+      if (!revision || revision.documentId !== state.document.id)
+        throw new ControlledDocumentError(
+          409,
+          'CROSS_DOCUMENT_REVISION',
+          'Revision does not belong to this controlled document'
+        );
+      if (!revision.filePath || getExternalRedirectUrl(revision.filePath))
+        throw new ControlledDocumentError(
+          422,
+          'IMMUTABLE_REVISION_FILE_REQUIRED',
+          'Approval requires an immutable EPOCH-managed file'
+        );
+      const bytes = await readControlledDocumentBytes(revision.filePath);
+      const result = await approveAndReleaseControlledRevision({
+        documentId: state.document.id,
+        revisionId,
+        filePath: revision.filePath,
+        observedChecksum: checksumFile(bytes),
+        idempotencyKey: String(req.headers['idempotency-key'] || ''),
+        reason: String(req.body?.reason || req.body?.comment || ''),
+        effectiveDate:
+          typeof req.body?.effectiveDate === 'string'
+            ? req.body.effectiveDate
+            : null,
+        actor: lifecycleActor(req),
+        request: requestEvidence(req),
+        sessionToken: sessionToken(req),
+        readAuthoritativeBytes: readControlledDocumentBytes,
+      });
+      res.json(result);
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to approve and release controlled revision'
+      );
+    }
+  }
+);
+
+router.post(
+  '/:id/reject',
+  requireAuth,
+  requirePermission('documents.approve'),
+  requireStepUp(),
+  async (req: Request, res: Response) => {
+    try {
+      if (!isControlledDocumentPhase2Enabled())
+        return res.status(404).json({ error: 'PHASE2_DISABLED' });
+      await assertControlledDocumentPhase2SchemaReady();
+      const result = await rejectRegisteredControlledRevision({
+        documentId: req.params.id,
+        revisionId: String(req.body?.revisionId || ''),
+        reason: String(req.body?.reason || req.body?.comment || ''),
+        actor: lifecycleActor(req),
+        request: requestEvidence(req),
+        sessionToken: sessionToken(req),
+        readAuthoritativeBytes: readControlledDocumentBytes,
+      });
+      res.json(result);
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to reject registered controlled revision'
+      );
+    }
+  }
+);
+
+router.post(
+  '/:id/revisions/:revisionId/external-approval-evidence',
+  requireAuth,
+  requirePermission('documents.approve'),
+  async (req: Request, res: Response) => {
+    try {
+      const evidence = await attachExternalApprovalEvidence({
+        documentId: req.params.id,
+        revisionId: req.params.revisionId,
+        externalApprover: String(req.body?.externalApprover || ''),
+        externalOrganization:
+          typeof req.body?.externalOrganization === 'string'
+            ? req.body.externalOrganization
+            : undefined,
+        evidenceReference: String(req.body?.evidenceReference || ''),
+        comment: String(req.body?.comment || ''),
+        actor: lifecycleActor(req),
+        request: requestEvidence(req),
+      });
+      res.status(201).json({ evidence });
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to attach external approval evidence'
+      );
+    }
+  }
+);
+
+// Create new document with file upload (admin/owner/document managers only)
+// Auth middleware runs BEFORE upload to prevent anonymous file uploads
+router.post(
+  '/',
+  requireDocumentEditor,
+  requirePermission('documents.create'),
+  upload.single('file'),
+  async (req: Request, res: Response) => {
+    try {
+      const filePath = req.file
+        ? await persistControlledDocumentUpload(
+            req.file,
+            req.body.documentNumber
+          )
+        : null;
+      const result = await createControlledDocument({
+        document: {
+          documentNumber: req.body.documentNumber,
+          documentName: req.body.documentName,
+          templateKey: req.body.templateKey || null,
+          documentType: req.body.documentType,
+          department: req.body.department,
+          category: req.body.category || null,
+          description: req.body.description || null,
+          revisionValue: req.body.currentVersion || '1.0',
+          retentionLength: req.body.retentionLength || '10 years',
+          documentOwner: req.body.documentOwner || null,
+          classification: req.body.classification || 'internal',
+          cuiCategory: req.body.cuiCategory || null,
+          itarCategory: req.body.itarCategory || null,
+          exportControlJurisdiction: req.body.exportControlJurisdiction || null,
+          customerId: req.body.customerId || null,
+          contractArtifactType: req.body.contractArtifactType || null,
+          accessRule: req.body.accessRule || 'authenticated',
+          mfaRequired:
+            req.body.mfaRequired === 'true' || req.body.mfaRequired === true,
+        },
+        file:
+          req.file && filePath
+            ? {
+                path: filePath,
+                name: req.file.originalname,
+                mediaType: req.file.mimetype,
+                size: req.file.size,
+                buffer: req.file.buffer,
+              }
+            : null,
+        actor: lifecycleActor(req),
+        request: requestEvidence(req),
+      });
+      res.status(201).json(result.document);
+    } catch (error: any) {
+      sendLifecycleError(res, error, 'Failed to create controlled document');
+    }
+  }
+);
+
+// Update document / Create new version (admin/owner/document managers only)
+// Auth middleware runs BEFORE upload to prevent anonymous file uploads
+router.put(
+  '/:id',
+  requireDocumentEditor,
+  requirePermission('documents.edit_draft'),
+  upload.single('file'),
+  async (req: Request, res: Response) => {
+    try {
+      const { createNewVersion, changeDescription } = req.body;
+
+      const [existingDoc] = await db
+        .select()
+        .from(controlledDocuments)
+        .where(eq(controlledDocuments.id, req.params.id));
+
+      if (!existingDoc) {
+        return res.status(404).json({ error: 'Document not found' });
+      }
+
+      if (
+        req.file &&
+        !(createNewVersion === 'true' || createNewVersion === true)
+      ) {
+        await updateDraftMetadata({
+          documentId: req.params.id,
+          patch: req.body,
+          containsFile: true,
+          actor: lifecycleActor(req),
+          request: requestEvidence(req),
+        });
+        return;
+      }
+
+      if (req.file) {
+        if (!String(changeDescription || '').trim()) {
+          return res.status(400).json({
+            error: 'REVISION_REASON_REQUIRED',
+            message: 'A revision reason is required',
+          });
+        }
+        const filePath = await persistControlledDocumentUpload(
+          req.file,
+          existingDoc.id
+        );
+        const result = await createControlledRevision({
+          documentId: req.params.id,
+          expectedCurrentRevisionId:
+            typeof req.body.currentRevisionId === 'string'
+              ? req.body.currentRevisionId
+              : undefined,
+          revisionValue: String(
+            req.body.revisionValue ||
+              nextRevisionVersion(existingDoc.currentVersion)
+          ),
+          reason: String(changeDescription),
+          file: {
+            path: filePath,
+            name: req.file.originalname,
+            mediaType: req.file.mimetype,
+            size: req.file.size,
+            buffer: req.file.buffer,
+          },
+          actor: lifecycleActor(req),
+          request: requestEvidence(req),
+        });
+        return res.json(result.document);
+      }
+
+      const metadataResult = await updateDraftMetadata({
+        documentId: req.params.id,
+        patch: req.body,
+        containsFile: false,
+        actor: lifecycleActor(req),
+        request: requestEvidence(req),
+      });
+      return res.json(metadataResult.document);
+    } catch (error) {
+      sendLifecycleError(res, error, 'Failed to update controlled document');
+    }
+  }
+);
 
 // Approve document — requires documents.approve capability
-router.post('/:id/approve', requireAuth, requirePermission('documents.approve'), requireLegacyLifecycle, requireStepUp(), async (req: Request, res: Response) => {
-  try {
-    const preflight = await getControlledDocumentState(req.params.id);
-    const requestedRevisionId = typeof req.body?.revisionId === 'string' ? req.body.revisionId : null;
-    const revision = requestedRevisionId
-      ? preflight.revisions.find((candidate) => candidate.id === requestedRevisionId)
-      : preflight.currentRevision;
-    if (!revision?.filePath || getExternalRedirectUrl(revision.filePath)) {
-      throw new ControlledDocumentError(422, 'IMMUTABLE_REVISION_FILE_REQUIRED', 'External references cannot be approved; upload an immutable verified copy');
+router.post(
+  '/:id/approve',
+  requireAuth,
+  requirePermission('documents.approve'),
+  requireLegacyLifecycle,
+  requireStepUp(),
+  async (req: Request, res: Response) => {
+    try {
+      const preflight = await getControlledDocumentState(req.params.id);
+      const requestedRevisionId =
+        typeof req.body?.revisionId === 'string' ? req.body.revisionId : null;
+      const revision = requestedRevisionId
+        ? preflight.revisions.find(
+            (candidate) => candidate.id === requestedRevisionId
+          )
+        : preflight.currentRevision;
+      if (!revision?.filePath || getExternalRedirectUrl(revision.filePath)) {
+        throw new ControlledDocumentError(
+          422,
+          'IMMUTABLE_REVISION_FILE_REQUIRED',
+          'External references cannot be approved; upload an immutable verified copy'
+        );
+      }
+      const bytes = await readControlledDocumentBytes(revision.filePath);
+      await verifyStoredRevision(
+        preflight.document.id,
+        revision,
+        revision.filePath,
+        bytes,
+        req
+      );
+      const state = await transitionControlledRevision({
+        documentId: req.params.id,
+        revisionId:
+          typeof req.body?.revisionId === 'string'
+            ? req.body.revisionId
+            : undefined,
+        action: 'approve',
+        decision: 'APPROVED',
+        reason:
+          typeof req.body?.comment === 'string' && req.body.comment.trim()
+            ? req.body.comment.trim()
+            : 'Authenticated controlled revision approval',
+        actor: lifecycleActor(req),
+        request: requestEvidence(req),
+      });
+      res.json(state.document);
+    } catch (error) {
+      sendLifecycleError(res, error, 'Failed to approve controlled revision');
     }
-    const bytes = await readControlledDocumentBytes(revision.filePath);
-    await verifyStoredRevision(preflight.document.id, revision, revision.filePath, bytes, req);
-    const state = await transitionControlledRevision({
-      documentId: req.params.id,
-      revisionId: typeof req.body?.revisionId === 'string' ? req.body.revisionId : undefined,
-      action: 'approve',
-      decision: 'APPROVED',
-      reason: typeof req.body?.comment === 'string' && req.body.comment.trim()
-        ? req.body.comment.trim()
-        : 'Authenticated controlled revision approval',
-      actor: lifecycleActor(req),
-      request: requestEvidence(req),
-    });
-    res.json(state.document);
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to approve controlled revision');
   }
-});
+);
 
 // View PDF document file inline - requires authentication + step-up re-auth (credentials verified within 30 min)
 // ACL enforcement: restricted/classified docs require an explicit vault access grant or admin/owner role
-router.get('/:id/view', requireAuth, requirePermission('documents.view'), controlledDocumentAccessPolicy, async (req: Request, res: Response) => {
-  const actor = (req as any).user as { id: number; username: string; role: string };
-  const ipAddress = (
-    (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
-    req.socket?.remoteAddress ||
-    'unknown'
-  );
+router.get(
+  '/:id/view',
+  requireAuth,
+  requirePermission('documents.view'),
+  controlledDocumentAccessPolicy,
+  async (req: Request, res: Response) => {
+    const actor = (req as any).user as {
+      id: number;
+      username: string;
+      role: string;
+    };
+    const ipAddress =
+      (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
+      req.socket?.remoteAddress ||
+      'unknown';
 
-  try {
-    const [doc] = await db
-      .select()
-      .from(controlledDocuments)
-      .where(eq(controlledDocuments.id, req.params.id));
+    try {
+      const [doc] = await db
+        .select()
+        .from(controlledDocuments)
+        .where(eq(controlledDocuments.id, req.params.id));
 
-    if (!doc) {
-      return res.status(404).json({ error: 'Document not found' });
-    }
+      if (!doc) {
+        return res.status(404).json({ error: 'Document not found' });
+      }
 
-    // ACL enforcement for restricted/classified documents
-    const classification = (doc as any).classification ?? 'internal';
-    if (classification === 'restricted' || classification === 'classified') {
-      const isAdminOrOwner = actor.role === 'ADMIN' || actor.role === 'OWNER';
-      if (!isAdminOrOwner) {
-        // Check for explicit vault grant
-        const grantCheck = await pool.query<{ id: number }>(
-          `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
+      // ACL enforcement for restricted/classified documents
+      const classification = (doc as any).classification ?? 'internal';
+      if (classification === 'restricted' || classification === 'classified') {
+        const isAdminOrOwner = actor.role === 'ADMIN' || actor.role === 'OWNER';
+        if (!isAdminOrOwner) {
+          // Check for explicit vault grant
+          const grantCheck = await pool.query<{ id: number }>(
+            `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
              (grantee_type = 'user' AND grantee_name = $2)
              OR (grantee_type = 'role' AND grantee_name = $3)
            ) LIMIT 1`,
-          [doc.id, actor.username, actor.role]
-        );
-        if (grantCheck.rows.length === 0) {
-          // Write denied log entry — never silently discard
-          await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'denied', ipAddress });
-          return res.status(403).json({ error: 'Access denied: insufficient clearance for this document' });
+            [doc.id, actor.username, actor.role]
+          );
+          if (grantCheck.rows.length === 0) {
+            // Write denied log entry — never silently discard
+            await writeAccessLog({
+              documentId: doc.id,
+              userId: actor.username,
+              action: 'denied',
+              ipAddress,
+            });
+            return res.status(403).json({
+              error: 'Access denied: insufficient clearance for this document',
+            });
+          }
         }
       }
-    }
 
-    const state = await getControlledDocumentState(doc.id);
-    const revision = await getReleasedRevisionForControlledUse(req, doc, state.revisions);
-    const authoritativeFilePath = revision.filePath;
+      const state = await getControlledDocumentState(doc.id);
+      const revision = await getReleasedRevisionForControlledUse(
+        req,
+        doc,
+        state.revisions
+      );
+      const authoritativeFilePath = revision.filePath;
 
-    if (!authoritativeFilePath) {
-      return res.status(422).json({ error: 'FILE_REFERENCE_MISSING', message: 'No file reference is attached to this document' });
-    }
+      if (!authoritativeFilePath) {
+        return res.status(422).json({
+          error: 'FILE_REFERENCE_MISSING',
+          message: 'No file reference is attached to this document',
+        });
+      }
 
-    const externalRedirectUrl = getExternalRedirectUrl(authoritativeFilePath);
-    if (externalRedirectUrl) {
-      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'denied', ipAddress });
-      return res.status(422).json({ error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION', message: 'This external reference must be reconciled to an EPOCH-managed file before controlled access is available' });
-    }
+      const externalRedirectUrl = getExternalRedirectUrl(authoritativeFilePath);
+      if (externalRedirectUrl) {
+        await writeAccessLog({
+          documentId: doc.id,
+          userId: actor.username,
+          action: 'denied',
+          ipAddress,
+        });
+        return res.status(422).json({
+          error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
+          message:
+            'This external reference must be reconciled to an EPOCH-managed file before controlled access is available',
+        });
+      }
 
-    if (authoritativeFilePath.startsWith('/objects/') || authoritativeFilePath.startsWith('/supabase-objects/')) {
-      const buffer = await readControlledDocumentBytes(authoritativeFilePath);
-      if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
+      if (
+        authoritativeFilePath.startsWith('/objects/') ||
+        authoritativeFilePath.startsWith('/supabase-objects/')
+      ) {
+        const buffer = await readControlledDocumentBytes(authoritativeFilePath);
+        if (revision)
+          await verifyStoredRevision(
+            doc.id,
+            revision,
+            authoritativeFilePath,
+            buffer,
+            req
+          );
+        const stampedPdf = revision
+          ? await addControlledDocumentFooter(buffer, doc, revision)
+          : buffer;
+        await writeAccessLog({
+          documentId: doc.id,
+          userId: actor.username,
+          action: 'view',
+          ipAddress,
+        });
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader(
+          'Content-Disposition',
+          `inline; filename="${doc.documentNumber}.pdf"`
+        );
+        return res.send(stampedPdf);
+      }
+
+      const filePath = resolveControlledDocumentFile(authoritativeFilePath);
+      if (!filePath) {
+        return res.status(422).json({
+          error: 'FILE_NOT_ACCESSIBLE',
+          message: 'The file reference is not supported by this EPOCH server',
+        });
+      }
+
+      // Check if file exists
+      try {
+        await fs.access(filePath);
+      } catch {
+        return res.status(404).json({
+          error: 'FILE_NOT_ACCESSIBLE',
+          message:
+            'The referenced file is not accessible from this EPOCH server',
+        });
+      }
+
+      if (path.extname(filePath).toLowerCase() !== '.pdf') {
+        return res.status(415).json({
+          error: 'UNSUPPORTED_PREVIEW_TYPE',
+          message: 'This file type cannot be previewed; use Download Original',
+        });
+      }
+
+      const buffer = await fs.readFile(filePath);
+      if (revision)
+        await verifyStoredRevision(
+          doc.id,
+          revision,
+          authoritativeFilePath,
+          buffer,
+          req
+        );
       const stampedPdf = revision
         ? await addControlledDocumentFooter(buffer, doc, revision)
         : buffer;
-      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'view', ipAddress });
+      await writeAccessLog({
+        documentId: doc.id,
+        userId: actor.username,
+        action: 'view',
+        ipAddress,
+      });
+
       res.setHeader('Content-Type', 'application/pdf');
-      res.setHeader('Content-Disposition', `inline; filename="${doc.documentNumber}.pdf"`);
-      return res.send(stampedPdf);
+      res.setHeader(
+        'Content-Disposition',
+        `inline; filename="${path.basename(filePath)}"`
+      );
+      res.send(stampedPdf);
+    } catch (error) {
+      sendLifecycleError(res, error, 'Failed to view document');
     }
-
-    const filePath = resolveControlledDocumentFile(authoritativeFilePath);
-    if (!filePath) {
-      return res.status(422).json({ error: 'FILE_NOT_ACCESSIBLE', message: 'The file reference is not supported by this EPOCH server' });
-    }
-    
-    // Check if file exists
-    try {
-      await fs.access(filePath);
-    } catch {
-      return res.status(404).json({ error: 'FILE_NOT_ACCESSIBLE', message: 'The referenced file is not accessible from this EPOCH server' });
-    }
-
-    if (path.extname(filePath).toLowerCase() !== '.pdf') {
-      return res.status(415).json({ error: 'UNSUPPORTED_PREVIEW_TYPE', message: 'This file type cannot be previewed; use Download Original' });
-    }
-
-    const buffer = await fs.readFile(filePath);
-    if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
-    const stampedPdf = revision
-      ? await addControlledDocumentFooter(buffer, doc, revision)
-      : buffer;
-    await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'view', ipAddress });
-
-    res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader('Content-Disposition', `inline; filename="${path.basename(filePath)}"`);
-    res.send(stampedPdf);
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to view document');
   }
-});
+);
 
 // Download document file - requires authentication + step-up re-auth (credentials verified within 30 min)
 // ACL enforcement: restricted/classified docs require an explicit vault access grant or admin/owner role
-router.get('/:id/download', requireAuth, requirePermission('documents.view'), controlledDocumentAccessPolicy, async (req: Request, res: Response) => {
-  const actor = (req as any).user as { id: number; username: string; role: string };
-  const ipAddress = (
-    (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
-    req.socket?.remoteAddress ||
-    'unknown'
-  );
+router.get(
+  '/:id/download',
+  requireAuth,
+  requirePermission('documents.view'),
+  controlledDocumentAccessPolicy,
+  async (req: Request, res: Response) => {
+    const actor = (req as any).user as {
+      id: number;
+      username: string;
+      role: string;
+    };
+    const ipAddress =
+      (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
+      req.socket?.remoteAddress ||
+      'unknown';
 
-  try {
-    const [doc] = await db
-      .select()
-      .from(controlledDocuments)
-      .where(eq(controlledDocuments.id, req.params.id));
+    try {
+      const [doc] = await db
+        .select()
+        .from(controlledDocuments)
+        .where(eq(controlledDocuments.id, req.params.id));
 
-    if (!doc) {
-      return res.status(404).json({ error: 'Document not found' });
-    }
+      if (!doc) {
+        return res.status(404).json({ error: 'Document not found' });
+      }
 
-    // ACL enforcement for restricted/classified documents
-    const classification = (doc as any).classification ?? 'internal';
-    if (classification === 'restricted' || classification === 'classified') {
-      const isAdminOrOwner = actor.role === 'ADMIN' || actor.role === 'OWNER';
-      if (!isAdminOrOwner) {
-        // Check for explicit vault grant
-        const grantCheck = await pool.query<{ id: number }>(
-          `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
+      // ACL enforcement for restricted/classified documents
+      const classification = (doc as any).classification ?? 'internal';
+      if (classification === 'restricted' || classification === 'classified') {
+        const isAdminOrOwner = actor.role === 'ADMIN' || actor.role === 'OWNER';
+        if (!isAdminOrOwner) {
+          // Check for explicit vault grant
+          const grantCheck = await pool.query<{ id: number }>(
+            `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
              (grantee_type = 'user' AND grantee_name = $2)
              OR (grantee_type = 'role' AND grantee_name = $3)
            ) LIMIT 1`,
-          [doc.id, actor.username, actor.role]
-        );
-        if (grantCheck.rows.length === 0) {
-          // Write denied log entry - never silently discard
-          await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'denied', ipAddress });
-          return res.status(403).json({ error: 'Access denied: insufficient clearance for this document' });
-        }
-      }
-    }
-
-    const state = await getControlledDocumentState(doc.id);
-    const revision = await getReleasedRevisionForControlledUse(req, doc, state.revisions);
-    const authoritativeFilePath = revision.filePath;
-
-    if (!authoritativeFilePath) {
-      return res.status(422).json({ error: 'FILE_REFERENCE_MISSING', message: 'No file reference is attached to this document' });
-    }
-
-    const externalRedirectUrl = getExternalRedirectUrl(authoritativeFilePath);
-    if (externalRedirectUrl) {
-      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'denied', ipAddress });
-      return res.status(422).json({ error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION', message: 'This external reference must be reconciled to an EPOCH-managed file before controlled access is available' });
-    }
-
-    if (authoritativeFilePath.startsWith('/objects/') || authoritativeFilePath.startsWith('/supabase-objects/')) {
-      const buffer = await readControlledDocumentBytes(authoritativeFilePath);
-      if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
-      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
-      res.setHeader('Content-Type', revision?.mediaType || 'application/octet-stream');
-      res.setHeader('Content-Disposition', `attachment; filename="${revision?.fileName || doc.documentNumber}"`);
-      return res.send(buffer);
-    }
-
-    const filePath = resolveControlledDocumentFile(authoritativeFilePath);
-    if (!filePath) {
-      return res.status(422).json({ error: 'FILE_NOT_ACCESSIBLE', message: 'The file reference is not supported by this EPOCH server' });
-    }
-
-    // Check if file exists
-    try {
-      await fs.access(filePath);
-    } catch {
-      return res.status(404).json({ error: 'FILE_NOT_ACCESSIBLE', message: 'The referenced file is not accessible from this EPOCH server' });
-    }
-
-    if (path.extname(filePath).toLowerCase() === '.pdf') {
-      const buffer = await fs.readFile(filePath);
-      if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
-      await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
-      res.setHeader('Content-Type', 'application/pdf');
-      res.setHeader('Content-Disposition', `attachment; filename="${path.basename(filePath)}"`);
-      return res.send(buffer);
-    }
-
-    // Send file with appropriate content type
-    const buffer = await fs.readFile(filePath);
-    if (revision) await verifyStoredRevision(doc.id, revision, authoritativeFilePath, buffer, req);
-    await writeAccessLog({ documentId: doc.id, userId: actor.username, action: 'download', ipAddress });
-    res.setHeader('Content-Type', revision?.mediaType || 'application/octet-stream');
-    res.setHeader('Content-Disposition', `attachment; filename="${revision?.fileName || path.basename(filePath)}"`);
-    res.send(buffer);
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to download document');
-  }
-});
-
-// Delete document (admin/owner only)
-router.delete('/:id', requireAdminOrOwner, async (req: Request, res: Response) => {
-  try {
-    const [doc] = await db
-      .select()
-      .from(controlledDocuments)
-      .where(eq(controlledDocuments.id, req.params.id));
-
-    if (!doc) {
-      return res.status(404).json({ error: 'Document not found' });
-    }
-
-    await recordRejectedHardDelete({
-      documentId: doc.id,
-      actor: lifecycleActor(req),
-      request: requestEvidence(req),
-    });
-
-    res.status(410).json({
-      error: 'HARD_DELETE_DISABLED',
-      message: doc.lifecycleStatus === 'RELEASED' || doc.currentReleasedRevisionId
-        ? 'Controlled documents and revision history cannot be deleted. Use the authorized Obsolete action.'
-        : 'Controlled documents and revision history cannot be deleted. Use the authorized Void action.',
-      lifecycleStatus: doc.lifecycleStatus,
-    });
-  } catch (error) {
-    sendLifecycleError(res, error, 'Failed to reject controlled document hard deletion');
-  }
-});
-
-// CSV Import (admin/owner/document managers only)
-router.post('/import/csv', requireDocumentEditor, requirePermission('documents.number_admin'), csvUpload.single('file'), async (req: Request, res: Response) => {
-  try {
-    const user = (req as any).user!;
-    
-    if (!req.file) {
-      return res.status(400).json({ error: 'No CSV file uploaded' });
-    }
-
-    // Convert buffer to string (file is stored in memory)
-    const fileContent = req.file.buffer.toString('utf-8');
-    
-    // Parse CSV
-    const parseResult = Papa.parse(fileContent, {
-      header: true,
-      skipEmptyLines: true,
-      transformHeader: (header: string) => header.trim(),
-    });
-
-    if (parseResult.errors.length > 0) {
-      console.error('CSV parsing errors:', parseResult.errors);
-      return res.status(400).json({ 
-        error: 'CSV parsing failed',
-        details: parseResult.errors 
-      });
-    }
-
-    const rows = parseResult.data as any[];
-    
-    // Debug: Log the columns we found
-    if (rows.length > 0) {
-      console.log('CSV Columns found:', Object.keys(rows[0]));
-      console.log('First row sample:', rows[0]);
-    }
-    
-    // Skip the first row if it's a title row
-    const dataRows = rows[0]?.TITLE?.includes('QMS MASTER LIST') ? rows.slice(1) : rows;
-    
-    const importResults = {
-      success: 0,
-      skipped: 0,
-      errors: [] as string[],
-    };
-
-    // Helper function to determine document type from code
-    const determineDocumentType = (code: string): string => {
-      const upperCode = code?.toUpperCase() || '';
-      if (upperCode.includes('POSTER')) return 'POSTER';
-      if (upperCode.includes('FORM')) return 'FORM';
-      if (upperCode.includes('DOC')) return 'PROCEDURE';
-      return 'OTHER';
-    };
-
-    const parsedDocuments = [];
-
-    // Process and validate each row before writing so the database work can be batched.
-    for (let i = 0; i < dataRows.length; i++) {
-      const row = dataRows[i];
-      
-      try {
-        // Skip rows with missing critical data
-        if (!row.TITLE || !row.CODE) {
-          importResults.skipped++;
-          importResults.errors.push(`Row ${i + 2}: Missing TITLE or CODE`);
-          continue;
-        }
-
-        const documentNumber = String(row.CODE || '').trim();
-        const documentName = String(row.TITLE || '').trim();
-        const department = String(row.Department || 'General Use').trim();
-        const currentVersion = String(row.Version || '1.0').trim();
-        const retentionLength = String(row['Record Retention Length'] || 'N/A').trim();
-        const description = String(row['Summary of Changes (if needed)'] || '').trim();
-        const dateStr = String(row.Date || '').trim();
-        const filePath = await normalizeImportedFilePath(row, documentName);
-        
-        // Parse effective date
-        let effectiveDate = null;
-        if (dateStr && dateStr !== 'N/A' && dateStr !== 'on-going') {
-          try {
-            const parsedDate = new Date(dateStr);
-            if (!isNaN(parsedDate.getTime())) {
-              effectiveDate = parsedDate.toISOString().split('T')[0];
-            }
-          } catch {
-            // Invalid date, leave as null
+            [doc.id, actor.username, actor.role]
+          );
+          if (grantCheck.rows.length === 0) {
+            // Write denied log entry - never silently discard
+            await writeAccessLog({
+              documentId: doc.id,
+              userId: actor.username,
+              action: 'denied',
+              ipAddress,
+            });
+            return res.status(403).json({
+              error: 'Access denied: insufficient clearance for this document',
+            });
           }
         }
-
-        const documentType = determineDocumentType(documentNumber);
-
-        // Calculate expiration date (1 year from effective date or now)
-        const baseDate = effectiveDate ? new Date(effectiveDate) : new Date();
-        const expirationDate = new Date(baseDate);
-        expirationDate.setFullYear(expirationDate.getFullYear() + 1);
-
-        parsedDocuments.push({
-          documentNumber,
-          documentName,
-          documentType,
-          department,
-          currentVersion,
-          retentionLength,
-          description,
-          filePath,
-          effectiveDate,
-          expirationDate: expirationDate.toISOString().split('T')[0],
-          rowNumber: i + 2,
-        });
-      } catch (error: any) {
-        const errorMsg = `Row ${i + 2}: ${error.message}`;
-        console.error('CSV import error:', errorMsg);
-        importResults.errors.push(errorMsg);
       }
-    }
 
-    const seenDocumentNumbers = new Set<string>();
-    const importDocuments = parsedDocuments.filter((doc) => {
-      if (seenDocumentNumbers.has(doc.documentNumber)) {
-        importResults.skipped++;
-        importResults.errors.push(`Row ${doc.rowNumber}: Duplicate CODE "${doc.documentNumber}" in import file`);
-        return false;
-      }
-      seenDocumentNumbers.add(doc.documentNumber);
-      return true;
-    });
+      const state = await getControlledDocumentState(doc.id);
+      const revision = await getReleasedRevisionForControlledUse(
+        req,
+        doc,
+        state.revisions
+      );
+      const authoritativeFilePath = revision.filePath;
 
-    const existingDocuments = importDocuments.length > 0
-      ? await db
-          .select()
-          .from(controlledDocuments)
-          .where(inArray(
-            controlledDocuments.documentNumber,
-            importDocuments.map((doc) => doc.documentNumber)
-          ))
-      : [];
-
-    const existingByNumber = new Map(existingDocuments.map((doc) => [doc.documentNumber, doc]));
-    const documentsToCreate = [];
-
-    for (const doc of importDocuments) {
-      const existing = existingByNumber.get(doc.documentNumber);
-
-      if (existing) {
-        await db
-          .update(controlledDocuments)
-          .set({
-            retentionLength: doc.retentionLength,
-            description: doc.description || existing.description,
-            expirationDate: doc.expirationDate,
-            updatedAt: new Date(),
-          })
-          .where(eq(controlledDocuments.id, existing.id));
-      } else {
-        documentsToCreate.push({
-          documentNumber: doc.documentNumber,
-          documentName: doc.documentName,
-          documentType: doc.documentType,
-          department: doc.department,
-          currentVersion: doc.currentVersion,
-          status: 'draft',
-          lifecycleStatus: 'DRAFT',
-          numberControlStatus: 'RESERVED',
-          retentionLength: doc.retentionLength,
-          description: doc.description,
-          filePath: doc.filePath,
-          effectiveDate: doc.effectiveDate,
-          expirationDate: doc.expirationDate,
-          createdBy: user.username,
+      if (!authoritativeFilePath) {
+        return res.status(422).json({
+          error: 'FILE_REFERENCE_MISSING',
+          message: 'No file reference is attached to this document',
         });
       }
 
-      importResults.success++;
-    }
-
-    if (documentsToCreate.length > 0) {
-      const newDocs = await db.insert(controlledDocuments).values(documentsToCreate).returning();
-
-      for (const newDoc of newDocs) {
-        await db.transaction(async (tx) => {
-          await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`document-number:${newDoc.documentNumber.trim().toUpperCase()}`}))`);
-          await tx.insert(controlledDocumentNumberRegistry).values({
-            normalizedNumber: newDoc.documentNumber.trim().toUpperCase(),
-            displayNumber: newDoc.documentNumber.trim(),
-            controlledDocumentId: newDoc.id,
-            status: 'RESERVED',
-          });
-          const [revision] = await tx.insert(documentVersionHistory).values({
-            documentId: newDoc.id,
-            versionNumber: newDoc.currentVersion,
-            revisionSequence: 1,
-            lifecycleStatus: 'DRAFT',
-            changeDescription: newDoc.description || 'Imported from CSV',
-            revisionReason: 'Imported from CSV; legacy file checksum requires verification',
-            changeType: 'major',
-            status: 'draft',
-            createdBy: user.username,
-            filePath: newDoc.filePath,
-            checksumStatus: newDoc.filePath ? 'PENDING_BACKFILL' : 'NOT_APPLICABLE',
-            effectiveDate: newDoc.effectiveDate,
-            expirationDate: newDoc.expirationDate,
-            metadata: { provenance: 'LEGACY_CSV_IMPORT' },
-          }).returning();
-          await tx.update(controlledDocuments).set({
-            currentRevisionId: revision.id,
-            workingDraftRevisionId: revision.id,
-          }).where(eq(controlledDocuments.id, newDoc.id));
+      const externalRedirectUrl = getExternalRedirectUrl(authoritativeFilePath);
+      if (externalRedirectUrl) {
+        await writeAccessLog({
+          documentId: doc.id,
+          userId: actor.username,
+          action: 'denied',
+          ipAddress,
+        });
+        return res.status(422).json({
+          error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
+          message:
+            'This external reference must be reconciled to an EPOCH-managed file before controlled access is available',
         });
       }
+
+      if (
+        authoritativeFilePath.startsWith('/objects/') ||
+        authoritativeFilePath.startsWith('/supabase-objects/')
+      ) {
+        const buffer = await readControlledDocumentBytes(authoritativeFilePath);
+        if (revision)
+          await verifyStoredRevision(
+            doc.id,
+            revision,
+            authoritativeFilePath,
+            buffer,
+            req
+          );
+        await writeAccessLog({
+          documentId: doc.id,
+          userId: actor.username,
+          action: 'download',
+          ipAddress,
+        });
+        res.setHeader(
+          'Content-Type',
+          revision?.mediaType || 'application/octet-stream'
+        );
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="${revision?.fileName || doc.documentNumber}"`
+        );
+        return res.send(buffer);
+      }
+
+      const filePath = resolveControlledDocumentFile(authoritativeFilePath);
+      if (!filePath) {
+        return res.status(422).json({
+          error: 'FILE_NOT_ACCESSIBLE',
+          message: 'The file reference is not supported by this EPOCH server',
+        });
+      }
+
+      // Check if file exists
+      try {
+        await fs.access(filePath);
+      } catch {
+        return res.status(404).json({
+          error: 'FILE_NOT_ACCESSIBLE',
+          message:
+            'The referenced file is not accessible from this EPOCH server',
+        });
+      }
+
+      if (path.extname(filePath).toLowerCase() === '.pdf') {
+        const buffer = await fs.readFile(filePath);
+        if (revision)
+          await verifyStoredRevision(
+            doc.id,
+            revision,
+            authoritativeFilePath,
+            buffer,
+            req
+          );
+        await writeAccessLog({
+          documentId: doc.id,
+          userId: actor.username,
+          action: 'download',
+          ipAddress,
+        });
+        res.setHeader('Content-Type', 'application/pdf');
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="${path.basename(filePath)}"`
+        );
+        return res.send(buffer);
+      }
+
+      // Send file with appropriate content type
+      const buffer = await fs.readFile(filePath);
+      if (revision)
+        await verifyStoredRevision(
+          doc.id,
+          revision,
+          authoritativeFilePath,
+          buffer,
+          req
+        );
+      await writeAccessLog({
+        documentId: doc.id,
+        userId: actor.username,
+        action: 'download',
+        ipAddress,
+      });
+      res.setHeader(
+        'Content-Type',
+        revision?.mediaType || 'application/octet-stream'
+      );
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${revision?.fileName || path.basename(filePath)}"`
+      );
+      res.send(buffer);
+    } catch (error) {
+      sendLifecycleError(res, error, 'Failed to download document');
     }
-
-    // Log final results
-    console.log('CSV Import Results:', {
-      total: dataRows.length,
-      success: importResults.success,
-      skipped: importResults.skipped,
-      errors: importResults.errors.length,
-      firstFewErrors: importResults.errors.slice(0, 5)
-    });
-
-    res.json({
-      message: 'CSV import completed',
-      results: importResults,
-    });
-  } catch (error) {
-    console.error('Error importing CSV:', error);
-    res.status(500).json({ error: 'Failed to import CSV' });
   }
-});
+);
+
+// Delete document (admin/owner only)
+router.delete(
+  '/:id',
+  requireAdminOrOwner,
+  async (req: Request, res: Response) => {
+    try {
+      const [doc] = await db
+        .select()
+        .from(controlledDocuments)
+        .where(eq(controlledDocuments.id, req.params.id));
+
+      if (!doc) {
+        return res.status(404).json({ error: 'Document not found' });
+      }
+
+      await recordRejectedHardDelete({
+        documentId: doc.id,
+        actor: lifecycleActor(req),
+        request: requestEvidence(req),
+      });
+
+      res.status(410).json({
+        error: 'HARD_DELETE_DISABLED',
+        message:
+          doc.lifecycleStatus === 'RELEASED' || doc.currentReleasedRevisionId
+            ? 'Controlled documents and revision history cannot be deleted. Use the authorized Obsolete action.'
+            : 'Controlled documents and revision history cannot be deleted. Use the authorized Void action.',
+        lifecycleStatus: doc.lifecycleStatus,
+      });
+    } catch (error) {
+      sendLifecycleError(
+        res,
+        error,
+        'Failed to reject controlled document hard deletion'
+      );
+    }
+  }
+);
+
+// CSV Import (admin/owner/document managers only)
+router.post(
+  '/import/csv',
+  requireDocumentEditor,
+  requirePermission('documents.number_admin'),
+  csvUpload.single('file'),
+  async (req: Request, res: Response) => {
+    try {
+      const user = (req as any).user!;
+
+      if (!req.file) {
+        return res.status(400).json({ error: 'No CSV file uploaded' });
+      }
+
+      // Convert buffer to string (file is stored in memory)
+      const fileContent = req.file.buffer.toString('utf-8');
+
+      // Parse CSV
+      const parseResult = Papa.parse(fileContent, {
+        header: true,
+        skipEmptyLines: true,
+        transformHeader: (header: string) => header.trim(),
+      });
+
+      if (parseResult.errors.length > 0) {
+        console.error('CSV parsing errors:', parseResult.errors);
+        return res.status(400).json({
+          error: 'CSV parsing failed',
+          details: parseResult.errors,
+        });
+      }
+
+      const rows = parseResult.data as any[];
+
+      // Debug: Log the columns we found
+      if (rows.length > 0) {
+        console.log('CSV Columns found:', Object.keys(rows[0]));
+        console.log('First row sample:', rows[0]);
+      }
+
+      // Skip the first row if it's a title row
+      const dataRows = rows[0]?.TITLE?.includes('QMS MASTER LIST')
+        ? rows.slice(1)
+        : rows;
+
+      const importResults = {
+        success: 0,
+        skipped: 0,
+        errors: [] as string[],
+      };
+
+      // Helper function to determine document type from code
+      const determineDocumentType = (code: string): string => {
+        const upperCode = code?.toUpperCase() || '';
+        if (upperCode.includes('POSTER')) return 'POSTER';
+        if (upperCode.includes('FORM')) return 'FORM';
+        if (upperCode.includes('DOC')) return 'PROCEDURE';
+        return 'OTHER';
+      };
+
+      const parsedDocuments = [];
+
+      // Process and validate each row before writing so the database work can be batched.
+      for (let i = 0; i < dataRows.length; i++) {
+        const row = dataRows[i];
+
+        try {
+          // Skip rows with missing critical data
+          if (!row.TITLE || !row.CODE) {
+            importResults.skipped++;
+            importResults.errors.push(`Row ${i + 2}: Missing TITLE or CODE`);
+            continue;
+          }
+
+          const documentNumber = String(row.CODE || '').trim();
+          const documentName = String(row.TITLE || '').trim();
+          const department = String(row.Department || 'General Use').trim();
+          const currentVersion = String(row.Version || '1.0').trim();
+          const retentionLength = String(
+            row['Record Retention Length'] || 'N/A'
+          ).trim();
+          const description = String(
+            row['Summary of Changes (if needed)'] || ''
+          ).trim();
+          const dateStr = String(row.Date || '').trim();
+          const filePath = await normalizeImportedFilePath(row, documentName);
+
+          // Parse effective date
+          let effectiveDate = null;
+          if (dateStr && dateStr !== 'N/A' && dateStr !== 'on-going') {
+            try {
+              const parsedDate = new Date(dateStr);
+              if (!isNaN(parsedDate.getTime())) {
+                effectiveDate = parsedDate.toISOString().split('T')[0];
+              }
+            } catch {
+              // Invalid date, leave as null
+            }
+          }
+
+          const documentType = determineDocumentType(documentNumber);
+
+          // Calculate expiration date (1 year from effective date or now)
+          const baseDate = effectiveDate ? new Date(effectiveDate) : new Date();
+          const expirationDate = new Date(baseDate);
+          expirationDate.setFullYear(expirationDate.getFullYear() + 1);
+
+          parsedDocuments.push({
+            documentNumber,
+            documentName,
+            documentType,
+            department,
+            currentVersion,
+            retentionLength,
+            description,
+            filePath,
+            effectiveDate,
+            expirationDate: expirationDate.toISOString().split('T')[0],
+            rowNumber: i + 2,
+          });
+        } catch (error: any) {
+          const errorMsg = `Row ${i + 2}: ${error.message}`;
+          console.error('CSV import error:', errorMsg);
+          importResults.errors.push(errorMsg);
+        }
+      }
+
+      const seenDocumentNumbers = new Set<string>();
+      const importDocuments = parsedDocuments.filter((doc) => {
+        if (seenDocumentNumbers.has(doc.documentNumber)) {
+          importResults.skipped++;
+          importResults.errors.push(
+            `Row ${doc.rowNumber}: Duplicate CODE "${doc.documentNumber}" in import file`
+          );
+          return false;
+        }
+        seenDocumentNumbers.add(doc.documentNumber);
+        return true;
+      });
+
+      const existingDocuments =
+        importDocuments.length > 0
+          ? await db
+              .select()
+              .from(controlledDocuments)
+              .where(
+                inArray(
+                  controlledDocuments.documentNumber,
+                  importDocuments.map((doc) => doc.documentNumber)
+                )
+              )
+          : [];
+
+      const existingByNumber = new Map(
+        existingDocuments.map((doc) => [doc.documentNumber, doc])
+      );
+      const documentsToCreate = [];
+
+      for (const doc of importDocuments) {
+        const existing = existingByNumber.get(doc.documentNumber);
+
+        if (existing) {
+          await db
+            .update(controlledDocuments)
+            .set({
+              retentionLength: doc.retentionLength,
+              description: doc.description || existing.description,
+              expirationDate: doc.expirationDate,
+              updatedAt: new Date(),
+            })
+            .where(eq(controlledDocuments.id, existing.id));
+        } else {
+          documentsToCreate.push({
+            documentNumber: doc.documentNumber,
+            documentName: doc.documentName,
+            documentType: doc.documentType,
+            department: doc.department,
+            currentVersion: doc.currentVersion,
+            status: 'draft',
+            lifecycleStatus: 'DRAFT',
+            numberControlStatus: 'RESERVED',
+            retentionLength: doc.retentionLength,
+            description: doc.description,
+            filePath: doc.filePath,
+            effectiveDate: doc.effectiveDate,
+            expirationDate: doc.expirationDate,
+            createdBy: user.username,
+          });
+        }
+
+        importResults.success++;
+      }
+
+      if (documentsToCreate.length > 0) {
+        const newDocs = await db
+          .insert(controlledDocuments)
+          .values(documentsToCreate)
+          .returning();
+
+        for (const newDoc of newDocs) {
+          await db.transaction(async (tx) => {
+            await tx.execute(
+              sql`SELECT pg_advisory_xact_lock(hashtext(${`document-number:${newDoc.documentNumber.trim().toUpperCase()}`}))`
+            );
+            await tx.insert(controlledDocumentNumberRegistry).values({
+              normalizedNumber: newDoc.documentNumber.trim().toUpperCase(),
+              displayNumber: newDoc.documentNumber.trim(),
+              controlledDocumentId: newDoc.id,
+              status: 'RESERVED',
+            });
+            const [revision] = await tx
+              .insert(documentVersionHistory)
+              .values({
+                documentId: newDoc.id,
+                versionNumber: newDoc.currentVersion,
+                revisionSequence: 1,
+                lifecycleStatus: 'DRAFT',
+                changeDescription: newDoc.description || 'Imported from CSV',
+                revisionReason:
+                  'Imported from CSV; legacy file checksum requires verification',
+                changeType: 'major',
+                status: 'draft',
+                createdBy: user.username,
+                filePath: newDoc.filePath,
+                checksumStatus: newDoc.filePath
+                  ? 'PENDING_BACKFILL'
+                  : 'NOT_APPLICABLE',
+                effectiveDate: newDoc.effectiveDate,
+                expirationDate: newDoc.expirationDate,
+                metadata: { provenance: 'LEGACY_CSV_IMPORT' },
+              })
+              .returning();
+            await tx
+              .update(controlledDocuments)
+              .set({
+                currentRevisionId: revision.id,
+                workingDraftRevisionId: revision.id,
+              })
+              .where(eq(controlledDocuments.id, newDoc.id));
+          });
+        }
+      }
+
+      // Log final results
+      console.log('CSV Import Results:', {
+        total: dataRows.length,
+        success: importResults.success,
+        skipped: importResults.skipped,
+        errors: importResults.errors.length,
+        firstFewErrors: importResults.errors.slice(0, 5),
+      });
+
+      res.json({
+        message: 'CSV import completed',
+        results: importResults,
+      });
+    } catch (error) {
+      console.error('Error importing CSV:', error);
+      res.status(500).json({ error: 'Failed to import CSV' });
+    }
+  }
+);
 
 export default router;

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -92,6 +92,14 @@ const sendLifecycleError = (
       .json({ error: error.code, message: error.message, ...error.details });
     return;
   }
+  if (error instanceof ControlledDocumentSchemaNotReadyError) {
+    res.status(503).json({
+      error: error.code,
+      message: error.message,
+      missingObjects: error.missingObjects,
+    });
+    return;
+  }
   console.error(fallback, error);
   res
     .status(500)
@@ -280,6 +288,25 @@ const verifyStoredRevision = async (
 type ControlledDocumentRecord = typeof controlledDocuments.$inferSelect;
 type ControlledRevisionRecord = typeof documentVersionHistory.$inferSelect;
 
+const recordControlledDocumentDenial = async (
+  req: Request,
+  documentId: string,
+  actor: { username: string },
+  ipAddress: string
+) => {
+  const requestState = req as Request & {
+    controlledDocumentDeniedAccessLogged?: boolean;
+  };
+  if (requestState.controlledDocumentDeniedAccessLogged) return;
+  await writeAccessLog({
+    documentId,
+    userId: actor.username,
+    action: 'denied',
+    ipAddress,
+  });
+  requestState.controlledDocumentDeniedAccessLogged = true;
+};
+
 const isPrivilegedDocumentActor = (actor: { role: string }) =>
   actor.role === 'ADMIN' || actor.role === 'OWNER';
 
@@ -369,12 +396,12 @@ const getReleasedRevisionForControlledUse = async (
 ) => {
   if (!document.currentReleasedRevisionId) {
     const actor = lifecycleActor(req);
-    await writeAccessLog({
-      documentId: document.id,
-      userId: actor.username,
-      action: 'denied',
-      ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
-    });
+    await recordControlledDocumentDenial(
+      req,
+      document.id,
+      actor,
+      requestEvidence(req).ipAddress ?? 'unknown'
+    );
     throw new ControlledDocumentError(
       409,
       'NO_RELEASED_REVISION',
@@ -386,12 +413,12 @@ const getReleasedRevisionForControlledUse = async (
   );
   if (!revision || revision.documentId !== document.id) {
     const actor = lifecycleActor(req);
-    await writeAccessLog({
-      documentId: document.id,
-      userId: actor.username,
-      action: 'denied',
-      ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
-    });
+    await recordControlledDocumentDenial(
+      req,
+      document.id,
+      actor,
+      requestEvidence(req).ipAddress ?? 'unknown'
+    );
     await recordAuditEvent({
       eventType: 'CONTROLLED_DOCUMENT_RELEASE_POINTER_INVALID',
       subjectType: 'controlled_document',
@@ -512,9 +539,28 @@ const getImportedFileReference = (filePath: string | null | undefined) => {
   return null;
 };
 
+const hasUnsafeControlledDocumentEncoding = (value: string) => {
+  let decoded = value;
+  for (let pass = 0; pass < 3; pass += 1) {
+    if (decoded.includes('\0')) return true;
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    } catch {
+      return true;
+    }
+  }
+  if (decoded.includes('\0')) return true;
+  return decoded
+    .replace(/\\/g, '/')
+    .split('/')
+    .some((segment) => segment === '..');
+};
+
 const resolveControlledDocumentFile = (filePath: string | null | undefined) => {
   const trimmed = String(filePath || '').trim();
-  if (!trimmed) return null;
+  if (!trimmed || hasUnsafeControlledDocumentEncoding(trimmed)) return null;
 
   const centralMediaRoot = path.resolve(
     process.cwd(),
@@ -1930,13 +1976,7 @@ router.get(
             [doc.id, actor.username, actor.role]
           );
           if (grantCheck.rows.length === 0) {
-            // Write denied log entry — never silently discard
-            await writeAccessLog({
-              documentId: doc.id,
-              userId: actor.username,
-              action: 'denied',
-              ipAddress,
-            });
+            await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
             return res.status(403).json({
               error: 'Access denied: insufficient clearance for this document',
             });
@@ -1953,6 +1993,7 @@ router.get(
       const authoritativeFilePath = revision.filePath;
 
       if (!authoritativeFilePath) {
+        await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
         return res.status(422).json({
           error: 'FILE_REFERENCE_MISSING',
           message: 'No file reference is attached to this document',
@@ -1961,12 +2002,7 @@ router.get(
 
       const externalRedirectUrl = getExternalRedirectUrl(authoritativeFilePath);
       if (externalRedirectUrl) {
-        await writeAccessLog({
-          documentId: doc.id,
-          userId: actor.username,
-          action: 'denied',
-          ipAddress,
-        });
+        await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
         return res.status(422).json({
           error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
           message:
@@ -2006,6 +2042,7 @@ router.get(
 
       const filePath = resolveControlledDocumentFile(authoritativeFilePath);
       if (!filePath) {
+        await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
         return res.status(422).json({
           error: 'FILE_NOT_ACCESSIBLE',
           message: 'The file reference is not supported by this EPOCH server',
@@ -2013,6 +2050,7 @@ router.get(
       }
 
       if (path.extname(filePath).toLowerCase() !== '.pdf') {
+        await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
         return res.status(415).json({
           error: 'UNSUPPORTED_PREVIEW_TYPE',
           message: 'This file type cannot be previewed; use Download Original',
@@ -2045,6 +2083,12 @@ router.get(
       );
       res.send(stampedPdf);
     } catch (error) {
+      await recordControlledDocumentDenial(
+        req,
+        req.params.id,
+        actor,
+        ipAddress
+      );
       sendLifecycleError(res, error, 'Failed to view document');
     }
   }
@@ -2092,13 +2136,7 @@ router.get(
             [doc.id, actor.username, actor.role]
           );
           if (grantCheck.rows.length === 0) {
-            // Write denied log entry - never silently discard
-            await writeAccessLog({
-              documentId: doc.id,
-              userId: actor.username,
-              action: 'denied',
-              ipAddress,
-            });
+            await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
             return res.status(403).json({
               error: 'Access denied: insufficient clearance for this document',
             });
@@ -2115,6 +2153,7 @@ router.get(
       const authoritativeFilePath = revision.filePath;
 
       if (!authoritativeFilePath) {
+        await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
         return res.status(422).json({
           error: 'FILE_REFERENCE_MISSING',
           message: 'No file reference is attached to this document',
@@ -2123,12 +2162,7 @@ router.get(
 
       const externalRedirectUrl = getExternalRedirectUrl(authoritativeFilePath);
       if (externalRedirectUrl) {
-        await writeAccessLog({
-          documentId: doc.id,
-          userId: actor.username,
-          action: 'denied',
-          ipAddress,
-        });
+        await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
         return res.status(422).json({
           error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
           message:
@@ -2168,6 +2202,7 @@ router.get(
 
       const filePath = resolveControlledDocumentFile(authoritativeFilePath);
       if (!filePath) {
+        await recordControlledDocumentDenial(req, doc.id, actor, ipAddress);
         return res.status(422).json({
           error: 'FILE_NOT_ACCESSIBLE',
           message: 'The file reference is not supported by this EPOCH server',
@@ -2224,6 +2259,12 @@ router.get(
       );
       res.send(buffer);
     } catch (error) {
+      await recordControlledDocumentDenial(
+        req,
+        req.params.id,
+        actor,
+        ipAddress
+      );
       sendLifecycleError(res, error, 'Failed to download document');
     }
   }

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -18,6 +18,8 @@ import { PDFDocument, PDFFont, StandardFonts, rgb } from 'pdf-lib';
 import { getFileStorageProvider, getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
 import {
   ControlledDocumentError,
+  approveAndReleaseControlledRevision,
+  rejectRegisteredControlledRevision,
   attachExternalApprovalEvidence,
   createControlledDocument,
   createControlledRevision,
@@ -27,9 +29,12 @@ import {
   transitionControlledRevision,
   updateDraftMetadata,
   verifyControlledRevisionFile,
+  checksumFile,
 } from '../services/controlledDocumentLifecycleService';
+import { isControlledDocumentPhase2Enabled } from '../services/controlledDocumentPhase2Gate';
 import {
   assertControlledDocumentSchemaReady,
+  assertControlledDocumentPhase2SchemaReady,
   ControlledDocumentSchemaNotReadyError,
 } from '../services/controlledDocumentSchemaReadiness';
 
@@ -112,6 +117,12 @@ const requireAuth = async (req: Request, res: Response, next: any) => {
   (req as any).user = user;
   next();
 };
+
+/* eslint-disable prettier/prettier */
+router.get('/phase2/availability', requireAuth, (_req: Request, res: Response) => {
+  res.json({ enabled: isControlledDocumentPhase2Enabled(), workflow: 'REGISTER_APPROVE_RELEASE' });
+});
+/* eslint-enable prettier/prettier */
 
 // Authorization middleware - check for admin/owner role
 const requireAdminOrOwner = async (req: Request, res: Response, next: any) => {
@@ -975,12 +986,53 @@ const lifecycleHandler = (
   }
 };
 
-router.post('/:id/submit', requireAuth, requirePermission('documents.submit'), lifecycleHandler('submit'));
-router.post('/:id/decision', requireAuth, requirePermission('documents.approve'), lifecycleHandler('approve'));
-router.post('/:id/release', requireAuth, requirePermission('documents.release'), lifecycleHandler('release'));
+/* eslint-disable prettier/prettier */
+const requireLegacyLifecycle = (_req: Request, res: Response, next: NextFunction) => {
+  if (!isControlledDocumentPhase2Enabled()) return next();
+  return res.status(409).json({ error: 'PHASE2_OBSOLETE_ACTION', message: 'Registered revisions are approved and released atomically; Submit and Release are not routine Phase 2 actions.' });
+};
+router.post('/:id/submit', requireAuth, requirePermission('documents.submit'), requireLegacyLifecycle, lifecycleHandler('submit'));
+router.post('/:id/decision', requireAuth, requirePermission('documents.approve'), requireLegacyLifecycle, lifecycleHandler('approve'));
+router.post('/:id/release', requireAuth, requirePermission('documents.release'), requireLegacyLifecycle, lifecycleHandler('release'));
 router.post('/:id/supersede', requireAuth, requirePermission('documents.supersede'), lifecycleHandler('supersede'));
 router.post('/:id/obsolete', requireAuth, requirePermission('documents.obsolete'), lifecycleHandler('obsolete'));
 router.post('/:id/void', requireAuth, requirePermission('documents.void'), lifecycleHandler('void'));
+
+router.post('/:id/approve-and-release', requireAuth, requirePermission('documents.approve'), requireStepUp(), async (req: Request, res: Response) => {
+  try {
+    if (!isControlledDocumentPhase2Enabled()) return res.status(404).json({ error: 'PHASE2_DISABLED', message: 'Atomic approval and release is disabled.' });
+    await assertControlledDocumentPhase2SchemaReady();
+    const state = await getControlledDocumentState(req.params.id);
+    const revisionId = String(req.body?.revisionId || '');
+    const revision = state.revisions.find((candidate) => candidate.id === revisionId);
+    if (!revision || revision.documentId !== state.document.id) throw new ControlledDocumentError(409, 'CROSS_DOCUMENT_REVISION', 'Revision does not belong to this controlled document');
+    if (!revision.filePath || getExternalRedirectUrl(revision.filePath)) throw new ControlledDocumentError(422, 'IMMUTABLE_REVISION_FILE_REQUIRED', 'Approval requires an immutable EPOCH-managed file');
+    const bytes = await readControlledDocumentBytes(revision.filePath);
+    const result = await approveAndReleaseControlledRevision({
+      documentId: state.document.id, revisionId, filePath: revision.filePath, observedChecksum: checksumFile(bytes),
+      idempotencyKey: String(req.headers['idempotency-key'] || ''), reason: String(req.body?.reason || req.body?.comment || ''),
+      effectiveDate: typeof req.body?.effectiveDate === 'string' ? req.body.effectiveDate : null,
+      actor: lifecycleActor(req), request: requestEvidence(req),
+    });
+    res.json(result);
+  } catch (error) {
+    sendLifecycleError(res, error, 'Failed to approve and release controlled revision');
+  }
+});
+
+router.post('/:id/reject', requireAuth, requirePermission('documents.approve'), requireStepUp(), async (req: Request, res: Response) => {
+  try {
+    if (!isControlledDocumentPhase2Enabled()) return res.status(404).json({ error: 'PHASE2_DISABLED' });
+    await assertControlledDocumentPhase2SchemaReady();
+    const result = await rejectRegisteredControlledRevision({ documentId: req.params.id,
+      revisionId: String(req.body?.revisionId || ''), reason: String(req.body?.reason || req.body?.comment || ''),
+      actor: lifecycleActor(req), request: requestEvidence(req) });
+    res.json(result);
+  } catch (error) {
+    sendLifecycleError(res, error, 'Failed to reject registered controlled revision');
+  }
+});
+/* eslint-enable prettier/prettier */
 
 router.post('/:id/revisions/:revisionId/external-approval-evidence', requireAuth, requirePermission('documents.approve'), async (req: Request, res: Response) => {
   try {

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -244,7 +244,11 @@ const readControlledDocumentBytes = async (filePath: string) => {
     );
   }
   try {
-    return await fs.readFile(resolvedPath);
+    const containedPath = await assertContainedControlledDocumentPath(
+      filePath,
+      resolvedPath
+    );
+    return await fs.readFile(containedPath);
   } catch (error: any) {
     if (error?.code === 'ENOENT') {
       throw new ControlledDocumentError(
@@ -581,6 +585,61 @@ const resolveControlledDocumentFile = (filePath: string | null | undefined) => {
   return null;
 };
 
+const pathIdentity = (value: string) =>
+  process.platform === 'win32'
+    ? path.resolve(value).toLowerCase()
+    : path.resolve(value);
+
+const assertContainedControlledDocumentPath = async (
+  fileReference: string,
+  resolvedPath: string
+) => {
+  const canonicalPath = await fs.realpath(resolvedPath);
+  if (pathIdentity(canonicalPath) !== pathIdentity(resolvedPath)) {
+    throw new ControlledDocumentError(
+      422,
+      'FILE_NOT_ACCESSIBLE',
+      'Symbolic-link file references are not permitted for controlled documents'
+    );
+  }
+
+  const normalizedReference = fileReference.replace(/\\/g, '/');
+  let allowedRoot: string | null = null;
+  if (
+    normalizedReference.startsWith('/api/media/file/') ||
+    normalizedReference.replace(/^\//, '').startsWith('uploads/media-library/')
+  ) {
+    allowedRoot = path.resolve(process.cwd(), 'uploads', 'media-library');
+  } else if (
+    normalizedReference.replace(/^\//, '').startsWith('assets/documents/') ||
+    /^[^/]+\.[a-z0-9]{2,5}$/i.test(normalizedReference)
+  ) {
+    allowedRoot = path.resolve(process.cwd(), 'server/src/assets/documents');
+  }
+
+  if (allowedRoot) {
+    const canonicalRoot = await fs.realpath(allowedRoot);
+    const relative = path.relative(canonicalRoot, canonicalPath);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new ControlledDocumentError(
+        422,
+        'FILE_NOT_ACCESSIBLE',
+        'The file reference escapes its controlled storage root'
+      );
+    }
+    return canonicalPath;
+  }
+
+  if (!isAllowedImportedAbsolutePath(canonicalPath)) {
+    throw new ControlledDocumentError(
+      422,
+      'FILE_NOT_ACCESSIBLE',
+      'The imported file reference is outside approved controlled storage'
+    );
+  }
+  return canonicalPath;
+};
+
 const getControlledFileReferenceType = (
   filePath: string | null | undefined
 ) => {
@@ -685,6 +744,37 @@ const controlledDocumentAccessPolicy = async (
       res,
       error,
       'Failed to evaluate controlled document access policy'
+    );
+  }
+};
+
+const controlledDocumentViewPermission = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const actor = lifecycleActor(req);
+  try {
+    const privileged = actor.role === 'ADMIN' || actor.role === 'OWNER';
+    const { permissionSet } = await getUserPermissions(actor.id, actor.role);
+    if (!privileged && !permissionSet.has('documents.view')) {
+      await writeAccessLog({
+        documentId: req.params.id,
+        userId: actor.username,
+        action: 'denied',
+        ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+      });
+      return res.status(403).json({
+        error: 'ACCESS_DENIED',
+        message: 'documents.view authority is required',
+      });
+    }
+    return next();
+  } catch (error) {
+    sendLifecycleError(
+      res,
+      error,
+      'Failed to evaluate controlled document view permission'
     );
   }
 };
@@ -1248,7 +1338,7 @@ router.get(
 router.get(
   '/:id/revisions/:revisionId/download',
   requireAuth,
-  requirePermission('documents.view'),
+  controlledDocumentViewPermission,
   controlledDocumentAccessPolicy,
   async (req: Request, res: Response) => {
     try {
@@ -1803,7 +1893,7 @@ router.post(
 router.get(
   '/:id/view',
   requireAuth,
-  requirePermission('documents.view'),
+  controlledDocumentViewPermission,
   controlledDocumentAccessPolicy,
   async (req: Request, res: Response) => {
     const actor = (req as any).user as {
@@ -1922,17 +2012,6 @@ router.get(
         });
       }
 
-      // Check if file exists
-      try {
-        await fs.access(filePath);
-      } catch {
-        return res.status(404).json({
-          error: 'FILE_NOT_ACCESSIBLE',
-          message:
-            'The referenced file is not accessible from this EPOCH server',
-        });
-      }
-
       if (path.extname(filePath).toLowerCase() !== '.pdf') {
         return res.status(415).json({
           error: 'UNSUPPORTED_PREVIEW_TYPE',
@@ -1940,7 +2019,7 @@ router.get(
         });
       }
 
-      const buffer = await fs.readFile(filePath);
+      const buffer = await readControlledDocumentBytes(authoritativeFilePath);
       if (revision)
         await verifyStoredRevision(
           doc.id,
@@ -1976,7 +2055,7 @@ router.get(
 router.get(
   '/:id/download',
   requireAuth,
-  requirePermission('documents.view'),
+  controlledDocumentViewPermission,
   controlledDocumentAccessPolicy,
   async (req: Request, res: Response) => {
     const actor = (req as any).user as {
@@ -2095,19 +2174,8 @@ router.get(
         });
       }
 
-      // Check if file exists
-      try {
-        await fs.access(filePath);
-      } catch {
-        return res.status(404).json({
-          error: 'FILE_NOT_ACCESSIBLE',
-          message:
-            'The referenced file is not accessible from this EPOCH server',
-        });
-      }
-
       if (path.extname(filePath).toLowerCase() === '.pdf') {
-        const buffer = await fs.readFile(filePath);
+        const buffer = await readControlledDocumentBytes(authoritativeFilePath);
         if (revision)
           await verifyStoredRevision(
             doc.id,
@@ -2131,7 +2199,7 @@ router.get(
       }
 
       // Send file with appropriate content type
-      const buffer = await fs.readFile(filePath);
+      const buffer = await readControlledDocumentBytes(authoritativeFilePath);
       if (revision)
         await verifyStoredRevision(
           doc.id,

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -53,6 +53,10 @@ const requestEvidence = (req: Request) => ({
   userAgent: req.headers['user-agent'] ?? null,
 });
 
+const sessionToken = (req: Request) => String(
+  req.cookies?.sessionToken || req.headers.authorization?.replace(/^Bearer\s+/i, '') || ''
+);
+
 const sendLifecycleError = (res: Response, error: unknown, fallback: string) => {
   if (error instanceof ControlledDocumentError) {
     res.status(error.statusCode).json({ error: error.code, message: error.message, ...error.details });
@@ -1013,6 +1017,7 @@ router.post('/:id/approve-and-release', requireAuth, requirePermission('document
       idempotencyKey: String(req.headers['idempotency-key'] || ''), reason: String(req.body?.reason || req.body?.comment || ''),
       effectiveDate: typeof req.body?.effectiveDate === 'string' ? req.body.effectiveDate : null,
       actor: lifecycleActor(req), request: requestEvidence(req),
+      sessionToken: sessionToken(req), readAuthoritativeBytes: readControlledDocumentBytes,
     });
     res.json(result);
   } catch (error) {
@@ -1026,7 +1031,8 @@ router.post('/:id/reject', requireAuth, requirePermission('documents.approve'), 
     await assertControlledDocumentPhase2SchemaReady();
     const result = await rejectRegisteredControlledRevision({ documentId: req.params.id,
       revisionId: String(req.body?.revisionId || ''), reason: String(req.body?.reason || req.body?.comment || ''),
-      actor: lifecycleActor(req), request: requestEvidence(req) });
+      actor: lifecycleActor(req), request: requestEvidence(req), sessionToken: sessionToken(req),
+      readAuthoritativeBytes: readControlledDocumentBytes });
     res.json(result);
   } catch (error) {
     sendLifecycleError(res, error, 'Failed to reject registered controlled revision');
@@ -1159,7 +1165,7 @@ router.put('/:id', requireDocumentEditor, requirePermission('documents.edit_draf
 });
 
 // Approve document — requires documents.approve capability
-router.post('/:id/approve', requireAuth, requirePermission('documents.approve'), async (req: Request, res: Response) => {
+router.post('/:id/approve', requireAuth, requirePermission('documents.approve'), requireLegacyLifecycle, requireStepUp(), async (req: Request, res: Response) => {
   try {
     const preflight = await getControlledDocumentState(req.params.id);
     const requestedRevisionId = typeof req.body?.revisionId === 'string' ? req.body.revisionId : null;
@@ -1230,11 +1236,8 @@ router.get('/:id/view', requireAuth, requirePermission('documents.view'), contro
     }
 
     const state = await getControlledDocumentState(doc.id);
-    const revision = doc.currentReleasedRevisionId
-      ? await getReleasedRevisionForControlledUse(req, doc, state.revisions)
-      : state.currentRevision;
-    const authoritativeFilePath = revision?.filePath
-      || (!doc.currentReleasedRevisionId ? doc.filePath : null);
+    const revision = await getReleasedRevisionForControlledUse(req, doc, state.revisions);
+    const authoritativeFilePath = revision.filePath;
 
     if (!authoritativeFilePath) {
       return res.status(422).json({ error: 'FILE_REFERENCE_MISSING', message: 'No file reference is attached to this document' });
@@ -1331,11 +1334,8 @@ router.get('/:id/download', requireAuth, requirePermission('documents.view'), co
     }
 
     const state = await getControlledDocumentState(doc.id);
-    const revision = doc.currentReleasedRevisionId
-      ? await getReleasedRevisionForControlledUse(req, doc, state.revisions)
-      : state.currentRevision;
-    const authoritativeFilePath = revision?.filePath
-      || (!doc.currentReleasedRevisionId ? doc.filePath : null);
+    const revision = await getReleasedRevisionForControlledUse(req, doc, state.revisions);
+    const authoritativeFilePath = revision.filePath;
 
     if (!authoritativeFilePath) {
       return res.status(422).json({ error: 'FILE_REFERENCE_MISSING', message: 'No file reference is attached to this document' });

--- a/server/src/services/controlledDocumentLifecycleService.ts
+++ b/server/src/services/controlledDocumentLifecycleService.ts
@@ -63,7 +63,7 @@ async function revalidatePhase2Actor(
   sessionToken: string
 ) {
   const authentication = await client.execute(sql`
-    SELECT u.id, u.username, u.role
+    SELECT u.id, u.username, u.role, u.employee_id AS "employeeId"
     FROM user_sessions session
     JOIN users u ON u.id = session.user_id
     WHERE session.session_token = ${sessionToken}
@@ -73,7 +73,10 @@ async function revalidatePhase2Actor(
       AND u.is_active = true
     FOR SHARE OF session, u
   `);
-  if (resultRows(authentication).length !== 1) {
+  const [authenticatedActor] = resultRows<{ employeeId: number | null }>(
+    authentication
+  );
+  if (!authenticatedActor) {
     throw new ControlledDocumentError(
       401,
       'STEP_UP_REQUIRED',
@@ -104,6 +107,7 @@ async function revalidatePhase2Actor(
       'documents.approve authority is required'
     );
   }
+  return authenticatedActor;
 }
 
 const actorEvidence = async (actor: ControlledDocumentActor) => {
@@ -145,7 +149,8 @@ const audit = async (
   after: DocumentLifecycle | null,
   request: RequestEvidence,
   client: Client,
-  extra: Record<string, AuditPayloadValue> = {}
+  extra: Record<string, AuditPayloadValue> = {},
+  auditActorId?: number | null
 ) =>
   recordAuditEvent(
     {
@@ -153,7 +158,10 @@ const audit = async (
       subjectType: 'controlled_document',
       subjectId: document.id,
       sourceService: 'controlledDocumentLifecycle.service',
-      actor,
+      actor: {
+        ...actor,
+        id: auditActorId === undefined ? actor.id : auditActorId,
+      },
       reason,
       ipAddress: request.ipAddress,
       userAgent: request.userAgent,
@@ -902,7 +910,7 @@ export async function approveAndReleaseControlledRevision(
     await tx.execute(
       sql`SELECT id FROM controlled_document_number_registry WHERE controlled_document_id = ${input.documentId}::uuid OR normalized_number = ${normalizeDocumentNumber(context.document.documentNumber)} ORDER BY id FOR UPDATE`
     );
-    await revalidatePhase2Actor(
+    const authenticatedActor = await revalidatePhase2Actor(
       tx as unknown as Client,
       input.actor,
       input.sessionToken
@@ -1148,7 +1156,8 @@ export async function approveAndReleaseControlledRevision(
       'RELEASED',
       input.request ?? {},
       tx as unknown as Client,
-      { approvalId: approval.id, idempotencyKey, effectiveDate }
+      { approvalId: approval.id, idempotencyKey, effectiveDate },
+      authenticatedActor.employeeId
     );
     return getControlledDocumentState(
       input.documentId,
@@ -1189,7 +1198,7 @@ export async function rejectRegisteredControlledRevision(
       tx as unknown as Client,
       true
     );
-    await revalidatePhase2Actor(
+    const authenticatedActor = await revalidatePhase2Actor(
       tx as unknown as Client,
       input.actor,
       input.sessionToken
@@ -1303,7 +1312,9 @@ export async function rejectRegisteredControlledRevision(
       'DRAFT',
       'REJECTED',
       input.request ?? {},
-      tx as unknown as Client
+      tx as unknown as Client,
+      {},
+      authenticatedActor.employeeId
     );
     return getControlledDocumentState(
       input.documentId,

--- a/server/src/services/controlledDocumentLifecycleService.ts
+++ b/server/src/services/controlledDocumentLifecycleService.ts
@@ -17,10 +17,23 @@ import { getUserPermissions } from './permissionService';
 
 type Client = typeof db;
 export type DocumentLifecycle =
-  | 'DRAFT' | 'IN_REVIEW' | 'APPROVED' | 'REJECTED' | 'RELEASED'
-  | 'SUPERSEDED' | 'OBSOLETE' | 'VOID';
-export type ControlledDocumentActor = { id: number; username: string; role: string };
-export type RequestEvidence = { ipAddress?: string | null; userAgent?: string | null };
+  | 'DRAFT'
+  | 'IN_REVIEW'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'RELEASED'
+  | 'SUPERSEDED'
+  | 'OBSOLETE'
+  | 'VOID';
+export type ControlledDocumentActor = {
+  id: number;
+  username: string;
+  role: string;
+};
+export type RequestEvidence = {
+  ipAddress?: string | null;
+  userAgent?: string | null;
+};
 
 export class ControlledDocumentError extends Error {
   constructor(
@@ -34,15 +47,21 @@ export class ControlledDocumentError extends Error {
 }
 
 export const normalizeDocumentNumber = (value: unknown) =>
-  String(value ?? '').trim().toUpperCase();
+  String(value ?? '')
+    .trim()
+    .toUpperCase();
 
 export const checksumFile = (buffer: Buffer) =>
   crypto.createHash('sha256').update(buffer).digest('hex');
 
 const resultRows = <T>(result: unknown) =>
-  ((((result as { rows?: T[] })?.rows ?? result) || []) as T[]);
+  (((result as { rows?: T[] })?.rows ?? result) || []) as T[];
 
-async function revalidatePhase2Actor(client: Client, actor: ControlledDocumentActor, sessionToken: string) {
+async function revalidatePhase2Actor(
+  client: Client,
+  actor: ControlledDocumentActor,
+  sessionToken: string
+) {
   const authentication = await client.execute(sql`
     SELECT u.id, u.username, u.role
     FROM user_sessions session
@@ -55,7 +74,11 @@ async function revalidatePhase2Actor(client: Client, actor: ControlledDocumentAc
     FOR SHARE OF session, u
   `);
   if (resultRows(authentication).length !== 1) {
-    throw new ControlledDocumentError(401, 'STEP_UP_REQUIRED', 'Current authenticated step-up evidence is required');
+    throw new ControlledDocumentError(
+      401,
+      'STEP_UP_REQUIRED',
+      'Current authenticated step-up evidence is required'
+    );
   }
   const permission = await client.execute(sql`
     SELECT EXISTS (
@@ -75,13 +98,21 @@ async function revalidatePhase2Actor(client: Client, actor: ControlledDocumentAc
     ) AS allowed
   `);
   if (!resultRows<{ allowed: boolean }>(permission)[0]?.allowed) {
-    throw new ControlledDocumentError(403, 'APPROVAL_PERMISSION_REQUIRED', 'documents.approve authority is required');
+    throw new ControlledDocumentError(
+      403,
+      'APPROVAL_PERMISSION_REQUIRED',
+      'documents.approve authority is required'
+    );
   }
 }
 
 const actorEvidence = async (actor: ControlledDocumentActor) => {
   if (!Number.isInteger(actor.id) || actor.id <= 0) {
-    throw new ControlledDocumentError(401, 'AUTHENTICATION_REQUIRED', 'Authenticated user identity is required');
+    throw new ControlledDocumentError(
+      401,
+      'AUTHENTICATION_REQUIRED',
+      'Authenticated user identity is required'
+    );
   }
   const [snapshot, permissions] = await Promise.all([
     resolveUserSnapshot(actor.id),
@@ -101,7 +132,12 @@ const actorEvidence = async (actor: ControlledDocumentActor) => {
 const audit = async (
   eventType: string,
   document: { id: string; documentNumber: string },
-  revision: { id: string; versionNumber: string; revisionSequence: number; fileChecksum?: string | null } | null,
+  revision: {
+    id: string;
+    versionNumber: string;
+    revisionSequence: number;
+    fileChecksum?: string | null;
+  } | null,
   actor: ControlledDocumentActor,
   actorCapabilities: string[],
   reason: string,
@@ -110,93 +146,142 @@ const audit = async (
   request: RequestEvidence,
   client: Client,
   extra: Record<string, AuditPayloadValue> = {}
-) => recordAuditEvent({
-  eventType,
-  subjectType: 'controlled_document',
-  subjectId: document.id,
-  sourceService: 'controlledDocumentLifecycle.service',
-  actor,
-  reason,
-  ipAddress: request.ipAddress,
-  userAgent: request.userAgent,
-  fieldsChanged: before && after ? { lifecycleStatus: { before, after } } : null,
-  payload: {
-    controlledDocumentId: document.id,
-    documentNumber: document.documentNumber,
-    revisionId: revision?.id ?? null,
-    revisionValue: revision?.versionNumber ?? null,
-    revisionSequence: revision?.revisionSequence ?? null,
-    fileChecksum: revision?.fileChecksum ?? null,
-    actorCapabilities,
-    beforeLifecycle: before,
-    afterLifecycle: after,
-    ...extra,
-  },
-}, client);
+) =>
+  recordAuditEvent(
+    {
+      eventType,
+      subjectType: 'controlled_document',
+      subjectId: document.id,
+      sourceService: 'controlledDocumentLifecycle.service',
+      actor,
+      reason,
+      ipAddress: request.ipAddress,
+      userAgent: request.userAgent,
+      fieldsChanged:
+        before && after ? { lifecycleStatus: { before, after } } : null,
+      payload: {
+        controlledDocumentId: document.id,
+        documentNumber: document.documentNumber,
+        revisionId: revision?.id ?? null,
+        revisionValue: revision?.versionNumber ?? null,
+        revisionSequence: revision?.revisionSequence ?? null,
+        fileChecksum: revision?.fileChecksum ?? null,
+        actorCapabilities,
+        beforeLifecycle: before,
+        afterLifecycle: after,
+        ...extra,
+      },
+    },
+    client
+  );
 
 async function loadDocument(documentId: string, client: Client, lock = false) {
   if (lock) {
-    await client.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`controlled-document:${documentId}`}))`);
-    /* eslint-disable prettier/prettier */
-    await client.execute(sql`SELECT id FROM controlled_documents WHERE id = ${documentId}::uuid FOR UPDATE`);
-    await client.execute(sql`SELECT id FROM document_version_history WHERE document_id = ${documentId}::uuid ORDER BY revision_sequence FOR UPDATE`);
-    /* eslint-enable prettier/prettier */
+    await client.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${`controlled-document:${documentId}`}))`
+    );
+    await client.execute(
+      sql`SELECT id FROM controlled_documents WHERE id = ${documentId}::uuid FOR UPDATE`
+    );
+    await client.execute(
+      sql`SELECT id FROM document_version_history WHERE document_id = ${documentId}::uuid ORDER BY revision_sequence FOR UPDATE`
+    );
   }
-  const [document] = await client.select().from(controlledDocuments)
-    .where(eq(controlledDocuments.id, documentId)).limit(1);
-  if (!document) throw new ControlledDocumentError(404, 'DOCUMENT_NOT_FOUND', 'Controlled document not found');
-  const revisions = await client.select().from(documentVersionHistory)
+  const [document] = await client
+    .select()
+    .from(controlledDocuments)
+    .where(eq(controlledDocuments.id, documentId))
+    .limit(1);
+  if (!document)
+    throw new ControlledDocumentError(
+      404,
+      'DOCUMENT_NOT_FOUND',
+      'Controlled document not found'
+    );
+  const revisions = await client
+    .select()
+    .from(documentVersionHistory)
     .where(eq(documentVersionHistory.documentId, documentId))
     .orderBy(asc(documentVersionHistory.revisionSequence));
-  const currentRevision = revisions.find((row) => row.id === document.currentRevisionId)
-    ?? revisions[revisions.length - 1]
-    ?? null;
+  const currentRevision =
+    revisions.find((row) => row.id === document.currentRevisionId) ??
+    revisions[revisions.length - 1] ??
+    null;
   return { document, revisions, currentRevision };
 }
 
-export async function getControlledDocumentState(documentId: string, client: Client = db) {
+export async function getControlledDocumentState(
+  documentId: string,
+  client: Client = db
+) {
   const context = await loadDocument(documentId, client);
-  const approvals = await client.select().from(controlledDocumentRevisionApprovals)
-    .where(eq(controlledDocumentRevisionApprovals.controlledDocumentId, documentId))
+  const approvals = await client
+    .select()
+    .from(controlledDocumentRevisionApprovals)
+    .where(
+      eq(controlledDocumentRevisionApprovals.controlledDocumentId, documentId)
+    )
     .orderBy(asc(controlledDocumentRevisionApprovals.createdAt));
   return { ...context, approvals };
 }
 
-export async function verifyControlledRevisionFile(input: {
-  documentId: string;
-  revisionId: string;
-  filePath: string;
-  fileBuffer: Buffer;
-  actor: ControlledDocumentActor;
-  request?: RequestEvidence;
-}, client: Client = db) {
+export async function verifyControlledRevisionFile(
+  input: {
+    documentId: string;
+    revisionId: string;
+    filePath: string;
+    fileBuffer: Buffer;
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+  },
+  client: Client = db
+) {
   const evidence = await actorEvidence(input.actor);
   const observedChecksum = checksumFile(input.fileBuffer);
 
   const verification = await client.transaction(async (tx) => {
-    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
-    const revision = context.revisions.find((row) => row.id === input.revisionId);
+    const context = await loadDocument(
+      input.documentId,
+      tx as unknown as Client,
+      true
+    );
+    const revision = context.revisions.find(
+      (row) => row.id === input.revisionId
+    );
     if (!revision) {
-      throw new ControlledDocumentError(404, 'REVISION_NOT_FOUND', 'Controlled document revision not found');
+      throw new ControlledDocumentError(
+        404,
+        'REVISION_NOT_FOUND',
+        'Controlled document revision not found'
+      );
     }
 
     if (revision.fileChecksum && revision.fileChecksum !== observedChecksum) {
       return { mismatch: true as const, document: context.document, revision };
     }
 
-    if (revision.fileChecksum === observedChecksum && revision.checksumStatus === 'VERIFIED') {
+    if (
+      revision.fileChecksum === observedChecksum &&
+      revision.checksumStatus === 'VERIFIED'
+    ) {
       return { mismatch: false as const, revision };
     }
 
-    const [verifiedRevision] = await tx.update(documentVersionHistory).set({
-      filePath: revision.filePath || input.filePath,
-      fileChecksum: observedChecksum,
-      checksumStatus: 'VERIFIED',
-      fileSize: input.fileBuffer.length,
-    }).where(and(
-      eq(documentVersionHistory.id, revision.id),
-      eq(documentVersionHistory.documentId, context.document.id),
-    )).returning();
+    const [verifiedRevision] = await tx
+      .update(documentVersionHistory)
+      .set({
+        filePath: revision.filePath || input.filePath,
+        fileChecksum: observedChecksum,
+        checksumStatus: 'VERIFIED',
+        fileSize: input.fileBuffer.length,
+      })
+      .where(
+        and(
+          eq(documentVersionHistory.id, revision.id),
+          eq(documentVersionHistory.documentId, context.document.id)
+        )
+      )
+      .returning();
 
     await audit(
       'CONTROLLED_DOCUMENT_FILE_CHECKSUM_VERIFIED',
@@ -242,16 +327,26 @@ export async function verifyControlledRevisionFile(input: {
 }
 
 export async function getDocumentNumberConflicts(client: Client = db) {
-  return client.select().from(controlledDocumentNumberRegistry)
-    .where(eq(controlledDocumentNumberRegistry.status, 'NUMBER_RECONCILIATION_REQUIRED'))
+  return client
+    .select()
+    .from(controlledDocumentNumberRegistry)
+    .where(
+      eq(
+        controlledDocumentNumberRegistry.status,
+        'NUMBER_RECONCILIATION_REQUIRED'
+      )
+    )
     .orderBy(asc(controlledDocumentNumberRegistry.normalizedNumber));
 }
 
-export async function recordRejectedHardDelete(input: {
-  documentId: string;
-  actor: ControlledDocumentActor;
-  request?: RequestEvidence;
-}, client: Client = db) {
+export async function recordRejectedHardDelete(
+  input: {
+    documentId: string;
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+  },
+  client: Client = db
+) {
   const evidence = await actorEvidence(input.actor);
   const context = await loadDocument(input.documentId, client);
   await audit(
@@ -269,18 +364,25 @@ export async function recordRejectedHardDelete(input: {
   return context;
 }
 
-export async function attachExternalApprovalEvidence(input: {
-  documentId: string;
-  revisionId: string;
-  externalApprover: string;
-  externalOrganization?: string;
-  evidenceReference: string;
-  comment: string;
-  actor: ControlledDocumentActor;
-  request?: RequestEvidence;
-}, client: Client = db) {
+export async function attachExternalApprovalEvidence(
+  input: {
+    documentId: string;
+    revisionId: string;
+    externalApprover: string;
+    externalOrganization?: string;
+    evidenceReference: string;
+    comment: string;
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+  },
+  client: Client = db
+) {
   const evidence = await actorEvidence(input.actor);
-  if (!input.externalApprover.trim() || !input.evidenceReference.trim() || !input.comment.trim()) {
+  if (
+    !input.externalApprover.trim() ||
+    !input.evidenceReference.trim() ||
+    !input.comment.trim()
+  ) {
     throw new ControlledDocumentError(
       400,
       'EXTERNAL_EVIDENCE_DETAILS_REQUIRED',
@@ -288,34 +390,48 @@ export async function attachExternalApprovalEvidence(input: {
     );
   }
   return client.transaction(async (tx) => {
-    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
-    const revision = context.revisions.find((row) => row.id === input.revisionId);
+    const context = await loadDocument(
+      input.documentId,
+      tx as unknown as Client,
+      true
+    );
+    const revision = context.revisions.find(
+      (row) => row.id === input.revisionId
+    );
     if (!revision?.fileChecksum) {
-      throw new ControlledDocumentError(422, 'VERIFIED_CHECKSUM_REQUIRED', 'External evidence must reference an exact checksummed revision');
+      throw new ControlledDocumentError(
+        422,
+        'VERIFIED_CHECKSUM_REQUIRED',
+        'External evidence must reference an exact checksummed revision'
+      );
     }
-    const [approval] = await tx.insert(controlledDocumentRevisionApprovals).values({
-      controlledDocumentId: context.document.id,
-      revisionId: revision.id,
-      fileChecksum: revision.fileChecksum,
-      documentNumberSnapshot: context.document.documentNumber,
-      revisionSnapshot: revision.versionNumber,
-      decision: 'APPROVED',
-      signatureMeaning: 'External approval evidence witnessed and attached by an authenticated internal custodian.',
-      decisionComment: input.comment.trim(),
-      actorUserId: input.actor.id,
-      actorUsernameSnapshot: input.actor.username,
-      actorRoleSnapshot: input.actor.role,
-      actorCapabilitiesSnapshot: evidence.capabilities,
-      approvalStatus: 'EXTERNAL_EVIDENCE',
-      metadata: {
-        provenance: 'EXTERNAL_APPROVAL_EVIDENCE',
-        externalApprover: input.externalApprover.trim(),
-        externalOrganization: input.externalOrganization?.trim() || null,
-        evidenceReference: input.evidenceReference.trim(),
-        internalCustodian: evidence.snapshot,
-        satisfiesReleaseGate: false,
-      },
-    }).returning();
+    const [approval] = await tx
+      .insert(controlledDocumentRevisionApprovals)
+      .values({
+        controlledDocumentId: context.document.id,
+        revisionId: revision.id,
+        fileChecksum: revision.fileChecksum,
+        documentNumberSnapshot: context.document.documentNumber,
+        revisionSnapshot: revision.versionNumber,
+        decision: 'APPROVED',
+        signatureMeaning:
+          'External approval evidence witnessed and attached by an authenticated internal custodian.',
+        decisionComment: input.comment.trim(),
+        actorUserId: input.actor.id,
+        actorUsernameSnapshot: input.actor.username,
+        actorRoleSnapshot: input.actor.role,
+        actorCapabilitiesSnapshot: evidence.capabilities,
+        approvalStatus: 'EXTERNAL_EVIDENCE',
+        metadata: {
+          provenance: 'EXTERNAL_APPROVAL_EVIDENCE',
+          externalApprover: input.externalApprover.trim(),
+          externalOrganization: input.externalOrganization?.trim() || null,
+          evidenceReference: input.evidenceReference.trim(),
+          internalCustodian: evidence.snapshot,
+          satisfiesReleaseGate: false,
+        },
+      })
+      .returning();
     await audit(
       'CONTROLLED_DOCUMENT_EXTERNAL_APPROVAL_EVIDENCE_ATTACHED',
       context.document,
@@ -327,48 +443,80 @@ export async function attachExternalApprovalEvidence(input: {
       revision.lifecycleStatus as DocumentLifecycle,
       input.request ?? {},
       tx as unknown as Client,
-      { approvalEvidenceId: approval.id, evidenceReference: input.evidenceReference.trim() }
+      {
+        approvalEvidenceId: approval.id,
+        evidenceReference: input.evidenceReference.trim(),
+      }
     );
     return approval;
   });
 }
 
-export async function createControlledDocument(input: {
-  document: {
-    documentNumber: string;
-    documentName: string;
-    templateKey?: string | null;
-    documentType: string;
-    department: string;
-    category?: string | null;
-    description?: string | null;
-    revisionValue: string;
-    retentionLength?: string | null;
-    documentOwner?: string | null;
-    classification?: string;
-    cuiCategory?: string | null;
-    itarCategory?: string | null;
-    exportControlJurisdiction?: string | null;
-    customerId?: string | null;
-    contractArtifactType?: string | null;
-    accessRule?: string;
-    mfaRequired?: boolean;
-  };
-  file?: { path: string; name: string; mediaType: string; size: number; buffer: Buffer } | null;
-  actor: ControlledDocumentActor;
-  request?: RequestEvidence;
-}, client: Client = db) {
+export async function createControlledDocument(
+  input: {
+    document: {
+      documentNumber: string;
+      documentName: string;
+      templateKey?: string | null;
+      documentType: string;
+      department: string;
+      category?: string | null;
+      description?: string | null;
+      revisionValue: string;
+      retentionLength?: string | null;
+      documentOwner?: string | null;
+      classification?: string;
+      cuiCategory?: string | null;
+      itarCategory?: string | null;
+      exportControlJurisdiction?: string | null;
+      customerId?: string | null;
+      contractArtifactType?: string | null;
+      accessRule?: string;
+      mfaRequired?: boolean;
+    };
+    file?: {
+      path: string;
+      name: string;
+      mediaType: string;
+      size: number;
+      buffer: Buffer;
+    } | null;
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+  },
+  client: Client = db
+) {
   const evidence = await actorEvidence(input.actor);
   const displayNumber = input.document.documentNumber.trim();
   const normalizedNumber = normalizeDocumentNumber(displayNumber);
-  if (!normalizedNumber) throw new ControlledDocumentError(400, 'DOCUMENT_NUMBER_REQUIRED', 'Document number is required');
-  if (!input.document.documentName?.trim() || !input.document.documentType?.trim() || !input.document.department?.trim()) {
-    throw new ControlledDocumentError(400, 'DOCUMENT_METADATA_REQUIRED', 'Document name, type, and department are required');
+  if (!normalizedNumber)
+    throw new ControlledDocumentError(
+      400,
+      'DOCUMENT_NUMBER_REQUIRED',
+      'Document number is required'
+    );
+  if (
+    !input.document.documentName?.trim() ||
+    !input.document.documentType?.trim() ||
+    !input.document.department?.trim()
+  ) {
+    throw new ControlledDocumentError(
+      400,
+      'DOCUMENT_METADATA_REQUIRED',
+      'Document name, type, and department are required'
+    );
   }
   return client.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`document-number:${normalizedNumber}`}))`);
-    const [reservation] = await tx.select().from(controlledDocumentNumberRegistry)
-      .where(eq(controlledDocumentNumberRegistry.normalizedNumber, normalizedNumber)).limit(1);
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${`document-number:${normalizedNumber}`}))`
+    );
+    const [reservation] = await tx
+      .select()
+      .from(controlledDocumentNumberRegistry)
+      .where(
+        eq(controlledDocumentNumberRegistry.normalizedNumber, normalizedNumber)
+      )
+      .limit(1);
     if (reservation) {
       throw new ControlledDocumentError(
         409,
@@ -380,55 +528,66 @@ export async function createControlledDocument(input: {
       );
     }
     const checksum = input.file ? checksumFile(input.file.buffer) : null;
-    const [document] = await tx.insert(controlledDocuments).values({
-      documentNumber: displayNumber,
-      documentName: input.document.documentName.trim(),
-      templateKey: input.document.templateKey ?? null,
-      documentType: input.document.documentType.trim(),
-      department: input.document.department.trim(),
-      category: input.document.category ?? null,
-      description: input.document.description ?? null,
-      currentVersion: input.document.revisionValue,
-      status: 'draft',
-      lifecycleStatus: 'DRAFT',
-      numberControlStatus: 'RESERVED',
-      retentionLength: input.document.retentionLength ?? '10 years',
-      documentOwner: input.document.documentOwner ?? null,
-      filePath: input.file?.path ?? null,
-      classification: input.document.classification ?? 'internal',
-      cuiCategory: input.document.cuiCategory ?? null,
-      itarCategory: input.document.itarCategory ?? null,
-      exportControlJurisdiction: input.document.exportControlJurisdiction ?? null,
-      customerId: input.document.customerId ?? null,
-      contractArtifactType: input.document.contractArtifactType ?? null,
-      accessRule: input.document.accessRule ?? 'authenticated',
-      mfaRequired: input.document.mfaRequired ?? false,
-      downloadTrackingRequired: true,
-      createdBy: input.actor.username,
-    }).returning();
-    const [revision] = await tx.insert(documentVersionHistory).values({
-      documentId: document.id,
-      versionNumber: input.document.revisionValue,
-      revisionSequence: 1,
-      lifecycleStatus: 'DRAFT',
-      changeDescription: 'Initial controlled revision',
-      revisionReason: 'Initial controlled revision',
-      changeType: 'major',
-      filePath: input.file?.path ?? null,
-      fileName: input.file?.name ?? null,
-      mediaType: input.file?.mediaType ?? null,
-      fileSize: input.file?.size ?? null,
-      fileChecksum: checksum,
-      checksumStatus: checksum ? 'VERIFIED' : 'NOT_APPLICABLE',
-      status: 'draft',
-      createdBy: input.actor.username,
-      metadata: { provenance: 'CONTROLLED_DOCUMENT_LIFECYCLE_SERVICE' },
-    }).returning();
-    const [updated] = await tx.update(controlledDocuments).set({
-      currentRevisionId: revision.id,
-      workingDraftRevisionId: revision.id,
-      updatedAt: new Date(),
-    }).where(eq(controlledDocuments.id, document.id)).returning();
+    const [document] = await tx
+      .insert(controlledDocuments)
+      .values({
+        documentNumber: displayNumber,
+        documentName: input.document.documentName.trim(),
+        templateKey: input.document.templateKey ?? null,
+        documentType: input.document.documentType.trim(),
+        department: input.document.department.trim(),
+        category: input.document.category ?? null,
+        description: input.document.description ?? null,
+        currentVersion: input.document.revisionValue,
+        status: 'draft',
+        lifecycleStatus: 'DRAFT',
+        numberControlStatus: 'RESERVED',
+        retentionLength: input.document.retentionLength ?? '10 years',
+        documentOwner: input.document.documentOwner ?? null,
+        filePath: input.file?.path ?? null,
+        classification: input.document.classification ?? 'internal',
+        cuiCategory: input.document.cuiCategory ?? null,
+        itarCategory: input.document.itarCategory ?? null,
+        exportControlJurisdiction:
+          input.document.exportControlJurisdiction ?? null,
+        customerId: input.document.customerId ?? null,
+        contractArtifactType: input.document.contractArtifactType ?? null,
+        accessRule: input.document.accessRule ?? 'authenticated',
+        mfaRequired: input.document.mfaRequired ?? false,
+        downloadTrackingRequired: true,
+        createdBy: input.actor.username,
+      })
+      .returning();
+    const [revision] = await tx
+      .insert(documentVersionHistory)
+      .values({
+        documentId: document.id,
+        versionNumber: input.document.revisionValue,
+        revisionSequence: 1,
+        lifecycleStatus: 'DRAFT',
+        changeDescription: 'Initial controlled revision',
+        revisionReason: 'Initial controlled revision',
+        changeType: 'major',
+        filePath: input.file?.path ?? null,
+        fileName: input.file?.name ?? null,
+        mediaType: input.file?.mediaType ?? null,
+        fileSize: input.file?.size ?? null,
+        fileChecksum: checksum,
+        checksumStatus: checksum ? 'VERIFIED' : 'NOT_APPLICABLE',
+        status: 'draft',
+        createdBy: input.actor.username,
+        metadata: { provenance: 'CONTROLLED_DOCUMENT_LIFECYCLE_SERVICE' },
+      })
+      .returning();
+    const [updated] = await tx
+      .update(controlledDocuments)
+      .set({
+        currentRevisionId: revision.id,
+        workingDraftRevisionId: revision.id,
+        updatedAt: new Date(),
+      })
+      .where(eq(controlledDocuments.id, document.id))
+      .returning();
     await tx.insert(controlledDocumentNumberRegistry).values({
       normalizedNumber,
       displayNumber,
@@ -437,266 +596,721 @@ export async function createControlledDocument(input: {
       reservedByUserId: input.actor.id,
       reservedBySnapshot: evidence.snapshot,
     });
-    await audit('CONTROLLED_DOCUMENT_CREATED', document, revision, input.actor, evidence.capabilities,
-      'Initial controlled document and exact revision created', null, 'DRAFT', input.request ?? {}, tx as unknown as Client);
-    await audit('CONTROLLED_DOCUMENT_NUMBER_RESERVED', document, revision, input.actor, evidence.capabilities,
-      `Reserved normalized document number ${normalizedNumber}`, null, 'DRAFT', input.request ?? {}, tx as unknown as Client,
-      { normalizedNumber });
+    await audit(
+      'CONTROLLED_DOCUMENT_CREATED',
+      document,
+      revision,
+      input.actor,
+      evidence.capabilities,
+      'Initial controlled document and exact revision created',
+      null,
+      'DRAFT',
+      input.request ?? {},
+      tx as unknown as Client
+    );
+    await audit(
+      'CONTROLLED_DOCUMENT_NUMBER_RESERVED',
+      document,
+      revision,
+      input.actor,
+      evidence.capabilities,
+      `Reserved normalized document number ${normalizedNumber}`,
+      null,
+      'DRAFT',
+      input.request ?? {},
+      tx as unknown as Client,
+      { normalizedNumber }
+    );
     return { document: updated, revision };
   });
 }
 
-export async function updateDraftMetadata(input: {
-  documentId: string;
-  patch: Record<string, unknown>;
-  containsFile: boolean;
-  actor: ControlledDocumentActor;
-  request?: RequestEvidence;
-}, client: Client = db) {
+export async function updateDraftMetadata(
+  input: {
+    documentId: string;
+    patch: Record<string, unknown>;
+    containsFile: boolean;
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+  },
+  client: Client = db
+) {
   const evidence = await actorEvidence(input.actor);
   if (input.containsFile) {
     const context = await loadDocument(input.documentId, client);
-    await audit('CONTROLLED_DOCUMENT_FILE_REPLACEMENT_REJECTED', context.document, context.currentRevision,
-      input.actor, evidence.capabilities, 'Ordinary metadata route cannot accept file bytes',
-      context.document.lifecycleStatus as DocumentLifecycle, context.document.lifecycleStatus as DocumentLifecycle,
-      input.request ?? {}, client);
-    throw new ControlledDocumentError(409, 'CREATE_REVISION_REQUIRED',
-      'New file content must use the controlled Create Revision action with a revision reason');
+    await audit(
+      'CONTROLLED_DOCUMENT_FILE_REPLACEMENT_REJECTED',
+      context.document,
+      context.currentRevision,
+      input.actor,
+      evidence.capabilities,
+      'Ordinary metadata route cannot accept file bytes',
+      context.document.lifecycleStatus as DocumentLifecycle,
+      context.document.lifecycleStatus as DocumentLifecycle,
+      input.request ?? {},
+      client
+    );
+    throw new ControlledDocumentError(
+      409,
+      'CREATE_REVISION_REQUIRED',
+      'New file content must use the controlled Create Revision action with a revision reason'
+    );
   }
   return client.transaction(async (tx) => {
-    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
+    const context = await loadDocument(
+      input.documentId,
+      tx as unknown as Client,
+      true
+    );
     if (context.document.lifecycleStatus !== 'DRAFT') {
-      throw new ControlledDocumentError(409, 'DOCUMENT_IMMUTABLE',
-        'Only a draft may be edited through the metadata route; use Return for Revision or Create Revision');
+      throw new ControlledDocumentError(
+        409,
+        'DOCUMENT_IMMUTABLE',
+        'Only a draft may be edited through the metadata route; use Return for Revision or Create Revision'
+      );
     }
-    const allowed = ['documentName', 'templateKey', 'category', 'description', 'retentionLength', 'documentOwner'];
-    const patch = Object.fromEntries(allowed
-      .filter((key) => input.patch[key] !== undefined)
-      .map((key) => [key, input.patch[key]]));
-    const [document] = await tx.update(controlledDocuments).set({ ...patch, updatedAt: new Date() })
-      .where(eq(controlledDocuments.id, input.documentId)).returning();
-    await audit('CONTROLLED_DOCUMENT_METADATA_UPDATED', document, context.currentRevision,
-      input.actor, evidence.capabilities, 'Draft metadata updated',
-      context.document.lifecycleStatus as DocumentLifecycle, context.document.lifecycleStatus as DocumentLifecycle,
-      input.request ?? {}, tx as unknown as Client, { updatedFields: Object.keys(patch) });
+    const allowed = [
+      'documentName',
+      'templateKey',
+      'category',
+      'description',
+      'retentionLength',
+      'documentOwner',
+    ];
+    const patch = Object.fromEntries(
+      allowed
+        .filter((key) => input.patch[key] !== undefined)
+        .map((key) => [key, input.patch[key]])
+    );
+    const [document] = await tx
+      .update(controlledDocuments)
+      .set({ ...patch, updatedAt: new Date() })
+      .where(eq(controlledDocuments.id, input.documentId))
+      .returning();
+    await audit(
+      'CONTROLLED_DOCUMENT_METADATA_UPDATED',
+      document,
+      context.currentRevision,
+      input.actor,
+      evidence.capabilities,
+      'Draft metadata updated',
+      context.document.lifecycleStatus as DocumentLifecycle,
+      context.document.lifecycleStatus as DocumentLifecycle,
+      input.request ?? {},
+      tx as unknown as Client,
+      { updatedFields: Object.keys(patch) }
+    );
     return { document, revision: context.currentRevision };
   });
 }
 
-export async function createControlledRevision(input: {
-  documentId: string;
-  expectedCurrentRevisionId?: string;
-  revisionValue: string;
-  reason: string;
-  file: { path: string; name: string; mediaType: string; size: number; buffer: Buffer };
-  actor: ControlledDocumentActor;
-  request?: RequestEvidence;
-}, client: Client = db) {
+export async function createControlledRevision(
+  input: {
+    documentId: string;
+    expectedCurrentRevisionId?: string;
+    revisionValue: string;
+    reason: string;
+    file: {
+      path: string;
+      name: string;
+      mediaType: string;
+      size: number;
+      buffer: Buffer;
+    };
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+  },
+  client: Client = db
+) {
   const evidence = await actorEvidence(input.actor);
-  if (!input.reason.trim()) throw new ControlledDocumentError(400, 'REVISION_REASON_REQUIRED', 'Revision reason is required');
-  if (!input.revisionValue.trim()) throw new ControlledDocumentError(400, 'REVISION_VALUE_REQUIRED', 'Revision value is required');
+  if (!input.reason.trim())
+    throw new ControlledDocumentError(
+      400,
+      'REVISION_REASON_REQUIRED',
+      'Revision reason is required'
+    );
+  if (!input.revisionValue.trim())
+    throw new ControlledDocumentError(
+      400,
+      'REVISION_VALUE_REQUIRED',
+      'Revision value is required'
+    );
   return client.transaction(async (tx) => {
-    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
+    const context = await loadDocument(
+      input.documentId,
+      tx as unknown as Client,
+      true
+    );
     if (['OBSOLETE', 'VOID'].includes(context.document.lifecycleStatus)) {
-      throw new ControlledDocumentError(409, 'DOCUMENT_NOT_REVISABLE', 'Obsolete or void documents cannot create a new-use revision');
+      throw new ControlledDocumentError(
+        409,
+        'DOCUMENT_NOT_REVISABLE',
+        'Obsolete or void documents cannot create a new-use revision'
+      );
     }
-    if (input.expectedCurrentRevisionId && context.currentRevision?.id !== input.expectedCurrentRevisionId) {
-      throw new ControlledDocumentError(409, 'STALE_REVISION', 'The current document revision changed; refresh before revising');
+    if (
+      input.expectedCurrentRevisionId &&
+      context.currentRevision?.id !== input.expectedCurrentRevisionId
+    ) {
+      throw new ControlledDocumentError(
+        409,
+        'STALE_REVISION',
+        'The current document revision changed; refresh before revising'
+      );
     }
-    if (context.revisions.some((revision) => revision.versionNumber === input.revisionValue.trim())) {
-      throw new ControlledDocumentError(409, 'REVISION_VALUE_CONFLICT', 'That revision value already exists for this document');
+    if (
+      context.revisions.some(
+        (revision) => revision.versionNumber === input.revisionValue.trim()
+      )
+    ) {
+      throw new ControlledDocumentError(
+        409,
+        'REVISION_VALUE_CONFLICT',
+        'That revision value already exists for this document'
+      );
     }
-    const nextSequence = Math.max(0, ...context.revisions.map((row) => row.revisionSequence)) + 1;
-    const [revision] = await tx.insert(documentVersionHistory).values({
-      documentId: context.document.id,
-      versionNumber: input.revisionValue.trim(),
-      revisionSequence: nextSequence,
-      lifecycleStatus: 'DRAFT',
-      status: 'draft',
-      changeDescription: input.reason.trim(),
-      revisionReason: input.reason.trim(),
-      changeType: 'controlled_revision',
-      filePath: input.file.path,
-      fileName: input.file.name,
-      mediaType: input.file.mediaType,
-      fileSize: input.file.size,
-      fileChecksum: checksumFile(input.file.buffer),
-      checksumStatus: 'VERIFIED',
-      createdBy: input.actor.username,
-      metadata: { provenance: 'CONTROLLED_DOCUMENT_LIFECYCLE_SERVICE' },
-    }).returning();
-    const [document] = await tx.update(controlledDocuments).set({
-      currentRevisionId: revision.id,
-      workingDraftRevisionId: revision.id,
-      currentVersion: context.document.currentReleasedRevisionId
-        ? context.document.currentVersion
-        : revision.versionNumber,
-      filePath: context.document.currentReleasedRevisionId
-        ? context.document.filePath
-        : revision.filePath,
-      lifecycleStatus: 'DRAFT',
-      lifecycleReason: input.reason.trim(),
-      status: 'draft',
-      updatedAt: new Date(),
-    }).where(eq(controlledDocuments.id, context.document.id)).returning();
-    await audit('CONTROLLED_DOCUMENT_REVISION_CREATED', document, revision, input.actor, evidence.capabilities,
-      input.reason.trim(), context.document.lifecycleStatus as DocumentLifecycle, 'DRAFT', input.request ?? {},
-      tx as unknown as Client, { priorRevisionId: context.currentRevision?.id ?? null });
+    const nextSequence =
+      Math.max(0, ...context.revisions.map((row) => row.revisionSequence)) + 1;
+    const [revision] = await tx
+      .insert(documentVersionHistory)
+      .values({
+        documentId: context.document.id,
+        versionNumber: input.revisionValue.trim(),
+        revisionSequence: nextSequence,
+        lifecycleStatus: 'DRAFT',
+        status: 'draft',
+        changeDescription: input.reason.trim(),
+        revisionReason: input.reason.trim(),
+        changeType: 'controlled_revision',
+        filePath: input.file.path,
+        fileName: input.file.name,
+        mediaType: input.file.mediaType,
+        fileSize: input.file.size,
+        fileChecksum: checksumFile(input.file.buffer),
+        checksumStatus: 'VERIFIED',
+        createdBy: input.actor.username,
+        metadata: { provenance: 'CONTROLLED_DOCUMENT_LIFECYCLE_SERVICE' },
+      })
+      .returning();
+    const [document] = await tx
+      .update(controlledDocuments)
+      .set({
+        currentRevisionId: revision.id,
+        workingDraftRevisionId: revision.id,
+        currentVersion: context.document.currentReleasedRevisionId
+          ? context.document.currentVersion
+          : revision.versionNumber,
+        filePath: context.document.currentReleasedRevisionId
+          ? context.document.filePath
+          : revision.filePath,
+        lifecycleStatus: 'DRAFT',
+        lifecycleReason: input.reason.trim(),
+        status: 'draft',
+        updatedAt: new Date(),
+      })
+      .where(eq(controlledDocuments.id, context.document.id))
+      .returning();
+    await audit(
+      'CONTROLLED_DOCUMENT_REVISION_CREATED',
+      document,
+      revision,
+      input.actor,
+      evidence.capabilities,
+      input.reason.trim(),
+      context.document.lifecycleStatus as DocumentLifecycle,
+      'DRAFT',
+      input.request ?? {},
+      tx as unknown as Client,
+      { priorRevisionId: context.currentRevision?.id ?? null }
+    );
     return { document, revision };
   });
 }
 
-/* eslint-disable prettier/prettier */
-export async function approveAndReleaseControlledRevision(input: {
-  documentId: string; revisionId: string; filePath: string; observedChecksum: string;
-  idempotencyKey: string; reason: string; effectiveDate?: string | null;
-  actor: ControlledDocumentActor; request?: RequestEvidence; sessionToken: string;
-  readAuthoritativeBytes: (filePath: string) => Promise<Buffer>;
-}, client: Client = db) {
+export async function approveAndReleaseControlledRevision(
+  input: {
+    documentId: string;
+    revisionId: string;
+    filePath: string;
+    observedChecksum: string;
+    idempotencyKey: string;
+    reason: string;
+    effectiveDate?: string | null;
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+    sessionToken: string;
+    readAuthoritativeBytes: (filePath: string) => Promise<Buffer>;
+  },
+  client: Client = db
+) {
   const reason = input.reason.trim();
   const idempotencyKey = input.idempotencyKey.trim();
-  if (!reason) throw new ControlledDocumentError(400, 'TRANSITION_REASON_REQUIRED', 'Approval reason or comment is required');
-  if (!idempotencyKey) throw new ControlledDocumentError(400, 'IDEMPOTENCY_KEY_REQUIRED', 'An Idempotency-Key is required');
-  if (!/^[0-9a-f]{64}$/.test(input.observedChecksum)) throw new ControlledDocumentError(422, 'CHECKSUM_INVALID', 'Exact SHA-256 checksum is required');
-  const requestIdentityHash = checksumFile(Buffer.from(JSON.stringify({
-    action: 'APPROVE_AND_RELEASE', documentId: input.documentId, revisionId: input.revisionId,
-    fileChecksum: input.observedChecksum, reason, effectiveDate: input.effectiveDate ?? null,
-    actorId: input.actor.id, actorUsername: input.actor.username.toLowerCase(),
-  })));
+  if (!reason)
+    throw new ControlledDocumentError(
+      400,
+      'TRANSITION_REASON_REQUIRED',
+      'Approval reason or comment is required'
+    );
+  if (!idempotencyKey)
+    throw new ControlledDocumentError(
+      400,
+      'IDEMPOTENCY_KEY_REQUIRED',
+      'An Idempotency-Key is required'
+    );
+  if (!/^[0-9a-f]{64}$/.test(input.observedChecksum))
+    throw new ControlledDocumentError(
+      422,
+      'CHECKSUM_INVALID',
+      'Exact SHA-256 checksum is required'
+    );
+  const requestIdentityHash = checksumFile(
+    Buffer.from(
+      JSON.stringify({
+        action: 'APPROVE_AND_RELEASE',
+        documentId: input.documentId,
+        revisionId: input.revisionId,
+        fileChecksum: input.observedChecksum,
+        reason,
+        effectiveDate: input.effectiveDate ?? null,
+        actorId: input.actor.id,
+        actorUsername: input.actor.username.toLowerCase(),
+      })
+    )
+  );
   return client.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${`controlled-document-idempotency:${idempotencyKey}`}, 0))`);
-    if (!isControlledDocumentPhase2Enabled()) throw new ControlledDocumentError(404, 'PHASE2_DISABLED', 'Atomic approval and release is disabled');
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${`controlled-document-idempotency:${idempotencyKey}`}, 0))`
+    );
+    if (!isControlledDocumentPhase2Enabled())
+      throw new ControlledDocumentError(
+        404,
+        'PHASE2_DISABLED',
+        'Atomic approval and release is disabled'
+      );
     await assertControlledDocumentPhase2SchemaReady(tx as unknown as Client);
-    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
-    await tx.execute(sql`SELECT id FROM controlled_document_revision_approvals WHERE controlled_document_id = ${input.documentId}::uuid ORDER BY id FOR UPDATE`);
-    await tx.execute(sql`SELECT id FROM controlled_document_approval_release_events WHERE idempotency_key = ${idempotencyKey} OR controlled_document_id = ${input.documentId}::uuid ORDER BY id FOR UPDATE`);
-    await tx.execute(sql`SELECT id FROM controlled_document_number_registry WHERE controlled_document_id = ${input.documentId}::uuid OR normalized_number = ${normalizeDocumentNumber(context.document.documentNumber)} ORDER BY id FOR UPDATE`);
-    await revalidatePhase2Actor(tx as unknown as Client, input.actor, input.sessionToken);
+    const context = await loadDocument(
+      input.documentId,
+      tx as unknown as Client,
+      true
+    );
+    await tx.execute(
+      sql`SELECT id FROM controlled_document_revision_approvals WHERE controlled_document_id = ${input.documentId}::uuid ORDER BY id FOR UPDATE`
+    );
+    await tx.execute(
+      sql`SELECT id FROM controlled_document_approval_release_events WHERE idempotency_key = ${idempotencyKey} OR controlled_document_id = ${input.documentId}::uuid ORDER BY id FOR UPDATE`
+    );
+    await tx.execute(
+      sql`SELECT id FROM controlled_document_number_registry WHERE controlled_document_id = ${input.documentId}::uuid OR normalized_number = ${normalizeDocumentNumber(context.document.documentNumber)} ORDER BY id FOR UPDATE`
+    );
+    await revalidatePhase2Actor(
+      tx as unknown as Client,
+      input.actor,
+      input.sessionToken
+    );
     const evidence = await actorEvidence(input.actor);
-    if (!evidence.capabilities.includes('documents.approve')) throw new ControlledDocumentError(403, 'APPROVAL_PERMISSION_REQUIRED', 'documents.approve authority is required');
-    const revision = context.revisions.find((row) => row.id === input.revisionId);
-    if (!revision || revision.documentId !== context.document.id) throw new ControlledDocumentError(409, 'CROSS_DOCUMENT_REVISION', 'Revision does not belong to this controlled document');
-    const [replay] = await tx.select().from(controlledDocumentApprovalReleaseEvents)
-      .where(eq(controlledDocumentApprovalReleaseEvents.idempotencyKey, idempotencyKey)).limit(1);
+    if (!evidence.capabilities.includes('documents.approve'))
+      throw new ControlledDocumentError(
+        403,
+        'APPROVAL_PERMISSION_REQUIRED',
+        'documents.approve authority is required'
+      );
+    const revision = context.revisions.find(
+      (row) => row.id === input.revisionId
+    );
+    if (!revision || revision.documentId !== context.document.id)
+      throw new ControlledDocumentError(
+        409,
+        'CROSS_DOCUMENT_REVISION',
+        'Revision does not belong to this controlled document'
+      );
+    const [replay] = await tx
+      .select()
+      .from(controlledDocumentApprovalReleaseEvents)
+      .where(
+        eq(
+          controlledDocumentApprovalReleaseEvents.idempotencyKey,
+          idempotencyKey
+        )
+      )
+      .limit(1);
     if (replay) {
       if (replay.requestIdentityHash !== requestIdentityHash) {
-        throw new ControlledDocumentError(409, 'IDEMPOTENCY_KEY_CONFLICT', 'Idempotency-Key was used for different approval evidence');
+        throw new ControlledDocumentError(
+          409,
+          'IDEMPOTENCY_KEY_CONFLICT',
+          'Idempotency-Key was used for different approval evidence'
+        );
       }
-      return getControlledDocumentState(input.documentId, tx as unknown as Client);
+      return getControlledDocumentState(
+        input.documentId,
+        tx as unknown as Client
+      );
     }
-    const [numberReservation] = await tx.select().from(controlledDocumentNumberRegistry)
-      .where(eq(controlledDocumentNumberRegistry.normalizedNumber, normalizeDocumentNumber(context.document.documentNumber))).limit(1);
-    if (!numberReservation || numberReservation.controlledDocumentId !== context.document.id ||
-        numberReservation.status === 'NUMBER_RECONCILIATION_REQUIRED' ||
-        (Array.isArray(numberReservation.conflictDocumentIds) && numberReservation.conflictDocumentIds.length > 0)) {
-      throw new ControlledDocumentError(409, 'DOCUMENT_NUMBER_CONFLICT', 'The locked document-number registration is missing or contradictory');
+    const [numberReservation] = await tx
+      .select()
+      .from(controlledDocumentNumberRegistry)
+      .where(
+        eq(
+          controlledDocumentNumberRegistry.normalizedNumber,
+          normalizeDocumentNumber(context.document.documentNumber)
+        )
+      )
+      .limit(1);
+    if (
+      !numberReservation ||
+      numberReservation.controlledDocumentId !== context.document.id ||
+      numberReservation.status === 'NUMBER_RECONCILIATION_REQUIRED' ||
+      (Array.isArray(numberReservation.conflictDocumentIds) &&
+        numberReservation.conflictDocumentIds.length > 0)
+    ) {
+      throw new ControlledDocumentError(
+        409,
+        'DOCUMENT_NUMBER_CONFLICT',
+        'The locked document-number registration is missing or contradictory'
+      );
     }
-    if (context.document.currentRevisionId !== revision.id || context.document.workingDraftRevisionId !== revision.id) throw new ControlledDocumentError(409, 'STALE_REVISION', 'Approval must target the exact current registered revision');
-    if (revision.lifecycleStatus !== 'DRAFT') throw new ControlledDocumentError(409, 'ILLEGAL_LIFECYCLE_TRANSITION', `Cannot approve a ${revision.lifecycleStatus} revision`);
-    if (!revision.filePath || revision.filePath !== input.filePath || revision.fileChecksum !== input.observedChecksum || revision.checksumStatus !== 'VERIFIED') throw new ControlledDocumentError(422, 'EXACT_VERIFIED_BYTES_REQUIRED', 'The locked revision path and verified checksum must match the exact authoritative bytes');
-    const lockedChecksum = checksumFile(await input.readAuthoritativeBytes(revision.filePath));
-    if (lockedChecksum !== revision.fileChecksum || lockedChecksum !== input.observedChecksum) {
-      throw new ControlledDocumentError(409, 'AUTHORITATIVE_FILE_CHANGED', 'The authoritative file changed after preflight; approval was not recorded');
+    if (
+      context.document.currentRevisionId !== revision.id ||
+      context.document.workingDraftRevisionId !== revision.id
+    )
+      throw new ControlledDocumentError(
+        409,
+        'STALE_REVISION',
+        'Approval must target the exact current registered revision'
+      );
+    if (revision.lifecycleStatus !== 'DRAFT')
+      throw new ControlledDocumentError(
+        409,
+        'ILLEGAL_LIFECYCLE_TRANSITION',
+        `Cannot approve a ${revision.lifecycleStatus} revision`
+      );
+    if (
+      !revision.filePath ||
+      revision.filePath !== input.filePath ||
+      revision.fileChecksum !== input.observedChecksum ||
+      revision.checksumStatus !== 'VERIFIED'
+    )
+      throw new ControlledDocumentError(
+        422,
+        'EXACT_VERIFIED_BYTES_REQUIRED',
+        'The locked revision path and verified checksum must match the exact authoritative bytes'
+      );
+    const lockedChecksum = checksumFile(
+      await input.readAuthoritativeBytes(revision.filePath)
+    );
+    if (
+      lockedChecksum !== revision.fileChecksum ||
+      lockedChecksum !== input.observedChecksum
+    ) {
+      throw new ControlledDocumentError(
+        409,
+        'AUTHORITATIVE_FILE_CHANGED',
+        'The authoritative file changed after preflight; approval was not recorded'
+      );
     }
-    if (revision.createdBy.trim().toLowerCase() === input.actor.username.trim().toLowerCase()) throw new ControlledDocumentError(403, 'SELF_APPROVAL_PROHIBITED', 'The revision author cannot approve and release the same revision');
-    const pointerRevision = context.document.currentReleasedRevisionId ? context.revisions.find((row) => row.id === context.document.currentReleasedRevisionId) : null;
-    if (context.document.currentReleasedRevisionId && !pointerRevision) throw new ControlledDocumentError(409, 'INVALID_RELEASED_REVISION_POINTER', 'Existing released revision pointer is invalid');
-    if (pointerRevision && pointerRevision.lifecycleStatus !== 'RELEASED') throw new ControlledDocumentError(409, 'CONFLICTING_RELEASED_REVISION', 'Existing released pointer does not identify a released revision');
-    const conflictingReleased = context.revisions.find((row) => row.lifecycleStatus === 'RELEASED' && row.id !== pointerRevision?.id);
-    if (conflictingReleased) throw new ControlledDocumentError(409, 'CONFLICTING_RELEASED_REVISION', 'Multiple released revisions conflict with the authoritative pointer');
+    if (
+      revision.createdBy.trim().toLowerCase() ===
+      input.actor.username.trim().toLowerCase()
+    )
+      throw new ControlledDocumentError(
+        403,
+        'SELF_APPROVAL_PROHIBITED',
+        'The revision author cannot approve and release the same revision'
+      );
+    const pointerRevision = context.document.currentReleasedRevisionId
+      ? context.revisions.find(
+          (row) => row.id === context.document.currentReleasedRevisionId
+        )
+      : null;
+    if (context.document.currentReleasedRevisionId && !pointerRevision)
+      throw new ControlledDocumentError(
+        409,
+        'INVALID_RELEASED_REVISION_POINTER',
+        'Existing released revision pointer is invalid'
+      );
+    if (pointerRevision && pointerRevision.lifecycleStatus !== 'RELEASED')
+      throw new ControlledDocumentError(
+        409,
+        'CONFLICTING_RELEASED_REVISION',
+        'Existing released pointer does not identify a released revision'
+      );
+    const conflictingReleased = context.revisions.find(
+      (row) =>
+        row.lifecycleStatus === 'RELEASED' && row.id !== pointerRevision?.id
+    );
+    if (conflictingReleased)
+      throw new ControlledDocumentError(
+        409,
+        'CONFLICTING_RELEASED_REVISION',
+        'Multiple released revisions conflict with the authoritative pointer'
+      );
     const now = new Date();
     const effectiveDate = input.effectiveDate ?? now.toISOString().slice(0, 10);
-    const [approval] = await tx.insert(controlledDocumentRevisionApprovals).values({
-      controlledDocumentId: context.document.id, revisionId: revision.id, fileChecksum: revision.fileChecksum,
-      documentNumberSnapshot: context.document.documentNumber, revisionSnapshot: revision.versionNumber,
-      decision: 'APPROVED', signatureMeaning: 'I approve and release this exact immutable controlled document revision and checksum.',
-      decisionComment: reason, actorUserId: input.actor.id, actorUsernameSnapshot: input.actor.username,
-      actorRoleSnapshot: input.actor.role, actorCapabilitiesSnapshot: evidence.capabilities,
-      approvalStatus: 'VALID', metadata: { provenance: 'AUTHENTICATED_ATOMIC_APPROVAL_RELEASE' },
-    }).returning();
-    if (pointerRevision && pointerRevision.id !== revision.id) await tx.update(documentVersionHistory).set({
-      lifecycleStatus: 'SUPERSEDED', status: 'superseded', supersededByRevisionId: revision.id,
-      supersededAt: now, supersededByUserId: input.actor.id,
-    }).where(and(eq(documentVersionHistory.id, pointerRevision.id), eq(documentVersionHistory.documentId, context.document.id)));
-    await tx.update(documentVersionHistory).set({
-      lifecycleStatus: 'RELEASED', status: 'released', approvedAt: now, approvedBy: input.actor.username,
-      approvedByUserId: input.actor.id, approvedBySnapshot: evidence.snapshot, reviewedAt: now,
-      reviewedByUserId: input.actor.id, reviewedBySnapshot: evidence.snapshot, releasedAt: now,
-      releasedByUserId: input.actor.id, releasedBySnapshot: evidence.snapshot, effectiveDate,
-    }).where(and(eq(documentVersionHistory.id, revision.id), eq(documentVersionHistory.documentId, context.document.id)));
-    const [document] = await tx.update(controlledDocuments).set({
-      lifecycleStatus: 'RELEASED', status: 'released', lifecycleReason: reason,
-      currentReleasedRevisionId: revision.id, workingDraftRevisionId: null, currentVersion: revision.versionNumber,
-      filePath: revision.filePath, effectiveDate, updatedAt: now,
-    }).where(eq(controlledDocuments.id, context.document.id)).returning();
+    const [approval] = await tx
+      .insert(controlledDocumentRevisionApprovals)
+      .values({
+        controlledDocumentId: context.document.id,
+        revisionId: revision.id,
+        fileChecksum: revision.fileChecksum,
+        documentNumberSnapshot: context.document.documentNumber,
+        revisionSnapshot: revision.versionNumber,
+        decision: 'APPROVED',
+        signatureMeaning:
+          'I approve and release this exact immutable controlled document revision and checksum.',
+        decisionComment: reason,
+        actorUserId: input.actor.id,
+        actorUsernameSnapshot: input.actor.username,
+        actorRoleSnapshot: input.actor.role,
+        actorCapabilitiesSnapshot: evidence.capabilities,
+        approvalStatus: 'VALID',
+        metadata: { provenance: 'AUTHENTICATED_ATOMIC_APPROVAL_RELEASE' },
+      })
+      .returning();
+    if (pointerRevision && pointerRevision.id !== revision.id)
+      await tx
+        .update(documentVersionHistory)
+        .set({
+          lifecycleStatus: 'SUPERSEDED',
+          status: 'superseded',
+          supersededByRevisionId: revision.id,
+          supersededAt: now,
+          supersededByUserId: input.actor.id,
+        })
+        .where(
+          and(
+            eq(documentVersionHistory.id, pointerRevision.id),
+            eq(documentVersionHistory.documentId, context.document.id)
+          )
+        );
+    await tx
+      .update(documentVersionHistory)
+      .set({
+        lifecycleStatus: 'RELEASED',
+        status: 'released',
+        approvedAt: now,
+        approvedBy: input.actor.username,
+        approvedByUserId: input.actor.id,
+        approvedBySnapshot: evidence.snapshot,
+        reviewedAt: now,
+        reviewedByUserId: input.actor.id,
+        reviewedBySnapshot: evidence.snapshot,
+        releasedAt: now,
+        releasedByUserId: input.actor.id,
+        releasedBySnapshot: evidence.snapshot,
+        effectiveDate,
+      })
+      .where(
+        and(
+          eq(documentVersionHistory.id, revision.id),
+          eq(documentVersionHistory.documentId, context.document.id)
+        )
+      );
+    const [document] = await tx
+      .update(controlledDocuments)
+      .set({
+        lifecycleStatus: 'RELEASED',
+        status: 'released',
+        lifecycleReason: reason,
+        currentReleasedRevisionId: revision.id,
+        workingDraftRevisionId: null,
+        currentVersion: revision.versionNumber,
+        filePath: revision.filePath,
+        effectiveDate,
+        updatedAt: now,
+      })
+      .where(eq(controlledDocuments.id, context.document.id))
+      .returning();
     await tx.insert(controlledDocumentApprovalReleaseEvents).values({
-      controlledDocumentId: document.id, revisionId: revision.id, approvalId: approval.id,
-      idempotencyKey, requestIdentityHash, fileChecksum: revision.fileChecksum,
-      documentNumberSnapshot: document.documentNumber, revisionSnapshot: revision.versionNumber,
-      actorUserId: input.actor.id, actorSnapshot: evidence.snapshot, authoritySnapshot: evidence.capabilities,
-      reason, beforeLifecycle: 'DRAFT', afterLifecycle: 'RELEASED', effectiveDate,
+      controlledDocumentId: document.id,
+      revisionId: revision.id,
+      approvalId: approval.id,
+      idempotencyKey,
+      requestIdentityHash,
+      fileChecksum: revision.fileChecksum,
+      documentNumberSnapshot: document.documentNumber,
+      revisionSnapshot: revision.versionNumber,
+      actorUserId: input.actor.id,
+      actorSnapshot: evidence.snapshot,
+      authoritySnapshot: evidence.capabilities,
+      reason,
+      beforeLifecycle: 'DRAFT',
+      afterLifecycle: 'RELEASED',
+      effectiveDate,
     });
-    await audit('CONTROLLED_DOCUMENT_APPROVED_AND_RELEASED', document, revision, input.actor, evidence.capabilities,
-      reason, 'DRAFT', 'RELEASED', input.request ?? {}, tx as unknown as Client,
-      { approvalId: approval.id, idempotencyKey, effectiveDate });
-    return getControlledDocumentState(input.documentId, tx as unknown as Client);
+    await audit(
+      'CONTROLLED_DOCUMENT_APPROVED_AND_RELEASED',
+      document,
+      revision,
+      input.actor,
+      evidence.capabilities,
+      reason,
+      'DRAFT',
+      'RELEASED',
+      input.request ?? {},
+      tx as unknown as Client,
+      { approvalId: approval.id, idempotencyKey, effectiveDate }
+    );
+    return getControlledDocumentState(
+      input.documentId,
+      tx as unknown as Client
+    );
   });
 }
 
-export async function rejectRegisteredControlledRevision(input: {
-  documentId: string; revisionId: string; reason: string; actor: ControlledDocumentActor;
-  request?: RequestEvidence; sessionToken: string;
-  readAuthoritativeBytes: (filePath: string) => Promise<Buffer>;
-}, client: Client = db) {
+export async function rejectRegisteredControlledRevision(
+  input: {
+    documentId: string;
+    revisionId: string;
+    reason: string;
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+    sessionToken: string;
+    readAuthoritativeBytes: (filePath: string) => Promise<Buffer>;
+  },
+  client: Client = db
+) {
   const reason = input.reason.trim();
-  if (!reason) throw new ControlledDocumentError(400, 'TRANSITION_REASON_REQUIRED', 'Rejection reason is required');
+  if (!reason)
+    throw new ControlledDocumentError(
+      400,
+      'TRANSITION_REASON_REQUIRED',
+      'Rejection reason is required'
+    );
   return client.transaction(async (tx) => {
-    if (!isControlledDocumentPhase2Enabled()) throw new ControlledDocumentError(404, 'PHASE2_DISABLED', 'Phase 2 rejection is disabled');
+    if (!isControlledDocumentPhase2Enabled())
+      throw new ControlledDocumentError(
+        404,
+        'PHASE2_DISABLED',
+        'Phase 2 rejection is disabled'
+      );
     await assertControlledDocumentPhase2SchemaReady(tx as unknown as Client);
-    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
-    await revalidatePhase2Actor(tx as unknown as Client, input.actor, input.sessionToken);
+    const context = await loadDocument(
+      input.documentId,
+      tx as unknown as Client,
+      true
+    );
+    await revalidatePhase2Actor(
+      tx as unknown as Client,
+      input.actor,
+      input.sessionToken
+    );
     const evidence = await actorEvidence(input.actor);
-    if (!evidence.capabilities.includes('documents.approve')) throw new ControlledDocumentError(403, 'APPROVAL_PERMISSION_REQUIRED', 'documents.approve authority is required');
-    const revision = context.revisions.find((row) => row.id === input.revisionId);
-    if (!revision || revision.documentId !== context.document.id) throw new ControlledDocumentError(409, 'CROSS_DOCUMENT_REVISION', 'Revision does not belong to this controlled document');
-    if (context.document.currentRevisionId !== revision.id || context.document.workingDraftRevisionId !== revision.id || revision.lifecycleStatus !== 'DRAFT') throw new ControlledDocumentError(409, 'STALE_REVISION', 'Rejection must target the exact current registered revision');
+    if (!evidence.capabilities.includes('documents.approve'))
+      throw new ControlledDocumentError(
+        403,
+        'APPROVAL_PERMISSION_REQUIRED',
+        'documents.approve authority is required'
+      );
+    const revision = context.revisions.find(
+      (row) => row.id === input.revisionId
+    );
+    if (!revision || revision.documentId !== context.document.id)
+      throw new ControlledDocumentError(
+        409,
+        'CROSS_DOCUMENT_REVISION',
+        'Revision does not belong to this controlled document'
+      );
+    if (
+      context.document.currentRevisionId !== revision.id ||
+      context.document.workingDraftRevisionId !== revision.id ||
+      revision.lifecycleStatus !== 'DRAFT'
+    )
+      throw new ControlledDocumentError(
+        409,
+        'STALE_REVISION',
+        'Rejection must target the exact current registered revision'
+      );
     let rejectionChecksum: string | null = null;
     let checksumVerificationStatus = 'UNAVAILABLE';
-    let checksumUnavailableReason = 'No verified authoritative checksum was available at rejection.';
-    if (revision.filePath && revision.fileChecksum && revision.checksumStatus === 'VERIFIED') {
+    let checksumUnavailableReason =
+      'No verified authoritative checksum was available at rejection.';
+    if (
+      revision.filePath &&
+      revision.fileChecksum &&
+      revision.checksumStatus === 'VERIFIED'
+    ) {
       try {
-        const observedChecksum = checksumFile(await input.readAuthoritativeBytes(revision.filePath));
+        const observedChecksum = checksumFile(
+          await input.readAuthoritativeBytes(revision.filePath)
+        );
         if (observedChecksum === revision.fileChecksum) {
           rejectionChecksum = observedChecksum;
           checksumVerificationStatus = 'VERIFIED';
           checksumUnavailableReason = '';
         } else {
           checksumVerificationStatus = 'MISMATCH';
-          checksumUnavailableReason = 'Authoritative bytes did not match the stored verified checksum at rejection.';
+          checksumUnavailableReason =
+            'Authoritative bytes did not match the stored verified checksum at rejection.';
         }
       } catch {
-        checksumUnavailableReason = 'Authoritative bytes were unavailable at rejection.';
+        checksumUnavailableReason =
+          'Authoritative bytes were unavailable at rejection.';
       }
     }
     await tx.insert(controlledDocumentRevisionApprovals).values({
-      controlledDocumentId: context.document.id, revisionId: revision.id,
-      fileChecksum: rejectionChecksum, checksumVerificationStatus, documentNumberSnapshot: context.document.documentNumber,
-      revisionSnapshot: revision.versionNumber, decision: 'REJECTED',
-      signatureMeaning: 'I rejected this exact registered controlled document revision.', decisionComment: reason,
-      actorUserId: input.actor.id, actorUsernameSnapshot: input.actor.username, actorRoleSnapshot: input.actor.role,
-      actorCapabilitiesSnapshot: evidence.capabilities, approvalStatus: 'VALID',
-      metadata: { provenance: 'AUTHENTICATED_PHASE2_REJECTION', checksumUnavailableReason: checksumUnavailableReason || null },
+      controlledDocumentId: context.document.id,
+      revisionId: revision.id,
+      fileChecksum: rejectionChecksum,
+      checksumVerificationStatus,
+      documentNumberSnapshot: context.document.documentNumber,
+      revisionSnapshot: revision.versionNumber,
+      decision: 'REJECTED',
+      signatureMeaning:
+        'I rejected this exact registered controlled document revision.',
+      decisionComment: reason,
+      actorUserId: input.actor.id,
+      actorUsernameSnapshot: input.actor.username,
+      actorRoleSnapshot: input.actor.role,
+      actorCapabilitiesSnapshot: evidence.capabilities,
+      approvalStatus: 'VALID',
+      metadata: {
+        provenance: 'AUTHENTICATED_PHASE2_REJECTION',
+        checksumUnavailableReason: checksumUnavailableReason || null,
+      },
     });
-    await tx.update(documentVersionHistory).set({ lifecycleStatus: 'REJECTED', status: 'rejected', reviewedAt: new Date(), reviewedByUserId: input.actor.id, reviewedBySnapshot: evidence.snapshot })
-      .where(and(eq(documentVersionHistory.id, revision.id), eq(documentVersionHistory.documentId, context.document.id)));
-    const [document] = await tx.update(controlledDocuments).set({ lifecycleStatus: 'REJECTED', status: 'rejected', lifecycleReason: reason, updatedAt: new Date() })
-      .where(eq(controlledDocuments.id, context.document.id)).returning();
-    await audit('CONTROLLED_DOCUMENT_REJECTED', document, revision, input.actor, evidence.capabilities, reason,
-      'DRAFT', 'REJECTED', input.request ?? {}, tx as unknown as Client);
-    return getControlledDocumentState(input.documentId, tx as unknown as Client);
+    await tx
+      .update(documentVersionHistory)
+      .set({
+        lifecycleStatus: 'REJECTED',
+        status: 'rejected',
+        reviewedAt: new Date(),
+        reviewedByUserId: input.actor.id,
+        reviewedBySnapshot: evidence.snapshot,
+      })
+      .where(
+        and(
+          eq(documentVersionHistory.id, revision.id),
+          eq(documentVersionHistory.documentId, context.document.id)
+        )
+      );
+    const [document] = await tx
+      .update(controlledDocuments)
+      .set({
+        lifecycleStatus: 'REJECTED',
+        status: 'rejected',
+        lifecycleReason: reason,
+        updatedAt: new Date(),
+      })
+      .where(eq(controlledDocuments.id, context.document.id))
+      .returning();
+    await audit(
+      'CONTROLLED_DOCUMENT_REJECTED',
+      document,
+      revision,
+      input.actor,
+      evidence.capabilities,
+      reason,
+      'DRAFT',
+      'REJECTED',
+      input.request ?? {},
+      tx as unknown as Client
+    );
+    return getControlledDocumentState(
+      input.documentId,
+      tx as unknown as Client
+    );
   });
 }
-/* eslint-enable prettier/prettier */
 
 const transitions: Record<string, DocumentLifecycle[]> = {
   submit: ['DRAFT'],
@@ -707,48 +1321,89 @@ const transitions: Record<string, DocumentLifecycle[]> = {
   void: ['DRAFT', 'IN_REVIEW'],
 };
 
-export async function transitionControlledRevision(input: {
-  documentId: string;
-  revisionId?: string;
-  action: keyof typeof transitions;
-  decision?: 'APPROVED' | 'REJECTED' | 'RETURNED_FOR_REVISION';
-  reason: string;
-  effectiveDate?: string | null;
-  actor: ControlledDocumentActor;
-  request?: RequestEvidence;
-}, client: Client = db) {
+export async function transitionControlledRevision(
+  input: {
+    documentId: string;
+    revisionId?: string;
+    action: keyof typeof transitions;
+    decision?: 'APPROVED' | 'REJECTED' | 'RETURNED_FOR_REVISION';
+    reason: string;
+    effectiveDate?: string | null;
+    actor: ControlledDocumentActor;
+    request?: RequestEvidence;
+  },
+  client: Client = db
+) {
   const evidence = await actorEvidence(input.actor);
-  if (!input.reason.trim()) throw new ControlledDocumentError(400, 'TRANSITION_REASON_REQUIRED', 'Transition reason or comment is required');
+  if (!input.reason.trim())
+    throw new ControlledDocumentError(
+      400,
+      'TRANSITION_REASON_REQUIRED',
+      'Transition reason or comment is required'
+    );
   return client.transaction(async (tx) => {
-    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
+    const context = await loadDocument(
+      input.documentId,
+      tx as unknown as Client,
+      true
+    );
     const revision = input.revisionId
       ? context.revisions.find((row) => row.id === input.revisionId)
       : context.currentRevision;
     if (!revision || revision.id !== context.document.currentRevisionId) {
-      throw new ControlledDocumentError(409, 'STALE_REVISION', 'Lifecycle action must target the exact current revision');
+      throw new ControlledDocumentError(
+        409,
+        'STALE_REVISION',
+        'Lifecycle action must target the exact current revision'
+      );
     }
     const before = revision.lifecycleStatus as DocumentLifecycle;
     let after: DocumentLifecycle;
-    if (input.action === 'approve' && input.decision && input.decision !== 'APPROVED') {
+    if (
+      input.action === 'approve' &&
+      input.decision &&
+      input.decision !== 'APPROVED'
+    ) {
       after = 'DRAFT';
     } else {
       const targets: Record<keyof typeof transitions, DocumentLifecycle> = {
-        submit: 'IN_REVIEW', approve: 'APPROVED', release: 'RELEASED',
-        supersede: 'SUPERSEDED', obsolete: 'OBSOLETE', void: 'VOID',
+        submit: 'IN_REVIEW',
+        approve: 'APPROVED',
+        release: 'RELEASED',
+        supersede: 'SUPERSEDED',
+        obsolete: 'OBSOLETE',
+        void: 'VOID',
       };
       after = targets[input.action];
     }
     if (!transitions[input.action].includes(before)) {
-      throw new ControlledDocumentError(409, 'ILLEGAL_LIFECYCLE_TRANSITION',
-        `Cannot ${input.action} a ${before} revision`, { before, action: input.action });
+      throw new ControlledDocumentError(
+        409,
+        'ILLEGAL_LIFECYCLE_TRANSITION',
+        `Cannot ${input.action} a ${before} revision`,
+        { before, action: input.action }
+      );
     }
     const now = new Date();
     if (input.action === 'approve') {
-      if (input.decision && !['APPROVED', 'REJECTED', 'RETURNED_FOR_REVISION'].includes(input.decision)) {
-        throw new ControlledDocumentError(400, 'INVALID_APPROVAL_DECISION', 'Approval decision is invalid');
+      if (
+        input.decision &&
+        !['APPROVED', 'REJECTED', 'RETURNED_FOR_REVISION'].includes(
+          input.decision
+        )
+      ) {
+        throw new ControlledDocumentError(
+          400,
+          'INVALID_APPROVAL_DECISION',
+          'Approval decision is invalid'
+        );
       }
       if (!revision.fileChecksum || revision.checksumStatus !== 'VERIFIED') {
-        throw new ControlledDocumentError(422, 'VERIFIED_CHECKSUM_REQUIRED', 'Exact verified file checksum is required for approval');
+        throw new ControlledDocumentError(
+          422,
+          'VERIFIED_CHECKSUM_REQUIRED',
+          'Exact verified file checksum is required for approval'
+        );
       }
       await tx.insert(controlledDocumentRevisionApprovals).values({
         controlledDocumentId: context.document.id,
@@ -757,7 +1412,8 @@ export async function transitionControlledRevision(input: {
         documentNumberSnapshot: context.document.documentNumber,
         revisionSnapshot: revision.versionNumber,
         decision: input.decision ?? 'APPROVED',
-        signatureMeaning: 'I reviewed this exact controlled document revision and file checksum.',
+        signatureMeaning:
+          'I reviewed this exact controlled document revision and file checksum.',
         decisionComment: input.reason.trim(),
         actorUserId: input.actor.id,
         actorUsernameSnapshot: input.actor.username,
@@ -768,43 +1424,80 @@ export async function transitionControlledRevision(input: {
       });
     }
     if (input.action === 'release') {
-      const [approval] = await tx.select().from(controlledDocumentRevisionApprovals).where(and(
-        eq(controlledDocumentRevisionApprovals.revisionId, revision.id),
-        eq(controlledDocumentRevisionApprovals.fileChecksum, revision.fileChecksum!),
-        eq(controlledDocumentRevisionApprovals.decision, 'APPROVED'),
-        eq(controlledDocumentRevisionApprovals.approvalStatus, 'VALID')
-      )).limit(1);
-      if (!approval) throw new ControlledDocumentError(422, 'EXACT_APPROVAL_REQUIRED',
-        'Release requires valid authenticated approval for this exact revision checksum');
-      const previousReleased = context.revisions.find((row) =>
-        row.id === context.document.currentReleasedRevisionId && row.id !== revision.id);
+      const [approval] = await tx
+        .select()
+        .from(controlledDocumentRevisionApprovals)
+        .where(
+          and(
+            eq(controlledDocumentRevisionApprovals.revisionId, revision.id),
+            eq(
+              controlledDocumentRevisionApprovals.fileChecksum,
+              revision.fileChecksum!
+            ),
+            eq(controlledDocumentRevisionApprovals.decision, 'APPROVED'),
+            eq(controlledDocumentRevisionApprovals.approvalStatus, 'VALID')
+          )
+        )
+        .limit(1);
+      if (!approval)
+        throw new ControlledDocumentError(
+          422,
+          'EXACT_APPROVAL_REQUIRED',
+          'Release requires valid authenticated approval for this exact revision checksum'
+        );
+      const previousReleased = context.revisions.find(
+        (row) =>
+          row.id === context.document.currentReleasedRevisionId &&
+          row.id !== revision.id
+      );
       if (previousReleased) {
-        await tx.update(documentVersionHistory).set({
-          lifecycleStatus: 'SUPERSEDED',
-          status: 'superseded',
-          supersededByRevisionId: revision.id,
-          supersededAt: now,
-          supersededByUserId: input.actor.id,
-        }).where(eq(documentVersionHistory.id, previousReleased.id));
+        await tx
+          .update(documentVersionHistory)
+          .set({
+            lifecycleStatus: 'SUPERSEDED',
+            status: 'superseded',
+            supersededByRevisionId: revision.id,
+            supersededAt: now,
+            supersededByUserId: input.actor.id,
+          })
+          .where(eq(documentVersionHistory.id, previousReleased.id));
       }
     }
-    const revisionPatch: Record<string, unknown> = { lifecycleStatus: after, status: after.toLowerCase() };
-    if (input.action === 'submit') Object.assign(revisionPatch, {
-      submittedAt: now, submittedByUserId: input.actor.id, submittedBySnapshot: evidence.snapshot,
-    });
-    if (input.action === 'approve' && after === 'APPROVED') Object.assign(revisionPatch, {
-      approvedAt: now, approvedBy: input.actor.username, approvedByUserId: input.actor.id,
-      approvedBySnapshot: evidence.snapshot, reviewedAt: now, reviewedByUserId: input.actor.id,
-      reviewedBySnapshot: evidence.snapshot,
-    });
-    if (input.action === 'release') Object.assign(revisionPatch, {
-      releasedAt: now, releasedByUserId: input.actor.id, releasedBySnapshot: evidence.snapshot,
-      effectiveDate: input.effectiveDate ?? now.toISOString().slice(0, 10),
-    });
-    if (input.action === 'obsolete') Object.assign(revisionPatch, {
-      obsoletedAt: now, obsoletedByUserId: input.actor.id,
-    });
-    await tx.update(documentVersionHistory).set(revisionPatch as any)
+    const revisionPatch: Record<string, unknown> = {
+      lifecycleStatus: after,
+      status: after.toLowerCase(),
+    };
+    if (input.action === 'submit')
+      Object.assign(revisionPatch, {
+        submittedAt: now,
+        submittedByUserId: input.actor.id,
+        submittedBySnapshot: evidence.snapshot,
+      });
+    if (input.action === 'approve' && after === 'APPROVED')
+      Object.assign(revisionPatch, {
+        approvedAt: now,
+        approvedBy: input.actor.username,
+        approvedByUserId: input.actor.id,
+        approvedBySnapshot: evidence.snapshot,
+        reviewedAt: now,
+        reviewedByUserId: input.actor.id,
+        reviewedBySnapshot: evidence.snapshot,
+      });
+    if (input.action === 'release')
+      Object.assign(revisionPatch, {
+        releasedAt: now,
+        releasedByUserId: input.actor.id,
+        releasedBySnapshot: evidence.snapshot,
+        effectiveDate: input.effectiveDate ?? now.toISOString().slice(0, 10),
+      });
+    if (input.action === 'obsolete')
+      Object.assign(revisionPatch, {
+        obsoletedAt: now,
+        obsoletedByUserId: input.actor.id,
+      });
+    await tx
+      .update(documentVersionHistory)
+      .set(revisionPatch as any)
       .where(eq(documentVersionHistory.id, revision.id));
     const documentPatch: Record<string, unknown> = {
       lifecycleStatus: after,
@@ -812,21 +1505,38 @@ export async function transitionControlledRevision(input: {
       status: after.toLowerCase(),
       updatedAt: now,
     };
-    if (input.action === 'release') Object.assign(documentPatch, {
-      currentReleasedRevisionId: revision.id,
-      workingDraftRevisionId: null,
-      currentVersion: revision.versionNumber,
-      filePath: revision.filePath,
-      effectiveDate: input.effectiveDate ?? now.toISOString().slice(0, 10),
-    });
+    if (input.action === 'release')
+      Object.assign(documentPatch, {
+        currentReleasedRevisionId: revision.id,
+        workingDraftRevisionId: null,
+        currentVersion: revision.versionNumber,
+        filePath: revision.filePath,
+        effectiveDate: input.effectiveDate ?? now.toISOString().slice(0, 10),
+      });
     if (input.action === 'void' || input.action === 'obsolete') {
       Object.assign(documentPatch, { workingDraftRevisionId: null });
     }
-    const [document] = await tx.update(controlledDocuments).set(documentPatch as any)
-      .where(eq(controlledDocuments.id, context.document.id)).returning();
-    await audit(`CONTROLLED_DOCUMENT_${after}`, document, revision,
-      input.actor, evidence.capabilities, input.reason.trim(), before, after, input.request ?? {},
-      tx as unknown as Client, { decision: input.decision ?? null });
-    return getControlledDocumentState(input.documentId, tx as unknown as Client);
+    const [document] = await tx
+      .update(controlledDocuments)
+      .set(documentPatch as any)
+      .where(eq(controlledDocuments.id, context.document.id))
+      .returning();
+    await audit(
+      `CONTROLLED_DOCUMENT_${after}`,
+      document,
+      revision,
+      input.actor,
+      evidence.capabilities,
+      input.reason.trim(),
+      before,
+      after,
+      input.request ?? {},
+      tx as unknown as Client,
+      { decision: input.decision ?? null }
+    );
+    return getControlledDocumentState(
+      input.documentId,
+      tx as unknown as Client
+    );
   });
 }

--- a/server/src/services/controlledDocumentLifecycleService.ts
+++ b/server/src/services/controlledDocumentLifecycleService.ts
@@ -11,6 +11,8 @@ import {
 } from '../../schema';
 import { resolveUserSnapshot } from '../../utils/userSnapshot';
 import { recordAuditEvent, type AuditPayloadValue } from './auditLedgerService';
+import { isControlledDocumentPhase2Enabled } from './controlledDocumentPhase2Gate';
+import { assertControlledDocumentPhase2SchemaReady } from './controlledDocumentSchemaReadiness';
 import { getUserPermissions } from './permissionService';
 
 type Client = typeof db;
@@ -36,6 +38,46 @@ export const normalizeDocumentNumber = (value: unknown) =>
 
 export const checksumFile = (buffer: Buffer) =>
   crypto.createHash('sha256').update(buffer).digest('hex');
+
+const resultRows = <T>(result: unknown) =>
+  ((((result as { rows?: T[] })?.rows ?? result) || []) as T[]);
+
+async function revalidatePhase2Actor(client: Client, actor: ControlledDocumentActor, sessionToken: string) {
+  const authentication = await client.execute(sql`
+    SELECT u.id, u.username, u.role
+    FROM user_sessions session
+    JOIN users u ON u.id = session.user_id
+    WHERE session.session_token = ${sessionToken}
+      AND session.is_active = true AND session.expires_at > NOW()
+      AND session.last_credential_verified_at >= NOW() - INTERVAL '30 minutes'
+      AND u.id = ${actor.id} AND lower(u.username) = lower(${actor.username})
+      AND u.is_active = true
+    FOR SHARE OF session, u
+  `);
+  if (resultRows(authentication).length !== 1) {
+    throw new ControlledDocumentError(401, 'STEP_UP_REQUIRED', 'Current authenticated step-up evidence is required');
+  }
+  const permission = await client.execute(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM users u
+      JOIN perm_roles role ON role.name = u.role
+      JOIN perm_role_capabilities role_capability ON role_capability.role_id = role.id
+      JOIN perm_capabilities capability ON capability.id = role_capability.capability_id
+      WHERE u.id = ${actor.id} AND capability.key = 'documents.approve'
+      UNION ALL
+      SELECT 1 FROM perm_user_overrides override
+      JOIN perm_capabilities capability ON capability.id = override.capability_id
+      WHERE override.user_id = ${actor.id} AND capability.key = 'documents.approve' AND override.effect = 'allow'
+    ) AND NOT EXISTS (
+      SELECT 1 FROM perm_user_overrides override
+      JOIN perm_capabilities capability ON capability.id = override.capability_id
+      WHERE override.user_id = ${actor.id} AND capability.key = 'documents.approve' AND override.effect = 'deny'
+    ) AS allowed
+  `);
+  if (!resultRows<{ allowed: boolean }>(permission)[0]?.allowed) {
+    throw new ControlledDocumentError(403, 'APPROVAL_PERMISSION_REQUIRED', 'documents.approve authority is required');
+  }
+}
 
 const actorEvidence = async (actor: ControlledDocumentActor) => {
   if (!Number.isInteger(actor.id) || actor.id <= 0) {
@@ -508,29 +550,54 @@ export async function createControlledRevision(input: {
 export async function approveAndReleaseControlledRevision(input: {
   documentId: string; revisionId: string; filePath: string; observedChecksum: string;
   idempotencyKey: string; reason: string; effectiveDate?: string | null;
-  actor: ControlledDocumentActor; request?: RequestEvidence;
+  actor: ControlledDocumentActor; request?: RequestEvidence; sessionToken: string;
+  readAuthoritativeBytes: (filePath: string) => Promise<Buffer>;
 }, client: Client = db) {
   const reason = input.reason.trim();
+  const idempotencyKey = input.idempotencyKey.trim();
   if (!reason) throw new ControlledDocumentError(400, 'TRANSITION_REASON_REQUIRED', 'Approval reason or comment is required');
-  if (!input.idempotencyKey.trim()) throw new ControlledDocumentError(400, 'IDEMPOTENCY_KEY_REQUIRED', 'An Idempotency-Key is required');
+  if (!idempotencyKey) throw new ControlledDocumentError(400, 'IDEMPOTENCY_KEY_REQUIRED', 'An Idempotency-Key is required');
   if (!/^[0-9a-f]{64}$/.test(input.observedChecksum)) throw new ControlledDocumentError(422, 'CHECKSUM_INVALID', 'Exact SHA-256 checksum is required');
+  const requestIdentityHash = checksumFile(Buffer.from(JSON.stringify({
+    action: 'APPROVE_AND_RELEASE', documentId: input.documentId, revisionId: input.revisionId,
+    fileChecksum: input.observedChecksum, reason, effectiveDate: input.effectiveDate ?? null,
+    actorId: input.actor.id, actorUsername: input.actor.username.toLowerCase(),
+  })));
   return client.transaction(async (tx) => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${`controlled-document-idempotency:${idempotencyKey}`}, 0))`);
+    if (!isControlledDocumentPhase2Enabled()) throw new ControlledDocumentError(404, 'PHASE2_DISABLED', 'Atomic approval and release is disabled');
+    await assertControlledDocumentPhase2SchemaReady(tx as unknown as Client);
     const context = await loadDocument(input.documentId, tx as unknown as Client, true);
+    await tx.execute(sql`SELECT id FROM controlled_document_revision_approvals WHERE controlled_document_id = ${input.documentId}::uuid ORDER BY id FOR UPDATE`);
+    await tx.execute(sql`SELECT id FROM controlled_document_approval_release_events WHERE idempotency_key = ${idempotencyKey} OR controlled_document_id = ${input.documentId}::uuid ORDER BY id FOR UPDATE`);
+    await tx.execute(sql`SELECT id FROM controlled_document_number_registry WHERE controlled_document_id = ${input.documentId}::uuid OR normalized_number = ${normalizeDocumentNumber(context.document.documentNumber)} ORDER BY id FOR UPDATE`);
+    await revalidatePhase2Actor(tx as unknown as Client, input.actor, input.sessionToken);
     const evidence = await actorEvidence(input.actor);
     if (!evidence.capabilities.includes('documents.approve')) throw new ControlledDocumentError(403, 'APPROVAL_PERMISSION_REQUIRED', 'documents.approve authority is required');
     const revision = context.revisions.find((row) => row.id === input.revisionId);
     if (!revision || revision.documentId !== context.document.id) throw new ControlledDocumentError(409, 'CROSS_DOCUMENT_REVISION', 'Revision does not belong to this controlled document');
     const [replay] = await tx.select().from(controlledDocumentApprovalReleaseEvents)
-      .where(eq(controlledDocumentApprovalReleaseEvents.idempotencyKey, input.idempotencyKey.trim())).limit(1);
+      .where(eq(controlledDocumentApprovalReleaseEvents.idempotencyKey, idempotencyKey)).limit(1);
     if (replay) {
-      if (replay.controlledDocumentId !== context.document.id || replay.revisionId !== revision.id || replay.fileChecksum !== input.observedChecksum) {
+      if (replay.requestIdentityHash !== requestIdentityHash) {
         throw new ControlledDocumentError(409, 'IDEMPOTENCY_KEY_CONFLICT', 'Idempotency-Key was used for different approval evidence');
       }
       return getControlledDocumentState(input.documentId, tx as unknown as Client);
     }
+    const [numberReservation] = await tx.select().from(controlledDocumentNumberRegistry)
+      .where(eq(controlledDocumentNumberRegistry.normalizedNumber, normalizeDocumentNumber(context.document.documentNumber))).limit(1);
+    if (!numberReservation || numberReservation.controlledDocumentId !== context.document.id ||
+        numberReservation.status === 'NUMBER_RECONCILIATION_REQUIRED' ||
+        (Array.isArray(numberReservation.conflictDocumentIds) && numberReservation.conflictDocumentIds.length > 0)) {
+      throw new ControlledDocumentError(409, 'DOCUMENT_NUMBER_CONFLICT', 'The locked document-number registration is missing or contradictory');
+    }
     if (context.document.currentRevisionId !== revision.id || context.document.workingDraftRevisionId !== revision.id) throw new ControlledDocumentError(409, 'STALE_REVISION', 'Approval must target the exact current registered revision');
     if (revision.lifecycleStatus !== 'DRAFT') throw new ControlledDocumentError(409, 'ILLEGAL_LIFECYCLE_TRANSITION', `Cannot approve a ${revision.lifecycleStatus} revision`);
     if (!revision.filePath || revision.filePath !== input.filePath || revision.fileChecksum !== input.observedChecksum || revision.checksumStatus !== 'VERIFIED') throw new ControlledDocumentError(422, 'EXACT_VERIFIED_BYTES_REQUIRED', 'The locked revision path and verified checksum must match the exact authoritative bytes');
+    const lockedChecksum = checksumFile(await input.readAuthoritativeBytes(revision.filePath));
+    if (lockedChecksum !== revision.fileChecksum || lockedChecksum !== input.observedChecksum) {
+      throw new ControlledDocumentError(409, 'AUTHORITATIVE_FILE_CHANGED', 'The authoritative file changed after preflight; approval was not recorded');
+    }
     if (revision.createdBy.trim().toLowerCase() === input.actor.username.trim().toLowerCase()) throw new ControlledDocumentError(403, 'SELF_APPROVAL_PROHIBITED', 'The revision author cannot approve and release the same revision');
     const pointerRevision = context.document.currentReleasedRevisionId ? context.revisions.find((row) => row.id === context.document.currentReleasedRevisionId) : null;
     if (context.document.currentReleasedRevisionId && !pointerRevision) throw new ControlledDocumentError(409, 'INVALID_RELEASED_REVISION_POINTER', 'Existing released revision pointer is invalid');
@@ -564,38 +631,61 @@ export async function approveAndReleaseControlledRevision(input: {
     }).where(eq(controlledDocuments.id, context.document.id)).returning();
     await tx.insert(controlledDocumentApprovalReleaseEvents).values({
       controlledDocumentId: document.id, revisionId: revision.id, approvalId: approval.id,
-      idempotencyKey: input.idempotencyKey.trim(), fileChecksum: revision.fileChecksum,
+      idempotencyKey, requestIdentityHash, fileChecksum: revision.fileChecksum,
       documentNumberSnapshot: document.documentNumber, revisionSnapshot: revision.versionNumber,
       actorUserId: input.actor.id, actorSnapshot: evidence.snapshot, authoritySnapshot: evidence.capabilities,
       reason, beforeLifecycle: 'DRAFT', afterLifecycle: 'RELEASED', effectiveDate,
     });
     await audit('CONTROLLED_DOCUMENT_APPROVED_AND_RELEASED', document, revision, input.actor, evidence.capabilities,
       reason, 'DRAFT', 'RELEASED', input.request ?? {}, tx as unknown as Client,
-      { approvalId: approval.id, idempotencyKey: input.idempotencyKey.trim(), effectiveDate });
+      { approvalId: approval.id, idempotencyKey, effectiveDate });
     return getControlledDocumentState(input.documentId, tx as unknown as Client);
   });
 }
 
 export async function rejectRegisteredControlledRevision(input: {
-  documentId: string; revisionId: string; reason: string; actor: ControlledDocumentActor; request?: RequestEvidence;
+  documentId: string; revisionId: string; reason: string; actor: ControlledDocumentActor;
+  request?: RequestEvidence; sessionToken: string;
+  readAuthoritativeBytes: (filePath: string) => Promise<Buffer>;
 }, client: Client = db) {
   const reason = input.reason.trim();
   if (!reason) throw new ControlledDocumentError(400, 'TRANSITION_REASON_REQUIRED', 'Rejection reason is required');
   return client.transaction(async (tx) => {
+    if (!isControlledDocumentPhase2Enabled()) throw new ControlledDocumentError(404, 'PHASE2_DISABLED', 'Phase 2 rejection is disabled');
+    await assertControlledDocumentPhase2SchemaReady(tx as unknown as Client);
     const context = await loadDocument(input.documentId, tx as unknown as Client, true);
+    await revalidatePhase2Actor(tx as unknown as Client, input.actor, input.sessionToken);
     const evidence = await actorEvidence(input.actor);
     if (!evidence.capabilities.includes('documents.approve')) throw new ControlledDocumentError(403, 'APPROVAL_PERMISSION_REQUIRED', 'documents.approve authority is required');
     const revision = context.revisions.find((row) => row.id === input.revisionId);
     if (!revision || revision.documentId !== context.document.id) throw new ControlledDocumentError(409, 'CROSS_DOCUMENT_REVISION', 'Revision does not belong to this controlled document');
     if (context.document.currentRevisionId !== revision.id || context.document.workingDraftRevisionId !== revision.id || revision.lifecycleStatus !== 'DRAFT') throw new ControlledDocumentError(409, 'STALE_REVISION', 'Rejection must target the exact current registered revision');
+    let rejectionChecksum: string | null = null;
+    let checksumVerificationStatus = 'UNAVAILABLE';
+    let checksumUnavailableReason = 'No verified authoritative checksum was available at rejection.';
+    if (revision.filePath && revision.fileChecksum && revision.checksumStatus === 'VERIFIED') {
+      try {
+        const observedChecksum = checksumFile(await input.readAuthoritativeBytes(revision.filePath));
+        if (observedChecksum === revision.fileChecksum) {
+          rejectionChecksum = observedChecksum;
+          checksumVerificationStatus = 'VERIFIED';
+          checksumUnavailableReason = '';
+        } else {
+          checksumVerificationStatus = 'MISMATCH';
+          checksumUnavailableReason = 'Authoritative bytes did not match the stored verified checksum at rejection.';
+        }
+      } catch {
+        checksumUnavailableReason = 'Authoritative bytes were unavailable at rejection.';
+      }
+    }
     await tx.insert(controlledDocumentRevisionApprovals).values({
       controlledDocumentId: context.document.id, revisionId: revision.id,
-      fileChecksum: revision.fileChecksum || 'UNVERIFIED', documentNumberSnapshot: context.document.documentNumber,
+      fileChecksum: rejectionChecksum, checksumVerificationStatus, documentNumberSnapshot: context.document.documentNumber,
       revisionSnapshot: revision.versionNumber, decision: 'REJECTED',
       signatureMeaning: 'I rejected this exact registered controlled document revision.', decisionComment: reason,
       actorUserId: input.actor.id, actorUsernameSnapshot: input.actor.username, actorRoleSnapshot: input.actor.role,
       actorCapabilitiesSnapshot: evidence.capabilities, approvalStatus: 'VALID',
-      metadata: { provenance: 'AUTHENTICATED_PHASE2_REJECTION' },
+      metadata: { provenance: 'AUTHENTICATED_PHASE2_REJECTION', checksumUnavailableReason: checksumUnavailableReason || null },
     });
     await tx.update(documentVersionHistory).set({ lifecycleStatus: 'REJECTED', status: 'rejected', reviewedAt: new Date(), reviewedByUserId: input.actor.id, reviewedBySnapshot: evidence.snapshot })
       .where(and(eq(documentVersionHistory.id, revision.id), eq(documentVersionHistory.documentId, context.document.id)));

--- a/server/src/services/controlledDocumentLifecycleService.ts
+++ b/server/src/services/controlledDocumentLifecycleService.ts
@@ -3,6 +3,7 @@ import { and, asc, desc, eq, sql } from 'drizzle-orm';
 
 import { db } from '../../db';
 import {
+  controlledDocumentApprovalReleaseEvents,
   controlledDocumentNumberRegistry,
   controlledDocumentRevisionApprovals,
   controlledDocuments,
@@ -14,7 +15,7 @@ import { getUserPermissions } from './permissionService';
 
 type Client = typeof db;
 export type DocumentLifecycle =
-  | 'DRAFT' | 'IN_REVIEW' | 'APPROVED' | 'RELEASED'
+  | 'DRAFT' | 'IN_REVIEW' | 'APPROVED' | 'REJECTED' | 'RELEASED'
   | 'SUPERSEDED' | 'OBSOLETE' | 'VOID';
 export type ControlledDocumentActor = { id: number; username: string; role: string };
 export type RequestEvidence = { ipAddress?: string | null; userAgent?: string | null };
@@ -94,6 +95,10 @@ const audit = async (
 async function loadDocument(documentId: string, client: Client, lock = false) {
   if (lock) {
     await client.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`controlled-document:${documentId}`}))`);
+    /* eslint-disable prettier/prettier */
+    await client.execute(sql`SELECT id FROM controlled_documents WHERE id = ${documentId}::uuid FOR UPDATE`);
+    await client.execute(sql`SELECT id FROM document_version_history WHERE document_id = ${documentId}::uuid ORDER BY revision_sequence FOR UPDATE`);
+    /* eslint-enable prettier/prettier */
   }
   const [document] = await client.select().from(controlledDocuments)
     .where(eq(controlledDocuments.id, documentId)).limit(1);
@@ -498,6 +503,110 @@ export async function createControlledRevision(input: {
     return { document, revision };
   });
 }
+
+/* eslint-disable prettier/prettier */
+export async function approveAndReleaseControlledRevision(input: {
+  documentId: string; revisionId: string; filePath: string; observedChecksum: string;
+  idempotencyKey: string; reason: string; effectiveDate?: string | null;
+  actor: ControlledDocumentActor; request?: RequestEvidence;
+}, client: Client = db) {
+  const reason = input.reason.trim();
+  if (!reason) throw new ControlledDocumentError(400, 'TRANSITION_REASON_REQUIRED', 'Approval reason or comment is required');
+  if (!input.idempotencyKey.trim()) throw new ControlledDocumentError(400, 'IDEMPOTENCY_KEY_REQUIRED', 'An Idempotency-Key is required');
+  if (!/^[0-9a-f]{64}$/.test(input.observedChecksum)) throw new ControlledDocumentError(422, 'CHECKSUM_INVALID', 'Exact SHA-256 checksum is required');
+  return client.transaction(async (tx) => {
+    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
+    const evidence = await actorEvidence(input.actor);
+    if (!evidence.capabilities.includes('documents.approve')) throw new ControlledDocumentError(403, 'APPROVAL_PERMISSION_REQUIRED', 'documents.approve authority is required');
+    const revision = context.revisions.find((row) => row.id === input.revisionId);
+    if (!revision || revision.documentId !== context.document.id) throw new ControlledDocumentError(409, 'CROSS_DOCUMENT_REVISION', 'Revision does not belong to this controlled document');
+    const [replay] = await tx.select().from(controlledDocumentApprovalReleaseEvents)
+      .where(eq(controlledDocumentApprovalReleaseEvents.idempotencyKey, input.idempotencyKey.trim())).limit(1);
+    if (replay) {
+      if (replay.controlledDocumentId !== context.document.id || replay.revisionId !== revision.id || replay.fileChecksum !== input.observedChecksum) {
+        throw new ControlledDocumentError(409, 'IDEMPOTENCY_KEY_CONFLICT', 'Idempotency-Key was used for different approval evidence');
+      }
+      return getControlledDocumentState(input.documentId, tx as unknown as Client);
+    }
+    if (context.document.currentRevisionId !== revision.id || context.document.workingDraftRevisionId !== revision.id) throw new ControlledDocumentError(409, 'STALE_REVISION', 'Approval must target the exact current registered revision');
+    if (revision.lifecycleStatus !== 'DRAFT') throw new ControlledDocumentError(409, 'ILLEGAL_LIFECYCLE_TRANSITION', `Cannot approve a ${revision.lifecycleStatus} revision`);
+    if (!revision.filePath || revision.filePath !== input.filePath || revision.fileChecksum !== input.observedChecksum || revision.checksumStatus !== 'VERIFIED') throw new ControlledDocumentError(422, 'EXACT_VERIFIED_BYTES_REQUIRED', 'The locked revision path and verified checksum must match the exact authoritative bytes');
+    if (revision.createdBy.trim().toLowerCase() === input.actor.username.trim().toLowerCase()) throw new ControlledDocumentError(403, 'SELF_APPROVAL_PROHIBITED', 'The revision author cannot approve and release the same revision');
+    const pointerRevision = context.document.currentReleasedRevisionId ? context.revisions.find((row) => row.id === context.document.currentReleasedRevisionId) : null;
+    if (context.document.currentReleasedRevisionId && !pointerRevision) throw new ControlledDocumentError(409, 'INVALID_RELEASED_REVISION_POINTER', 'Existing released revision pointer is invalid');
+    if (pointerRevision && pointerRevision.lifecycleStatus !== 'RELEASED') throw new ControlledDocumentError(409, 'CONFLICTING_RELEASED_REVISION', 'Existing released pointer does not identify a released revision');
+    const conflictingReleased = context.revisions.find((row) => row.lifecycleStatus === 'RELEASED' && row.id !== pointerRevision?.id);
+    if (conflictingReleased) throw new ControlledDocumentError(409, 'CONFLICTING_RELEASED_REVISION', 'Multiple released revisions conflict with the authoritative pointer');
+    const now = new Date();
+    const effectiveDate = input.effectiveDate ?? now.toISOString().slice(0, 10);
+    const [approval] = await tx.insert(controlledDocumentRevisionApprovals).values({
+      controlledDocumentId: context.document.id, revisionId: revision.id, fileChecksum: revision.fileChecksum,
+      documentNumberSnapshot: context.document.documentNumber, revisionSnapshot: revision.versionNumber,
+      decision: 'APPROVED', signatureMeaning: 'I approve and release this exact immutable controlled document revision and checksum.',
+      decisionComment: reason, actorUserId: input.actor.id, actorUsernameSnapshot: input.actor.username,
+      actorRoleSnapshot: input.actor.role, actorCapabilitiesSnapshot: evidence.capabilities,
+      approvalStatus: 'VALID', metadata: { provenance: 'AUTHENTICATED_ATOMIC_APPROVAL_RELEASE' },
+    }).returning();
+    if (pointerRevision && pointerRevision.id !== revision.id) await tx.update(documentVersionHistory).set({
+      lifecycleStatus: 'SUPERSEDED', status: 'superseded', supersededByRevisionId: revision.id,
+      supersededAt: now, supersededByUserId: input.actor.id,
+    }).where(and(eq(documentVersionHistory.id, pointerRevision.id), eq(documentVersionHistory.documentId, context.document.id)));
+    await tx.update(documentVersionHistory).set({
+      lifecycleStatus: 'RELEASED', status: 'released', approvedAt: now, approvedBy: input.actor.username,
+      approvedByUserId: input.actor.id, approvedBySnapshot: evidence.snapshot, reviewedAt: now,
+      reviewedByUserId: input.actor.id, reviewedBySnapshot: evidence.snapshot, releasedAt: now,
+      releasedByUserId: input.actor.id, releasedBySnapshot: evidence.snapshot, effectiveDate,
+    }).where(and(eq(documentVersionHistory.id, revision.id), eq(documentVersionHistory.documentId, context.document.id)));
+    const [document] = await tx.update(controlledDocuments).set({
+      lifecycleStatus: 'RELEASED', status: 'released', lifecycleReason: reason,
+      currentReleasedRevisionId: revision.id, workingDraftRevisionId: null, currentVersion: revision.versionNumber,
+      filePath: revision.filePath, effectiveDate, updatedAt: now,
+    }).where(eq(controlledDocuments.id, context.document.id)).returning();
+    await tx.insert(controlledDocumentApprovalReleaseEvents).values({
+      controlledDocumentId: document.id, revisionId: revision.id, approvalId: approval.id,
+      idempotencyKey: input.idempotencyKey.trim(), fileChecksum: revision.fileChecksum,
+      documentNumberSnapshot: document.documentNumber, revisionSnapshot: revision.versionNumber,
+      actorUserId: input.actor.id, actorSnapshot: evidence.snapshot, authoritySnapshot: evidence.capabilities,
+      reason, beforeLifecycle: 'DRAFT', afterLifecycle: 'RELEASED', effectiveDate,
+    });
+    await audit('CONTROLLED_DOCUMENT_APPROVED_AND_RELEASED', document, revision, input.actor, evidence.capabilities,
+      reason, 'DRAFT', 'RELEASED', input.request ?? {}, tx as unknown as Client,
+      { approvalId: approval.id, idempotencyKey: input.idempotencyKey.trim(), effectiveDate });
+    return getControlledDocumentState(input.documentId, tx as unknown as Client);
+  });
+}
+
+export async function rejectRegisteredControlledRevision(input: {
+  documentId: string; revisionId: string; reason: string; actor: ControlledDocumentActor; request?: RequestEvidence;
+}, client: Client = db) {
+  const reason = input.reason.trim();
+  if (!reason) throw new ControlledDocumentError(400, 'TRANSITION_REASON_REQUIRED', 'Rejection reason is required');
+  return client.transaction(async (tx) => {
+    const context = await loadDocument(input.documentId, tx as unknown as Client, true);
+    const evidence = await actorEvidence(input.actor);
+    if (!evidence.capabilities.includes('documents.approve')) throw new ControlledDocumentError(403, 'APPROVAL_PERMISSION_REQUIRED', 'documents.approve authority is required');
+    const revision = context.revisions.find((row) => row.id === input.revisionId);
+    if (!revision || revision.documentId !== context.document.id) throw new ControlledDocumentError(409, 'CROSS_DOCUMENT_REVISION', 'Revision does not belong to this controlled document');
+    if (context.document.currentRevisionId !== revision.id || context.document.workingDraftRevisionId !== revision.id || revision.lifecycleStatus !== 'DRAFT') throw new ControlledDocumentError(409, 'STALE_REVISION', 'Rejection must target the exact current registered revision');
+    await tx.insert(controlledDocumentRevisionApprovals).values({
+      controlledDocumentId: context.document.id, revisionId: revision.id,
+      fileChecksum: revision.fileChecksum || 'UNVERIFIED', documentNumberSnapshot: context.document.documentNumber,
+      revisionSnapshot: revision.versionNumber, decision: 'REJECTED',
+      signatureMeaning: 'I rejected this exact registered controlled document revision.', decisionComment: reason,
+      actorUserId: input.actor.id, actorUsernameSnapshot: input.actor.username, actorRoleSnapshot: input.actor.role,
+      actorCapabilitiesSnapshot: evidence.capabilities, approvalStatus: 'VALID',
+      metadata: { provenance: 'AUTHENTICATED_PHASE2_REJECTION' },
+    });
+    await tx.update(documentVersionHistory).set({ lifecycleStatus: 'REJECTED', status: 'rejected', reviewedAt: new Date(), reviewedByUserId: input.actor.id, reviewedBySnapshot: evidence.snapshot })
+      .where(and(eq(documentVersionHistory.id, revision.id), eq(documentVersionHistory.documentId, context.document.id)));
+    const [document] = await tx.update(controlledDocuments).set({ lifecycleStatus: 'REJECTED', status: 'rejected', lifecycleReason: reason, updatedAt: new Date() })
+      .where(eq(controlledDocuments.id, context.document.id)).returning();
+    await audit('CONTROLLED_DOCUMENT_REJECTED', document, revision, input.actor, evidence.capabilities, reason,
+      'DRAFT', 'REJECTED', input.request ?? {}, tx as unknown as Client);
+    return getControlledDocumentState(input.documentId, tx as unknown as Client);
+  });
+}
+/* eslint-enable prettier/prettier */
 
 const transitions: Record<string, DocumentLifecycle[]> = {
   submit: ['DRAFT'],

--- a/server/src/services/controlledDocumentPhase2Gate.ts
+++ b/server/src/services/controlledDocumentPhase2Gate.ts
@@ -1,0 +1,8 @@
+export const CONTROLLED_DOCUMENT_PHASE2_FLAG =
+  'CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED' as const;
+
+export function isControlledDocumentPhase2Enabled(
+  value = process.env.CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED
+) {
+  return value === 'true';
+}

--- a/server/src/services/controlledDocumentSchemaReadiness.ts
+++ b/server/src/services/controlledDocumentSchemaReadiness.ts
@@ -137,7 +137,21 @@ export async function assertControlledDocumentPhase2SchemaReady(
     UNION ALL SELECT 'column:controlled_document_revision_approvals.checksum_verification_status'
       WHERE NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public'
         AND table_name = 'controlled_document_revision_approvals' AND column_name = 'checksum_verification_status'
-        AND data_type = 'text' AND is_nullable = 'YES')
+        AND data_type = 'text' AND is_nullable = 'YES' AND column_default IS NULL)
+    UNION ALL SELECT 'column:controlled_document_revision_approvals.file_checksum'
+      WHERE NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public'
+        AND table_name = 'controlled_document_revision_approvals' AND column_name = 'file_checksum'
+        AND data_type = 'text' AND is_nullable = 'YES' AND column_default IS NULL)
+    UNION ALL SELECT 'constraint:controlled_document_revision_approvals.checksum_verification_status'
+      WHERE NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = to_regclass('public.controlled_document_revision_approvals')
+          AND contype = 'c'
+          AND pg_get_constraintdef(oid) ILIKE '%checksum_verification_status%'
+          AND pg_get_constraintdef(oid) ILIKE '%VERIFIED%'
+          AND pg_get_constraintdef(oid) ILIKE '%UNAVAILABLE%'
+          AND pg_get_constraintdef(oid) ILIKE '%MISMATCH%'
+      )
   `);
   const rows = (((result as any)?.rows ?? result) || []) as Array<{
     issue?: string;

--- a/server/src/services/controlledDocumentSchemaReadiness.ts
+++ b/server/src/services/controlledDocumentSchemaReadiness.ts
@@ -152,6 +152,36 @@ export async function assertControlledDocumentPhase2SchemaReady(
           AND pg_get_constraintdef(oid) ILIKE '%UNAVAILABLE%'
           AND pg_get_constraintdef(oid) ILIKE '%MISMATCH%'
       )
+    UNION ALL SELECT 'constraint:controlled_documents.lifecycle_status'
+      WHERE NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = to_regclass('public.controlled_documents')
+          AND contype = 'c'
+          AND pg_get_constraintdef(oid) ILIKE '%lifecycle_status%'
+          AND pg_get_constraintdef(oid) ILIKE '%DRAFT%'
+          AND pg_get_constraintdef(oid) ILIKE '%IN_REVIEW%'
+          AND pg_get_constraintdef(oid) ILIKE '%APPROVED%'
+          AND pg_get_constraintdef(oid) ILIKE '%REJECTED%'
+          AND pg_get_constraintdef(oid) ILIKE '%RELEASED%'
+          AND pg_get_constraintdef(oid) ILIKE '%SUPERSEDED%'
+          AND pg_get_constraintdef(oid) ILIKE '%OBSOLETE%'
+          AND pg_get_constraintdef(oid) ILIKE '%VOID%'
+      )
+    UNION ALL SELECT 'constraint:document_version_history.lifecycle_status'
+      WHERE NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = to_regclass('public.document_version_history')
+          AND contype = 'c'
+          AND pg_get_constraintdef(oid) ILIKE '%lifecycle_status%'
+          AND pg_get_constraintdef(oid) ILIKE '%DRAFT%'
+          AND pg_get_constraintdef(oid) ILIKE '%IN_REVIEW%'
+          AND pg_get_constraintdef(oid) ILIKE '%APPROVED%'
+          AND pg_get_constraintdef(oid) ILIKE '%REJECTED%'
+          AND pg_get_constraintdef(oid) ILIKE '%RELEASED%'
+          AND pg_get_constraintdef(oid) ILIKE '%SUPERSEDED%'
+          AND pg_get_constraintdef(oid) ILIKE '%OBSOLETE%'
+          AND pg_get_constraintdef(oid) ILIKE '%VOID%'
+      )
   `);
   const rows = (((result as any)?.rows ?? result) || []) as Array<{
     issue?: string;

--- a/server/src/services/controlledDocumentSchemaReadiness.ts
+++ b/server/src/services/controlledDocumentSchemaReadiness.ts
@@ -75,11 +75,71 @@ export async function assertControlledDocumentSchemaReady(
 /* eslint-disable prettier/prettier, @typescript-eslint/no-explicit-any */
 export async function assertControlledDocumentPhase2SchemaReady(client: Pick<typeof db, 'execute'> = db) {
   await assertControlledDocumentSchemaReady(client);
-  const result = await client.execute(sql`SELECT to_regclass('public.controlled_document_approval_release_events')::text AS object_name`);
-  const rows = (((result as any)?.rows ?? result) || []) as Array<{ object_name?: string | null }>;
-  if (rows[0]?.object_name !== 'controlled_document_approval_release_events') {
-    throw new ControlledDocumentSchemaNotReadyError(['controlled_document_approval_release_events']);
-  }
+  const result = await client.execute(sql`
+    WITH expected_columns(name, data_type, nullable, default_fragment) AS (
+      VALUES
+        ('id', 'uuid', 'NO', 'gen_random_uuid'), ('controlled_document_id', 'uuid', 'NO', NULL),
+        ('revision_id', 'uuid', 'NO', NULL), ('approval_id', 'uuid', 'NO', NULL),
+        ('idempotency_key', 'text', 'NO', NULL), ('request_identity_hash', 'text', 'NO', NULL),
+        ('file_checksum', 'text', 'NO', NULL), ('document_number_snapshot', 'text', 'NO', NULL),
+        ('revision_snapshot', 'text', 'NO', NULL), ('actor_user_id', 'integer', 'NO', NULL),
+        ('actor_snapshot', 'jsonb', 'NO', NULL), ('authority_snapshot', 'jsonb', 'NO', NULL),
+        ('reason', 'text', 'NO', NULL), ('before_lifecycle', 'text', 'NO', NULL),
+        ('after_lifecycle', 'text', 'NO', NULL), ('effective_date', 'date', 'NO', NULL),
+        ('created_at', 'timestamp with time zone', 'NO', 'now()')
+    ), column_issues AS (
+      SELECT 'column:' || expected.name AS issue FROM expected_columns expected
+      LEFT JOIN information_schema.columns actual ON actual.table_schema = 'public'
+        AND actual.table_name = 'controlled_document_approval_release_events' AND actual.column_name = expected.name
+      WHERE actual.column_name IS NULL OR actual.data_type <> expected.data_type OR actual.is_nullable <> expected.nullable
+        OR (expected.default_fragment IS NOT NULL AND COALESCE(actual.column_default, '') NOT ILIKE '%' || expected.default_fragment || '%')
+    ), required_constraints(name, kind, fragments) AS (
+      VALUES
+        ('events.primary_key', 'p', ARRAY['PRIMARY KEY (id)']),
+        ('events.idempotency_unique', 'u', ARRAY['UNIQUE (idempotency_key)']),
+        ('events.revision_unique', 'u', ARRAY['UNIQUE (revision_id)']),
+        ('events.document_fk', 'f', ARRAY['FOREIGN KEY (controlled_document_id)', 'REFERENCES controlled_documents(id)', 'ON DELETE RESTRICT']),
+        ('events.revision_fk', 'f', ARRAY['FOREIGN KEY (revision_id)', 'REFERENCES document_version_history(id)', 'ON DELETE RESTRICT']),
+        ('events.approval_fk', 'f', ARRAY['FOREIGN KEY (approval_id)', 'REFERENCES controlled_document_revision_approvals(id)', 'ON DELETE RESTRICT']),
+        ('events.actor_fk', 'f', ARRAY['FOREIGN KEY (actor_user_id)', 'REFERENCES users(id)', 'ON DELETE RESTRICT']),
+        ('events.checksum_check', 'c', ARRAY['file_checksum', '[0-9a-f]{64}']),
+        ('events.request_identity_check', 'c', ARRAY['request_identity_hash', '[0-9a-f]{64}']),
+        ('events.reason_check', 'c', ARRAY['btrim(reason)', '<>']),
+        ('events.lifecycle_check', 'c', ARRAY['after_lifecycle', 'RELEASED'])
+    ), constraint_defs AS (
+      SELECT contype, pg_get_constraintdef(oid) AS definition FROM pg_constraint
+      WHERE conrelid = to_regclass('public.controlled_document_approval_release_events')
+    ), constraint_issues AS (
+      SELECT 'constraint:' || required.name AS issue FROM required_constraints required
+      WHERE NOT EXISTS (SELECT 1 FROM constraint_defs actual WHERE actual.contype = required.kind::"char"
+        AND NOT EXISTS (SELECT 1 FROM unnest(required.fragments) fragment WHERE actual.definition NOT ILIKE '%' || fragment || '%'))
+    ), trigger_issue AS (
+      SELECT 'trigger:controlled_document_approval_release_events_append_only' AS issue WHERE NOT EXISTS (
+        SELECT 1 FROM pg_trigger trigger JOIN pg_proc function ON function.oid = trigger.tgfoid
+        WHERE trigger.tgrelid = to_regclass('public.controlled_document_approval_release_events')
+          AND trigger.tgname = 'controlled_document_approval_release_events_append_only'
+          AND NOT trigger.tgisinternal AND trigger.tgenabled = 'O' AND trigger.tgtype = 27
+          AND function.proname = 'reject_controlled_document_approval_release_event_mutation'
+          AND function.prosrc ILIKE '%RAISE EXCEPTION%')
+    ), index_issue AS (
+      SELECT 'index:controlled_document_approval_release_document_idx' AS issue WHERE NOT EXISTS (
+        SELECT 1 FROM pg_indexes WHERE schemaname = 'public'
+          AND tablename = 'controlled_document_approval_release_events'
+          AND indexname = 'controlled_document_approval_release_document_idx'
+          AND indexdef ILIKE '%(controlled_document_id, created_at)%')
+    )
+    SELECT issue FROM column_issues UNION ALL SELECT issue FROM constraint_issues
+    UNION ALL SELECT issue FROM trigger_issue UNION ALL SELECT issue FROM index_issue
+    UNION ALL SELECT 'table:controlled_document_approval_release_events'
+      WHERE to_regclass('public.controlled_document_approval_release_events') IS NULL
+    UNION ALL SELECT 'column:controlled_document_revision_approvals.checksum_verification_status'
+      WHERE NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public'
+        AND table_name = 'controlled_document_revision_approvals' AND column_name = 'checksum_verification_status'
+        AND data_type = 'text' AND is_nullable = 'YES')
+  `);
+  const rows = (((result as any)?.rows ?? result) || []) as Array<{ issue?: string }>;
+  const issues = rows.flatMap((row) => row.issue ? [row.issue] : []);
+  if (issues.length) throw new ControlledDocumentSchemaNotReadyError(issues);
 }
 /* eslint-enable prettier/prettier, @typescript-eslint/no-explicit-any */
 

--- a/server/src/services/controlledDocumentSchemaReadiness.ts
+++ b/server/src/services/controlledDocumentSchemaReadiness.ts
@@ -72,8 +72,10 @@ export async function assertControlledDocumentSchemaReady(
   if (missing.length) throw new ControlledDocumentSchemaNotReadyError(missing);
 }
 
-/* eslint-disable prettier/prettier, @typescript-eslint/no-explicit-any */
-export async function assertControlledDocumentPhase2SchemaReady(client: Pick<typeof db, 'execute'> = db) {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export async function assertControlledDocumentPhase2SchemaReady(
+  client: Pick<typeof db, 'execute'> = db
+) {
   await assertControlledDocumentSchemaReady(client);
   const result = await client.execute(sql`
     WITH expected_columns(name, data_type, nullable, default_fragment) AS (
@@ -137,11 +139,13 @@ export async function assertControlledDocumentPhase2SchemaReady(client: Pick<typ
         AND table_name = 'controlled_document_revision_approvals' AND column_name = 'checksum_verification_status'
         AND data_type = 'text' AND is_nullable = 'YES')
   `);
-  const rows = (((result as any)?.rows ?? result) || []) as Array<{ issue?: string }>;
-  const issues = rows.flatMap((row) => row.issue ? [row.issue] : []);
+  const rows = (((result as any)?.rows ?? result) || []) as Array<{
+    issue?: string;
+  }>;
+  const issues = rows.flatMap((row) => (row.issue ? [row.issue] : []));
   if (issues.length) throw new ControlledDocumentSchemaNotReadyError(issues);
 }
-/* eslint-enable prettier/prettier, @typescript-eslint/no-explicit-any */
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 const reconciliationTables = [
   'controlled_document_reconciliation_previews',

--- a/server/src/services/controlledDocumentSchemaReadiness.ts
+++ b/server/src/services/controlledDocumentSchemaReadiness.ts
@@ -8,6 +8,8 @@ export const requiredControlledDocumentReconciliationMigration =
   '0245_controlled_document_legacy_reconciliation.sql';
 export const requiredControlledDocumentReconciliationCorrectiveMigration =
   '0254_controlled_document_reconciliation_certification_controls.sql';
+export const requiredControlledDocumentPhase2Migration =
+  '0256_controlled_document_atomic_approval_release.sql';
 export const requiredControlledDocumentTables = [
   'controlled_documents',
   'document_version_history',
@@ -69,6 +71,17 @@ export async function assertControlledDocumentSchemaReady(
   const missing = required.filter((object) => !present.has(object));
   if (missing.length) throw new ControlledDocumentSchemaNotReadyError(missing);
 }
+
+/* eslint-disable prettier/prettier, @typescript-eslint/no-explicit-any */
+export async function assertControlledDocumentPhase2SchemaReady(client: Pick<typeof db, 'execute'> = db) {
+  await assertControlledDocumentSchemaReady(client);
+  const result = await client.execute(sql`SELECT to_regclass('public.controlled_document_approval_release_events')::text AS object_name`);
+  const rows = (((result as any)?.rows ?? result) || []) as Array<{ object_name?: string | null }>;
+  if (rows[0]?.object_name !== 'controlled_document_approval_release_events') {
+    throw new ControlledDocumentSchemaNotReadyError(['controlled_document_approval_release_events']);
+  }
+}
+/* eslint-enable prettier/prettier, @typescript-eslint/no-explicit-any */
 
 const reconciliationTables = [
   'controlled_document_reconciliation_previews',


### PR DESCRIPTION
## Summary

Phase 2 prospectively simplifies controlled-document lifecycle to **Register/draft -> authorized approval and automatic release**. Approval and release target the exact immutable revision and commit atomically; no routine Submit, approve-only, or separate Release action is available for eligible Phase 2 records.

Exact final certified base/head:

- Base: `f6cd117a6a17d4af29c6c667323811147f3e56b3`
- Head: `e4a64e8f3592403d73616c590bb0e0d4209a0d23`
- Migration: `migrations/0256_controlled_document_atomic_approval_release.sql`
- Current main preserves `migrations/0257_restore_shipping_qc_after_0171_replay.sql` but intentionally retired its safe-boot runner entry in PR #1655. This branch preserves that current-main behavior, registers 0256 after 0255, and does not reintroduce 0257 into the runner.

## Lifecycle, schema, and evidence

- Approval revalidates the exact feature flag, complete schema contract, session and recent step-up, database permission, separation of duties, document/revision pointers, number reservation, immutable file identity, and SHA-256 checksum after stable locks.
- A global key-derived advisory lock serializes idempotency across documents. Identical retries replay; mismatched reuse returns `409 IDEMPOTENCY_KEY_CONFLICT`.
- Approval evidence, released lifecycle, released-revision pointer, immutable event, and tamper-evident audit entry commit in one transaction.
- Rejection leaves the document registered and unreleased. It stores a real checksum only when verified; otherwise checksum is null with a truthful verification status and reason.
- Migration 0256 prospectively permits the truthful `REJECTED` lifecycle state on controlled documents and revisions without rewriting historical rows.
- Phase 2 readiness validates nullable `file_checksum`, checksum-verification status, lifecycle constraints including `REJECTED`, event columns/constraints/indexes, and the append-only trigger. Partial or malformed schema returns controlled schema-not-ready before mutation.

## Viewing and access correction

- Normal View/Download serves only `current_released_revision_id`; no draft/latest/file-path fallback exists.
- Exact draft/review access requires lifecycle authority; authorized released and historical released-compatible revisions remain available.
- Server-side permission, classification, access rule, step-up, and vault grants are enforced centrally for View, Download, and exact-revision download.
- Allowed and denied attempts are audited. Encoded/double-encoded traversal, mixed separators, POSIX/drive/UNC paths, malformed encoding/null bytes, symlink escape, guessed IDs, cross-document revisions, and mutable external references fail closed without returning paths or unintended bytes.

## Historical-data and feature containment

Migration 0256 is prospective, replay-safe, and inert while Phase 2 is disabled. It does not update, delete, relabel, or backfill historical documents, revisions, approvals, evidence, identifiers, timestamps, links, lifecycle events, or operational references. Migrations 0245, 0253, 0254, and the preserved 0257 file remain byte-identical to current main. Phase 1B reconciliation remains independently default-disabled.

The sole activation flag is `CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED`; only exact lowercase `true` enables Phase 2. Migration application, permission assignment, and UI visibility do not activate it. `CONTROLLED_DOCUMENT_RECONCILIATION_ENABLED` remains untouched and disabled by default.

## Final verification on rebased head e4a64e8f3

All GitHub checks are green:

- Comprehensive certification: **445 passed, 0 failed, 0 skipped** across its Vitest groups.
  - Controlled-document Phase 2 PostgreSQL 16.4 suite: **33 passed** across 2 files.
  - TypeScript exact-main comparison: 1,516 head / 1,516 base diagnostics; no new diagnostic.
  - Scoped ESLint: 50 unique files, 0 new errors/warnings; Prettier and `git diff --check` passed.
  - Schema creation, safe boot twice, migration replay, schema idempotency, EPOCH validation, legacy preservation, pilot, and client/server regressions passed.
- Synthetic-pilot/safe-boot certification: **180 passed, 0 failed, 0 skipped**; outbound attempts = 0.
- Part Specification PostgreSQL certification: **39 passed, 0 failed, 0 skipped**.
- Total reported GitHub Vitest assertions: **664 passed, 0 failed, 0 skipped**.
- Local controlled-document regression suite: **101 passed, 0 failed, 0 skipped** across 10 files.

The live Phase 2 suite proves nullable/malformed/partial schema behavior; truthful unavailable-checksum rejection; stale revision; conflicting release; injected post-mutation rollback; idempotent/concurrent requests; permission, step-up, expiry, and self-approval denials; independent approval success; obsolete-action blocking; ordinary released viewing; denied-access auditing; and the full path-containment matrix.

## Rollout

1. Apply migration 0256 with both controlled-document flags unset.
2. Confirm safe boot, readiness, managed storage/checksum access, step-up, vault grants, and access logging.
3. Assign `documents.approve` only to authorized independent approvers.
4. Complete the three-role authenticated browser walkthrough and obtain Quality/system-owner approval.
5. Prospectively set `CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED=true` only after authorization.

## Rollback / containment

Unset the Phase 2 flag to stop new Phase 2 actions. Do not delete append-only evidence or reverse released records. Schema rollback is permitted only before any Phase 2 evidence exists; after evidence exists, use a forward corrective migration. Historical records are never rewritten.

No production data was accessed or modified, no reconciliation was run, no feature was enabled, and nothing was deployed. Browser certification remains an activation prerequisite.
