### PR TITLE
Stop Shipping QC orders from regressing to production

### DIFF
--- a/migrations/0171_all_orders_finalize_to_p1_queue.sql
+++ b/migrations/0171_all_orders_finalize_to_p1_queue.sql
@@ -14,7 +14,7 @@ SET
 WHERE
   current_department = 'Awaiting Customer ' || 'Signature'
   OR (
-    current_department IN ('P1 Production Queue', 'Shipping QC')
+    current_department = 'P1 Production Queue'
     AND status IN ('PENDING_' || 'SIGNATURE', 'IN_PROGRESS')
   );
 

--- a/migrations/0257_restore_shipping_qc_after_0171_replay.sql
+++ b/migrations/0257_restore_shipping_qc_after_0171_replay.sql
@@ -1,0 +1,95 @@
+-- Restore P1 orders whose canonical all_orders row was regressed from
+-- Shipping QC to P1 Production Queue by the replayed migration 0171.
+--
+-- Migration 0171 did not update order_department_transitions for this path.
+-- The single open transition therefore remains the authoritative evidence of
+-- the order's actual department. Fail closed when that evidence is absent or
+-- ambiguous; never infer restoration from order number or date alone.
+
+CREATE TEMP TABLE tmp_restore_shipping_qc_after_0171 ON COMMIT DROP AS
+SELECT DISTINCT
+  ao.order_id,
+  transition.id AS transition_id,
+  transition.entered_at AS shipping_qc_entered_at
+FROM all_orders ao
+JOIN order_department_transitions transition
+  ON transition.entity_type = 'p1_order'
+ AND transition.entity_id = ao.order_id
+ AND transition.department = 'Shipping QC'
+ AND transition.exited_at IS NULL
+WHERE ao.status = 'FINALIZED'
+  AND ao.current_department = 'P1 Production Queue'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM order_department_transitions other_open
+    WHERE other_open.entity_type = 'p1_order'
+      AND other_open.entity_id = ao.order_id
+      AND other_open.exited_at IS NULL
+      AND other_open.id <> transition.id
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM order_activity_events prior_repair
+    WHERE prior_repair.order_id = ao.order_id
+      AND prior_repair.reason_code = 'RESTORE_SHIPPING_QC_AFTER_0171_REPLAY'
+  );
+
+INSERT INTO order_activity_events (
+  order_id, event_type, event_category, occurred_at, actor_type,
+  actor_display_name, source, source_route, reason_code, reason_text,
+  status_from, status_to, department_from, department_to, field_diff, metadata
+)
+SELECT
+  repair.order_id,
+  'STATUS_DEPARTMENT_RESTORED',
+  'admin',
+  NOW(),
+  'system',
+  'migration 0257',
+  'migration',
+  'migrations/0257_restore_shipping_qc_after_0171_replay.sql',
+  'RESTORE_SHIPPING_QC_AFTER_0171_REPLAY',
+  'Restored the single open Shipping QC transition after migration 0171 reset the canonical order state.',
+  'FINALIZED',
+  'IN_PROGRESS',
+  'P1 Production Queue',
+  'Shipping QC',
+  jsonb_build_object(
+    'status', jsonb_build_object(
+      'before', 'FINALIZED',
+      'after', 'IN_PROGRESS',
+      'label', 'Order Status'
+    ),
+    'currentDepartment', jsonb_build_object(
+      'before', 'P1 Production Queue',
+      'after', 'Shipping QC',
+      'label', 'Current Department'
+    )
+  ),
+  jsonb_build_object(
+    'migration', '0257_restore_shipping_qc_after_0171_replay',
+    'cause', '0171_safe_boot_replay',
+    'openTransitionId', repair.transition_id,
+    'shippingQcEnteredAt', repair.shipping_qc_entered_at
+  )
+FROM tmp_restore_shipping_qc_after_0171 repair;
+
+UPDATE all_orders ao
+SET
+  status = 'IN_PROGRESS',
+  current_department = 'Shipping QC',
+  updated_at = NOW()
+FROM tmp_restore_shipping_qc_after_0171 repair
+WHERE ao.order_id = repair.order_id
+  AND ao.status = 'FINALIZED'
+  AND ao.current_department = 'P1 Production Queue';
+
+-- Migration 0171 normally left production_orders in Shipping QC. Repair only
+-- a matching regressed value if another synchronization path copied the drift.
+UPDATE production_orders po
+SET
+  current_department = 'Shipping QC',
+  updated_at = NOW()
+FROM tmp_restore_shipping_qc_after_0171 repair
+WHERE po.order_id = repair.order_id
+  AND po.current_department = 'P1 Production Queue';

