### PR TITLE
Show people in Design Control assignee fields

### DIFF
--- a/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
+++ b/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
@@ -41,12 +41,22 @@ describe('unified Design Control step editor', () => {
     expect(presentationFor('1', 'Design type').kind).toBe('select');
     expect(presentationFor('1', 'Target manufacturing date').kind).toBe('date');
     expect(presentationFor('1', 'Responsible engineer').kind).toBe('person');
+    expect(presentationFor('1', 'Responsible engineer').help).toMatch(
+      /accountable person/i
+    );
     expect(presentationFor('2', 'Approval roles').kind).toBe('role');
     expect(presentationFor('9', 'Evidence attachment').kind).toBe('attachment');
     expect(presentationFor('9', 'Pass/fail').options).toEqual(['PASS', 'FAIL']);
     expect(presentationFor('9', 'Engineering disposition').kind).not.toBe(
       'person'
     );
+
+    const editor = source(
+      'client/src/features/design-control/DesignControlStepEditor.tsx'
+    );
+    expect(editor).toContain('Select a person...');
+    expect(editor).toContain('{person.label}');
+    expect(editor).not.toContain('<datalist');
   });
 
   it('opens normalized records only where an authoritative register exists', () => {

--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -403,6 +403,26 @@ export function DesignControlStepEditor({
                     value={value}
                     onChange={(event) => update(event.target.value)}
                   />
+                ) : presentation.kind === 'person' && people.length > 0 ? (
+                  <select
+                    aria-describedby={`${fieldId}-help`}
+                    aria-invalid={missing}
+                    className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                    id={fieldId}
+                    value={value}
+                    onChange={(event) => update(event.target.value)}
+                  >
+                    <option value="">Select a person...</option>
+                    {value &&
+                      !people.some((person) => person.value === value) && (
+                        <option value={value}>Existing person: {value}</option>
+                      )}
+                    {people.map((person) => (
+                      <option key={person.label} value={person.value}>
+                        {person.label}
+                      </option>
+                    ))}
+                  </select>
                 ) : presentation.kind === 'select' ||
                   presentation.kind === 'role' ? (
                   <select
@@ -429,11 +449,6 @@ export function DesignControlStepEditor({
                       aria-describedby={`${fieldId}-help`}
                       aria-invalid={missing}
                       id={fieldId}
-                      list={
-                        presentation.kind === 'person'
-                          ? `${fieldId}-people`
-                          : undefined
-                      }
                       placeholder={presentation.placeholder}
                       type={
                         presentation.kind === 'date' &&
@@ -444,15 +459,6 @@ export function DesignControlStepEditor({
                       value={value}
                       onChange={(event) => update(event.target.value)}
                     />
-                    {presentation.kind === 'person' && people.length > 0 && (
-                      <datalist id={`${fieldId}-people`}>
-                        {people.map((person) => (
-                          <option key={person.label} value={person.value}>
-                            {person.label}
-                          </option>
-                        ))}
-                      </datalist>
-                    )}
                   </>
                 )}
                 <p

--- a/client/src/features/design-control/designControlFieldPresentation.ts
+++ b/client/src/features/design-control/designControlFieldPresentation.ts
@@ -114,7 +114,8 @@ export function getDesignControlFieldPresentation(
   if (personPattern.test(label)) {
     return {
       kind: 'person',
-      help: 'Select an active Design Control project assignment when available, or enter the accountable person.',
+      help: 'Select the accountable person assigned to this Design Control project.',
+      placeholder: "Enter the accountable person's name",
     };
   }
   if (rolePattern.test(label)) {


### PR DESCRIPTION
## Summary
- replace the project-assignment datalist with an explicit person selector
- show each assigned user's name and Design Control role
- use manual accountable-person entry only when no assigned users are available
- remove misleading project-centric field instructions

## Validation
- git diff --check
- focused source regression assertions updated
- GitHub certification is the execution gate because this worktree's local Vitest module is unavailable