### PR TITLE
Harden Master Document Register creation failures

### DIFF
--- a/server/__tests__/controlledDocumentLifecycleHardening.test.ts
+++ b/server/__tests__/controlledDocumentLifecycleHardening.test.ts
@@ -36,6 +36,16 @@ describe('Master Document Register lifecycle hardening', () => {
     );
   });
 
+  it('checks create readiness before upload and cleans up failed creates', () => {
+    const route = read('server/src/routes/controlledDocuments.ts');
+    const createRoute = route.slice(route.indexOf('// Create new document'));
+    expect(
+      createRoute.indexOf('assertControlledDocumentCreateSchemaReady()')
+    ).toBeLessThan(createRoute.indexOf('persistControlledDocumentUpload('));
+    expect(createRoute).toContain('CONTROLLED_DOCUMENT_STORAGE_UNAVAILABLE');
+    expect(createRoute).toContain('.deleteObject(uploadedFilePath)');
+  });
+
   it('provides exact-revision lifecycle routes without trusting body actor identity', () => {
     const route = read('server/src/routes/controlledDocuments.ts');
     for (const operation of [

--- a/server/__tests__/controlledDocumentSchemaReadiness.test.ts
+++ b/server/__tests__/controlledDocumentSchemaReadiness.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('../db', () => ({ db: {} }));
 
 import {
+  assertControlledDocumentCreateSchemaReady,
   assertControlledDocumentReconciliationSchemaReady,
   assertControlledDocumentSchemaReady,
+  controlledDocumentCreateColumns,
   controlledDocumentReconciliationSchemaManifest,
   requiredControlledDocumentReconciliationCorrectiveMigration,
   requiredControlledDocumentReconciliationMigration,
@@ -24,6 +26,9 @@ type BaseSchemaClient = Parameters<
 >[0];
 type ReconciliationSchemaClient = Parameters<
   typeof assertControlledDocumentReconciliationSchemaReady
+>[0];
+type CreateSchemaClient = Parameters<
+  typeof assertControlledDocumentCreateSchemaReady
 >[0];
 
 const completeReconciliationFacts = () => {
@@ -106,6 +111,49 @@ describe('controlled document schema readiness', () => {
         execute: async () => objects.map((object_name) => ({ object_name })),
       } as unknown as BaseSchemaClient)
     ).resolves.toBeUndefined();
+  });
+
+  it('checks create-only revision, registry, and audit dependencies', async () => {
+    const baseObjects = [
+      ...requiredControlledDocumentTables,
+      'controlled_documents.lifecycle_status',
+      'controlled_documents.current_revision_id',
+      'controlled_documents.current_released_revision_id',
+      'controlled_documents.working_draft_revision_id',
+      'controlled_documents.number_control_status',
+      'document_version_history.revision_sequence',
+      'document_version_history.lifecycle_status',
+      'document_version_history.file_checksum',
+      'document_version_history.checksum_status',
+    ];
+    const completeColumns = Object.entries(
+      controlledDocumentCreateColumns
+    ).flatMap(([table_name, columns]) =>
+      columns.map((column_name) => ({ table_name, column_name }))
+    );
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(
+        baseObjects.map((object_name) => ({ object_name }))
+      )
+      .mockResolvedValueOnce(
+        completeColumns.filter(
+          (row) =>
+            !(
+              row.table_name === 'audit_events' &&
+              row.column_name === 'sequence_number'
+            )
+        )
+      );
+
+    await expect(
+      assertControlledDocumentCreateSchemaReady({
+        execute,
+      } as unknown as CreateSchemaClient)
+    ).rejects.toMatchObject({
+      code: 'CONTROLLED_DOCUMENT_SCHEMA_NOT_READY',
+      missingObjects: ['audit_events.sequence_number'],
+    });
   });
 
   it('requires the complete Phase 1B migration shape without permanent caching', async () => {

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -25,6 +25,7 @@ import { PDFDocument, PDFFont, StandardFonts, rgb } from 'pdf-lib';
 import {
   getFileStorageProvider,
   getFileStorageProviderForObjectPath,
+  getStorageErrorResponse,
 } from '../services/fileStorageProvider';
 import {
   ControlledDocumentError,
@@ -43,6 +44,7 @@ import {
 } from '../services/controlledDocumentLifecycleService';
 import { isControlledDocumentPhase2Enabled } from '../services/controlledDocumentPhase2Gate';
 import {
+  assertControlledDocumentCreateSchemaReady,
   assertControlledDocumentSchemaReady,
   assertControlledDocumentPhase2SchemaReady,
   ControlledDocumentSchemaNotReadyError,
@@ -1808,20 +1810,51 @@ router.post(
   requirePermission('documents.create'),
   upload.single('file'),
   async (req: Request, res: Response) => {
+    let uploadedFilePath: string | null = null;
     try {
-      const filePath = req.file
-        ? await persistControlledDocumentUpload(
+      const documentNumber = String(req.body.documentNumber || '').trim();
+      const documentName = String(req.body.documentName || '').trim();
+      const documentType = String(req.body.documentType || '').trim();
+      const department = String(req.body.department || '').trim();
+      if (!documentNumber) {
+        throw new ControlledDocumentError(
+          400,
+          'DOCUMENT_NUMBER_REQUIRED',
+          'Document number is required'
+        );
+      }
+      if (!documentName || !documentType || !department) {
+        throw new ControlledDocumentError(
+          400,
+          'DOCUMENT_METADATA_REQUIRED',
+          'Document name, type, and department are required'
+        );
+      }
+
+      await assertControlledDocumentCreateSchemaReady();
+      if (req.file) {
+        try {
+          uploadedFilePath = await persistControlledDocumentUpload(
             req.file,
-            req.body.documentNumber
-          )
-        : null;
+            documentNumber
+          );
+        } catch (storageError) {
+          const storage = getStorageErrorResponse(storageError);
+          throw new ControlledDocumentError(
+            storage.status,
+            'CONTROLLED_DOCUMENT_STORAGE_UNAVAILABLE',
+            storage.message,
+            { reason: storage.reason }
+          );
+        }
+      }
       const result = await createControlledDocument({
         document: {
-          documentNumber: req.body.documentNumber,
-          documentName: req.body.documentName,
+          documentNumber,
+          documentName,
           templateKey: req.body.templateKey || null,
-          documentType: req.body.documentType,
-          department: req.body.department,
+          documentType,
+          department,
           category: req.body.category || null,
           description: req.body.description || null,
           revisionValue: req.body.currentVersion || '1.0',
@@ -1838,9 +1871,9 @@ router.post(
             req.body.mfaRequired === 'true' || req.body.mfaRequired === true,
         },
         file:
-          req.file && filePath
+          req.file && uploadedFilePath
             ? {
-                path: filePath,
+                path: uploadedFilePath,
                 name: req.file.originalname,
                 mediaType: req.file.mimetype,
                 size: req.file.size,
@@ -1852,6 +1885,18 @@ router.post(
       });
       res.status(201).json(result.document);
     } catch (error: any) {
+      if (uploadedFilePath) {
+        try {
+          await getFileStorageProviderForObjectPath(
+            uploadedFilePath
+          ).deleteObject(uploadedFilePath);
+        } catch (cleanupError) {
+          console.error(
+            'Failed to clean up controlled document upload after create failure',
+            { uploadedFilePath, cleanupError }
+          );
+        }
+      }
       sendLifecycleError(res, error, 'Failed to create controlled document');
     }
   }

--- a/server/src/services/controlledDocumentSchemaReadiness.ts
+++ b/server/src/services/controlledDocumentSchemaReadiness.ts
@@ -72,6 +72,85 @@ export async function assertControlledDocumentSchemaReady(
   if (missing.length) throw new ControlledDocumentSchemaNotReadyError(missing);
 }
 
+export const controlledDocumentCreateColumns: Record<string, string[]> = {
+  controlled_documents: [
+    'template_key',
+    'lifecycle_status',
+    'current_revision_id',
+    'working_draft_revision_id',
+    'number_control_status',
+    'classification',
+    'cui_category',
+    'itar_category',
+    'export_control_jurisdiction',
+    'customer_id',
+    'contract_artifact_type',
+    'access_rule',
+    'mfa_required',
+    'download_tracking_required',
+  ],
+  document_version_history: [
+    'revision_sequence',
+    'lifecycle_status',
+    'revision_reason',
+    'file_name',
+    'media_type',
+    'file_size',
+    'file_checksum',
+    'checksum_status',
+    'metadata',
+  ],
+  controlled_document_number_registry: [
+    'normalized_number',
+    'display_number',
+    'controlled_document_id',
+    'status',
+    'reserved_by_user_id',
+    'reserved_by_snapshot',
+  ],
+  audit_events: [
+    'subject_type',
+    'subject_id',
+    'payload_json',
+    'payload_hash',
+    'prev_hash',
+    'row_hash',
+    'occurred_at',
+    'recorded_at',
+    'source_service',
+    'sequence_number',
+  ],
+};
+
+/** Check every create-only dependency before accepting central-storage bytes. */
+export async function assertControlledDocumentCreateSchemaReady(
+  client: Pick<typeof db, 'execute'> = db
+) {
+  await assertControlledDocumentSchemaReady(client);
+  const result = await client.execute(sql`
+    SELECT table_name, column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name IN (
+        'controlled_documents', 'document_version_history',
+        'controlled_document_number_registry', 'audit_events'
+      )
+  `);
+  const rows = (((result as any)?.rows ?? result) || []) as Array<{
+    table_name?: string;
+    column_name?: string;
+  }>;
+  const present = new Set(
+    rows.map((row) => `${row.table_name}.${row.column_name}`)
+  );
+  const missing = Object.entries(controlledDocumentCreateColumns)
+    .flatMap(([tableName, columns]) =>
+      columns.map((columnName) => `${tableName}.${columnName}`)
+    )
+    .filter((objectName) => !present.has(objectName));
+  if (missing.length) throw new ControlledDocumentSchemaNotReadyError(missing);
+}
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export async function assertControlledDocumentPhase2SchemaReady(
   client: Pick<typeof db, 'execute'> = db


### PR DESCRIPTION
## What changed

- validate required controlled-document metadata before accepting file bytes
- verify all create-only lifecycle, revision, number-registry, and audit-ledger schema dependencies
- return actionable storage/readiness errors instead of collapsing them into `CONTROLLED_DOCUMENT_OPERATION_FAILED`
- remove a newly uploaded central-storage object when the database transaction fails
- add focused readiness and lifecycle regression coverage

## Why

Creating a document in the Master Document Register could fail with the same generic HTTP 500 for storage, partial-schema, or audit-ledger failures. The route also uploaded the file before validating the database transaction, leaving a possible orphan object after a failed create.

This keeps controlled-document creation fail closed while making the real dependency failure visible and keeping central storage consistent.

## Validation

- `23` focused controlled-document tests passed
- `git diff --check` passed
- `git merge-tree --write-tree origin/main HEAD` passed
- repository-wide TypeScript check was attempted but timed out after 124 seconds without a result

## Deployment boundary

This PR does not claim the production issue is corrected until it is merged, republished, and verified through the live Master Document Register create route.