### PR TITLE
Certify transactional P2 launch persistence

### DIFF
--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -69,6 +69,11 @@ import {
   submitCloseoutReview,
 } from '../src/services/projectShippingCloseoutService';
 import { getP2V2StagesForDefinitionVersion } from '../src/services/projectWorkflowRegistry';
+import {
+  persistProductionLaunch,
+  persistProductionLaunchForCertification,
+} from '../src/services/productionLaunchPersistenceService';
+import { getProductionLaunchPreview } from '../src/services/productionLaunchPreviewService';
 
 // This established lifecycle suite certifies immutable definition v2. The
 // prospective definition-v3 handoff has a separate PostgreSQL suite.
@@ -840,6 +845,98 @@ async function cleanLaunchState(fixture: Fixture) {
   return result.rows[0];
 }
 
+type PreviewNode = {
+  partNumber: string;
+  productionPlanAssemblyPath: string;
+  extendedProjectQuantity: number;
+  children: PreviewNode[];
+};
+
+const flattenPreview = (nodes: PreviewNode[]): PreviewNode[] =>
+  nodes.flatMap((node) => [node, ...flattenPreview(node.children)]);
+
+async function prepareRecursivePersistenceFixture(fixture: Fixture) {
+  await query(
+    `UPDATE inventory_items SET order_url='https://synthetic.invalid/order'
+     WHERE id IN (SELECT inventory_item_id FROM p2_purchase_order_items WHERE po_id=$1)
+        OR ag_part_number IN (
+          SELECT part_number FROM project_production_plan_items WHERE production_plan_id=$2
+        )`,
+    [fixture.poId, fixture.planId]
+  );
+  await query(
+    `INSERT INTO p2_part_planning_classifications
+       (inventory_item_id,revision_number,classification,part_configuration_revision,
+        status,effective_from,ownership_source,source_record_type,source_record_id,
+        source_revision,change_reason,content_checksum,created_by,created_by_display_name,
+        created_by_role,released_by,released_by_display_name,released_by_role,released_at)
+     SELECT DISTINCT ii.id,1,
+       CASE WHEN ii.ag_part_number LIKE 'PARENT-%' THEN 'MANUFACTURED' ELSE 'PURCHASED' END,
+       'A','RELEASED',now()-interval '1 day','SYNTHETIC_CERTIFICATION',
+       'inventory_item',ii.id::text,'A','Seed recursive launch certification',
+       repeat('a',64),$2::integer,'Phase 8 Certifier','ADMIN',$2::integer,'Phase 8 Certifier','ADMIN',now()
+     FROM inventory_items ii
+     JOIN project_production_plan_items ppi ON ppi.part_number=ii.ag_part_number
+     WHERE ppi.production_plan_id=$1
+     ON CONFLICT (inventory_item_id,revision_number) DO NOTHING`,
+    [fixture.planId, actor.userId]
+  );
+  await query(
+    `INSERT INTO routing_operations
+       (part_routing_id,step_number,department_name,operation_name,operation_type,
+        estimated_minutes,requires_signature,requires_certification,instruction_pack)
+     SELECT DISTINCT ppi.routing_id,10,'Assembly','Synthetic launch assembly','RUN',30,true,false,
+       '{"instruction":"SYNTHETIC-LAUNCH-CERT"}'::jsonb
+     FROM project_production_plan_items ppi
+     WHERE ppi.production_plan_id=$1 AND ppi.part_number LIKE 'PARENT-%'
+       AND ppi.routing_id IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM routing_operations ro WHERE ro.part_routing_id=ppi.routing_id)`,
+    [fixture.planId]
+  );
+
+  process.env.P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED = 'true';
+  process.env.P2_V2_PRODUCTION_LAUNCH_PERSISTENCE_ENABLED = 'true';
+  const initialPreview = await getProductionLaunchPreview(fixture.projectId);
+  expect(initialPreview.blockers).toEqual([]);
+  const nodes = flattenPreview(
+    initialPreview.nodes as unknown as PreviewNode[]
+  );
+  const templates = await query<{ part_number: string; snapshot: unknown }>(
+    `SELECT part_number,to_jsonb(ppi) snapshot
+     FROM project_production_plan_items ppi WHERE production_plan_id=$1
+     ORDER BY id`,
+    [fixture.planId]
+  );
+  const byPart = new Map(
+    templates.rows.map((row) => [row.part_number, row.snapshot])
+  );
+  await query(
+    `DELETE FROM project_production_plan_items WHERE production_plan_id=$1`,
+    [fixture.planId]
+  );
+  for (const node of nodes) {
+    const template = byPart.get(node.partNumber);
+    if (!template)
+      throw new Error(`Missing plan template for ${node.partNumber}`);
+    await query(
+      `INSERT INTO project_production_plan_items
+       SELECT (jsonb_populate_record(NULL::project_production_plan_items,
+         $1::jsonb || jsonb_build_object(
+           'id',gen_random_uuid(),'assembly_path',$2::text,
+           'extended_project_quantity',$3::numeric,'created_at',now(),'updated_at',now()
+         ))).*`,
+      [
+        JSON.stringify(template),
+        node.productionPlanAssemblyPath,
+        node.extendedProjectQuantity,
+      ]
+    );
+  }
+  const preview = await getProductionLaunchPreview(fixture.projectId);
+  expect(preview.blockers).toEqual([]);
+  return preview;
+}
+
 beforeAll(async () => {
   await query(`TRUNCATE audit_events RESTART IDENTITY CASCADE`);
   await query(
@@ -1006,6 +1103,91 @@ describe('real launch feature gate', () => {
   it('enables only exact lowercase true', () => {
     process.env.P2_V2_PRODUCTION_LAUNCH_ENABLED = 'true';
     expect(isP2V2ProductionLaunchEnabled()).toBe(true);
+  });
+});
+
+describe('recursive Production Launch persistence against PostgreSQL', () => {
+  it('rolls back launch, demand, allocation, dependency, and audit rows after real inserts', async () => {
+    const fixture = await createFixture(
+      '00000000-0000-4000-8000-000000000821',
+      'RECURSIVE-ROLLBACK'
+    );
+    const preview = await prepareRecursivePersistenceFixture(fixture);
+    await expect(
+      persistProductionLaunchForCertification(
+        fixture.projectId,
+        {
+          idempotencyKey: 'recursive-persistence-rollback',
+          expectedPreviewDigest: preview.resultChecksum,
+          signatureMeaning: 'Certify atomic recursive planning rollback',
+        },
+        actor,
+        (point) => {
+          if (point === 'BEFORE_AUDIT')
+            throw new Error('CERTIFICATION_RECURSIVE_PERSISTENCE_ROLLBACK');
+        }
+      )
+    ).rejects.toThrow('CERTIFICATION_RECURSIVE_PERSISTENCE_ROLLBACK');
+    const evidence = await query<{
+      launches: number;
+      demands: number;
+      allocations: number;
+      dependencies: number;
+      events: number;
+    }>(
+      `SELECT
+        (SELECT count(*)::int FROM project_production_launches WHERE project_id=$1) launches,
+        (SELECT count(*)::int FROM project_production_demands WHERE project_id=$1) demands,
+        (SELECT count(*)::int FROM project_production_demand_allocations WHERE project_id=$1) allocations,
+        (SELECT count(*)::int FROM project_production_demand_dependencies WHERE project_id=$1) dependencies,
+        (SELECT count(*)::int FROM project_production_launch_events WHERE project_id=$1) events`,
+      [fixture.projectId]
+    );
+    expect(evidence.rows[0]).toEqual({
+      launches: 0,
+      demands: 0,
+      allocations: 0,
+      dependencies: 0,
+      events: 0,
+    });
+  });
+
+  it('serializes simultaneous identical requests into one launch and one exact replay', async () => {
+    const fixture = await createFixture(
+      '00000000-0000-4000-8000-000000000822',
+      'RECURSIVE-CONCURRENT'
+    );
+    const preview = await prepareRecursivePersistenceFixture(fixture);
+    const input = {
+      idempotencyKey: 'recursive-persistence-concurrent',
+      expectedPreviewDigest: preview.resultChecksum,
+      signatureMeaning: 'Certify concurrent recursive planning persistence',
+    };
+    const results = await Promise.all([
+      persistProductionLaunch(fixture.projectId, input, actor),
+      persistProductionLaunch(fixture.projectId, input, actor),
+    ]);
+    expect(results.map((result) => result.replayed).sort()).toEqual([
+      false,
+      true,
+    ]);
+    const evidence = await query<{
+      launches: number;
+      demands: number;
+      events: number;
+      execution_links: number;
+    }>(
+      `SELECT
+        (SELECT count(*)::int FROM project_production_launches WHERE project_id=$1) launches,
+        (SELECT count(*)::int FROM project_production_demands WHERE project_id=$1) demands,
+        (SELECT count(*)::int FROM project_production_launch_events WHERE project_id=$1) events,
+        (SELECT count(*)::int FROM project_production_demand_execution_links WHERE project_id=$1) execution_links`,
+      [fixture.projectId]
+    );
+    expect(evidence.rows[0].launches).toBe(1);
+    expect(evidence.rows[0].demands).toBeGreaterThan(0);
+    expect(evidence.rows[0].events).toBe(1);
+    expect(evidence.rows[0].execution_links).toBe(0);
   });
 });
 

--- a/server/__tests__/productionLaunchPreviewService.test.ts
+++ b/server/__tests__/productionLaunchPreviewService.test.ts
@@ -16,6 +16,7 @@ const route = readFileSync(
 describe('Production Launch Phase 1 preview boundary', () => {
   it('executes inside an explicit read-only transaction', () => {
     expect(service).toContain('SET TRANSACTION READ ONLY');
+    expect(service).toContain("projectLock: 'NONE' | 'UPDATE'");
     expect(service).not.toMatch(
       /sql`[^`]*\b(?:INSERT\s+INTO|UPDATE\s+\w+\s+SET|DELETE\s+FROM)\b[^`]*`/i
     );
@@ -41,5 +42,19 @@ describe('Production Launch Phase 1 preview boundary', () => {
   it('uses a stable UTC effectivity date in the preview digest', () => {
     expect(service).toContain('effectiveAt.toISOString().slice(0, 10)');
     expect(service).toContain('authorityEffectiveAt.toISOString()');
+  });
+
+  it('binds multiple recursive roots as an explicit PostgreSQL text array', () => {
+    expect(service).toContain('ARRAY[${rootPartList}]::text[]');
+    expect(service).not.toContain('${rootPartNumbers}::text[]');
+  });
+
+  it('normalizes and deduplicates routing candidates before the union', () => {
+    expect(service).toContain(
+      'SELECT DISTINCT ppi.part_number,pr.id,ppi.routing_revision::text routing_revision'
+    );
+    expect(service).toContain(
+      'SELECT pr.part_number,pr.id,pr.routing_revision::text routing_revision'
+    );
   });
 });

--- a/server/src/services/productionLaunchPersistenceService.ts
+++ b/server/src/services/productionLaunchPersistenceService.ts
@@ -30,6 +30,17 @@ export type ProductionLaunchPersistenceInput = {
   signatureMeaning: string;
 };
 
+export type ProductionLaunchPersistenceFault =
+  | 'AFTER_LAUNCH'
+  | 'AFTER_FIRST_DEMAND'
+  | 'AFTER_ALLOCATIONS'
+  | 'AFTER_DEPENDENCIES'
+  | 'BEFORE_AUDIT';
+
+type PersistenceDependencies = {
+  fault?: (point: ProductionLaunchPersistenceFault) => void | Promise<void>;
+};
+
 const clean = (value: string) => value.trim();
 const fail = (
   code: string,
@@ -69,6 +80,15 @@ export async function persistProductionLaunch(
   projectId: string,
   input: ProductionLaunchPersistenceInput,
   actor: PlanningActor
+) {
+  return persistProductionLaunchWithDependencies(projectId, input, actor, {});
+}
+
+async function persistProductionLaunchWithDependencies(
+  projectId: string,
+  input: ProductionLaunchPersistenceInput,
+  actor: PlanningActor,
+  dependencies: PersistenceDependencies
 ) {
   validateInput(input);
   if (!isP2V2ProductionLaunchPersistenceEnabled())
@@ -270,8 +290,9 @@ export async function persistProductionLaunch(
         ${String(evidence.workflow_instance_id)},${String(evidence.configuration_baseline_id)},
         ${String(evidence.production_plan_id)},${String(evidence.wad_authorization_id)},${requestHash},
         ${preview.resultChecksum},${evidenceDigest},${clean(input.signatureMeaning)})`);
+    await dependencies.fault?.('AFTER_LAUNCH');
 
-    for (const demand of graph.demands) {
+    for (const [index, demand] of graph.demands.entries()) {
       const demandId = demandIds.get(demand.key)!;
       await tx.execute(sql`
         INSERT INTO project_production_demands
@@ -297,6 +318,7 @@ export async function persistProductionLaunch(
           ${demand.routingRevisionSnapshot},${demand.firstDepartmentSnapshot},${String(evidence.wad_authorization_id)},
           ${demand.demandStatus},${JSON.stringify(demand.blockerSnapshot)}::jsonb,
           ${JSON.stringify({ ...requestEvidence, demandKey: demand.demandKey })}::jsonb)`);
+      if (index === 0) await dependencies.fault?.('AFTER_FIRST_DEMAND');
       const netted = demand.grossRequiredQuantity - demand.shortageQuantity;
       if (demand.inventoryItemId != null && netted > 0) {
         const allocationId = randomUUID();
@@ -308,6 +330,7 @@ export async function persistProductionLaunch(
             ${String(netted)}::numeric,'PLANNED',${JSON.stringify({ previewDigest: preview.resultChecksum, createsReservation: false })}::jsonb)`);
       }
     }
+    await dependencies.fault?.('AFTER_ALLOCATIONS');
     for (const dependency of graph.dependencies) {
       const dependencyId = randomUUID();
       dependencyIds.push(dependencyId);
@@ -318,12 +341,14 @@ export async function persistProductionLaunch(
           ${demandIds.get(dependency.successorKey)!},${dependency.dependencyType},'OPEN',
           ${JSON.stringify({ previewDigest: preview.resultChecksum })}::jsonb)`);
     }
+    await dependencies.fault?.('AFTER_DEPENDENCIES');
     const createdRecordIds = {
       launchId,
       demandIds: Array.from(demandIds.values()),
       allocationIds,
       dependencyIds,
     };
+    await dependencies.fault?.('BEFORE_AUDIT');
     await tx.execute(sql`
       INSERT INTO project_production_launch_events
         (project_id,production_launch_id,event_type,request_hash,evidence_digest,created_record_ids,
@@ -336,5 +361,16 @@ export async function persistProductionLaunch(
       launch: { id: launchId, status: 'COMPLETE', evidenceDigest },
       createdRecordIds,
     };
+  });
+}
+
+export function persistProductionLaunchForCertification(
+  projectId: string,
+  input: ProductionLaunchPersistenceInput,
+  actor: PlanningActor,
+  fault: NonNullable<PersistenceDependencies['fault']>
+) {
+  return persistProductionLaunchWithDependencies(projectId, input, actor, {
+    fault,
   });
 }

--- a/server/src/services/productionLaunchPreviewService.ts
+++ b/server/src/services/productionLaunchPreviewService.ts
@@ -58,11 +58,15 @@ function sourceFor(
   return {
     async prepare(roots, effectiveAt) {
       const rootPartNumbers = roots.map((root) => root.partNumber.trim());
+      const rootPartList = sql.join(
+        rootPartNumbers.map((part) => sql`${part}`),
+        sql`, `
+      );
       const reachable = rows(
         await tx.execute(sql`
           WITH RECURSIVE graph(part_number,path,depth) AS (
             SELECT root.part_number,ARRAY[upper(trim(root.part_number))],0
-            FROM unnest(${rootPartNumbers}::text[]) root(part_number)
+            FROM unnest(ARRAY[${rootPartList}]::text[]) root(part_number)
             UNION
             SELECT bl.child_part_ag_number,
               graph.path||upper(trim(bl.child_part_ag_number)),graph.depth+1
@@ -141,7 +145,7 @@ function sourceFor(
           ORDER BY bl.revision_id,bl.operation_seq,bl.id`),
           tx.execute(sql`
           WITH candidates AS (
-            SELECT ppi.part_number,pr.id,ppi.routing_revision,pr.is_active,
+            SELECT DISTINCT ppi.part_number,pr.id,ppi.routing_revision::text routing_revision,pr.is_active,
               ARRAY(SELECT ro.department_name FROM routing_operations ro
                 WHERE ro.part_routing_id=pr.id ORDER BY ro.step_number,ro.id) department_sequence,
               pct.approval_status,1 precedence
@@ -151,7 +155,7 @@ function sourceFor(
             LEFT JOIN production_control_templates pct ON pct.id=pr.created_from_template_id
             WHERE pp.project_id=${projectId} AND pp.status='RELEASED' AND ppi.part_number IN (${partList})
             UNION ALL
-            SELECT pr.part_number,pr.id,pr.routing_revision,pr.is_active,
+            SELECT pr.part_number,pr.id,pr.routing_revision::text routing_revision,pr.is_active,
               ARRAY(SELECT ro.department_name FROM routing_operations ro
                 WHERE ro.part_routing_id=pr.id ORDER BY ro.step_number,ro.id),
               pct.approval_status,3 precedence
@@ -427,7 +431,7 @@ export async function getProductionLaunchPreview(
 
   return db.transaction(async (tx) => {
     await tx.execute(sql`SET TRANSACTION READ ONLY`);
-    return buildProductionLaunchPreview(projectId, effectiveAt, tx, 'SHARE');
+    return buildProductionLaunchPreview(projectId, effectiveAt, tx, 'NONE');
   });
 }
 
@@ -436,7 +440,7 @@ export async function buildProductionLaunchPreview(
   projectId: string,
   effectiveAt: Date,
   tx: Executor,
-  projectLock: 'SHARE' | 'UPDATE' = 'SHARE'
+  projectLock: 'NONE' | 'UPDATE' = 'NONE'
 ) {
   const authorityEffectiveAt = new Date(
     `${effectiveAt.toISOString().slice(0, 10)}T00:00:00.000Z`
@@ -445,7 +449,7 @@ export async function buildProductionLaunchPreview(
     await tx.execute(
       projectLock === 'UPDATE'
         ? sql`SELECT id,project_code,workflow_version,po_id,current_stage FROM projects WHERE id=${projectId} FOR UPDATE`
-        : sql`SELECT id,project_code,workflow_version,po_id,current_stage FROM projects WHERE id=${projectId} FOR SHARE`
+        : sql`SELECT id,project_code,workflow_version,po_id,current_stage FROM projects WHERE id=${projectId}`
     )
   )[0];
   if (!project)


### PR DESCRIPTION
﻿## What changed

- add disposable PostgreSQL certification for transactional recursive Production Launch persistence
- prove forced failures roll back launch, demand, allocation, dependency, and audit writes
- prove simultaneous identical requests serialize into one launch and one exact replay
- make read-only preview use a plain project read while persistence retains its update lock
- bind recursive roots as an explicit PostgreSQL text array
- normalize and deduplicate routing candidates across released planning and routing sources

## Why

The persistence foundation needed certification against real PostgreSQL behavior rather than mocked transactions. That exercise exposed PostgreSQL-specific preview defects that prevented the writer from reaching its transactional boundary: locking rows inside a read-only transaction, array parameter encoding, and incompatible routing revision types across a UNION.

## Impact and boundaries

This hardens the existing preview and persistence foundation without creating work orders, travelers, or other downstream execution records. Feature flags remain fail-closed and are not enabled by this PR. Migration 0267 is intentionally outside this synthetic certification because it requires the production-specific P18380 record.

## Validation

- full PostgreSQL certification suite: 27/27 passed
- focused preview and persistence unit tests: 9/9 passed
- Prettier check: passed
- ESLint on the four changed files: passed
- `git diff --check`: passed

The disposable PostgreSQL cluster and its data directory were removed after validation.
