### PR TITLE
Expose P2 repair RMA actions

### DIFF
--- a/client/src/__tests__/P2ScrappedItemsTab.component.test.tsx
+++ b/client/src/__tests__/P2ScrappedItemsTab.component.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import P2NonconformingTab from '../components/p2/P2ScrappedItemsTab';
+
+const item = {
+  id: 'item-1',
+  serialNumber: 'ROC2600720',
+  barcode: 'ROC2600720',
+  partNumber: 'RW-PART',
+  partName: 'Rock West Part',
+  poId: 72,
+  poNumber: 'PO-RW',
+  customerName: 'Rock West',
+  currentDepartment: 'Pending Layup',
+  status: 'SCRAPPED',
+  scrapReason: 'Remake required',
+  scrapBy: 'Supervisor',
+  scrapAt: '2026-08-06T12:00:00.000Z',
+  createdAt: '2026-08-06T12:00:00.000Z',
+  disposition: {
+    id: 91,
+    serializedItemId: 'item-1',
+    dispositionType: 'Repair',
+    poId: 72,
+    poNumber: 'PO-RW',
+    authorization: 'Supervisor',
+    partNumber: 'RW-PART',
+    serialNumber: 'ROC2600720',
+    dispositionDate: '2026-08-06',
+    reasonType: 'other',
+    reasonOther: 'Remake required',
+    notes: null,
+    resolved: false,
+    resolvedAt: null,
+    createdAt: '2026-08-06T12:00:00.000Z',
+  },
+};
+
+describe('P2NonconformingTab', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      const body = url.includes('/api/p2/nonconforming-rmas')
+        ? [{
+            rma: {
+              id: 55,
+              dispositionId: 91,
+              serializedItemId: 'item-1',
+              rmaNumber: 'RMA-P2-20260806-1',
+              status: 'open',
+              traceableMaterials: [],
+              shippedAt: null,
+              completedAt: null,
+              notes: null,
+              createdAt: '2026-08-06T12:00:00.000Z',
+            },
+            disposition: item.disposition,
+            item,
+          }]
+        : url.includes('/api/p2/serialized-items/scrapped')
+          ? [item]
+          : [];
+      return Promise.resolve({ ok: true, json: async () => body } as Response);
+    }));
+  });
+
+  it('opens the linked RMA directly from an in-progress Repair row', async () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <P2NonconformingTab />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage rma/i }));
+
+    expect(await screen.findByText('RMA-P2-20260806-1')).toBeInTheDocument();
+    expect(screen.getByText('Traceable Materials')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /mark shipped/i })).toBeEnabled();
+  });
+});

--- a/client/src/components/p2/P2ScrappedItemsTab.tsx
+++ b/client/src/components/p2/P2ScrappedItemsTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -414,13 +414,25 @@ function DispositionDialog({
   );
 }
 
-function RmaRow({ rma, onUpdated }: { rma: Rma; onUpdated: () => void }) {
+function RmaRow({
+  rma,
+  onUpdated,
+  reveal,
+}: {
+  rma: Rma;
+  onUpdated: () => void;
+  reveal?: boolean;
+}) {
   const { toast } = useToast();
   const [expanded, setExpanded] = useState(false);
   const [materials, setMaterials] = useState<TraceableMaterial[]>(
     rma.rma.traceableMaterials || []
   );
   const [newMaterial, setNewMaterial] = useState<TraceableMaterial>({ name: '', lot: '', qty: '' });
+
+  useEffect(() => {
+    if (reveal) setExpanded(true);
+  }, [reveal]);
 
   const { data: inventoryItems = [] } = useQuery<InventoryItemOption[]>({
     queryKey: ['/api/inventory/items/part-numbers'],
@@ -642,6 +654,8 @@ function RmaRow({ rma, onUpdated }: { rma: Rma; onUpdated: () => void }) {
 export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOIds?: number[] } = {}) {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedItem, setSelectedItem] = useState<ScrappedItem | null>(null);
+  const [activeTab, setActiveTab] = useState('items');
+  const [revealedRmaId, setRevealedRmaId] = useState<number | null>(null);
 
   const { data: openNcrItemsRaw = [], isLoading, isError, error, refetch: refetchItems } = useQuery<ScrappedItem[]>({
     queryKey: ['/api/p2/serialized-items/scrapped'],
@@ -722,7 +736,7 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
         />
       )}
 
-      <Tabs defaultValue="items" className="space-y-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <TabsList>
           <TabsTrigger value="items" className="flex items-center gap-2">
             <AlertTriangle className="h-4 w-4" />
@@ -810,6 +824,12 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
                       {filtered.map((item) => {
                         const hasDispo = !!item.disposition;
                         const isResolved = item.disposition?.resolved;
+                        const linkedRma = item.disposition?.dispositionType === 'Repair'
+                          ? rmas.find((entry) =>
+                              entry.rma.dispositionId === item.disposition?.id
+                              || entry.rma.serializedItemId === item.id
+                            )
+                          : undefined;
                         return (
                           <TableRow
                             key={item.id}
@@ -850,7 +870,7 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
                               {formatDateTime(item.scrapAt)}
                             </TableCell>
                             <TableCell>
-                              {!hasDispo && (
+                              {!hasDispo ? (
                                 <Button
                                   size="sm"
                                   variant="outline"
@@ -863,7 +883,25 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
                                   <ClipboardList className="h-3 w-3 mr-1" />
                                   File Disposition
                                 </Button>
-                              )}
+                              ) : linkedRma && !isResolved ? (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="text-xs"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    setRevealedRmaId(linkedRma.rma.id);
+                                    setActiveTab('rmas');
+                                  }}
+                                >
+                                  <Wrench className="h-3 w-3 mr-1" />
+                                  Manage RMA
+                                </Button>
+                              ) : item.disposition?.dispositionType === 'Repair' && !isResolved ? (
+                                <Badge variant="destructive" className="text-xs whitespace-nowrap">
+                                  RMA record unavailable
+                                </Badge>
+                              ) : null}
                             </TableCell>
                           </TableRow>
                         );
@@ -912,6 +950,7 @@ export default function P2NonconformingTab({ selectedPOIds = [] }: { selectedPOI
                     <RmaRow
                       key={rma.rma.id}
                       rma={rma}
+                      reveal={revealedRmaId === rma.rma.id}
                       onUpdated={() => {
                         refetchItems();
                         refetchRmas();


### PR DESCRIPTION
## Summary
- add a direct Manage RMA action to in-progress Repair rows in Open Nonconforming
- switch to and expand the linked RMA controls instead of leaving the NCR row inert
- show an explicit RMA record unavailable indicator when the expected link is missing
- add focused regression coverage for the ROC2600720-style repair/remake flow

## Validation
- git diff --cached --check passed before commit
- git merge-tree --write-tree origin/main HEAD passed
- focused Vitest test added but could not be executed locally: dependency installation timed out and the available sibling Vitest install was incomplete

## Data safety
- no production data migration or record mutation
- preserves the original NCR, RMA, replacement, and audit records