### PR TITLE
Repair Replit P2 demand FK migration diff

### DIFF
--- a/migrations/0262_p2_customer_demand_quantity_ledger.sql
+++ b/migrations/0262_p2_customer_demand_quantity_ledger.sql
@@ -51,14 +51,52 @@ CREATE TABLE IF NOT EXISTS p2_customer_demand_quantity_events (
   CONSTRAINT p2_demand_event_hash_unique UNIQUE (event_hash)
 );
 
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='p2_demand_event_item_identity_fk') THEN
-    ALTER TABLE p2_customer_demand_quantity_events
-      ADD CONSTRAINT p2_demand_event_item_identity_fk
-      FOREIGN KEY (po_item_id,demand_line_identity)
-      REFERENCES p2_purchase_order_items(id,demand_line_identity) ON DELETE RESTRICT;
+-- Replit's schema-diff generator can reverse the local columns of a composite
+-- foreign key on an existing development database. Enforce the same identity
+-- relationship with triggers so deployment generation cannot emit a crossed
+-- (uuid, integer) -> (integer, uuid) constraint.
+CREATE OR REPLACE FUNCTION validate_p2_demand_event_item_identity()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM p2_purchase_order_items item
+    WHERE item.id = NEW.po_item_id
+      AND item.demand_line_identity = NEW.demand_line_identity
+  ) THEN
+    RAISE EXCEPTION 'P2 demand event item identity does not match purchase-order item %', NEW.po_item_id
+      USING ERRCODE = '23503';
   END IF;
+  RETURN NEW;
 END $$;
+
+DROP TRIGGER IF EXISTS p2_demand_event_item_identity_validate
+  ON p2_customer_demand_quantity_events;
+CREATE TRIGGER p2_demand_event_item_identity_validate
+BEFORE INSERT OR UPDATE OF po_item_id, demand_line_identity
+ON p2_customer_demand_quantity_events
+FOR EACH ROW EXECUTE FUNCTION validate_p2_demand_event_item_identity();
+
+CREATE OR REPLACE FUNCTION protect_p2_po_item_demand_identity()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.demand_line_identity IS DISTINCT FROM OLD.demand_line_identity
+     AND EXISTS (
+       SELECT 1
+       FROM p2_customer_demand_quantity_events event
+       WHERE event.po_item_id = OLD.id
+     ) THEN
+    RAISE EXCEPTION 'P2 purchase-order item demand identity is referenced by quantity events'
+      USING ERRCODE = '23503';
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS p2_po_item_demand_identity_protect
+  ON p2_purchase_order_items;
+CREATE TRIGGER p2_po_item_demand_identity_protect
+BEFORE UPDATE OF demand_line_identity ON p2_purchase_order_items
+FOR EACH ROW EXECUTE FUNCTION protect_p2_po_item_demand_identity();
 
 CREATE INDEX IF NOT EXISTS p2_demand_events_identity_time_idx
   ON p2_customer_demand_quantity_events(demand_line_identity, effective_at, id);

--- a/migrations/0268_replit_p2_demand_composite_fk_repair.sql
+++ b/migrations/0268_replit_p2_demand_composite_fk_repair.sql
@@ -1,0 +1,48 @@
+-- Replace the P2 demand composite FK with trigger-based relational integrity.
+-- Replit generated the local columns in physical table order while retaining
+-- the referenced unique-key order, producing an invalid crossed-type FK.
+ALTER TABLE p2_customer_demand_quantity_events
+  DROP CONSTRAINT IF EXISTS p2_demand_event_item_identity_fk;
+
+CREATE OR REPLACE FUNCTION validate_p2_demand_event_item_identity()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM p2_purchase_order_items item
+    WHERE item.id = NEW.po_item_id
+      AND item.demand_line_identity = NEW.demand_line_identity
+  ) THEN
+    RAISE EXCEPTION 'P2 demand event item identity does not match purchase-order item %', NEW.po_item_id
+      USING ERRCODE = '23503';
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS p2_demand_event_item_identity_validate
+  ON p2_customer_demand_quantity_events;
+CREATE TRIGGER p2_demand_event_item_identity_validate
+BEFORE INSERT OR UPDATE OF po_item_id, demand_line_identity
+ON p2_customer_demand_quantity_events
+FOR EACH ROW EXECUTE FUNCTION validate_p2_demand_event_item_identity();
+
+CREATE OR REPLACE FUNCTION protect_p2_po_item_demand_identity()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.demand_line_identity IS DISTINCT FROM OLD.demand_line_identity
+     AND EXISTS (
+       SELECT 1
+       FROM p2_customer_demand_quantity_events event
+       WHERE event.po_item_id = OLD.id
+     ) THEN
+    RAISE EXCEPTION 'P2 purchase-order item demand identity is referenced by quantity events'
+      USING ERRCODE = '23503';
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS p2_po_item_demand_identity_protect
+  ON p2_purchase_order_items;
+CREATE TRIGGER p2_po_item_demand_identity_protect
+BEFORE UPDATE OF demand_line_identity ON p2_purchase_order_items
+FOR EACH ROW EXECUTE FUNCTION protect_p2_po_item_demand_identity();

