### PR TITLE
Reconcile recursive P2 production demand foundation

### DIFF
--- a/migrations/0264_p2_recursive_production_demand_foundation.sql
+++ b/migrations/0264_p2_recursive_production_demand_foundation.sql
@@ -1,0 +1,242 @@
+-- Phase 2 foundation for controlled recursive P2 production demand.
+-- Additive only: no legacy backfill, no execution records, and no stage changes.
+
+CREATE UNIQUE INDEX IF NOT EXISTS project_production_plan_items_identity_key
+  ON project_production_plan_items(id,production_plan_id,project_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid='project_production_plan_items'::regclass
+      AND conname='project_production_plan_items_identity_key'
+  ) THEN
+    ALTER TABLE project_production_plan_items
+      ADD CONSTRAINT project_production_plan_items_identity_key
+      UNIQUE USING INDEX project_production_plan_items_identity_key;
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS project_production_demands (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  production_release_id UUID NOT NULL REFERENCES project_production_releases(id) ON DELETE RESTRICT,
+  production_launch_id UUID NOT NULL,
+  production_plan_id UUID NOT NULL REFERENCES project_production_plans(id) ON DELETE RESTRICT,
+  production_plan_item_id UUID NOT NULL REFERENCES project_production_plan_items(id) ON DELETE RESTRICT,
+  po_id INTEGER NOT NULL REFERENCES p2_purchase_orders(id) ON DELETE RESTRICT,
+  po_item_id INTEGER NOT NULL REFERENCES p2_purchase_order_items(id) ON DELETE RESTRICT,
+  demand_line_identity UUID NOT NULL,
+  demand_key TEXT NOT NULL,
+  parent_demand_id UUID REFERENCES project_production_demands(id) ON DELETE RESTRICT,
+  supersedes_demand_id UUID REFERENCES project_production_demands(id) ON DELETE RESTRICT,
+  replacement_for_demand_id UUID REFERENCES project_production_demands(id) ON DELETE RESTRICT,
+  assembly_path TEXT NOT NULL,
+  path_depth INTEGER NOT NULL CHECK (path_depth >= 0),
+  inventory_item_id INTEGER REFERENCES inventory_items(id) ON DELETE RESTRICT,
+  part_number TEXT NOT NULL,
+  part_revision TEXT,
+  description TEXT,
+  classification TEXT NOT NULL CHECK (classification IN (
+    'PACKET','KIT','MACHINED_PART','CORE','SUB_ASSEMBLY','ASSEMBLY',
+    'FINAL_ASSEMBLY','COMPOSITE','COMPONENT','MANUFACTURED_COMPONENT',
+    'PURCHASED_COMPONENT','RAW_MATERIAL','OUTSIDE_PROCESS','PHANTOM',
+    'STOCK_SATISFIED','BLOCKED_UNRESOLVED'
+  )),
+  disposition TEXT NOT NULL CHECK (disposition IN ('MAKE','BUY','OUTSIDE_PROCESS','PHANTOM','STOCK_SATISFIED','UNRESOLVED')),
+  quantity_per_parent NUMERIC(18,6) NOT NULL CHECK (quantity_per_parent > 0),
+  gross_required_quantity NUMERIC(18,6) NOT NULL CHECK (gross_required_quantity > 0),
+  available_quantity_snapshot NUMERIC(18,6) NOT NULL DEFAULT 0 CHECK (available_quantity_snapshot >= 0),
+  allocated_quantity_snapshot NUMERIC(18,6) NOT NULL DEFAULT 0 CHECK (allocated_quantity_snapshot >= 0),
+  shortage_quantity NUMERIC(18,6) NOT NULL CHECK (shortage_quantity >= 0),
+  original_customer_quantity NUMERIC(18,6) NOT NULL CHECK (original_customer_quantity >= 0),
+  effective_customer_quantity NUMERIC(18,6) NOT NULL CHECK (effective_customer_quantity >= 0),
+  customer_demand_event_digest TEXT NOT NULL CHECK (customer_demand_event_digest ~ '^[0-9a-f]{64}$'),
+  customer_demand_snapshot JSONB NOT NULL,
+  unit_of_measure TEXT,
+  required_by_date DATE,
+  bom_id UUID REFERENCES boms(id) ON DELETE RESTRICT,
+  bom_revision_id UUID REFERENCES bom_revisions(id) ON DELETE RESTRICT,
+  bom_revision_snapshot TEXT,
+  routing_id UUID REFERENCES part_routings(id) ON DELETE RESTRICT,
+  routing_revision_snapshot TEXT,
+  first_department_snapshot TEXT,
+  wad_authorization_id UUID REFERENCES project_wad_authorizations(id) ON DELETE RESTRICT,
+  demand_status TEXT NOT NULL DEFAULT 'PLANNED'
+    CHECK (demand_status IN ('PLANNED','STOCK_SATISFIED','BLOCKED','AUTHORIZED','IN_PROCESS','COMPLETE','CANCELLED','SUPERSEDED')),
+  blocker_snapshot JSONB NOT NULL DEFAULT '[]'::jsonb,
+  authority_snapshot JSONB NOT NULL,
+  status_reason TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT project_production_demands_launch_project_fk
+    FOREIGN KEY (production_launch_id,project_id)
+    REFERENCES project_production_launches(id,project_id)
+    ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+  CONSTRAINT project_production_demands_plan_project_fk
+    FOREIGN KEY (production_plan_item_id,production_plan_id,project_id)
+    REFERENCES project_production_plan_items(id,production_plan_id,project_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT project_production_demands_po_line_identity_fk
+    FOREIGN KEY (po_item_id,demand_line_identity)
+    REFERENCES p2_purchase_order_items(id,demand_line_identity)
+    ON DELETE RESTRICT,
+  CONSTRAINT project_production_demands_release_project_fk
+    FOREIGN KEY (production_release_id,project_id)
+    REFERENCES project_production_releases(id,project_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT project_production_demands_parent_project_fk
+    FOREIGN KEY (parent_demand_id,project_id)
+    REFERENCES project_production_demands(id,project_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT project_production_demands_supersedes_project_fk
+    FOREIGN KEY (supersedes_demand_id,project_id)
+    REFERENCES project_production_demands(id,project_id)
+    ON DELETE RESTRICT,
+  CONSTRAINT project_production_demands_replacement_project_fk
+    FOREIGN KEY (replacement_for_demand_id,project_id)
+    REFERENCES project_production_demands(id,project_id)
+    ON DELETE RESTRICT,
+  CHECK (shortage_quantity <= gross_required_quantity),
+  CHECK (parent_demand_id IS NULL OR parent_demand_id <> id),
+  CHECK (supersedes_demand_id IS NULL OR supersedes_demand_id <> id),
+  CHECK (replacement_for_demand_id IS NULL OR replacement_for_demand_id <> id),
+  CONSTRAINT project_production_demands_id_project_unique UNIQUE (id,project_id),
+  CONSTRAINT project_production_demands_launch_key_unique
+    UNIQUE (production_launch_id,demand_key),
+  CONSTRAINT project_production_demands_plan_identity_unique
+    UNIQUE (production_launch_id,production_plan_item_id,po_item_id,assembly_path)
+);
+
+CREATE INDEX IF NOT EXISTS project_production_demands_project_status_idx
+  ON project_production_demands(project_id,demand_status,assembly_path);
+CREATE INDEX IF NOT EXISTS project_production_demands_parent_idx
+  ON project_production_demands(parent_demand_id) WHERE parent_demand_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS project_production_demands_inventory_idx
+  ON project_production_demands(inventory_item_id) WHERE inventory_item_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS project_production_demand_dependencies (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  predecessor_demand_id UUID NOT NULL,
+  successor_demand_id UUID NOT NULL,
+  dependency_type TEXT NOT NULL
+    CHECK (dependency_type IN ('COMPLETE','ACCEPT','ISSUE_OR_SCAN')),
+  status TEXT NOT NULL DEFAULT 'OPEN'
+    CHECK (status IN ('OPEN','SATISFIED','WAIVED','CANCELLED')),
+  satisfied_at TIMESTAMP,
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  FOREIGN KEY (predecessor_demand_id,project_id)
+    REFERENCES project_production_demands(id,project_id) ON DELETE RESTRICT,
+  FOREIGN KEY (successor_demand_id,project_id)
+    REFERENCES project_production_demands(id,project_id) ON DELETE RESTRICT,
+  CHECK (predecessor_demand_id <> successor_demand_id),
+  UNIQUE (predecessor_demand_id,successor_demand_id,dependency_type)
+);
+
+CREATE INDEX IF NOT EXISTS project_production_demand_dependencies_successor_idx
+  ON project_production_demand_dependencies(successor_demand_id,status);
+
+CREATE TABLE IF NOT EXISTS project_production_demand_execution_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  demand_id UUID NOT NULL,
+  p2_production_order_id INTEGER REFERENCES p2_production_orders(id) ON DELETE RESTRICT,
+  production_work_order_id UUID REFERENCES production_work_orders(id) ON DELETE RESTRICT,
+  traveler_id VARCHAR(255) REFERENCES travelers(id) ON DELETE RESTRICT,
+  cnc_job_id INTEGER REFERENCES cnc_jobs(id) ON DELETE RESTRICT,
+  manufacturing_queue_id INTEGER REFERENCES manufacturing_queue(id) ON DELETE RESTRICT,
+  cutting_demand_id UUID REFERENCES cutting_packet_schedule(id) ON DELETE RESTRICT,
+  link_type TEXT NOT NULL
+    CHECK (link_type IN ('P2_PRODUCTION_ORDER','WAD','TRAVELER','CNC_JOB','MANUFACTURING_QUEUE','CUTTING_DEMAND')),
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  FOREIGN KEY (demand_id,project_id)
+    REFERENCES project_production_demands(id,project_id) ON DELETE RESTRICT,
+  CHECK (num_nonnulls(p2_production_order_id,production_work_order_id,traveler_id,cnc_job_id,manufacturing_queue_id,cutting_demand_id) = 1),
+  UNIQUE NULLS NOT DISTINCT
+    (demand_id,link_type,p2_production_order_id,production_work_order_id,traveler_id,cnc_job_id,manufacturing_queue_id,cutting_demand_id)
+);
+
+CREATE INDEX IF NOT EXISTS project_production_demand_execution_links_demand_idx
+  ON project_production_demand_execution_links(demand_id,link_type);
+
+CREATE TABLE IF NOT EXISTS project_production_demand_allocations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  demand_id UUID NOT NULL,
+  inventory_item_id INTEGER NOT NULL REFERENCES inventory_items(id) ON DELETE RESTRICT,
+  material_lot_id UUID REFERENCES material_lots(id) ON DELETE RESTRICT,
+  allocation_type TEXT NOT NULL CHECK (allocation_type IN ('NETTING_SNAPSHOT','RESERVATION','ISSUE','REPLACEMENT')),
+  quantity NUMERIC(18,6) NOT NULL CHECK (quantity > 0),
+  status TEXT NOT NULL DEFAULT 'PLANNED' CHECK (status IN ('PLANNED','ACTIVE','CONSUMED','RELEASED','CANCELLED')),
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  FOREIGN KEY (demand_id,project_id)
+    REFERENCES project_production_demands(id,project_id) ON DELETE RESTRICT,
+  UNIQUE NULLS NOT DISTINCT
+    (demand_id,allocation_type,inventory_item_id,material_lot_id)
+);
+
+CREATE INDEX IF NOT EXISTS project_production_demand_allocations_demand_idx
+  ON project_production_demand_allocations(demand_id,status);
+
+CREATE OR REPLACE FUNCTION protect_project_production_demand_authority()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.project_id IS DISTINCT FROM OLD.project_id
+     OR NEW.production_release_id IS DISTINCT FROM OLD.production_release_id
+     OR NEW.production_launch_id IS DISTINCT FROM OLD.production_launch_id
+     OR NEW.production_plan_id IS DISTINCT FROM OLD.production_plan_id
+     OR NEW.production_plan_item_id IS DISTINCT FROM OLD.production_plan_item_id
+     OR NEW.po_id IS DISTINCT FROM OLD.po_id
+     OR NEW.po_item_id IS DISTINCT FROM OLD.po_item_id
+     OR NEW.demand_line_identity IS DISTINCT FROM OLD.demand_line_identity
+     OR NEW.demand_key IS DISTINCT FROM OLD.demand_key
+     OR NEW.parent_demand_id IS DISTINCT FROM OLD.parent_demand_id
+     OR NEW.assembly_path IS DISTINCT FROM OLD.assembly_path
+     OR NEW.part_number IS DISTINCT FROM OLD.part_number
+     OR NEW.disposition IS DISTINCT FROM OLD.disposition
+     OR NEW.gross_required_quantity IS DISTINCT FROM OLD.gross_required_quantity
+     OR NEW.original_customer_quantity IS DISTINCT FROM OLD.original_customer_quantity
+     OR NEW.effective_customer_quantity IS DISTINCT FROM OLD.effective_customer_quantity
+     OR NEW.customer_demand_event_digest IS DISTINCT FROM OLD.customer_demand_event_digest
+     OR NEW.customer_demand_snapshot IS DISTINCT FROM OLD.customer_demand_snapshot
+     OR NEW.bom_revision_id IS DISTINCT FROM OLD.bom_revision_id
+     OR NEW.routing_id IS DISTINCT FROM OLD.routing_id
+     OR NEW.routing_revision_snapshot IS DISTINCT FROM OLD.routing_revision_snapshot
+     OR NEW.authority_snapshot IS DISTINCT FROM OLD.authority_snapshot
+  THEN
+    RAISE EXCEPTION 'Production demand authority snapshots are immutable';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE OR REPLACE FUNCTION enforce_project_production_demand_status_transition()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.demand_status IS NOT DISTINCT FROM OLD.demand_status THEN RETURN NEW; END IF;
+  IF OLD.demand_status IN ('COMPLETE','CANCELLED','SUPERSEDED')
+     OR (OLD.demand_status='BLOCKED' AND NEW.demand_status NOT IN ('CANCELLED','SUPERSEDED'))
+     OR (OLD.demand_status='PLANNED' AND NEW.demand_status NOT IN ('AUTHORIZED','CANCELLED','SUPERSEDED'))
+     OR (OLD.demand_status='STOCK_SATISFIED' AND NEW.demand_status NOT IN ('COMPLETE','CANCELLED','SUPERSEDED'))
+     OR (OLD.demand_status='AUTHORIZED' AND NEW.demand_status NOT IN ('IN_PROCESS','CANCELLED','SUPERSEDED'))
+     OR (OLD.demand_status='IN_PROCESS' AND NEW.demand_status NOT IN ('COMPLETE','CANCELLED'))
+  THEN RAISE EXCEPTION 'Invalid production demand status transition: % to %',OLD.demand_status,NEW.demand_status;
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS protect_project_production_demand_authority_trigger
+  ON project_production_demands;
+CREATE TRIGGER protect_project_production_demand_authority_trigger
+BEFORE UPDATE ON project_production_demands
+FOR EACH ROW EXECUTE FUNCTION protect_project_production_demand_authority();
+
+DROP TRIGGER IF EXISTS enforce_project_production_demand_status_transition_trigger
+  ON project_production_demands;
+CREATE TRIGGER enforce_project_production_demand_status_transition_trigger
+BEFORE UPDATE OF demand_status ON project_production_demands
+FOR EACH ROW EXECUTE FUNCTION enforce_project_production_demand_status_transition();

--- a/server/__tests__/p2RecursiveProductionDemandFoundation.test.ts
+++ b/server/__tests__/p2RecursiveProductionDemandFoundation.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  criticalMigrationFiles,
+  safeMigrationFiles,
+} from '../scripts/migrations/runSafeBootMigrations';
+
+const migrationName = '0264_p2_recursive_production_demand_foundation.sql';
+const migration = readFileSync(
+  join(process.cwd(), 'migrations', migrationName),
+  'utf8'
+);
+const schema = readFileSync(join(process.cwd(), 'server/schema.ts'), 'utf8');
+
+describe('P2 recursive production-demand Phase 2 foundation', () => {
+  it('is registered for deterministic safe boot', () => {
+    expect(safeMigrationFiles).toContain(migrationName);
+    expect(criticalMigrationFiles.has(migrationName)).toBe(true);
+  });
+
+  it('aligns the four migration-owned tables with application schema models', () => {
+    for (const table of [
+      'project_production_demands',
+      'project_production_demand_dependencies',
+      'project_production_demand_execution_links',
+      'project_production_demand_allocations',
+    ]) {
+      expect(migration).toContain(`TABLE IF NOT EXISTS ${table}`);
+      expect(schema).toContain(`'${table}'`);
+    }
+    for (const column of [
+      'demand_line_identity',
+      'demand_key',
+      'effective_customer_quantity',
+      'customer_demand_event_digest',
+      'replacement_for_demand_id',
+    ]) {
+      expect(schema).toContain(`'${column}'`);
+    }
+  });
+
+  it('is additive and performs no legacy backfill or execution mutation', () => {
+    expect(migration).not.toMatch(
+      /\b(?:UPDATE\s+[a-z_]+\s+SET|DELETE\s+FROM|TRUNCATE)\b/i
+    );
+    expect(migration).not.toMatch(
+      /INSERT\s+INTO\s+(?:p2_production_orders|production_work_orders|travelers)/i
+    );
+    expect(migration).toContain('no legacy backfill');
+  });
+
+  it('owns a launch-scoped recursive demand identity', () => {
+    expect(migration).toContain('project_production_demands');
+    expect(migration).toContain('parent_demand_id UUID');
+    expect(migration).toContain(
+      'UNIQUE (production_launch_id,production_plan_item_id,po_item_id,assembly_path)'
+    );
+    expect(migration).toContain('DEFERRABLE INITIALLY DEFERRED');
+    expect(migration).toContain('UNIQUE (production_launch_id,demand_key)');
+  });
+
+  it('freezes BOM, routing, plan, release, quantity, and authority evidence', () => {
+    for (const field of [
+      'production_release_id',
+      'production_plan_item_id',
+      'gross_required_quantity',
+      'bom_revision_id',
+      'routing_revision_snapshot',
+      'authority_snapshot',
+      'demand_line_identity',
+      'customer_demand_event_digest',
+      'customer_demand_snapshot',
+    ]) {
+      expect(migration).toContain(`NEW.${field} IS DISTINCT FROM OLD.${field}`);
+    }
+  });
+
+  it('binds root quantities to the current-main immutable customer-demand ledger', () => {
+    expect(migration).toContain(
+      'FOREIGN KEY (po_item_id,demand_line_identity)'
+    );
+    expect(migration).toContain('original_customer_quantity');
+    expect(migration).toContain('effective_customer_quantity');
+    expect(migration).toContain(
+      "customer_demand_event_digest ~ '^[0-9a-f]{64}$'"
+    );
+  });
+
+  it('models controlled cancellation, supersession, scrap, and replacement lineage', () => {
+    expect(migration).toContain('supersedes_demand_id UUID');
+    expect(migration).toContain('replacement_for_demand_id UUID');
+    expect(migration).toContain("'CANCELLED','SUPERSEDED'");
+    expect(migration).toContain("'ISSUE','REPLACEMENT'");
+    expect(migration).toContain(
+      'enforce_project_production_demand_status_transition'
+    );
+  });
+
+  it('accepts UNRESOLVED only as explicit blocked evidence', () => {
+    expect(migration).toContain("'STOCK_SATISFIED','UNRESOLVED'");
+    expect(migration).toContain("'BLOCKED_UNRESOLVED'");
+  });
+
+  it('models child gates without silently authorizing floor work', () => {
+    expect(migration).toContain('project_production_demand_dependencies');
+    expect(migration).toContain("'COMPLETE','ACCEPT','ISSUE_OR_SCAN'");
+    expect(migration).toContain('project_production_demand_execution_links');
+    expect(migration).toContain('project_production_demand_allocations');
+  });
+
+  it('keeps stock netting distinct from reservation and issue evidence', () => {
+    expect(migration).toContain(
+      "'NETTING_SNAPSHOT','RESERVATION','ISSUE','REPLACEMENT'"
+    );
+    expect(migration).toContain(
+      "'PLANNED','ACTIVE','CONSUMED','RELEASED','CANCELLED'"
+    );
+  });
+});

