### PR TITLE
Phase 1: read-only recursive P2 Production Launch preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Database
 DATABASE_URL="postgresql://username:password@localhost:5432/database_name"
 
+# Phase 1 read-only recursive P2 Production Launch preview. Keep disabled until validated.
+P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED="false"
+
 # SendGrid Configuration
 SENDGRID_API_KEY="your_sendgrid_api_key_here"
 SENDGRID_FROM_EMAIL="noreply@yourcompany.com"

--- a/server/__tests__/productionLaunchPreviewFeatureGate.test.ts
+++ b/server/__tests__/productionLaunchPreviewFeatureGate.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isP2V2ProductionLaunchPreviewEnabled } from '../src/lib/featureFlags';
+
+describe('Production Launch preview feature gate', () => {
+  afterEach(() => delete process.env.P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED);
+
+  it.each([undefined, 'false', 'TRUE', ' true ', '1'])(
+    'fails closed for %s',
+    (value) => {
+      if (value === undefined)
+        delete process.env.P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED;
+      else process.env.P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED = value;
+      expect(isP2V2ProductionLaunchPreviewEnabled()).toBe(false);
+    }
+  );
+
+  it('enables only the exact true value', () => {
+    process.env.P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED = 'true';
+    expect(isP2V2ProductionLaunchPreviewEnabled()).toBe(true);
+  });
+});

