### PR TITLE
Fix Phase 2 controlled-document audit evidence

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -435,6 +435,21 @@ export default function MasterDocumentRegister() {
     const compatibilityStatus = (doc as any).compatibilityStatus as
       string | undefined;
     /* eslint-enable prettier/prettier */
+    if (
+      phase2Enabled &&
+      (
+        doc as ControlledDocument & {
+          phase2ProspectiveRelease?: boolean;
+        }
+      ).phase2ProspectiveRelease === true &&
+      doc.lifecycleStatus === 'RELEASED'
+    ) {
+      return (
+        <Badge className="bg-emerald-700">
+          Released — approved and available for use
+        </Badge>
+      );
+    }
     if (compatibilityStatus === 'Released and Verified') {
       return <Badge className="bg-emerald-700">Released and Verified</Badge>;
     }
@@ -796,7 +811,9 @@ export default function MasterDocumentRegister() {
       setNewDocumentType('');
       toast({
         title: 'Success',
-        description: 'Document created successfully',
+        description: phase2Enabled
+          ? 'Document registered and awaiting approval'
+          : 'Document created successfully',
       });
     },
     onError: (error: any) => {
@@ -1103,7 +1120,7 @@ export default function MasterDocumentRegister() {
                     }}
                   >
                     <Plus className="h-4 w-4" />
-                    New Document
+                    {phase2Enabled ? 'Register Document' : 'New Document'}
                   </Button>
                 </>
               )}
@@ -1666,12 +1683,18 @@ export default function MasterDocumentRegister() {
                                   size="sm"
                                   variant="default"
                                   className="bg-green-600 hover:bg-green-700"
-                                  title="Approve"
+                                  title={
+                                    phase2Enabled
+                                      ? 'Approve and Release'
+                                      : 'Approve'
+                                  }
                                   onClick={() => openApproveDialog(doc)}
                                   data-testid={`button-approve-${doc.id}`}
                                 >
                                   <CheckCircle className="h-4 w-4 mr-1" />
-                                  Approve
+                                  {phase2Enabled
+                                    ? 'Approve and Release'
+                                    : 'Approve'}
                                 </Button>
                               )}
                             {phase2Enabled &&
@@ -1759,9 +1782,15 @@ export default function MasterDocumentRegister() {
       <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Create New Controlled Document</DialogTitle>
+            <DialogTitle>
+              {phase2Enabled
+                ? 'Register Controlled Document'
+                : 'Create New Controlled Document'}
+            </DialogTitle>
             <DialogDescription>
-              Upload a new controlled document for P1 or P2 operations
+              {phase2Enabled
+                ? 'Registration counts as submission and awaits independent approval.'
+                : 'Upload a new controlled document for P1 or P2 operations'}
             </DialogDescription>
           </DialogHeader>
 
@@ -1958,8 +1987,12 @@ export default function MasterDocumentRegister() {
                 data-testid="button-submit-create"
               >
                 {createDocumentMutation.isPending
-                  ? 'Creating...'
-                  : 'Create Document'}
+                  ? phase2Enabled
+                    ? 'Registering...'
+                    : 'Creating...'
+                  : phase2Enabled
+                    ? 'Register Document'
+                    : 'Create Document'}
               </Button>
             </DialogFooter>
           </form>

--- a/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
+++ b/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
@@ -113,8 +113,14 @@ describe('truthful gated UI', () => {
     expect(client).toContain(
       "phase2Enabled ? 'approve-and-release' : 'decision'"
     );
+    expect(client).toContain(
+      "phase2Enabled ? 'Register Document' : 'New Document'"
+    );
+    expect(client).toContain('Registration counts as submission');
     expect(client).toContain('Registered — awaiting approval');
+    expect(client).toContain('Released — approved and available for use');
     expect(client).toContain('Rejected — correction required');
+    expect(client).toContain("? 'Approve and Release'");
     expect(client).toContain('Historical/legacy — retained');
   });
 });

--- a/server/__tests__/controlledDocumentPhase2Postgres.test.ts
+++ b/server/__tests__/controlledDocumentPhase2Postgres.test.ts
@@ -35,9 +35,14 @@ const viewerSessionToken = `mdr-viewer-session-${randomUUID()}`;
 const deniedRole = `MDR_DENIED_CERT_${randomUUID()}`;
 const deniedUsername = `mdr-denied-${randomUUID()}`;
 const deniedSessionToken = `mdr-denied-session-${randomUUID()}`;
