### PR TITLE
Fix P2 demand composite FK ordering

### DIFF
--- a/migrations/0262_p2_customer_demand_quantity_ledger.sql
+++ b/migrations/0262_p2_customer_demand_quantity_ledger.sql
@@ -24,9 +24,10 @@ END $$;
 
 CREATE TABLE IF NOT EXISTS p2_customer_demand_quantity_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  demand_line_identity UUID NOT NULL,
   po_id INTEGER NOT NULL REFERENCES p2_purchase_orders(id) ON DELETE RESTRICT,
+  -- Keep these columns in composite-FK order for schema-diff generators.
   po_item_id INTEGER NOT NULL REFERENCES p2_purchase_order_items(id) ON DELETE RESTRICT,
+  demand_line_identity UUID NOT NULL,
   event_type TEXT NOT NULL CHECK (event_type IN (
     'CUSTOMER_CANCELLATION','CUSTOMER_REINSTATEMENT','QUANTITY_CORRECTION',
     'SCOPE_INCREASE','SCOPE_DECREASE','LINE_SUPERSESSION','REPLACEMENT_DEMAND'

--- a/server/__tests__/p2CustomerDemandQuantityFoundation.test.ts
+++ b/server/__tests__/p2CustomerDemandQuantityFoundation.test.ts
@@ -63,6 +63,30 @@ describe('P2 customer-demand quantity policy', () => {
     expect(migration).not.toContain("'RESERVATION_RELEASE'");
   });
 
+  it('declares the demand event composite key columns in foreign-key order', () => {
+    const migration = read(
+      'migrations/0262_p2_customer_demand_quantity_ledger.sql'
+    );
+    const eventTable = migration.slice(
+      migration.indexOf(
+        'CREATE TABLE IF NOT EXISTS p2_customer_demand_quantity_events'
+      ),
+      migration.indexOf(
+        'DO $$ BEGIN',
+        migration.indexOf(
+          'CREATE TABLE IF NOT EXISTS p2_customer_demand_quantity_events'
+        )
+      )
+    );
+
+    expect(eventTable.indexOf('po_item_id INTEGER')).toBeLessThan(
+      eventTable.indexOf('demand_line_identity UUID')
+    );
+    expect(migration).toContain(
+      'FOREIGN KEY (po_item_id,demand_line_identity)\n      REFERENCES p2_purchase_order_items(id,demand_line_identity)'
+    );
+  });
+
   it('removes part-number and row-position inference from future revision lineage', () => {
     const route = read('server/src/routes/index.ts');
     const block = route.slice(


### PR DESCRIPTION
## What changed

- declare `po_item_id` before `demand_line_identity` in migration 0262 so schema-diff generation preserves the composite foreign-key order
- add a regression assertion covering both the table declaration order and the explicit composite FK mapping

## Root cause

The checked-in FK maps `(po_item_id, demand_line_identity)` to `(id, demand_line_identity)`, but the event table declared `demand_line_identity` first. The deployment migration generator reordered the child columns by table declaration order and emitted `(demand_line_identity, po_item_id)`, which does not match the parent's unique key.

## Impact

Generated deployment migrations retain the valid positional mapping and avoid PostgreSQL's `there is no unique constraint matching given keys` failure.

## Validation

- focused static migration-order check passed
- `git diff --check` passed
- `git diff --cached --check` passed before commit
- clean one-commit/two-file compare against `origin/main`
- non-destructive `git merge-tree --write-tree origin/main HEAD` passed

Focused Vitest was not run because the clean worktree has no installed `node_modules` and npm is unavailable on PATH.