### PR TITLE
Fix controlled document end-to-end workflow

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -210,6 +210,45 @@ type DesignControlTemplateReconciliationView = {
   }>;
 };
 
+type ControlledDocumentView = ControlledDocument & {
+  fileReferenceAvailable?: boolean;
+  currentRevisionId?: string | null;
+  currentReleasedRevisionId?: string | null;
+  workingDraftRevisionId?: string | null;
+  releasedRevisionVersion?: string | null;
+  releasedRevisionMediaType?: string | null;
+  releasedRevisionFileName?: string | null;
+  releasedRevisionAvailable?: boolean;
+  releasedRevisionIsPdf?: boolean;
+  currentRevisionVersion?: string | null;
+  currentRevisionFileName?: string | null;
+  currentRevisionChecksumStatus?: string | null;
+  currentRevisionHasFile?: boolean;
+  currentRevisionIsPdf?: boolean;
+  workingDraftRevisionVersion?: string | null;
+  compatibilityStatus?: string | null;
+  phase2ProspectiveRelease?: boolean;
+};
+
+type DocumentVersionHistoryView = DocumentVersionHistory & {
+  lifecycleStatus?: string | null;
+  fileChecksum?: string | null;
+  checksumStatus?: string | null;
+  fileReferenceAvailable?: boolean;
+  fileName?: string | null;
+  mediaType?: string | null;
+};
+
+type ControlledDocumentPhase2Availability = {
+  configured: boolean;
+  enabled: boolean;
+  schemaReady: boolean;
+  workflow: 'REGISTER_APPROVE_RELEASE';
+  requiredMigration: string;
+  blocker: string | null;
+  missingObjects?: string[];
+};
+
 export default function MasterDocumentRegister() {
   const { can } = usePermissions();
   const [searchQuery, setSearchQuery] = useState('');
@@ -224,7 +263,7 @@ export default function MasterDocumentRegister() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [selectedDocument, setSelectedDocument] =
-    useState<ControlledDocument | null>(null);
+    useState<ControlledDocumentView | null>(null);
   const [createNewVersion, setCreateNewVersion] = useState(false);
   const [newDocumentDepartment, setNewDocumentDepartment] = useState('');
   const [newDocumentType, setNewDocumentType] = useState('');
@@ -243,9 +282,9 @@ export default function MasterDocumentRegister() {
   const { toast } = useToast();
 
   // Fetch controlled documents
-  const { data: documents = [], isLoading } = useQuery<ControlledDocument[]>({
-    queryKey: ['/api/controlled-documents'],
-  });
+  const { data: documents = [], isLoading } = useQuery<
+    ControlledDocumentView[]
+  >({ queryKey: ['/api/controlled-documents'] });
 
   const {
     data: designControlTemplates = [],
@@ -262,13 +301,25 @@ export default function MasterDocumentRegister() {
   const { data: session } = useQuery<{ username: string; role: string }>({
     queryKey: ['/api/auth/session'],
   });
-  const { data: phase2Availability } = useQuery<{ enabled: boolean }>({
+  const {
+    data: phase2Availability,
+    isLoading: isPhase2AvailabilityLoading,
+    isError: isPhase2AvailabilityError,
+  } = useQuery<ControlledDocumentPhase2Availability>({
     queryKey: ['/api/controlled-documents/phase2/availability'],
   });
+  const phase2ModeKnown =
+    !isPhase2AvailabilityLoading &&
+    !isPhase2AvailabilityError &&
+    Boolean(phase2Availability);
   const phase2Enabled = phase2Availability?.enabled === true;
+  const legacyLifecycleEnabled =
+    phase2ModeKnown && phase2Availability?.configured === false;
+  const phase2Blocked =
+    phase2Availability?.configured === true && !phase2Enabled;
 
   const { data: versionHistory = [], isLoading: isHistoryLoading } = useQuery<
-    DocumentVersionHistory[]
+    DocumentVersionHistoryView[]
   >({
     queryKey: ['/api/controlled-documents', selectedDocument?.id, 'versions'],
     enabled: isHistoryDialogOpen && Boolean(selectedDocument?.id),
@@ -431,18 +482,11 @@ export default function MasterDocumentRegister() {
     return matchesSearch && matchesDepartment && matchesType && matchesStatus;
   });
 
-  const getStatusBadge = (doc: ControlledDocument) => {
-    /* eslint-disable prettier/prettier -- Linux CI and Windows disagree on this union layout. */
-    const compatibilityStatus = (doc as any).compatibilityStatus as
-      string | undefined;
-    /* eslint-enable prettier/prettier */
+  const getStatusBadge = (doc: ControlledDocumentView) => {
+    const compatibilityStatus = doc.compatibilityStatus ?? undefined;
     if (
       phase2Enabled &&
-      (
-        doc as ControlledDocument & {
-          phase2ProspectiveRelease?: boolean;
-        }
-      ).phase2ProspectiveRelease === true &&
+      doc.phase2ProspectiveRelease === true &&
       doc.lifecycleStatus === 'RELEASED'
     ) {
       return (
@@ -523,7 +567,6 @@ export default function MasterDocumentRegister() {
         );
       case 'APPROVED':
       case 'approved':
-      case 'approved':
         return (
           <Badge
             variant="default"
@@ -575,17 +618,20 @@ export default function MasterDocumentRegister() {
     })}`;
   };
 
-  const isPdfDocument = (doc: ControlledDocument) =>
-    Boolean(doc.filePath?.toLowerCase().endsWith('.pdf'));
-
-  const getFileTypeLabel = (filePath?: string | null) => {
-    if (!filePath) return 'No file';
-    if (/^https?:\/\//i.test(filePath)) return 'External reference';
-    const extension = filePath.split(/[?#]/)[0].split('.').pop()?.toUpperCase();
+  const getReleasedFileTypeLabel = (doc: ControlledDocumentView) => {
+    if (!doc.currentReleasedRevisionId) return 'Not released';
+    if (!doc.releasedRevisionAvailable) return 'Released file unavailable';
+    const extension = doc.releasedRevisionFileName
+      ?.split(/[?#]/)[0]
+      .split('.')
+      .pop()
+      ?.toUpperCase();
     if (extension === 'PDF') return 'PDF';
     if (['DOC', 'DOCX'].includes(extension || '')) return 'Word document';
     if (['XLS', 'XLSX'].includes(extension || '')) return 'Excel workbook';
-    return extension ? `${extension} file` : 'Original file';
+    return extension || doc.releasedRevisionMediaType
+      ? `${extension || doc.releasedRevisionMediaType} file`
+      : 'Released file';
   };
 
   const getAuthHeaders = (): Record<string, string> => {
@@ -933,6 +979,16 @@ export default function MasterDocumentRegister() {
       id: string;
       effectiveDate: string;
     }) => {
+      if (!phase2ModeKnown) {
+        throw new Error(
+          'The controlled-document workflow mode could not be verified. Approval was not attempted.'
+        );
+      }
+      if (phase2Blocked) {
+        throw new Error(
+          `Approve-and-release is configured but not schema-ready. Apply and certify ${phase2Availability?.requiredMigration}.`
+        );
+      }
       return await apiRequest(
         `/api/controlled-documents/${id}/${phase2Enabled ? 'approve-and-release' : 'decision'}`,
         {
@@ -1128,6 +1184,44 @@ export default function MasterDocumentRegister() {
               )}
             </div>
           </div>
+          {isPhase2AvailabilityLoading ? (
+            <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+              Verifying the controlled-document workflow mode. Lifecycle actions
+              remain unavailable until verification completes.
+            </div>
+          ) : isPhase2AvailabilityError || !phase2Availability ? (
+            <div
+              className="rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900"
+              role="alert"
+            >
+              The controlled-document workflow mode could not be verified.
+              Create remains available, but approval and release actions are
+              fail-closed.
+            </div>
+          ) : phase2Blocked ? (
+            <div
+              className="rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900"
+              role="alert"
+            >
+              Approve-and-release is configured but its certified schema is
+              incomplete. Required migration:{' '}
+              {phase2Availability.requiredMigration}
+              {phase2Availability.missingObjects?.length
+                ? `. Missing: ${phase2Availability.missingObjects.join(', ')}`
+                : ''}
+            </div>
+          ) : phase2Enabled ? (
+            <div className="rounded-md border border-green-300 bg-green-50 px-4 py-3 text-sm text-green-900">
+              Register → Approve and Release is active. Approval targets the
+              exact immutable current revision and releases it atomically.
+            </div>
+          ) : (
+            <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+              Compatibility workflow is active. Submit, Approve, and Release
+              remain separate until the certified Phase 2 activation is
+              authorized.
+            </div>
+          )}
         </div>
 
         {/* Filters */}
@@ -1230,7 +1324,7 @@ export default function MasterDocumentRegister() {
           <CardContent>
             {Boolean(
               designTemplateReconciliation?.conflicts.length ||
-              designTemplateReconciliation?.legacyTemplates.length
+                designTemplateReconciliation?.legacyTemplates.length
             ) && (
               <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
                 <div className="font-medium">
@@ -1528,14 +1622,16 @@ export default function MasterDocumentRegister() {
                         <TableCell className="text-xs">
                           <div>
                             Released:{' '}
-                            {(doc as any).currentReleasedRevisionId
-                              ? doc.currentVersion
+                            {doc.currentReleasedRevisionId
+                              ? doc.releasedRevisionVersion || 'Unknown'
                               : 'None'}
                           </div>
                           <div>
                             Working draft:{' '}
-                            {(doc as any).workingDraftRevisionId
-                              ? doc.currentVersion
+                            {doc.workingDraftRevisionId
+                              ? doc.workingDraftRevisionVersion ||
+                                doc.currentRevisionVersion ||
+                                'Unknown'
                               : 'None'}
                           </div>
                           {(doc as any).numberControlStatus ===
@@ -1569,12 +1665,12 @@ export default function MasterDocumentRegister() {
                         </TableCell>
                         <TableCell>
                           <div className="flex items-center gap-2">
-                            {doc.filePath && (
+                            {doc.releasedRevisionAvailable ? (
                               <>
                                 <span className="text-xs text-muted-foreground">
-                                  {getFileTypeLabel(doc.filePath)}
+                                  {getReleasedFileTypeLabel(doc)}
                                 </span>
-                                {isPdfDocument(doc) && (
+                                {doc.releasedRevisionIsPdf && (
                                   <Badge
                                     variant="outline"
                                     role="button"
@@ -1605,7 +1701,7 @@ export default function MasterDocumentRegister() {
                                   size="sm"
                                   variant="ghost"
                                   className="h-8 w-8 p-0"
-                                  title="Download Original"
+                                  title="Download Released Revision"
                                   disabled={openingDocumentId === doc.id}
                                   onClick={() =>
                                     openDocumentFile(doc, 'download')
@@ -1615,6 +1711,21 @@ export default function MasterDocumentRegister() {
                                   <Download className="h-4 w-4" />
                                 </Button>
                               </>
+                            ) : (
+                              <Badge
+                                variant={
+                                  doc.currentReleasedRevisionId
+                                    ? 'destructive'
+                                    : 'outline'
+                                }
+                                title={
+                                  doc.currentReleasedRevisionId
+                                    ? 'The released revision is not verified and available for controlled use. Use Document File Recovery.'
+                                    : 'A document becomes available for controlled use only after approval and release.'
+                                }
+                              >
+                                {getReleasedFileTypeLabel(doc)}
+                              </Badge>
                             )}
                             <Button
                               size="sm"
@@ -1658,7 +1769,39 @@ export default function MasterDocumentRegister() {
                                   Create Revision
                                 </Button>
                               )}
-                            {!phase2Enabled &&
+                            {!isDesignControlTemplate(doc) &&
+                              doc.currentRevisionId &&
+                              doc.currentRevisionHasFile &&
+                              doc.currentRevisionIsPdf &&
+                              (canApprove ||
+                                can('documents.edit_draft') ||
+                                can('documents.revise')) &&
+                              [
+                                'DRAFT',
+                                'IN_REVIEW',
+                                'APPROVED',
+                                'REJECTED',
+                              ].includes(
+                                String(doc.lifecycleStatus || '').toUpperCase()
+                              ) && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    openDocumentFile(
+                                      doc,
+                                      'view',
+                                      undefined,
+                                      `/api/controlled-documents/${doc.id}/revisions/${doc.currentRevisionId}/view`
+                                    )
+                                  }
+                                  data-testid={`button-preview-revision-${doc.id}`}
+                                >
+                                  <Eye className="mr-1 h-4 w-4" />
+                                  Preview Revision
+                                </Button>
+                              )}
+                            {legacyLifecycleEnabled &&
                               !isDesignControlTemplate(doc) &&
                               can('documents.submit') &&
                               doc.lifecycleStatus === 'DRAFT' && (
@@ -1679,7 +1822,7 @@ export default function MasterDocumentRegister() {
                               canApprove &&
                               ((phase2Enabled &&
                                 doc.lifecycleStatus === 'DRAFT') ||
-                                (!phase2Enabled &&
+                                (legacyLifecycleEnabled &&
                                   doc.lifecycleStatus === 'IN_REVIEW')) && (
                                 <Button
                                   size="sm"
@@ -1716,7 +1859,7 @@ export default function MasterDocumentRegister() {
                                   Reject
                                 </Button>
                               )}
-                            {!phase2Enabled &&
+                            {legacyLifecycleEnabled &&
                               !isDesignControlTemplate(doc) &&
                               can('documents.release') &&
                               doc.lifecycleStatus === 'APPROVED' && (
@@ -2228,9 +2371,9 @@ export default function MasterDocumentRegister() {
                       </div>
                     )}
                   </div>
-                  {selectedDocument.filePath && (
+                  {selectedDocument.currentRevisionFileName && (
                     <p className="text-xs text-gray-500">
-                      Current file: {selectedDocument.filePath.split('/').pop()}
+                      Current file: {selectedDocument.currentRevisionFileName}
                     </p>
                   )}
                 </div>
@@ -2294,7 +2437,13 @@ export default function MasterDocumentRegister() {
                     <div>{selectedDocument.documentName}</div>
                     <div className="font-medium">Version:</div>
                     <div className="font-mono">
-                      {selectedDocument.currentVersion}
+                      {selectedDocument.currentRevisionVersion ||
+                        selectedDocument.currentVersion}
+                    </div>
+                    <div className="font-medium">Checksum:</div>
+                    <div className="font-mono">
+                      {selectedDocument.currentRevisionChecksumStatus ||
+                        'Unknown'}
                     </div>
                     <div className="font-medium">Type:</div>
                     <div>{selectedDocument.documentType}</div>
@@ -2303,6 +2452,44 @@ export default function MasterDocumentRegister() {
                   </div>
                 </CardContent>
               </Card>
+
+              {selectedDocument.currentRevisionId &&
+                selectedDocument.currentRevisionHasFile &&
+                selectedDocument.currentRevisionIsPdf && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full"
+                    onClick={() =>
+                      openDocumentFile(
+                        selectedDocument,
+                        'view',
+                        undefined,
+                        `/api/controlled-documents/${selectedDocument.id}/revisions/${selectedDocument.currentRevisionId}/view`
+                      )
+                    }
+                    data-testid="button-preview-exact-revision"
+                  >
+                    <Eye className="mr-2 h-4 w-4" />
+                    Preview Exact Revision Before Approval
+                  </Button>
+                )}
+
+              {phase2Enabled &&
+                (!selectedDocument.currentRevisionId ||
+                  !selectedDocument.currentRevisionHasFile ||
+                  selectedDocument.currentRevisionChecksumStatus !==
+                    'VERIFIED') && (
+                  <div
+                    className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900"
+                    role="alert"
+                  >
+                    Approval is unavailable until the exact current revision has
+                    immutable EPOCH-managed bytes and a VERIFIED checksum. Use
+                    Document File Recovery when the historical source is
+                    missing.
+                  </div>
+                )}
 
               <div className="space-y-2">
                 <Label htmlFor="effectiveDate">Effective Date *</Label>
@@ -2335,7 +2522,14 @@ export default function MasterDocumentRegister() {
                 </Button>
                 <Button
                   type="submit"
-                  disabled={approveDocumentMutation.isPending}
+                  disabled={
+                    approveDocumentMutation.isPending ||
+                    (phase2Enabled &&
+                      (!selectedDocument.currentRevisionId ||
+                        !selectedDocument.currentRevisionHasFile ||
+                        selectedDocument.currentRevisionChecksumStatus !==
+                          'VERIFIED'))
+                  }
                   className="bg-green-600 hover:bg-green-700"
                   data-testid="button-submit-approve"
                 >
@@ -2395,12 +2589,12 @@ export default function MasterDocumentRegister() {
                         {version.changeDescription || 'No change note recorded'}
                       </TableCell>
                       <TableCell>
-                        {(version as any).lifecycleStatus || version.status}
+                        {version.lifecycleStatus || version.status}
                       </TableCell>
                       <TableCell className="font-mono text-xs">
-                        {(version as any).fileChecksum
-                          ? String((version as any).fileChecksum).slice(0, 12)
-                          : (version as any).checksumStatus || 'Legacy unknown'}
+                        {version.fileChecksum
+                          ? version.fileChecksum.slice(0, 12)
+                          : version.checksumStatus || 'Legacy unknown'}
                       </TableCell>
                       <TableCell>
                         <div className="text-sm">
@@ -2409,24 +2603,6 @@ export default function MasterDocumentRegister() {
                         <div className="text-xs text-gray-500">
                           {version.createdBy}
                         </div>
-                      </TableCell>
-                      <TableCell>
-                        {(version as any).filePath && selectedDocument && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() =>
-                              openDocumentFile(
-                                selectedDocument,
-                                'download',
-                                null,
-                                `/api/controlled-documents/${selectedDocument.id}/revisions/${version.id}/download`
-                              )
-                            }
-                          >
-                            Download Exact Revision
-                          </Button>
-                        )}
                       </TableCell>
                       <TableCell>
                         {version.approvedAt ? (
@@ -2442,6 +2618,45 @@ export default function MasterDocumentRegister() {
                           <span className="text-sm text-gray-500">
                             Not approved
                           </span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {version.fileReferenceAvailable && selectedDocument && (
+                          <div className="flex flex-col gap-2">
+                            {(version.mediaType === 'application/pdf' ||
+                              String(version.fileName || '')
+                                .toLowerCase()
+                                .endsWith('.pdf')) && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() =>
+                                  openDocumentFile(
+                                    selectedDocument,
+                                    'view',
+                                    undefined,
+                                    `/api/controlled-documents/${selectedDocument.id}/revisions/${version.id}/view`
+                                  )
+                                }
+                              >
+                                Preview Exact Revision
+                              </Button>
+                            )}
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                openDocumentFile(
+                                  selectedDocument,
+                                  'download',
+                                  null,
+                                  `/api/controlled-documents/${selectedDocument.id}/revisions/${version.id}/download`
+                                )
+                              }
+                            >
+                              Download Exact Revision
+                            </Button>
+                          </div>
                         )}
                       </TableCell>
                     </TableRow>

--- a/server/__tests__/controlledDocumentPhase1ACompatibility.test.ts
+++ b/server/__tests__/controlledDocumentPhase1ACompatibility.test.ts
@@ -28,13 +28,13 @@ describe('Master Document Register Phase 1A compatibility', () => {
     expect(auth).toContain("code: 'STEP_UP_REQUIRED'");
   });
 
-  it('uses one access-policy evaluator for View, Download, and Exact Revision', () => {
+  it('uses one access-policy evaluator for View, Download, history, and Exact Revision', () => {
     expect(
       route.match(
         /controlledDocumentViewPermission,\s*controlledDocumentAccessPolicy/g
       )
-    ).toHaveLength(3);
-    expect(route).toContain('hasControlledDocumentGrant');
+    ).toHaveLength(8);
+    expect(route).toContain('hasPolicyVaultGrant');
     expect(route).toContain("action: 'denied'");
   });
 
@@ -48,10 +48,12 @@ describe('Master Document Register Phase 1A compatibility', () => {
   });
 
   it('offers inline View only for PDF and labels original file types', () => {
-    expect(client).toContain('{isPdfDocument(doc) && (');
-    expect(client).toContain('getFileTypeLabel');
-    expect(client).toContain('Download Original');
+    expect(client).toContain('{doc.releasedRevisionIsPdf && (');
+    expect(client).toContain('getReleasedFileTypeLabel');
+    expect(client).toContain('Download Released Revision');
+    expect(client).toContain('Preview Exact Revision');
     expect(route).toContain("'UNSUPPORTED_PREVIEW_TYPE'");
+    expect(route).toContain("'PREVIEW_UNAVAILABLE'");
   });
 
   it('returns useful file, access, revision, and reconciliation errors', () => {

--- a/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
+++ b/server/__tests__/controlledDocumentPhase2ApproveRelease.test.ts
@@ -104,12 +104,16 @@ describe('atomic approve-and-release contract', () => {
     expect(routes).toMatch(
       /router\.post\(\s*'\/:id\/approve',[\s\S]{0,400}requireLegacyLifecycle[\s\S]{0,200}requireStepUp\(\)/
     );
+    expect(routes).toMatch(
+      /'\/phase2\/availability'[\s\S]*assertControlledDocumentPhase2SchemaReady\(\)/
+    );
+    expect(routes).toContain('blocker: error.code');
   });
 });
 
 describe('truthful gated UI', () => {
   it('removes routine submit and release actions only when Phase 2 is enabled', () => {
-    expect(client).toContain('!phase2Enabled &&');
+    expect(client).toContain('legacyLifecycleEnabled &&');
     expect(client).toContain(
       "phase2Enabled ? 'approve-and-release' : 'decision'"
     );
@@ -121,6 +125,12 @@ describe('truthful gated UI', () => {
     expect(client).toContain('Released — approved and available for use');
     expect(client).toContain('Rejected — correction required');
     expect(client).toContain("? 'Approve and Release'");
+    expect(client).toContain('phase2ModeKnown');
+    expect(client).toContain('legacyLifecycleEnabled');
+    expect(client).toContain(
+      'The controlled-document workflow mode could not be verified. Approval was not attempted.'
+    );
+    expect(client).toContain('Register → Approve and Release is active.');
     expect(client).toContain('Historical/legacy — retained');
   });
 });

--- a/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
+++ b/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
@@ -57,10 +57,39 @@ describe('Master Document Register released-revision access', () => {
   });
 
   it('requires lifecycle permission for exact draft and review revision bytes', () => {
-    expect(route).toContain('assertExactRevisionPermission(actor, revision)');
-    expect(route).toContain("['documents.edit_draft', 'documents.revise']");
+    expect(route).toContain(
+      'assertExactRevisionPermission(actor, state.document, revision)'
+    );
+    expect(route).toContain("'documents.edit_draft'");
+    expect(route).toContain("'documents.revise'");
     expect(route).toContain("['documents.approve', 'documents.release']");
+    expect(route).toContain('phase2CurrentApprovalCandidate');
+    expect(route).toContain("'documents.approve'");
     expect(route).toContain("'DRAFT_REVISION_ACCESS_DENIED'");
+  });
+
+  it('provides an authorized checksum-verified exact-revision preview for approvers', () => {
+    expect(route).toContain("'/:id/revisions/:revisionId/view'");
+    expect(route).toContain("exactRevisionFileHandler('view')");
+    expect(route).toContain("exactRevisionFileHandler('download')");
+    expect(route).toContain("mode === 'view'");
+    expect(route).toMatch(
+      /mode === 'view'[\s\S]*addControlledDocumentFooter\([\s\S]*state\.document,[\s\S]*revision/
+    );
+    expect(route).toContain('action: mode');
+    expect(route).toContain("'PREVIEW_UNAVAILABLE'");
+    expect(client).toContain('Preview Exact Revision Before Approval');
+  });
+
+  it('does not expose draft revision metadata through general document history', () => {
+    expect(route).toContain('authorizedRevisionHistory');
+    expect(route).toMatch(
+      /'\/:id\/versions'[\s\S]*controlledDocumentViewPermission,[\s\S]*controlledDocumentAccessPolicy/
+    );
+    expect(route).toMatch(
+      /'\/:id\/revisions',[\s\S]*controlledDocumentViewPermission,[\s\S]*controlledDocumentAccessPolicy/
+    );
+    expect(route).toContain('visibleRevisionIds.has(row.revisionId)');
   });
 
   it('centralizes restricted, explicit-grant, and admin-only enforcement', () => {
@@ -68,15 +97,36 @@ describe('Master Document Register released-revision access', () => {
       route.match(
         /controlledDocumentViewPermission,\s*controlledDocumentAccessPolicy/g
       )
-    ).toHaveLength(3);
+    ).toHaveLength(8);
+    expect(route).toContain('canAccessControlledDocument');
     expect(route).toContain("accessRule === 'explicit_grant'");
-    expect(route).toContain("classification === 'restricted'");
-    expect(route).toContain("classification === 'classified'");
-    expect(route).toContain("accessRule !== 'admin_only'");
-    expect(route).toContain('hasControlledDocumentGrant');
+    expect(route).toContain(
+      "['restricted', 'classified', 'cui', 'itar'].includes(classification)"
+    );
+    expect(route).toContain("if (accessRule === 'admin_only') return false");
+    expect(route).toContain('hasPolicyVaultGrant');
     expect(route).not.toContain(
       "requirePermission('documents.view'), requireStepUp(), async"
     );
+  });
+
+  it('drives normal controlled-use actions from released revision readiness, not document-level filePath', () => {
+    expect(route).toContain('releasedRevisionAvailable: releasedVerified');
+    expect(route).toContain('releasedRevisionVersion: released?.versionNumber');
+    expect(route).toContain('workingDraftRevisionVersion:');
+    expect(client).toContain('doc.releasedRevisionAvailable');
+    expect(client).toContain('doc.releasedRevisionVersion');
+    expect(client).not.toContain('{doc.filePath && (');
+  });
+
+  it('redacts internal file references from viewer metadata responses', () => {
+    expect(route).toContain('controlledDocumentMetadata');
+    expect(route).toContain('controlledRevisionMetadata');
+    expect(route).toMatch(/const \{ filePath, \.\.\.metadata \} = document/);
+    expect(route).toMatch(/const \{ filePath, \.\.\.metadata \} = revision/);
+    expect(route).toContain('fileReferenceAvailable: Boolean(filePath)');
+    expect(client).not.toContain('selectedDocument.filePath');
+    expect(client).not.toContain('version.filePath');
   });
 
   it('verifies the selected revision checksum before recording allowed access', () => {

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -179,11 +179,34 @@ const requireAuth = async (req: Request, res: Response, next: any) => {
 router.get(
   '/phase2/availability',
   requireAuth,
-  (_req: Request, res: Response) => {
-    res.json({
-      enabled: isControlledDocumentPhase2Enabled(),
-      workflow: 'REGISTER_APPROVE_RELEASE',
-    });
+  async (_req: Request, res: Response) => {
+    const configured = isControlledDocumentPhase2Enabled();
+    try {
+      await assertControlledDocumentPhase2SchemaReady();
+      return res.json({
+        configured,
+        enabled: configured,
+        schemaReady: true,
+        workflow: 'REGISTER_APPROVE_RELEASE',
+        requiredMigration:
+          '0256_controlled_document_atomic_approval_release.sql',
+        blocker: configured ? null : 'CONTROLLED_DOCUMENT_PHASE2_DISABLED',
+      });
+    } catch (error) {
+      if (error instanceof ControlledDocumentSchemaNotReadyError) {
+        return res.json({
+          configured,
+          enabled: false,
+          schemaReady: false,
+          workflow: 'REGISTER_APPROVE_RELEASE',
+          requiredMigration:
+            '0256_controlled_document_atomic_approval_release.sql',
+          blocker: error.code,
+          missingObjects: error.missingObjects,
+        });
+      }
+      throw error;
+    }
   }
 );
 
@@ -305,6 +328,33 @@ const verifyStoredRevision = async (
 type ControlledDocumentRecord = typeof controlledDocuments.$inferSelect;
 type ControlledRevisionRecord = typeof documentVersionHistory.$inferSelect;
 
+const controlledDocumentMetadata = (document: ControlledDocumentRecord) => {
+  const { filePath, ...metadata } = document;
+  return {
+    ...metadata,
+    fileReferenceAvailable: Boolean(filePath),
+  };
+};
+
+const controlledRevisionMetadata = (revision: ControlledRevisionRecord) => {
+  const { filePath, ...metadata } = revision;
+  return {
+    ...metadata,
+    fileReferenceAvailable: Boolean(filePath),
+  };
+};
+
+const controlledDocumentStateMetadata = (
+  state: Awaited<ReturnType<typeof getControlledDocumentState>>
+) => ({
+  ...state,
+  document: controlledDocumentMetadata(state.document),
+  currentRevision: state.currentRevision
+    ? controlledRevisionMetadata(state.currentRevision)
+    : null,
+  revisions: state.revisions.map(controlledRevisionMetadata),
+});
+
 const recordControlledDocumentDenial = async (
   req: Request,
   documentId: string,
@@ -327,62 +377,9 @@ const recordControlledDocumentDenial = async (
 const isPrivilegedDocumentActor = (actor: { role: string }) =>
   actor.role === 'ADMIN' || actor.role === 'OWNER';
 
-const hasControlledDocumentGrant = async (
-  documentId: string,
-  actor: { username: string; role: string }
-) => {
-  const result = await pool.query<{ id: number }>(
-    `SELECT id FROM vault_access_grants WHERE document_id = $1 AND (
-       (grantee_type = 'user' AND grantee_name = $2)
-       OR (grantee_type = 'role' AND grantee_name = $3)
-     ) LIMIT 1`,
-    [documentId, actor.username, actor.role]
-  );
-  return result.rows.length > 0;
-};
-
-const authorizeControlledDocumentAccess = async (
-  req: Request,
-  document: ControlledDocumentRecord
-) => {
-  const actor = lifecycleActor(req);
-  if (isPrivilegedDocumentActor(actor)) return actor;
-
-  const classification = String(
-    document.classification || 'internal'
-  ).toLowerCase();
-  const accessRule = String(
-    document.accessRule || 'authenticated'
-  ).toLowerCase();
-  const grantRequired =
-    accessRule === 'explicit_grant' ||
-    classification === 'restricted' ||
-    classification === 'classified';
-  const allowed =
-    accessRule !== 'admin_only' &&
-    (!grantRequired || (await hasControlledDocumentGrant(document.id, actor)));
-
-  if (!allowed) {
-    await recordControlledDocumentDenial(
-      req,
-      document.id,
-      actor,
-      requestEvidence(req).ipAddress ?? 'unknown'
-    );
-    throw new ControlledDocumentError(
-      403,
-      'CONTROLLED_DOCUMENT_ACCESS_DENIED',
-      accessRule === 'admin_only'
-        ? 'This document is restricted to administrators and owners'
-        : 'An explicit vault grant is required to access this document',
-      { classification, accessRule }
-    );
-  }
-  return actor;
-};
-
 const assertExactRevisionPermission = async (
   actor: { id: number; role: string },
+  document: ControlledDocumentRecord,
   revision: ControlledRevisionRecord
 ) => {
   if (isPrivilegedDocumentActor(actor)) return;
@@ -392,10 +389,18 @@ const assertExactRevisionPermission = async (
   if (['RELEASED', 'SUPERSEDED', 'OBSOLETE'].includes(lifecycle)) return;
 
   const { permissionSet } = await getUserPermissions(actor.id, actor.role);
+  const phase2CurrentApprovalCandidate =
+    isControlledDocumentPhase2Enabled() &&
+    lifecycle === 'DRAFT' &&
+    String(document.lifecycleStatus || '').toUpperCase() === 'DRAFT' &&
+    document.currentRevisionId === revision.id &&
+    document.workingDraftRevisionId === revision.id;
   const required =
     lifecycle === 'IN_REVIEW' || lifecycle === 'APPROVED'
       ? ['documents.approve', 'documents.release']
-      : ['documents.edit_draft', 'documents.revise'];
+      : phase2CurrentApprovalCandidate
+        ? ['documents.edit_draft', 'documents.revise', 'documents.approve']
+        : ['documents.edit_draft', 'documents.revise'];
   if (!required.some((capability) => permissionSet.has(capability))) {
     throw new ControlledDocumentError(
       403,
@@ -404,6 +409,29 @@ const assertExactRevisionPermission = async (
       { lifecycleStatus: lifecycle, requiredAnyCapability: required }
     );
   }
+};
+
+const authorizedRevisionHistory = async (
+  actor: { id: number; role: string },
+  document: ControlledDocumentRecord,
+  revisions: ControlledRevisionRecord[]
+) => {
+  const authorized: ControlledRevisionRecord[] = [];
+  for (const revision of revisions) {
+    try {
+      await assertExactRevisionPermission(actor, document, revision);
+      authorized.push(revision);
+    } catch (error) {
+      if (
+        error instanceof ControlledDocumentError &&
+        error.code === 'DRAFT_REVISION_ACCESS_DENIED'
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  return authorized;
 };
 
 const getReleasedRevisionForControlledUse = async (
@@ -750,11 +778,11 @@ const controlledDocumentRequiresStepUp = (
   const accessRule = String(doc.accessRule || 'authenticated').toLowerCase();
   return Boolean(
     doc.mfaRequired ||
-    ['restricted', 'classified', 'cui', 'itar'].includes(classification) ||
-    accessRule === 'explicit_grant' ||
-    accessRule === 'admin_only' ||
-    doc.cuiCategory ||
-    doc.itarCategory
+      ['restricted', 'classified', 'cui', 'itar'].includes(classification) ||
+      accessRule === 'explicit_grant' ||
+      accessRule === 'admin_only' ||
+      doc.cuiCategory ||
+      doc.itarCategory
   );
 };
 
@@ -771,6 +799,24 @@ const hasPolicyVaultGrant = async (
     [documentId, username, role]
   );
   return result.rows.length > 0;
+};
+
+const canAccessControlledDocument = async (
+  doc: ControlledDocumentRecord,
+  actor: { username: string; role: string }
+) => {
+  if (isPrivilegedDocumentActor(actor)) return true;
+  const classification = String(doc.classification || 'internal').toLowerCase();
+  const accessRule = String(doc.accessRule || 'authenticated').toLowerCase();
+  if (accessRule === 'admin_only') return false;
+  const grantRequired =
+    accessRule === 'explicit_grant' ||
+    ['restricted', 'classified', 'cui', 'itar'].includes(classification) ||
+    Boolean(doc.cuiCategory || doc.itarCategory);
+  return (
+    !grantRequired ||
+    (await hasPolicyVaultGrant(doc.id, actor.username, actor.role))
+  );
 };
 
 const controlledDocumentAccessPolicy = async (
@@ -791,20 +837,7 @@ const controlledDocumentAccessPolicy = async (
         message: 'Controlled document record was not found',
       });
 
-    const privileged = actor.role === 'ADMIN' || actor.role === 'OWNER';
-    const classification = String(
-      doc.classification || 'internal'
-    ).toLowerCase();
-    const accessRule = String(doc.accessRule || 'authenticated').toLowerCase();
-    const grantRequired =
-      accessRule === 'explicit_grant' ||
-      ['restricted', 'classified', 'cui', 'itar'].includes(classification) ||
-      Boolean(doc.cuiCategory || doc.itarCategory);
-    const allowed =
-      privileged ||
-      (accessRule !== 'admin_only' &&
-        (!grantRequired ||
-          (await hasPolicyVaultGrant(doc.id, actor.username, actor.role))));
+    const allowed = await canAccessControlledDocument(doc, actor);
     if (!allowed) {
       await writeAccessLog({
         documentId: doc.id,
@@ -1015,21 +1048,37 @@ router.get(
   requirePermission('documents.view'),
   async (req: Request, res: Response) => {
     try {
-      const docs = await db
+      const allDocs = await db
         .select()
         .from(controlledDocuments)
         .orderBy(desc(controlledDocuments.createdAt));
-      const revisionIds = docs
-        .map((doc) => doc.currentReleasedRevisionId)
-        .filter((id): id is string => Boolean(id));
-      const releasedRevisions = revisionIds.length
+      const actor = lifecycleActor(req);
+      const docs = (
+        await Promise.all(
+          allDocs.map(async (doc) =>
+            (await canAccessControlledDocument(doc, actor)) ? doc : null
+          )
+        )
+      ).filter((doc): doc is ControlledDocumentRecord => Boolean(doc));
+      const revisionIds = Array.from(
+        new Set(
+          docs.flatMap((doc) =>
+            [
+              doc.currentRevisionId,
+              doc.currentReleasedRevisionId,
+              doc.workingDraftRevisionId,
+            ].filter((id): id is string => Boolean(id))
+          )
+        )
+      );
+      const currentRevisions = revisionIds.length
         ? await db
             .select()
             .from(documentVersionHistory)
             .where(inArray(documentVersionHistory.id, revisionIds))
         : [];
-      const releasedById = new Map(
-        releasedRevisions.map((revision) => [revision.id, revision])
+      const revisionById = new Map(
+        currentRevisions.map((revision) => [revision.id, revision])
       );
       const phase2ReleasedDocumentIds = new Set<string>();
       if (isControlledDocumentPhase2Enabled() && docs.length > 0) {
@@ -1046,7 +1095,13 @@ router.get(
       res.json(
         docs.map((doc) => {
           const released = doc.currentReleasedRevisionId
-            ? releasedById.get(doc.currentReleasedRevisionId)
+            ? revisionById.get(doc.currentReleasedRevisionId)
+            : null;
+          const current = doc.currentRevisionId
+            ? revisionById.get(doc.currentRevisionId)
+            : null;
+          const workingDraft = doc.workingDraftRevisionId
+            ? revisionById.get(doc.workingDraftRevisionId)
             : null;
           const releasedVerified =
             released?.documentId === doc.id &&
@@ -1061,7 +1116,23 @@ router.get(
               String(doc.status || '').toLowerCase()
             ) || String(doc.lifecycleStatus || '').toUpperCase() === 'RELEASED';
           return {
-            ...doc,
+            ...controlledDocumentMetadata(doc),
+            releasedRevisionVersion: released?.versionNumber ?? null,
+            releasedRevisionMediaType: released?.mediaType ?? null,
+            releasedRevisionFileName: released?.fileName ?? null,
+            releasedRevisionAvailable: releasedVerified,
+            releasedRevisionIsPdf:
+              releasedVerified &&
+              (released?.mediaType === 'application/pdf' ||
+                Boolean(released?.fileName?.toLowerCase().endsWith('.pdf'))),
+            currentRevisionVersion: current?.versionNumber ?? null,
+            currentRevisionFileName: current?.fileName ?? null,
+            currentRevisionChecksumStatus: current?.checksumStatus ?? null,
+            currentRevisionHasFile: Boolean(current?.filePath),
+            currentRevisionIsPdf:
+              current?.mediaType === 'application/pdf' ||
+              Boolean(current?.fileName?.toLowerCase().endsWith('.pdf')),
+            workingDraftRevisionVersion: workingDraft?.versionNumber ?? null,
             phase2ProspectiveRelease: phase2ReleasedDocumentIds.has(doc.id),
             compatibilityStatus: releasedVerified
               ? 'Released and Verified'
@@ -1164,11 +1235,11 @@ router.get(
           const fileReferenceType = getControlledFileReferenceType(
             authoritativeReference
           );
-          /* eslint-disable prettier/prettier -- Linux CI and Windows disagree on this union layout. */
           let fileAccessibility:
-            'ACCESSIBLE' | 'INACCESSIBLE' | 'EXTERNAL_MUTABLE' | 'MISSING' =
-            'MISSING';
-          /* eslint-enable prettier/prettier */
+            | 'ACCESSIBLE'
+            | 'INACCESSIBLE'
+            | 'EXTERNAL_MUTABLE'
+            | 'MISSING' = 'MISSING';
           if (fileReferenceType === 'EXTERNAL_MUTABLE_URL') {
             fileAccessibility = 'EXTERNAL_MUTABLE';
           } else if (authoritativeReference) {
@@ -1283,7 +1354,7 @@ router.get(
               'MISSING_APPROVAL_IDENTITY_OR_DATE',
             Boolean(
               document.expirationDate &&
-              new Date(document.expirationDate) < new Date()
+                new Date(document.expirationDate) < new Date()
             ) && 'EXPIRED_OR_REVIEW_DUE',
             !authoritativeReference && 'NO_FILE_ATTACHED',
           ].filter(Boolean);
@@ -1337,19 +1408,28 @@ router.get(
 router.get(
   '/:id',
   requireAuth,
-  requirePermission('documents.view'),
+  controlledDocumentViewPermission,
+  controlledDocumentAccessPolicy,
   async (req: Request, res: Response) => {
     try {
-      const [doc] = await db
-        .select()
-        .from(controlledDocuments)
-        .where(eq(controlledDocuments.id, req.params.id));
+      const doc = (
+        req as Request & {
+          controlledDocument?: ControlledDocumentRecord;
+        }
+      ).controlledDocument;
 
       if (!doc) {
         return res.status(404).json({ error: 'Document not found' });
       }
 
-      res.json(doc);
+      const actor = lifecycleActor(req);
+      await writeAccessLog({
+        documentId: doc.id,
+        userId: actor.username,
+        action: 'view',
+        ipAddress: requestEvidence(req).ipAddress ?? 'unknown',
+      });
+      res.json(controlledDocumentMetadata(doc));
     } catch (error) {
       console.error('Error fetching document:', error);
       res.status(500).json({ error: 'Failed to fetch document' });
@@ -1361,19 +1441,27 @@ router.get(
 router.get(
   '/:id/versions',
   requireAuth,
-  requirePermission('documents.view'),
+  controlledDocumentViewPermission,
+  controlledDocumentAccessPolicy,
   async (req: Request, res: Response) => {
     try {
-      const versions = await db
-        .select()
-        .from(documentVersionHistory)
-        .where(eq(documentVersionHistory.documentId, req.params.id))
-        .orderBy(desc(documentVersionHistory.createdAt));
-
-      res.json(versions);
+      const state = await getControlledDocumentState(req.params.id);
+      const versions = await authorizedRevisionHistory(
+        lifecycleActor(req),
+        state.document,
+        state.revisions
+      );
+      res.json(
+        versions
+          .sort(
+            (left, right) =>
+              new Date(right.createdAt).getTime() -
+              new Date(left.createdAt).getTime()
+          )
+          .map(controlledRevisionMetadata)
+      );
     } catch (error) {
-      console.error('Error fetching version history:', error);
-      res.status(500).json({ error: 'Failed to fetch version history' });
+      sendLifecycleError(res, error, 'Failed to fetch version history');
     }
   }
 );
@@ -1381,15 +1469,28 @@ router.get(
 router.get(
   '/:id/revisions',
   requireAuth,
-  requirePermission('documents.view'),
+  controlledDocumentViewPermission,
+  controlledDocumentAccessPolicy,
   async (req: Request, res: Response) => {
     try {
       const state = await getControlledDocumentState(req.params.id);
+      const revisions = await authorizedRevisionHistory(
+        lifecycleActor(req),
+        state.document,
+        state.revisions
+      );
+      const visibleRevisionIds = new Set(revisions.map((row) => row.id));
       res.json({
-        document: state.document,
-        currentRevision: state.currentRevision,
-        revisions: state.revisions,
-        approvals: state.approvals,
+        document: controlledDocumentMetadata(state.document),
+        currentRevision:
+          state.currentRevision &&
+          visibleRevisionIds.has(state.currentRevision.id)
+            ? controlledRevisionMetadata(state.currentRevision)
+            : null,
+        revisions: revisions.map(controlledRevisionMetadata),
+        approvals: state.approvals.filter((row) =>
+          visibleRevisionIds.has(row.revisionId)
+        ),
       });
     } catch (error) {
       sendLifecycleError(
@@ -1404,23 +1505,50 @@ router.get(
 router.get(
   '/:id/revisions/:revisionId',
   requireAuth,
-  requirePermission('documents.view'),
+  controlledDocumentViewPermission,
+  controlledDocumentAccessPolicy,
   async (req: Request, res: Response) => {
+    const actor = lifecycleActor(req);
+    const ipAddress = requestEvidence(req).ipAddress ?? 'unknown';
+    let documentIdForAudit: string | null = null;
     try {
       const state = await getControlledDocumentState(req.params.id);
+      documentIdForAudit = state.document.id;
       const revision = state.revisions.find(
         (candidate) => candidate.id === req.params.revisionId
       );
-      if (!revision)
+      if (!revision) {
+        await recordControlledDocumentDenial(
+          req,
+          state.document.id,
+          actor,
+          ipAddress
+        );
         return res.status(404).json({ error: 'REVISION_NOT_FOUND' });
+      }
+      await assertExactRevisionPermission(actor, state.document, revision);
+      await writeAccessLog({
+        documentId: state.document.id,
+        userId: actor.username,
+        action: 'view',
+        ipAddress,
+      });
       res.json({
-        document: state.document,
-        revision,
+        document: controlledDocumentMetadata(state.document),
+        revision: controlledRevisionMetadata(revision),
         approvals: state.approvals.filter(
           (row) => row.revisionId === revision.id
         ),
       });
     } catch (error) {
+      if (documentIdForAudit) {
+        await recordControlledDocumentDenial(
+          req,
+          documentIdForAudit,
+          actor,
+          ipAddress
+        );
+      }
       sendLifecycleError(
         res,
         error,
@@ -1430,12 +1558,8 @@ router.get(
   }
 );
 
-router.get(
-  '/:id/revisions/:revisionId/download',
-  requireAuth,
-  controlledDocumentViewPermission,
-  controlledDocumentAccessPolicy,
-  async (req: Request, res: Response) => {
+const exactRevisionFileHandler =
+  (mode: 'view' | 'download') => async (req: Request, res: Response) => {
     const actor = lifecycleActor(req);
     const ipAddress = requestEvidence(req).ipAddress ?? 'unknown';
     let documentIdForAudit: string | null = null;
@@ -1470,8 +1594,7 @@ router.get(
           message: 'This revision has no file reference',
         });
       }
-      await authorizeControlledDocumentAccess(req, state.document);
-      await assertExactRevisionPermission(actor, revision);
+      await assertExactRevisionPermission(actor, state.document, revision);
       if (getExternalRedirectUrl(revision.filePath)) {
         await recordControlledDocumentDenial(
           req,
@@ -1493,21 +1616,42 @@ router.get(
         buffer,
         req
       );
+      const isPdf =
+        revision.mediaType === 'application/pdf' ||
+        revision.fileName?.toLowerCase().endsWith('.pdf') ||
+        revision.filePath.toLowerCase().endsWith('.pdf');
+      if (mode === 'view' && !isPdf) {
+        throw new ControlledDocumentError(
+          422,
+          'PREVIEW_UNAVAILABLE',
+          'This exact revision cannot be previewed in the browser; use Download Exact Revision'
+        );
+      }
+      const responseBuffer =
+        mode === 'view'
+          ? await addControlledDocumentFooter(buffer, state.document, revision)
+          : buffer;
       await writeAccessLog({
         documentId: state.document.id,
         userId: actor.username,
-        action: 'download',
+        action: mode,
         ipAddress,
       });
       res.setHeader(
         'Content-Type',
-        revision.mediaType || 'application/octet-stream'
+        isPdf
+          ? 'application/pdf'
+          : revision.mediaType || 'application/octet-stream'
       );
+      res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader(
         'Content-Disposition',
-        `attachment; filename="${revision.fileName || `${state.document.documentNumber}-${revision.versionNumber}`}"`
+        `${mode === 'view' ? 'inline' : 'attachment'}; filename="${safeDownloadFilename(
+          revision.fileName,
+          `${state.document.documentNumber}-${revision.versionNumber}${isPdf ? '.pdf' : ''}`
+        )}"`
       );
-      res.send(buffer);
+      res.send(responseBuffer);
     } catch (error) {
       if (documentIdForAudit) {
         await recordControlledDocumentDenial(
@@ -1520,10 +1664,25 @@ router.get(
       sendLifecycleError(
         res,
         error,
-        'Failed to download exact controlled revision'
+        `Failed to ${mode} exact controlled revision`
       );
     }
-  }
+  };
+
+router.get(
+  '/:id/revisions/:revisionId/view',
+  requireAuth,
+  controlledDocumentViewPermission,
+  controlledDocumentAccessPolicy,
+  exactRevisionFileHandler('view')
+);
+
+router.get(
+  '/:id/revisions/:revisionId/download',
+  requireAuth,
+  controlledDocumentViewPermission,
+  controlledDocumentAccessPolicy,
+  exactRevisionFileHandler('download')
 );
 
 router.post(
@@ -1557,7 +1716,10 @@ router.post(
         actor: lifecycleActor(req),
         request: requestEvidence(req),
       });
-      res.status(201).json(result);
+      res.status(201).json({
+        document: controlledDocumentMetadata(result.document),
+        revision: controlledRevisionMetadata(result.revision),
+      });
     } catch (error) {
       sendLifecycleError(res, error, 'Failed to create controlled revision');
     }
@@ -1626,7 +1788,7 @@ const lifecycleHandler =
         actor: lifecycleActor(req),
         request: requestEvidence(req),
       });
-      res.json(result);
+      res.json(controlledDocumentStateMetadata(result));
     } catch (error) {
       sendLifecycleError(res, error, `Failed to ${action} controlled revision`);
     }
@@ -1731,7 +1893,7 @@ router.post(
         sessionToken: sessionToken(req),
         readAuthoritativeBytes: readControlledDocumentBytes,
       });
-      res.json(result);
+      res.json(controlledDocumentStateMetadata(result));
     } catch (error) {
       sendLifecycleError(
         res,
@@ -1761,7 +1923,7 @@ router.post(
         sessionToken: sessionToken(req),
         readAuthoritativeBytes: readControlledDocumentBytes,
       });
-      res.json(result);
+      res.json(controlledDocumentStateMetadata(result));
     } catch (error) {
       sendLifecycleError(
         res,
@@ -1883,7 +2045,7 @@ router.post(
         actor: lifecycleActor(req),
         request: requestEvidence(req),
       });
-      res.status(201).json(result.document);
+      res.status(201).json(controlledDocumentMetadata(result.document));
     } catch (error: any) {
       if (uploadedFilePath) {
         try {
@@ -1968,7 +2130,7 @@ router.put(
           actor: lifecycleActor(req),
           request: requestEvidence(req),
         });
-        return res.json(result.document);
+        return res.json(controlledDocumentMetadata(result.document));
       }
 
       const metadataResult = await updateDraftMetadata({
@@ -1978,7 +2140,7 @@ router.put(
         actor: lifecycleActor(req),
         request: requestEvidence(req),
       });
-      return res.json(metadataResult.document);
+      return res.json(controlledDocumentMetadata(metadataResult.document));
     } catch (error) {
       sendLifecycleError(res, error, 'Failed to update controlled document');
     }
@@ -2032,7 +2194,7 @@ router.post(
         actor: lifecycleActor(req),
         request: requestEvidence(req),
       });
-      res.json(state.document);
+      res.json(controlledDocumentMetadata(state.document));
     } catch (error) {
       sendLifecycleError(res, error, 'Failed to approve controlled revision');
     }