+const creatorRole = `MDR_CREATOR_CERT_${randomUUID()}`;
+const creatorUsername = `mdr-creator-${randomUUID()}`;
+const creatorSessionToken = `mdr-creator-session-${randomUUID()}`;
 let approverId = 0;
 let approverEmployeeId = 0;
 let viewerId = 0;
+let creatorId = 0;
+let creatorEmployeeId = 0;
 let releasedPdfBytes = Buffer.alloc(0);
 let releasedPdfChecksum = '';
 const documentAssetRoot = path.resolve(
@@ -52,9 +57,9 @@ const outsidePdfPath = path.resolve(
   '..',
   `mdr-phase2-outside-${randomUUID()}.pdf`
 );
-const symlinkPdfName = `mdr-phase2-link-${randomUUID()}.pdf`;
-const symlinkPdfReference = `assets/documents/${symlinkPdfName}`;
-const symlinkPdfPath = path.join(documentAssetRoot, symlinkPdfName);
+const symlinkDirectoryName = `mdr-phase2-link-${randomUUID()}`;
+const symlinkDirectoryPath = path.join(documentAssetRoot, symlinkDirectoryName);
+const symlinkPdfReference = `assets/documents/${symlinkDirectoryName}/${path.basename(outsidePdfPath)}`;
 
 const accessApp = express();
 accessApp.use(express.json());
@@ -283,7 +288,11 @@ beforeAll(async () => {
   releasedPdfChecksum = checksumFile(releasedPdfBytes);
   await fs.writeFile(releasedPdfPath, releasedPdfBytes);
   await fs.writeFile(outsidePdfPath, releasedPdfBytes);
-  await fs.symlink(outsidePdfPath, symlinkPdfPath);
+  await fs.symlink(
+    path.dirname(outsidePdfPath),
+    symlinkDirectoryPath,
+    'junction'
+  );
   const employee = await pgPool.query(
     `INSERT INTO employees (name, user_role)
      VALUES ($1, 'EMPLOYEE') RETURNING id`,
@@ -337,6 +346,21 @@ beforeAll(async () => {
      VALUES ($1, 'Disposable denied viewer role')`,
     [deniedRole]
   );
+  const createCapability = await pgPool.query(
+    `INSERT INTO perm_capabilities (key, description, category)
+     VALUES ('documents.create', 'Register controlled documents', 'documents')
+     ON CONFLICT (key) DO UPDATE SET key = EXCLUDED.key RETURNING id`
+  );
+  const creatorRoleRow = await pgPool.query(
+    `INSERT INTO perm_roles (name, description)
+     VALUES ($1, 'Disposable document creator role') RETURNING id`,
+    [creatorRole]
+  );
+  await pgPool.query(
+    `INSERT INTO perm_role_capabilities (role_id, capability_id)
+     VALUES ($1, $2)`,
+    [creatorRoleRow.rows[0].id, createCapability.rows[0].id]
+  );
   const user = await pgPool.query(
     `INSERT INTO users (username, password_hash, role, employee_id)
      VALUES ($1, 'not-a-login-secret', $2, $3) RETURNING id`,
@@ -367,11 +391,24 @@ beforeAll(async () => {
      VALUES ($1, 'not-a-login-secret', $2) RETURNING id`,
     [deniedUsername, deniedRole]
   );
+  const creatorEmployee = await pgPool.query(
+    `INSERT INTO employees (name, user_role)
+     VALUES ($1, 'EMPLOYEE') RETURNING id`,
+    [`Phase 2 creator ${creatorUsername}`]
+  );
+  creatorEmployeeId = creatorEmployee.rows[0].id;
+  const creator = await pgPool.query(
+    `INSERT INTO users (username, password_hash, role, employee_id)
+     VALUES ($1, 'not-a-login-secret', $2, $3) RETURNING id`,
+    [creatorUsername, creatorRole, creatorEmployeeId]
+  );
+  creatorId = creator.rows[0].id;
   await pgPool.query(
     `INSERT INTO user_sessions
        (session_token, user_id, username, expires_at, is_active, last_credential_verified_at)
      VALUES ($1, $2, $3, NOW() + INTERVAL '1 hour', true, NOW()),
-            ($4, $5, $6, NOW() + INTERVAL '1 hour', true, NOW())`,
+            ($4, $5, $6, NOW() + INTERVAL '1 hour', true, NOW()),
+            ($7, $8, $9, NOW() + INTERVAL '1 hour', true, NOW())`,
     [
       viewerSessionToken,
       viewerId,
@@ -379,6 +416,9 @@ beforeAll(async () => {
       deniedSessionToken,
       denied.rows[0].id,
       deniedUsername,
+      creatorSessionToken,
+      creatorId,
+      creatorUsername,
     ]
   );
 });
@@ -388,12 +428,44 @@ afterAll(async () => {
   await Promise.allSettled([
     fs.unlink(releasedPdfPath),
     fs.unlink(outsidePdfPath),
-    fs.unlink(symlinkPdfPath),
+    fs.unlink(symlinkDirectoryPath),
   ]);
   await pgPool.end();
 });
 
 describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
+  it('registers through the authenticated route when user and employee IDs differ', async () => {
+    expect(creatorId).not.toBe(creatorEmployeeId);
+    const documentNumber = `MDR-REGISTER-${randomUUID()}`.toUpperCase();
+    const response = await request(accessApp)
+      .post('/api/controlled-documents')
+      .set('Authorization', `Bearer ${creatorSessionToken}`)
+      .field('documentNumber', documentNumber)
+      .field('documentName', 'Phase 2 authenticated registration')
+      .field('documentType', 'PROCEDURE')
+      .field('department', 'Quality')
+      .field('currentVersion', '1.0');
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      documentNumber,
+      lifecycleStatus: 'DRAFT',
+      status: 'draft',
+    });
+    const audit = await pgPool.query(
+      `SELECT actor_id, actor_name
+       FROM audit_events
+       WHERE subject_type = 'controlled_document'
+         AND subject_id = $1
+       ORDER BY id DESC LIMIT 1`,
+      [response.body.id]
+    );
+    expect(audit.rows[0]).toMatchObject({
+      actor_id: creatorEmployeeId,
+      actor_name: creatorUsername,
+    });
+  });
+
   it('certifies the complete Phase 2 schema contract and append-only trigger', async () => {
     await expect(
       assertControlledDocumentPhase2SchemaReady()
@@ -930,6 +1002,20 @@ describe('controlled-document Phase 2 PostgreSQL 16.4 certification', () => {
       )
       .set('Authorization', `Bearer ${viewerSessionToken}`);
     expect(guessed.status).toBe(404);
+
+    const denied = await pgPool.query<{ document_id: string; count: number }>(
+      `SELECT document_id, count(*)::int AS count
+       FROM object_access_log
+       WHERE user_id = $1 AND action = 'denied' AND document_id = ANY($2::uuid[])
+       GROUP BY document_id`,
+      [viewerUsername, [draft.documentId, other.documentId]]
+    );
+    expect(
+      Object.fromEntries(denied.rows.map((row) => [row.document_id, row.count]))
+    ).toEqual({
+      [draft.documentId]: 3,
+      [other.documentId]: 1,
+    });
   });
 
   it('supports authorized historical released bytes and audits authenticated path containment denials', async () => {

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -63,6 +63,10 @@ const lifecycleActor = (req: Request) => {
     id: Number(user.id),
     username: String(user.username),
     role: String(user.role),
+    auditActorId:
+      user.employeeId != null && Number.isInteger(Number(user.employeeId))
+        ? Number(user.employeeId)
+        : null,
   };
 };
 
@@ -142,7 +146,8 @@ async function getUserFromSession(req: Request): Promise<any | null> {
 
     // Get user data from database
     const dbUserResult = await pool.query(
-      `SELECT id, username, role FROM users WHERE username = $1 AND is_active = true`,
+      `SELECT id, username, role, employee_id AS "employeeId"
+       FROM users WHERE username = $1 AND is_active = true`,
       [session.username.toLowerCase()]
     );
 
@@ -346,12 +351,12 @@ const authorizeControlledDocumentAccess = async (
     (!grantRequired || (await hasControlledDocumentGrant(document.id, actor)));
 
   if (!allowed) {
-    await writeAccessLog({
-      documentId: document.id,
-      userId: actor.username,
-      action: 'denied',
-      ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
-    });
+    await recordControlledDocumentDenial(
+      req,
+      document.id,
+      actor,
+      requestEvidence(req).ipAddress ?? 'unknown'
+    );
     throw new ControlledDocumentError(
       403,
       'CONTROLLED_DOCUMENT_ACCESS_DENIED',
@@ -995,6 +1000,18 @@ router.get(
       const releasedById = new Map(
         releasedRevisions.map((revision) => [revision.id, revision])
       );
+      const phase2ReleasedDocumentIds = new Set<string>();
+      if (isControlledDocumentPhase2Enabled() && docs.length > 0) {
+        const phase2ReleaseEvents = await pool.query(
+          `SELECT DISTINCT controlled_document_id::text AS document_id
+           FROM controlled_document_approval_release_events
+           WHERE controlled_document_id = ANY($1::uuid[])`,
+          [docs.map((doc) => doc.id)]
+        );
+        for (const row of phase2ReleaseEvents.rows) {
+          phase2ReleasedDocumentIds.add(String(row.document_id));
+        }
+      }
       res.json(
         docs.map((doc) => {
           const released = doc.currentReleasedRevisionId
@@ -1014,6 +1031,7 @@ router.get(
             ) || String(doc.lifecycleStatus || '').toUpperCase() === 'RELEASED';
           return {
             ...doc,
+            phase2ProspectiveRelease: phase2ReleasedDocumentIds.has(doc.id),
             compatibilityStatus: releasedVerified
               ? 'Released and Verified'
               : legacyApproved && doc.filePath
@@ -1387,44 +1405,49 @@ router.get(
   controlledDocumentViewPermission,
   controlledDocumentAccessPolicy,
   async (req: Request, res: Response) => {
+    const actor = lifecycleActor(req);
+    const ipAddress = requestEvidence(req).ipAddress ?? 'unknown';
+    let documentIdForAudit: string | null = null;
     try {
       const state = await getControlledDocumentState(req.params.id);
+      documentIdForAudit = state.document.id;
       const revision = state.revisions.find(
         (candidate) => candidate.id === req.params.revisionId
       );
-      if (!revision)
+      if (!revision) {
+        await recordControlledDocumentDenial(
+          req,
+          state.document.id,
+          actor,
+          ipAddress
+        );
         return res.status(404).json({
           error: 'REVISION_RECORD_MISSING',
           message:
             'The requested revision record does not exist for this document',
         });
-      if (!revision.filePath)
+      }
+      if (!revision.filePath) {
+        await recordControlledDocumentDenial(
+          req,
+          state.document.id,
+          actor,
+          ipAddress
+        );
         return res.status(422).json({
           error: 'FILE_REFERENCE_MISSING',
           message: 'This revision has no file reference',
         });
-      const actor = await authorizeControlledDocumentAccess(
-        req,
-        state.document
-      );
-      try {
-        await assertExactRevisionPermission(actor, revision);
-      } catch (error) {
-        await writeAccessLog({
-          documentId: state.document.id,
-          userId: actor.username,
-          action: 'denied',
-          ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
-        });
-        throw error;
       }
+      await authorizeControlledDocumentAccess(req, state.document);
+      await assertExactRevisionPermission(actor, revision);
       if (getExternalRedirectUrl(revision.filePath)) {
-        await writeAccessLog({
-          documentId: state.document.id,
-          userId: actor.username,
-          action: 'denied',
-          ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
-        });
+        await recordControlledDocumentDenial(
+          req,
+          state.document.id,
+          actor,
+          ipAddress
+        );
         return res.status(422).json({
           error: 'EXTERNAL_REFERENCE_REQUIRES_RECONCILIATION',
           message:
@@ -1443,7 +1466,7 @@ router.get(
         documentId: state.document.id,
         userId: actor.username,
         action: 'download',
-        ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+        ipAddress,
       });
       res.setHeader(
         'Content-Type',
@@ -1455,6 +1478,14 @@ router.get(
       );
       res.send(buffer);
     } catch (error) {
+      if (documentIdForAudit) {
+        await recordControlledDocumentDenial(
+          req,
+          documentIdForAudit,
+          actor,
+          ipAddress
+        );
+      }
       sendLifecycleError(
         res,
         error,

--- a/server/src/services/controlledDocumentLifecycleService.ts
+++ b/server/src/services/controlledDocumentLifecycleService.ts
@@ -29,6 +29,7 @@ export type ControlledDocumentActor = {
   id: number;
   username: string;
   role: string;
+  auditActorId?: number | null;
 };
 export type RequestEvidence = {
   ipAddress?: string | null;
@@ -160,7 +161,12 @@ const audit = async (
       sourceService: 'controlledDocumentLifecycle.service',
       actor: {
         ...actor,
-        id: auditActorId === undefined ? actor.id : auditActorId,
+        id:
+          auditActorId === undefined
+            ? actor.auditActorId === undefined
+              ? actor.id
+              : actor.auditActorId
+            : auditActorId,
       },
       reason,
       ipAddress: request.ipAddress,


### PR DESCRIPTION
## Summary

This narrowly scoped corrective PR closes issues found during the post-merge Phase 2 browser/database certification:

- records controlled-document audit events against the linked employee actor when the authenticated user and employee identifiers differ;
- logs denied exact-revision attempts consistently, including draft, guessed, cross-document, missing-file, external-reference, path-containment, and checksum-failure paths;
- exposes a server-derived prospective Phase 2 release marker so the register can distinguish new atomic releases from historical compatibility records;
- makes Phase 2 register, approval, and released-state language truthful while preserving the disabled/legacy UI behavior;
- makes the PostgreSQL path-containment fixture portable on Windows by using a directory junction escape.

No migration or historical data rewrite is included. Migration `0256_controlled_document_atomic_approval_release.sql` remains unchanged.

## Root cause

The lifecycle service historically used the authenticated `users.id` as the audit actor, while `audit_events.actor_id` represents the linked employee identity. Synthetic certification deliberately separated those identifiers and exposed the mismatch. Exact-revision routes also returned several fail-closed errors before the shared denial logger ran, so enforcement succeeded but access evidence was incomplete.

## Validation

- Controlled-document Vitest regression group: **101 passed, 0 failed, 0 skipped** across 10 files.
- PostgreSQL 16.4 Phase 2 certification: **27 passed, 0 failed, 0 skipped**.
- Migration 0256 applied and replayed twice; schema SHA-256 remained identical before/after: `88AE66147271E16382B14740B9858766D0A11E7D447D058B8053FD285ABADB77`.
- Scoped ESLint exact-main comparison: head **35 errors / 60 warnings**, exact main **35 errors / 60 warnings** (no regression; repository baseline remains non-green).
- Prettier: pass on all five changed files.
- `git diff --check`: pass.
- Repository-wide TypeScript could not be completed on this host: exact main and head both terminated at exit 134 with the default heap; the sequential 8 GB retry was terminated by the host. CI remains required for a full typecheck result.

## Synthetic browser/database evidence

The isolated loopback certification exercised real authenticated UI/API flows with disposable identities, PostgreSQL 16.4, and a private mock managed-storage endpoint:

- creator registered immutable revision 1.0;
- an independent approver atomically approved and released that exact revision;
- an ordinary viewer opened and downloaded the released bytes with an exact SHA-256 match;
- rejected revision 1.0 remained preserved and unreleased; corrected immutable revision 1.1 was then approved and released;
- unauthorized, draft, guessed, cross-document, unsafe-path, external-reference, and checksum scenarios failed closed and produced access evidence.

No production systems or production data were accessed.

## Rollout and authorization prerequisites

Keep both controls disabled while this draft is reviewed:

- `CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED` must remain unset or any value other than exact lowercase `true`.
- `CONTROLLED_DOCUMENT_RECONCILIATION_ENABLED` must remain unset/non-`true`.

Before an authorized activation, Quality/system owners must confirm:

1. managed private storage is configured and immutable bytes/checksums are readable by EPOCH;
2. creator roles receive only required register/draft capabilities;
3. independent approver roles receive `documents.view` and `documents.approve`, with supported step-up authentication and separation-of-duties policy;
4. ordinary controlled-use viewers receive only `documents.view`, plus explicit vault grants where classification/access rules require them;
5. browser acceptance is repeated in the target non-production deployment before production authorization.

Applying migrations alone does not activate Phase 2 or Phase 1B reconciliation.

## Rollback / containment

Set `CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED` to unset/non-`true` and restart the authorized application process. This restores legacy actions without deleting or rewriting any document, revision, approval, release event, access log, or audit evidence. Keep reconciliation disabled. Do not roll back by deleting historical evidence.
