### PR TITLE
Retain Design Control release artifacts in PostgreSQL

### DIFF
--- a/migrations/0259_design_control_form_template_database_artifacts.sql
+++ b/migrations/0259_design_control_form_template_database_artifacts.sql
@@ -1,0 +1,44 @@
+-- Retain the small generated Design Control blank PDFs in PostgreSQL so an
+-- exact released artifact does not depend on optional deployment object storage.
+-- Existing object-storage artifacts remain valid and readable.
+
+ALTER TABLE design_control_form_template_revisions
+  ADD COLUMN IF NOT EXISTS blank_pdf_base64 text;
+
+ALTER TABLE design_control_form_template_revisions
+  DROP CONSTRAINT IF EXISTS design_control_form_template_revisions_database_pdf_check;
+ALTER TABLE design_control_form_template_revisions
+  ADD CONSTRAINT design_control_form_template_revisions_database_pdf_check CHECK (
+    (blank_pdf_path IS NULL AND blank_pdf_base64 IS NULL)
+    OR
+    (blank_pdf_path LIKE 'database://%' AND blank_pdf_base64 IS NOT NULL AND length(blank_pdf_base64) > 0)
+    OR
+    (blank_pdf_path NOT LIKE 'database://%' AND blank_pdf_base64 IS NULL)
+  );
+
+CREATE OR REPLACE FUNCTION prevent_design_control_template_revision_mutation()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'Design Control template revisions are append-only';
+  END IF;
+  IF OLD.lifecycle_status IN ('RELEASED', 'SUPERSEDED', 'OBSOLETE') AND (
+    NEW.canonical_definition IS DISTINCT FROM OLD.canonical_definition
+    OR NEW.definition_checksum IS DISTINCT FROM OLD.definition_checksum
+    OR NEW.document_version_history_id IS DISTINCT FROM OLD.document_version_history_id
+    OR NEW.template_schema_version IS DISTINCT FROM OLD.template_schema_version
+    OR NEW.renderer_version IS DISTINCT FROM OLD.renderer_version
+    OR NEW.document_number_snapshot IS DISTINCT FROM OLD.document_number_snapshot
+    OR NEW.document_revision_snapshot IS DISTINCT FROM OLD.document_revision_snapshot
+    OR NEW.template_key_snapshot IS DISTINCT FROM OLD.template_key_snapshot
+    OR NEW.blank_pdf_path IS DISTINCT FROM OLD.blank_pdf_path
+    OR NEW.blank_pdf_base64 IS DISTINCT FROM OLD.blank_pdf_base64
+    OR NEW.blank_pdf_checksum IS DISTINCT FROM OLD.blank_pdf_checksum
+  ) THEN
+    RAISE EXCEPTION 'Released Design Control template definition and artifact identity are immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+
+COMMENT ON COLUMN design_control_form_template_revisions.blank_pdf_base64 IS
+  'Immutable base64 encoding of the exact retained released blank PDF; populated before release.';

--- a/server/__tests__/designControlFormTemplates.test.ts
+++ b/server/__tests__/designControlFormTemplates.test.ts
@@ -98,6 +98,23 @@ describe('Phase 4 controlled Design Control form templates', () => {
     expect(pdf.getPageCount()).toBeGreaterThan(0);
   });
 
