### PR TITLE
Fix validation responsibility acceptance lock

### DIFF
--- a/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
@@ -61,6 +61,8 @@ describe('EPOCH validation wizard Phase 1 architecture', () => {
     expect(route).toContain('responsibilityDecisionIdentityError');
     expect(route).toContain('authenticatedEmployeeId');
     expect(route).toContain('WHERE id=$1 FOR SHARE');
+    expect(route).toContain('FOR UPDATE OF r`');
+    expect(route).not.toContain('FOR UPDATE OF r,e');
     expect(route).toContain('packageRevision: packageRow.revision');
     expect(route).toContain('productionVersion: packageRow.production_version');
     expect(route).toContain('e.job_title AS position');

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -1211,7 +1211,7 @@ async function decideResponsibility(
         `SELECT r.*,e.is_active AS employee_active
            FROM qms_epoch_validation_responsibilities r
            JOIN employees e ON e.id=r.employee_id
-           WHERE r.id=$1 AND r.package_id=$2 AND r.active=true FOR UPDATE OF r,e`,
+           WHERE r.id=$1 AND r.package_id=$2 AND r.active=true FOR UPDATE OF r`,
         [assignmentId, p.id]
       )
     )[0];


### PR DESCRIPTION
## What changed

- Narrow the responsibility-decision row lock to `qms_epoch_validation_responsibilities` only.
- Add a regression assertion preventing the employee join from being unnecessarily update-locked.

## Root cause

The decision transaction first acquired a shared lock on the authenticated employee and then attempted to upgrade the joined employee row to an update lock. Concurrent responsibility decisions for the same employee could therefore block one another until the browser's 135-second timeout.

The employee row is read only. The assignment row remains exclusively locked, preserving serialized, idempotent decisions while avoiding the lock upgrade.

## User impact

Assigned employees can accept EPOCH Software Validation responsibilities without the request hanging. Existing identity checks, immutable-package enforcement, replay behavior, and audit-event creation remain unchanged.

## Validation

- `epochSoftwareValidationWizardPhase1Architecture.test.ts`: 7/7 passed
- `git diff --check`: passed