--- a/server/__tests__/productionDemandGraph.test.ts
+++ b/server/__tests__/productionDemandGraph.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compileProductionDemandGraph,
+  ProductionDemandGraphError,
+  type FrozenProductionPlanItem,
+} from '../src/services/productionDemandGraph';
+import type { ProductionLaunchPreviewNode } from '../src/services/productionLaunchPreviewResolver';
+
+const node = (
+  partNumber: string,
+  assemblyPath: string,
+  makeBuy: ProductionLaunchPreviewNode['makeBuy'],
+  shortageQuantity: number,
+  children: ProductionLaunchPreviewNode[] = []
+): ProductionLaunchPreviewNode => ({
+  path: ['po-item:20', partNumber],
+  productionPlanAssemblyPath: assemblyPath,
+  bomLineId: assemblyPath.includes('/line:')
+    ? assemblyPath.split('/line:').at(-1)!
+    : null,
+  demandLineIdentity: '00000000-0000-4000-8000-000000000020',
+  originalCustomerQuantity: 4,
+  effectiveCustomerQuantity: 4,
+  customerDemandEventDigest: '0'.repeat(64),
+  customerDemandSnapshot: { originalQuantity: 4, events: [] },
+  parentPartNumber: null,
+  inventoryItemId: 1,
+  partNumber,
+  revision: 'A',
+  description: `${partNumber} description`,
+  classification:
+    makeBuy === 'MAKE' ? 'MANUFACTURED_COMPONENT' : 'PURCHASED_COMPONENT',
+  makeBuy,
+  quantityPerParent: 1,
+  extendedProjectQuantity: 4,
+  unitOfMeasure: 'EA',
+  bomId: makeBuy === 'MAKE' ? 'bom' : null,
+  bomRevisionId: makeBuy === 'MAKE' ? 'bom-rev' : null,
+  bomRevision: makeBuy === 'MAKE' ? 'A' : null,
+  routingId: makeBuy === 'MAKE' ? 'route' : null,
+  routingRevision: makeBuy === 'MAKE' ? '1' : null,
+  firstDepartment: makeBuy === 'MAKE' ? 'CNC' : null,
+  availableQuantity: 4 - shortageQuantity,
+  allocatedQuantity: 0,
+  shortageQuantity,
+  requiredByDate: '2026-10-01',
+  demandStatus:
+    shortageQuantity === 0
+      ? 'STOCK_SATISFIED'
+      : makeBuy === 'MAKE'
+        ? 'MAKE_REQUIRED'
+        : 'BUY_REQUIRED',
+  blockers: [],
+  children,
+});
+
+const plan = (
+  ...entries: Array<[string, string]>
+): FrozenProductionPlanItem[] =>
+  entries.map(([assemblyPath, partNumber], index) => ({
+    id: `plan-item-${index + 1}`,
+    assemblyPath,
+    partNumber,
+    productionPlanId: 'plan-1',
+    projectId: 'project-1',
+  }));
+
+describe('controlled Production Demand graph compiler', () => {
+  it('compiles multilevel MAKE and BUY demand with exact released-plan identity', () => {
+    const buy = node('RAW-STOCK', 'root:20/line:left/line:stock', 'BUY', 2);
+    const left = node('PITOT-CNC-LEFT', 'root:20/line:left', 'MAKE', 4, [buy]);
+    const right = node('PITOT-CNC-RIGHT', 'root:20/line:right', 'MAKE', 4);
+    const root = node('HEATED-PITOT', 'root:20', 'MAKE', 4, [left, right]);
+    const graph = compileProductionDemandGraph(
+      [root],
+      plan(
+        ['root:20', 'HEATED-PITOT'],
+        ['root:20/line:left', 'PITOT-CNC-LEFT'],
+        ['root:20/line:left/line:stock', 'RAW-STOCK'],
+        ['root:20/line:right', 'PITOT-CNC-RIGHT']
+      )
+    );
+    expect(graph.demands).toHaveLength(4);
+    expect(graph.demands[1]).toMatchObject({
+      parentKey: '20:root:20',
+      productionPlanItemId: 'plan-item-2',
+      firstDepartmentSnapshot: 'CNC',
+      disposition: 'MAKE',
+      demandLineIdentity: '00000000-0000-4000-8000-000000000020',
+      customerDemandEventDigest: '0'.repeat(64),
+    });
+    expect(graph.dependencies).toContainEqual({
+      predecessorKey: '20:root:20/line:left',
+      successorKey: '20:root:20',
+      dependencyType: 'ISSUE_OR_SCAN',
+    });
+  });
+
+  it('propagates the authoritative customer-demand quantity snapshot to every descendant', () => {
+    const child = node('CHILD', 'root:20/line:child', 'BUY', 2);
+    const root = node('ASSEMBLY', 'root:20', 'MAKE', 6, [child]);
+    root.originalCustomerQuantity = 4;
+    root.effectiveCustomerQuantity = 6;
+    root.customerDemandEventDigest = 'a'.repeat(64);
+    root.customerDemandSnapshot = {
+      originalQuantity: 4,
+      effectiveQuantity: 6,
+      events: [{ eventType: 'SCOPE_INCREASE', quantityDelta: 2 }],
+    };
+    child.originalCustomerQuantity = root.originalCustomerQuantity;
+    child.effectiveCustomerQuantity = root.effectiveCustomerQuantity;
+    child.customerDemandEventDigest = root.customerDemandEventDigest;
+    child.customerDemandSnapshot = root.customerDemandSnapshot;
+    const graph = compileProductionDemandGraph(
+      [root],
+      plan(['root:20', 'ASSEMBLY'], ['root:20/line:child', 'CHILD'])
+    );
+    expect(graph.demands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          originalCustomerQuantity: 4,
+          effectiveCustomerQuantity: 6,
+          customerDemandEventDigest: 'a'.repeat(64),
+        }),
+      ])
+    );
+    expect(
+      graph.demands.every((demand) => demand.effectiveCustomerQuantity === 6)
+    ).toBe(true);
+  });
+
+  it('retains stock-satisfied traceability without creating a parent gate', () => {
+    const stocked = node('STOCKED-BUY', 'root:20/line:stocked', 'BUY', 0);
+    const root = node('ASSEMBLY', 'root:20', 'MAKE', 1, [stocked]);
+    const graph = compileProductionDemandGraph(
+      [root],
+      plan(['root:20', 'ASSEMBLY'], ['root:20/line:stocked', 'STOCKED-BUY'])
+    );
+    expect(graph.demands[1]).toMatchObject({
+      disposition: 'STOCK_SATISFIED',
+      demandStatus: 'STOCK_SATISFIED',
+    });
+    expect(graph.dependencies).toEqual([]);
+  });
+
+  it('fails closed when the recursive preview differs from the released plan', () => {
+    const root = node('ASSEMBLY', 'root:20', 'MAKE', 1);
+    expect(() => compileProductionDemandGraph([root], [])).toThrowError(
+      expect.objectContaining<Partial<ProductionDemandGraphError>>({
+        code: 'PLAN_ITEM_MISSING',
+      })
+    );
+    expect(() =>
+      compileProductionDemandGraph([root], plan(['root:20', 'OTHER-PART']))
+    ).toThrowError(
+      expect.objectContaining<Partial<ProductionDemandGraphError>>({
+        code: 'PLAN_ITEM_MISMATCH',
+      })
+    );
+  });
+});