--- a/server/__tests__/shippingQc0171ReplayRepair.test.ts
+++ b/server/__tests__/shippingQc0171ReplayRepair.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  criticalMigrationFiles,
+  safeMigrationFiles,
+} from '../scripts/migrations/runSafeBootMigrations';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const repairMigration = '0257_restore_shipping_qc_after_0171_replay.sql';
+
+describe('Shipping QC migration 0171 replay repair', () => {
+  it('does not move Shipping QC orders back to P1 Production Queue', () => {
+    const sql = fs.readFileSync(
+      path.join(root, 'migrations/0171_all_orders_finalize_to_p1_queue.sql'),
+      'utf8',
+    );
+
+    expect(sql).not.toContain("current_department IN ('P1 Production Queue', 'Shipping QC')");
+    expect(sql).not.toMatch(/current_department\s*=\s*'Shipping QC'[\s\S]*current_department\s*=\s*'P1 Production Queue'/);
+    expect(sql).toContain("current_department = 'Awaiting Customer ' || 'Signature'");
+  });
+
+  it('restores only unambiguous open Shipping QC transitions and records evidence', () => {
+    const sql = fs.readFileSync(
+      path.join(root, 'migrations', repairMigration),
+      'utf8',
+    );
+
+    expect(sql).toContain("ao.status = 'FINALIZED'");
+    expect(sql).toContain("ao.current_department = 'P1 Production Queue'");
+    expect(sql).toContain("transition.entity_type = 'p1_order'");
+    expect(sql).toContain("transition.department = 'Shipping QC'");
+    expect(sql).toContain('transition.exited_at IS NULL');
+    expect(sql).toContain('other_open.exited_at IS NULL');
+    expect(sql).toContain("reason_code = 'RESTORE_SHIPPING_QC_AFTER_0171_REPLAY'");
+    expect(sql).toContain("status = 'IN_PROGRESS'");
+    expect(sql).toContain("current_department = 'Shipping QC'");
+    expect(sql).not.toMatch(/DELETE\s+FROM/i);
+  });
+
+  it('runs the restoration as a critical safe-boot migration', () => {
+    expect(safeMigrationFiles).toContain(repairMigration);
+    expect(criticalMigrationFiles.has(repairMigration)).toBe(true);
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -319,6 +319,7 @@ export const safeMigrationFiles = [
   '0253_void_duplicate_epoch_validation_packages.sql',
   '0254_controlled_document_reconciliation_certification_controls.sql',
   '0255_p2_v2_definition_v3_handoff.sql',
+  '0257_restore_shipping_qc_after_0171_replay.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -388,6 +389,7 @@ export const criticalMigrationFiles = new Set([
   '0245_controlled_document_legacy_reconciliation.sql',
   '0250_epoch_validation_wizard_phase1.sql',
   '0255_p2_v2_definition_v3_handoff.sql',
+  '0257_restore_shipping_qc_after_0171_replay.sql',
 ]);
 
 export async function runSafeBootMigrations() {


### PR DESCRIPTION
## Summary

- remove `Shipping QC` from the replayed migration 0171 predicate that resets orders to `P1 Production Queue`
- add critical safe-boot migration 0257 to restore every currently drifted order whose single open department transition proves its actual department is Shipping QC
- synchronize `all_orders` and any regressed `production_orders` rows and record an immutable correction event with the supporting transition ID and timestamp
- add focused regression coverage for the guard, fail-closed restoration population, no-delete contract, and safe/critical registration

## Root cause

Historical migration `0171_all_orders_finalize_to_p1_queue.sql` is replayed during safe boot. Its predicate included `Shipping QC` orders with `IN_PROGRESS` or `PENDING_SIGNATURE` status, changing them to `FINALIZED / P1 Production Queue`. That can make completed downstream work appear as manufacturing demand and create a duplicate-remake risk.

## Restoration safety

Migration 0257 does not infer affected records from dates or a hard-coded list. It selects only orders currently showing `FINALIZED / P1 Production Queue` when `order_department_transitions` has exactly one open `p1_order` transition and that transition is `Shipping QC`. Missing or ambiguous transition history fails closed. The correction is idempotent and performs no deletes.

## Validation

- `vitest run --config vitest.config.server.ts server/__tests__/shippingQc0171ReplayRepair.test.ts` — 3/3 passed
- static migration contract checks — passed
- `git diff --cached --check` — passed
- branch refreshed against current `origin/main`
- migration prefix checked against open main-targeting PRs; `0256` is occupied by PR #1648 and `0257` is collision-free

## Required deployment verification

After merge and deployment, verify the runtime database identity, safe-boot completion, the exact `RESTORE_SHIPPING_QC_AFTER_0171_REPLAY` event population, final `all_orders`/`production_orders` department alignment, and zero affected orders in Production Queue after a second restart.