### PR TITLE
Fail closed when generated controlled-document storage fails

### DIFF
--- a/server/__tests__/routingDocumentTemplateCentralStorageFallback.test.ts
+++ b/server/__tests__/routingDocumentTemplateCentralStorageFallback.test.ts
@@ -8,11 +8,12 @@ describe('generated template document central-storage save path', () => {
   const end = route.indexOf("router.post('/documents/from-template'", start);
   const handler = route.slice(start, end);
 
-  it('falls back to the served central media directory when object storage rejects a buffer upload', () => {
+  it('fails closed instead of creating a deployment-local file when object storage rejects the upload', () => {
     expect(route).toContain('async function saveGeneratedTemplatePdf');
-    expect(route).toContain("path.posix.join('uploads', 'media-library', storedFileName)");
-    expect(route).toContain('await fs.promises.writeFile');
-    expect(route).toContain('fileUrl: `/api/media/file/${encodeURIComponent(storedFileName)}`');
+    expect(route).toContain('await saveSpecSheetPdfFile(fileName, fileBuffer)');
+    expect(route).not.toContain("path.posix.join('uploads', 'media-library', storedFileName)");
+    expect(route).not.toContain('Generated template PDF used central-storage local fallback');
+    expect(route).not.toContain('fileUrl: `/api/media/file/${encodeURIComponent(storedFileName)}`');
   });
 
   it('registers central storage before queueing the Master Document record', () => {

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -716,27 +716,8 @@ async function saveSpecSheetPdfFile(fileName: string, fileBuffer: Buffer) {
 }
 
 async function saveGeneratedTemplatePdf(fileName: string, fileBuffer: Buffer) {
-  try {
-    const fileUrl = await saveSpecSheetPdfFile(fileName, fileBuffer);
-    return { fileUrl, storagePath: fileUrl, storageWarning: null };
-  } catch (error) {
-    const { reason, message } = getStorageErrorResponse(error);
-    const storedFileName = sanitizeFileName(fileName);
-    const relativePath = path.posix.join('uploads', 'media-library', storedFileName);
-    const absoluteDirectory = path.join(process.cwd(), 'uploads', 'media-library');
-    await fs.promises.mkdir(absoluteDirectory, { recursive: true });
-    await fs.promises.writeFile(path.join(absoluteDirectory, storedFileName), fileBuffer);
-    console.warn('Generated template PDF used central-storage local fallback', {
-      fileName: storedFileName,
-      reason,
-      message,
-    });
-    return {
-      fileUrl: `/api/media/file/${encodeURIComponent(storedFileName)}`,
-      storagePath: relativePath,
-      storageWarning: message,
-    };
-  }
+  const fileUrl = await saveSpecSheetPdfFile(fileName, fileBuffer);
+  return { fileUrl, storagePath: fileUrl, storageWarning: null };
 }
 
 // Helper to format UUID bytes to string if needed


### PR DESCRIPTION
## What changed

- remove the deployment-local `uploads/media-library` fallback for generated Form & Document Builder PDFs
- require generated controlled PDFs to be persisted through the app's central object-storage provider
- update the regression test to reject local-disk and `/api/media/file/` fallback references

## Root cause

When central object storage rejected an upload, EPOCH wrote the generated PDF to deployment-local storage and still created the media, routing-document, and Master Document Register records. A restart or deployment could remove those local bytes while leaving the database row, causing “document is no longer available” for an EPOCH-created document.

## Impact

New generated controlled documents now fail visibly before the MDR record is created if central storage is unavailable. This prevents future orphaned controlled-document records.

This change does not fabricate or replace the already-missing bytes for document 26247; that existing record still requires controlled reconciliation.

## Validation

- focused static storage assertions passed
- `git diff --check` passed
- focused Vitest startup was attempted, but the shared checkout is missing `@alloc/quick-lru`; this is reported as blocked, not passed