### PR TITLE
Show R&D project names in Design Control links

### DIFF
--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Link } from 'wouter';
 import { DESIGN_CONTROL_WORKFLOW } from '@shared/designControlWorkflow';
 import {
   DESIGN_CONTROL_PHASES,
@@ -79,6 +80,7 @@ type Detail = {
   validation: LiveRow[];
   changes: LiveRow[];
   releaseGate?: { status?: string; blockers?: unknown[] } | null;
+  linkedProject?: { id: string; projectName: string } | null;
 };
 
 function displayStatus(value?: string | null) {
@@ -227,6 +229,8 @@ export function DesignControlWorkspace({
   }
 
   const detail = detailQuery.data;
+  const linkedProjectName =
+    detail.linkedProject?.projectName || 'R&D project';
   const stepByKey = new Map(detail.steps.map((step) => [step.stepKey, step]));
   const selectedDefinition =
     DESIGN_CONTROL_WORKFLOW.find((step) => step.key === activeStep) ??
@@ -308,6 +312,15 @@ export function DesignControlWorkspace({
                 Record {detail.record.recordNumber || detail.record.id} ·
                 generation {detail.record.recordVersion || 1}
               </CardDescription>
+              <p className="mt-1 text-sm">
+                R&amp;D project:{' '}
+                <Link
+                  href={`/design/rd-projects?projectId=${encodeURIComponent(projectId)}`}
+                  className="font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  {linkedProjectName}
+                </Link>
+              </p>
             </div>
             <div className="flex flex-wrap gap-2">
               <Badge variant="outline">

--- a/server/__tests__/designControlWorkspacePhase11.test.ts
+++ b/server/__tests__/designControlWorkspacePhase11.test.ts
@@ -104,6 +104,14 @@ describe('Phase 11 unified Design Control workspace', () => {
     expect(route).not.toContain('p2Projects');
   });
 
+  it('labels the R&D project link with the authoritative project name', () => {
+    expect(route).toContain('linkedProject: linkedProject[0] ?? null');
+    expect(route).toContain('projectName: rdProjects.projectName');
+    expect(workspace).toContain('detail.linkedProject?.projectName');
+    expect(workspace).toContain('{linkedProjectName}');
+    expect(workspace).toContain('/design/rd-projects?projectId=');
+  });
+
   it('provides bounded server pagination and filtering', () => {
     expect(route).toMatch(/Math\.min\(\s*50/);
     expect(route).toContain('.limit(pageSize)');

--- a/server/src/routes/qmsDesignControl.ts
+++ b/server/src/routes/qmsDesignControl.ts
@@ -822,6 +822,7 @@ router.get(
         validation,
         changes,
         releaseGate,
+        linkedProject,
       ] = await Promise.all([
         getSteps(record.id),
         db
@@ -852,6 +853,16 @@ router.get(
           .select()
           .from(designControlReleaseGate)
           .where(eq(designControlReleaseGate.recordId, record.id)),
+        record.projectId
+          ? db
+              .select({
+                id: rdProjects.id,
+                projectName: rdProjects.projectName,
+              })
+              .from(rdProjects)
+              .where(eq(rdProjects.id, record.projectId))
+              .limit(1)
+          : Promise.resolve([]),
       ]);
 
       res.json({
@@ -864,6 +875,7 @@ router.get(
         validation,
         changes,
         releaseGate: releaseGate[0] ?? null,
+        linkedProject: linkedProject[0] ?? null,
       });
     } catch (error) {
       console.error('[qms-design-control] Failed to load record', error);


### PR DESCRIPTION
## Summary
- return the authoritative linked R&D project identity with Design Control record details
- label the R&D project link with the project name instead of its UUID
- preserve direct-link behavior with a safe generic fallback when the linked project cannot be resolved

## Validation
- git diff --check
- focused source regression coverage added
- local Vitest execution blocked because this worktree's node_modules is incomplete (vitest module missing); GitHub checks are the certification gate