--- a/server/__tests__/productionLaunchPreviewResolver.test.ts
+++ b/server/__tests__/productionLaunchPreviewResolver.test.ts
@@ -89,6 +89,11 @@ const roots = (partNumber: string, quantity = 1) => [
     quantity,
     inventoryItemId: null,
     requiredByDate: '2026-10-01',
+    demandLineIdentity: '00000000-0000-4000-8000-000000000020',
+    originalCustomerQuantity: quantity,
+    effectiveCustomerQuantity: quantity,
+    customerDemandEventDigest: '0'.repeat(64),
+    customerDemandSnapshot: { originalQuantity: quantity, events: [] },
   },
 ];
 

--- a/server/__tests__/productionLaunchPreviewService.test.ts
+++ b/server/__tests__/productionLaunchPreviewService.test.ts
@@ -16,7 +16,9 @@ const route = readFileSync(
 describe('Production Launch Phase 1 preview boundary', () => {
   it('executes inside an explicit read-only transaction', () => {
     expect(service).toContain('SET TRANSACTION READ ONLY');
-    expect(service).not.toMatch(/\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\b/i);
+    expect(service).not.toMatch(
+      /sql`[^`]*\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\b[^`]*`/i
+    );
     expect(service).toContain("mode: 'PREVIEW_ONLY'");
     expect(service).toContain('createsRecords: false');
   });
@@ -27,5 +29,12 @@ describe('Production Launch Phase 1 preview boundary', () => {
     );
     expect(service).toContain('isP2V2ProductionLaunchPreviewEnabled()');
     expect(service).toContain('P2_V2_PRODUCTION_LAUNCH_PREVIEW_DISABLED');
+  });
+
+  it('uses the immutable customer-demand event ledger for root quantity authority', () => {
+    expect(service).toContain('p2_customer_demand_quantity_events');
+    expect(service).toContain('poi.quantity+COALESCE(SUM(e.quantity_delta),0)');
+    expect(service).toContain('demandLineIdentity');
+    expect(service).toContain("createHash('sha256')");
   });
 });

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -371,24 +371,29 @@ export const potentialOrderDuplicateReviews = pgTable(
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
   },
   (table) => ({
-    orderPairUnique: uniqueIndex('potential_order_duplicate_reviews_pair_unique').on(
-      table.newOrderId,
-      table.candidateOrderId
+    orderPairUnique: uniqueIndex(
+      'potential_order_duplicate_reviews_pair_unique'
+    ).on(table.newOrderId, table.candidateOrderId),
+    newOrderIdx: index('potential_order_duplicate_reviews_new_order_idx').on(
+      table.newOrderId
     ),
-    newOrderIdx: index('potential_order_duplicate_reviews_new_order_idx').on(table.newOrderId),
-    candidateOrderIdx: index('potential_order_duplicate_reviews_candidate_order_idx').on(table.candidateOrderId),
-    statusRiskIdx: index('potential_order_duplicate_reviews_status_risk_idx').on(
-      table.status,
-      table.riskLevel
-    ),
+    candidateOrderIdx: index(
+      'potential_order_duplicate_reviews_candidate_order_idx'
+    ).on(table.candidateOrderId),
+    statusRiskIdx: index(
+      'potential_order_duplicate_reviews_status_risk_idx'
+    ).on(table.status, table.riskLevel),
   })
 );
 
 export const insertPotentialOrderDuplicateReviewSchema = createInsertSchema(
   potentialOrderDuplicateReviews
 ).omit({ id: true, createdAt: true, updatedAt: true });
