### PR TITLE
Accept active Express sessions in API authentication

### DIFF
--- a/server/__tests__/authenticateTokenExpressSession.test.ts
+++ b/server/__tests__/authenticateTokenExpressSession.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+
+vi.mock('../auth', () => ({
+  AuthService: {
+    verifyJWT: vi.fn(),
+    getUserById: vi.fn(),
+    getUserBySession: vi.fn(),
+  },
+}));
+
+import { AuthService } from '../auth';
+import { authenticateToken } from '../middleware/auth';
+
+describe('authenticateToken Express session support', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts an active user from the server-side login session without a token cookie', async () => {
+    const sessionUser = {
+      id: 2,
+      username: 'glennj',
+      role: 'ADMIN',
+      employeeId: null,
+      canOverridePrices: true,
+      isActive: true,
+    };
+    const req = {
+      headers: {},
+      cookies: {},
+      session: { user: sessionUser },
+    } as unknown as Request;
+    const res = {} as Response;
+    const next = vi.fn() as NextFunction;
+
+    await authenticateToken(req, res, next);
+
+    expect(req.user).toBe(sessionUser);
+    expect(next).toHaveBeenCalledOnce();
+    expect(AuthService.getUserBySession).not.toHaveBeenCalled();
+  });
+
+  it('does not accept a disabled user from the server-side session', async () => {
+    const req = {
+      headers: {},
+      cookies: {},
+      session: {
+        user: {
+          id: 2,
+          username: 'disabled',
+          role: 'ADMIN',
+          employeeId: null,
+          canOverridePrices: false,
+          isActive: false,
+        },
+      },
+    } as unknown as Request;
+    const status = vi.fn().mockReturnThis();
+    const json = vi.fn().mockReturnThis();
+    const res = { status, json } as unknown as Response;
+    const next = vi.fn() as NextFunction;
+
+    await authenticateToken(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: 'No session token' });
+  });
+});

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -62,6 +62,16 @@ export async function authenticateToken(
   next: NextFunction
 ) {
   try {
+    // Browser logins are stored in the Express session. In hosted development
+    // environments the separate sessionToken cookie may be unavailable (for
+    // example inside the Replit preview iframe), so honor the authenticated
+    // server-side session before falling back to token authentication.
+    const sessionUser = (req as any).session?.user;
+    if (sessionUser && sessionUser.username && sessionUser.isActive !== false) {
+      req.user = sessionUser;
+      return next();
+    }
+
     const authHeader = req.headers['authorization'];
     const bearerToken = authHeader && authHeader.split(' ')[1]; // Bearer TOKEN
     const cookieToken = req.cookies?.sessionToken;


### PR DESCRIPTION
## What changed

- recognize an active authenticated Express-session user in the global API authentication middleware before token fallback
- preserve JWT, session-token cookie, and explicit development-bypass behavior
- add regression coverage for active and disabled Express-session users

## Root cause

The dev app could report that the login session was alive through `/api/auth/session`, while authenticated API routes only checked bearer tokens and the `sessionToken` cookie. In the hosted Replit development iframe, that mismatch caused P2 customer lookup and creation to return `401 Authentication required` before reaching the customer route.

## User impact

Authenticated dev users can reach P2 customer lookup and creation using the existing server-side session. Disabled session users remain rejected.

## Validation

- `git diff --cached --check` passed before commit
- focused Vitest coverage was added but could not be executed locally because the clean worktree has no installed dependencies; the available pnpm install path could not use the repository's npm lockfile
- live Replit verification remains required after deployment/restart