### PR TITLE
Continue existing Privateer Design Review records

### DIFF
--- a/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
+++ b/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
@@ -97,6 +97,39 @@ describe('Design Control structured workspaces', () => {
           return new Response(JSON.stringify({ records: [] }), { status: 200 });
         if (url.endsWith('/structured/VALIDATION'))
           return new Response(JSON.stringify({ records: [] }), { status: 200 });
+        if (url.endsWith('/structured/REVIEW'))
+          return new Response(
+            JSON.stringify({
+              records: [
+                {
+                  id: 'privateer-review-1',
+                  title: 'Privateer Unmanned Aircraft System Design Review',
+                  status: 'draft',
+                  currentVersion: {
+                    id: 'privateer-review-version-1',
+                    version: 1,
+                    lifecycleStatus: 'DRAFT',
+                    contentSnapshot: {
+                      reviewNumber: '',
+                      reviewType: '',
+                      reviewPurpose:
+                        'Evaluate design maturity and readiness for tooling and first articles.',
+                      attendees: [
+                        {
+                          name: 'Synthetic Engineering Lead',
+                          role: 'Engineering Lead',
+                        },
+                      ],
+                      productDescription: 'Privateer Unmanned Aircraft System',
+                      sourceMappingStatus: 'PENDING_AUTHORIZED_CONFIRMATION',
+                    },
+                  },
+                  reviewActions: [],
+                },
+              ],
+            }),
+            { status: 200 }
+          );
         if (url.endsWith('/engineering-release-preview'))
           return new Response(
             JSON.stringify({
@@ -284,6 +317,61 @@ describe('Design Control structured workspaces', () => {
     expect(
       screen.queryByText('Design Inputs / Requirements')
     ).not.toBeInTheDocument();
+  });
+
+  it('continues the existing Privateer Design Review draft without creating a duplicate', async () => {
+    renderWithQuery(
+      <StructuredRecordsWorkspace
+        allowedTypes={['REVIEW']}
+        initialType="REVIEW"
+        readOnly={false}
+        recordId="record-1"
+      />
+    );
+
+    const continueButton = await screen.findByRole('button', {
+      name: 'Continue Design Review',
+    });
+    expect(
+      screen.getAllByText(/Privateer Unmanned Aircraft System/)
+    ).not.toHaveLength(0);
+    fireEvent.click(continueButton);
+    expect(
+      screen.getByDisplayValue(
+        'Evaluate design maturity and readiness for tooling and first articles.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/complete Review number/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Create draft' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/design-maturity evidence only/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/DR \(Design Review\)/i)).toBeInTheDocument();
+  });
+
+  it('requires a reason when a Design Review assessment uses N/A (Not Applicable)', async () => {
+    renderWithQuery(
+      <StructuredRecordsWorkspace
+        allowedTypes={['REVIEW']}
+        initialType="REVIEW"
+        readOnly={false}
+        recordId="record-1"
+      />
+    );
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Continue Design Review' })
+    );
+    fireEvent.change(
+      screen.getByLabelText('Manufacturing-readiness assessment', {
+        exact: false,
+      }),
+      { target: { value: 'N/A' } }
+    );
+    expect(
+      screen.getByText(/complete .*N\/A \(Not Applicable\) justification/i)
+    ).toBeInTheDocument();
   });
 
   it('shows server-calculated Engineering Release blockers and keeps release disabled', async () => {

--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { DESIGN_CONTROL_WORKFLOW } from '@shared/designControlWorkflow';
+import {
+  DESIGN_CONTROL_PHASES,
+  designControlPhaseForStep,
+} from '@shared/designControlPhases';
 import { expandDesignControlTerm } from '@shared/designControlTerminology';
 import {
   AlertTriangle,
@@ -76,21 +80,6 @@ type Detail = {
   changes: LiveRow[];
   releaseGate?: { status?: string; blockers?: unknown[] } | null;
 };
-
-const lifecycleLabels = [
-  'Project Intake',
-  'Design Planning',
-  'Design Inputs',
-  'Requirements Review',
-  'Design Risk',
-  'Concept / Preliminary Review',
-  'Design Outputs',
-  'Prototype / First Article',
-  'Verification',
-  'Validation',
-  'Final Design Review',
-  'Engineering Release',
-] as const;
 
 function displayStatus(value?: string | null) {
   const normalized = (value || 'not_started').toLowerCase();
@@ -251,6 +240,31 @@ export function DesignControlWorkspace({
   );
   const structuredRecordType =
     STRUCTURED_RECORD_TYPE_BY_STEP[selectedDefinition.key];
+  const activePhase = designControlPhaseForStep(selectedDefinition.key)!;
+  const phaseStatus = (stepKeys: readonly string[]) => {
+    const statuses = stepKeys.map(
+      (key) => stepByKey.get(key)?.status?.toLowerCase() || 'not_started'
+    );
+    if (statuses.some((status) => ['rejected', 'blocked'].includes(status)))
+      return 'Blocked';
+    if (
+      statuses.some((status) =>
+        ['returned', 'returned_for_revision'].includes(status)
+      )
+    )
+      return 'Returned';
+    if (statuses.every((status) => ['approved', 'complete'].includes(status)))
+      return 'Approved';
+    if (
+      statuses.some((status) =>
+        ['submitted', 'submitted_for_approval'].includes(status)
+      )
+    )
+      return 'Ready for review';
+    if (statuses.every((status) => status === 'not_started'))
+      return 'Not started';
+    return 'In progress';
+  };
 
   return (
     <section className="space-y-4" aria-label="Design Control workspace">
@@ -272,6 +286,9 @@ export function DesignControlWorkspace({
                 Status: {displayStatus(detail.record.status)}
               </Badge>
               <Badge variant="outline">Progress: {completed}/12</Badge>
+              <Badge variant="outline">
+                Phase {activePhase.order}: {activePhase.title}
+              </Badge>
               {readOnly && (
                 <Badge variant="secondary">
                   <LockKeyhole className="mr-1 h-3 w-3" />
@@ -283,15 +300,31 @@ export function DesignControlWorkspace({
         </CardHeader>
         <CardContent>
           <ol
-            className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4"
-            aria-label="Design lifecycle"
+            className="grid gap-2 md:grid-cols-2 xl:grid-cols-3"
+            aria-label="Six Design Control phases"
           >
-            {lifecycleLabels.map((label, index) => (
-              <li className="rounded-md border p-2 text-xs" key={label}>
-                <span className="font-semibold">{index + 1}.</span> {label}
+            {DESIGN_CONTROL_PHASES.map((phase) => (
+              <li
+                className={`rounded-md border p-3 text-sm ${phase.key === activePhase.key ? 'border-primary bg-primary/5' : ''}`}
+                key={phase.key}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="font-semibold">
+                    {phase.order}. {phase.title}
+                  </span>
+                  <Badge variant="outline">{phaseStatus(phase.stepKeys)}</Badge>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {phase.explanation}
+                </p>
               </li>
             ))}
           </ol>
+          <p className="mt-3 text-sm">
+            Six plain-language phases organize the work. All 12 controlled
+            lifecycle stages, approvals, versions, and audit events remain
+            intact underneath.
+          </p>
           <p className="mt-3 text-sm text-muted-foreground">
             Revision A establishes the initial baseline. Released designs use
             {expandDesignControlTerm('ECR')} approval and{' '}
@@ -303,7 +336,7 @@ export function DesignControlWorkspace({
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList className="h-auto flex-wrap justify-start">
-          <TabsTrigger value="lifecycle">12 steps</TabsTrigger>
+          <TabsTrigger value="lifecycle">Design phases</TabsTrigger>
           <TabsTrigger value="evidence">Evidence registers</TabsTrigger>
           <TabsTrigger value="traceability">Traceability</TabsTrigger>
           <TabsTrigger value="final-review">Final review</TabsTrigger>

--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { DESIGN_CONTROL_WORKFLOW } from '@shared/designControlWorkflow';
+import { expandDesignControlTerm } from '@shared/designControlTerminology';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -293,8 +294,9 @@ export function DesignControlWorkspace({
           </ol>
           <p className="mt-3 text-sm text-muted-foreground">
             Revision A establishes the initial baseline. Released designs use
-            ECR approval and ECN implementation before a Revision B+ baseline is
-            released.
+            {expandDesignControlTerm('ECR')} approval and{' '}
+            {expandDesignControlTerm('ECN')} implementation before a Revision B+
+            baseline is released.
           </p>
         </CardContent>
       </Card>
@@ -309,7 +311,9 @@ export function DesignControlWorkspace({
           <TabsTrigger value="configuration">Configuration</TabsTrigger>
           <TabsTrigger value="changes">Engineering changes</TabsTrigger>
           <TabsTrigger value="documents">Forms &amp; copies</TabsTrigger>
-          <TabsTrigger value="dhf">DHF &amp; package</TabsTrigger>
+          <TabsTrigger value="dhf">
+            {expandDesignControlTerm('DHF')} &amp; package
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent
@@ -469,9 +473,11 @@ export function DesignControlWorkspace({
         <TabsContent value="changes" className="space-y-4">
           <Card>
             <CardContent className="pt-6 text-sm">
-              <strong>ECR</strong> asks whether a change should be made.{' '}
-              <strong>ECN</strong> controls implementation. Engineering Release
-              establishes the resulting controlled baseline.
+              <strong>{expandDesignControlTerm('ECR')}</strong> asks whether a
+              change should be made.{' '}
+              <strong>{expandDesignControlTerm('ECN')}</strong> controls
+              implementation. Engineering Release establishes the resulting
+              controlled baseline.
             </CardContent>
           </Card>
           <EngineeringChangeRequestRegister
@@ -512,7 +518,8 @@ export function DesignControlWorkspace({
           ) : (
             <div className="rounded-md border p-6 text-sm text-muted-foreground">
               <FileSearch className="mb-2 h-5 w-5" />A released Engineering
-              baseline is required before a DHF can be generated.
+              baseline is required before a {expandDesignControlTerm('DHF')} can
+              be generated.
             </div>
           )}
           {!releaseId && (

--- a/client/src/features/design-control/DesignProjectConfigurationWorkspace.tsx
+++ b/client/src/features/design-control/DesignProjectConfigurationWorkspace.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { expandDesignControlTerm } from '@shared/designControlTerminology';
 import {
   ChevronDown,
   ChevronRight,
@@ -129,8 +130,8 @@ const steps = [
   },
 ];
 const labels: Record<string, string> = {
-  DRAWING_CAD: 'Drawing / CAD',
-  BOM: 'BOM',
+  DRAWING_CAD: `Drawing / ${expandDesignControlTerm('CAD')}`,
+  BOM: expandDesignControlTerm('BOM'),
   ROUTING: 'Routing',
   TRAVELER: 'Traveler',
   WORK_INSTRUCTION: 'Work instructions',
@@ -841,7 +842,7 @@ export function DesignProjectConfigurationWorkspace({
                         />
                       </Label>
                       <Label>
-                        ECR ID
+                        {expandDesignControlTerm('ECR')} identifier
                         <Input
                           value={revisionForm.sourceEcrId}
                           onChange={(e) =>
@@ -853,7 +854,7 @@ export function DesignProjectConfigurationWorkspace({
                         />
                       </Label>
                       <Label>
-                        ECN ID
+                        {expandDesignControlTerm('ECN')} identifier
                         <Input
                           value={revisionForm.sourceEcnId}
                           onChange={(e) =>

--- a/client/src/features/design-control/StructuredRecordsWorkspace.tsx
+++ b/client/src/features/design-control/StructuredRecordsWorkspace.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import type { StructuredDesignControlRecordType } from './designControlFieldPresentation';
+import { expandDesignControlTerm } from '@shared/designControlTerminology';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -30,6 +31,17 @@ type Definition = {
   singular: string;
   fields: Field[];
 };
+
+const reviewTypes = [
+  'General Design Review',
+  expandDesignControlTerm('PDR'),
+  expandDesignControlTerm('CDR'),
+  'Combined PDR/CDR (Combined Preliminary Design Review and Critical Design Review)',
+  expandDesignControlTerm('TRR'),
+  expandDesignControlTerm('PRR'),
+  'Final Design Review',
+  'Other controlled review type',
+];
 
 const verificationMethods = [
   'Inspection',
@@ -200,8 +212,14 @@ const definitions: Definition[] = [
       {
         key: 'reviewType',
         label: 'Review type',
-        options: ['PRELIMINARY', 'FINAL'],
-        guidance: 'Select Preliminary or Final Design Review.',
+        options: reviewTypes,
+        guidance:
+          'Confirm the classification and purpose. EPOCH may recommend a type, but never assigns one silently.',
+      },
+      {
+        key: 'reviewPurpose',
+        label: 'Purpose and objectives',
+        guidance: 'Explain what the review team is deciding and why.',
       },
       { key: 'reviewDate', label: 'Review date', guidance: 'Use YYYY-MM-DD.' },
       {
@@ -211,15 +229,26 @@ const definitions: Definition[] = [
         guidance: 'One attendee per line as Name | Role.',
       },
       {
+        key: 'productDescription',
+        label: 'Design description',
+        guidance: 'Describe the product, system, and maturity being reviewed.',
+      },
+      {
         key: 'reviewedConfiguration',
-        label: 'Reviewed configuration / revision',
+        label: 'System configuration and revision reviewed',
         guidance: 'Identify the exact reviewed baseline.',
       },
       {
         key: 'decision',
-        label: 'Decision',
-        options: ['PROCEED', 'PROCEED_WITH_CONDITIONS', 'HOLD'],
-        guidance: 'Record the review disposition.',
+        label: 'Review decision',
+        options: [
+          'APPROVED',
+          'APPROVED_WITH_ACTION_ITEMS',
+          'CONDITIONAL_APPROVAL',
+          'NOT_APPROVED',
+        ],
+        guidance:
+          'This Design Review decision records design maturity only. It never releases manufacturing.',
       },
       {
         key: 'conditions',
@@ -228,8 +257,58 @@ const definitions: Definition[] = [
       },
       {
         key: 'minutesEvidence',
-        label: 'Minutes / evidence',
+        label: 'Review minutes and evidence',
         guidance: 'Reference retained minutes and objective evidence.',
+      },
+      {
+        key: 'requirementsAssessment',
+        label: 'Design requirements and performance assessment',
+        guidance:
+          'Link authoritative requirements and record Complete, Partial, Open, or N/A (Not Applicable).',
+      },
+      {
+        key: 'manufacturingAssessment',
+        label: 'Manufacturing-readiness assessment',
+        guidance:
+          'Assess tooling, first articles, instructions, inspection, materials, and processes without releasing them.',
+      },
+      {
+        key: 'preliminaryAnalysis',
+        label: 'Preliminary analysis and design outputs reviewed',
+        guidance:
+          'Identify controlled analyses, drawings, models, and calculations.',
+      },
+      {
+        key: 'risksAndOpenIssues',
+        label: 'Linked risks and open issues',
+        guidance:
+          'Link the authoritative Design Risk Register; do not copy risks here.',
+      },
+      {
+        key: 'readinessCriteria',
+        label: 'Readiness and exit criteria',
+        guidance:
+          'Record each criterion as Complete, Partial, Open, or N/A (Not Applicable).',
+      },
+      {
+        key: 'notApplicableJustification',
+        label: 'N/A (Not Applicable) justification',
+        guidance:
+          'Required whenever any assessment is marked N/A (Not Applicable).',
+        required: false,
+      },
+      {
+        key: 'controlledDocumentReference',
+        label: `${expandDesignControlTerm('MDR')} controlled document reference`,
+        guidance:
+          'Link the existing Design Review report and exact revision. Do not replace or overwrite the original.',
+      },
+      {
+        key: 'sourceMappingStatus',
+        label: 'Source-document mapping status',
+        options: ['PENDING_AUTHORIZED_CONFIRMATION', 'CONFIRMED'],
+        guidance:
+          'Mapped Word-form values remain non-authoritative until an authorized user confirms them.',
       },
       {
         key: 'requiredApprovals',
@@ -295,8 +374,7 @@ const definitions: Definition[] = [
       {
         key: 'exceptionDisposition',
         label: 'Exception / disposition',
-        guidance:
-          'Required for a failed result; reference action, risk, NCR, ECR, or ECN.',
+        guidance: `Required for a failed result; reference an action, risk, ${expandDesignControlTerm('NCR')}, ${expandDesignControlTerm('ECR')}, or ${expandDesignControlTerm('ECN')}.`,
       },
       {
         key: 'reviewer',
@@ -514,6 +592,15 @@ export function StructuredRecordsWorkspace({
     mandatory: true,
   });
 
+  const activeDraftReview =
+    type === 'REVIEW'
+      ? query.data?.records.find((row) =>
+          ['DRAFT', 'RETURNED', 'REJECTED'].includes(
+            row.currentVersion?.lifecycleStatus || ''
+          )
+        )
+      : undefined;
+
   useEffect(() => {
     const content = selected?.currentVersion?.contentSnapshot ?? {};
     setValues(
@@ -542,6 +629,13 @@ export function StructuredRecordsWorkspace({
             'correctiveAction',
             'customerAcceptance',
           ].includes(field.key)
+        )
+          return false;
+        if (
+          field.key === 'notApplicableJustification' &&
+          !Object.values(values).some((value) =>
+            /(^|\W)N\/?A(\W|$)/i.test(value)
+          )
         )
           return false;
         return (
@@ -591,6 +685,20 @@ export function StructuredRecordsWorkspace({
               {item.title}
             </Button>
           ))}
+        </div>
+      )}
+      {type === 'REVIEW' && activeDraftReview && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-blue-500/40 bg-blue-50 p-4 text-sm">
+          <div>
+            <strong>Existing Design Review draft found.</strong> Continue the
+            same controlled record; no duplicate will be created.
+          </div>
+          <Button
+            onClick={() => setSelectedId(activeDraftReview.id)}
+            type="button"
+          >
+            Continue Design Review
+          </Button>
         </div>
       )}
       <div
@@ -734,6 +842,16 @@ export function StructuredRecordsWorkspace({
               <div className="rounded-md border border-amber-500/40 bg-amber-50 p-3 text-sm">
                 <strong>Before submission:</strong> complete{' '}
                 {missing.map((field) => field.label).join(', ')}.
+              </div>
+            )}
+            {type === 'REVIEW' && (
+              <div className="rounded-md border p-3 text-sm text-muted-foreground">
+                <strong className="text-foreground">Controlled handoff:</strong>{' '}
+                approval of this {expandDesignControlTerm('DR')} is
+                design-maturity evidence only. A separate item-level or
+                complete-product Engineering Release, with Engineering and
+                Quality approval, is always required before manufacturing
+                receives an approved baseline.
               </div>
             )}
             {!readOnly && (

--- a/server/__tests__/designControlWorkspacePhase11.test.ts
+++ b/server/__tests__/designControlWorkspacePhase11.test.ts
@@ -41,12 +41,35 @@ const terminology = fs.readFileSync(
   path.join(root, 'shared/designControlTerminology.ts'),
   'utf8'
 );
+const phases = fs.readFileSync(
+  path.join(root, 'shared/designControlPhases.ts'),
+  'utf8'
+);
 
 describe('Phase 11 unified Design Control workspace', () => {
   it('uses the canonical twelve-step definition', () => {
     expect(workspace).toContain('import { DESIGN_CONTROL_WORKFLOW }');
     expect(workspace).toContain('Progress: {completed}/12');
     expect(workspace).not.toMatch(/const\s+workflowSteps\s*=/);
+  });
+
+  it('presents six plain-language phases while preserving all twelve stages', () => {
+    for (const title of [
+      'Define the Project',
+      'Requirements and Risks',
+      'Develop the Design',
+      'Build, Review, and Test',
+      'Final Design Approval',
+      'Release to Manufacturing',
+    ]) {
+      expect(phases).toContain(title);
+    }
+    for (let step = 1; step <= 12; step += 1) {
+      expect(phases).toContain(`'${step}'`);
+    }
+    expect(workspace).toContain('Six Design Control phases');
+    expect(workspace).toContain('All 12 controlled');
+    expect(workspace).toContain('Design phases');
   });
 
   it('is shared by R&D project mode and QMS oversight mode', () => {

--- a/server/__tests__/designControlWorkspacePhase11.test.ts
+++ b/server/__tests__/designControlWorkspacePhase11.test.ts
@@ -30,6 +30,17 @@ const route = fs.readFileSync(
   path.join(root, 'server/src/routes/qmsDesignControl.ts'),
   'utf8'
 );
+const lifecycleService = fs.readFileSync(
+  path.join(
+    root,
+    'server/src/services/designControlStructuredLifecycleService.ts'
+  ),
+  'utf8'
+);
+const terminology = fs.readFileSync(
+  path.join(root, 'shared/designControlTerminology.ts'),
+  'utf8'
+);
 
 describe('Phase 11 unified Design Control workspace', () => {
   it('uses the canonical twelve-step definition', () => {
@@ -90,11 +101,43 @@ describe('Phase 11 unified Design Control workspace', () => {
   });
 
   it('explains ECR, ECN, and release distinctions', () => {
-    expect(workspace).toContain(
-      'ECR</strong> asks whether a change should be made'
-    );
-    expect(workspace).toContain('ECN</strong> controls implementation');
+    expect(workspace).toContain("expandDesignControlTerm('ECR')");
+    expect(workspace).toContain("expandDesignControlTerm('ECN')");
     expect(workspace).toMatch(/Engineering Release\s+establishes/);
+  });
+
+  it('continues an existing Design Review and explains controlled terminology', () => {
+    expect(structuredWorkspace).toContain('Continue Design Review');
+    expect(structuredWorkspace).toContain('no duplicate will be created');
+    expect(structuredWorkspace).toContain("expandDesignControlTerm('DR')");
+    for (const acronym of [
+      'SOW',
+      'PDR',
+      'CDR',
+      'TRR',
+      'PRR',
+      'BOM',
+      'CAD',
+      'ECR',
+      'ECN',
+      'DHF',
+      'UAS',
+      'FAI',
+      'WIP',
+      'QMS',
+      'MDR',
+      'P1',
+      'P2',
+      'AS9100',
+    ]) {
+      expect(terminology).toMatch(new RegExp(`\\b${acronym}:`));
+    }
+  });
+
+  it('enforces source confirmation, N/A reasons, and decision comments server-side', () => {
+    expect(lifecycleService).toContain('SOURCE_MAPPING_CONFIRMATION_REQUIRED');
+    expect(lifecycleService).toContain('NOT_APPLICABLE_JUSTIFICATION_REQUIRED');
+    expect(lifecycleService).toContain('REVIEW_DECISION_COMMENTS_REQUIRED');
   });
 
   it('distinguishes Revision A and Revision B+', () => {

--- a/server/src/services/designControlStructuredLifecycleService.ts
+++ b/server/src/services/designControlStructuredLifecycleService.ts
@@ -103,15 +103,47 @@ const schemas = {
   }),
   REVIEW: z.object({
     reviewNumber: requiredText,
-    reviewType: z.enum(['PRELIMINARY', 'FINAL']),
+    reviewType: z.enum([
+      'PRELIMINARY',
+      'FINAL',
+      'General Design Review',
+      'PDR (Preliminary Design Review)',
+      'CDR (Critical Design Review)',
+      'Combined PDR/CDR (Combined Preliminary Design Review and Critical Design Review)',
+      'TRR (Test Readiness Review)',
+      'PRR (Production Readiness Review)',
+      'Final Design Review',
+      'Other controlled review type',
+    ]),
+    reviewPurpose: requiredText,
     reviewDate: requiredText,
     attendees: z
       .array(z.object({ name: requiredText, role: requiredText }))
       .min(1),
+    productDescription: requiredText,
     reviewedConfiguration: requiredText,
-    decision: z.enum(['PROCEED', 'PROCEED_WITH_CONDITIONS', 'HOLD']),
+    decision: z.enum([
+      'PROCEED',
+      'PROCEED_WITH_CONDITIONS',
+      'HOLD',
+      'APPROVED',
+      'APPROVED_WITH_ACTION_ITEMS',
+      'CONDITIONAL_APPROVAL',
+      'NOT_APPROVED',
+    ]),
     conditions: optionalText,
     minutesEvidence: requiredText,
+    requirementsAssessment: requiredText,
+    manufacturingAssessment: requiredText,
+    preliminaryAnalysis: requiredText,
+    risksAndOpenIssues: requiredText,
+    readinessCriteria: requiredText,
+    notApplicableJustification: optionalText,
+    controlledDocumentReference: requiredText,
+    sourceMappingStatus: z.enum([
+      'PENDING_AUTHORIZED_CONFIRMATION',
+      'CONFIRMED',
+    ]),
     requiredApprovals: z.array(requiredText).min(1),
   }),
   VERIFICATION: z.object({
@@ -691,6 +723,45 @@ export async function submitStructuredRecord(input: {
           ),
         }
       );
+    if (input.type === 'REVIEW') {
+      const review = parsed.data;
+      if (
+        [
+          'APPROVED_WITH_ACTION_ITEMS',
+          'CONDITIONAL_APPROVAL',
+          'NOT_APPROVED',
+          'PROCEED_WITH_CONDITIONS',
+          'HOLD',
+        ].includes(String(review.decision)) &&
+        !String(review.conditions ?? '').trim()
+      )
+        throw new DesignControlStructuredError(
+          422,
+          'REVIEW_DECISION_COMMENTS_REQUIRED',
+          'Comments or conditions are required for this Design Review decision'
+        );
+      const hasNotApplicable = [
+        review.requirementsAssessment,
+        review.manufacturingAssessment,
+        review.preliminaryAnalysis,
+        review.readinessCriteria,
+      ].some((value) => /(^|\W)N\/?A(\W|$)/i.test(String(value ?? '')));
+      if (
+        hasNotApplicable &&
+        !String(review.notApplicableJustification ?? '').trim()
+      )
+        throw new DesignControlStructuredError(
+          422,
+          'NOT_APPLICABLE_JUSTIFICATION_REQUIRED',
+          'N/A (Not Applicable) requires a reason'
+        );
+      if (review.sourceMappingStatus !== 'CONFIRMED')
+        throw new DesignControlStructuredError(
+          422,
+          'SOURCE_MAPPING_CONFIRMATION_REQUIRED',
+          'An authorized user must confirm source-document mappings before submission'
+        );
+    }
     if (
       input.type === 'VERIFICATION' &&
       current.contentSnapshot.passFail === 'FAIL' &&

--- a/shared/designControlPhases.ts
+++ b/shared/designControlPhases.ts
@@ -1,0 +1,56 @@
+export const DESIGN_CONTROL_PHASES = [
+  {
+    key: 'define-project',
+    order: 1,
+    title: 'Define the Project',
+    stepKeys: ['1', '2'],
+    explanation:
+      'Describe the project, its purpose, responsibilities, plan, and required evidence.',
+  },
+  {
+    key: 'requirements-risks',
+    order: 2,
+    title: 'Requirements and Risks',
+    stepKeys: ['3', '4', '5'],
+    explanation:
+      'Confirm what the design must do, resolve unclear requirements, and control design risk.',
+  },
+  {
+    key: 'develop-design',
+    order: 3,
+    title: 'Develop the Design',
+    stepKeys: ['6', '7'],
+    explanation:
+      'Review the design direction and create controlled outputs that satisfy the requirements.',
+  },
+  {
+    key: 'build-review-test',
+    order: 4,
+    title: 'Build, Review, and Test',
+    stepKeys: ['8', '9', '10'],
+    explanation:
+      'Build the correct configuration and retain separate verification and validation evidence.',
+  },
+  {
+    key: 'final-approval',
+    order: 5,
+    title: 'Final Design Approval',
+    stepKeys: ['11'],
+    explanation:
+      'Resolve readiness blockers and obtain an authenticated final design decision.',
+  },
+  {
+    key: 'manufacturing-release',
+    order: 6,
+    title: 'Release to Manufacturing',
+    stepKeys: ['12'],
+    explanation:
+      'Create the separately approved, immutable Engineering Release baseline.',
+  },
+] as const;
+
+export function designControlPhaseForStep(stepKey: string) {
+  return DESIGN_CONTROL_PHASES.find((phase) =>
+    (phase.stepKeys as readonly string[]).includes(stepKey)
+  );
+}

--- a/shared/designControlTerminology.ts
+++ b/shared/designControlTerminology.ts
@@ -1,0 +1,35 @@
+export const DESIGN_CONTROL_TERMINOLOGY = {
+  AS9100: 'Aerospace Quality Management System Standard',
+  BOM: 'Bill of Materials',
+  CAD: 'Computer-Aided Design',
+  CDR: 'Critical Design Review',
+  DHF: 'Design History File',
+  DR: 'Design Review',
+  ECN: 'Engineering Change Notice',
+  ECR: 'Engineering Change Request',
+  FAI: 'First Article Inspection',
+  MDR: 'Master Document Register',
+  NCR: 'Nonconformance Report',
+  P1: 'Production Line 1',
+  P2: 'Production Line 2',
+  PDR: 'Preliminary Design Review',
+  PRR: 'Production Readiness Review',
+  QMS: 'Quality Management System',
+  SOW: 'Statement of Work',
+  TRR: 'Test Readiness Review',
+  UAS: 'Unmanned Aircraft System',
+  WIP: 'Work in Process',
+} as const;
+
+export type DesignControlAcronym = keyof typeof DESIGN_CONTROL_TERMINOLOGY;
+
+export function expandDesignControlTerm(term: DesignControlAcronym) {
+  return `${term} (${DESIGN_CONTROL_TERMINOLOGY[term]})`;
+}
+
+export const DESIGN_CONTROL_UNITS = {
+  kts: 'knots',
+  hrs: 'hours',
+  ft: 'feet',
+  nm: 'nautical miles',
+} as const;


### PR DESCRIPTION
## Summary
- continue an existing active Design Review draft instead of creating a duplicate
- map the legacy 15-section Design Review form into the authoritative versioned structured-review record
- require authorized confirmation of Word-form mappings before submission
- enforce N/A justification and comments for conditional or negative review decisions on the server
- centralize and expand Design Control acronyms in the touched workspace UI
- preserve the separate Engineering Release gate; Design Review approval cannot release manufacturing

## Privateer compatibility
The supplied Privateer scenario is represented only in synthetic client coverage. No real project number, document number, effective date, signature, approval date, requirement, test evidence, or production value is fabricated. The runtime resumes whichever existing active draft is returned by the authoritative Design Control API and preserves its versioned history.

## Validation
- PASS: formatting on all 7 changed files
- PASS: TypeScript/TSX transpile syntax validation on all 7 changed files
- PASS: git diff --check
- PASS: 14 focused static assertions for continuation, no-duplicate messaging, terminology dictionary, and server guards
- PASS: non-destructive merge-tree against current origin/main
- BLOCKED: focused Vitest suite could not start because the isolated worktree has no complete node_modules; offline install was missing @replit/vite-plugin-cartographer
- NOT RUN: browser acceptance and live PostgreSQL migration tests; no database migration was required for this additive use of existing versioned JSON records

## Safety boundaries
No merge, deployment, production database access, backfill, feature activation, legacy conversion, production-record edit, or manufacturing release occurred.