### PR TITLE
Save P1 schedules before print preparation

### DIFF
--- a/client/src/__tests__/layupSchedulePreview.component.test.tsx
+++ b/client/src/__tests__/layupSchedulePreview.component.test.tsx
@@ -31,12 +31,22 @@ describe('LayupSchedulePreview printing', () => {
 
   it('saves a newly generated schedule before writing printable content', async () => {
     const writes: string[] = [];
+    let printWindow: {
+      document: {
+        write: ReturnType<typeof vi.fn>;
+        open: ReturnType<typeof vi.fn>;
+        close: ReturnType<typeof vi.fn>;
+      };
+      close: ReturnType<typeof vi.fn>;
+      print: ReturnType<typeof vi.fn>;
+      onload: null | (() => void);
+    };
     const printDocument = {
       write: vi.fn((value: string) => writes.push(value)),
       open: vi.fn(),
-      close: vi.fn(),
+      close: vi.fn(() => expect(printWindow.onload).toBeTypeOf('function')),
     };
-    const printWindow = {
+    printWindow = {
       document: printDocument,
       close: vi.fn(),
       print: vi.fn(),
@@ -112,6 +122,43 @@ describe('LayupSchedulePreview printing', () => {
     await waitFor(() => expect(onApprove).toHaveBeenCalledTimes(1));
     expect(alertSpy).toHaveBeenCalledWith(
       'Schedule saved. Please allow popups, then reprint it from Schedule History.'
+    );
+  });
+
+  it('still saves the schedule when barcode preparation fails', async () => {
+    const printWindow = {
+      document: { write: vi.fn(), open: vi.fn(), close: vi.fn() },
+      close: vi.fn(),
+      print: vi.fn(),
+      onload: null,
+    };
+    vi.spyOn(window, 'open').mockReturnValue(printWindow as unknown as Window);
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const onApprove = vi.fn().mockResolvedValue({ entriesSaved: 1 });
+
+    render(
+      <LayupSchedulePreview
+        open
+        onClose={vi.fn()}
+        scheduledItems={scheduledItems}
+        overflowItems={[]}
+        weekStart="2026-07-20"
+        totalItems={1}
+        onApprove={onApprove}
+        isApproving={false}
+      />
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector('svg rect')).not.toBeNull()
+    );
+    document.querySelector('svg')?.replaceChildren();
+    fireEvent.click(screen.getByTestId('button-print-schedule'));
+
+    await waitFor(() => expect(onApprove).toHaveBeenCalledTimes(1));
+    expect(printWindow.close).toHaveBeenCalledTimes(1);
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Schedule saved, but the barcode was not ready to print. Reprint it from Schedule History.'
     );
   });
 });

--- a/client/src/components/LayupSchedulePreview.tsx
+++ b/client/src/components/LayupSchedulePreview.tsx
@@ -130,19 +130,19 @@ export function LayupSchedulePreview({
   }, [scheduleBarcode, open]);
 
   const handlePrint = async () => {
-    // Ensure barcode is fully rendered before printing
-    if (!barcodeRef.current) {
-      console.warn('⚠️ Barcode not ready for printing');
-      alert('Please wait a moment for the barcode to load, then try again.');
-      return;
-    }
-
-    // Wait a bit to ensure SVG is fully rendered
-    await new Promise(resolve => setTimeout(resolve, 100));
-
-    // Convert SVG barcode to data URL
+    // Best-effort print preparation must not prevent a newly generated
+    // schedule from being committed. Capture any barcode failure now, then
+    // save before reporting the recoverable print problem.
     let barcodeDataURL = '';
+    let barcodeError: unknown = null;
     try {
+      if (!barcodeRef.current) {
+        throw new Error('Barcode not ready for printing');
+      }
+
+      // Wait a bit to ensure SVG is fully rendered
+      await new Promise(resolve => setTimeout(resolve, 100));
+
       const svgElement = barcodeRef.current;
       
       // Check if the SVG has content
@@ -164,12 +164,8 @@ export function LayupSchedulePreview({
       console.log('📊 Barcode data URL length:', barcodeDataURL.length);
     } catch (error) {
       console.error('❌ Error converting barcode:', error);
-      alert('Error generating barcode for printing. Please try again.');
-      return;
+      barcodeError = error;
     }
-    
-    // Generate the HTML content
-    const printHTML = generatePrintHTML(barcodeDataURL);
 
     // Open the window during the user's click so popup blockers allow it. A
     // newly generated schedule must be committed before anything is printed;
@@ -194,6 +190,16 @@ export function LayupSchedulePreview({
       }
     }
 
+    if (barcodeError) {
+      printWindow?.close();
+      alert(
+        isHistoricalReprint
+          ? 'The barcode is not ready for printing. Please close and reopen the saved schedule, then try again.'
+          : 'Schedule saved, but the barcode was not ready to print. Reprint it from Schedule History.'
+      );
+      return;
+    }
+
     // Popup blocking must never prevent the approved schedule from being
     // persisted. The user can enable popups and reprint the saved schedule
     // from history without recreating or progressing the schedule again.
@@ -201,18 +207,23 @@ export function LayupSchedulePreview({
       alert('Schedule saved. Please allow popups, then reprint it from Schedule History.');
       return;
     }
-    
+
+    // Generate the HTML only after the schedule save has succeeded.
+    const printHTML = generatePrintHTML(barcodeDataURL);
+
     printWindow.document.open();
     printWindow.document.write(printHTML);
-    printWindow.document.close();
-    
-    // Wait for content to load, then print
+
+    // Register before closing the document. A fast popup can finish loading
+    // synchronously during close(), which previously lost the event and never
+    // opened the browser print dialog.
     printWindow.onload = () => {
       setTimeout(() => {
         printWindow.print();
         // Don't auto-close so user can save as PDF
       }, 250);
     };
+    printWindow.document.close();
   };
 
   const generatePrintHTML = (barcodeDataURL: string) => {


### PR DESCRIPTION
## What changed

- save newly generated P1 layup schedules even when barcode preparation fails
- register the popup load handler before closing the print document so fast-loading windows still open the print dialog
- add regression coverage for both barcode-preparation failure and print-event ordering

## Root cause

The Save & Print handler treated barcode serialization as a prerequisite for schedule persistence. If the SVG was unavailable or empty, the handler returned before calling the schedule save mutation. Separately, the popup load handler was assigned after `document.close()`, allowing a fast popup to finish loading before the print callback existed.

## User impact

Selected P1 queue items now retain their approved schedule when printing cannot be prepared immediately. A successful print preparation reliably triggers the browser print dialog, while recoverable barcode failures direct the user to reprint the saved schedule from Schedule History.

## Validation

- `git diff --check origin/main...HEAD` passed
- focused Vitest test was attempted but could not run because the isolated worktree lacked dependencies and package-registry access timed out