### PR DESCRIPTION
## Summary

Completes the Master Document Register end-to-end workflow correction for register/create, exact-revision preview, approval and automatic release, and controlled-use viewing/downloading.

## Root cause

The register UI and route layer still had several drift points:

- approvers with only lifecycle approval authority could not preview the current Phase 2 draft revision;
- normal register actions were derived from document-level file metadata instead of exact released-revision readiness;
- revision-history metadata and the single-document metadata route did not consistently use the centralized access policy;
- Phase 2 availability did not fail closed when its schema was unavailable;
- metadata responses could expose internal storage references.

## Changes

- Adds checksum-verified exact-revision browser preview with the exact revision footer.
- Allows an authorized approver to preview only the current Phase 2 approval candidate while retaining stronger controls for other drafts.
- Drives ordinary View/Download exclusively from the verified released revision.
- Separates released and working-draft version labels in the register.
- Verifies the Phase 2 feature flag and schema before lifecycle actions; no fallback to legacy approval occurs when Phase 2 is configured but unavailable.
- Applies centralized classification, access-rule, vault-grant, step-up, and exact-revision permissions to document metadata, history, preview, and download routes.
- Filters inaccessible documents from the register and redacts internal file paths from viewer and lifecycle responses.
- Adds behavior coverage for preview, released-revision selection, authorization, and metadata redaction.

