### PR TITLE
Correct retired migration 0253 test expectation

### DIFF
--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
@@ -73,11 +73,10 @@ describe('EPOCH validation duplicate cleanup', () => {
     expect(migration).toContain('SELECT count(*)');
   });
 
-  it('registers migration 0253 in both safe and critical boot lists', () => {
-    expect(
-      safeBoot.match(/0253_void_duplicate_epoch_validation_packages\.sql/g)
-        ?.length
-    ).toBe(2);
+  it('keeps retired migration 0253 out of recurring safe boot', () => {
+    expect(safeBoot).not.toContain(
+      '0253_void_duplicate_epoch_validation_packages.sql'
+    );
   });
 
   it('keeps the migration matrix and validation regressions in certification', () => {


### PR DESCRIPTION
## Summary
- update the stale EPOCH Validation architecture assertion to match commit 4ff881be7
- prove migration 0253 remains retired from recurring safe boot
- preserve migration, registry, workflow, schema, and application behavior unchanged

## Validation
- original failing file: 5/5 passed after correction
- complete EPOCH Validation regression set: 36/36 passed
- targeted ESLint: passed
- exact-lockfile Prettier 3.6.2: passed
- git diff --check: passed

No migration, application behavior, feature flag, or production data changes.