### PR TITLE
Repair P2 certification gates

### DIFF
--- a/migrations/0267_reconcile_p18380_persisted_shipment.sql
+++ b/migrations/0267_reconcile_p18380_persisted_shipment.sql
@@ -9,6 +9,7 @@ DECLARE
   v_shipped_at timestamp;
   v_tracking_number text;
   v_shipment_count integer;
+  v_orphaned_evidence_count integer;
   v_reason constant text :=
     'Reconciled legacy cancelled production state to the persisted March 25, 2026 OEM shipment; tracking 1Z27835W0391723408.';
 BEGIN
@@ -19,7 +20,30 @@ BEGIN
    FOR UPDATE;
 
   IF NOT FOUND THEN
-    RAISE EXCEPTION 'P18380 repair aborted: production order not found';
+    SELECT
+      (SELECT COUNT(*)
+         FROM shipment_items AS item
+         LEFT JOIN shipment_records AS shipment ON shipment.id = item.shipment_id
+        WHERE item.order_id = 'PO-P18380-46-1'
+           OR shipment.master_tracking_number = '1Z27835W0391723408')
+      + (SELECT COUNT(*)
+           FROM order_department_transitions
+          WHERE entity_id = 'PO-P18380-46-1')
+      + (SELECT COUNT(*)
+           FROM audit_events
+          WHERE entity_id = 'PO-P18380-46-1'
+             OR subject_id = 'PO-P18380-46-1')
+      INTO v_orphaned_evidence_count;
+
+    IF v_orphaned_evidence_count = 0 THEN
+      RAISE NOTICE
+        'P18380 repair skipped: target order and persisted evidence are absent';
+      RETURN;
+    END IF;
+
+    RAISE EXCEPTION
+      'P18380 repair aborted: production order not found while % targeted evidence row(s) remain',
+      v_orphaned_evidence_count;
   END IF;
 
   IF v_order.po_number IS DISTINCT FROM 'P18380'

--- a/server/__tests__/migrationSafety.test.ts
+++ b/server/__tests__/migrationSafety.test.ts
@@ -483,17 +483,6 @@ const KNOWN_BROKEN_ON_SCHEMA_BASELINE: Record<string, string> = {
     'Adds column/index to charge_code_employee_assignments, which is created at runtime ' +
     '(ensureChargeCodeAssignmentTable in employees.ts), not via a migration. ' +
     'Table exists in production but is absent in a fresh scratch-DB baseline replay.',
-  // Migration 0267 is a one-off data-repair that reconciles a single legacy production
-  // order (PO-P18380-46-1) with its persisted March 2026 OEM shipment record.  It is
-  // deliberately fail-closed: if the exact order, PO line, shipment, and tracking number
-  // do not match it raises an EXCEPTION rather than silently doing nothing.  The
-  // schema-baseline replay runs against a schema-only pg_dump (no live rows), so the
-  // production_orders lookup always returns NOT FOUND.  This is expected — the repair
-  // was applied exactly once against the real production data at its correct epoch.
-  '0267_reconcile_p18380_persisted_shipment.sql':
-    'Data-repair migration that fail-closes when production order PO-P18380-46-1 is absent. ' +
-    'Schema-baseline has no live rows so the NOT FOUND guard fires; this is correct behaviour ' +
-    'for a one-off repair that was already applied against real production data.',
 };
 
 // ---------------------------------------------------------------------------

--- a/server/__tests__/p18380PersistedShipmentReconciliation.test.ts
+++ b/server/__tests__/p18380PersistedShipmentReconciliation.test.ts
@@ -36,6 +36,18 @@ describe('P18380 persisted shipment reconciliation', () => {
     expect(sql).toContain('IF v_shipment_count <> 1 THEN');
   });
 
+  it('skips a clean database but fails closed on orphaned target evidence', () => {
+    expect(sql).toContain('IF v_orphaned_evidence_count = 0 THEN');
+    expect(sql).toContain(
+      'P18380 repair skipped: target order and persisted evidence are absent'
+    );
+    expect(sql).toContain(
+      'production order not found while % targeted evidence row(s) remain'
+    );
+    expect(sql).toContain("entity_id = 'PO-P18380-46-1'");
+    expect(sql).toContain("subject_id = 'PO-P18380-46-1'");
+  });
+
   it('repairs fulfillment and records transition and audit evidence', () => {
     expect(sql).toContain("production_status = 'SHIPPED'");
     expect(sql).toContain("current_department = 'Shipped'");

--- a/server/src/services/productionLaunchPersistenceService.ts
+++ b/server/src/services/productionLaunchPersistenceService.ts
@@ -292,7 +292,8 @@ async function persistProductionLaunchWithDependencies(
         ${preview.resultChecksum},${evidenceDigest},${clean(input.signatureMeaning)})`);
     await dependencies.fault?.('AFTER_LAUNCH');
 
-    for (const [index, demand] of graph.demands.entries()) {
+    for (let index = 0; index < graph.demands.length; index += 1) {
+      const demand = graph.demands[index];
       const demandId = demandIds.get(demand.key)!;
       await tx.execute(sql`
         INSERT INTO project_production_demands


### PR DESCRIPTION
﻿## What changed

- replace `graph.demands.entries()` iteration with target-compatible indexed iteration
- make migration `0267` safely skip when the P18380 target order and all targeted shipment, transition, and audit evidence are absent
- preserve fail-closed behavior when the order is absent but any targeted evidence remains
- remove the obsolete schema-baseline exemption for migration `0267`
- add regression coverage for clean-database skip and orphaned-evidence rejection

## Why

Merged PR #1699 exposed two failures in the P2 V2 PostgreSQL certification workflow:

1. the full repository TypeScript comparison reported a new `TS2802` diagnostic in `productionLaunchPersistenceService.ts`
2. synthetic safe boot aborted because the production-specific P18380 order does not exist in a clean database

The migration must remain strict when partial production evidence exists, but a genuinely clean database has nothing to reconcile and must be able to complete safe boot.

## Impact and boundaries

This PR repairs certification gates only. It does not enable Production Launch, alter release gates, create work orders or travelers, or modify the reviewed P18380 correction when its authoritative target data exists.

## Validation

- complete P2 V2 PostgreSQL certification: 27/27 passed
- focused migration and persistence regressions: 7/7 passed
- complete safe-boot migration set executed twice: passed
- repository-wide TypeScript run no longer reports a diagnostic for `productionLaunchPersistenceService.ts`; unrelated baseline diagnostics remain
- focused Prettier and ESLint: passed
- `git diff --check`: passed

The disposable PostgreSQL cluster and temporary dependency junction were removed after validation.
