### PR TITLE
Fix Production Launch iterator compatibility

### DIFF
--- a/server/src/services/productionLaunchPersistenceService.ts
+++ b/server/src/services/productionLaunchPersistenceService.ts
@@ -320,7 +320,7 @@ export async function persistProductionLaunch(
     }
     const createdRecordIds = {
       launchId,
-      demandIds: [...demandIds.values()],
+      demandIds: Array.from(demandIds.values()),
       allocationIds,
       dependencyIds,
     };


### PR DESCRIPTION
## Summary

Replace direct `MapIterator` spreading with `Array.from` in the Production Launch persistence audit record ID snapshot.

## Why

PR #1692 merged with one new TypeScript diagnostic in the P2 V2 PostgreSQL certification workflow. The repository target does not support directly iterating `MapIterator` without `downlevelIteration`, causing TS2802 and skipping the remaining certification steps.

## Validation

- repository-target full TypeScript run: 1,526 baseline diagnostics and zero diagnostics in `productionLaunchPersistenceService.ts`
- 27 focused persistence, feature-gate, route, foundation, and graph tests passed
- targeted ESLint passed with zero warnings
- Prettier and `git diff --check` passed

This is a one-line compatibility correction and does not change Production Launch behavior, feature flags, database writes, or release gates.