--- a/server/__tests__/productionLaunchPreviewResolver.test.ts
+++ b/server/__tests__/productionLaunchPreviewResolver.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveProductionLaunchPreview,
+  type PreviewBomCandidate,
+  type PreviewBomLine,
+  type PreviewInventoryItem,
+  type PreviewRoutingCandidate,
+  type ProductionLaunchPreviewSource,
+} from '../src/services/productionLaunchPreviewResolver';
+
+type Fixture = {
+  inventory: PreviewInventoryItem[];
+  boms: Record<
+    string,
+    Array<
+      Omit<PreviewBomCandidate, 'isActive' | 'isReleased' | 'isEffective'> &
+        Partial<
+          Pick<PreviewBomCandidate, 'isActive' | 'isReleased' | 'isEffective'>
+        >
+    >
+  >;
+  lines: Record<string, PreviewBomLine[]>;
+  routings: Record<string, PreviewRoutingCandidate[]>;
+};
+
+const key = (value: string) => value.trim().toUpperCase();
+const item = (
+  id: number,
+  partNumber: string,
+  itemType: 'MANUFACTURED' | 'PURCHASED',
+  availableQuantity = 0
+): PreviewInventoryItem => ({
+  id,
+  partNumber,
+  description: `${partNumber} description`,
+  itemType,
+  manufacturedCategory: itemType === 'MANUFACTURED' ? 'MACHINED_PART' : null,
+  manufacturingLevel: itemType === 'MANUFACTURED' ? 'COMPONENT' : null,
+  unitOfMeasure: 'EA',
+  availableQuantity,
+  allocatedQuantity: 0,
+  vendorId: itemType === 'PURCHASED' ? 99 : null,
+  orderUrl: null,
+});
+
+const routing = (
+  id: string,
+  departments: string[] = ['CNC']
+): PreviewRoutingCandidate => ({
+  id,
+  revision: '1',
+  isActive: true,
+  releaseStatus: 'APPROVED',
+  departmentSequence: departments,
+  precedence: 1,
+});
+
+function source(fixture: Fixture): ProductionLaunchPreviewSource {
+  return {
+    async findInventory(partNumber, inventoryItemId) {
+      return fixture.inventory.filter((entry) =>
+        inventoryItemId == null
+          ? key(entry.partNumber) === key(partNumber)
+          : entry.id === inventoryItemId
+      );
+    },
+    async findBoms(partNumber) {
+      return (fixture.boms[key(partNumber)] ?? []).map((entry) => ({
+        isActive: true,
+        isReleased: true,
+        isEffective: true,
+        ...entry,
+      }));
+    },
+    async getBomLines(revisionId) {
+      return fixture.lines[revisionId] ?? [];
+    },
+    async findRoutings(partNumber) {
+      return fixture.routings[key(partNumber)] ?? [];
+    },
+  };
+}
+
+const roots = (partNumber: string, quantity = 1) => [
+  {
+    poItemId: 20,
+    partNumber,
+    quantity,
+    inventoryItemId: null,
+    requiredByDate: '2026-10-01',
+  },
+];
+
+describe('Production Launch recursive preview', () => {
+  it('expands a heated-pitot assembly into two CNC MAKE children without a Layup fallback', async () => {
+    const fixture: Fixture = {
+      inventory: [
+        {
+          ...item(1, 'AG-SYS-HEATED-PITOT-0003', 'MANUFACTURED'),
+          manufacturedCategory: 'ASSEMBLY',
+          manufacturingLevel: 'FINAL',
+        },
+        item(2, 'PITOT-CNC-LEFT', 'MANUFACTURED'),
+        item(3, 'PITOT-CNC-RIGHT', 'MANUFACTURED'),
+      ],
+      boms: {
+        'AG-SYS-HEATED-PITOT-0003': [
+          { bomId: 'bom-root', revisionId: 'rev-root', revision: 'A' },
+        ],
+        'PITOT-CNC-LEFT': [
+          { bomId: 'bom-left', revisionId: 'rev-left', revision: 'A' },
+        ],
+        'PITOT-CNC-RIGHT': [
+          { bomId: 'bom-right', revisionId: 'rev-right', revision: 'A' },
+        ],
+      },
+      lines: {
+        'rev-root': [
+          {
+            id: 'line-left',
+            childPartNumber: 'PITOT-CNC-LEFT',
+            quantityPerParent: 2,
+          },
+          {
+            id: 'line-right',
+            childPartNumber: 'PITOT-CNC-RIGHT',
+            quantityPerParent: 1,
+          },
+        ],
+        'rev-left': [
+          {
+            id: 'left-buy',
+            childPartNumber: 'LEFT-STOCK',
+            quantityPerParent: 1,
+          },
+        ],
+        'rev-right': [
+          {
+            id: 'right-buy',
+            childPartNumber: 'RIGHT-STOCK',
+            quantityPerParent: 1,
+          },
+        ],
+      },
+      routings: {
+        'AG-SYS-HEATED-PITOT-0003': [routing('routing-root', ['Assembly'])],
+        'PITOT-CNC-LEFT': [routing('routing-left')],
+        'PITOT-CNC-RIGHT': [routing('routing-right')],
+      },
+    };
+    fixture.inventory.push(
+      item(4, 'LEFT-STOCK', 'PURCHASED'),
+      item(5, 'RIGHT-STOCK', 'PURCHASED')
+    );
+
+    const preview = await resolveProductionLaunchPreview(
+      roots('AG-SYS-HEATED-PITOT-0003', 3),
+      source(fixture)
+    );
+
+    expect(preview.ready).toBe(true);
+    expect(preview.nodes[0]).toMatchObject({
+      classification: 'ASSEMBLY',
+      extendedProjectQuantity: 3,
+    });
+    expect(preview.nodes[0].children).toEqual([
+      expect.objectContaining({
+        partNumber: 'PITOT-CNC-LEFT',
+        extendedProjectQuantity: 6,
+        firstDepartment: 'CNC',
+      }),
+      expect.objectContaining({
+        partNumber: 'PITOT-CNC-RIGHT',
+        extendedProjectQuantity: 3,
+        firstDepartment: 'CNC',
+      }),
+    ]);
+    expect(preview.nodes[0].children[0].children[0]).toMatchObject({
+      path: [
+        'po-item:20',
+        'AG-SYS-HEATED-PITOT-0003',
+        'PITOT-CNC-LEFT',
+        'LEFT-STOCK',
+      ],
+      makeBuy: 'BUY',
+      extendedProjectQuantity: 6,
+    });
+  });
+
+  it('reports a complete BOM cycle path instead of silently truncating recursion', async () => {
+    const fixture: Fixture = {
+      inventory: [item(1, 'A', 'MANUFACTURED'), item(2, 'B', 'MANUFACTURED')],
+      boms: {
+        A: [{ bomId: 'bom-a', revisionId: 'rev-a', revision: '1' }],
+        B: [{ bomId: 'bom-b', revisionId: 'rev-b', revision: '1' }],
+      },
+      lines: {
+        'rev-a': [{ id: 'a-b', childPartNumber: 'B', quantityPerParent: 1 }],
+        'rev-b': [{ id: 'b-a', childPartNumber: 'A', quantityPerParent: 1 }],
+      },
+      routings: { A: [routing('route-a')], B: [routing('route-b')] },
+    };
+
+    const preview = await resolveProductionLaunchPreview(
+      roots('A'),
+      source(fixture)
+    );
+    expect(preview.ready).toBe(false);
+    expect(preview.blockers).toContainEqual(
+      expect.objectContaining({
+        code: 'BOM_CYCLE',
+        path: ['po-item:20', 'A', 'B', 'A'],
+      })
+    );
+  });
+
+  it('fails closed for duplicate effective BOMs and missing routing', async () => {
+    const fixture: Fixture = {
+      inventory: [item(1, 'MAKE-1', 'MANUFACTURED')],
+      boms: {
+        'MAKE-1': [
+          { bomId: 'bom-1', revisionId: 'rev-1', revision: 'A' },
+          { bomId: 'bom-2', revisionId: 'rev-2', revision: 'B' },
+        ],
+      },
+      lines: {},
+      routings: {},
+    };
+    const preview = await resolveProductionLaunchPreview(
+      roots('MAKE-1'),
+      source(fixture)
+    );
+    expect(preview.blockers.map((entry) => entry.code)).toEqual(
+      expect.arrayContaining(['BOM_AMBIGUOUS', 'ROUTING_MISSING'])
+    );
+  });
+
+  it('nets partial purchased stock and creates no manufactured routing requirement', async () => {
+    const fixture: Fixture = {
+      inventory: [item(1, 'BUY-1', 'PURCHASED', 4)],
+      boms: {},
+      lines: {},
+      routings: {},
+    };
+    const preview = await resolveProductionLaunchPreview(
+      roots('BUY-1', 10),
+      source(fixture)
+    );
+    expect(preview.ready).toBe(true);
+    expect(preview.nodes[0]).toMatchObject({
+      makeBuy: 'BUY',
+      availableQuantity: 4,
+      shortageQuantity: 6,
+      demandStatus: 'BUY_REQUIRED',
+      routingId: null,
+    });
+  });
+
+  it('marks a purchased leaf as stock satisfied when usable stock covers demand', async () => {
+    const fixture: Fixture = {
+      inventory: [item(1, 'BUY-STOCKED', 'PURCHASED', 12)],
+      boms: {},
+      lines: {},
+      routings: {},
+    };
+    const preview = await resolveProductionLaunchPreview(
+      roots('BUY-STOCKED', 10),
+      source(fixture)
+    );
+    expect(preview.nodes[0]).toMatchObject({
+      shortageQuantity: 0,
+      demandStatus: 'STOCK_SATISFIED',
+    });
+  });
+
+  it('blocks missing inventory identity and missing make-buy classification', async () => {
+    const unresolved = item(1, 'UNRESOLVED', 'PURCHASED');
+    unresolved.itemType = null;
+    const fixture: Fixture = {
+      inventory: [unresolved],
+      boms: {},
+      lines: {},
+      routings: {},
+    };
+    const missing = await resolveProductionLaunchPreview(
+      roots('MISSING'),
+      source(fixture)
+    );
+    const missingDecision = await resolveProductionLaunchPreview(
+      roots('UNRESOLVED'),
+      source(fixture)
+    );
+    expect(missing.blockers[0]).toMatchObject({
+      code: 'INVENTORY_ITEM_MISSING',
+      path: ['po-item:20', 'MISSING'],
+    });
+    expect(missingDecision.blockers).toContainEqual(
+      expect.objectContaining({ code: 'MAKE_BUY_MISSING' })
+    );
+  });
+
+  it.each([
+    ['BOM_INACTIVE', { isActive: false }],
+    ['BOM_NOT_RELEASED', { isReleased: false }],
+    ['BOM_NOT_EFFECTIVE', { isEffective: false }],
+  ] as const)(
+    'distinguishes %s BOM authority failures',
+    async (code, state) => {
+      const fixture: Fixture = {
+        inventory: [item(1, 'MAKE-STATE', 'MANUFACTURED')],
+        boms: {
+          'MAKE-STATE': [
+            { bomId: 'bom', revisionId: 'rev', revision: 'A', ...state },
+          ],
+        },
+        lines: {},
+        routings: { 'MAKE-STATE': [routing('route')] },
+      };
+      const preview = await resolveProductionLaunchPreview(
+        roots('MAKE-STATE'),
+        source(fixture)
+      );
+      expect(preview.blockers).toContainEqual(
+        expect.objectContaining({ code })
+      );
+    }
+  );
+
+  it('fails closed when only a live routing lacks provable effectivity', async () => {
+    const fixture: Fixture = {
+      inventory: [item(1, 'MAKE-LIVE-ROUTE', 'MANUFACTURED')],
+      boms: {
+        'MAKE-LIVE-ROUTE': [{ bomId: 'bom', revisionId: 'rev', revision: 'A' }],
+      },
+      lines: {
+        rev: [{ id: 'leaf', childPartNumber: 'BUY', quantityPerParent: 1 }],
+      },
+      routings: {
+        'MAKE-LIVE-ROUTE': [{ ...routing('live-route'), precedence: 3 }],
+      },
+    };
+    fixture.inventory.push(item(2, 'BUY', 'PURCHASED'));
+    const preview = await resolveProductionLaunchPreview(
+      roots('MAKE-LIVE-ROUTE'),
+      source(fixture)
+    );
+    expect(preview.blockers).toContainEqual(
+      expect.objectContaining({ code: 'ROUTING_EFFECTIVITY_UNRESOLVED' })
+    );
+    expect(preview.nodes[0].firstDepartment).toBeNull();
+  });
+
+  it('blocks an empty released routing rather than defaulting to Layup', async () => {
+    const fixture: Fixture = {
+      inventory: [item(1, 'MAKE-EMPTY-ROUTE', 'MANUFACTURED')],
+      boms: {
+        'MAKE-EMPTY-ROUTE': [
+          { bomId: 'bom', revisionId: 'rev', revision: 'A' },
+        ],
+      },
+      lines: {
+        rev: [{ id: 'buy', childPartNumber: 'BUY-LEAF', quantityPerParent: 1 }],
+      },
+      routings: { 'MAKE-EMPTY-ROUTE': [routing('route-empty', [])] },
+    };
+    fixture.inventory.push(item(2, 'BUY-LEAF', 'PURCHASED'));
+    const preview = await resolveProductionLaunchPreview(
+      roots('MAKE-EMPTY-ROUTE'),
+      source(fixture)
+    );
+    expect(preview.blockers).toContainEqual(
+      expect.objectContaining({ code: 'ROUTING_EMPTY' })
+    );
+    expect(preview.nodes[0].firstDepartment).toBeNull();
+  });
+
+  it('blocks a released manufactured BOM with no component lines', async () => {
+    const fixture: Fixture = {
+      inventory: [item(1, 'EMPTY-BOM', 'MANUFACTURED')],
+      boms: {
+        'EMPTY-BOM': [{ bomId: 'bom', revisionId: 'rev', revision: 'A' }],
+      },
+      lines: { rev: [] },
+      routings: { 'EMPTY-BOM': [routing('route')] },
+    };
+    const preview = await resolveProductionLaunchPreview(
+      roots('EMPTY-BOM'),
+      source(fixture)
+    );
+    expect(preview.blockers).toContainEqual(
+      expect.objectContaining({ code: 'BOM_EMPTY' })
+    );
+  });
+});

