### PR TITLE
Use controlled Design Review dropdowns

### DIFF
--- a/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
+++ b/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
@@ -22,7 +22,7 @@ describe('unified Design Control step editor', () => {
       for (const field of step.fields) {
         const presentation = getDesignControlFieldPresentation(step.key, field);
         expect(presentation.kind).toMatch(
-          /^(text|textarea|date|select|person|role|attachment)$/
+          /^(text|textarea|date|select|project|person|role|attachment)$/
         );
         expect(presentation.help.trim()).not.toBe('');
       }
@@ -39,6 +39,9 @@ describe('unified Design Control step editor', () => {
     };
 
     expect(presentationFor('1', 'Design type').kind).toBe('select');
+    expect(presentationFor('1', 'Project / customer / order link').kind).toBe(
+      'project'
+    );
     expect(presentationFor('1', 'Target manufacturing date').kind).toBe('date');
     expect(presentationFor('1', 'Responsible engineer').kind).toBe('person');
     expect(presentationFor('2', 'Approval roles').kind).toBe('role');
@@ -85,6 +88,10 @@ describe('unified Design Control step editor', () => {
     expect(editor).toContain("window.addEventListener('beforeunload'");
     expect(editor).toContain('Save and Continue');
     expect(editor).toContain('payload.message || payload.error');
+    expect(editor).toContain('Select an active project assignment');
+    expect(editor).toContain('Enter another accountable person');
+    expect(editor).toContain('Enter another customer or order link');
+    expect(editor).not.toContain('<datalist');
     expect(forms).toContain("window.addEventListener('beforeunload'");
     expect(forms).toContain('/attachments`');
     expect(forms).toContain('Objective evidence attached');

--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -75,6 +75,7 @@ type ApprovalState = {
 
 type Props = {
   recordId: string;
+  projectId?: string;
   definition: DesignControlWorkflowStep;
   step?: StepRow;
   readOnly: boolean;
@@ -100,6 +101,7 @@ async function responsePayload(response: Response) {
 
 export function DesignControlStepEditor({
   recordId,
+  projectId,
   definition,
   step,
   readOnly,
@@ -119,6 +121,12 @@ export function DesignControlStepEditor({
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [manualPersonFields, setManualPersonFields] = useState<Set<string>>(
+    new Set()
+  );
+  const [manualProjectFields, setManualProjectFields] = useState<Set<string>>(
+    new Set()
+  );
   const [lastSavedAt, setLastSavedAt] = useState<string | null>(
     step?.updatedAt ?? null
   );
@@ -138,6 +146,8 @@ export function DesignControlStepEditor({
     setMessage('');
     setError('');
     setDirty(false);
+    setManualPersonFields(new Set());
+    setManualProjectFields(new Set());
     setLastSavedAt(step?.updatedAt ?? null);
   }, [definition.key, step?.formData, step?.checklist, step?.updatedAt]);
 
@@ -423,17 +433,116 @@ export function DesignControlStepEditor({
                       </option>
                     ))}
                   </select>
+                ) : presentation.kind === 'project' ? (
+                  <>
+                    <select
+                      aria-describedby={`${fieldId}-help`}
+                      aria-invalid={missing}
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                      id={fieldId}
+                      value={
+                        manualProjectFields.has(field.key)
+                          ? '__MANUAL__'
+                          : value
+                      }
+                      onChange={(event) => {
+                        if (event.target.value === '__MANUAL__') {
+                          setManualProjectFields((current) =>
+                            new Set(current).add(field.key)
+                          );
+                          update('');
+                          return;
+                        }
+                        setManualProjectFields((current) => {
+                          const next = new Set(current);
+                          next.delete(field.key);
+                          return next;
+                        });
+                        update(event.target.value);
+                      }}
+                    >
+                      <option value="">Select the controlled link…</option>
+                      {value && value !== projectId && (
+                        <option value={value}>Existing value: {value}</option>
+                      )}
+                      {projectId && (
+                        <option value={projectId}>Linked project: {projectId}</option>
+                      )}
+                      <option value="__MANUAL__">
+                        Enter another customer or order link…
+                      </option>
+                    </select>
+                    {manualProjectFields.has(field.key) && (
+                      <Input
+                        aria-label={`${field.label} manual entry`}
+                        placeholder="Enter the controlled customer or order reference"
+                        value={value}
+                        onChange={(event) => update(event.target.value)}
+                      />
+                    )}
+                  </>
+                ) : presentation.kind === 'person' ? (
+                  <>
+                    <select
+                      aria-describedby={`${fieldId}-help`}
+                      aria-invalid={missing}
+                      className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                      id={fieldId}
+                      value={
+                        manualPersonFields.has(field.key)
+                          ? '__MANUAL__'
+                          : value
+                      }
+                      onChange={(event) => {
+                        if (event.target.value === '__MANUAL__') {
+                          setManualPersonFields((current) =>
+                            new Set(current).add(field.key)
+                          );
+                          update('');
+                          return;
+                        }
+                        setManualPersonFields((current) => {
+                          const next = new Set(current);
+                          next.delete(field.key);
+                          return next;
+                        });
+                        update(event.target.value);
+                      }}
+                    >
+                      <option value="">
+                        Select an active project assignment…
+                      </option>
+                      {value &&
+                        !people.some((person) => person.value === value) && (
+                          <option value={value}>Existing value: {value}</option>
+                        )}
+                      {people.map((person) => (
+                        <option
+                          key={`${person.value}-${person.label}`}
+                          value={person.value}
+                        >
+                          {person.label}
+                        </option>
+                      ))}
+                      <option value="__MANUAL__">
+                        Enter another accountable person…
+                      </option>
+                    </select>
+                    {manualPersonFields.has(field.key) && (
+                      <Input
+                        aria-label={`${field.label} manual entry`}
+                        placeholder="Enter the accountable person's full name"
+                        value={value}
+                        onChange={(event) => update(event.target.value)}
+                      />
+                    )}
+                  </>
                 ) : (
                   <>
                     <Input
                       aria-describedby={`${fieldId}-help`}
                       aria-invalid={missing}
                       id={fieldId}
-                      list={
-                        presentation.kind === 'person'
-                          ? `${fieldId}-people`
-                          : undefined
-                      }
                       placeholder={presentation.placeholder}
                       type={
                         presentation.kind === 'date' &&
@@ -444,15 +553,6 @@ export function DesignControlStepEditor({
                       value={value}
                       onChange={(event) => update(event.target.value)}
                     />
-                    {presentation.kind === 'person' && people.length > 0 && (
-                      <datalist id={`${fieldId}-people`}>
-                        {people.map((person) => (
-                          <option key={person.label} value={person.value}>
-                            {person.label}
-                          </option>
-                        ))}
-                      </datalist>
-                    )}
                   </>
                 )}
                 <p

--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -581,6 +581,7 @@ export function DesignControlWorkspace({
                 }
                 readOnly={readOnly}
                 recordId={recordId}
+                projectId={projectId}
                 step={selectedStep}
               />
               {structuredRecordType && (

--- a/client/src/features/design-control/designControlFieldPresentation.ts
+++ b/client/src/features/design-control/designControlFieldPresentation.ts
@@ -5,6 +5,7 @@ export type DesignControlFieldKind =
   | 'textarea'
   | 'date'
   | 'select'
+  | 'project'
   | 'person'
   | 'role'
   | 'attachment';
@@ -90,6 +91,12 @@ export function getDesignControlFieldPresentation(
   item: DesignControlWorkflowItem
 ): DesignControlFieldPresentation {
   const label = item.label;
+  if (label === 'Project / customer / order link') {
+    return {
+      kind: 'project',
+      help: 'Use the linked Design Control project when applicable, or enter another controlled customer or order reference.',
+    };
+  }
   const options = optionSets[label];
   if (options) {
     return {


### PR DESCRIPTION
## What changed

- Render the controlled project/customer/order reference as a dropdown containing the linked Design Control project.
- Render responsible engineer, quality representative, and manufacturing representative as active project-assignment dropdowns.
- Preserve previously saved values and provide explicit manual-entry fallbacks for legitimate exceptions.
- Extend focused presentation assertions for the new controlled project field and visible dropdown behavior.

## Why

The personnel fields were classified as controlled person fields but rendered as ordinary text inputs with browser datalist suggestions. This made controlled assignments difficult to discover and allowed unnecessary free-form variation. The project link was also free text even when the workspace already had an authoritative linked project.

## User impact

Design Review intake now favors existing authoritative project and assignment data while still allowing controlled exception entry. Narrative evidence fields remain free text.

## Validation

- `git diff --check` passed.
- Focused Vitest execution was attempted twice but could not start because the isolated worktree lacks cached dependencies and pnpm registry access failed with `ERR_PNPM_META_FETCH_FAIL` / `EACCES`.
