### PR TITLE
Fix completed P2 units in Shipping counts

### DIFF
--- a/client/src/__tests__/p2ShippingUnitStatus.test.ts
+++ b/client/src/__tests__/p2ShippingUnitStatus.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { isHistoricalP2InventoryUnit } from '../lib/p2ShippingUnitStatus';
+import { isCompletedP2ShippingUnit, isHistoricalP2InventoryUnit } from '../lib/p2ShippingUnitStatus';
+
+describe('isCompletedP2ShippingUnit', () => {
+  it('recognizes a durable completed status when the legacy timestamp is missing', () => {
+    expect(isCompletedP2ShippingUnit({ status: 'complete', completedAt: null })).toBe(true);
+    expect(isCompletedP2ShippingUnit({ status: ' COMPLETED ', completedAt: null })).toBe(true);
+    expect(isCompletedP2ShippingUnit({ status: 'CLOSED', completedAt: null })).toBe(true);
+  });
+
+  it('keeps active units in production and accepts the legacy completion timestamp', () => {
+    expect(isCompletedP2ShippingUnit({ status: 'ACTIVE', completedAt: null })).toBe(false);
+    expect(isCompletedP2ShippingUnit({ status: 'ACTIVE', completedAt: '2026-08-07T12:00:00Z' })).toBe(true);
+  });
+});
 
 describe('isHistoricalP2InventoryUnit', () => {
   it('excludes completed non-finalized inventory records from active production', () => {

--- a/client/src/components/p2/P2ShippingTab.tsx
+++ b/client/src/components/p2/P2ShippingTab.tsx
@@ -40,7 +40,7 @@ import { queryClient, apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import ShipmentSummaryModal from './ShipmentSummaryModal';
 import P2InvoicePreviewButton from './P2InvoicePreviewButton';
-import { isHistoricalP2InventoryUnit } from '@/lib/p2ShippingUnitStatus';
+import { isCompletedP2ShippingUnit, isHistoricalP2InventoryUnit } from '@/lib/p2ShippingUnitStatus';
 
 type SerializedUnit = {
   id: string;
@@ -310,7 +310,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
       if (unit.finalizedAt && unit.sku && unit.drawingName) {
         groups[key].finalizedCount++;
       }
-      if (unit.completedAt) {
+      if (isCompletedP2ShippingUnit(unit)) {
         groups[key].readyToShip++;
       } else {
         groups[key].inProduction++;
@@ -348,7 +348,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
     const group = poGroups.find((g) => g.poNumber === expandedPO);
     if (!group) return;
     const unfinalized = group.units.filter(
-      (u) => u.completedAt && (!u.finalizedAt || !u.sku || !u.drawingName)
+      (u) => isCompletedP2ShippingUnit(u) && (!u.finalizedAt || !u.sku || !u.drawingName)
     );
     if (unfinalized.length === 0) return;
     const sample = unfinalized[0];
@@ -679,7 +679,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
       finalized += g.finalizedCount;
       readyToShip += g.readyToShip;
       needsFinalization += currentUnits.filter(
-        (u) => u.completedAt && (!u.finalizedAt || !u.sku || !u.drawingName)
+        (u) => isCompletedP2ShippingUnit(u) && (!u.finalizedAt || !u.sku || !u.drawingName)
       ).length;
     }
     return { totalUnits, finalized, readyToShip, needsFinalization, poCount: poGroups.length };
@@ -754,7 +754,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
           {filteredGroups.map((group) => {
             const isExpanded = expandedPO === group.poNumber;
             const completedUnfinalized = group.units.filter(
-              (u) => u.completedAt && (!u.finalizedAt || !u.sku || !u.drawingName)
+              (u) => isCompletedP2ShippingUnit(u) && (!u.finalizedAt || !u.sku || !u.drawingName)
             );
             const finalizedUnits = group.units.filter(
               (u) => !!(u.finalizedAt && u.sku && u.drawingName)
@@ -945,9 +945,9 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
                     {(() => {
                       const historicalInventoryUnits = group.units.filter(isHistoricalP2InventoryUnit);
                       const currentUnits = group.units.filter((u) => !isHistoricalP2InventoryUnit(u));
-                      const inProductionUnits = currentUnits.filter((u) => !u.completedAt);
+                      const inProductionUnits = currentUnits.filter((u) => !isCompletedP2ShippingUnit(u));
                       const needsFinalizationUnits = group.units.filter(
-                        (u) => !isHistoricalP2InventoryUnit(u) && u.completedAt && !(u.finalizedAt && u.sku && u.drawingName)
+                        (u) => !isHistoricalP2InventoryUnit(u) && isCompletedP2ShippingUnit(u) && !(u.finalizedAt && u.sku && u.drawingName)
                       );
 
                       // Build status sections — only render non-empty ones
@@ -961,7 +961,7 @@ export default function P2ShippingTab({ initialPO, initialUnits, selectedPOIds =
                       const renderTableRows = (units: SerializedUnit[]) =>
                         units.map((unit) => {
                           const isFinalized = !!(unit.finalizedAt && unit.sku && unit.drawingName);
-                          const isCompleted = !!unit.completedAt;
+                          const isCompleted = isCompletedP2ShippingUnit(unit);
                           const isNeedingFinalization = isCompleted && !isFinalized;
                           const isSelectedForFinalize = finSelForPO.has(unit.id);
                           const isSelectedForShip = shipSelForPO.has(unit.id);

--- a/client/src/lib/p2ShippingUnitStatus.ts
+++ b/client/src/lib/p2ShippingUnitStatus.ts
@@ -1,10 +1,16 @@
 export interface P2ShippingUnitStatusInput {
   status?: string | null;
   currentDepartment?: string | null;
+  completedAt?: string | Date | null;
   finalizedAt?: string | Date | null;
 }
 
 const normalized = (value: unknown) => String(value ?? '').trim().toUpperCase();
+
+export function isCompletedP2ShippingUnit(unit: P2ShippingUnitStatusInput): boolean {
+  return !!unit.completedAt
+    || ['COMPLETE', 'COMPLETED', 'CLOSED'].includes(normalized(unit.status));
+}
 
 export function isHistoricalP2InventoryUnit(unit: P2ShippingUnitStatusInput): boolean {
   return normalized(unit.currentDepartment) === 'INVENTORY'


### PR DESCRIPTION
## What changed

- Added one shared completion predicate for P2 Shipping units.
- Treats `COMPLETE`, `COMPLETED`, and `CLOSED` statuses as completed even when the legacy `completedAt` timestamp is absent.
- Applied the predicate consistently to PO card counts, unit sections, summary totals, status rendering, and finalization selection.
- Added focused regression coverage.

## Why

PO `SG022317` showed 115 units as **In Production** in the P2 Control Center Shipping tab even though their durable item status was complete. The UI rendered their status as completed but counted them from `completedAt` alone, producing contradictory state.

## Impact

Completed units no longer inflate the Shipping tab's **In Production** count and instead follow the completed/finalization flow. Active units remain unchanged.

## Validation

- 5 direct completion-predicate checks passed.
- `git diff --check` passed.
- The repository's focused Vitest command was unavailable in the clean worktree because the package runner hung before producing output.