--- a/server/__tests__/productionLaunchPreviewRoute.test.ts
+++ b/server/__tests__/productionLaunchPreviewRoute.test.ts
@@ -1,0 +1,90 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getUserPermissions: vi.fn(),
+  getProductionLaunchPreview: vi.fn(),
+}));
+
+vi.mock('../src/services/permissionService', () => ({
+  getUserPermissions: mocks.getUserPermissions,
+}));
+
+vi.mock('../src/services/projectProductionPlanningService', () => {
+  class ProjectProductionPlanningError extends Error {
+    constructor(
+      public code: string,
+      message: string,
+      public status: number,
+      public details: Record<string, unknown> = {}
+    ) {
+      super(message);
+    }
+  }
+  return {
+    ProjectProductionPlanningError,
+    createDraftFromCurrentConfiguration: vi.fn(),
+    getCurrentProductionPlan: vi.fn(),
+    recordEngineeringDecision: vi.fn(),
+    recordOperationsDecision: vi.fn(),
+    recordQualityDecision: vi.fn(),
+    refreshDraft: vi.fn(),
+    revisePlan: vi.fn(),
+    submitForApproval: vi.fn(),
+    updatePlanItemDecision: vi.fn(),
+  };
+});
+
+vi.mock('../src/services/productionLaunchPreviewService', () => ({
+  getProductionLaunchPreview: mocks.getProductionLaunchPreview,
+}));
+
+import projectProductionPlanningRouter from '../src/routes/projectProductionPlanning';
+
+const app = express();
+app.use((req, _res, next) => {
+  req.user = { id: 7, username: 'phase-one-reviewer', role: 'ENGINEERING' };
+  next();
+});
+app.use(
+  '/api/projects/:id/workflow-v2/production-planning',
+  projectProductionPlanningRouter
+);
+
+describe('Production Launch preview route boundary', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 403 before resolving preview data without the capability', async () => {
+    mocks.getUserPermissions.mockResolvedValue({ permissionSet: new Set() });
+    const response = await request(app).get(
+      '/api/projects/project-1/workflow-v2/production-planning/launch-preview'
+    );
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('FORBIDDEN');
+    expect(mocks.getProductionLaunchPreview).not.toHaveBeenCalled();
+  });
+
+  it('exposes only the explicit preview response to an authorized caller', async () => {
+    mocks.getUserPermissions.mockResolvedValue({
+      permissionSet: new Set(['projects.production_planning.manage']),
+    });
+    mocks.getProductionLaunchPreview.mockResolvedValue({
+      mode: 'PREVIEW_ONLY',
+      createsRecords: false,
+      ready: false,
+      blockers: [{ code: 'BOM_MISSING' }],
+      nodes: [],
+    });
+    const response = await request(app).get(
+      '/api/projects/project-1/workflow-v2/production-planning/launch-preview'
+    );
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      mode: 'PREVIEW_ONLY',
+      createsRecords: false,
+      ready: false,
+    });
+    expect(mocks.getProductionLaunchPreview).toHaveBeenCalledWith('project-1');
+  });
+});

