### PR TITLE
Simplify released Design Control template footer

### DIFF
--- a/server/__tests__/designControlFormTemplates.test.ts
+++ b/server/__tests__/designControlFormTemplates.test.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { PDFDocument } from 'pdf-lib';
+import { PDFParse } from 'pdf-parse';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../db', () => ({ db: {} }));
@@ -93,8 +94,20 @@ describe('Phase 4 controlled Design Control form templates', () => {
     expect(pdf.getSubject()).toContain('revision 1.0');
     expect(pdf.getCreator()).toBe('EPOCH Master Document Register');
     expect(DESIGN_CONTROL_FORM_RENDERER_VERSION).toBe(
-      'design-control-blank-pdf/1'
+      'design-control-blank-pdf/2'
     );
+    const parser = new PDFParse({ data: first });
+    try {
+      const { text } = await parser.getText();
+      expect(text).toContain('Configuration Controlled | Verify in MDR');
+      expect(text).not.toContain('Template revision:');
+      expect(text).not.toContain('Generated:');
+      expect(text).not.toContain(
+        '/api/design-control-form-templates/revisions/'
+      );
+    } finally {
+      await parser.destroy();
+    }
     expect(pdf.getPageCount()).toBeGreaterThan(0);
   });
 
@@ -221,12 +234,16 @@ describe('Phase 4 controlled Design Control form templates', () => {
     expect(route).not.toMatch(/req\.body\.(actor|actorId|userId|username)/);
   });
 
-  it('includes controlled header, footer, page count, revision, and stable revision barcode content', () => {
+  it('keeps a compact visible footer while retaining exact revision barcode content', () => {
     const renderer = read('server/src/services/designControlFormPdfService.ts');
     expect(renderer).toContain('AG COMPOSITES — DESIGN CONTROL FORM');
     expect(renderer).toContain('Page ${index + 1} of ${pages.length}');
     expect(renderer).toContain('Revision ${input.documentRevision}');
-    expect(renderer).toContain('input.definition.identification.footerText');
+    expect(renderer).toContain('Configuration Controlled | Verify in MDR');
+    expect(renderer).not.toContain(
+      'current.drawText(`Template revision: ${input.templateRevisionId}`'
+    );
+    expect(renderer).not.toContain('`Generated: ${fixedDate.toISOString()}');
     expect(renderer).toContain(
       '/api/design-control-form-templates/revisions/${input.templateRevisionId}'
     );

--- a/server/__tests__/projectFormInstances.test.ts
+++ b/server/__tests__/projectFormInstances.test.ts
@@ -32,7 +32,7 @@ describe('Phase 5 Design Project Form Instances', () => {
     expect(DESIGN_CONTROL_FORM_CATALOG[12].changeRecordType).toBe('ECR');
     expect(DESIGN_CONTROL_FORM_CATALOG[13].changeRecordType).toBe('ECN');
     expect(DESIGN_CONTROL_FORM_RENDERER_VERSION).toBe(
-      'design-control-blank-pdf/1'
+      'design-control-blank-pdf/2'
     );
   });
 

--- a/server/src/services/designControlFormPdfService.ts
+++ b/server/src/services/designControlFormPdfService.ts
@@ -2,9 +2,13 @@ import crypto from 'crypto';
 import QRCode from 'qrcode';
 import { PDFDocument, StandardFonts, rgb, type PDFPage } from 'pdf-lib';
 
-import type { DesignControlFormDefinition } from '../../../shared/designControlFormCatalog';
+import {
+  DESIGN_CONTROL_FORM_RENDERER_VERSION,
+  type DesignControlFormDefinition,
+} from '../../../shared/designControlFormCatalog';
 
-export const DESIGN_CONTROL_PDF_RENDERER_VERSION = 'design-control-blank-pdf/1';
+export const DESIGN_CONTROL_PDF_RENDERER_VERSION =
+  DESIGN_CONTROL_FORM_RENDERER_VERSION;
 
 export type BlankFormPdfInput = {
   templateRevisionId: string;
@@ -31,7 +35,7 @@ export async function renderDesignControlBlankPdf(
   const fixedDate = new Date(input.generatedAt.toISOString());
   pdf.setTitle(`${input.documentNumber} ${input.definition.title}`);
   pdf.setSubject(
-    `Controlled blank Design Control form revision ${input.documentRevision}`
+    `Controlled blank Design Control form revision ${input.documentRevision}; template revision ${input.templateRevisionId}`
   );
   pdf.setProducer(DESIGN_CONTROL_PDF_RENDERER_VERSION);
   pdf.setCreator('EPOCH Master Document Register');
@@ -174,22 +178,7 @@ export async function renderDesignControlBlankPdf(
     );
     if (index === 0)
       current.drawImage(qr, { x: 510, y: 615, width: 54, height: 54 });
-    current.drawText(`Template revision: ${input.templateRevisionId}`, {
-      x: MARGIN,
-      y: 50,
-      size: 7,
-      font: regular,
-    });
-    current.drawText(
-      `Generated: ${fixedDate.toISOString()}  |  ${stableRevisionUrl}`,
-      {
-        x: MARGIN,
-        y: 39,
-        size: 7,
-        font: regular,
-      }
-    );
-    current.drawText(input.definition.identification.footerText, {
+    current.drawText('Configuration Controlled | Verify in MDR', {
       x: MARGIN,
       y: 28,
       size: 7,

--- a/shared/designControlFormCatalog.ts
+++ b/shared/designControlFormCatalog.ts
@@ -5,7 +5,7 @@ import {
 
 export const DESIGN_CONTROL_TEMPLATE_SCHEMA_VERSION = '1.0.0';
 export const DESIGN_CONTROL_FORM_RENDERER_VERSION =
-  'design-control-blank-pdf/1';
+  'design-control-blank-pdf/2';
 
 export type DesignControlFormField = {
   key: string;


### PR DESCRIPTION
## Summary

Simplifies the visible footer on newly generated Design Control template PDFs.

The previous footer printed three lines containing the full template UUID, generation timestamp, raw revision API path, and a long configuration-control sentence. The new visible footer is a single compact line:

`Configuration Controlled | Verify in MDR`

The page count remains aligned at the right.

## Traceability retained

- The full immutable template revision UUID remains encoded in the QR code.
- The full template revision UUID remains in PDF metadata.
- Document number, document revision, and lifecycle status remain in the controlled header.
- The renderer version advances prospectively from `design-control-blank-pdf/1` to `design-control-blank-pdf/2`.

## Historical-data safety

- No released PDF bytes are modified.
- No document, template revision, checksum, approval, audit evidence, or database record is rewritten.
- Existing released templates retain their original footer and bytes.
- To use the compact footer on an existing released template, Document Control must create and release a new immutable controlled revision through the normal workflow.

## Validation

- Design Control, Project Form, ECR, and ECN Vitest: **4 files, 105 passed, 0 failed**
- Generated representative two-page PDF and rendered page 1 with Poppler.
- Visual verification confirmed the footer is legible, aligned, and does not overlap the page number or form body.
- PDF text extraction confirms the visible footer no longer contains the UUID, generation timestamp, or raw API route.
- Prettier: passed for the changed production files and focused test set before preserving unrelated baseline formatting.
- Service syntax bundle: passed.
- `git diff --check`: passed.

## Rollback

Revert this commit for future renders. Previously released artifacts remain unchanged and need no rollback.
