### PR TITLE
Make the Design Control 12-step workspace operational

### DIFF
--- a/client/src/__tests__/designControlAuthority.client.test.ts
+++ b/client/src/__tests__/designControlAuthority.client.test.ts
@@ -79,7 +79,12 @@ describe('Design Control client authority foundation', () => {
     expect(editorSource).toContain('design-control-missing-summary');
     expect(editorSource).toContain('Version and decision history');
     expect(editorSource).toContain('contentVersionId:');
-    expect(editorSource).toContain('Save controlled draft');
+    expect(editorSource).toContain('Save Draft');
+    expect(editorSource).toContain('Save and Continue');
+    expect(editorSource).toContain("window.addEventListener('beforeunload'");
+    expect(editorSource).toContain('You have unsaved changes');
+    expect(editorSource).toContain('Last saved');
+    expect(editorSource).toContain('Next action');
     expect(editorSource).toContain('Submit current version');
     expect(editorSource).toContain('Previous stage');
     expect(editorSource).toContain('Next stage');

--- a/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
+++ b/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
@@ -1,11 +1,21 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DESIGN_CONTROL_WORKFLOW } from '@shared/designControlWorkflow';
 
+import { DesignControlStepEditor } from '../features/design-control/DesignControlStepEditor';
 import { FinalDesignReviewPanel } from '../features/design-control/FinalDesignReviewPanel';
+import { EngineeringReleaseGatePanel } from '../features/design-control/EngineeringReleaseGatePanel';
 import { ProjectTeamPanel } from '../features/design-control/ProjectTeamPanel';
 import { StructuredRecordsWorkspace } from '../features/design-control/StructuredRecordsWorkspace';
 import { TraceabilityMatrix } from '../features/design-control/TraceabilityMatrix';
@@ -14,7 +24,20 @@ function renderWithQuery(ui: ReactElement) {
   return render(
     <QueryClientProvider
       client={
-        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        new QueryClient({
+          defaultOptions: {
+            queries: {
+              retry: false,
+              queryFn: async ({ queryKey }) => {
+                const response = await fetch(String(queryKey[0]), {
+                  credentials: 'include',
+                });
+                if (!response.ok) throw new Error('Query failed');
+                return response.json();
+              },
+            },
+          },
+        })
       }
     >
       {ui}
@@ -23,13 +46,73 @@ function renderWithQuery(ui: ReactElement) {
 }
 
 describe('Design Control structured workspaces', () => {
+  let failDraftSave = false;
+
   beforeEach(() => {
+    failDraftSave = false;
     vi.stubGlobal(
       'fetch',
-      vi.fn(async (input: unknown) => {
+      vi.fn(async (input: unknown, init?: globalThis.RequestInit) => {
         const url = String(input);
+        if (url.endsWith('/api/auth/session'))
+          return new Response(
+            JSON.stringify({ id: 1, username: 'synthetic-admin' }),
+            { status: 200 }
+          );
+        if (url.endsWith('/api/permissions/me'))
+          return new Response(
+            JSON.stringify({
+              permissions: [
+                'design.assignment.admin',
+                'design.control.edit',
+                'design.control.submit',
+                'design.control.approve',
+                'design.release',
+              ],
+            }),
+            { status: 200 }
+          );
+        if (url.includes('/steps/') && url.endsWith('/approvals'))
+          return new Response(
+            JSON.stringify({
+              currentContentVersion: null,
+              versions: [],
+              approvals: [],
+              approvalSlots: [],
+            }),
+            { status: 200 }
+          );
+        if (
+          failDraftSave &&
+          init?.method === 'PATCH' &&
+          url.endsWith('/steps/1')
+        )
+          return new Response(
+            JSON.stringify({
+              message: 'Synthetic save rejected: stale version',
+            }),
+            { status: 409 }
+          );
         if (url.endsWith('/structured/REQUIREMENT'))
           return new Response(JSON.stringify({ records: [] }), { status: 200 });
+        if (url.endsWith('/structured/VALIDATION'))
+          return new Response(JSON.stringify({ records: [] }), { status: 200 });
+        if (url.endsWith('/engineering-release-preview'))
+          return new Response(
+            JSON.stringify({
+              preview: {
+                ready: false,
+                proposedReleaseNumber: 'ER-SYNTHETIC-001',
+                proposedReleaseRevision: 'A',
+                effectiveDate: '2026-08-06',
+                missingEvidence: ['Validation evidence is incomplete.'],
+                baselineItems: [],
+                changedSinceReleaseWarnings: [],
+                existingRelease: null,
+              },
+            }),
+            { status: 200 }
+          );
         if (url.endsWith('/traceability'))
           return new Response(
             JSON.stringify({
@@ -122,6 +205,100 @@ describe('Design Control structured workspaces', () => {
     expect(
       screen.getByText(/State one clear, testable requirement/i)
     ).toBeInTheDocument();
+  });
+
+  it('renders usable inputs and both draft actions for every controlled step', async () => {
+    for (const [index, definition] of DESIGN_CONTROL_WORKFLOW.entries()) {
+      const view = renderWithQuery(
+        <DesignControlStepEditor
+          definition={definition}
+          hasNext={index < DESIGN_CONTROL_WORKFLOW.length - 1}
+          hasPrevious={index > 0}
+          onChanged={vi.fn(async () => undefined)}
+          onNext={vi.fn()}
+          onPrevious={vi.fn()}
+          readOnly={false}
+          recordId="record-1"
+          step={{ stepKey: definition.key, status: 'draft' }}
+        />
+      );
+
+      expect(
+        screen.getByLabelText(definition.fields[0].label, { exact: false })
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('button', { name: 'Save Draft' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Save and Continue' })
+      ).toBeInTheDocument();
+      view.unmount();
+    }
+  });
+
+  it('keeps unsaved data visible and displays an actionable server save error', async () => {
+    failDraftSave = true;
+    const definition = DESIGN_CONTROL_WORKFLOW[0];
+    renderWithQuery(
+      <DesignControlStepEditor
+        definition={definition}
+        hasNext
+        hasPrevious={false}
+        onChanged={vi.fn(async () => undefined)}
+        onNext={vi.fn()}
+        onPrevious={vi.fn()}
+        readOnly={false}
+        recordId="record-1"
+        step={{ stepKey: definition.key, status: 'draft' }}
+      />
+    );
+
+    const field = await screen.findByLabelText(definition.fields[0].label, {
+      exact: false,
+    });
+    const saveButton = await screen.findByRole('button', {
+      name: 'Save Draft',
+    });
+    fireEvent.change(field, { target: { value: 'SYNTHETIC-PROJECT-1' } });
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    fireEvent.click(saveButton);
+    expect(
+      await screen.findByText('Synthetic save rejected: stale version')
+    ).toBeInTheDocument();
+    expect(field).toHaveValue('SYNTHETIC-PROJECT-1');
+  });
+
+  it('can focus the stage workspace on the matching authoritative register', async () => {
+    renderWithQuery(
+      <StructuredRecordsWorkspace
+        allowedTypes={['VALIDATION']}
+        initialType="VALIDATION"
+        readOnly={false}
+        recordId="record-1"
+      />
+    );
+    expect(
+      await screen.findByRole('button', { name: /Add validation record/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Design Inputs / Requirements')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows server-calculated Engineering Release blockers and keeps release disabled', async () => {
+    renderWithQuery(
+      <EngineeringReleaseGatePanel readOnly={false} recordId="record-1" />
+    );
+    expect(await screen.findByText('ER-SYNTHETIC-001')).toBeInTheDocument();
+    expect(
+      screen.getByText('Validation evidence is incomplete.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('BLOCKED')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {
+        name: /Create authoritative Engineering Release/i,
+      })
+    ).toBeDisabled();
   });
 
   it('renders server-calculated traceability and direct remediation', async () => {

--- a/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
+++ b/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
@@ -208,7 +208,8 @@ describe('Design Control structured workspaces', () => {
   });
 
   it('renders usable inputs and both draft actions for every controlled step', async () => {
-    for (const [index, definition] of DESIGN_CONTROL_WORKFLOW.entries()) {
+    for (let index = 0; index < DESIGN_CONTROL_WORKFLOW.length; index += 1) {
+      const definition = DESIGN_CONTROL_WORKFLOW[index];
       const view = renderWithQuery(
         <DesignControlStepEditor
           definition={definition}

--- a/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
+++ b/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { DESIGN_CONTROL_WORKFLOW } from '@shared/designControlWorkflow';
+
+import {
+  getDesignControlFieldPresentation,
+  nextActionForStep,
+  STRUCTURED_RECORD_TYPE_BY_STEP,
+} from '../features/design-control/designControlFieldPresentation';
+
+const source = (path: string) =>
+  readFileSync(join(process.cwd(), path), 'utf8');
+
+describe('unified Design Control step editor', () => {
+  it('gives every field in all twelve controlled stages a typed presentation and guidance', () => {
+    expect(DESIGN_CONTROL_WORKFLOW).toHaveLength(12);
+
+    for (const step of DESIGN_CONTROL_WORKFLOW) {
+      expect(step.fields.length).toBeGreaterThan(0);
+      for (const field of step.fields) {
+        const presentation = getDesignControlFieldPresentation(step.key, field);
+        expect(presentation.kind).toMatch(
+          /^(text|textarea|date|select|person|role|attachment)$/
+        );
+        expect(presentation.help.trim()).not.toBe('');
+      }
+    }
+  });
+
+  it('uses constrained controls for dates, people, roles, evidence, and enumerations', () => {
+    const presentationFor = (stepKey: string, label: string) => {
+      const step = DESIGN_CONTROL_WORKFLOW.find(
+        (item) => item.key === stepKey
+      )!;
+      const field = step.fields.find((item) => item.label === label)!;
+      return getDesignControlFieldPresentation(stepKey, field);
+    };
+
+    expect(presentationFor('1', 'Design type').kind).toBe('select');
+    expect(presentationFor('1', 'Target manufacturing date').kind).toBe('date');
+    expect(presentationFor('1', 'Responsible engineer').kind).toBe('person');
+    expect(presentationFor('2', 'Approval roles').kind).toBe('role');
+    expect(presentationFor('9', 'Evidence attachment').kind).toBe('attachment');
+    expect(presentationFor('9', 'Pass/fail').options).toEqual(['PASS', 'FAIL']);
+    expect(presentationFor('9', 'Engineering disposition').kind).not.toBe(
+      'person'
+    );
+  });
+
+  it('opens normalized records only where an authoritative register exists', () => {
+    expect(STRUCTURED_RECORD_TYPE_BY_STEP).toEqual({
+      '3': 'REQUIREMENT',
+      '5': 'RISK',
+      '6': 'REVIEW',
+      '9': 'VERIFICATION',
+      '10': 'VALIDATION',
+      '11': 'REVIEW',
+    });
+  });
+
+  it('states actionable next steps without inventing completion', () => {
+    expect(nextActionForStep('submitted_for_approval', 0)).toMatch(
+      /authorized, independent reviewer/i
+    );
+    expect(nextActionForStep('approved', 0)).toMatch(/approved/i);
+    expect(nextActionForStep('draft', 2)).toMatch(/2 missing required items/i);
+    expect(nextActionForStep('draft', 0)).toMatch(
+      /submit the exact saved version/i
+    );
+  });
+
+  it('keeps unsaved-change, evidence, and release actions on existing server APIs', () => {
+    const editor = source(
+      'client/src/features/design-control/DesignControlStepEditor.tsx'
+    );
+    const forms = source(
+      'client/src/components/design-control/ProjectFormInstancesPanel.tsx'
+    );
+    const release = source(
+      'client/src/features/design-control/EngineeringReleaseGatePanel.tsx'
+    );
+
+    expect(editor).toContain("window.addEventListener('beforeunload'");
+    expect(editor).toContain('Save and Continue');
+    expect(editor).toContain('payload.message || payload.error');
+    expect(forms).toContain("window.addEventListener('beforeunload'");
+    expect(forms).toContain('/attachments`');
+    expect(forms).toContain('Objective evidence attached');
+    expect(release).toContain('/engineering-release-preview`');
+    expect(release).toContain('/engineering-release`');
+    expect(release).toContain('disabled={!preview.ready || busy}');
+    expect(release).not.toMatch(/bypassRelease|forceRelease|skipReadiness/);
+  });
+});

--- a/client/src/components/design-control/ProjectFormInstancesPanel.tsx
+++ b/client/src/components/design-control/ProjectFormInstancesPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   CheckCircle2,
   FilePenLine,
@@ -7,12 +7,12 @@ import {
   Printer,
   RefreshCw,
 } from 'lucide-react';
-
 import type {
   DesignControlFormDefinition,
   DesignControlFormField,
 } from '@shared/designControlFormCatalog';
 import type { ProjectFormContent } from '@shared/projectFormValidation';
+
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -34,6 +34,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { usePermissions } from '@/hooks/usePermissions';
+import { getDesignControlFieldPresentation } from '@/features/design-control/designControlFieldPresentation';
 
 type ProjectFormInstance = {
   id: string;
@@ -46,11 +47,13 @@ type ProjectFormInstance = {
   currentContentRevisionId: string | null;
   retainedPdfChecksum: string | null;
   draftContent: ProjectFormContent;
+  updatedAt?: string | null;
 };
 
 type Props = {
   recordId: string;
   oversightMode?: boolean;
+  stepKey?: string;
 };
 
 type TemplateReadiness = {
@@ -76,13 +79,34 @@ const fieldControl = (
   field: DesignControlFormField,
   value: unknown,
   onChange: (value: unknown) => void
-) =>
-  field.type === 'checkbox' || field.type === 'yes_no' ? (
+) => {
+  const presentation = getDesignControlFieldPresentation('', field);
+  const stringValue = String(value ?? '');
+  const selectOptions = field.options ?? presentation.options ?? [];
+  return field.type === 'checkbox' || field.type === 'yes_no' ? (
     <Checkbox
       checked={value === true}
       onCheckedChange={(checked) => onChange(checked === true)}
     />
-  ) : field.type === 'textarea' ? (
+  ) : field.options?.length ||
+    presentation.kind === 'select' ||
+    presentation.kind === 'role' ? (
+    <select
+      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+      value={stringValue}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">Select…</option>
+      {stringValue && !selectOptions.includes(stringValue) && (
+        <option value={stringValue}>Existing value: {stringValue}</option>
+      )}
+      {selectOptions.map((option) => (
+        <option key={option} value={option}>
+          {option.replaceAll('_', ' ')}
+        </option>
+      ))}
+    </select>
+  ) : field.type === 'textarea' && presentation.kind === 'textarea' ? (
     <Textarea
       value={String(value ?? '')}
       onChange={(event) => onChange(event.target.value)}
@@ -90,20 +114,23 @@ const fieldControl = (
   ) : (
     <Input
       type={
-        field.type === 'date'
+        (field.type === 'date' || presentation.kind === 'date') &&
+        (!stringValue || /^\d{4}-\d{2}-\d{2}$/.test(stringValue))
           ? 'date'
           : field.type === 'number'
             ? 'number'
             : 'text'
       }
-      value={String(value ?? '')}
+      value={stringValue}
       onChange={(event) => onChange(event.target.value)}
     />
   );
+};
 
 export function ProjectFormInstancesPanel({
   recordId,
   oversightMode = false,
+  stepKey,
 }: Props) {
   const { can } = usePermissions();
   const [catalog, setCatalog] = useState<DesignControlFormDefinition[]>([]);
@@ -115,12 +142,26 @@ export function ProjectFormInstancesPanel({
   const [content, setContent] = useState<ProjectFormContent>(emptyContent);
   const [message, setMessage] = useState('');
   const [busy, setBusy] = useState(false);
+  const [formDirty, setFormDirty] = useState(false);
   const paperInput = useRef<HTMLInputElement>(null);
   const [paperTarget, setPaperTarget] = useState<ProjectFormInstance | null>(
     null
   );
+  const evidenceInput = useRef<HTMLInputElement>(null);
+  const [evidenceTarget, setEvidenceTarget] =
+    useState<ProjectFormInstance | null>(null);
 
-  const load = async () => {
+  useEffect(() => {
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!formDirty) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', warnBeforeUnload);
+    return () => window.removeEventListener('beforeunload', warnBeforeUnload);
+  }, [formDirty]);
+
+  const load = useCallback(async () => {
     const [catalogResponse, formsResponse, readinessResponse] =
       await Promise.all([
         fetch('/api/design-control-form-templates/catalog', {
@@ -148,11 +189,11 @@ export function ProjectFormInstancesPanel({
     setTemplateReadiness(
       new Map(readiness.steps.map((item) => [item.stepKey, item]))
     );
-  };
+  }, [recordId]);
 
   useEffect(() => {
     load().catch((error) => setMessage(error.message));
-  }, [recordId]);
+  }, [load]);
 
   const formsByStep = useMemo(
     () =>
@@ -165,10 +206,17 @@ export function ProjectFormInstancesPanel({
       ),
     [forms]
   );
+  const visibleCatalog = useMemo(
+    () =>
+      stepKey
+        ? catalog.filter((definition) => definition.workflowStepKey === stepKey)
+        : catalog,
+    [catalog, stepKey]
+  );
 
   const mutate = async (
     url: string,
-    options: RequestInit,
+    options: globalThis.RequestInit,
     successMessage: string
   ) => {
     setBusy(true);
@@ -189,8 +237,8 @@ export function ProjectFormInstancesPanel({
       setMessage(successMessage);
       await load();
       return payload;
-    } catch (error: any) {
-      setMessage(error.message);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Action failed');
       return null;
     } finally {
       setBusy(false);
@@ -210,6 +258,7 @@ export function ProjectFormInstancesPanel({
   const edit = (form: ProjectFormInstance) => {
     setEditing(form);
     setContent(form.draftContent ?? emptyContent());
+    setFormDirty(false);
   };
 
   const updateField = (
@@ -217,6 +266,7 @@ export function ProjectFormInstancesPanel({
     field: DesignControlFormField,
     value: unknown
   ) => {
+    setFormDirty(true);
     setContent((current) => ({
       ...current,
       sections: {
@@ -238,6 +288,7 @@ export function ProjectFormInstancesPanel({
     field: DesignControlFormField,
     value: unknown
   ) => {
+    setFormDirty(true);
     setContent((current) => {
       const rows = [...((current.repeatingRows ?? {})[sectionKey] ?? [])];
       rows[rowIndex] = { ...(rows[rowIndex] ?? {}), [field.key]: value };
@@ -264,7 +315,26 @@ export function ProjectFormInstancesPanel({
       },
       'Draft saved with audit evidence'
     );
-    if (result) setEditing(null);
+    if (result) {
+      setFormDirty(false);
+      setEditing(null);
+    }
+  };
+
+  const uploadEvidence = async (file: File) => {
+    if (!evidenceTarget) return;
+    const body = new FormData();
+    body.append('file', file);
+    body.append(
+      'indexingMetadata',
+      JSON.stringify({ workflowStepKey: evidenceTarget.stepKey })
+    );
+    const result = await mutate(
+      `/api/project-forms/${evidenceTarget.id}/attachments`,
+      { method: 'POST', body },
+      'Objective evidence attached to the controlled form'
+    );
+    if (result) setEvidenceTarget(null);
   };
 
   const uploadPaper = async (file: File) => {
@@ -294,7 +364,9 @@ export function ProjectFormInstancesPanel({
           <CardDescription>
             {oversightMode
               ? 'Oversight view of the shared Design Project form workflow.'
-              : 'Complete the 12 Design Control step forms electronically or retain an original paper scan.'}
+              : stepKey
+                ? `Complete the controlled form and attach objective evidence for step ${stepKey}.`
+                : 'Complete the 12 Design Control step forms electronically or retain an original paper scan.'}
           </CardDescription>
         </div>
         <Button
@@ -313,7 +385,7 @@ export function ProjectFormInstancesPanel({
             {message}
           </div>
         )}
-        {catalog.map((definition) => {
+        {visibleCatalog.map((definition) => {
           const form = formsByStep.get(definition.workflowStepKey ?? '');
           const readiness = templateReadiness.get(
             definition.workflowStepKey ?? ''
@@ -389,6 +461,23 @@ export function ProjectFormInstancesPanel({
                     >
                       <FilePenLine className="mr-1 h-4 w-4" />
                       Edit
+                    </Button>
+                  )}
+                {form &&
+                  ['DRAFT', 'IN_PROGRESS', 'RETURNED_FOR_REVISION'].includes(
+                    form.lifecycleStatus
+                  ) &&
+                  can('design.forms.edit') && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setEvidenceTarget(form);
+                        evidenceInput.current?.click();
+                      }}
+                    >
+                      <FileUp className="mr-1 h-4 w-4" />
+                      Attach evidence
                     </Button>
                   )}
                 {form &&
@@ -579,11 +668,33 @@ export function ProjectFormInstancesPanel({
             event.target.value = '';
           }}
         />
+        <input
+          ref={evidenceInput}
+          type="file"
+          accept="application/pdf,image/png,image/jpeg,text/plain,.csv,.xlsx,.doc,.docx"
+          className="hidden"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) uploadEvidence(file);
+            event.target.value = '';
+          }}
+        />
       </CardContent>
 
       <Dialog
         open={Boolean(editing)}
-        onOpenChange={(open) => !open && setEditing(null)}
+        onOpenChange={(open) => {
+          if (open) return;
+          if (
+            formDirty &&
+            !window.confirm(
+              'You have unsaved controlled-form changes. Close without saving?'
+            )
+          )
+            return;
+          setFormDirty(false);
+          setEditing(null);
+        }}
       >
         <DialogContent className="max-h-[85vh] max-w-3xl overflow-y-auto">
           <DialogHeader>
@@ -632,6 +743,30 @@ export function ProjectFormInstancesPanel({
                                   )}
                                 </div>
                               ))}
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => {
+                                  setFormDirty(true);
+                                  setContent((current) => ({
+                                    ...current,
+                                    repeatingRows: {
+                                      ...(current.repeatingRows ?? {}),
+                                      [section.key]: (
+                                        (current.repeatingRows ?? {})[
+                                          section.key
+                                        ] ?? []
+                                      ).filter(
+                                        (_item, itemIndex) =>
+                                          itemIndex !== rowIndex
+                                      ),
+                                    },
+                                  }));
+                                }}
+                              >
+                                Remove row
+                              </Button>
                             </div>
                           )
                         )}
@@ -639,7 +774,8 @@ export function ProjectFormInstancesPanel({
                           type="button"
                           variant="outline"
                           size="sm"
-                          onClick={() =>
+                          onClick={() => {
+                            setFormDirty(true);
                             setContent((current) => ({
                               ...current,
                               repeatingRows: {
@@ -651,8 +787,8 @@ export function ProjectFormInstancesPanel({
                                   {},
                                 ],
                               },
-                            }))
-                          }
+                            }));
+                          }}
                         >
                           Add row
                         </Button>
@@ -683,7 +819,20 @@ export function ProjectFormInstancesPanel({
                 ))}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setEditing(null)}>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (
+                  formDirty &&
+                  !window.confirm(
+                    'You have unsaved controlled-form changes. Close without saving?'
+                  )
+                )
+                  return;
+                setFormDirty(false);
+                setEditing(null);
+              }}
+            >
               Cancel
             </Button>
             <Button onClick={saveDraft} disabled={busy}>

--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { DesignControlWorkflowStep } from '@shared/designControlWorkflow';
+
+import {
+  getDesignControlFieldPresentation,
+  nextActionForStep,
+} from './designControlFieldPresentation';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -17,6 +22,18 @@ type StepRow = {
   formData?: Record<string, unknown>;
   checklist?: Record<string, unknown>;
   attachments?: unknown[];
+  updatedAt?: string | null;
+};
+
+type ProjectTeam = {
+  assignments: Array<{
+    userId: number;
+    username: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    projectRole: string;
+    status: string;
+  }>;
 };
 
 type ApprovalSlot = {
@@ -102,6 +119,9 @@ export function DesignControlStepEditor({
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(
+    step?.updatedAt ?? null
+  );
   const approvalQueryKey = [
     '/api/qms/design-control',
     recordId,
@@ -118,7 +138,47 @@ export function DesignControlStepEditor({
     setMessage('');
     setError('');
     setDirty(false);
-  }, [definition.key, step?.formData, step?.checklist]);
+    setLastSavedAt(step?.updatedAt ?? null);
+  }, [definition.key, step?.formData, step?.checklist, step?.updatedAt]);
+
+  useEffect(() => {
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!dirty) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', warnBeforeUnload);
+    return () => window.removeEventListener('beforeunload', warnBeforeUnload);
+  }, [dirty]);
+
+  const teamQuery = useQuery<ProjectTeam>({
+    queryKey: ['/api/qms/design-control', recordId, 'project-team'],
+    queryFn: async () =>
+      responsePayload(
+        await fetch(`/api/qms/design-control/${recordId}/project-team`, {
+          credentials: 'include',
+        })
+      ),
+    retry: false,
+  });
+
+  const people = useMemo(
+    () =>
+      (teamQuery.data?.assignments ?? [])
+        .filter((assignment) => assignment.status === 'ACTIVE')
+        .map((assignment) => ({
+          value:
+            [assignment.firstName, assignment.lastName]
+              .filter(Boolean)
+              .join(' ') || assignment.username,
+          label: `${
+            [assignment.firstName, assignment.lastName]
+              .filter(Boolean)
+              .join(' ') || assignment.username
+          } (${assignment.projectRole.replaceAll('_', ' ')})`,
+        })),
+    [teamQuery.data?.assignments]
+  );
 
   const approvalQuery = useQuery<ApprovalState>({
     queryKey: approvalQueryKey,
@@ -147,19 +207,21 @@ export function DesignControlStepEditor({
       setMessage(success);
       setDirty(false);
       await refresh();
+      return true;
     } catch (actionError) {
       setError(
         actionError instanceof Error
           ? actionError.message
           : 'The controlled action failed.'
       );
+      return false;
     } finally {
       setBusy(false);
     }
   };
 
-  const saveDraft = () =>
-    run(async () => {
+  const saveDraft = async (continueAfterSave = false) => {
+    const saved = await run(async () => {
       const response = await fetch(
         `/api/qms/design-control/${encodeURIComponent(recordId)}/steps/${encodeURIComponent(definition.key)}`,
         {
@@ -178,6 +240,9 @@ export function DesignControlStepEditor({
       );
       return responsePayload(response);
     }, 'Draft saved as a controlled content version.');
+    if (saved) setLastSavedAt(new Date().toISOString());
+    if (saved && continueAfterSave && hasNext) onNext();
+  };
 
   const submit = () =>
     run(async () => {
@@ -233,9 +298,41 @@ export function DesignControlStepEditor({
     (item) => checklist[item.key] !== true
   );
   const missingCount = missingFields.length + missingChecklist.length;
+  const confirmNavigation = (navigate: () => void) => {
+    if (
+      dirty &&
+      !window.confirm(
+        'You have unsaved changes. Leave this step without saving?'
+      )
+    )
+      return;
+    navigate();
+  };
 
   return (
     <div className="space-y-5">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-md border p-3 text-sm">
+          <span className="text-xs text-muted-foreground">Draft state</span>
+          <p className="font-medium">
+            {dirty ? 'Unsaved changes' : 'Saved to the server'}
+          </p>
+        </div>
+        <div className="rounded-md border p-3 text-sm">
+          <span className="text-xs text-muted-foreground">Last saved</span>
+          <p className="font-medium">
+            {lastSavedAt
+              ? new Date(lastSavedAt).toLocaleString()
+              : 'No saved draft yet'}
+          </p>
+        </div>
+        <div className="rounded-md border p-3 text-sm">
+          <span className="text-xs text-muted-foreground">Next action</span>
+          <p className="font-medium">
+            {nextActionForStep(step?.status, missingCount)}
+          </p>
+        </div>
+      </div>
       <fieldset className="space-y-4" disabled={!editable || busy}>
         <legend className="font-semibold">Required information</legend>
         <p className="text-sm text-muted-foreground">
@@ -268,26 +365,122 @@ export function DesignControlStepEditor({
           )}
         </div>
         <div className="grid gap-4 md:grid-cols-2">
-          {definition.fields.map((field) => (
-            <div className="space-y-1.5" key={field.key}>
-              <Label htmlFor={`design-control-${definition.key}-${field.key}`}>
-                {field.label} <span aria-hidden="true">*</span>
-              </Label>
-              <Textarea
-                id={`design-control-${definition.key}-${field.key}`}
-                rows={3}
-                value={String(formData[field.key] ?? '')}
-                onChange={(event) => {
-                  setFormData((current) => ({
-                    ...current,
-                    [field.key]: event.target.value,
-                  }));
-                  setDirty(true);
-                }}
-              />
-            </div>
-          ))}
+          {definition.fields.map((field) => {
+            const presentation = getDesignControlFieldPresentation(
+              definition.key,
+              field
+            );
+            const fieldId = `design-control-${definition.key}-${field.key}`;
+            const value = String(formData[field.key] ?? '');
+            const missing = !value.trim();
+            const update = (nextValue: string) => {
+              setFormData((current) => ({
+                ...current,
+                [field.key]: nextValue,
+              }));
+              setDirty(true);
+            };
+            return (
+              <div
+                className={`space-y-1.5 ${
+                  presentation.kind === 'textarea' ? 'md:col-span-2' : ''
+                }`}
+                key={field.key}
+              >
+                <Label htmlFor={fieldId}>
+                  {field.label}{' '}
+                  <span className="text-destructive" aria-label="required">
+                    *
+                  </span>
+                </Label>
+                {presentation.kind === 'textarea' ? (
+                  <Textarea
+                    aria-describedby={`${fieldId}-help`}
+                    aria-invalid={missing}
+                    id={fieldId}
+                    placeholder={presentation.placeholder}
+                    rows={3}
+                    value={value}
+                    onChange={(event) => update(event.target.value)}
+                  />
+                ) : presentation.kind === 'select' ||
+                  presentation.kind === 'role' ? (
+                  <select
+                    aria-describedby={`${fieldId}-help`}
+                    aria-invalid={missing}
+                    className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                    id={fieldId}
+                    value={value}
+                    onChange={(event) => update(event.target.value)}
+                  >
+                    <option value="">Select…</option>
+                    {value && !(presentation.options ?? []).includes(value) && (
+                      <option value={value}>Existing value: {value}</option>
+                    )}
+                    {(presentation.options ?? []).map((option) => (
+                      <option key={option} value={option}>
+                        {option.replaceAll('_', ' ')}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <>
+                    <Input
+                      aria-describedby={`${fieldId}-help`}
+                      aria-invalid={missing}
+                      id={fieldId}
+                      list={
+                        presentation.kind === 'person'
+                          ? `${fieldId}-people`
+                          : undefined
+                      }
+                      placeholder={presentation.placeholder}
+                      type={
+                        presentation.kind === 'date' &&
+                        (!value || /^\d{4}-\d{2}-\d{2}$/.test(value))
+                          ? 'date'
+                          : 'text'
+                      }
+                      value={value}
+                      onChange={(event) => update(event.target.value)}
+                    />
+                    {presentation.kind === 'person' && people.length > 0 && (
+                      <datalist id={`${fieldId}-people`}>
+                        {people.map((person) => (
+                          <option key={person.label} value={person.value}>
+                            {person.label}
+                          </option>
+                        ))}
+                      </datalist>
+                    )}
+                  </>
+                )}
+                <p
+                  className={`text-xs ${
+                    missing ? 'text-destructive' : 'text-muted-foreground'
+                  }`}
+                  id={`${fieldId}-help`}
+                >
+                  {missing ? 'Required. ' : ''}
+                  {presentation.help}
+                </p>
+              </div>
+            );
+          })}
         </div>
+
+        {definition.examples && definition.examples.length > 0 && (
+          <details className="rounded-md border p-3 text-sm">
+            <summary className="cursor-pointer font-medium">
+              Examples for this step
+            </summary>
+            <ul className="mt-2 list-disc pl-5 text-muted-foreground">
+              {definition.examples.map((example) => (
+                <li key={example}>{example}</li>
+              ))}
+            </ul>
+          </details>
+        )}
 
         {definition.checklist.length > 0 && (
           <div className="space-y-2">
@@ -330,9 +523,23 @@ export function DesignControlStepEditor({
 
       <div className="flex flex-wrap gap-2">
         {editable && (
-          <Button disabled={busy} onClick={saveDraft} type="button">
-            Save controlled draft
-          </Button>
+          <>
+            <Button
+              disabled={busy || !dirty}
+              onClick={() => saveDraft()}
+              type="button"
+            >
+              Save Draft
+            </Button>
+            <Button
+              disabled={busy || !dirty}
+              onClick={() => saveDraft(true)}
+              type="button"
+              variant="secondary"
+            >
+              Save and Continue
+            </Button>
+          </>
         )}
         {canSubmit && (
           <Button
@@ -527,7 +734,7 @@ export function DesignControlStepEditor({
       <div className="flex justify-between border-t pt-4">
         <Button
           disabled={!hasPrevious}
-          onClick={onPrevious}
+          onClick={() => confirmNavigation(onPrevious)}
           type="button"
           variant="outline"
         >
@@ -535,7 +742,7 @@ export function DesignControlStepEditor({
         </Button>
         <Button
           disabled={!hasNext}
-          onClick={onNext}
+          onClick={() => confirmNavigation(onNext)}
           type="button"
           variant="outline"
         >

--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -10,11 +10,13 @@ import {
 } from 'lucide-react';
 
 import { DesignControlStepEditor } from './DesignControlStepEditor';
+import { EngineeringReleaseGatePanel } from './EngineeringReleaseGatePanel';
 import { DesignProjectConfigurationWorkspace } from './DesignProjectConfigurationWorkspace';
 import { FinalDesignReviewPanel } from './FinalDesignReviewPanel';
 import { ProjectTeamPanel } from './ProjectTeamPanel';
 import { StructuredRecordsWorkspace } from './StructuredRecordsWorkspace';
 import { TraceabilityMatrix } from './TraceabilityMatrix';
+import { STRUCTURED_RECORD_TYPE_BY_STEP } from './designControlFieldPresentation';
 
 import { ControlledCopyPanel } from '@/components/design-control/ControlledCopyPanel';
 import { DesignHistoryFilePanel } from '@/components/design-control/DesignHistoryFilePanel';
@@ -76,21 +78,38 @@ type Detail = {
 
 const lifecycleLabels = [
   'Project Intake',
-  'Planning',
-  'Inputs',
-  'Reviews and Risk',
-  'Outputs',
-  'Prototype',
+  'Design Planning',
+  'Design Inputs',
+  'Requirements Review',
+  'Design Risk',
+  'Concept / Preliminary Review',
+  'Design Outputs',
+  'Prototype / First Article',
   'Verification',
   'Validation',
-  'Final Review',
+  'Final Design Review',
   'Engineering Release',
-  'Post-release Change Control',
-  'DHF',
 ] as const;
 
 function displayStatus(value?: string | null) {
-  return (value || 'not started').replaceAll('_', ' ');
+  const normalized = (value || 'not_started').toLowerCase();
+  const labels: Record<string, string> = {
+    not_started: 'Not started',
+    draft: 'Draft',
+    needs_approval: 'Draft',
+    submitted: 'Submitted',
+    submitted_for_approval: 'Submitted',
+    approved: 'Approved',
+    returned: 'Returned',
+    returned_for_revision: 'Returned',
+    rejected: 'Rejected',
+  };
+  return (
+    labels[normalized] ??
+    normalized
+      .replaceAll('_', ' ')
+      .replace(/\b\w/g, (character) => character.toUpperCase())
+  );
 }
 
 function LiveRegister({ title, rows }: { title: string; rows: LiveRow[] }) {
@@ -229,6 +248,8 @@ export function DesignControlWorkspace({
   const selectedIndex = DESIGN_CONTROL_WORKFLOW.findIndex(
     (step) => step.key === selectedDefinition.key
   );
+  const structuredRecordType =
+    STRUCTURED_RECORD_TYPE_BY_STEP[selectedDefinition.key];
 
   return (
     <section className="space-y-4" aria-label="Design Control workspace">
@@ -374,9 +395,47 @@ export function DesignControlWorkspace({
                 recordId={recordId}
                 step={selectedStep}
               />
+              {structuredRecordType && (
+                <section
+                  className="space-y-3 border-t pt-5"
+                  aria-label={`${selectedDefinition.title} authoritative register`}
+                >
+                  <div>
+                    <h3 className="font-semibold">
+                      Authoritative structured records
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Add and revise individual records here. These normalized,
+                      versioned records remain the source for traceability and
+                      readiness; the stage summary does not replace them.
+                    </p>
+                  </div>
+                  <StructuredRecordsWorkspace
+                    key={`${selectedDefinition.key}-${structuredRecordType}`}
+                    allowedTypes={[structuredRecordType]}
+                    compact
+                    initialType={structuredRecordType}
+                    readOnly={readOnly}
+                    recordId={recordId}
+                  />
+                </section>
+              )}
+              {selectedDefinition.key === '11' && (
+                <FinalDesignReviewPanel
+                  readOnly={readOnly}
+                  recordId={recordId}
+                />
+              )}
+              {selectedDefinition.key === '12' && (
+                <EngineeringReleaseGatePanel
+                  readOnly={readOnly}
+                  recordId={recordId}
+                />
+              )}
               <ProjectFormInstancesPanel
                 recordId={recordId}
                 oversightMode={readOnly}
+                stepKey={selectedDefinition.key}
               />
             </CardContent>
           </Card>

--- a/client/src/features/design-control/EngineeringReleaseGatePanel.tsx
+++ b/client/src/features/design-control/EngineeringReleaseGatePanel.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { usePermissions } from '@/hooks/usePermissions';
+
+type BaselineItem = {
+  immutableSnapshotId: string;
+  baselineCategory: string;
+  sourceModule: string | null;
+  sourceRecordId: string | null;
+  sourceRevision: string | null;
+  sourceStatus: string | null;
+  sourceChecksum: string;
+};
+
+type Preview = {
+  ready: boolean;
+  proposedReleaseNumber: string;
+  proposedReleaseRevision: string;
+  effectiveDate: string;
+  missingEvidence: string[];
+  baselineItems: BaselineItem[];
+  changedSinceReleaseWarnings: string[];
+  existingRelease?: {
+    releaseNumber: string;
+    releaseRevision: string;
+    releaseStatus: string;
+  } | null;
+};
+
+async function request(url: string, method = 'GET', body?: unknown) {
+  const response = await fetch(url, {
+    method,
+    credentials: 'include',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const missing = Array.isArray(payload.missingEvidence)
+      ? ` ${payload.missingEvidence.join('; ')}`
+      : '';
+    throw new Error(
+      `${payload.message || payload.error || 'Engineering Release failed.'}${missing}`
+    );
+  }
+  return payload;
+}
+
+export function EngineeringReleaseGatePanel({
+  recordId,
+  readOnly,
+}: {
+  recordId: string;
+  readOnly: boolean;
+}) {
+  const { can } = usePermissions();
+  const query = useQuery<{ preview: Preview }>({
+    queryKey: [
+      '/api/qms/design-control',
+      recordId,
+      'engineering-release-preview',
+    ],
+    queryFn: () =>
+      request(
+        `/api/qms/design-control/${recordId}/engineering-release-preview`
+      ),
+  });
+  const [effectiveDate, setEffectiveDate] = useState('');
+  const [message, setMessage] = useState('');
+  const [busy, setBusy] = useState(false);
+  const preview = query.data?.preview;
+
+  const release = async () => {
+    setBusy(true);
+    setMessage('');
+    try {
+      await request(
+        `/api/qms/design-control/${recordId}/engineering-release`,
+        'POST',
+        { effectiveDate: effectiveDate || preview?.effectiveDate }
+      );
+      await query.refetch();
+      setMessage('The authoritative Engineering Release was created.');
+    } catch (error) {
+      setMessage((error as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Engineering Release baseline</CardTitle>
+        <CardDescription>
+          This is the existing authoritative Engineering Release mechanism.
+          Readiness and blockers are calculated by the server; this workspace
+          does not invent completion state.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {query.isLoading && <p className="text-sm">Calculating readiness…</p>}
+        {query.isError && (
+          <p className="rounded-md border border-destructive/40 p-3 text-sm text-destructive">
+            {(query.error as Error).message}
+          </p>
+        )}
+        {preview && (
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={preview.ready ? 'default' : 'destructive'}>
+                {preview.ready ? 'READY' : 'BLOCKED'}
+              </Badge>
+              <strong>{preview.proposedReleaseNumber}</strong>
+              <span className="text-sm text-muted-foreground">
+                Revision {preview.proposedReleaseRevision}
+              </span>
+            </div>
+            {preview.missingEvidence.length > 0 && (
+              <div className="rounded-md border border-amber-500/40 bg-amber-50 p-3 text-sm text-amber-950">
+                <p className="font-medium">Release blockers</p>
+                <ul className="mt-2 list-disc pl-5">
+                  {preview.missingEvidence.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {preview.changedSinceReleaseWarnings.length > 0 && (
+              <div className="rounded-md border p-3 text-sm">
+                <p className="font-medium">Changed since prior release</p>
+                <ul className="mt-2 list-disc pl-5 text-muted-foreground">
+                  {preview.changedSinceReleaseWarnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full min-w-[48rem] text-left text-sm">
+                <thead className="bg-muted/50">
+                  <tr>
+                    <th className="p-2">Baseline category</th>
+                    <th className="p-2">Source</th>
+                    <th className="p-2">Revision</th>
+                    <th className="p-2">Status</th>
+                    <th className="p-2">Snapshot</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.baselineItems.map((item) => (
+                    <tr className="border-t" key={item.immutableSnapshotId}>
+                      <td className="p-2 font-medium">
+                        {item.baselineCategory.replaceAll('_', ' ')}
+                      </td>
+                      <td className="p-2">
+                        {item.sourceModule || 'Design Control'}
+                        {item.sourceRecordId ? ` / ${item.sourceRecordId}` : ''}
+                      </td>
+                      <td className="p-2">{item.sourceRevision || '—'}</td>
+                      <td className="p-2">{item.sourceStatus || '—'}</td>
+                      <td className="p-2 font-mono text-xs">
+                        {item.sourceChecksum.slice(0, 12)}…
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {preview.existingRelease ? (
+              <p className="rounded-md border p-3 text-sm">
+                Existing release {preview.existingRelease.releaseNumber},
+                revision {preview.existingRelease.releaseRevision} is{' '}
+                {preview.existingRelease.releaseStatus}.
+              </p>
+            ) : (
+              !readOnly &&
+              can('design.release') && (
+                <div className="flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-end">
+                  <label className="flex-1 text-sm font-medium">
+                    Effective date
+                    <Input
+                      className="mt-1"
+                      type="date"
+                      value={effectiveDate || preview.effectiveDate}
+                      onChange={(event) => setEffectiveDate(event.target.value)}
+                    />
+                  </label>
+                  <Button
+                    disabled={!preview.ready || busy}
+                    onClick={release}
+                    type="button"
+                  >
+                    Create authoritative Engineering Release
+                  </Button>
+                </div>
+              )
+            )}
+          </>
+        )}
+        {message && (
+          <p className="rounded-md border p-3 text-sm" role="status">
+            {message}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/features/design-control/StructuredRecordsWorkspace.tsx
+++ b/client/src/features/design-control/StructuredRecordsWorkspace.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
+import type { StructuredDesignControlRecordType } from './designControlFieldPresentation';
+
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -13,18 +15,14 @@ import {
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 
-type RecordType =
-  | 'REQUIREMENT'
-  | 'RISK'
-  | 'REVIEW'
-  | 'VERIFICATION'
-  | 'VALIDATION';
+type RecordType = StructuredDesignControlRecordType;
 type Field = {
   key: string;
   label: string;
   kind?: 'boolean' | 'list' | 'attendees';
   options?: string[];
   guidance: string;
+  required?: boolean;
 };
 type Definition = {
   type: RecordType;
@@ -74,6 +72,11 @@ const definitions: Definition[] = [
         guidance: 'State one clear, testable requirement.',
       },
       {
+        key: 'revision',
+        label: 'Requirement revision',
+        guidance: 'Identify the retained requirement revision.',
+      },
+      {
         key: 'acceptanceCriterion',
         label: 'Acceptance criterion',
         guidance: 'Define the objective pass condition.',
@@ -100,6 +103,12 @@ const definitions: Definition[] = [
         key: 'owner',
         label: 'Owner',
         guidance: 'Name the accountable project role or assigned user.',
+      },
+      {
+        key: 'recordStatus',
+        label: 'Requirement status',
+        options: ['DRAFT', 'ACTIVE', 'SUPERSEDED', 'CLOSED'],
+        guidance: 'Select the lifecycle status of this requirement.',
       },
       {
         key: 'clarification',
@@ -373,6 +382,14 @@ const definitions: Definition[] = [
         key: 'customerAcceptance',
         label: 'Customer acceptance evidence',
         guidance: 'Reference acceptance when required.',
+        required: false,
+      },
+      {
+        key: 'disposition',
+        label: 'Validation disposition',
+        options: ['ACCEPTED', 'CORRECTION_REQUIRED', 'REJECTED'],
+        guidance:
+          'Record the controlled disposition; approval remains a separate authenticated server decision.',
       },
     ],
   },
@@ -451,11 +468,20 @@ function fromEditorValue(field: Field, value: string) {
 export function StructuredRecordsWorkspace({
   recordId,
   readOnly,
+  initialType = 'REQUIREMENT',
+  allowedTypes,
+  compact = false,
 }: {
   recordId: string;
   readOnly: boolean;
+  initialType?: RecordType;
+  allowedTypes?: readonly RecordType[];
+  compact?: boolean;
 }) {
-  const [type, setType] = useState<RecordType>('REQUIREMENT');
+  const availableDefinitions = allowedTypes
+    ? definitions.filter((definition) => allowedTypes.includes(definition.type))
+    : definitions;
+  const [type, setType] = useState<RecordType>(initialType);
   const definition = definitions.find((item) => item.type === type)!;
   const query = useQuery<{ records: Row[] }>({
     queryKey: ['/api/qms/design-control', recordId, 'structured', type],
@@ -463,6 +489,10 @@ export function StructuredRecordsWorkspace({
       request(`/api/qms/design-control/${recordId}/structured/${type}`),
   });
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  useEffect(() => {
+    setType(initialType);
+    setSelectedId(null);
+  }, [initialType]);
   const selected =
     query.data?.records.find((item) => item.id === selectedId) ?? null;
   const [values, setValues] = useState<Record<string, string>>({});
@@ -500,6 +530,7 @@ export function StructuredRecordsWorkspace({
   const missing = useMemo(
     () =>
       definition.fields.filter((field) => {
+        if (field.required === false) return false;
         if (
           [
             'clarification',
@@ -542,25 +573,29 @@ export function StructuredRecordsWorkspace({
 
   return (
     <div className="space-y-4">
+      {availableDefinitions.length > 1 && (
+        <div
+          className="flex flex-wrap gap-2"
+          aria-label="Structured Design Control registers"
+        >
+          {availableDefinitions.map((item) => (
+            <Button
+              key={item.type}
+              size="sm"
+              variant={type === item.type ? 'default' : 'outline'}
+              onClick={() => {
+                setType(item.type);
+                setSelectedId(null);
+              }}
+            >
+              {item.title}
+            </Button>
+          ))}
+        </div>
+      )}
       <div
-        className="flex flex-wrap gap-2"
-        aria-label="Structured Design Control registers"
+        className={`grid gap-4 ${compact ? 'xl:grid-cols-[18rem_1fr]' : 'lg:grid-cols-[20rem_1fr]'}`}
       >
-        {definitions.map((item) => (
-          <Button
-            key={item.type}
-            size="sm"
-            variant={type === item.type ? 'default' : 'outline'}
-            onClick={() => {
-              setType(item.type);
-              setSelectedId(null);
-            }}
-          >
-            {item.title}
-          </Button>
-        ))}
-      </div>
-      <div className="grid gap-4 lg:grid-cols-[20rem_1fr]">
         <Card>
           <CardHeader>
             <CardTitle className="text-base">{definition.title}</CardTitle>
@@ -671,6 +706,13 @@ export function StructuredRecordsWorkspace({
                     />
                   ) : (
                     <Input
+                      type={
+                        field.key === 'dueDate' ||
+                        field.key === 'reviewDate' ||
+                        field.key === 'performedDate'
+                          ? 'date'
+                          : 'text'
+                      }
                       className="mt-1"
                       disabled={readOnly}
                       value={values[field.key] ?? ''}

--- a/client/src/features/design-control/designControlFieldPresentation.ts
+++ b/client/src/features/design-control/designControlFieldPresentation.ts
@@ -1,0 +1,154 @@
+import type { DesignControlWorkflowItem } from '@shared/designControlWorkflow';
+
+export type DesignControlFieldKind =
+  | 'text'
+  | 'textarea'
+  | 'date'
+  | 'select'
+  | 'person'
+  | 'role'
+  | 'attachment';
+
+export type DesignControlFieldPresentation = {
+  kind: DesignControlFieldKind;
+  options?: readonly string[];
+  help: string;
+  placeholder?: string;
+};
+
+export type StructuredDesignControlRecordType =
+  | 'REQUIREMENT'
+  | 'RISK'
+  | 'REVIEW'
+  | 'VERIFICATION'
+  | 'VALIDATION';
+
+export const STRUCTURED_RECORD_TYPE_BY_STEP: Partial<
+  Record<string, StructuredDesignControlRecordType>
+> = {
+  '3': 'REQUIREMENT',
+  '5': 'RISK',
+  '6': 'REVIEW',
+  '9': 'VERIFICATION',
+  '10': 'VALIDATION',
+  '11': 'REVIEW',
+};
+
+const optionSets: Record<string, readonly string[]> = {
+  'Design type': [
+    'NEW_PRODUCT',
+    'DERIVATIVE_DESIGN',
+    'DESIGN_CHANGE',
+    'RESEARCH_AND_DEVELOPMENT',
+  ],
+  'Requirement category': [
+    'CUSTOMER',
+    'FUNCTIONAL',
+    'PERFORMANCE',
+    'REGULATORY',
+    'SAFETY',
+    'MATERIAL',
+    'MANUFACTURING',
+    'INSPECTION',
+    'TEST',
+    'PACKAGING_SHIPPING',
+  ],
+  'Verification method': [
+    'Inspection',
+    'Analysis',
+    'Demonstration',
+    'Test',
+    'Similarity',
+    'Alternative calculation',
+  ],
+  Priority: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+  Status: ['DRAFT', 'OPEN', 'IN_REVIEW', 'APPROVED', 'CLOSED'],
+  Severity: ['1', '2', '3', '4', '5'],
+  Occurrence: ['1', '2', '3', '4', '5'],
+  Detection: ['1', '2', '3', '4', '5'],
+  'Risk priority': ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+  'Approval status': ['PENDING', 'APPROVED', 'REJECTED', 'RETURNED'],
+  'Pass/fail': ['PASS', 'FAIL'],
+  Disposition: [
+    'ACCEPTED',
+    'REWORK_REQUIRED',
+    'USE_AS_IS_APPROVED',
+    'REJECTED',
+  ],
+};
+
+const personPattern =
+  /responsible engineer|representative|owner|builder|verified by|performed by|responsible person/i;
+const rolePattern = /approval roles|responsibilities|role$/i;
+const datePattern = /date|due date|target manufacturing/i;
+const attachmentPattern = /attachment|photos|linked .*package/i;
+const multilinePattern =
+  /summary|requirements|deliverables|scope|milestones|activities|resources|suppliers|tools|notes|criteria|statement|gaps|conflicts|risk|failure|cause|effect|mitigation|concept|alternatives|assumptions|questions|concerns|package|lots|deviations|issues|result|disposition|intended use|mission|configuration baseline|baseline|instructions/i;
+
+export function getDesignControlFieldPresentation(
+  _stepKey: string,
+  item: DesignControlWorkflowItem
+): DesignControlFieldPresentation {
+  const label = item.label;
+  const options = optionSets[label];
+  if (options) {
+    return {
+      kind: 'select',
+      options,
+      help: `Choose the controlled ${label.toLowerCase()} value.`,
+    };
+  }
+  if (datePattern.test(label)) {
+    return {
+      kind: 'date',
+      help: 'Use the date applicable to this exact controlled stage version.',
+    };
+  }
+  if (attachmentPattern.test(label)) {
+    return {
+      kind: 'attachment',
+      help: 'Identify the controlled artifact here, then upload objective evidence in the controlled-form evidence section below.',
+      placeholder: 'Document number, revision, or retained evidence reference',
+    };
+  }
+  if (personPattern.test(label)) {
+    return {
+      kind: 'person',
+      help: 'Select an active Design Control project assignment when available, or enter the accountable person.',
+    };
+  }
+  if (rolePattern.test(label)) {
+    return {
+      kind: 'role',
+      options: [
+        'DESIGN_AUTHORITY',
+        'PROJECT_MANAGER',
+        'QUALITY',
+        'MANUFACTURING',
+        'REVIEWER',
+        'CONTRIBUTOR',
+      ],
+      help: 'Use the accountable project role, not an informal job title.',
+    };
+  }
+  if (multilinePattern.test(label)) {
+    return {
+      kind: 'textarea',
+      help: `Record objective ${label.toLowerCase()} evidence for this stage.`,
+    };
+  }
+  return {
+    kind: 'text',
+    help: `Enter the controlled ${label.toLowerCase()} value.`,
+  };
+}
+
+export function nextActionForStep(status?: string | null, missingCount = 0) {
+  if (status === 'submitted_for_approval')
+    return 'An authorized, independent reviewer must record the next decision.';
+  if (status === 'approved')
+    return 'This controlled stage is approved. Continue to the next lifecycle step.';
+  if (missingCount > 0)
+    return `Complete the ${missingCount} missing required item${missingCount === 1 ? '' : 's'}, then save the draft.`;
+  return 'Save this controlled draft, then submit the exact saved version for review.';
+}

--- a/server/src/services/designControlStructuredLifecycleService.ts
+++ b/server/src/services/designControlStructuredLifecycleService.ts
@@ -66,6 +66,7 @@ const schemas = {
     source: requiredText,
     sourceReference: requiredText,
     requirementStatement: requiredText,
+    revision: optionalText,
     acceptanceCriterion: requiredText,
     verificationMethod: z.enum([
       'Inspection',
@@ -78,6 +79,9 @@ const schemas = {
     validationRequired: z.boolean(),
     criticality: z.enum(['NON_CRITICAL', 'CRITICAL', 'SAFETY_CRITICAL']),
     owner: requiredText,
+    recordStatus: z
+      .enum(['DRAFT', 'ACTIVE', 'SUPERSEDED', 'CLOSED'])
+      .optional(),
     clarification: optionalText,
     resolution: optionalText,
   }),
@@ -146,6 +150,9 @@ const schemas = {
     correctiveAction: optionalText,
     customerAcceptanceRequired: z.boolean(),
     customerAcceptance: optionalText,
+    disposition: z
+      .enum(['ACCEPTED', 'CORRECTION_REQUIRED', 'REJECTED'])
+      .optional(),
   }),
 } satisfies Record<StructuredRecordType, z.ZodType<Record<string, unknown>>>;
 


### PR DESCRIPTION
## Summary

- replace the non-operational Design Control field-name presentation with typed, controlled inputs for all 12 lifecycle stages
- add Save Draft, Save and Continue, last-saved state, missing-information guidance, unsaved-change protection, and actionable server errors
- surface the existing normalized requirement, risk, review, verification, and validation registers in their applicable stages
- reuse Project Form Instances for controlled evidence and attachments, and reuse the existing server-calculated Engineering Release preview/release service
- preserve auditor read-only behavior and all existing version, approval, ECR, ECN, controlled-copy, and DHF authority boundaries

## Safety boundary

- no migration
- no database table, route, capability, feature flag, or production workflow change
- no P1, P2, layup, mold, employee, payroll, labor, training, scheduling, shipping, or production file change
- no production/shared database or external application service accessed
- existing unknown select/date values remain visible and are not silently discarded
- Engineering Release remains fail-closed and server-calculated; the client adds no bypass or competing release state

## Validation

- client/component Design Control: 16 passed
- server authorization, atomic rollback, Project Forms, and release gate: 76 passed
- Engineering Release, ECR, ECN, and DHF authority regressions: 97 passed
- scoped ESLint: passed with zero warnings
- exact-lockfile Prettier: passed
- git diff --check: passed
- bounded TypeScript comparison: zero new diagnostics versus exact main; 13 baseline test diagnostics removed. The full repository pass exceeded the six-minute local bound without emitting a diagnostic, so GitHub's bounded comparison remains required.

## Remaining certification limit

Authenticated responsive browser testing was not run because this machine has no disposable local PostgreSQL service and no Docker/Podman runtime. No remote or shared environment was substituted. Keep Design Control operational activation blocked until the Engineering, Quality, Manufacturing, Program Manager, and auditor browser walkthrough passes against an isolated disposable PostgreSQL environment.

Recommendation: MERGE only after required CI and review are green. DO NOT ENABLE for operational projects until the authenticated browser gate is complete.