### PR TITLE
Allow Wilson Combat in P1 fast track

### DIFF
--- a/client/src/pages/admin/OrderOverridePage.tsx
+++ b/client/src/pages/admin/OrderOverridePage.tsx
@@ -459,10 +459,10 @@ export default function OrderOverridePage() {
       <Card className="border-blue-200">
         <CardHeader className="pb-3">
           <CardTitle className="text-base flex items-center gap-2">
-            <FastForward className="w-4 h-4 text-blue-600" /> Pure Precision Fast Track
+            <FastForward className="w-4 h-4 text-blue-600" /> P1 Customer Fast Track
           </CardTitle>
           <p className="text-sm text-muted-foreground">
-            Move FB250–FB265 directly to Shipping QC without completing or signing skipped department steps.
+            Move approved Pure Precision or Wilson Combat orders directly to Shipping QC without completing or signing skipped department steps.
             The normal P1 route is not changed.
           </p>
         </CardHeader>

--- a/server/__tests__/p1ExpediteProductionLookup.test.ts
+++ b/server/__tests__/p1ExpediteProductionLookup.test.ts
@@ -17,6 +17,12 @@ describe('P1 expedite helper lookup authority', () => {
     expect(source).not.toContain("if (row.order_id && !row.production_order_id)");
   });
 
+  it('allows both approved fast-track customers', () => {
+    expect(source).toContain("['pure precision', 'wilson combat']");
+    expect(source).toContain('isExpediteCustomer(row.customer_name)');
+    expect(source).toContain('not Pure Precision or Wilson Combat');
+  });
+
   it('supports an audited all-or-nothing reversal of a selected batch', () => {
     expect(source).toContain("event_type = 'P1_EXPEDITED_TO_SHIPPING_QC'");
     expect(source).toContain("'P1_EXPEDITE_BATCH_REVERSED'");

--- a/server/src/services/p1ExpediteService.ts
+++ b/server/src/services/p1ExpediteService.ts
@@ -7,6 +7,12 @@ export const PURE_PRECISION_EXPEDITE_IDS = Array.from(
 );
 
 const TARGET_DEPARTMENT = 'Shipping QC';
+const EXPEDITE_CUSTOMER_NAMES = ['pure precision', 'wilson combat'] as const;
+
+function isExpediteCustomer(customerName: unknown): boolean {
+  const normalized = String(customerName ?? '').trim().toLowerCase();
+  return EXPEDITE_CUSTOMER_NAMES.some(name => normalized.includes(name));
+}
 
 type Actor = { id?: number | null; username: string; role?: string | null };
 
@@ -63,8 +69,8 @@ async function loadPreview(ids: string[], query = pgPool.query.bind(pgPool)): Pr
   return result.rows.map((row: any) => {
     const blockers: string[] = [];
     if (!row.production_order_id) blockers.push('P1 production order not found');
-    if (row.customer_name && !String(row.customer_name).toLowerCase().includes('pure precision')) {
-      blockers.push(`Customer is ${row.customer_name}, not Pure Precision`);
+    if (row.customer_name && !isExpediteCustomer(row.customer_name)) {
+      blockers.push(`Customer is ${row.customer_name}, not Pure Precision or Wilson Combat`);
     }
     if (row.production_order_id && !row.customer_name) blockers.push('Customer could not be verified');
     if (row.scrap_date || String(row.status || '').toUpperCase().includes('SCRAP')) blockers.push('Order is scrapped');


### PR DESCRIPTION
## What changed

- Allow Wilson Combat orders through the audited P1 fast-track customer validation.
- Keep Pure Precision support unchanged and continue rejecting all other customers.
- Rename the admin card to **P1 Customer Fast Track** and clarify its approved-customer scope.
- Add focused regression coverage for both approved customers.

## Why

Wilson Combat PO WC-102743 produced five completed stocks that need to move directly from Barcode to Shipping QC so an invoice can be issued. The override was hard-coded to accept only Pure Precision, even though the same guarded, audited workflow is appropriate here.

## Impact

Authorized employees can preview and fast-track Wilson Combat orders using `/admin/order-override`. Existing all-or-nothing validation, audit logging, and reversal behavior remain intact.

## Validation

- `npx vitest run --config vitest.config.server.ts server/__tests__/p1ExpediteProductionLookup.test.ts` — 5 tests passed.
- `git diff --check` — passed.
- Full repository TypeScript check still reports pre-existing unrelated errors.