### PR TITLE
Add atomic receipt reversal workflow

### DIFF
--- a/client/src/pages/InventoryReceivingControlCenter.tsx
+++ b/client/src/pages/InventoryReceivingControlCenter.tsx
@@ -895,6 +895,9 @@ function CenterPanel({
   onReceiptUpdate: (r: Receipt) => void;
 }) {
   const [step, setStep] = useState(0);
+  const [reversalDialogOpen, setReversalDialogOpen] = useState(false);
+  const [reversalReason, setReversalReason] = useState('');
+  const [reversalPreview, setReversalPreview] = useState<{ canReverse: boolean; unitCount: number; totalQuantity: number; blockers: string[] } | null>(null);
   const queryClient = useQueryClient();
   const reopenActiveReceiptMutation = useMutation({
     mutationFn: async () => {
@@ -916,6 +919,40 @@ function CenterPanel({
       toast.success(`Reopened ${updated.receiptNumber} for adjustment`);
     },
     onError: (err: any) => toast.error(err?.message ?? 'Failed to reopen receipt'),
+  });
+  const loadReversalPreview = async () => {
+    if (!receipt) return;
+    try {
+      setReversalPreview(await apiRequest(`/api/receipts/${receipt.id}/reversal-preview`));
+      setReversalDialogOpen(true);
+    } catch (err: any) {
+      toast.error(err?.message ?? 'Failed to check receipt reversal');
+    }
+  };
+  const reverseReceiptMutation = useMutation({
+    mutationFn: async () => {
+      if (!receipt) throw new Error('No receipt selected');
+      return apiRequest(`/api/receipts/${receipt.id}/reverse`, {
+        method: 'POST',
+        body: JSON.stringify({ reason: reversalReason }),
+      });
+    },
+    onSuccess: async (result: any) => {
+      const updated = await apiRequest(`/api/receipts/${receipt!.id}`);
+      onReceiptUpdate(updated);
+      setReversalDialogOpen(false);
+      setReversalReason('');
+      setReversalPreview(null);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['/api/receipts'] }),
+        queryClient.invalidateQueries({ queryKey: ['/api/receipts', 'complete'] }),
+        queryClient.invalidateQueries({ queryKey: ['/api/receipts/pending-by-po'] }),
+        queryClient.invalidateQueries({ queryKey: ['/api/vendor-pos'] }),
+        queryClient.invalidateQueries({ queryKey: ['/api/cutting-table/fabric-inventory'] }),
+      ]);
+      toast.success(`Reversed ${result.reversedUnits} units (${result.reversedQuantity} total) without deleting traceability`);
+    },
+    onError: (err: any) => toast.error(err?.message ?? 'Failed to reverse receipt'),
   });
 
   if (!receipt) {
@@ -946,6 +983,11 @@ function CenterPanel({
             <Badge variant={receipt.status === 'complete' ? 'default' : 'outline'} className="text-xs">
               {receipt.status === 'complete' ? 'Complete' : receipt.status === 'in_progress' ? 'In Progress' : receipt.status}
             </Badge>
+            {receipt.status !== 'cancelled' && (
+              <Button size="sm" variant="destructive" onClick={loadReversalPreview}>
+                <Trash2 className="w-3 h-3 mr-1" /> Reverse Receipt
+              </Button>
+            )}
           </div>
         </div>
         <StepIndicator currentStep={step} totalSteps={5} />
@@ -953,7 +995,15 @@ function CenterPanel({
       </div>
 
       <div className="flex-1 overflow-y-auto p-3">
-        {receipt.status === 'complete' ? (
+        {receipt.status === 'cancelled' ? (
+          <div className="h-full flex items-center justify-center">
+            <div className="border border-red-200 rounded-lg p-4 max-w-md text-center space-y-2 bg-red-50 dark:bg-red-950/20">
+              <XCircle className="w-8 h-8 text-red-600 mx-auto" />
+              <div className="text-sm font-semibold">Receipt Cancelled / Reversed</div>
+              <div className="text-xs text-gray-500">The original receipt and unit records remain available in History for audit traceability.</div>
+            </div>
+          </div>
+        ) : receipt.status === 'complete' ? (
           <div className="h-full flex items-center justify-center">
             <div className="border rounded-lg p-4 max-w-md text-center space-y-3 bg-gray-50 dark:bg-gray-900">
               <CheckCircle2 className="w-8 h-8 text-green-600 mx-auto" />
@@ -961,10 +1011,12 @@ function CenterPanel({
                 <div className="text-sm font-semibold">Receipt Complete</div>
                 <div className="text-xs text-gray-500 mt-1">Use the Docs tab to attach a CoC or other receiving record. Reopen only when receiving data itself needs correction.</div>
               </div>
-              <Button size="sm" onClick={() => reopenActiveReceiptMutation.mutate()} disabled={reopenActiveReceiptMutation.isPending}>
-                {reopenActiveReceiptMutation.isPending ? <Loader2 className="w-3 h-3 animate-spin mr-1" /> : <RefreshCw className="w-3 h-3 mr-1" />}
-                Reopen for Adjustment
-              </Button>
+              <div className="flex items-center justify-center gap-2">
+                <Button size="sm" onClick={() => reopenActiveReceiptMutation.mutate()} disabled={reopenActiveReceiptMutation.isPending}>
+                  {reopenActiveReceiptMutation.isPending ? <Loader2 className="w-3 h-3 animate-spin mr-1" /> : <RefreshCw className="w-3 h-3 mr-1" />}
+                  Reopen for Adjustment
+                </Button>
+              </div>
             </div>
           </div>
         ) : step === 0 && (
@@ -1006,7 +1058,7 @@ function CenterPanel({
         )}
       </div>
 
-      {receipt.status !== 'complete' && (
+      {receipt.status !== 'complete' && receipt.status !== 'cancelled' && (
         <div className="p-3 border-t flex items-center justify-between bg-white dark:bg-gray-950">
           <Button variant="outline" size="sm" onClick={() => setStep(s => Math.max(0, s - 1))} disabled={step === 0}>
             Back
@@ -1018,6 +1070,37 @@ function CenterPanel({
           )}
         </div>
       )}
+
+      <Dialog open={reversalDialogOpen} onOpenChange={setReversalDialogOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Reverse receipt {receipt.receiptNumber}?</DialogTitle>
+            <DialogDescription>This creates offsetting inventory and ledger entries without deleting receipt or traceability records.</DialogDescription>
+          </DialogHeader>
+          {reversalPreview && (
+            <div className="space-y-3 text-sm">
+              <div className="rounded border p-3 bg-gray-50 dark:bg-gray-900">{reversalPreview.unitCount} units · {reversalPreview.totalQuantity} total quantity</div>
+              {reversalPreview.blockers.length > 0 && (
+                <div className="rounded border border-red-300 bg-red-50 p-3 text-red-800">
+                  <div className="font-medium mb-1">Reversal is blocked:</div>
+                  <ul className="list-disc pl-5 space-y-1">{reversalPreview.blockers.map(blocker => <li key={blocker}>{blocker}</li>)}</ul>
+                </div>
+              )}
+              <div className="space-y-1">
+                <Label htmlFor="receipt-reversal-reason">Required audit reason</Label>
+                <Textarea id="receipt-reversal-reason" value={reversalReason} onChange={event => setReversalReason(event.target.value)} placeholder="Duplicate receipt created from price-only PO revision" />
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setReversalDialogOpen(false)}>Cancel</Button>
+            <Button variant="destructive" disabled={!reversalPreview?.canReverse || reversalReason.trim().length < 10 || reverseReceiptMutation.isPending} onClick={() => reverseReceiptMutation.mutate()}>
+              {reverseReceiptMutation.isPending ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <RefreshCw className="w-4 h-4 mr-1" />}
+              Reverse Receipt
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/server/__tests__/receiptReversalContract.test.ts
+++ b/server/__tests__/receiptReversalContract.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const service = readFileSync(new URL('../src/services/receiptReversalService.ts', import.meta.url), 'utf8');
+const routes = readFileSync(new URL('../src/routes/receiving.ts', import.meta.url), 'utf8');
+const ui = readFileSync(new URL('../../client/src/pages/InventoryReceivingControlCenter.tsx', import.meta.url), 'utf8');
+
+describe('controlled receipt reversal contract', () => {
+  it('uses one transaction, preserves source records, and writes offsetting audit entries', () => {
+    expect(service).toContain('return db.transaction(async tx =>');
+    expect(service).toContain("transactionType: 'REVERSAL'");
+    expect(service).toContain("transactionType: 'ADJUST'");
+    expect(service).toContain("changeType: 'ADJUSTMENT'");
+    expect(service).toContain("action: 'receipt_reversed'");
+    expect(service).not.toContain('tx.delete(');
+  });
+
+  it('blocks reversal after downstream consumption, reservation, project, or cutting usage', () => {
+    expect(service).toContain('travelerMaterialConsumption');
+    expect(service).toContain('materialLotReservations');
+    expect(service).toContain('projectReceivedMaterials');
+    expect(service).toContain('cuttingPacketSessionLots');
+    expect(service).toContain('cuttingPacketBOMCuts');
+    expect(service).toContain('cuttingBuiltPacketFabricSources');
+  });
+
+  it('limits preview and execution to administrators or owners and requires a reason', () => {
+    expect(routes).toContain("const requireReceiptReversalAccess = requireRole('ADMIN', 'OWNER')");
+    expect(routes).toContain("router.get('/:id/reversal-preview', requireReceiptReversalAccess");
+    expect(routes).toContain("router.post('/:id/reverse', requireReceiptReversalAccess");
+    expect(service).toContain('trimmedReason.length < 10');
+  });
+
+  it('exposes preflight blockers and an explicit confirmation in Receiving Control Center', () => {
+    expect(ui).toContain('Required audit reason');
+    expect(ui).toContain('reversalPreview.blockers');
+    expect(ui).toContain('Reverse Receipt');
+  });
+});

--- a/server/src/routes/receiving.ts
+++ b/server/src/routes/receiving.ts
@@ -47,6 +47,7 @@ import { createInventoryEvent } from '../services/inventoryEventService';
 import { recordInventoryLedgerEntry } from '../services/inventoryTransactionLedgerService';
 import { ensureInventoryItemForReceipt } from '../services/ensureInventoryItemForReceipt';
 import { syncLinkedPartsRequestsReceivedForVendorPo } from '../services/partsRequestVendorPoSyncService';
+import { previewReceiptReversal, ReceiptReversalError, reverseReceipt } from '../services/receiptReversalService';
 
 const router = Router();
 
@@ -73,6 +74,7 @@ function uploadReceiptDocument(req: Request, res: Response, next: NextFunction) 
 // All authenticated employees (ADMIN, EMPLOYEE, OWNER) may perform receiving operations.
 // Applied to all mutating endpoints at the route level for defence-in-depth beyond global auth.
 const requireReceivingAccess = requireRole('ADMIN', 'EMPLOYEE', 'OWNER');
+const requireReceiptReversalAccess = requireRole('ADMIN', 'OWNER');
 
 const RECEIVING_MEDIA_FOLDER_NAME = 'Receiving';
 const RECEIVING_MEDIA_STORAGE_DIR = path.join('uploads', 'media-library', 'receiving');
@@ -836,6 +838,35 @@ router.get('/:id', requireReceivingAccess, async (req: Request, res: Response) =
   } catch (err: any) {
     console.error('GET /api/receipts/:id:', err);
     res.status(500).json({ error: 'Failed to fetch receipt' });
+  }
+});
+
+router.get('/:id/reversal-preview', requireReceiptReversalAccess, async (req: Request, res: Response) => {
+  try {
+    res.json(await previewReceiptReversal(parseInt(req.params.id, 10)));
+  } catch (err: any) {
+    const status = err instanceof ReceiptReversalError ? err.status : 500;
+    res.status(status).json({ error: err.message ?? 'Failed to preview receipt reversal', blockers: err.blockers ?? [] });
+  }
+});
+
+router.post('/:id/reverse', requireReceiptReversalAccess, async (req: Request, res: Response) => {
+  try {
+    const user = req.user;
+    const result = await reverseReceipt(parseInt(req.params.id, 10), String(req.body?.reason ?? ''), {
+      userId: user?.id ?? null,
+      employeeId: user?.employeeId ?? null,
+      displayName: actorName(user),
+    });
+    if (result.vendorPoStatus && result.vendorPoStatus !== 'Fully Received') {
+      const [receipt] = await db.select({ vendorPoId: receipts.vendorPoId }).from(receipts).where(eq(receipts.id, parseInt(req.params.id, 10)));
+      if (receipt?.vendorPoId) await syncLinkedPartsRequestsReceivedForVendorPo(receipt.vendorPoId, actorName(user));
+    }
+    res.json(result);
+  } catch (err: any) {
+    console.error('POST /api/receipts/:id/reverse:', err);
+    const status = err instanceof ReceiptReversalError ? err.status : 500;
+    res.status(status).json({ error: err.message ?? 'Failed to reverse receipt', blockers: err.blockers ?? [] });
   }
 });
 

--- a/server/src/services/receiptReversalService.ts
+++ b/server/src/services/receiptReversalService.ts
@@ -1,0 +1,284 @@
+import { and, eq, inArray, ne, or, sql } from 'drizzle-orm';
+import { db } from '../../db';
+import {
+  cuttingBuiltPacketFabricSources,
+  cuttingFabricInventory,
+  cuttingFabricInventoryTransactions,
+  cuttingPacketBOMCuts,
+  cuttingPacketSessionLots,
+  inventoryBalances,
+  inventoryTransactionLedger,
+  inventoryTransactions,
+  materialLotReservations,
+  materialLots,
+  materialLotTransactions,
+  projectReceivedMaterials,
+  receiptAuditLog,
+  receiptLines,
+  receipts,
+  receivedUnits,
+  travelerMaterialConsumption,
+  vendorPOItems,
+  vendorPOs,
+} from '../../schema';
+import { recordInventoryLedgerEntry } from './inventoryTransactionLedgerService';
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export class ReceiptReversalError extends Error {
+  constructor(message: string, public readonly status = 422, public readonly blockers: string[] = []) {
+    super(message);
+  }
+}
+
+export interface ReceiptReversalActor {
+  userId: number | null;
+  employeeId: number | null;
+  displayName: string;
+}
+
+async function hasRow(query: PromiseLike<unknown[]>): Promise<boolean> {
+  return (await query).length > 0;
+}
+
+async function unitBlockers(tx: Tx, unit: typeof receivedUnits.$inferSelect, fabricId?: string): Promise<string[]> {
+  const blockers: string[] = [];
+  if (unit.materialLotId) {
+    if (await hasRow(tx.select({ id: travelerMaterialConsumption.id }).from(travelerMaterialConsumption)
+      .where(or(eq(travelerMaterialConsumption.receivedUnitId, unit.id), eq(travelerMaterialConsumption.materialLotId, unit.materialLotId))).limit(1))) {
+      blockers.push(`${unit.barcode}: material has traveler consumption`);
+    }
+    if (await hasRow(tx.select({ id: materialLotReservations.id }).from(materialLotReservations)
+      .where(and(eq(materialLotReservations.materialLotId, unit.materialLotId), ne(materialLotReservations.status, 'cancelled'))).limit(1))) {
+      blockers.push(`${unit.barcode}: material has an active or fulfilled reservation`);
+    }
+    if (await hasRow(tx.select({ id: materialLotTransactions.id }).from(materialLotTransactions)
+      .where(and(eq(materialLotTransactions.materialLotId, unit.materialLotId), ne(materialLotTransactions.transactionType, 'RECEIVE'))).limit(1))) {
+      blockers.push(`${unit.barcode}: material lot has downstream transactions`);
+    }
+  }
+  if (await hasRow(tx.select({ id: projectReceivedMaterials.id }).from(projectReceivedMaterials)
+    .where(eq(projectReceivedMaterials.receivedUnitId, unit.id)).limit(1))) {
+    blockers.push(`${unit.barcode}: material is assigned to a project`);
+  }
+  if (fabricId) {
+    if (await hasRow(tx.select({ id: cuttingFabricInventoryTransactions.id }).from(cuttingFabricInventoryTransactions)
+      .where(and(eq(cuttingFabricInventoryTransactions.fabricInventoryId, fabricId), ne(cuttingFabricInventoryTransactions.changeType, 'RECEIPT'))).limit(1))) {
+      blockers.push(`${unit.barcode}: fabric roll has downstream inventory activity`);
+    }
+    if (await hasRow(tx.select({ id: cuttingPacketSessionLots.id }).from(cuttingPacketSessionLots)
+      .where(eq(cuttingPacketSessionLots.fabricInventoryId, fabricId)).limit(1))) blockers.push(`${unit.barcode}: fabric roll is used by a packet session`);
+    if (await hasRow(tx.select({ id: cuttingPacketBOMCuts.id }).from(cuttingPacketBOMCuts)
+      .where(eq(cuttingPacketBOMCuts.fabricInventoryId, fabricId)).limit(1))) blockers.push(`${unit.barcode}: fabric roll has recorded cuts`);
+    if (await hasRow(tx.select({ id: cuttingBuiltPacketFabricSources.id }).from(cuttingBuiltPacketFabricSources)
+      .where(eq(cuttingBuiltPacketFabricSources.fabricInventoryId, fabricId)).limit(1))) blockers.push(`${unit.barcode}: fabric roll is linked to a built packet`);
+  }
+  return blockers;
+}
+
+async function loadReceiptForReversal(tx: Tx, receiptId: number) {
+  const [receipt] = await tx.select().from(receipts).where(eq(receipts.id, receiptId)).for('update');
+  if (!receipt) throw new ReceiptReversalError('Receipt not found', 404);
+  const units = await tx.select().from(receivedUnits).where(eq(receivedUnits.receiptId, receiptId)).orderBy(receivedUnits.unitSequence);
+  const lines = await tx.select().from(receiptLines).where(eq(receiptLines.receiptId, receiptId));
+  const fabricRows = units.length === 0 ? [] : await tx.select().from(cuttingFabricInventory).where(or(
+    inArray(cuttingFabricInventory.barcode, units.map(unit => unit.barcode)),
+    inArray(cuttingFabricInventory.internalControlNumber, units.map(unit => unit.internalControlNumber).filter((value): value is string => Boolean(value))),
+  ));
+  return { receipt, units, lines, fabricRows };
+}
+
+export async function previewReceiptReversal(receiptId: number) {
+  return db.transaction(async tx => {
+    const context = await loadReceiptForReversal(tx, receiptId);
+    const blockers: string[] = [];
+    const fabricByUnit = new Map(context.fabricRows.flatMap(row => [row.barcode, row.internalControlNumber].filter(Boolean).map(key => [key!, row] as const)));
+    for (const unit of context.units) {
+      blockers.push(...await unitBlockers(tx, unit, fabricByUnit.get(unit.barcode)?.id ?? fabricByUnit.get(unit.internalControlNumber ?? '')?.id));
+    }
+    return {
+      receiptId,
+      receiptNumber: context.receipt.receiptNumber,
+      status: context.receipt.status,
+      vendorPoId: context.receipt.vendorPoId,
+      vendorPoNumber: context.receipt.vendorPoNumber,
+      unitCount: context.units.length,
+      totalQuantity: context.units.reduce((sum, unit) => sum + Number(unit.quantity), 0),
+      blockers,
+      canReverse: context.units.length > 0 && blockers.length === 0 && context.receipt.status !== 'cancelled',
+    };
+  });
+}
+
+export async function reverseReceipt(receiptId: number, reason: string, actor: ReceiptReversalActor) {
+  const trimmedReason = reason.trim();
+  if (trimmedReason.length < 10) throw new ReceiptReversalError('A reversal reason of at least 10 characters is required', 400);
+
+  return db.transaction(async tx => {
+    const { receipt, units, lines, fabricRows } = await loadReceiptForReversal(tx, receiptId);
+    if (receipt.status === 'cancelled') {
+      const prior = await tx.select({ id: receiptAuditLog.id }).from(receiptAuditLog)
+        .where(and(eq(receiptAuditLog.receiptId, receiptId), eq(receiptAuditLog.action, 'receipt_reversed'))).limit(1);
+      if (prior.length) return { alreadyReversed: true, receiptNumber: receipt.receiptNumber, reversedUnits: 0 };
+      throw new ReceiptReversalError('Cancelled receipts without a reversal audit event cannot be reversed automatically');
+    }
+    if (units.length === 0) throw new ReceiptReversalError('Receipt has no units to reverse');
+
+    const fabricByUnit = new Map(fabricRows.flatMap(row => [row.barcode, row.internalControlNumber].filter(Boolean).map(key => [key!, row] as const)));
+    const blockers: string[] = [];
+    for (const unit of units) blockers.push(...await unitBlockers(tx, unit, fabricByUnit.get(unit.barcode)?.id ?? fabricByUnit.get(unit.internalControlNumber ?? '')?.id));
+    if (blockers.length) throw new ReceiptReversalError('Receipt reversal blocked by downstream usage', 409, blockers);
+
+    for (const unit of units) {
+      const quantity = Number(unit.quantity);
+      if (!Number.isFinite(quantity) || quantity <= 0) throw new ReceiptReversalError(`${unit.barcode}: invalid quantity`);
+      const [originalEvent] = await tx.select().from(inventoryTransactions).where(and(
+        eq(inventoryTransactions.transactionType, 'receipt'),
+        eq(inventoryTransactions.referenceType, 'RECEIVED_UNIT'),
+        eq(inventoryTransactions.referenceId, String(unit.id)),
+      )).limit(1);
+      if (!originalEvent) throw new ReceiptReversalError(`${unit.barcode}: original inventory receipt transaction is missing`);
+      const location = originalEvent.toLocation || unit.location || 'WAREHOUSE-MAIN';
+      const [balance] = await tx.select().from(inventoryBalances).where(and(
+        eq(inventoryBalances.agPartNumber, originalEvent.agPartNumber),
+        eq(inventoryBalances.locationId, location),
+      )).for('update');
+      if (!balance || balance.quantityOnHand - quantity < balance.quantityAllocated) {
+        throw new ReceiptReversalError(`${unit.barcode}: available inventory is insufficient for reversal`, 409);
+      }
+      const nextOnHand = balance.quantityOnHand - quantity;
+      await tx.update(inventoryBalances).set({
+        quantityOnHand: nextOnHand,
+        quantityAvailable: nextOnHand - balance.quantityAllocated,
+        updatedAt: new Date(),
+      }).where(eq(inventoryBalances.id, balance.id));
+      await tx.insert(inventoryTransactions).values({
+        agPartNumber: originalEvent.agPartNumber,
+        transactionType: 'adjustment',
+        quantity: -quantity,
+        unitOfMeasure: originalEvent.unitOfMeasure,
+        fromLocation: location,
+        referenceType: 'RECEIPT_REVERSAL',
+        referenceId: String(unit.id),
+        performedBy: actor.displayName,
+        notes: `Reversal of receipt ${receipt.receiptNumber}: ${trimmedReason}`,
+        metadata: { receiptId, receiptNumber: receipt.receiptNumber, receivedUnitId: unit.id, reversedInventoryTransactionId: originalEvent.id, reason: trimmedReason },
+      });
+
+      const originalLedgerEntries = await tx.select().from(inventoryTransactionLedger).where(and(
+        eq(inventoryTransactionLedger.sourceRecordId, String(unit.id)),
+        eq(inventoryTransactionLedger.transactionType, 'RECEIVE'),
+      ));
+      for (const originalLedger of originalLedgerEntries) {
+        const existing = await tx.select({ id: inventoryTransactionLedger.id }).from(inventoryTransactionLedger)
+          .where(eq(inventoryTransactionLedger.reversedTransactionId, originalLedger.id)).limit(1);
+        if (!existing.length) await recordInventoryLedgerEntry({
+          transactionType: 'REVERSAL',
+          inventoryItemId: originalLedger.inventoryItemId,
+          agPartNumber: originalLedger.agPartNumber,
+          lotId: originalLedger.lotId,
+          locationId: originalLedger.locationId,
+          quantityDelta: -Number(originalLedger.quantityDelta),
+          quantityBefore: Number(originalLedger.quantityAfter),
+          quantityAfter: Number(originalLedger.quantityAfter) - Number(originalLedger.quantityDelta),
+          unitOfMeasure: originalLedger.unitOfMeasure,
+          statusBefore: originalLedger.statusAfter,
+          statusAfter: originalLedger.statusBefore,
+          performedByUserId: actor.userId,
+          performedByDisplayName: actor.displayName,
+          reasonCode: 'DUPLICATE_RECEIPT_REVERSAL',
+          notes: trimmedReason,
+          sourceModule: 'receiving-reversal',
+          sourceRecordId: String(unit.id),
+          reversedTransactionId: originalLedger.id,
+          metadata: { receiptId, receiptNumber: receipt.receiptNumber, originalTransactionNumber: originalLedger.transactionNumber },
+        }, tx);
+      }
+
+      if (unit.materialLotId) {
+        const [lot] = await tx.select().from(materialLots).where(eq(materialLots.id, unit.materialLotId)).for('update');
+        if (lot) {
+          await tx.insert(materialLotTransactions).values({
+            materialLotId: lot.id,
+            internalControlNumber: lot.internalControlNumber,
+            transactionType: 'ADJUST',
+            qtyBefore: lot.remainingQty,
+            qtyChange: String(-quantity),
+            qtyAfter: '0',
+            referenceType: 'RECEIPT_REVERSAL',
+            referenceId: String(unit.id),
+            receiptId,
+            performedBy: actor.displayName,
+            reason: trimmedReason,
+            notes: `Voided duplicate receipt ${receipt.receiptNumber}`,
+          });
+          await tx.update(materialLots).set({ status: 'REJECTED', remainingQty: '0', lockedReason: `Receipt reversed: ${trimmedReason}`, lockedAt: new Date(), updatedAt: new Date() }).where(eq(materialLots.id, lot.id));
+        }
+      }
+
+      const fabric = fabricByUnit.get(unit.barcode) ?? fabricByUnit.get(unit.internalControlNumber ?? '');
+      if (fabric) {
+        await tx.insert(cuttingFabricInventoryTransactions).values({
+          fabricInventoryId: fabric.id,
+          changeType: 'ADJUSTMENT',
+          quantityDelta: -Math.max(1, Math.round(quantity)),
+          performedBy: actor.displayName,
+          notes: `Receipt reversal ${receipt.receiptNumber}: ${trimmedReason}`,
+        });
+        await tx.update(cuttingFabricInventory).set({
+          quantityInStock: 0,
+          squareMeters: '0',
+          status: 'depleted',
+          depletedAt: new Date(),
+          depletedBy: actor.displayName,
+          notes: sql`COALESCE(${cuttingFabricInventory.notes}, '') || ${`\nREVERSED ${receipt.receiptNumber}: ${trimmedReason}`}`,
+          updatedAt: new Date(),
+        }).where(eq(cuttingFabricInventory.id, fabric.id));
+      }
+
+      await tx.update(receivedUnits).set({
+        disposition: 'rejected',
+        dispositionNotes: `REVERSED DUPLICATE RECEIPT: ${trimmedReason}`,
+        dispositionByUserId: actor.employeeId,
+        dispositionByDisplayName: actor.displayName,
+        dispositionAt: new Date(),
+        updatedAt: new Date(),
+      }).where(eq(receivedUnits.id, unit.id));
+    }
+
+    for (const line of lines) await tx.update(receiptLines).set({
+      receivedQty: '0', isPartial: false, isOver: false,
+      notes: sql`COALESCE(${receiptLines.notes}, '') || ${`\nREVERSED ${receipt.receiptNumber}: ${trimmedReason}`}`,
+      updatedAt: new Date(),
+    }).where(eq(receiptLines.id, line.id));
+
+    await tx.update(receipts).set({
+      status: 'cancelled',
+      notes: sql`COALESCE(${receipts.notes}, '') || ${`\nREVERSED: ${trimmedReason}`}`,
+      updatedAt: new Date(),
+    }).where(eq(receipts.id, receiptId));
+
+    let vendorPoStatus: string | null = null;
+    if (receipt.vendorPoId) {
+      const poItems = await tx.select().from(vendorPOItems).where(eq(vendorPOItems.vendorPoId, receipt.vendorPoId));
+      const activeReceipts = await tx.select({ receivedQty: receiptLines.receivedQty, vendorPoItemId: receiptLines.vendorPoItemId })
+        .from(receiptLines).innerJoin(receipts, eq(receipts.id, receiptLines.receiptId))
+        .where(and(eq(receipts.vendorPoId, receipt.vendorPoId), ne(receipts.status, 'cancelled')));
+      const receivedByItem = new Map<number, number>();
+      for (const row of activeReceipts) if (row.vendorPoItemId != null) receivedByItem.set(row.vendorPoItemId, (receivedByItem.get(row.vendorPoItemId) ?? 0) + Number(row.receivedQty));
+      const anyReceived = Array.from(receivedByItem.values()).some(value => value > 0);
+      const allReceived = poItems.length > 0 && poItems.every(item => (receivedByItem.get(item.id) ?? 0) >= Number(item.quantity ?? 0));
+      vendorPoStatus = allReceived ? 'Fully Received' : anyReceived ? 'Partially Received' : 'Sent';
+      await tx.update(vendorPOs).set({ status: vendorPoStatus, updatedAt: new Date() }).where(eq(vendorPOs.id, receipt.vendorPoId));
+    }
+
+    await tx.insert(receiptAuditLog).values({
+      receiptId,
+      action: 'receipt_reversed',
+      actorUserId: actor.employeeId,
+      actorDisplayName: actor.displayName,
+      metadata: { reason: trimmedReason, reversedUnitIds: units.map(unit => unit.id), reversedQuantity: units.reduce((sum, unit) => sum + Number(unit.quantity), 0), vendorPoId: receipt.vendorPoId, vendorPoStatus },
+    });
+    return { alreadyReversed: false, receiptNumber: receipt.receiptNumber, reversedUnits: units.length, reversedQuantity: units.reduce((sum, unit) => sum + Number(unit.quantity), 0), vendorPoStatus };
+  });
+}


### PR DESCRIPTION
## What changed

- adds an Admin/Owner-only receipt reversal preview and execution API
- blocks reversal when units have consumption, reservations, project allocation, cutting activity, or built-packet usage
- creates offsetting inventory, material-lot, cutting-fabric, and immutable ledger entries in one transaction
- preserves receipt, unit, lot, and roll records while marking the receipt cancelled/reversed
- recomputes the linked vendor PO receiving status and writes a reasoned receipt audit event
- adds a Receiving Control Center confirmation dialog with blocker details and required audit reason

## Why

Hard-deleting duplicate fabric receipts fails on transaction foreign keys and would destroy required traceability. This workflow corrects stock without deleting source records or permitting partial reversals.

## Validation

- `vitest --config vitest.config.server.ts server/__tests__/receiptReversalContract.test.ts` — 4 passed
- backend and frontend esbuild bundle parses passed
- `git diff --check` passed
- full repository TypeScript check remains red on pre-existing unrelated errors; filtered output showed no remaining errors in the new reversal service, route additions, or UI changes.