--- a/server/__tests__/p2CustomerDemandQuantityFoundation.test.ts
+++ b/server/__tests__/p2CustomerDemandQuantityFoundation.test.ts
@@ -63,7 +63,7 @@ describe('P2 customer-demand quantity policy', () => {
     expect(migration).not.toContain("'RESERVATION_RELEASE'");
   });
 
-  it('declares the demand event composite key columns in foreign-key order', () => {
+  it('enforces item identity without a schema-diff-sensitive composite FK', () => {
     const migration = read(
       'migrations/0262_p2_customer_demand_quantity_ledger.sql'
     );
@@ -82,8 +82,21 @@ describe('P2 customer-demand quantity policy', () => {
     expect(eventTable.indexOf('po_item_id INTEGER')).toBeLessThan(
       eventTable.indexOf('demand_line_identity UUID')
     );
-    expect(migration).toContain(
-      'FOREIGN KEY (po_item_id,demand_line_identity)\n      REFERENCES p2_purchase_order_items(id,demand_line_identity)'
+    expect(migration).not.toContain(
+      'FOREIGN KEY (po_item_id,demand_line_identity)'
+    );
+    expect(migration).toContain('validate_p2_demand_event_item_identity');
+    expect(migration).toContain('p2_po_item_demand_identity_protect');
+
+    const repair = read(
+      'migrations/0268_replit_p2_demand_composite_fk_repair.sql'
+    );
+    expect(repair).toContain(
+      'DROP CONSTRAINT IF EXISTS p2_demand_event_item_identity_fk'
+    );
+    expect(repair).toContain('item.id = NEW.po_item_id');
+    expect(repair).toContain(
+      'item.demand_line_identity = NEW.demand_line_identity'
     );
   });
 

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -296,6 +296,7 @@ export const safeMigrationFiles = [
   '0265_p2_demand_planning_foundation.sql',
   '0266_p2_production_launch_persistence.sql',
   '0267_reconcile_p18380_persisted_shipment.sql',
+  '0268_replit_p2_demand_composite_fk_repair.sql',
 ];
 
 export const criticalMigrationFiles = new Set([
@@ -368,6 +369,7 @@ export const criticalMigrationFiles = new Set([
   '0265_p2_demand_planning_foundation.sql',
   '0266_p2_production_launch_persistence.sql',
   '0267_reconcile_p18380_persisted_shipment.sql',
+  '0268_replit_p2_demand_composite_fk_repair.sql',
 ]);
 
 export async function runSafeBootMigrations() {


### PR DESCRIPTION
## Summary
- replace the schema-diff-sensitive composite P2 demand FK with equivalent trigger-based integrity checks
- add idempotent migration 0268 to remove the existing composite constraint from development databases
- register the repair as a critical safe-boot migration and cover the policy in the focused foundation test

## Validation
- git diff --check
- static assertions confirmed the constraint drop, identity-pair validation, and both safe-boot registrations
- merge-tree against current origin/main completed without conflicts

## Validation boundary
- focused Vitest execution was blocked because dependency installation for the isolated worktree timed out; CI remains required
- after merge, the development app must run migration 0268 before retrying Replit deployment so the schema diff is regenerated without the composite FK