### PR TITLE
Expand Production Planning assembly review

### DIFF
--- a/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
@@ -20,6 +20,8 @@ const model = {
       part_number: 'MAKE-100',
       part_name: 'Final assembly',
       is_manufactured: true,
+      make_buy: 'MAKE',
+      quantity_per_parent: '1',
       extended_project_quantity: '2',
       bom_revision: 'B',
       bom_release_status: 'RELEASED',
@@ -32,6 +34,9 @@ const model = {
       part_number: 'BUY-20',
       part_name: 'Purchased fastener',
       is_manufactured: false,
+      make_buy: 'BUY',
+      parent_part_number: 'MAKE-100',
+      quantity_per_parent: '4',
       extended_project_quantity: '8',
       bom_release_status: 'NOT_REQUIRED_APPROVED',
       routing_release_status: 'NOT_REQUIRED_APPROVED',
@@ -155,11 +160,21 @@ describe('P2V2ProductionPlanning', () => {
         name: 'Page 2: Review Parts and Assemblies',
       })
     );
-    expect(await screen.findByText('MAKE-100')).toBeInTheDocument();
-    expect(screen.getByText('BUY-20')).toBeInTheDocument();
+    expect(await screen.findByTestId('assembly-review')).toHaveTextContent(
+      'MAKE-100'
+    );
+    expect(screen.getByTestId('assembly-review')).toHaveTextContent('BUY-20');
     expect(screen.getByText('MAKE')).toBeInTheDocument();
     expect(screen.getByText('BUY')).toBeInTheDocument();
-    expect(screen.getByText(/traveler decision required/i)).toBeInTheDocument();
+    expect(screen.getByTestId('assembly-review')).toHaveTextContent(
+      'Controlled assembly structure'
+    );
+    expect(screen.getAllByTestId('assembly-review-item')).toHaveLength(2);
+    expect(screen.getByText('Parent: MAKE-100')).toBeInTheDocument();
+    expect(screen.getByText('Blocked')).toBeInTheDocument();
+    expect(screen.getAllByText(/traveler decision required/i)).not.toHaveLength(
+      0
+    );
     expect(screen.getByTestId('production-plan-stale')).toHaveTextContent(
       'BOM revision/release changed'
     );

--- a/client/src/components/projects/P2V2ProductionPlanning.tsx
+++ b/client/src/components/projects/P2V2ProductionPlanning.tsx
@@ -384,35 +384,10 @@ export default function P2V2ProductionPlanning({
                 </section>
               )}
               {currentPage === 1 && !!data?.items.length && (
-                <>
-                  <section>
-                    <h3 className="font-semibold">Assembly tree</h3>
-                    <div className="mt-2 space-y-1 rounded border p-3">
-                      {data.items.map((item) => (
-                        <div
-                          key={value(item, 'id')}
-                          style={{
-                            paddingLeft: `${Math.max(0, value(item, 'assembly_path').split('/').length - 1) * 18}px`,
-                          }}
-                          className="text-sm"
-                        >
-                          <Badge
-                            variant={
-                              item.is_manufactured ? 'default' : 'outline'
-                            }
-                          >
-                            {item.is_manufactured ? 'MAKE' : 'BUY'}
-                          </Badge>{' '}
-                          <strong>{value(item, 'part_number')}</strong>{' '}
-                          {value(item, 'part_name')} · Qty{' '}
-                          {value(item, 'extended_project_quantity')} · BOM{' '}
-                          {value(item, 'bom_revision') || 'missing'} · Routing{' '}
-                          {value(item, 'routing_revision') || 'missing'}
-                        </div>
-                      ))}
-                    </div>
-                  </section>
-                </>
+                <AssemblyReview
+                  items={data.items}
+                  blockers={data.readiness.blockers}
+                />
               )}
               {currentPage === 2 && !!data?.items.length && (
                 <section className="space-y-3">
@@ -589,6 +564,95 @@ export default function P2V2ProductionPlanning({
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function AssemblyReview({
+  items,
+  blockers,
+}: {
+  items: Row[];
+  blockers: string[];
+}) {
+  return (
+    <section className="space-y-3" data-testid="assembly-review">
+      <div className="rounded border p-4">
+        <h3 className="font-semibold">Controlled assembly structure</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Quantities and relationships come from the saved Production Planning
+          baseline. Correct BOM or part-master information at its source.
+        </p>
+      </div>
+      {items.map((item) => {
+        const partNumber = value(item, 'part_number');
+        const itemBlockers = blockers.filter((blocker) =>
+          blocker.startsWith(`${partNumber}:`)
+        );
+        const classification =
+          value(item, 'planning_classification') ||
+          value(item, 'make_buy') ||
+          (item.is_manufactured ? 'MAKE' : 'BUY');
+        const ready =
+          itemBlockers.length === 0 &&
+          value(item, 'bom_release_status') !== 'MISSING' &&
+          (!item.is_manufactured ||
+            value(item, 'routing_release_status') === 'RELEASED');
+        return (
+          <article
+            className="rounded border p-4"
+            data-testid="assembly-review-item"
+            key={value(item, 'id')}
+            style={{
+              marginLeft: `${Math.max(0, value(item, 'assembly_path').split('/').length - 1) * 16}px`,
+            }}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <h4 className="font-semibold">
+                  {partNumber || 'Information Missing'} —{' '}
+                  {value(item, 'part_name') || 'Information Missing'}
+                </h4>
+                <p className="text-sm text-muted-foreground">
+                  Parent:{' '}
+                  {value(item, 'parent_part_number') || 'Top-level deliverable'}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Badge variant="outline">
+                  {classification.replaceAll('_', ' ')}
+                </Badge>
+                <Badge variant={ready ? 'default' : 'destructive'}>
+                  {ready ? 'Ready' : 'Blocked'}
+                </Badge>
+              </div>
+            </div>
+            <dl className="mt-3 grid gap-3 text-sm md:grid-cols-5">
+              <OrderFact
+                label="Quantity per parent"
+                current={item.quantity_per_parent}
+              />
+              <OrderFact
+                label="Extended quantity"
+                current={item.extended_project_quantity}
+              />
+              <OrderFact label="BOM revision" current={item.bom_revision} />
+              <OrderFact label="BOM status" current={item.bom_release_status} />
+              <OrderFact
+                label="Routing revision"
+                current={item.routing_revision}
+              />
+            </dl>
+            {!!itemBlockers.length && (
+              <ul className="mt-3 list-disc pl-5 text-sm text-amber-800">
+                {itemBlockers.map((blocker) => (
+                  <li key={blocker}>{blocker}</li>
+                ))}
+              </ul>
+            )}
+          </article>
+        );
+      })}
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

- replace Page 2's compressed assembly list with traceable component review cards
- show parent assembly, quantity per parent, extended quantity, planning classification, BOM revision/status, and routing revision
- derive plain Ready or Blocked status from the saved controlled baseline and existing readiness blockers
- show component-specific blockers next to the affected part and direct BOM/part corrections back to their authoritative source

## Why

The initial Page 2 tree proved recursive structure but compressed the evidence into one line per part. Planners need enough controlled context to understand each relationship, quantity, classification, and readiness problem without opening the full manufacturing-decision form.

## Validation

- 3 of 3 focused component tests passed
- focused ESLint and Prettier passed
- git diff --check passed
- git merge-tree against current origin/main passed
- final compare contains exactly the Step 5 component and its focused test

## Boundaries

- presentation uses the existing saved recursive Production Planning baseline
- no client-side BOM explosion or classification authority
- no schema, migration, release, work-order, purchase, reservation, traveler, deployment, feature-flag, or production-data changes