### PR TITLE
Add authoritative Production Planning order confirmation

### DIFF
--- a/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
@@ -54,6 +54,41 @@ const model = {
     },
   ],
   approvalHistory: [],
+  orderConfirmation: {
+    projectCode: 'PRJ-100',
+    projectName: 'Customer Assembly',
+    customer: 'Example Aerospace',
+    rfq: 'RFQ-100',
+    acceptedQuote: 'Q-100',
+    acceptedQuoteStatus: 'ACCEPTED',
+    customerPurchaseOrder: 'PO-100',
+    customerPurchaseOrderRevision: 3,
+    customerPurchaseOrderStatus: 'OPEN',
+    requiredDeliveryDate: '2026-10-01',
+    lines: [
+      {
+        id: 10,
+        customer_part_number: 'CUST-100',
+        ag_part_number: 'MAKE-100',
+        description: 'Final assembly',
+        quantity: 2,
+        due_date: '2026-10-01',
+      },
+    ],
+    technicalBaseline: { status: 'COMPLETE', sourceRevision: 'technical-3' },
+    sources: [
+      {
+        name: 'rfq risk assessment',
+        status: 'COMPLETE',
+        revision: 'rfq-2',
+      },
+      {
+        name: 'estimate quote',
+        status: 'COMPLETE',
+        revision: 'quote-4',
+      },
+    ],
+  },
   readiness: {
     ready: false,
     stale: true,
@@ -151,6 +186,15 @@ describe('P2V2ProductionPlanning', () => {
       await screen.findByTestId('production-planning-progress')
     ).toHaveTextContent('Page 1 of 10');
     expect(screen.getByText('Confirm the Order')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('confirm-order-summary')
+    ).toHaveTextContent('Example Aerospace');
+    expect(screen.getByTestId('confirm-order-summary')).toHaveTextContent(
+      'RFQ-100'
+    );
+    expect(screen.getByTestId('confirm-order-summary')).toHaveTextContent(
+      'CUST-100'
+    );
     expect(
       screen.getByRole('button', {
         name: 'Page 9: Preview Production Demand',

--- a/client/src/components/projects/P2V2ProductionPlanning.tsx
+++ b/client/src/components/projects/P2V2ProductionPlanning.tsx
@@ -25,6 +25,21 @@ type Row = Record<string, unknown>;
 type Model = {
   plan: Row | null;
   items: Row[];
+  orderConfirmation: {
+    projectCode: string | null;
+    projectName: string | null;
+    customer: string | null;
+    rfq: string | null;
+    acceptedQuote: string | null;
+    acceptedQuoteStatus: string | null;
+    customerPurchaseOrder: string | null;
+    customerPurchaseOrderRevision: number | null;
+    customerPurchaseOrderStatus: string | null;
+    requiredDeliveryDate: string | null;
+    lines: Row[];
+    technicalBaseline: Row | null;
+    sources: Row[];
+  };
   history: Row[];
   approvalHistory: Row[];
   readiness: {
@@ -277,37 +292,10 @@ export default function P2V2ProductionPlanning({
             <div className="space-y-6">
               {currentPage === 0 &&
                 (data?.plan ? (
-                  <section className="grid gap-3 rounded border p-4 md:grid-cols-4">
-                    <div>
-                      <span className="text-xs text-muted-foreground">
-                        Plan revision
-                      </span>
-                      <p>Rev {value(data.plan, 'revision_number')}</p>
-                    </div>
-                    <div>
-                      <span className="text-xs text-muted-foreground">
-                        Status
-                      </span>
-                      <div className="mt-1">
-                        <Badge>{status}</Badge>
-                      </div>
-                    </div>
-                    <div>
-                      <span className="text-xs text-muted-foreground">
-                        PO baseline
-                      </span>
-                      <p>
-                        {value(data.plan, 'po_number')} Rev{' '}
-                        {value(data.plan, 'po_revision_number')}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-xs text-muted-foreground">
-                        Effectivity
-                      </span>
-                      <p>{value(data.plan, 'effectivity_reference')}</p>
-                    </div>
-                  </section>
+                  <ConfirmOrderSummary
+                    confirmation={data.orderConfirmation}
+                    plan={data.plan}
+                  />
                 ) : (
                   <section className="grid gap-3 rounded border p-4 md:grid-cols-2">
                     <div>
@@ -601,6 +589,118 @@ export default function P2V2ProductionPlanning({
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function ConfirmOrderSummary({
+  confirmation,
+  plan,
+}: {
+  confirmation: Model['orderConfirmation'];
+  plan: Row;
+}) {
+  const fields: Array<[string, unknown]> = [
+    ['Customer', confirmation.customer],
+    ['Request for Quote', confirmation.rfq],
+    ['Accepted quote', confirmation.acceptedQuote],
+    ['Customer purchase order', confirmation.customerPurchaseOrder],
+    [
+      'Customer purchase order revision',
+      confirmation.customerPurchaseOrderRevision,
+    ],
+    ['Required delivery date', confirmation.requiredDeliveryDate],
+    ['Production plan revision', value(plan, 'revision_number')],
+    ['Planning effectivity', value(plan, 'effectivity_reference')],
+  ];
+  return (
+    <section className="space-y-4" data-testid="confirm-order-summary">
+      <div className="rounded border p-4">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div>
+            <h3 className="font-semibold">
+              {confirmation.projectCode || 'Project'} —{' '}
+              {confirmation.projectName || 'Information Missing'}
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Controlled values are read-only here. Correct them in their source
+              record and return to Production Planning.
+            </p>
+          </div>
+          <Badge>{value(plan, 'status')}</Badge>
+        </div>
+        <dl className="mt-4 grid gap-3 text-sm md:grid-cols-4">
+          {fields.map(([label, current]) => {
+            const displayed = String(current ?? '').trim();
+            return (
+              <div key={label}>
+                <dt className="text-muted-foreground">{label}</dt>
+                <dd className={displayed ? '' : 'font-medium text-amber-700'}>
+                  {displayed || 'Information Missing'}
+                </dd>
+              </div>
+            );
+          })}
+        </dl>
+      </div>
+      <div className="rounded border p-4">
+        <h3 className="font-semibold">Customer order lines</h3>
+        <div className="mt-2 space-y-2">
+          {confirmation.lines.map((line) => (
+            <div
+              className="grid gap-2 rounded border p-3 text-sm md:grid-cols-6"
+              key={value(line, 'id')}
+            >
+              <OrderFact
+                label="Customer part"
+                current={line.customer_part_number}
+              />
+              <OrderFact label="AG part" current={line.ag_part_number} />
+              <OrderFact label="Description" current={line.description} />
+              <OrderFact label="Quantity" current={line.quantity} />
+              <OrderFact label="Due date" current={line.due_date} />
+              <OrderFact
+                label="Technical baseline"
+                current={confirmation.technicalBaseline?.status}
+              />
+            </div>
+          ))}
+          {!confirmation.lines.length && (
+            <p className="text-sm font-medium text-amber-700">
+              Information Missing — the current customer order has no lines.
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="rounded border p-4">
+        <h3 className="font-semibold">Authoritative sources</h3>
+        <div className="mt-2 grid gap-2 md:grid-cols-3">
+          {confirmation.sources.map((source) => (
+            <div
+              className="rounded border p-3 text-sm"
+              key={value(source, 'name')}
+            >
+              <p className="font-medium capitalize">{value(source, 'name')}</p>
+              <p>Status: {value(source, 'status') || 'Information Missing'}</p>
+              <p>
+                Revision: {value(source, 'revision') || 'Information Missing'}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function OrderFact({ label, current }: { label: string; current: unknown }) {
+  const displayed = String(current ?? '').trim();
+  return (
+    <div>
+      <p className="text-muted-foreground">{label}</p>
+      <p className={displayed ? '' : 'font-medium text-amber-700'}>
+        {displayed || 'Information Missing'}
+      </p>
+    </div>
   );
 }
 

--- a/server/__tests__/projectProductionPlanning.test.ts
+++ b/server/__tests__/projectProductionPlanning.test.ts
@@ -108,4 +108,18 @@ describe('controlled configuration and approval behavior', () => {
     expect(service).toContain('SEGREGATION_OF_DUTIES');
     expect(service).toContain("status='SUPERSEDED'");
   });
+
+  it('builds Confirm the Order from authoritative PO, quote, commercial, and technical records', () => {
+    expect(service).toContain('orderConfirmation: {');
+    expect(service).toContain('LEFT JOIN quotes q ON q.id=po.source_quote_id');
+    expect(service).toContain('project_commercial_stage_reviews');
+    expect(service).toContain('project_technical_configuration_reviews');
+    expect(service).toContain(
+      'JOIN p2_purchase_order_items poi ON poi.po_id=p.po_id'
+    );
+    expect(service).toContain('customerPurchaseOrderRevision');
+    expect(service).toContain(
+      'releasedEvidence: technicalSource.released_evidence'
+    );
+  });
 });

--- a/server/src/services/projectProductionPlanningService.ts
+++ b/server/src/services/projectProductionPlanningService.ts
@@ -476,6 +476,49 @@ async function readModel(projectId: string, tx: Executor) {
         )
       )
     : [];
+  const order = resultRows(
+    await tx.execute(sql`
+      SELECT p.project_code,p.project_name,p.target_ship_date,
+             po.po_number,po.revision_number po_revision_number,
+             po.customer_name,po.expected_delivery,po.status po_status,
+             q.quote_number,q.status quote_status
+      FROM projects p
+      LEFT JOIN p2_purchase_orders po ON po.id=p.po_id
+      LEFT JOIN quotes q ON q.id=po.source_quote_id
+      WHERE p.id=${projectId}`)
+  )[0];
+  const orderLines = resultRows(
+    await tx.execute(sql`
+      SELECT poi.id,poi.part_number customer_part_number,
+             COALESCE(ii.ag_part_number,poi.part_number) ag_part_number,
+             COALESCE(ii.name,poi.part_name) description,
+             poi.quantity,poi.due_date
+      FROM projects p
+      JOIN p2_purchase_order_items poi ON poi.po_id=p.po_id
+      LEFT JOIN inventory_items ii ON ii.id=poi.inventory_item_id
+      WHERE p.id=${projectId}
+      ORDER BY poi.id`)
+  );
+  const commercialSources = resultRows(
+    await tx.execute(sql`
+      SELECT stage_type,status,source_record_type,source_revision,source_snapshot
+      FROM project_commercial_stage_reviews
+      WHERE project_id=${projectId} AND status<>'SUPERSEDED'
+      ORDER BY stage_type,revision_number DESC`)
+  );
+  const technicalSource = resultRows(
+    await tx.execute(sql`
+      SELECT status,source_revision,technical_baseline,released_evidence,
+             effectivity_reference
+      FROM project_technical_configuration_reviews
+      WHERE project_id=${projectId} AND status<>'SUPERSEDED'
+      ORDER BY revision_number DESC LIMIT 1`)
+  )[0];
+  const rfqSource = commercialSources.find(
+    (entry) => entry.stage_type === 'rfq_risk_assessment'
+  );
+  const rfqSnapshot = (rfqSource?.source_snapshot ?? {}) as Row;
+  const rfqRecord = (rfqSnapshot.rfq ?? {}) as Row;
   const currentApprovals = plan
     ? await approvals(plan.id, ctx.step.id, tx)
     : [];
@@ -570,6 +613,35 @@ async function readModel(projectId: string, tx: Executor) {
   return {
     plan,
     items,
+    orderConfirmation: {
+      projectCode: order?.project_code ?? null,
+      projectName: order?.project_name ?? null,
+      customer: order?.customer_name ?? null,
+      rfq: rfqRecord.rfq_number ?? rfqRecord.rfqNumber ?? null,
+      acceptedQuote: order?.quote_number ?? null,
+      acceptedQuoteStatus: order?.quote_status ?? null,
+      customerPurchaseOrder: order?.po_number ?? null,
+      customerPurchaseOrderRevision: order?.po_revision_number ?? null,
+      customerPurchaseOrderStatus: order?.po_status ?? null,
+      requiredDeliveryDate:
+        order?.expected_delivery ?? order?.target_ship_date ?? null,
+      lines: orderLines,
+      technicalBaseline: technicalSource
+        ? {
+            status: technicalSource.status,
+            sourceRevision: technicalSource.source_revision,
+            effectivityReference: technicalSource.effectivity_reference,
+            requirements: technicalSource.technical_baseline,
+            releasedEvidence: technicalSource.released_evidence,
+          }
+        : null,
+      sources: commercialSources.map((source) => ({
+        name: String(source.stage_type).replaceAll('_', ' '),
+        status: source.status,
+        type: source.source_record_type,
+        revision: source.source_revision,
+      })),
+    },
     history,
     approvals: currentApprovals,
     approvalHistory,


### PR DESCRIPTION
## Summary

- build a display-safe Confirm the Order read model from the current project, customer PO, accepted quote, commercial review snapshots, and technical configuration review
- show customer, RFQ, accepted quote, customer PO revision/status, required delivery date, customer and AG part identities, descriptions, quantities, and due dates
- show technical-baseline state and commercial source revisions without exposing raw source identifiers
- keep absent authoritative evidence visibly marked as Information Missing

## Why

Page 1 previously showed only Production Planning revision metadata. Planners need to confirm the actual controlled customer-order and configuration inputs already established in Steps 1 through 4 without re-entering or guessing them.

## User impact

Production Planning now begins with a read-only, source-grounded order summary. Corrections remain owned by the upstream authoritative record rather than editable duplicates in Step 5.

## Validation

- 8 of 8 focused server tests passed
- 3 of 3 focused component tests passed
- focused ESLint passed
- Prettier passed
- git diff --check passed
- git merge-tree against current origin/main passed
- final compare contains exactly four scoped service, component, and test files

## Boundaries

- no schema or migration changes
- no legacy workflow conversion or backfill
- no client-supplied order authority
- no raw database/source identifiers exposed
- no work orders, purchases, reservations, travelers, allocations, or production records created
- no deployment, feature flags, production configuration, or production data changed