--- a/server/__tests__/productionLaunchPreviewService.test.ts
+++ b/server/__tests__/productionLaunchPreviewService.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(__dirname, '../..');
+const service = readFileSync(
+  resolve(root, 'server/src/services/productionLaunchPreviewService.ts'),
+  'utf8'
+);
+const route = readFileSync(
+  resolve(root, 'server/src/routes/projectProductionPlanning.ts'),
+  'utf8'
+);
+
+describe('Production Launch Phase 1 preview boundary', () => {
+  it('executes inside an explicit read-only transaction', () => {
+    expect(service).toContain('SET TRANSACTION READ ONLY');
+    expect(service).not.toMatch(/\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\b/i);
+    expect(service).toContain("mode: 'PREVIEW_ONLY'");
+    expect(service).toContain('createsRecords: false');
+  });
+
+  it('is permission controlled and separately feature gated', () => {
+    expect(route).toMatch(
+      /router\.get\('\/launch-preview'[\s\S]*projects\.production_planning\.manage/
+    );
+    expect(service).toContain('isP2V2ProductionLaunchPreviewEnabled()');
+    expect(service).toContain('P2_V2_PRODUCTION_LAUNCH_PREVIEW_DISABLED');
+  });
+});

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -44,6 +44,11 @@ export function isP2V2ProductionLaunchEnabled(): boolean {
   return process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED === 'true';
 }
 
+/** Gates the read-only recursive Production Launch preview introduced in Phase 1. */
+export function isP2V2ProductionLaunchPreviewEnabled(): boolean {
+  return process.env.P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED === 'true';
+}
+
 /**
  * Cutover date for the punch_ledger migration.
  * For pay periods starting ON or AFTER this date, hour computations read

--- a/server/src/routes/projectProductionPlanning.ts
+++ b/server/src/routes/projectProductionPlanning.ts
@@ -15,6 +15,7 @@ import {
   updatePlanItemDecision,
   type PlanningActor,
 } from '../services/projectProductionPlanningService';
+import { getProductionLaunchPreview } from '../services/productionLaunchPreviewService';
 
 const router = Router({ mergeParams: true });
 const headerSchema = z.object({
@@ -150,6 +151,14 @@ const projectId = (req: Request) => String(req.params.id);
 router.get('/', async (req, res) => {
   try {
     res.json(await getCurrentProductionPlan(projectId(req)));
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.get('/launch-preview', async (req, res) => {
+  try {
+    await requireCapability(req, 'projects.production_planning.manage');
+    res.json(await getProductionLaunchPreview(projectId(req)));
   } catch (error) {
     fail(res, error);
   }

--- a/server/src/services/productionLaunchPreviewResolver.ts
+++ b/server/src/services/productionLaunchPreviewResolver.ts
@@ -1,0 +1,493 @@
+export type PreviewBlockerCode =
+  | 'INVENTORY_ITEM_MISSING'
+  | 'INVENTORY_ITEM_AMBIGUOUS'
+  | 'MAKE_BUY_MISSING'
+  | 'BOM_MISSING'
+  | 'BOM_EMPTY'
+  | 'BOM_INACTIVE'
+  | 'BOM_NOT_RELEASED'
+  | 'BOM_NOT_EFFECTIVE'
+  | 'BOM_AMBIGUOUS'
+  | 'BOM_CYCLE'
+  | 'CHILD_QUANTITY_INVALID'
+  | 'ROUTING_MISSING'
+  | 'ROUTING_AMBIGUOUS'
+  | 'ROUTING_INACTIVE'
+  | 'ROUTING_NOT_RELEASED'
+  | 'ROUTING_EMPTY'
+  | 'ROUTING_EFFECTIVITY_UNRESOLVED'
+  | 'PURCHASING_PATH_MISSING';
+
+export type PreviewBlocker = {
+  code: PreviewBlockerCode;
+  partNumber: string;
+  path: string[];
+  message: string;
+  correctionTarget: 'inventory' | 'bom' | 'routing' | 'purchasing';
+};
+
+export type PreviewInventoryItem = {
+  id: number;
+  partNumber: string;
+  description: string | null;
+  itemType: string | null;
+  manufacturedCategory: string | null;
+  manufacturingLevel: string | null;
+  unitOfMeasure: string | null;
+  availableQuantity: number;
+  allocatedQuantity: number;
+  vendorId: number | null;
+  orderUrl: string | null;
+};
+
+export type PreviewBomCandidate = {
+  bomId: string;
+  revisionId: string;
+  revision: string;
+  isActive: boolean;
+  isReleased: boolean;
+  isEffective: boolean;
+};
+
+export type PreviewBomLine = {
+  id: string;
+  childPartNumber: string;
+  quantityPerParent: number;
+};
+
+export type PreviewRoutingCandidate = {
+  id: string;
+  revision: string;
+  isActive: boolean;
+  releaseStatus: string | null;
+  departmentSequence: string[];
+  precedence: 1 | 3;
+};
+
+export type PreviewRoot = {
+  poItemId: number;
+  partNumber: string;
+  quantity: number;
+  inventoryItemId: number | null;
+  requiredByDate: string | null;
+};
+
+export interface ProductionLaunchPreviewSource {
+  findInventory(
+    partNumber: string,
+    inventoryItemId: number | null
+  ): Promise<PreviewInventoryItem[]>;
+  findBoms(
+    partNumber: string,
+    effectiveAt: Date
+  ): Promise<PreviewBomCandidate[]>;
+  getBomLines(revisionId: string): Promise<PreviewBomLine[]>;
+  findRoutings(
+    partNumber: string,
+    path: string[]
+  ): Promise<PreviewRoutingCandidate[]>;
+}
+
+export type ProductionLaunchPreviewNode = {
+  path: string[];
+  parentPartNumber: string | null;
+  inventoryItemId: number | null;
+  partNumber: string;
+  revision: string | null;
+  description: string | null;
+  classification: string;
+  makeBuy: 'MAKE' | 'BUY' | 'OUTSIDE_PROCESS' | 'PHANTOM' | 'UNRESOLVED';
+  quantityPerParent: number;
+  extendedProjectQuantity: number;
+  unitOfMeasure: string | null;
+  bomId: string | null;
+  bomRevisionId: string | null;
+  bomRevision: string | null;
+  routingId: string | null;
+  routingRevision: string | null;
+  firstDepartment: string | null;
+  availableQuantity: number;
+  allocatedQuantity: number;
+  shortageQuantity: number;
+  requiredByDate: string | null;
+  demandStatus:
+    | 'BLOCKED'
+    | 'STOCK_SATISFIED'
+    | 'MAKE_REQUIRED'
+    | 'BUY_REQUIRED'
+    | 'OUTSIDE_PROCESS_REQUIRED'
+    | 'PHANTOM_EXPANSION';
+  blockers: PreviewBlocker[];
+  children: ProductionLaunchPreviewNode[];
+};
+
+const normalized = (value: string) => value.trim().toUpperCase();
+const finitePositive = (value: number) => Number.isFinite(value) && value > 0;
+
+function blocker(
+  code: PreviewBlockerCode,
+  partNumber: string,
+  path: string[],
+  message: string,
+  correctionTarget: PreviewBlocker['correctionTarget']
+): PreviewBlocker {
+  return { code, partNumber, path, message, correctionTarget };
+}
+
+function classification(
+  item: PreviewInventoryItem | null,
+  makeBuy: ProductionLaunchPreviewNode['makeBuy']
+) {
+  if (!item) return 'BLOCKED_UNRESOLVED';
+  if (makeBuy === 'OUTSIDE_PROCESS') return 'OUTSIDE_PROCESS';
+  if (makeBuy === 'PHANTOM') return 'PHANTOM';
+  if (makeBuy === 'BUY')
+    return item.manufacturedCategory === 'RAW_MATERIAL'
+      ? 'RAW_MATERIAL'
+      : 'PURCHASED_COMPONENT';
+  return (
+    item.manufacturedCategory ||
+    (item.manufacturingLevel === 'FINAL'
+      ? 'ASSEMBLY'
+      : 'MANUFACTURED_COMPONENT')
+  );
+}
+
+export async function resolveProductionLaunchPreview(
+  roots: PreviewRoot[],
+  source: ProductionLaunchPreviewSource,
+  effectiveAt = new Date()
+) {
+  const allBlockers: PreviewBlocker[] = [];
+
+  async function visit(input: {
+    partNumber: string;
+    inventoryItemId: number | null;
+    parentPartNumber: string | null;
+    quantityPerParent: number;
+    extendedQuantity: number;
+    requiredByDate: string | null;
+    path: string[];
+    ancestry: string[];
+  }): Promise<ProductionLaunchPreviewNode> {
+    const partNumber = input.partNumber.trim();
+    const path = [...input.path, partNumber];
+    const nodeBlockers: PreviewBlocker[] = [];
+    const add = (entry: PreviewBlocker) => {
+      nodeBlockers.push(entry);
+      allBlockers.push(entry);
+    };
+
+    if (
+      !finitePositive(input.quantityPerParent) ||
+      !finitePositive(input.extendedQuantity)
+    )
+      add(
+        blocker(
+          'CHILD_QUANTITY_INVALID',
+          partNumber,
+          path,
+          `${partNumber} has a non-positive or invalid extended quantity.`,
+          'bom'
+        )
+      );
+
+    if (input.ancestry.includes(normalized(partNumber)))
+      add(
+        blocker(
+          'BOM_CYCLE',
+          partNumber,
+          path,
+          `BOM cycle detected at ${path.join(' > ')}.`,
+          'bom'
+        )
+      );
+
+    const inventoryMatches = await source.findInventory(
+      partNumber,
+      input.inventoryItemId
+    );
+    if (inventoryMatches.length === 0)
+      add(
+        blocker(
+          'INVENTORY_ITEM_MISSING',
+          partNumber,
+          path,
+          `${partNumber} does not resolve to an inventory item.`,
+          'inventory'
+        )
+      );
+    if (inventoryMatches.length > 1)
+      add(
+        blocker(
+          'INVENTORY_ITEM_AMBIGUOUS',
+          partNumber,
+          path,
+          `${partNumber} resolves to multiple inventory items.`,
+          'inventory'
+        )
+      );
+    const item = inventoryMatches.length === 1 ? inventoryMatches[0] : null;
+    const rawType = item?.itemType?.trim().toUpperCase() ?? '';
+    const makeBuy: ProductionLaunchPreviewNode['makeBuy'] =
+      rawType === 'MANUFACTURED'
+        ? 'MAKE'
+        : rawType === 'PURCHASED'
+          ? 'BUY'
+          : rawType === 'OUTSIDE_PROCESS'
+            ? 'OUTSIDE_PROCESS'
+            : rawType === 'PHANTOM'
+              ? 'PHANTOM'
+              : 'UNRESOLVED';
+    if (item && makeBuy === 'UNRESOLVED')
+      add(
+        blocker(
+          'MAKE_BUY_MISSING',
+          partNumber,
+          path,
+          `${partNumber} has no controlled MAKE/BUY classification.`,
+          'inventory'
+        )
+      );
+
+    const available = Math.max(0, Number(item?.availableQuantity ?? 0));
+    const allocated = Math.max(0, Number(item?.allocatedQuantity ?? 0));
+    const shortage = Math.max(0, input.extendedQuantity - available);
+    let bom: PreviewBomCandidate | null = null;
+    let routing: PreviewRoutingCandidate | null = null;
+    const children: ProductionLaunchPreviewNode[] = [];
+
+    if (makeBuy === 'BUY' && shortage > 0 && !item?.vendorId && !item?.orderUrl)
+      add(
+        blocker(
+          'PURCHASING_PATH_MISSING',
+          partNumber,
+          path,
+          `${partNumber} has a shortage but no approved purchasing path.`,
+          'purchasing'
+        )
+      );
+
+    if (
+      (makeBuy === 'MAKE' || makeBuy === 'PHANTOM') &&
+      !nodeBlockers.some((entry) => entry.code === 'BOM_CYCLE')
+    ) {
+      const candidates = await source.findBoms(partNumber, effectiveAt);
+      const active = candidates.filter((candidate) => candidate.isActive);
+      const releasedBoms = active.filter((candidate) => candidate.isReleased);
+      const effective = releasedBoms.filter(
+        (candidate) => candidate.isEffective
+      );
+      if (candidates.length === 0)
+        add(
+          blocker(
+            'BOM_MISSING',
+            partNumber,
+            path,
+            `${partNumber} has no unique effective released BOM.`,
+            'bom'
+          )
+        );
+      else if (active.length === 0)
+        add(
+          blocker(
+            'BOM_INACTIVE',
+            partNumber,
+            path,
+            `${partNumber} BOM is inactive.`,
+            'bom'
+          )
+        );
+      else if (releasedBoms.length === 0)
+        add(
+          blocker(
+            'BOM_NOT_RELEASED',
+            partNumber,
+            path,
+            `${partNumber} has no released BOM revision.`,
+            'bom'
+          )
+        );
+      else if (effective.length === 0)
+        add(
+          blocker(
+            'BOM_NOT_EFFECTIVE',
+            partNumber,
+            path,
+            `${partNumber} has no released BOM revision effective for the preview date.`,
+            'bom'
+          )
+        );
+      else if (effective.length > 1)
+        add(
+          blocker(
+            'BOM_AMBIGUOUS',
+            partNumber,
+            path,
+            `${partNumber} has multiple effective released BOM revisions.`,
+            'bom'
+          )
+        );
+      else bom = effective[0];
+
+      const routings = await source.findRoutings(partNumber, path);
+      const preferred = routings.filter(
+        (candidate) =>
+          candidate.precedence ===
+          Math.min(...routings.map((entry) => entry.precedence))
+      );
+      const released = preferred.filter(
+        (candidate) =>
+          candidate.isActive && candidate.releaseStatus === 'APPROVED'
+      );
+      if (routings.length === 0)
+        add(
+          blocker(
+            'ROUTING_MISSING',
+            partNumber,
+            path,
+            `${partNumber} has no routing candidate.`,
+            'routing'
+          )
+        );
+      else if (!preferred.some((candidate) => candidate.isActive))
+        add(
+          blocker(
+            'ROUTING_INACTIVE',
+            partNumber,
+            path,
+            `${partNumber} routing is inactive.`,
+            'routing'
+          )
+        );
+      else if (released.length === 0)
+        add(
+          blocker(
+            'ROUTING_NOT_RELEASED',
+            partNumber,
+            path,
+            `${partNumber} routing is not released.`,
+            'routing'
+          )
+        );
+      else if (released.length > 1)
+        add(
+          blocker(
+            'ROUTING_AMBIGUOUS',
+            partNumber,
+            path,
+            `${partNumber} has multiple released routings at the same precedence.`,
+            'routing'
+          )
+        );
+      else if (released[0].departmentSequence.length === 0)
+        add(
+          blocker(
+            'ROUTING_EMPTY',
+            partNumber,
+            path,
+            `${partNumber} released routing has no executable department.`,
+            'routing'
+          )
+        );
+      else if (released[0].precedence === 3)
+        add(
+          blocker(
+            'ROUTING_EFFECTIVITY_UNRESOLVED',
+            partNumber,
+            path,
+            `${partNumber} has a released routing, but the current schema cannot prove part revision and effectivity for fallback routing precedence.`,
+            'routing'
+          )
+        );
+      else routing = released[0];
+
+      if (bom && finitePositive(input.extendedQuantity)) {
+        const lines = await source.getBomLines(bom.revisionId);
+        if (lines.length === 0)
+          add(
+            blocker(
+              'BOM_EMPTY',
+              partNumber,
+              path,
+              `${partNumber} released BOM has no active component lines.`,
+              'bom'
+            )
+          );
+        for (const line of lines) {
+          const extended =
+            input.extendedQuantity * Number(line.quantityPerParent);
+          children.push(
+            await visit({
+              partNumber: line.childPartNumber,
+              inventoryItemId: null,
+              parentPartNumber: partNumber,
+              quantityPerParent: Number(line.quantityPerParent),
+              extendedQuantity: extended,
+              requiredByDate: input.requiredByDate,
+              path,
+              ancestry: [...input.ancestry, normalized(partNumber)],
+            })
+          );
+        }
+      }
+    }
+
+    const demandStatus: ProductionLaunchPreviewNode['demandStatus'] =
+      nodeBlockers.length
+        ? 'BLOCKED'
+        : shortage === 0
+          ? 'STOCK_SATISFIED'
+          : makeBuy === 'MAKE'
+            ? 'MAKE_REQUIRED'
+            : makeBuy === 'OUTSIDE_PROCESS'
+              ? 'OUTSIDE_PROCESS_REQUIRED'
+              : makeBuy === 'PHANTOM'
+                ? 'PHANTOM_EXPANSION'
+                : 'BUY_REQUIRED';
+
+    return {
+      path,
+      parentPartNumber: input.parentPartNumber,
+      inventoryItemId: item?.id ?? null,
+      partNumber,
+      revision: null,
+      description: item?.description ?? null,
+      classification: classification(item, makeBuy),
+      makeBuy,
+      quantityPerParent: input.quantityPerParent,
+      extendedProjectQuantity: input.extendedQuantity,
+      unitOfMeasure: item?.unitOfMeasure ?? null,
+      bomId: bom?.bomId ?? null,
+      bomRevisionId: bom?.revisionId ?? null,
+      bomRevision: bom?.revision ?? null,
+      routingId: routing?.id ?? null,
+      routingRevision: routing?.revision ?? null,
+      firstDepartment: routing?.departmentSequence[0] ?? null,
+      availableQuantity: available,
+      allocatedQuantity: allocated,
+      shortageQuantity: shortage,
+      requiredByDate: input.requiredByDate,
+      demandStatus,
+      blockers: nodeBlockers,
+      children,
+    };
+  }
+
+  const nodes = await Promise.all(
+    roots.map((root) =>
+      visit({
+        partNumber: root.partNumber,
+        inventoryItemId: root.inventoryItemId,
+        parentPartNumber: null,
+        quantityPerParent: root.quantity,
+        extendedQuantity: root.quantity,
+        requiredByDate: root.requiredByDate,
+        path: [`po-item:${root.poItemId}`],
+        ancestry: [],
+      })
+    )
+  );
+
+  return { ready: allBlockers.length === 0, blockers: allBlockers, nodes };
+}

--- a/server/src/services/productionLaunchPreviewService.ts
+++ b/server/src/services/productionLaunchPreviewService.ts
@@ -1,0 +1,278 @@
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { isP2V2ProductionLaunchPreviewEnabled } from '../lib/featureFlags';
+import { ProjectProductionPlanningError } from './projectProductionPlanningService';
+import {
+  resolveProductionLaunchPreview,
+  type PreviewBomCandidate,
+  type PreviewBomLine,
+  type PreviewInventoryItem,
+  type PreviewRoutingCandidate,
+  type ProductionLaunchPreviewSource,
+} from './productionLaunchPreviewResolver';
+
+type Row = Record<string, unknown>;
+type Executor = typeof db;
+const rows = <T extends Row>(value: unknown): T[] =>
+  Array.isArray(value)
+    ? (value as T[])
+    : ((value as { rows?: T[] } | null)?.rows ?? []);
+
+const textArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value
+        .map(String)
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : [];
+
+function sourceFor(
+  projectId: string,
+  tx: Executor
+): ProductionLaunchPreviewSource {
+  return {
+    async findInventory(partNumber, inventoryItemId) {
+      const result = rows(
+        await tx.execute(sql`
+        SELECT ii.id,ii.ag_part_number,ii.name,ii.description,
+          ii.item_type::text,ii.type,ii.manufactured_category::text,
+          ii.manufacturing_level::text,ii.usage_unit,
+          CASE
+            WHEN lot_totals.lot_count > 0 THEN
+              LEAST(COALESCE(balance.quantity_available,0),lot_totals.usable_quantity)
+            ELSE COALESCE(balance.quantity_available,0)
+          END available_quantity,
+          COALESCE(balance.quantity_allocated,0) allocated_quantity,
+          ii.vendor_id,ii.order_url
+        FROM inventory_items ii
+        LEFT JOIN LATERAL (
+          SELECT SUM(ib.quantity_available) quantity_available,
+            SUM(ib.quantity_allocated) quantity_allocated
+          FROM inventory_balances ib
+          WHERE upper(trim(ib.ag_part_number))=upper(trim(ii.ag_part_number))
+        ) balance ON true
+        LEFT JOIN LATERAL (
+          SELECT COUNT(*) lot_count,
+            COALESCE(SUM(CASE
+              WHEN ml.status='ACCEPTED'
+                AND (ml.expiration_date IS NULL OR ml.expiration_date>=CURRENT_DATE)
+              THEN ml.remaining_qty ELSE 0 END),0) usable_quantity
+          FROM material_lots ml WHERE ml.inventory_item_id=ii.id
+        ) lot_totals ON true
+        WHERE ii.is_active IS DISTINCT FROM false
+          AND (${inventoryItemId}::int IS NULL OR ii.id=${inventoryItemId})
+          AND (${inventoryItemId}::int IS NOT NULL OR upper(trim(ii.ag_part_number))=upper(trim(${partNumber})))
+        ORDER BY ii.id`)
+      );
+      return result.map(
+        (entry): PreviewInventoryItem => ({
+          id: Number(entry.id),
+          partNumber: String(entry.ag_part_number),
+          description:
+            String(entry.description ?? entry.name ?? '').trim() || null,
+          itemType: String(entry.item_type ?? entry.type ?? '').trim() || null,
+          manufacturedCategory:
+            String(entry.manufactured_category ?? '').trim() || null,
+          manufacturingLevel:
+            String(entry.manufacturing_level ?? '').trim() || null,
+          unitOfMeasure: String(entry.usage_unit ?? '').trim() || null,
+          availableQuantity: Number(entry.available_quantity ?? 0),
+          allocatedQuantity: Number(entry.allocated_quantity ?? 0),
+          vendorId: entry.vendor_id == null ? null : Number(entry.vendor_id),
+          orderUrl: String(entry.order_url ?? '').trim() || null,
+        })
+      );
+    },
+
+    async findBoms(partNumber, effectiveAt) {
+      const result = rows(
+        await tx.execute(sql`
+        SELECT b.id bom_id,br.id revision_id,br.rev_code,
+          b.is_active,
+          br.is_released,
+          ((br.effective_from IS NULL OR br.effective_from<=${effectiveAt})
+            AND (br.effective_to IS NULL OR br.effective_to>${effectiveAt})) is_effective
+        FROM boms b
+        JOIN bom_revisions br ON br.bom_id=b.id
+        WHERE upper(trim(b.parent_part_ag_number))=upper(trim(${partNumber}))
+        ORDER BY b.code,br.rev_code,br.id`)
+      );
+      return result.map(
+        (entry): PreviewBomCandidate => ({
+          bomId: String(entry.bom_id),
+          revisionId: String(entry.revision_id),
+          revision: String(entry.rev_code),
+          isActive: entry.is_active === true,
+          isReleased: entry.is_released === true,
+          isEffective: entry.is_effective === true,
+        })
+      );
+    },
+
+    async getBomLines(revisionId) {
+      const result = rows(
+        await tx.execute(sql`
+        SELECT id,child_part_ag_number,qty_per
+        FROM bom_lines WHERE revision_id=${revisionId}
+        ORDER BY operation_seq,id`)
+      );
+      return result.map(
+        (entry): PreviewBomLine => ({
+          id: String(entry.id),
+          childPartNumber: String(entry.child_part_ag_number),
+          quantityPerParent: Number(entry.qty_per),
+        })
+      );
+    },
+
+    async findRoutings(partNumber) {
+      const frozen = rows(
+        await tx.execute(sql`
+        SELECT DISTINCT ppi.routing_id id,ppi.routing_revision,
+          pr.is_active,
+          ARRAY(SELECT ro.department_name FROM routing_operations ro
+            WHERE ro.part_routing_id=pr.id ORDER BY ro.step_number,ro.id) department_sequence,
+          pct.approval_status
+        FROM project_production_plans pp
+        JOIN project_production_plan_items ppi ON ppi.production_plan_id=pp.id
+        JOIN part_routings pr ON pr.id=ppi.routing_id
+        LEFT JOIN production_control_templates pct ON pct.id=pr.created_from_template_id
+        WHERE pp.project_id=${projectId} AND pp.status='RELEASED'
+          AND upper(trim(ppi.part_number))=upper(trim(${partNumber}))
+          AND ppi.routing_id IS NOT NULL`)
+      );
+      const live = frozen.length
+        ? []
+        : rows(
+            await tx.execute(sql`
+        SELECT pr.id,pr.routing_revision,pr.is_active,
+          ARRAY(SELECT ro.department_name FROM routing_operations ro
+            WHERE ro.part_routing_id=pr.id ORDER BY ro.step_number,ro.id) department_sequence,
+          pct.approval_status
+        FROM part_routings pr
+        LEFT JOIN production_control_templates pct ON pct.id=pr.created_from_template_id
+        WHERE upper(trim(pr.part_number))=upper(trim(${partNumber}))
+          AND (pr.project_id=${projectId} OR pr.project_id IS NULL)
+        ORDER BY (pr.project_id=${projectId}) DESC,pr.routing_revision DESC,pr.id`)
+          );
+      return [
+        ...frozen.map((entry) => ({ entry, precedence: 1 as const })),
+        ...live.map((entry) => ({ entry, precedence: 3 as const })),
+      ].map(
+        ({ entry, precedence }): PreviewRoutingCandidate => ({
+          id: String(entry.id),
+          revision: String(entry.routing_revision ?? ''),
+          isActive: entry.is_active === true,
+          releaseStatus: String(entry.approval_status ?? '').trim() || null,
+          departmentSequence: textArray(entry.department_sequence),
+          precedence,
+        })
+      );
+    },
+  };
+}
+
+export async function getProductionLaunchPreview(projectId: string) {
+  if (!isP2V2ProductionLaunchPreviewEnabled())
+    throw new ProjectProductionPlanningError(
+      'P2_V2_PRODUCTION_LAUNCH_PREVIEW_DISABLED',
+      'Recursive Production Launch preview is disabled pending Phase 1 validation.',
+      503
+    );
+
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SET TRANSACTION READ ONLY`);
+    const project = rows(
+      await tx.execute(sql`
+      SELECT id,project_code,workflow_version,po_id,current_stage
+      FROM projects WHERE id=${projectId} FOR SHARE`)
+    )[0];
+    if (!project)
+      throw new ProjectProductionPlanningError(
+        'PROJECT_NOT_FOUND',
+        'Project not found.',
+        404
+      );
+    if (project.workflow_version !== 'p2_v2')
+      throw new ProjectProductionPlanningError(
+        'P2_V2_REQUIRED',
+        'Production Launch preview applies only to p2_v2 projects.',
+        409
+      );
+    const poId = Number(project.po_id);
+    if (!Number.isInteger(poId))
+      throw new ProjectProductionPlanningError(
+        'CURRENT_PO_REQUIRED',
+        'A linked P2 PO is required.',
+        409
+      );
+    const rootRows = rows(
+      await tx.execute(sql`
+      SELECT id,part_number,quantity,inventory_item_id,due_date
+      FROM p2_purchase_order_items WHERE po_id=${poId} ORDER BY id`)
+    );
+    if (!rootRows.length)
+      throw new ProjectProductionPlanningError(
+        'PO_ITEMS_REQUIRED',
+        'The linked P2 PO has no line items.',
+        409
+      );
+
+    const preview = await resolveProductionLaunchPreview(
+      rootRows.map((entry) => ({
+        poItemId: Number(entry.id),
+        partNumber: String(entry.part_number),
+        quantity: Number(entry.quantity),
+        inventoryItemId:
+          entry.inventory_item_id == null
+            ? null
+            : Number(entry.inventory_item_id),
+        requiredByDate: entry.due_date == null ? null : String(entry.due_date),
+      })),
+      sourceFor(projectId, tx as Executor)
+    );
+    return {
+      mode: 'PREVIEW_ONLY' as const,
+      createsRecords: false,
+      project: {
+        id: String(project.id),
+        code: String(project.project_code),
+        poId,
+        stage: String(project.current_stage ?? ''),
+      },
+      generatedAt: new Date().toISOString(),
+      authority: {
+        bom: 'boms / bom_revisions / bom_lines',
+        excludesDraftBomTables: true,
+        routingPrecedence: [
+          'released project production plan frozen routing',
+          'BOM-line routing unavailable in the current schema',
+          'live routing fallback blocks because revision effectivity cannot be proven',
+        ],
+      },
+      inventoryNetting: {
+        status: 'ESTIMATE' as const,
+        policy:
+          'Sum inventory_balances availability; when lots exist, cap it at accepted, unexpired remaining lot quantity.',
+        excludedLotStatuses: [
+          'QUARANTINE',
+          'REJECTED',
+          'EXPIRED',
+          'HOLD',
+          'LOCKED',
+          'ISSUED',
+          'CONSUMED',
+          'SCRAPPED',
+        ],
+        createsAllocations: false,
+      },
+      limitations: [
+        'Preview quantities are estimates and do not reserve or allocate inventory.',
+        'The current BOM-line schema has no controlled routing reference.',
+        'Live routing fallback is reported as a blocker until revision and effectivity can be proven.',
+      ],
+      ...preview,
+    };
+  });
+}


### PR DESCRIPTION
Base SHA: `07a7a0071ad8e2725bf51ebfefdae6d41fdc056f`  
Head SHA: `1af3307f1757b5a3b3de2252661b799d0817661d`  

## Phase 1 scope  Adds a read-only, feature-gated recursive P2 Production Launch preview. This PR does not create work orders, allocations, reservations, travelers, schedules, audit events, migrations, or other production records. It does not implement Phase 2.  ## BOM and routing authority  - BOM authority: active `boms` with released, date-effective `bom_revisions` and their `bom_lines`; draft BOM tables are explicitly excluded. - Routing precedence: released project production-plan frozen routing first. - The current BOM-line schema has no controlled routing reference, so precedence 2 is unavailable. - Live routing fallback fails closed because the current schema cannot prove part revision and effectivity. - First department is always the first released routing operation; there is no Layup fallback.  ## Inventory netting assumptions  - Availability is an estimate from `inventory_balances`. - Where material lots exist, availability is capped at accepted, unexpired remaining lot quantity. - Quarantine, rejected, expired, hold, locked, issued, consumed, and scrapped lots are excluded. - Preview does not allocate or reserve inventory.  ## Blocker behavior  The preview fails closed and returns path-specific correction targets for missing or ambiguous inventory identity, missing make/buy decisions, inactive/unreleased/ineffective/empty/ambiguous BOMs, cycles and invalid quantities, missing/inactive/unreleased/empty/ambiguous/unproven-effectivity routings, and missing purchasing paths.  ## Feature flag  `P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED` defaults to disabled and enables only for the exact value `true`. The endpoint also requires `projects.production_planning.manage`.  ## Validation  - Phase 1 focused: 4 files, 22 tests passed. - Targeted legacy regression: 73 tests passed across Production Planning, existing production-launch gate, preproduction readiness, and production execution. - `git diff --check` passed. - `git merge-tree --write-tree origin/main HEAD` passed without conflicts. - Full repository `tsc --noEmit` was attempted but exhausted Node's 2 GB heap before diagnostics; it is not reported as a pass. - Existing Vite warnings about duplicate labor-posting methods in `server/storage.ts` are outside this PR.  ## Deferred to Phase 2  - Consequential production creation and release workflow. - Inventory allocation/reservation. - A controlled BOM-line routing link or another schema-backed revision/effectivity authority. - Live-data/customer-data validation and deployment enablement.