### PR TITLE
Simplify Design Control phase navigation

### DIFF
--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -229,8 +229,7 @@ export function DesignControlWorkspace({
   }
 
   const detail = detailQuery.data;
-  const linkedProjectName =
-    detail.linkedProject?.projectName || 'R&D project';
+  const linkedProjectName = detail.linkedProject?.projectName || 'R&D project';
   const stepByKey = new Map(detail.steps.map((step) => [step.stepKey, step]));
   const selectedDefinition =
     DESIGN_CONTROL_WORKFLOW.find((step) => step.key === activeStep) ??

--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -269,6 +269,11 @@ export function DesignControlWorkspace({
       return 'Not started';
     return 'In progress';
   };
+  const phaseEntryStep = (stepKeys: readonly string[]) =>
+    stepKeys.find((key) => {
+      const status = stepByKey.get(key)?.status?.toLowerCase();
+      return !['approved', 'complete', 'completed'].includes(status || '');
+    }) ?? stepKeys[stepKeys.length - 1];
   const firstIncompleteDefinition =
     DESIGN_CONTROL_WORKFLOW.find((definition) => {
       const status = stepByKey.get(definition.key)?.status?.toLowerCase();
@@ -405,7 +410,7 @@ export function DesignControlWorkspace({
                   className="w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   onClick={() => {
                     setActiveTab('lifecycle');
-                    setActiveStep(phase.stepKeys[0]);
+                    setActiveStep(phaseEntryStep(phase.stepKeys));
                   }}
                   type="button"
                 >
@@ -425,9 +430,8 @@ export function DesignControlWorkspace({
             ))}
           </ol>
           <p className="mt-3 text-sm">
-            Six plain-language phases organize the work. All 12 controlled
-            lifecycle stages, approvals, versions, and audit events remain
-            intact underneath.
+            Follow the six phases in order. Controlled approvals, versions, and
+            audit history are preserved automatically.
           </p>
           <p className="mt-3 text-sm text-muted-foreground">
             Revision A establishes the initial baseline. Released designs use
@@ -455,9 +459,13 @@ export function DesignControlWorkspace({
 
         <TabsContent
           value="lifecycle"
-          className="grid gap-4 lg:grid-cols-[19rem_1fr]"
+          className="space-y-4"
         >
-          <nav className="space-y-2" aria-label="Design Control steps">
+          <nav
+            className="hidden"
+            aria-hidden="true"
+            aria-label="Controlled Design Control checkpoints"
+          >
             {DESIGN_CONTROL_WORKFLOW.map((definition) => {
               const step = stepByKey.get(definition.key);
               const selected = definition.key === activeStep;
@@ -489,9 +497,17 @@ export function DesignControlWorkspace({
           </nav>
           <Card>
             <CardHeader>
-              <CardTitle>
-                {selectedDefinition.order}. {selectedDefinition.title}
-              </CardTitle>
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div>
+                  <p className="text-sm font-medium text-primary">
+                    Phase {activePhase.order}: {activePhase.title}
+                  </p>
+                  <CardTitle>{selectedDefinition.title}</CardTitle>
+                </div>
+                <Badge variant="outline">
+                  Controlled checkpoint {selectedDefinition.order} of 12
+                </Badge>
+              </div>
               <CardDescription>{selectedDefinition.purpose}</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/server/__tests__/designControlWorkspacePhase11.test.ts
+++ b/server/__tests__/designControlWorkspacePhase11.test.ts
@@ -68,11 +68,17 @@ describe('Phase 11 unified Design Control workspace', () => {
       expect(phases).toContain(`'${step}'`);
     }
     expect(workspace).toContain('Six Design Control phases');
-    expect(workspace).toContain('All 12 controlled');
+    expect(workspace).toContain('Controlled approvals, versions, and');
     expect(workspace).toContain('Design phases');
     expect(workspace).toContain('Next required action');
     expect(workspace).toContain('Continue Design');
-    expect(workspace).toContain('setActiveStep(phase.stepKeys[0])');
+    expect(workspace).toContain('setActiveStep(phaseEntryStep(phase.stepKeys))');
+    expect(workspace).toContain(
+      'Controlled checkpoint {selectedDefinition.order} of 12'
+    );
+    expect(workspace).toContain(
+      'aria-label="Controlled Design Control checkpoints"'
+    );
   });
 
   it('gives every phase the same guided, correctable layout', () => {


### PR DESCRIPTION
## Summary
- make the six guided phases the only visible workflow navigation
- remove the competing twelve-checkpoint sidebar from the interface
- resume the first incomplete controlled checkpoint when a phase is selected
- retain checkpoint numbering inside the selected phase for audit context
- correct the Prettier diagnostic identified by the prior certification run

## Validation
- git diff --check
- focused source regression assertions updated
- local Vitest remains unavailable because this worktree's node_modules does not contain the Vitest module; GitHub certification is the execution gate