### PR TITLE
Keep P2 RMA remakes visible in scheduling

### DIFF
--- a/server/__tests__/p2ShipmentEvidence.test.ts
+++ b/server/__tests__/p2ShipmentEvidence.test.ts
@@ -8,6 +8,7 @@ import {
   countDistinctP2DemandUnits,
   countDistinctP2SerializedUnits,
   isHistoricalP2Unit,
+  partitionP2PendingRmaReplacements,
   p2PendingUnitDeficit,
 } from '../src/lib/p2SchedulingReconciliation';
 import {
@@ -81,6 +82,40 @@ describe('P2 shipment and scheduling reconciliation', () => {
     expect(p2PendingUnitDeficit(90, 81, 0)).toBe(9);
     expect(p2PendingUnitDeficit(90, 81, 9)).toBe(0);
     expect(p2PendingUnitDeficit(90, 81, 12)).toBe(0);
+  });
+
+  it('keeps an RMA remake visible outside the original PO demand capacity', () => {
+    const originalPending = { id: 'original', metadata: null };
+    const rmaReplacement = {
+      id: 'replacement',
+      metadata: {
+        isReplacement: true,
+        rmaRequired: true,
+        nonconformingRmaId: 55,
+      },
+    };
+
+    const partitioned = partitionP2PendingRmaReplacements([
+      originalPending,
+      rmaReplacement,
+    ]);
+
+    expect(partitioned.demandPending).toEqual([originalPending]);
+    expect(partitioned.rmaReplacements).toEqual([rmaReplacement]);
+    expect([
+      ...partitioned.demandPending.slice(0, 0),
+      ...partitioned.rmaReplacements,
+    ]).toEqual([rmaReplacement]);
+    expect(countDistinctP2DemandUnits([
+      { id: 'completed-original', serialNumber: 'ROC2600720', status: 'COMPLETED' },
+      {
+        id: 'replacement',
+        serialNumber: 'ROC2600721',
+        status: 'ACTIVE',
+        currentDepartment: 'Pending Layup',
+        metadata: rmaReplacement.metadata,
+      },
+    ], new Set())).toBe(1);
   });
 
   it('reports the distinct pending units that are actually exposed to Scheduling', () => {

--- a/server/src/lib/p2SchedulingReconciliation.ts
+++ b/server/src/lib/p2SchedulingReconciliation.ts
@@ -6,6 +6,28 @@ import {
 
 const normalized = (value: unknown) => String(value ?? '').trim().toUpperCase();
 
+type P2ReplacementMetadataRow = { metadata?: unknown };
+
+export function isP2RmaReplacement(row: P2ReplacementMetadataRow): boolean {
+  if (!row.metadata || typeof row.metadata !== 'object' || Array.isArray(row.metadata)) {
+    return false;
+  }
+  const metadata = row.metadata as Record<string, unknown>;
+  return metadata.isReplacement === true
+    && (metadata.rmaRequired === true || metadata.nonconformingRmaId != null);
+}
+
+export function partitionP2PendingRmaReplacements<T extends P2ReplacementMetadataRow>(
+  rows: readonly T[],
+): { demandPending: T[]; rmaReplacements: T[] } {
+  const demandPending: T[] = [];
+  const rmaReplacements: T[] = [];
+  for (const row of rows) {
+    (isP2RmaReplacement(row) ? rmaReplacements : demandPending).push(row);
+  }
+  return { demandPending, rmaReplacements };
+}
+
 export const isHistoricalP2Unit = (row: P2SerializedUnitLedgerRow) =>
   ['SCRAP', 'SCRAPPED', 'CANCELED', 'CANCELLED', 'VOID'].includes(normalized(row.status));
 
@@ -15,6 +37,7 @@ export function countDistinctP2SerializedUnits(
 ): number {
   const identities = new Set<string>();
   for (const row of rows) {
+    if (isP2RmaReplacement(row)) continue;
     if (isHistoricalP2Unit(row)) continue;
     const status = normalized(row.status);
     const department = normalized(row.currentDepartment ?? row.current_department);
@@ -43,6 +66,7 @@ export function p2UnitConsumesOrderedDemand(
   row: P2SerializedUnitLedgerRow,
   shippedItemIds: ReadonlySet<string>,
 ): boolean {
+  if (isP2RmaReplacement(row)) return false;
   return buildP2SerializedUnitLedger(1, [row], shippedItemIds).accounted > 0;
 }
 
@@ -50,5 +74,8 @@ export function countDistinctP2DemandUnits(
   rows: readonly P2SerializedUnitLedgerRow[],
   shippedItemIds: ReadonlySet<string>,
 ): number {
-  return countP2LedgerAccountedUnits(rows, shippedItemIds);
+  return countP2LedgerAccountedUnits(
+    rows.filter((row) => !isP2RmaReplacement(row)),
+    shippedItemIds,
+  );
 }

--- a/server/src/lib/p2SerializedUnitLedger.ts
+++ b/server/src/lib/p2SerializedUnitLedger.ts
@@ -11,6 +11,7 @@ export interface P2SerializedUnitLedgerRow {
   status?: string | null;
   currentDepartment?: string | null;
   current_department?: string | null;
+  metadata?: unknown;
   finalizedAt?: string | Date | null;
   finalized_at?: string | Date | null;
 }

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -27,6 +27,7 @@ import {
 } from '../lib/p2ShipmentEvidence';
 import {
   countDistinctP2DemandUnits,
+  partitionP2PendingRmaReplacements,
   p2PendingUnitDeficit,
 } from '../lib/p2SchedulingReconciliation';
 import {
@@ -5115,11 +5116,18 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           orderedQuantity - completedCount
         );
 
-        let pendingItems = items.filter((s: any) => {
+        const allPendingItems = items.filter((s: any) => {
           if (s.status !== 'ACTIVE') return false;
           const dept = String(s.currentDepartment || '').trim();
           return dept === '' || dept === 'Pending Layup';
         });
+        // RMA remakes are additive manufacturing demand, not additional PO
+        // quantity. Keep them outside the ordered-quantity capacity calculation
+        // so a replacement remains visible after its scrapped predecessor has
+        // already consumed the customer's original demand slot.
+        const pendingPartition = partitionP2PendingRmaReplacements(allPendingItems);
+        let pendingItems = pendingPartition.demandPending;
+        const pendingRmaReplacements = pendingPartition.rmaReplacements;
 
         const priorRevisionPoolKey = `${displayPoIdForPoId(Number(poItem.poId))}:${normalizeP2ControlPartKey(poItem.partNumber)}`;
         const priorRevisionPending = (
@@ -5150,7 +5158,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           }
         }
 
-        const pendingToShow = pendingItems.slice(0, earlyStageCapacity);
+        const pendingToShow = [
+          ...pendingItems.slice(0, earlyStageCapacity),
+          ...pendingRmaReplacements,
+        ].sort(sortBySequence);
 
         for (const s of pendingToShow) {
           schedulingList.push({


### PR DESCRIPTION
## Summary
- keep RMA remake units outside original PO demand-capacity accounting
- expose active Pending Layup RMA replacements in P2 Scheduling even after the original demand slot was consumed
- preserve original PO quantity, scrapped serial, NCR, RMA, replacement metadata, and audit history
- add focused reconciliation coverage for the ROC2600720-style flow

## Validation
- bundled Node syntax checks passed for the touched server TypeScript files
- git diff --check passed
- git merge-tree --write-tree origin/main HEAD passed
- focused Vitest execution remains unavailable locally because project dependency installation timed out

## Relationship
Follow-up to merged PR #1657. That PR exposed RMA controls; this PR corrects replacement visibility in Scheduling.