## Safety and rollout

- No migration is added or modified.
- No historical document, revision, approval, identifier, link, or timestamp is rewritten.
- `CONTROLLED_DOCUMENT_PHASE2_APPROVE_RELEASE_ENABLED` remains default-disabled.
- `CONTROLLED_DOCUMENT_RECONCILIATION_ENABLED` and document recovery remain default-disabled.
- External references and missing authoritative bytes remain fail-closed and require the existing authorized recovery/reconciliation process.
- Applying existing migrations alone does not activate these workflows.

## Validation

- Controlled-document Vitest: **11 files, 144 passed, 0 failed**
- Production Vite client build: **passed**
- Client/server esbuild syntax checks: **passed**
- Prettier: **passed**
- `git diff --check`: **passed**
- Scoped ESLint comparison: head **33 errors / 48 warnings**, exact main baseline **41 errors / 56 warnings**; no new diagnostics
- Read-only merge-tree against exact base `52ebcd9bc4ad37c07db038578eae9fe48bd6e4ac`: **clean**

## Validation limitations

- PostgreSQL suites could not collect because this host has no `DATABASE_URL`; PostgreSQL certification remains required.
- Authenticated browser certification remains an activation prerequisite.
- Existing inaccessible historical records still require upload/recovery of authoritative bytes; this PR intentionally does not bypass that control.