-export type PotentialOrderDuplicateReview = typeof potentialOrderDuplicateReviews.$inferSelect;
-export type InsertPotentialOrderDuplicateReview = z.infer<typeof insertPotentialOrderDuplicateReviewSchema>;
+export type PotentialOrderDuplicateReview =
+  typeof potentialOrderDuplicateReviews.$inferSelect;
+export type InsertPotentialOrderDuplicateReview = z.infer<
+  typeof insertPotentialOrderDuplicateReviewSchema
+>;
 
 // Follow-up Orders - New orders that require customer signature before production
 export const followupOrders = pgTable('followup_orders', {
@@ -12394,7 +12399,8 @@ export type QueueType =
 
 export function mapQueueType(
   category:
-    import('../shared/utils/supplySourceDashboard').ManufacturedCategory | null
+    | import('../shared/utils/supplySourceDashboard').ManufacturedCategory
+    | null
 ): { queueType: QueueType; department: string } | null {
   const route = resolveManufacturingRouteDefinition(category);
   if (!route?.queueType || !route.department) return null;
@@ -12542,25 +12548,40 @@ export const controlledDocumentRevisionApprovals = pgTable(
 );
 
 /* eslint-disable prettier/prettier */
-export const controlledDocumentApprovalReleaseEvents = pgTable('controlled_document_approval_release_events', {
-  id: uuid('id').defaultRandom().primaryKey(),
-  controlledDocumentId: uuid('controlled_document_id').references(() => controlledDocuments.id, { onDelete: 'restrict' }).notNull(),
-  revisionId: uuid('revision_id').references(() => documentVersionHistory.id, { onDelete: 'restrict' }).notNull(),
-  approvalId: uuid('approval_id').references(() => controlledDocumentRevisionApprovals.id, { onDelete: 'restrict' }).notNull(),
-  idempotencyKey: text('idempotency_key').notNull().unique(),
-  requestIdentityHash: text('request_identity_hash').notNull(),
-  fileChecksum: text('file_checksum').notNull(),
-  documentNumberSnapshot: text('document_number_snapshot').notNull(),
-  revisionSnapshot: text('revision_snapshot').notNull(),
-  actorUserId: integer('actor_user_id').references(() => users.id, { onDelete: 'restrict' }).notNull(),
-  actorSnapshot: jsonb('actor_snapshot').notNull(),
-  authoritySnapshot: jsonb('authority_snapshot').notNull(),
-  reason: text('reason').notNull(),
-  beforeLifecycle: text('before_lifecycle').notNull(),
-  afterLifecycle: text('after_lifecycle').notNull(),
-  effectiveDate: date('effective_date').notNull(),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-});
+export const controlledDocumentApprovalReleaseEvents = pgTable(
+  'controlled_document_approval_release_events',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    controlledDocumentId: uuid('controlled_document_id')
+      .references(() => controlledDocuments.id, { onDelete: 'restrict' })
+      .notNull(),
+    revisionId: uuid('revision_id')
+      .references(() => documentVersionHistory.id, { onDelete: 'restrict' })
+      .notNull(),
+    approvalId: uuid('approval_id')
+      .references(() => controlledDocumentRevisionApprovals.id, {
+        onDelete: 'restrict',
+      })
+      .notNull(),
+    idempotencyKey: text('idempotency_key').notNull().unique(),
+    requestIdentityHash: text('request_identity_hash').notNull(),
+    fileChecksum: text('file_checksum').notNull(),
+    documentNumberSnapshot: text('document_number_snapshot').notNull(),
+    revisionSnapshot: text('revision_snapshot').notNull(),
+    actorUserId: integer('actor_user_id')
+      .references(() => users.id, { onDelete: 'restrict' })
+      .notNull(),
+    actorSnapshot: jsonb('actor_snapshot').notNull(),
+    authoritySnapshot: jsonb('authority_snapshot').notNull(),
+    reason: text('reason').notNull(),
+    beforeLifecycle: text('before_lifecycle').notNull(),
+    afterLifecycle: text('after_lifecycle').notNull(),
+    effectiveDate: date('effective_date').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  }
+);
 /* eslint-enable prettier/prettier */
 
 export const controlledDocumentReconciliationPreviews = pgTable(
@@ -20785,7 +20806,7 @@ export const arInvoices = pgTable(
     isDisputed: boolean('is_disputed').default(false),
     disputeNote: text('dispute_note'),
     // creditMemoId â€” FK to credit_memos, set when a credit memo is applied/linked
-  creditMemoId: integer('credit_memo_id'),
+    creditMemoId: integer('credit_memo_id'),
     autoCreated: boolean('auto_created').default(false),
     pricingMismatch: boolean('pricing_mismatch').default(false),
     pricingAmbiguous: boolean('pricing_ambiguous').default(false),
@@ -28255,4 +28276,207 @@ export const qmsEpochValidationResponsibilities = pgTable(
       table.responsibilityRole
     ),
   })
+);
+
+// P2 recursive Production Launch demand evidence. Runtime creation remains
+// disabled; migration 0264 is the database authority for composite controls.
+export const projectProductionDemands = pgTable(
+  'project_production_demands',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, {
+        onDelete: 'restrict',
+      }),
+    productionReleaseId: uuid('production_release_id').notNull(),
+    productionLaunchId: uuid('production_launch_id').notNull(),
+    productionPlanId: uuid('production_plan_id').notNull(),
+    productionPlanItemId: uuid('production_plan_item_id').notNull(),
+    poId: integer('po_id')
+      .notNull()
+      .references(() => p2PurchaseOrders.id, {
+        onDelete: 'restrict',
+      }),
+    poItemId: integer('po_item_id')
+      .notNull()
+      .references(() => p2PurchaseOrderItems.id, { onDelete: 'restrict' }),
+    demandLineIdentity: uuid('demand_line_identity').notNull(),
+    demandKey: text('demand_key').notNull(),
+    parentDemandId: uuid('parent_demand_id').references(
+      (): AnyPgColumn => projectProductionDemands.id,
+      { onDelete: 'restrict' }
+    ),
+    supersedesDemandId: uuid('supersedes_demand_id').references(
+      (): AnyPgColumn => projectProductionDemands.id,
+      { onDelete: 'restrict' }
+    ),
+    replacementForDemandId: uuid('replacement_for_demand_id').references(
+      (): AnyPgColumn => projectProductionDemands.id,
+      { onDelete: 'restrict' }
+    ),
+    assemblyPath: text('assembly_path').notNull(),
+    pathDepth: integer('path_depth').notNull(),
+    inventoryItemId: integer('inventory_item_id').references(
+      () => inventoryItems.id,
+      { onDelete: 'restrict' }
+    ),
+    partNumber: text('part_number').notNull(),
+    partRevision: text('part_revision'),
+    description: text('description'),
+    classification: text('classification').notNull(),
+    disposition: text('disposition').notNull(),
+    quantityPerParent: numeric('quantity_per_parent', {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
+    grossRequiredQuantity: numeric('gross_required_quantity', {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
+    availableQuantitySnapshot: numeric('available_quantity_snapshot', {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
+    allocatedQuantitySnapshot: numeric('allocated_quantity_snapshot', {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
+    shortageQuantity: numeric('shortage_quantity', {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
+    originalCustomerQuantity: numeric('original_customer_quantity', {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
+    effectiveCustomerQuantity: numeric('effective_customer_quantity', {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
+    customerDemandEventDigest: text('customer_demand_event_digest').notNull(),
+    customerDemandSnapshot: jsonb('customer_demand_snapshot').notNull(),
+    unitOfMeasure: text('unit_of_measure'),
+    requiredByDate: date('required_by_date'),
+    bomId: uuid('bom_id').references(() => boms.id, {
+      onDelete: 'restrict',
+    }),
+    bomRevisionId: uuid('bom_revision_id').references(() => bomRevisions.id, {
+      onDelete: 'restrict',
+    }),
+    bomRevisionSnapshot: text('bom_revision_snapshot'),
+    routingId: uuid('routing_id').references(() => partRoutings.id, {
+      onDelete: 'restrict',
+    }),
+    routingRevisionSnapshot: text('routing_revision_snapshot'),
+    firstDepartmentSnapshot: text('first_department_snapshot'),
+    wadAuthorizationId: uuid('wad_authorization_id'),
+    demandStatus: text('demand_status').notNull().default('PLANNED'),
+    blockerSnapshot: jsonb('blocker_snapshot').notNull().default([]),
+    authoritySnapshot: jsonb('authority_snapshot').notNull(),
+    statusReason: text('status_reason'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => ({
+    launchKeyUnique: uniqueIndex(
+      'project_production_demands_launch_key_unique'
+    ).on(table.productionLaunchId, table.demandKey),
+    projectStatusIdx: index('project_production_demands_project_status_idx').on(
+      table.projectId,
+      table.demandStatus,
+      table.assemblyPath
+    ),
+  })
+);
+
+export const projectProductionDemandDependencies = pgTable(
+  'project_production_demand_dependencies',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, {
+        onDelete: 'restrict',
+      }),
+    predecessorDemandId: uuid('predecessor_demand_id')
+      .notNull()
+      .references(() => projectProductionDemands.id, { onDelete: 'restrict' }),
+    successorDemandId: uuid('successor_demand_id')
+      .notNull()
+      .references(() => projectProductionDemands.id, { onDelete: 'restrict' }),
+    dependencyType: text('dependency_type').notNull(),
+    status: text('status').notNull().default('OPEN'),
+    satisfiedAt: timestamp('satisfied_at'),
+    evidence: jsonb('evidence').notNull().default({}),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  }
+);
+
+export const projectProductionDemandExecutionLinks = pgTable(
+  'project_production_demand_execution_links',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, {
+        onDelete: 'restrict',
+      }),
+    demandId: uuid('demand_id')
+      .notNull()
+      .references(() => projectProductionDemands.id, { onDelete: 'restrict' }),
+    p2ProductionOrderId: integer('p2_production_order_id').references(
+      () => p2ProductionOrders.id,
+      { onDelete: 'restrict' }
+    ),
+    productionWorkOrderId: uuid('production_work_order_id').references(
+      () => productionWorkOrders.id,
+      { onDelete: 'restrict' }
+    ),
+    travelerId: varchar('traveler_id', { length: 255 }).references(
+      () => travelers.id,
+      { onDelete: 'restrict' }
+    ),
+    cncJobId: integer('cnc_job_id').references(() => cncJobs.id, {
+      onDelete: 'restrict',
+    }),
+    manufacturingQueueId: integer('manufacturing_queue_id').references(
+      () => manufacturingQueue.id,
+      { onDelete: 'restrict' }
+    ),
+    cuttingDemandId: uuid('cutting_demand_id').references(
+      () => cuttingPacketSchedule.id,
+      { onDelete: 'restrict' }
+    ),
+    linkType: text('link_type').notNull(),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+  }
+);
+
+export const projectProductionDemandAllocations = pgTable(
+  'project_production_demand_allocations',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, {
+        onDelete: 'restrict',
+      }),
+    demandId: uuid('demand_id')
+      .notNull()
+      .references(() => projectProductionDemands.id, { onDelete: 'restrict' }),
+    inventoryItemId: integer('inventory_item_id')
+      .notNull()
+      .references(() => inventoryItems.id, { onDelete: 'restrict' }),
+    materialLotId: uuid('material_lot_id').references(() => materialLots.id, {
+      onDelete: 'restrict',
+    }),
+    allocationType: text('allocation_type').notNull(),
+    quantity: numeric('quantity', { precision: 18, scale: 6 }).notNull(),
+    status: text('status').notNull().default('PLANNED'),
+    evidence: jsonb('evidence').notNull().default({}),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  }
 );

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -292,6 +292,7 @@ export const safeMigrationFiles = [
   '0261_payment_aware_refund_completion.sql',
   '0262_p2_customer_demand_quantity_ledger.sql',
   '0263_p1_customer_po_document_imports.sql',
+  '0264_p2_recursive_production_demand_foundation.sql',
 ];
 
 export const criticalMigrationFiles = new Set([
@@ -360,6 +361,7 @@ export const criticalMigrationFiles = new Set([
   '0261_payment_aware_refund_completion.sql',
   '0262_p2_customer_demand_quantity_ledger.sql',
   '0263_p1_customer_po_document_imports.sql',
+  '0264_p2_recursive_production_demand_foundation.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/services/productionDemandGraph.ts
+++ b/server/src/services/productionDemandGraph.ts
@@ -1,0 +1,181 @@
+import type { ProductionLaunchPreviewNode } from './productionLaunchPreviewResolver';
+
+export type FrozenProductionPlanItem = {
+  id: string;
+  assemblyPath: string;
+  partNumber: string;
+  productionPlanId: string;
+  projectId: string;
+};
+
+export type ProductionDemandSpec = {
+  key: string;
+  parentKey: string | null;
+  projectId: string;
+  productionPlanId: string;
+  productionPlanItemId: string;
+  poItemId: number;
+  demandLineIdentity: string;
+  demandKey: string;
+  assemblyPath: string;
+  pathDepth: number;
+  inventoryItemId: number | null;
+  partNumber: string;
+  partRevision: string | null;
+  description: string | null;
+  classification: string;
+  disposition:
+    | 'MAKE'
+    | 'BUY'
+    | 'OUTSIDE_PROCESS'
+    | 'PHANTOM'
+    | 'STOCK_SATISFIED'
+    | 'UNRESOLVED';
+  quantityPerParent: number;
+  grossRequiredQuantity: number;
+  availableQuantitySnapshot: number;
+  allocatedQuantitySnapshot: number;
+  shortageQuantity: number;
+  originalCustomerQuantity: number;
+  effectiveCustomerQuantity: number;
+  customerDemandEventDigest: string;
+  customerDemandSnapshot: unknown;
+  unitOfMeasure: string | null;
+  requiredByDate: string | null;
+  bomId: string | null;
+  bomRevisionId: string | null;
+  bomRevisionSnapshot: string | null;
+  routingId: string | null;
+  routingRevisionSnapshot: string | null;
+  firstDepartmentSnapshot: string | null;
+  demandStatus: 'PLANNED' | 'STOCK_SATISFIED' | 'BLOCKED';
+  blockerSnapshot: ProductionLaunchPreviewNode['blockers'];
+};
+
+export type ProductionDemandDependencySpec = {
+  predecessorKey: string;
+  successorKey: string;
+  dependencyType: 'COMPLETE' | 'ACCEPT' | 'ISSUE_OR_SCAN';
+};
+
+export class ProductionDemandGraphError extends Error {
+  constructor(
+    public code:
+      | 'PLAN_ITEM_MISSING'
+      | 'PLAN_ITEM_AMBIGUOUS'
+      | 'PLAN_ITEM_MISMATCH',
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+const normalize = (value: string) => value.trim().toUpperCase();
+
+function poItemId(node: ProductionLaunchPreviewNode) {
+  const match = /^root:(\d+)$/.exec(
+    node.productionPlanAssemblyPath.split('/')[0]
+  );
+  if (!match)
+    throw new ProductionDemandGraphError(
+      'PLAN_ITEM_MISMATCH',
+      `${node.partNumber} has an invalid Production Plan assembly path.`
+    );
+  return Number(match[1]);
+}
+
+export function compileProductionDemandGraph(
+  nodes: ProductionLaunchPreviewNode[],
+  planItems: FrozenProductionPlanItem[]
+) {
+  const planByPath = new Map<string, FrozenProductionPlanItem[]>();
+  for (const item of planItems) {
+    const matches = planByPath.get(item.assemblyPath) ?? [];
+    matches.push(item);
+    planByPath.set(item.assemblyPath, matches);
+  }
+  const demands: ProductionDemandSpec[] = [];
+  const dependencies: ProductionDemandDependencySpec[] = [];
+
+  function visit(node: ProductionLaunchPreviewNode, parentKey: string | null) {
+    const matches = planByPath.get(node.productionPlanAssemblyPath) ?? [];
+    if (matches.length === 0)
+      throw new ProductionDemandGraphError(
+        'PLAN_ITEM_MISSING',
+        `${node.partNumber} at ${node.productionPlanAssemblyPath} is absent from the released Production Plan.`
+      );
+    if (matches.length > 1)
+      throw new ProductionDemandGraphError(
+        'PLAN_ITEM_AMBIGUOUS',
+        `${node.productionPlanAssemblyPath} resolves to multiple released Production Plan items.`
+      );
+    const planItem = matches[0];
+    if (normalize(planItem.partNumber) !== normalize(node.partNumber))
+      throw new ProductionDemandGraphError(
+        'PLAN_ITEM_MISMATCH',
+        `${node.partNumber} does not match released Production Plan item ${planItem.partNumber}.`
+      );
+    const key = `${poItemId(node)}:${node.productionPlanAssemblyPath}`;
+    const disposition: ProductionDemandSpec['disposition'] =
+      node.shortageQuantity === 0 ? 'STOCK_SATISFIED' : node.makeBuy;
+    const demandStatus: ProductionDemandSpec['demandStatus'] = node.blockers
+      .length
+      ? 'BLOCKED'
+      : disposition === 'STOCK_SATISFIED'
+        ? 'STOCK_SATISFIED'
+        : 'PLANNED';
+    demands.push({
+      key,
+      parentKey,
+      projectId: planItem.projectId,
+      productionPlanId: planItem.productionPlanId,
+      productionPlanItemId: planItem.id,
+      poItemId: poItemId(node),
+      demandLineIdentity: node.demandLineIdentity,
+      demandKey: key,
+      assemblyPath: node.productionPlanAssemblyPath,
+      pathDepth: node.productionPlanAssemblyPath.split('/').length - 1,
+      inventoryItemId: node.inventoryItemId,
+      partNumber: node.partNumber,
+      partRevision: node.revision,
+      description: node.description,
+      classification: node.classification,
+      disposition,
+      quantityPerParent: node.quantityPerParent,
+      grossRequiredQuantity: node.extendedProjectQuantity,
+      availableQuantitySnapshot: node.availableQuantity,
+      allocatedQuantitySnapshot: node.allocatedQuantity,
+      shortageQuantity: node.shortageQuantity,
+      originalCustomerQuantity: node.originalCustomerQuantity,
+      effectiveCustomerQuantity: node.effectiveCustomerQuantity,
+      customerDemandEventDigest: node.customerDemandEventDigest,
+      customerDemandSnapshot: node.customerDemandSnapshot,
+      unitOfMeasure: node.unitOfMeasure,
+      requiredByDate: node.requiredByDate,
+      bomId: node.bomId,
+      bomRevisionId: node.bomRevisionId,
+      bomRevisionSnapshot: node.bomRevision,
+      routingId: node.routingId,
+      routingRevisionSnapshot: node.routingRevision,
+      firstDepartmentSnapshot: node.firstDepartment,
+      demandStatus,
+      blockerSnapshot: node.blockers,
+    });
+    if (parentKey && disposition !== 'STOCK_SATISFIED') {
+      const dependencyTypes: ProductionDemandDependencySpec['dependencyType'][] =
+        disposition === 'MAKE' || disposition === 'OUTSIDE_PROCESS'
+          ? ['COMPLETE', 'ACCEPT', 'ISSUE_OR_SCAN']
+          : ['ACCEPT', 'ISSUE_OR_SCAN'];
+      for (const dependencyType of dependencyTypes)
+        dependencies.push({
+          predecessorKey: key,
+          successorKey: parentKey,
+          dependencyType,
+        });
+    }
+    for (const child of node.children) visit(child, key);
+  }
+
+  for (const node of nodes) visit(node, null);
+  return { demands, dependencies };
+}

--- a/server/src/services/productionLaunchPreviewResolver.ts
+++ b/server/src/services/productionLaunchPreviewResolver.ts
@@ -70,6 +70,11 @@ export type PreviewRoot = {
   quantity: number;
   inventoryItemId: number | null;
   requiredByDate: string | null;
+  demandLineIdentity: string;
+  originalCustomerQuantity: number;
+  effectiveCustomerQuantity: number;
+  customerDemandEventDigest: string;
+  customerDemandSnapshot: unknown;
 };
 
 export interface ProductionLaunchPreviewSource {
@@ -90,6 +95,13 @@ export interface ProductionLaunchPreviewSource {
 
 export type ProductionLaunchPreviewNode = {
   path: string[];
+  productionPlanAssemblyPath: string;
+  bomLineId: string | null;
+  demandLineIdentity: string;
+  originalCustomerQuantity: number;
+  effectiveCustomerQuantity: number;
+  customerDemandEventDigest: string;
+  customerDemandSnapshot: unknown;
   parentPartNumber: string | null;
   inventoryItemId: number | null;
   partNumber: string;
@@ -169,6 +181,13 @@ export async function resolveProductionLaunchPreview(
     requiredByDate: string | null;
     path: string[];
     ancestry: string[];
+    productionPlanAssemblyPath: string;
+    bomLineId: string | null;
+    demandLineIdentity: string;
+    originalCustomerQuantity: number;
+    effectiveCustomerQuantity: number;
+    customerDemandEventDigest: string;
+    customerDemandSnapshot: unknown;
   }): Promise<ProductionLaunchPreviewNode> {
     const partNumber = input.partNumber.trim();
     const path = [...input.path, partNumber];
@@ -427,6 +446,13 @@ export async function resolveProductionLaunchPreview(
               requiredByDate: input.requiredByDate,
               path,
               ancestry: [...input.ancestry, normalized(partNumber)],
+              productionPlanAssemblyPath: `${input.productionPlanAssemblyPath}/line:${line.id}`,
+              bomLineId: line.id,
+              demandLineIdentity: input.demandLineIdentity,
+              originalCustomerQuantity: input.originalCustomerQuantity,
+              effectiveCustomerQuantity: input.effectiveCustomerQuantity,
+              customerDemandEventDigest: input.customerDemandEventDigest,
+              customerDemandSnapshot: input.customerDemandSnapshot,
             })
           );
         }
@@ -448,6 +474,13 @@ export async function resolveProductionLaunchPreview(
 
     return {
       path,
+      productionPlanAssemblyPath: input.productionPlanAssemblyPath,
+      bomLineId: input.bomLineId,
+      demandLineIdentity: input.demandLineIdentity,
+      originalCustomerQuantity: input.originalCustomerQuantity,
+      effectiveCustomerQuantity: input.effectiveCustomerQuantity,
+      customerDemandEventDigest: input.customerDemandEventDigest,
+      customerDemandSnapshot: input.customerDemandSnapshot,
       parentPartNumber: input.parentPartNumber,
       inventoryItemId: item?.id ?? null,
       partNumber,
@@ -485,6 +518,13 @@ export async function resolveProductionLaunchPreview(
         requiredByDate: root.requiredByDate,
         path: [`po-item:${root.poItemId}`],
         ancestry: [],
+        productionPlanAssemblyPath: `root:${root.poItemId}`,
+        bomLineId: null,
+        demandLineIdentity: root.demandLineIdentity,
+        originalCustomerQuantity: root.originalCustomerQuantity,
+        effectiveCustomerQuantity: root.effectiveCustomerQuantity,
+        customerDemandEventDigest: root.customerDemandEventDigest,
+        customerDemandSnapshot: root.customerDemandSnapshot,
       })
     )
   );

--- a/server/src/services/productionLaunchPreviewService.ts
+++ b/server/src/services/productionLaunchPreviewService.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { sql } from 'drizzle-orm';
 
 import { db } from '../../db';
@@ -209,8 +211,16 @@ export async function getProductionLaunchPreview(projectId: string) {
       );
     const rootRows = rows(
       await tx.execute(sql`
-      SELECT id,part_number,quantity,inventory_item_id,due_date
-      FROM p2_purchase_order_items WHERE po_id=${poId} ORDER BY id`)
+      SELECT poi.id,poi.part_number,poi.quantity original_quantity,
+        (poi.quantity+COALESCE(SUM(e.quantity_delta),0))::numeric effective_quantity,
+        poi.inventory_item_id,poi.due_date,poi.demand_line_identity,
+        COALESCE(jsonb_agg(to_jsonb(e) ORDER BY e.effective_at,e.id)
+          FILTER (WHERE e.id IS NOT NULL),'[]'::jsonb) customer_demand_events
+      FROM p2_purchase_order_items poi
+      LEFT JOIN p2_customer_demand_quantity_events e
+        ON e.po_item_id=poi.id AND e.demand_line_identity=poi.demand_line_identity
+      WHERE poi.po_id=${poId}
+      GROUP BY poi.id ORDER BY poi.id`)
     );
     if (!rootRows.length)
       throw new ProjectProductionPlanningError(
@@ -220,16 +230,37 @@ export async function getProductionLaunchPreview(projectId: string) {
       );
 
     const preview = await resolveProductionLaunchPreview(
-      rootRows.map((entry) => ({
-        poItemId: Number(entry.id),
-        partNumber: String(entry.part_number),
-        quantity: Number(entry.quantity),
-        inventoryItemId:
-          entry.inventory_item_id == null
-            ? null
-            : Number(entry.inventory_item_id),
-        requiredByDate: entry.due_date == null ? null : String(entry.due_date),
-      })),
+      rootRows.map((entry) => {
+        const events = Array.isArray(entry.customer_demand_events)
+          ? entry.customer_demand_events
+          : [];
+        const originalQuantity = Number(entry.original_quantity);
+        const effectiveQuantity = Number(entry.effective_quantity);
+        const snapshot = {
+          demandLineIdentity: String(entry.demand_line_identity),
+          originalQuantity,
+          effectiveQuantity,
+          events,
+        };
+        return {
+          poItemId: Number(entry.id),
+          partNumber: String(entry.part_number),
+          quantity: effectiveQuantity,
+          inventoryItemId:
+            entry.inventory_item_id == null
+              ? null
+              : Number(entry.inventory_item_id),
+          requiredByDate:
+            entry.due_date == null ? null : String(entry.due_date),
+          demandLineIdentity: String(entry.demand_line_identity),
+          originalCustomerQuantity: originalQuantity,
+          effectiveCustomerQuantity: effectiveQuantity,
+          customerDemandEventDigest: createHash('sha256')
+            .update(JSON.stringify(snapshot))
+            .digest('hex'),
+          customerDemandSnapshot: snapshot,
+        };
+      }),
       sourceFor(projectId, tx as Executor)
     );
     return {


### PR DESCRIPTION
## Summary

- add the recursive P2 production-demand foundation as migration 0264, following the current customer-demand ledger and P1 import migrations
- preserve immutable customer demand-line identity, effective quantity event evidence, deterministic demand keys, replacement and supersession lineage, and controlled unresolved dispositions
- add schema models, safe-boot registration, deterministic graph compilation, and read-only launch preview integration
- add focused migration, graph, resolver, and preview-service coverage

## Why

The original Phase 2 checkpoint collided with migrations added to `main` and predated the current customer-demand quantity authority. This reconciles that foundation onto current `main` without introducing transactional persistence or enabling production-launch behavior.

## Validation

- disposable PostgreSQL prerequisite-only apply plus immediate replay passed
- two independent full-schema migration sequences through migrations 0262, 0263, and 0264 passed
- constraint, lineage, status-transition, allocation, dependency, and execution-link rejection checks passed
- 126 tests passed across 11 focused and legacy suites
- targeted ESLint, formatting, resolver/graph TypeScript, schema runtime import, staged-diff, and merge-tree checks passed
- full-repository TypeScript checking exhausted its 4 GB heap before diagnostics and is not claimed as passing

## Boundaries

- no transactional persistence writer is included
- launch preview remains explicitly disabled and execution remains default-off
- no production data was accessed
- nothing was deployed or enabled