+  it('renders every canonical released blank PDF without external storage', async () => {
+    const rendered = await Promise.all(
+      DESIGN_CONTROL_FORM_CATALOG.map((definition) =>
+        renderDesignControlBlankPdf({
+          templateRevisionId: '11111111-1111-4111-8111-111111111111',
+          definition,
+          documentNumber: definition.documentNumber,
+          documentRevision: '1.0',
+          lifecycleStatus: 'RELEASED',
+          generatedAt: new Date('2026-08-06T00:00:00.000Z'),
+        })
+      )
+    );
+    expect(rendered).toHaveLength(14);
+    expect(rendered.every((pdf) => pdf.length > 0)).toBe(true);
+  });
+
   it('uses additive idempotent migration protections without auto release or destructive legacy rewrite', () => {
     const migration = read('migrations/0211_design_control_form_templates.sql');
     expect(migration).toContain(
@@ -125,6 +142,15 @@ describe('Phase 4 controlled Design Control form templates', () => {
     expect(
       runner.match(/0211_design_control_form_templates\.sql/g)
     ).toHaveLength(2);
+  });
+
+  it('retains generated blank artifacts in the database without rewriting legacy storage paths', () => {
+    const migration = read(
+      'migrations/0259_design_control_form_template_database_artifacts.sql'
+    );
+    expect(migration).toContain('ADD COLUMN IF NOT EXISTS blank_pdf_base64');
+    expect(migration).toContain('NEW.blank_pdf_base64 IS DISTINCT FROM OLD.blank_pdf_base64');
+    expect(migration).not.toMatch(/UPDATE\s+design_control_form_template_revisions/i);
   });
 
   it('uses distinct stable PostgreSQL identifiers for the revision history constraints', () => {
@@ -177,6 +203,8 @@ describe('Phase 4 controlled Design Control form templates', () => {
     expect(service).toContain('Only the active RELEASED template revision');
     expect(service).toContain('LEGACY_TEMPLATE_RECONCILIATION_REQUIRED');
     expect(service).toContain('RELEASED_ARTIFACT_CHECKSUM_MISMATCH');
+    expect(service).toContain("pdf.toString('base64')");
+    expect(service).toContain("startsWith('database://')");
   });
 
   it('enforces literal template capabilities and authenticated route actors', () => {

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -12700,6 +12700,7 @@ export const designControlFormTemplateRevisions = pgTable(
       .notNull()
       .default('DRAFT'),
     blankPdfPath: text('blank_pdf_path'),
+    blankPdfBase64: text('blank_pdf_base64'),
     blankPdfChecksum: text('blank_pdf_checksum'),
     blankPdfSize: integer('blank_pdf_size'),
     blankPdfGeneratedAt: timestamp('blank_pdf_generated_at'),

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -287,6 +287,7 @@ export const safeMigrationFiles = [
   '0255_p2_v2_definition_v3_handoff.sql',
   '0256_controlled_document_atomic_approval_release.sql',
   '0258_design_control_structured_lifecycle.sql',
+  '0259_design_control_form_template_database_artifacts.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -351,6 +352,7 @@ export const criticalMigrationFiles = new Set([
   '0250_epoch_validation_wizard_phase1.sql',
   '0255_p2_v2_definition_v3_handoff.sql',
   '0258_design_control_structured_lifecycle.sql',
+  '0259_design_control_form_template_database_artifacts.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/services/designControlTemplateSchemaReadiness.ts
+++ b/server/src/services/designControlTemplateSchemaReadiness.ts
@@ -3,7 +3,7 @@ import { sql } from 'drizzle-orm';
 import { db } from '../../db';
 
 export const requiredDesignControlTemplateMigration =
-  '0211_design_control_form_templates.sql';
+  '0259_design_control_form_template_database_artifacts.sql';
 
 export class DesignControlTemplateSchemaNotReadyError extends Error {
   code = 'DESIGN_CONTROL_TEMPLATE_SCHEMA_NOT_READY';
@@ -27,6 +27,12 @@ export async function assertDesignControlTemplateSchemaReady(
          'design_control_form_template_revisions',
          'design_control_form_template_reconciliation'
        )
+    UNION ALL
+    SELECT table_name || '.' || column_name AS object_name
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'design_control_form_template_revisions'
+       AND column_name = 'blank_pdf_base64'
   `);
   const rows = (((result as any)?.rows ?? result) || []) as Array<{
     object_name?: string;
@@ -36,6 +42,7 @@ export async function assertDesignControlTemplateSchemaReady(
     'design_control_form_templates',
     'design_control_form_template_revisions',
     'design_control_form_template_reconciliation',
+    'design_control_form_template_revisions.blank_pdf_base64',
   ];
   const missing = required.filter((object) => !present.has(object));
   if (missing.length)

--- a/server/src/services/designControlTemplateService.ts
+++ b/server/src/services/designControlTemplateService.ts
@@ -551,17 +551,12 @@ export async function prepareReleasedBlankPdf(input: {
     generatedAt: context.revision.createdAt,
   });
   const checksum = sha256Buffer(pdf);
-  const path = await getFileStorageProvider().uploadBuffer({
-    buffer: pdf,
-    fileName: `${context.revision.documentNumberSnapshot}-${context.revision.documentRevisionSnapshot}-blank.pdf`,
-    contentType: 'application/pdf',
-    scope: 'design-control-form-templates',
-    entityId: context.revision.id,
-  });
+  const path = `database://design-control-form-templates/${context.revision.id}/blank.pdf`;
   const [updated] = await db
     .update(designControlFormTemplateRevisions)
     .set({
       blankPdfPath: path,
+      blankPdfBase64: pdf.toString('base64'),
       blankPdfChecksum: checksum,
       blankPdfSize: pdf.length,
       blankPdfGeneratedAt: new Date(),
@@ -699,9 +694,18 @@ export async function getBlankFormArtifact(
         'Released blank form artifact is missing'
       );
     }
-    const buffer = await getFileStorageProvider().downloadBuffer(
-      context.revision.blankPdfPath
-    );
+    const buffer = context.revision.blankPdfPath.startsWith('database://')
+      ? Buffer.from(context.revision.blankPdfBase64 ?? '', 'base64')
+      : await getFileStorageProvider().downloadBuffer(
+          context.revision.blankPdfPath
+        );
+    if (!buffer.length || buffer.length !== context.revision.blankPdfSize) {
+      throw new ControlledDocumentError(
+        409,
+        'RELEASED_ARTIFACT_SIZE_MISMATCH',
+        'Retained released blank form failed size verification'
+      );
+    }
     if (sha256Buffer(buffer) !== context.revision.blankPdfChecksum) {
       throw new ControlledDocumentError(
         409,


### PR DESCRIPTION
## Summary

- retain generated Design Control blank PDFs in PostgreSQL before release
- verify retained byte length and SHA-256 when serving released artifacts
- preserve reads for legacy object-storage artifacts
- add additive migration `0259` to safe and critical boot registration
- extend schema readiness and canonical-template regression coverage

## Root cause

The form-template release path generated the required immutable blank PDF and then depended on optional external object-storage configuration. Storage failures escaped as a generic HTTP 500, preventing an otherwise approved template from being released.

## Impact

New Design Control template releases retain the exact small PDF artifact in the authoritative database and no longer depend on deployment object-storage availability. Existing released artifacts remain readable through their original storage provider. Approval, checksum, immutability, and lifecycle gates are unchanged.

## Validation

- 14/14 canonical PDFs rendered and survived a base64 database-artifact round trip with identical size and SHA-256
- modified schema/service modules imported successfully against a non-connecting test database URL
- migration `0259` is registered exactly once in both safe and critical lists
- `git diff --check` passed
- refreshed `origin/main`; `git merge-tree --write-tree origin/main HEAD` passed
- no open main-targeting PR uses migration `0259`

## Validation limits

- the repository-wide TypeScript check exhausted the 2 GB Node heap
- focused Vitest startup was blocked by the shared linked dependency layout in the clean worktree
- no live migration or production release transition was executed; production records were not modified