### PR TITLE
Begin guided P2 Production Planning wizard

### DIFF
--- a/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
@@ -112,4 +112,28 @@ describe('P2V2ProductionPlanning', () => {
     expect(screen.getByText(/Revision 1/)).toBeInTheDocument();
     expect(screen.getAllByTestId('production-plan-item')).toHaveLength(1);
   });
+
+  it('starts the ten-page guided workflow and provides simple navigation', async () => {
+    renderPlanning();
+    fireEvent.click(screen.getByTestId('open-production-planning'));
+
+    expect(
+      await screen.findByTestId('production-planning-progress')
+    ).toHaveTextContent('Page 1 of 10');
+    expect(screen.getByText('Confirm the Order')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Page 9: Preview Production Demand',
+      })
+    ).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Back' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(
+      screen.getByTestId('production-planning-progress')
+    ).toHaveTextContent('Page 2 of 10');
+    expect(screen.getByText('Review Parts and Assemblies')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Save and Exit' })).toBeEnabled();
+  });
 });

--- a/client/src/components/projects/P2V2ProductionPlanning.tsx
+++ b/client/src/components/projects/P2V2ProductionPlanning.tsx
@@ -58,12 +58,26 @@ const selectOptions = (values: string[]) =>
     </SelectItem>
   ));
 
+const wizardPages = [
+  'Confirm the Order',
+  'Review Parts and Assemblies',
+  'Review How Each Part Is Made',
+  'Check Materials',
+  'Check Tooling and Resources',
+  'Check Quality Requirements',
+  'Review Controlled Documents',
+  'Check Schedule and Capacity',
+  'Preview Production Demand',
+  'Review and Approve',
+] as const;
+
 export default function P2V2ProductionPlanning({
   projectId,
 }: {
   projectId: string;
 }) {
   const [open, setOpen] = useState(false);
+  const [currentPage, setCurrentPage] = useState(0);
   const [header, setHeader] = useState({
     requirementSource: 'Customer PO and released engineering configuration',
     planningBasis:
@@ -161,6 +175,47 @@ export default function P2V2ProductionPlanning({
               records.
             </DialogDescription>
           </DialogHeader>
+          <section
+            className="space-y-3 rounded border bg-muted/30 p-4"
+            aria-label="Production Planning progress"
+            data-testid="production-planning-progress"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-medium">
+                  Page {currentPage + 1} of {wizardPages.length}
+                </p>
+                <h2 className="text-lg font-semibold">
+                  {wizardPages[currentPage]}
+                </h2>
+              </div>
+              <div className="flex flex-wrap gap-2 text-xs">
+                <Badge variant="secondary">
+                  {data?.plan ? 'Plan started' : 'Information Missing'}
+                </Badge>
+                <Badge variant="outline">
+                  {data?.readiness.blockers.length ?? 0} blockers
+                </Badge>
+                {data?.readiness.stale && (
+                  <Badge variant="destructive">Source Changed</Badge>
+                )}
+              </div>
+            </div>
+            <div className="grid grid-cols-5 gap-1 md:grid-cols-10">
+              {wizardPages.map((page, index) => (
+                <button
+                  key={page}
+                  type="button"
+                  aria-label={`Page ${index + 1}: ${page}`}
+                  aria-current={index === currentPage ? 'step' : undefined}
+                  className={`h-2 rounded-full ${
+                    index <= currentPage ? 'bg-primary' : 'bg-muted'
+                  }`}
+                  onClick={() => setCurrentPage(index)}
+                />
+              ))}
+            </div>
+          </section>
           {isLoading ? (
             <p>Loading production plan…</p>
           ) : (
@@ -387,6 +442,34 @@ export default function P2V2ProductionPlanning({
                   ))}
                 </section>
               )}
+              <nav
+                className="flex flex-wrap items-center justify-between gap-2 border-t pt-4"
+                aria-label="Production Planning pages"
+              >
+                <Button
+                  variant="outline"
+                  disabled={currentPage === 0}
+                  onClick={() =>
+                    setCurrentPage((page) => Math.max(0, page - 1))
+                  }
+                >
+                  Back
+                </Button>
+                <Button variant="outline" onClick={() => setOpen(false)}>
+                  Save and Exit
+                </Button>
+                {currentPage < wizardPages.length - 1 && (
+                  <Button
+                    onClick={() =>
+                      setCurrentPage((page) =>
+                        Math.min(wizardPages.length - 1, page + 1)
+                      )
+                    }
+                  >
+                    Continue
+                  </Button>
+                )}
+              </nav>
             </div>
           )}
         </DialogContent>


### PR DESCRIPTION
## Summary

- add the ten named Production Planning pages as a guided Step 5 navigation model
- show the current page, overall position, blocker count, plan-started state, and source-change status
- provide accessible page controls plus Back, Continue, and Save and Exit actions
- preserve the existing Production Planning model, decisions, approvals, revision history, and feature boundaries

## Why

The current Step 5 experience presents the entire controlled production-planning form in one long dialog. This begins the review-by-exception wizard incrementally without changing server authority or introducing execution behavior.

## User impact

Planners can see the complete ten-page workflow and move through it with simple, keyboard-accessible controls. Existing planning content remains available while later Phase 2 slices connect each page to its authoritative source-specific view.

## Validation

- 2 of 2 focused component tests passed after reconciling with current origin/main
- focused ESLint passed
- git diff --check passed
- git merge-tree against origin/main passed
- final compare contains only the Step 5 component and its focused test

## Boundaries

- UI navigation foundation only; page-specific review-by-exception filtering remains follow-up work
- no schema or migration changes
- no work orders, purchases, reservations, travelers, or production records are created
- no feature flags, deployment configuration, or production data changed
- Production Launch remains separately gated