### PR TITLE
Add Training-owned Certification & Authorization Matrix

### DIFF
--- a/client/src/pages/CertificationAuthorizationMatrix.tsx
+++ b/client/src/pages/CertificationAuthorizationMatrix.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Award, History, Printer } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+type Props = { defaultProgram?: 'P2'; defaultStatus?: 'ACTIVE' };
+type Row = { id:string; employee_number:string; employee_name:string; program:string; part_number?:string; product_family?:string; department?:string; operation_scope?:string; authorization_type:string; status:string; effective_date?:string; expiration_date?:string; approver_username?:string; revision:number };
+const labels: Record<string,string> = { WORK:'Work Authorization', QC_INSPECTION:'QC Inspection', ROUTING_RELEASE:'Routing Release', FINAL_QC:'Final QC', FINAL_PRODUCT_RELEASE:'Final Product Release', COC_APPROVAL:'CoC Approval' };
+
+export default function CertificationAuthorizationMatrix({ defaultProgram, defaultStatus }: Props) {
+  const [employee, setEmployee] = useState(''); const [program,setProgram]=useState(defaultProgram || 'ALL');
+  const [status,setStatus]=useState(defaultStatus || 'ALL'); const [part,setPart]=useState(''); const [type,setType]=useState('ALL');
+  const params=new URLSearchParams(); if(program!=='ALL')params.set('program',program); if(status!=='ALL')params.set('status',status); if(part)params.set('partNumber',part); if(type!=='ALL')params.set('authorizationType',type);
+  const {data:rows=[],isLoading}=useQuery<Row[]>({queryKey:['/api/training/certification-authorizations',params.toString()],queryFn:async()=>{const r=await fetch(`/api/training/certification-authorizations?${params}`,{credentials:'include'});if(!r.ok)throw new Error('Unable to load authorization register');return r.json();}});
+  const visible=rows.filter(r=>!employee || `${r.employee_number} ${r.employee_name}`.toLowerCase().includes(employee.toLowerCase()));
+  const soon=(date?:string)=>date && new Date(date)>new Date() && new Date(date).getTime()<=Date.now()+60*86400000;
+  return <div className="space-y-4" data-testid="certification-authorization-matrix">
+    <div className="flex items-start justify-between gap-4"><div><h2 className="text-2xl font-bold flex items-center gap-2"><Award className="h-6 w-6"/>Certification &amp; Authorization Matrix</h2><p className="text-muted-foreground">Training-owned authoritative register. Training completion does not grant QC, product-release, or CoC authority.</p></div><Button variant="outline" onClick={()=>window.print()}><Printer className="h-4 w-4 mr-2"/>Print register</Button></div>
+    <Card><CardHeader><CardTitle>Current authorization register</CardTitle></CardHeader><CardContent className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-2 print:hidden"><Input value={employee} onChange={e=>setEmployee(e.target.value)} placeholder="Employee ID or name"/><Input value={part} onChange={e=>setPart(e.target.value)} placeholder="Exact part number"/>
+        <Select value={program} onValueChange={setProgram}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{['ALL','P1','P2','DESIGN','GENERAL','OTHER'].map(v=><SelectItem key={v} value={v}>{v}</SelectItem>)}</SelectContent></Select>
+        <Select value={type} onValueChange={setType}><SelectTrigger><SelectValue placeholder="Authority"/></SelectTrigger><SelectContent><SelectItem value="ALL">All authorities</SelectItem>{Object.entries(labels).map(([v,l])=><SelectItem key={v} value={v}>{l}</SelectItem>)}</SelectContent></Select>
+        <Select value={status} onValueChange={setStatus}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{['ALL','DRAFT','ACTIVE','SUSPENDED','EXPIRED','REVOKED'].map(v=><SelectItem key={v} value={v}>{v}</SelectItem>)}</SelectContent></Select></div>
+      {isLoading?<p>Loading…</p>:<Table><TableHeader><TableRow><TableHead>Employee</TableHead><TableHead>Program / scope</TableHead><TableHead>Authority</TableHead><TableHead>Status</TableHead><TableHead>Effective / review</TableHead><TableHead>Approver</TableHead><TableHead>History</TableHead></TableRow></TableHeader><TableBody>{visible.map(r=><TableRow key={r.id}><TableCell>{r.employee_number}<br/><span className="text-muted-foreground">{r.employee_name}</span></TableCell><TableCell>{r.program} · {r.part_number||r.product_family||'General'}<br/><span className="text-muted-foreground">{[r.department,r.operation_scope].filter(Boolean).join(' / ')}</span></TableCell><TableCell className="font-medium">{labels[r.authorization_type]}</TableCell><TableCell className={r.status==='EXPIRED'||r.status==='REVOKED'?'text-red-700':soon(r.expiration_date)?'text-amber-700':''}>{r.status}{soon(r.expiration_date)?' · expiring soon':''}</TableCell><TableCell>{r.effective_date?new Date(r.effective_date).toLocaleDateString():'—'}<br/>{r.expiration_date?new Date(r.expiration_date).toLocaleDateString():'No expiration'}</TableCell><TableCell>{r.approver_username||'Pending'}</TableCell><TableCell><Button variant="ghost" size="sm" asChild><a href={`/api/training/certification-authorizations/${r.id}/history`} target="_blank" rel="noreferrer"><History className="h-4 w-4"/><span className="sr-only">View history revision {r.revision}</span></a></Button></TableCell></TableRow>)}</TableBody></Table>}
+    </CardContent></Card>
+  </div>;
+}

--- a/client/src/pages/CertificationAuthorizationMatrix.tsx
+++ b/client/src/pages/CertificationAuthorizationMatrix.tsx
@@ -4,28 +4,244 @@ import { Award, History, Printer } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
 type Props = { defaultProgram?: 'P2'; defaultStatus?: 'ACTIVE' };
-type Row = { id:string; employee_number:string; employee_name:string; program:string; part_number?:string; product_family?:string; department?:string; operation_scope?:string; authorization_type:string; status:string; effective_date?:string; expiration_date?:string; approver_username?:string; revision:number };
-const labels: Record<string,string> = { WORK:'Work Authorization', QC_INSPECTION:'QC Inspection', ROUTING_RELEASE:'Routing Release', FINAL_QC:'Final QC', FINAL_PRODUCT_RELEASE:'Final Product Release', COC_APPROVAL:'CoC Approval' };
+type Row = {
+  id: string;
+  employee_number: string;
+  employee_name: string;
+  program: string;
+  part_number?: string;
+  product_family?: string;
+  department?: string;
+  operation_scope?: string;
+  authorization_type: string;
+  status: string;
+  effective_date?: string;
+  expiration_date?: string;
+  approver_username?: string;
+  revision: number;
+};
+const labels: Record<string, string> = {
+  WORK: 'Work Authorization',
+  QC_INSPECTION: 'QC Inspection',
+  ROUTING_RELEASE: 'Routing Release',
+  FINAL_QC: 'Final QC',
+  FINAL_PRODUCT_RELEASE: 'Final Product Release',
+  COC_APPROVAL: 'CoC Approval',
+};
 
-export default function CertificationAuthorizationMatrix({ defaultProgram, defaultStatus }: Props) {
-  const [employee, setEmployee] = useState(''); const [program,setProgram]=useState(defaultProgram || 'ALL');
-  const [status,setStatus]=useState(defaultStatus || 'ALL'); const [part,setPart]=useState(''); const [type,setType]=useState('ALL');
-  const params=new URLSearchParams(); if(program!=='ALL')params.set('program',program); if(status!=='ALL')params.set('status',status); if(part)params.set('partNumber',part); if(type!=='ALL')params.set('authorizationType',type);
-  const {data:rows=[],isLoading}=useQuery<Row[]>({queryKey:['/api/training/certification-authorizations',params.toString()],queryFn:async()=>{const r=await fetch(`/api/training/certification-authorizations?${params}`,{credentials:'include'});if(!r.ok)throw new Error('Unable to load authorization register');return r.json();}});
-  const visible=rows.filter(r=>!employee || `${r.employee_number} ${r.employee_name}`.toLowerCase().includes(employee.toLowerCase()));
-  const soon=(date?:string)=>date && new Date(date)>new Date() && new Date(date).getTime()<=Date.now()+60*86400000;
-  return <div className="space-y-4" data-testid="certification-authorization-matrix">
-    <div className="flex items-start justify-between gap-4"><div><h2 className="text-2xl font-bold flex items-center gap-2"><Award className="h-6 w-6"/>Certification &amp; Authorization Matrix</h2><p className="text-muted-foreground">Training-owned authoritative register. Training completion does not grant QC, product-release, or CoC authority.</p></div><Button variant="outline" onClick={()=>window.print()}><Printer className="h-4 w-4 mr-2"/>Print register</Button></div>
-    <Card><CardHeader><CardTitle>Current authorization register</CardTitle></CardHeader><CardContent className="space-y-4">
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-2 print:hidden"><Input value={employee} onChange={e=>setEmployee(e.target.value)} placeholder="Employee ID or name"/><Input value={part} onChange={e=>setPart(e.target.value)} placeholder="Exact part number"/>
-        <Select value={program} onValueChange={setProgram}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{['ALL','P1','P2','DESIGN','GENERAL','OTHER'].map(v=><SelectItem key={v} value={v}>{v}</SelectItem>)}</SelectContent></Select>
-        <Select value={type} onValueChange={setType}><SelectTrigger><SelectValue placeholder="Authority"/></SelectTrigger><SelectContent><SelectItem value="ALL">All authorities</SelectItem>{Object.entries(labels).map(([v,l])=><SelectItem key={v} value={v}>{l}</SelectItem>)}</SelectContent></Select>
-        <Select value={status} onValueChange={setStatus}><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>{['ALL','DRAFT','ACTIVE','SUSPENDED','EXPIRED','REVOKED'].map(v=><SelectItem key={v} value={v}>{v}</SelectItem>)}</SelectContent></Select></div>
-      {isLoading?<p>Loading…</p>:<Table><TableHeader><TableRow><TableHead>Employee</TableHead><TableHead>Program / scope</TableHead><TableHead>Authority</TableHead><TableHead>Status</TableHead><TableHead>Effective / review</TableHead><TableHead>Approver</TableHead><TableHead>History</TableHead></TableRow></TableHeader><TableBody>{visible.map(r=><TableRow key={r.id}><TableCell>{r.employee_number}<br/><span className="text-muted-foreground">{r.employee_name}</span></TableCell><TableCell>{r.program} · {r.part_number||r.product_family||'General'}<br/><span className="text-muted-foreground">{[r.department,r.operation_scope].filter(Boolean).join(' / ')}</span></TableCell><TableCell className="font-medium">{labels[r.authorization_type]}</TableCell><TableCell className={r.status==='EXPIRED'||r.status==='REVOKED'?'text-red-700':soon(r.expiration_date)?'text-amber-700':''}>{r.status}{soon(r.expiration_date)?' · expiring soon':''}</TableCell><TableCell>{r.effective_date?new Date(r.effective_date).toLocaleDateString():'—'}<br/>{r.expiration_date?new Date(r.expiration_date).toLocaleDateString():'No expiration'}</TableCell><TableCell>{r.approver_username||'Pending'}</TableCell><TableCell><Button variant="ghost" size="sm" asChild><a href={`/api/training/certification-authorizations/${r.id}/history`} target="_blank" rel="noreferrer"><History className="h-4 w-4"/><span className="sr-only">View history revision {r.revision}</span></a></Button></TableCell></TableRow>)}</TableBody></Table>}
-    </CardContent></Card>
-  </div>;
+export default function CertificationAuthorizationMatrix({
+  defaultProgram,
+  defaultStatus,
+}: Props) {
+  const [employee, setEmployee] = useState('');
+  const [program, setProgram] = useState(defaultProgram || 'ALL');
+  const [status, setStatus] = useState(defaultStatus || 'ALL');
+  const [part, setPart] = useState('');
+  const [type, setType] = useState('ALL');
+  const params = new URLSearchParams();
+  if (program !== 'ALL') params.set('program', program);
+  if (status !== 'ALL') params.set('status', status);
+  if (part) params.set('partNumber', part);
+  if (type !== 'ALL') params.set('authorizationType', type);
+  const { data: rows = [], isLoading } = useQuery<Row[]>({
+    queryKey: ['/api/training/certification-authorizations', params.toString()],
+    queryFn: async () => {
+      const r = await fetch(
+        `/api/training/certification-authorizations?${params}`,
+        { credentials: 'include' }
+      );
+      if (!r.ok) throw new Error('Unable to load authorization register');
+      return r.json();
+    },
+  });
+  const visible = rows.filter(
+    (r) =>
+      !employee ||
+      `${r.employee_number} ${r.employee_name}`
+        .toLowerCase()
+        .includes(employee.toLowerCase())
+  );
+  const soon = (date?: string) =>
+    date &&
+    new Date(date) > new Date() &&
+    new Date(date).getTime() <= Date.now() + 60 * 86400000;
+  return (
+    <div className="space-y-4" data-testid="certification-authorization-matrix">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold flex items-center gap-2">
+            <Award className="h-6 w-6" />
+            Certification &amp; Authorization Matrix
+          </h2>
+          <p className="text-muted-foreground">
+            Training-owned authoritative register. Training completion does not
+            grant QC, product-release, or CoC authority.
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => window.print()}>
+          <Printer className="h-4 w-4 mr-2" />
+          Print register
+        </Button>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Current authorization register</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-2 print:hidden">
+            <Input
+              value={employee}
+              onChange={(e) => setEmployee(e.target.value)}
+              placeholder="Employee ID or name"
+            />
+            <Input
+              value={part}
+              onChange={(e) => setPart(e.target.value)}
+              placeholder="Exact part number"
+            />
+            <Select value={program} onValueChange={setProgram}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {['ALL', 'P1', 'P2', 'DESIGN', 'GENERAL', 'OTHER'].map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={type} onValueChange={setType}>
+              <SelectTrigger>
+                <SelectValue placeholder="Authority" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="ALL">All authorities</SelectItem>
+                {Object.entries(labels).map(([v, l]) => (
+                  <SelectItem key={v} value={v}>
+                    {l}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={status} onValueChange={setStatus}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[
+                  'ALL',
+                  'DRAFT',
+                  'ACTIVE',
+                  'SUSPENDED',
+                  'EXPIRED',
+                  'REVOKED',
+                ].map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {isLoading ? (
+            <p>Loading…</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Employee</TableHead>
+                  <TableHead>Program / scope</TableHead>
+                  <TableHead>Authority</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Effective / review</TableHead>
+                  <TableHead>Approver</TableHead>
+                  <TableHead>History</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {visible.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell>
+                      {r.employee_number}
+                      <br />
+                      <span className="text-muted-foreground">
+                        {r.employee_name}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      {r.program} ·{' '}
+                      {r.part_number || r.product_family || 'General'}
+                      <br />
+                      <span className="text-muted-foreground">
+                        {[r.department, r.operation_scope]
+                          .filter(Boolean)
+                          .join(' / ')}
+                      </span>
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      {labels[r.authorization_type]}
+                    </TableCell>
+                    <TableCell
+                      className={
+                        r.status === 'EXPIRED' || r.status === 'REVOKED'
+                          ? 'text-red-700'
+                          : soon(r.expiration_date)
+                            ? 'text-amber-700'
+                            : ''
+                      }
+                    >
+                      {r.status}
+                      {soon(r.expiration_date) ? ' · expiring soon' : ''}
+                    </TableCell>
+                    <TableCell>
+                      {r.effective_date
+                        ? new Date(r.effective_date).toLocaleDateString()
+                        : '—'}
+                      <br />
+                      {r.expiration_date
+                        ? new Date(r.expiration_date).toLocaleDateString()
+                        : 'No expiration'}
+                    </TableCell>
+                    <TableCell>{r.approver_username || 'Pending'}</TableCell>
+                    <TableCell>
+                      <Button variant="ghost" size="sm" asChild>
+                        <a
+                          href={`/api/training/certification-authorizations/${r.id}/history`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          <History className="h-4 w-4" />
+                          <span className="sr-only">
+                            View history revision {r.revision}
+                          </span>
+                        </a>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
 }

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -41,7 +41,7 @@ import P2BOMWizard from '@/components/p2/P2BOMWizard';
 import P2ProductionScheduler from '@/components/p2/P2ProductionScheduler';
 import P2StatusDashboard from '@/components/p2/P2StatusDashboard';
 import P2ProductionQueue from '@/components/p2/P2ProductionQueue';
-import P2CertificationsManager from './P2CertificationsManager';
+import CertificationAuthorizationMatrix from './CertificationAuthorizationMatrix';
 import PartRoutingManagement from './PartRoutingManagement';
 import RoutingDocumentManagement from './RoutingDocumentManagement';
 import P2ChangesTab from '@/components/p2/P2ChangesTab';
@@ -926,7 +926,7 @@ export default function P2ControlCenter() {
         </TabsContent>
 
         <TabsContent value="certifications">
-          <P2CertificationsManager />
+          <CertificationAuthorizationMatrix defaultProgram="P2" defaultStatus="ACTIVE" />
         </TabsContent>
 
         <TabsContent value="scrapped">

--- a/client/src/pages/TrainingControlCenter.tsx
+++ b/client/src/pages/TrainingControlCenter.tsx
@@ -14,6 +14,7 @@ import {
   UserCheck,
   BookOpen,
   Wrench
+  ,Award
 } from 'lucide-react';
 
 import Training from './Training';
@@ -22,6 +23,7 @@ import TrainingManagement from './TrainingManagement';
 import TrainingMatrixManage from './TrainingMatrixManage';
 import TrainTheTrainer from './TrainTheTrainer';
 import TrainingContentLibrary from './TrainingContentLibrary';
+import CertificationAuthorizationMatrix from './CertificationAuthorizationMatrix';
 
 interface TrainingStats {
   totalModules: number;
@@ -32,7 +34,7 @@ interface TrainingStats {
 }
 
 type Language = 'en' | 'es';
-type TrainingTab = 'modules' | 'library' | 'matrix' | 'assignments' | 'trainer' | 'management';
+type TrainingTab = 'modules' | 'library' | 'matrix' | 'authorizations' | 'assignments' | 'trainer' | 'management';
 
 const translations = {
   en: {
@@ -168,7 +170,7 @@ export default function TrainingControlCenter() {
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <div className="flex items-center gap-2">
-          <TabsList className="grid flex-1 grid-cols-6">
+          <TabsList className="grid flex-1 grid-cols-7">
           <TabsTrigger value="modules" className="flex items-center gap-2" data-testid="tab-modules">
             <GraduationCap className="h-4 w-4" />
             {t.tabModules}
@@ -180,6 +182,9 @@ export default function TrainingControlCenter() {
           <TabsTrigger value="matrix" className="flex items-center gap-2" data-testid="tab-matrix">
             <LayoutGrid className="h-4 w-4" />
             {t.tabMatrix}
+          </TabsTrigger>
+          <TabsTrigger value="authorizations" className="flex items-center gap-2" data-testid="tab-authorizations">
+            <Award className="h-4 w-4" /> Authorizations
           </TabsTrigger>
           <TabsTrigger value="assignments" className="flex items-center gap-2" data-testid="tab-assignments">
             <Users className="h-4 w-4" />
@@ -215,6 +220,9 @@ export default function TrainingControlCenter() {
 
         <TabsContent value="matrix" className="space-y-4">
           <TrainingMatrixView />
+        </TabsContent>
+        <TabsContent value="authorizations" className="space-y-4">
+          <CertificationAuthorizationMatrix />
         </TabsContent>
 
         <TabsContent value="assignments" className="space-y-4">

--- a/migrations/0270_certification_authorization_matrix.sql
+++ b/migrations/0270_certification_authorization_matrix.sql
@@ -93,7 +93,9 @@ SELECT pc.employee_id, 'P2', pc.part_number, pc.department, 'WORK', 'DRAFT',
        pc.id, u.id, u.id
 FROM p2_employee_part_certifications pc
 JOIN LATERAL (SELECT id FROM users WHERE role IN ('OWNER','ADMIN') ORDER BY id LIMIT 1) u ON true
-ON CONFLICT (legacy_p2_employee_certification_id) DO NOTHING;
+ON CONFLICT (legacy_p2_employee_certification_id)
+  WHERE legacy_p2_employee_certification_id IS NOT NULL
+DO NOTHING;
 
 INSERT INTO certification_authorization_events(authorization_id, revision, event_type, snapshot, reason, actor_user_id)
 SELECT a.id, a.revision, 'MIGRATED', to_jsonb(a),

--- a/migrations/0270_certification_authorization_matrix.sql
+++ b/migrations/0270_certification_authorization_matrix.sql
@@ -1,0 +1,115 @@
+-- Authoritative Training-owned Certification & Authorization Matrix.
+-- Prospective enforcement remains disabled until controlled rollout.
+CREATE TABLE IF NOT EXISTS certification_authorizations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  revision integer NOT NULL DEFAULT 1 CHECK (revision > 0),
+  employee_id integer NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+  employee_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  program text NOT NULL CHECK (program IN ('P1','P2','DESIGN','GENERAL','OTHER')),
+  part_number text,
+  product_family text,
+  department text,
+  operation_scope text,
+  authorization_type text NOT NULL CHECK (authorization_type IN ('WORK','QC_INSPECTION','ROUTING_RELEASE','FINAL_QC','FINAL_PRODUCT_RELEASE','COC_APPROVAL')),
+  status text NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT','ACTIVE','SUSPENDED','EXPIRED','REVOKED')),
+  effective_date timestamptz,
+  expiration_date timestamptz,
+  approved_by_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  approved_by_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  approved_at timestamptz,
+  signature_meaning text,
+  qualification_method text,
+  evidence_reference text,
+  notes text,
+  limitations text,
+  legacy_p2_employee_certification_id integer REFERENCES p2_employee_part_certifications(id) ON DELETE RESTRICT,
+  created_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  updated_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (part_number IS NOT NULL OR product_family IS NOT NULL OR program IN ('GENERAL','OTHER')),
+  CHECK (expiration_date IS NULL OR effective_date IS NULL OR expiration_date > effective_date),
+  CHECK (status <> 'ACTIVE' OR (approved_at IS NOT NULL AND signature_meaning IS NOT NULL AND effective_date IS NOT NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_cert_auth_legacy_p2
+  ON certification_authorizations(legacy_p2_employee_certification_id)
+  WHERE legacy_p2_employee_certification_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_cert_auth_active_scope
+  ON certification_authorizations(employee_id, program, COALESCE(part_number,''), COALESCE(product_family,''), COALESCE(department,''), COALESCE(operation_scope,''), authorization_type)
+  WHERE status = 'ACTIVE';
+CREATE INDEX IF NOT EXISTS idx_cert_auth_register
+  ON certification_authorizations(program, status, authorization_type, expiration_date);
+
+CREATE TABLE IF NOT EXISTS certification_authorization_events (
+  id bigserial PRIMARY KEY,
+  authorization_id uuid NOT NULL REFERENCES certification_authorizations(id) ON DELETE RESTRICT,
+  revision integer NOT NULL,
+  event_type text NOT NULL CHECK (event_type IN ('CREATED','APPROVED','UPDATED','SUSPENDED','REVOKED','RENEWED','EXPIRED','MIGRATED')),
+  snapshot jsonb NOT NULL,
+  reason text,
+  actor_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  actor_employee_id integer REFERENCES employees(id) ON DELETE RESTRICT,
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (authorization_id, revision)
+);
+
+CREATE TABLE IF NOT EXISTS certification_authorization_use_snapshots (
+  id bigserial PRIMARY KEY,
+  authorization_id uuid NOT NULL REFERENCES certification_authorizations(id) ON DELETE RESTRICT,
+  authorization_revision integer NOT NULL,
+  action_type text NOT NULL CHECK (action_type IN ('TRAVELER_START','QC_ACCEPTANCE','ROUTING_RELEASE','FINAL_PRODUCT_RELEASE','COC_APPROVAL')),
+  employee_id integer NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+  user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  part_number text,
+  product_family text,
+  qualification_status text NOT NULL,
+  effective_date timestamptz,
+  expiration_date timestamptz,
+  approver_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  used_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS certification_authorization_feature_flags (
+  key text PRIMARY KEY,
+  enabled boolean NOT NULL DEFAULT false,
+  updated_by_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+INSERT INTO certification_authorization_feature_flags(key, enabled)
+VALUES ('prospective_enforcement', false) ON CONFLICT (key) DO NOTHING;
+
+-- Conservative compatibility backfill: evidence becomes DRAFT WORK only.
+-- No QC, release, or CoC authority is inferred from legacy checkboxes.
+INSERT INTO certification_authorizations (
+  employee_id, program, part_number, department, authorization_type, status,
+  qualification_method, evidence_reference, notes,
+  legacy_p2_employee_certification_id, created_by_user_id, updated_by_user_id
+)
+SELECT pc.employee_id, 'P2', pc.part_number, pc.department, 'WORK', 'DRAFT',
+       'LEGACY_P2_COMPETENCY_REVIEW', 'p2_employee_part_certifications:' || pc.id,
+       'Conservative migration; requires controlled approval before activation.',
+       pc.id, u.id, u.id
+FROM p2_employee_part_certifications pc
+JOIN LATERAL (SELECT id FROM users WHERE role IN ('OWNER','ADMIN') ORDER BY id LIMIT 1) u ON true
+ON CONFLICT (legacy_p2_employee_certification_id) DO NOTHING;
+
+INSERT INTO certification_authorization_events(authorization_id, revision, event_type, snapshot, reason, actor_user_id)
+SELECT a.id, a.revision, 'MIGRATED', to_jsonb(a),
+       'Conservative legacy P2 backfill as DRAFT WORK authorization only.', a.created_by_user_id
+FROM certification_authorizations a
+WHERE a.legacy_p2_employee_certification_id IS NOT NULL
+ON CONFLICT (authorization_id, revision) DO NOTHING;
+
+INSERT INTO perm_capabilities(key, description, category) VALUES
+ ('training.authorization.view','View Certification & Authorization Matrix','training'),
+ ('training.authorization.grant','Create draft certification authorizations','training'),
+ ('training.authorization.approve','Approve or renew certification authorizations','training'),
+ ('training.authorization.change_status','Suspend or revoke certification authorizations','training')
+ON CONFLICT (key) DO UPDATE SET description=EXCLUDED.description, category=EXCLUDED.category;
+
+INSERT INTO perm_role_capabilities(role_id, capability_id)
+SELECT r.id, c.id FROM perm_roles r CROSS JOIN perm_capabilities c
+WHERE r.name IN ('OWNER','ADMIN') AND c.key LIKE 'training.authorization.%'
+ON CONFLICT DO NOTHING;

--- a/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
+++ b/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
@@ -29,10 +29,14 @@ describe('Certification & Authorization Matrix architecture', () => {
     expect(migration).toContain('certification_authorization_use_snapshots');
     expect(migration).toContain('uq_cert_auth_active_scope');
     expect(migration).toContain("WHERE status = 'ACTIVE'");
+    expect(migration).toContain('ON CONFLICT (legacy_p2_employee_certification_id)\n  WHERE legacy_p2_employee_certification_id IS NOT NULL');
   });
 
   it('gates traveler work and final product release server-side', () => {
-    expect(read('server/src/lib/travelerGates.ts')).toContain("type: 'WORK'");
+    const travelerGates = read('server/src/lib/travelerGates.ts');
+    expect(travelerGates).toContain("type: 'WORK'");
+    expect(travelerGates).toContain('const verifiedEmployeeId = options.employeeId;');
+    expect(travelerGates).toContain('employeeId: verifiedEmployeeId');
     expect(read('server/src/routes/projectQualityRelease.ts')).toContain("type:'FINAL_PRODUCT_RELEASE'");
   });
 });

--- a/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
+++ b/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const read = (file: string) => fs.readFileSync(path.resolve(process.cwd(), file), 'utf8');
+
+describe('Certification & Authorization Matrix architecture', () => {
+  it('uses one Training-owned API and the same component at both entry points', () => {
+    const matrix = read('client/src/pages/CertificationAuthorizationMatrix.tsx');
+    const training = read('client/src/pages/TrainingControlCenter.tsx');
+    const p2 = read('client/src/pages/P2ControlCenter.tsx');
+    expect(matrix).toContain('/api/training/certification-authorizations');
+    expect(training).toContain('<CertificationAuthorizationMatrix />');
+    expect(p2).toContain('<CertificationAuthorizationMatrix defaultProgram="P2" defaultStatus="ACTIVE" />');
+    expect(p2).not.toContain('<P2CertificationsManager />');
+  });
+
+  it('separates authorities and keeps prospective enforcement disabled by default', () => {
+    const migration = read('migrations/0270_certification_authorization_matrix.sql');
+    for (const authority of ['WORK','QC_INSPECTION','ROUTING_RELEASE','FINAL_QC','FINAL_PRODUCT_RELEASE','COC_APPROVAL']) expect(migration).toContain(`'${authority}'`);
+    expect(migration).toContain("VALUES ('prospective_enforcement', false)");
+    expect(migration).toContain("'WORK', 'DRAFT'");
+    expect(migration).not.toMatch(/legacy_p2[\s\S]{0,400}'FINAL_(QC|PRODUCT_RELEASE)'/);
+  });
+
+  it('retains immutable revisions, use snapshots, and prevents overlapping active scope', () => {
+    const migration = read('migrations/0270_certification_authorization_matrix.sql');
+    expect(migration).toContain('certification_authorization_events');
+    expect(migration).toContain('certification_authorization_use_snapshots');
+    expect(migration).toContain('uq_cert_auth_active_scope');
+    expect(migration).toContain("WHERE status = 'ACTIVE'");
+  });
+
+  it('gates traveler work and final product release server-side', () => {
+    expect(read('server/src/lib/travelerGates.ts')).toContain("type: 'WORK'");
+    expect(read('server/src/routes/projectQualityRelease.ts')).toContain("type:'FINAL_PRODUCT_RELEASE'");
+  });
+});

--- a/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
+++ b/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
@@ -64,7 +64,7 @@ describe('Certification & Authorization Matrix architecture', () => {
       'requireApplicableAuthorization({ employeeId: options.employeeId'
     );
     expect(read('server/src/routes/projectQualityRelease.ts')).toContain(
-      "type:'FINAL_PRODUCT_RELEASE'"
+      "type: 'FINAL_PRODUCT_RELEASE'"
     );
   });
 });

--- a/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
+++ b/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
@@ -37,6 +37,7 @@ describe('Certification & Authorization Matrix architecture', () => {
     expect(travelerGates).toContain("type: 'WORK'");
     expect(travelerGates).toContain('const verifiedEmployeeId = options.employeeId;');
     expect(travelerGates).toContain('employeeId: verifiedEmployeeId');
+    expect(travelerGates).not.toContain('requireApplicableAuthorization({ employeeId: options.employeeId');
     expect(read('server/src/routes/projectQualityRelease.ts')).toContain("type:'FINAL_PRODUCT_RELEASE'");
   });
 });

--- a/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
+++ b/server/__tests__/certificationAuthorizationMatrixArchitecture.test.ts
@@ -2,42 +2,69 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const read = (file: string) => fs.readFileSync(path.resolve(process.cwd(), file), 'utf8');
+const read = (file: string) =>
+  fs.readFileSync(path.resolve(process.cwd(), file), 'utf8');
 
 describe('Certification & Authorization Matrix architecture', () => {
   it('uses one Training-owned API and the same component at both entry points', () => {
-    const matrix = read('client/src/pages/CertificationAuthorizationMatrix.tsx');
+    const matrix = read(
+      'client/src/pages/CertificationAuthorizationMatrix.tsx'
+    );
     const training = read('client/src/pages/TrainingControlCenter.tsx');
     const p2 = read('client/src/pages/P2ControlCenter.tsx');
     expect(matrix).toContain('/api/training/certification-authorizations');
     expect(training).toContain('<CertificationAuthorizationMatrix />');
-    expect(p2).toContain('<CertificationAuthorizationMatrix defaultProgram="P2" defaultStatus="ACTIVE" />');
+    expect(p2).toContain(
+      '<CertificationAuthorizationMatrix defaultProgram="P2" defaultStatus="ACTIVE" />'
+    );
     expect(p2).not.toContain('<P2CertificationsManager />');
   });
 
   it('separates authorities and keeps prospective enforcement disabled by default', () => {
-    const migration = read('migrations/0270_certification_authorization_matrix.sql');
-    for (const authority of ['WORK','QC_INSPECTION','ROUTING_RELEASE','FINAL_QC','FINAL_PRODUCT_RELEASE','COC_APPROVAL']) expect(migration).toContain(`'${authority}'`);
+    const migration = read(
+      'migrations/0270_certification_authorization_matrix.sql'
+    );
+    for (const authority of [
+      'WORK',
+      'QC_INSPECTION',
+      'ROUTING_RELEASE',
+      'FINAL_QC',
+      'FINAL_PRODUCT_RELEASE',
+      'COC_APPROVAL',
+    ])
+      expect(migration).toContain(`'${authority}'`);
     expect(migration).toContain("VALUES ('prospective_enforcement', false)");
     expect(migration).toContain("'WORK', 'DRAFT'");
-    expect(migration).not.toMatch(/legacy_p2[\s\S]{0,400}'FINAL_(QC|PRODUCT_RELEASE)'/);
+    expect(migration).not.toMatch(
+      /legacy_p2[\s\S]{0,400}'FINAL_(QC|PRODUCT_RELEASE)'/
+    );
   });
 
   it('retains immutable revisions, use snapshots, and prevents overlapping active scope', () => {
-    const migration = read('migrations/0270_certification_authorization_matrix.sql');
+    const migration = read(
+      'migrations/0270_certification_authorization_matrix.sql'
+    );
     expect(migration).toContain('certification_authorization_events');
     expect(migration).toContain('certification_authorization_use_snapshots');
     expect(migration).toContain('uq_cert_auth_active_scope');
     expect(migration).toContain("WHERE status = 'ACTIVE'");
-    expect(migration).toContain('ON CONFLICT (legacy_p2_employee_certification_id)\n  WHERE legacy_p2_employee_certification_id IS NOT NULL');
+    expect(migration).toContain(
+      'ON CONFLICT (legacy_p2_employee_certification_id)\n  WHERE legacy_p2_employee_certification_id IS NOT NULL'
+    );
   });
 
   it('gates traveler work and final product release server-side', () => {
     const travelerGates = read('server/src/lib/travelerGates.ts');
     expect(travelerGates).toContain("type: 'WORK'");
-    expect(travelerGates).toContain('const verifiedEmployeeId = options.employeeId;');
+    expect(travelerGates).toContain(
+      'const verifiedEmployeeId = options.employeeId;'
+    );
     expect(travelerGates).toContain('employeeId: verifiedEmployeeId');
-    expect(travelerGates).not.toContain('requireApplicableAuthorization({ employeeId: options.employeeId');
-    expect(read('server/src/routes/projectQualityRelease.ts')).toContain("type:'FINAL_PRODUCT_RELEASE'");
+    expect(travelerGates).not.toContain(
+      'requireApplicableAuthorization({ employeeId: options.employeeId'
+    );
+    expect(read('server/src/routes/projectQualityRelease.ts')).toContain(
+      "type:'FINAL_PRODUCT_RELEASE'"
+    );
   });
 });

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -298,6 +298,7 @@ export const safeMigrationFiles = [
   '0267_reconcile_p18380_persisted_shipment.sql',
   '0268_replit_p2_demand_composite_fk_repair.sql',
   '0269_repair_composite_po_item_demand_fks.sql',
+  '0270_certification_authorization_matrix.sql',
 ];
 
 export const criticalMigrationFiles = new Set([
@@ -372,6 +373,7 @@ export const criticalMigrationFiles = new Set([
   '0267_reconcile_p18380_persisted_shipment.sql',
   '0268_replit_p2_demand_composite_fk_repair.sql',
   '0269_repair_composite_po_item_demand_fks.sql',
+  '0270_certification_authorization_matrix.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/lib/travelerGates.ts
+++ b/server/src/lib/travelerGates.ts
@@ -289,6 +289,7 @@ export async function evaluateTravelerStartGates(
       reason: `Employee identity is required before starting this step. Scan a valid badge before starting.`,
     };
   }
+  const verifiedEmployeeId = options.employeeId;
 
   // Gate 2a: Part authorization — when the traveler has a partNumber, the employee
   // must have an active authorization record for that part.
@@ -298,7 +299,7 @@ export async function evaluateTravelerStartGates(
     if (prospectiveAuthorizationEnforcementEnabled()) {
       try {
         await requireApplicableAuthorization({
-          employeeId: options.employeeId,
+          employeeId: verifiedEmployeeId,
           type: 'WORK',
           program: 'P2',
           partNumber: traveler.partNumber,
@@ -328,7 +329,7 @@ export async function evaluateTravelerStartGates(
         .from(travelerAuthorizations)
         .where(
           and(
-            eq(travelerAuthorizations.employeeId, options.employeeId),
+            eq(travelerAuthorizations.employeeId, verifiedEmployeeId),
             eq(travelerAuthorizations.partNumber, traveler.partNumber),
             eq(travelerAuthorizations.isActive, true)
           )
@@ -362,7 +363,7 @@ export async function evaluateTravelerStartGates(
         const certName = cert?.name ?? `Certification #${routingOp.certificationId}`;
         const name = options.employeeName || `Employee #${options.employeeId}`;
         const hasCert = await storage.checkEmployeeHasValidTrainingCertificationForCert(
-          options.employeeId,
+          verifiedEmployeeId,
           routingOp.certificationId
         );
         if (!hasCert) {
@@ -375,7 +376,7 @@ export async function evaluateTravelerStartGates(
 
       // Load active qualifications once for both machine-class and operation-type checks.
       const activeQuals = await storage.getActiveEmployeeMachineQualificationsForEmployee(
-        options.employeeId
+        verifiedEmployeeId
       );
 
       // Gate 2c: Machine-class qualification — if the routing operation has a CNC

--- a/server/src/lib/travelerGates.ts
+++ b/server/src/lib/travelerGates.ts
@@ -502,14 +502,7 @@ export async function evaluateStartGatesDetailed(
       reason: identityReason,
     });
     // Cannot evaluate part-auth or op-cert without identity; record them as pending.
-    if (traveler.partNumber && prospectiveAuthorizationEnforcementEnabled()) {
-      try {
-        await requireApplicableAuthorization({ employeeId: options.employeeId, type: 'WORK', program: 'P2', partNumber: traveler.partNumber, department: step.departmentName, operation: step.departmentName, actionType: 'TRAVELER_START', evidence: { travelerId, travelerStepId: stepId } });
-        results.push({ key: 'training', label: 'Work authorization', passed: true });
-      } catch (error: any) {
-        results.push({ key: 'training', label: 'Work authorization', passed: false, reason: error.message });
-      }
-    } else if (traveler.partNumber) {
+    if (traveler.partNumber) {
       results.push({
         key: 'training',
         label: 'Training verified',
@@ -518,11 +511,19 @@ export async function evaluateStartGatesDetailed(
       });
     }
   } else {
+    const verifiedEmployeeId = options.employeeId;
     results.push({ key: 'identity', label: 'Employee identity', passed: true });
 
     // Gate 2a: Part authorization (only when traveler has a partNumber).
     // Grandfather: only enforce when at least one authorization exists for this part.
-    if (traveler.partNumber) {
+    if (traveler.partNumber && prospectiveAuthorizationEnforcementEnabled()) {
+      try {
+        await requireApplicableAuthorization({ employeeId: verifiedEmployeeId, type: 'WORK', program: 'P2', partNumber: traveler.partNumber, department: step.departmentName, operation: step.departmentName, actionType: 'TRAVELER_START', evidence: { travelerId, travelerStepId: stepId } });
+        results.push({ key: 'training', label: 'Work authorization', passed: true });
+      } catch (error: any) {
+        results.push({ key: 'training', label: 'Work authorization', passed: false, reason: error.message });
+      }
+    } else if (traveler.partNumber) {
       const [anyAuth] = await db
         .select({ id: travelerAuthorizations.id })
         .from(travelerAuthorizations)
@@ -540,7 +541,7 @@ export async function evaluateStartGatesDetailed(
           .from(travelerAuthorizations)
           .where(
             and(
-              eq(travelerAuthorizations.employeeId, options.employeeId),
+              eq(travelerAuthorizations.employeeId, verifiedEmployeeId),
               eq(travelerAuthorizations.partNumber, traveler.partNumber),
               eq(travelerAuthorizations.isActive, true)
             )

--- a/server/src/lib/travelerGates.ts
+++ b/server/src/lib/travelerGates.ts
@@ -1,7 +1,16 @@
 import { storage } from '../../storage';
 import { db } from '../../db';
-import { calibrationAssets, calibrationUseLogs, productionWorkOrders, travelerAuthorizations, travelerMaterialConsumption } from '../../schema';
-import { prospectiveAuthorizationEnforcementEnabled, requireApplicableAuthorization } from '../services/certificationAuthorizationService';
+import {
+  calibrationAssets,
+  calibrationUseLogs,
+  productionWorkOrders,
+  travelerAuthorizations,
+  travelerMaterialConsumption,
+} from '../../schema';
+import {
+  prospectiveAuthorizationEnforcementEnabled,
+  requireApplicableAuthorization,
+} from '../services/certificationAuthorizationService';
 import { eq, and, inArray } from 'drizzle-orm';
 
 export interface GateResult {
@@ -41,7 +50,11 @@ export type AnyGateErrorBody = GateErrorBody | TrainingGateErrorBody;
  * Build a consistent HTTP error body for a gate rejection.
  * Includes both the new structured fields and legacy `error`/`reason` aliases for backward compat.
  */
-export function buildGateErrorBody(gate: string, message: string, detail: string): GateErrorBody {
+export function buildGateErrorBody(
+  gate: string,
+  message: string,
+  detail: string
+): GateErrorBody {
   return { gate, message, detail, error: message, reason: detail };
 }
 
@@ -55,7 +68,7 @@ export function buildTrainingGateErrorBody(
   detail: string,
   missingRequirement?: string,
   requirementType?: string,
-  gate = 'training',
+  gate = 'training'
 ): TrainingGateErrorBody {
   return {
     gate,
@@ -74,7 +87,9 @@ export function buildTrainingGateErrorBody(
  *
  * @param wadId  UUID of the production_work_orders row
  */
-export async function evaluateWadReleaseGate(wadId: string): Promise<GateResult> {
+export async function evaluateWadReleaseGate(
+  wadId: string
+): Promise<GateResult> {
   const [wad] = await db
     .select({
       id: productionWorkOrders.id,
@@ -85,11 +100,18 @@ export async function evaluateWadReleaseGate(wadId: string): Promise<GateResult>
     .where(eq(productionWorkOrders.id, wadId))
     .limit(1);
   if (!wad) {
-    return { allowed: false, reason: 'The linked production work order could not be found.' };
+    return {
+      allowed: false,
+      reason: 'The linked production work order could not be found.',
+    };
   }
 
-  const status = String(wad.status || '').trim().toUpperCase();
-  const wadStatus = String(wad.wadStatus || '').trim().toUpperCase();
+  const status = String(wad.status || '')
+    .trim()
+    .toUpperCase();
+  const wadStatus = String(wad.wadStatus || '')
+    .trim()
+    .toUpperCase();
 
   if (status === 'RELEASED' || status === 'IN_PROGRESS') {
     return { allowed: true };
@@ -97,7 +119,9 @@ export async function evaluateWadReleaseGate(wadId: string): Promise<GateResult>
 
   if (wadStatus === 'APPROVED') {
     await storage.updateWorkOrderStatus(wad.id, 'IN_PROGRESS');
-    console.log(`[TravelerGate] Promoted approved WAD ${wad.id} from ${wad.status} to IN_PROGRESS at traveler start`);
+    console.log(
+      `[TravelerGate] Promoted approved WAD ${wad.id} from ${wad.status} to IN_PROGRESS at traveler start`
+    );
     return { allowed: true };
   }
 
@@ -113,12 +137,16 @@ export async function evaluateWadReleaseGate(wadId: string): Promise<GateResult>
  *
  * @param travelerId  UUID of the traveler
  */
-export async function evaluateMaterialReadinessGate(travelerId: string): Promise<GateResult> {
+export async function evaluateMaterialReadinessGate(
+  travelerId: string
+): Promise<GateResult> {
   const traveler = await storage.getTraveler(travelerId);
   if (!traveler) {
     return { allowed: false, reason: 'Traveler not found.' };
   }
-  const hasMaterialOnTraveler = !!(traveler.lotNumber || traveler.internalControlNumber);
+  const hasMaterialOnTraveler = !!(
+    traveler.lotNumber || traveler.internalControlNumber
+  );
   if (!hasMaterialOnTraveler) {
     const [consumption] = await db
       .select({ id: travelerMaterialConsumption.id })
@@ -128,7 +156,8 @@ export async function evaluateMaterialReadinessGate(travelerId: string): Promise
     if (!consumption) {
       return {
         allowed: false,
-        reason: 'No material (lot number or ICN) has been allocated to this traveler. Assign material before starting.',
+        reason:
+          'No material (lot number or ICN) has been allocated to this traveler. Assign material before starting.',
       };
     }
   }
@@ -142,8 +171,15 @@ export interface GateCheckResult {
   reason?: string;
 }
 
-function isCalibrationAssetUsable(asset: { status: string; calibrationDueDate: Date | string | null }): boolean {
-  if (asset.status === 'locked_out' || asset.status === 'expired' || asset.status === 'retired') {
+function isCalibrationAssetUsable(asset: {
+  status: string;
+  calibrationDueDate: Date | string | null;
+}): boolean {
+  if (
+    asset.status === 'locked_out' ||
+    asset.status === 'expired' ||
+    asset.status === 'retired'
+  ) {
     return false;
   }
   if (!asset.calibrationDueDate) return false;
@@ -165,7 +201,9 @@ async function evaluateRequiredCalibrationAssets(
     logBlocked?: boolean;
   } = {}
 ): Promise<GateResult> {
-  const tags = Array.from(new Set(requiredAssetTags.map((tag) => tag.trim()).filter(Boolean)));
+  const tags = Array.from(
+    new Set(requiredAssetTags.map((tag) => tag.trim()).filter(Boolean))
+  );
   if (tags.length === 0) return { allowed: true };
 
   const assets = await db
@@ -179,13 +217,21 @@ async function evaluateRequiredCalibrationAssets(
 
   if (missing.length > 0 || blocked.length > 0) {
     const blockedDetails = blocked.map((asset) => {
-      const due = asset.calibrationDueDate ? ` due ${asset.calibrationDueDate}` : ' with no due date';
+      const due = asset.calibrationDueDate
+        ? ` due ${asset.calibrationDueDate}`
+        : ' with no due date';
       return `${asset.assetTag} (${asset.status}${due})`;
     });
     const reason = [
-      missing.length > 0 ? `Missing calibration asset(s): ${missing.join(', ')}` : null,
-      blockedDetails.length > 0 ? `Unavailable calibration asset(s): ${blockedDetails.join(', ')}` : null,
-    ].filter(Boolean).join('. ');
+      missing.length > 0
+        ? `Missing calibration asset(s): ${missing.join(', ')}`
+        : null,
+      blockedDetails.length > 0
+        ? `Unavailable calibration asset(s): ${blockedDetails.join(', ')}`
+        : null,
+    ]
+      .filter(Boolean)
+      .join('. ');
 
     if (context.logBlocked) {
       await db.insert(calibrationUseLogs).values(
@@ -251,7 +297,11 @@ async function evaluateRequiredCalibrationAssets(
 export async function evaluateTravelerStartGates(
   travelerId: string,
   stepId: string,
-  options: { employeeId?: number; employeeName?: string; skipOperationCertCheck?: boolean } = {}
+  options: {
+    employeeId?: number;
+    employeeName?: string;
+    skipOperationCertCheck?: boolean;
+  } = {}
 ): Promise<GateResult> {
   const traveler = await storage.getTraveler(travelerId);
   if (!traveler) {
@@ -312,38 +362,39 @@ export async function evaluateTravelerStartGates(
         return { allowed: false, reason: error.message };
       }
     } else {
-    const [anyAuth] = await db
-      .select({ id: travelerAuthorizations.id })
-      .from(travelerAuthorizations)
-      .where(
-        and(
-          eq(travelerAuthorizations.partNumber, traveler.partNumber),
-          eq(travelerAuthorizations.isActive, true)
-        )
-      )
-      .limit(1);
-
-    if (anyAuth) {
-      const [empAuth] = await db
+      const [anyAuth] = await db
         .select({ id: travelerAuthorizations.id })
         .from(travelerAuthorizations)
         .where(
           and(
-            eq(travelerAuthorizations.employeeId, verifiedEmployeeId),
             eq(travelerAuthorizations.partNumber, traveler.partNumber),
             eq(travelerAuthorizations.isActive, true)
           )
         )
         .limit(1);
 
-      if (!empAuth) {
-        const name = options.employeeName || `Employee #${options.employeeId}`;
-        return {
-          allowed: false,
-          reason: `${name} does not have a training authorization for part ${traveler.partNumber}. An authorization record must be created before work can begin.`,
-        };
+      if (anyAuth) {
+        const [empAuth] = await db
+          .select({ id: travelerAuthorizations.id })
+          .from(travelerAuthorizations)
+          .where(
+            and(
+              eq(travelerAuthorizations.employeeId, verifiedEmployeeId),
+              eq(travelerAuthorizations.partNumber, traveler.partNumber),
+              eq(travelerAuthorizations.isActive, true)
+            )
+          )
+          .limit(1);
+
+        if (!empAuth) {
+          const name =
+            options.employeeName || `Employee #${options.employeeId}`;
+          return {
+            allowed: false,
+            reason: `${name} does not have a training authorization for part ${traveler.partNumber}. An authorization record must be created before work can begin.`,
+          };
+        }
       }
-    }
     }
   }
 
@@ -359,13 +410,17 @@ export async function evaluateTravelerStartGates(
       // Phase 1 WARN policy: when skipOperationCertCheck=true, the cert was already
       // evaluated by the training gate above and a WARN was recorded. Do not double-block here.
       if (routingOp.certificationId && !options.skipOperationCertCheck) {
-        const cert = await storage.getCertificationById(routingOp.certificationId);
-        const certName = cert?.name ?? `Certification #${routingOp.certificationId}`;
-        const name = options.employeeName || `Employee #${options.employeeId}`;
-        const hasCert = await storage.checkEmployeeHasValidTrainingCertificationForCert(
-          verifiedEmployeeId,
+        const cert = await storage.getCertificationById(
           routingOp.certificationId
         );
+        const certName =
+          cert?.name ?? `Certification #${routingOp.certificationId}`;
+        const name = options.employeeName || `Employee #${options.employeeId}`;
+        const hasCert =
+          await storage.checkEmployeeHasValidTrainingCertificationForCert(
+            verifiedEmployeeId,
+            routingOp.certificationId
+          );
         if (!hasCert) {
           return {
             allowed: false,
@@ -375,20 +430,24 @@ export async function evaluateTravelerStartGates(
       }
 
       // Load active qualifications once for both machine-class and operation-type checks.
-      const activeQuals = await storage.getActiveEmployeeMachineQualificationsForEmployee(
-        verifiedEmployeeId
-      );
+      const activeQuals =
+        await storage.getActiveEmployeeMachineQualificationsForEmployee(
+          verifiedEmployeeId
+        );
 
       // Gate 2c: Machine-class qualification — if the routing operation has a CNC
       // extension with a machineClass, the employee must hold an active, non-expired
       // MACHINE_CLASS qualification for that class.
-      const cncOp = await storage.getRoutingCncOperationForRoutingOp(routingOp.id);
+      const cncOp = await storage.getRoutingCncOperationForRoutingOp(
+        routingOp.id
+      );
       if (cncOp?.machineClass) {
         const hasMachineQual = activeQuals.some(
           (q) => q.machineClass === cncOp.machineClass
         );
         if (!hasMachineQual) {
-          const name = options.employeeName || `Employee #${options.employeeId}`;
+          const name =
+            options.employeeName || `Employee #${options.employeeId}`;
           return {
             allowed: false,
             reason: `${name} does not have a valid machine-class qualification for "${cncOp.machineClass}". A qualification must be granted by an admin before starting this step.`,
@@ -404,7 +463,8 @@ export async function evaluateTravelerStartGates(
           (q) => q.operationType === routingOp.operationType
         );
         if (!hasOpTypeQual) {
-          const name = options.employeeName || `Employee #${options.employeeId}`;
+          const name =
+            options.employeeName || `Employee #${options.employeeId}`;
           return {
             allowed: false,
             reason: `${name} does not have a valid operation-type qualification for "${routingOp.operationType}". A qualification must be granted by an admin before starting this step.`,
@@ -430,7 +490,9 @@ export async function evaluateTravelerStartGates(
   }
 
   // Gate 3: Material — a lot/ICN must be allocated to the traveler
-  const hasMaterialOnTraveler = !!(traveler.lotNumber || traveler.internalControlNumber);
+  const hasMaterialOnTraveler = !!(
+    traveler.lotNumber || traveler.internalControlNumber
+  );
   if (!hasMaterialOnTraveler) {
     const [consumption] = await db
       .select({ id: travelerMaterialConsumption.id })
@@ -441,7 +503,8 @@ export async function evaluateTravelerStartGates(
     if (!consumption) {
       return {
         allowed: false,
-        reason: 'No material (lot number or ICN) has been allocated to this traveler. Assign material before starting.',
+        reason:
+          'No material (lot number or ICN) has been allocated to this traveler. Assign material before starting.',
       };
     }
   }
@@ -463,19 +526,32 @@ export async function evaluateStartGatesDetailed(
 
   const traveler = await storage.getTraveler(travelerId);
   if (!traveler) {
-    return [{ key: 'traveler', label: 'Traveler', passed: false, reason: 'Traveler not found.' }];
+    return [
+      {
+        key: 'traveler',
+        label: 'Traveler',
+        passed: false,
+        reason: 'Traveler not found.',
+      },
+    ];
   }
 
   const step = await storage.getTravelerStep(stepId);
   if (!step) {
-    return [{ key: 'step', label: 'Step', passed: false, reason: 'Step not found.' }];
+    return [
+      { key: 'step', label: 'Step', passed: false, reason: 'Step not found.' },
+    ];
   }
 
   // Gate 1: Sequence
   const allSteps = await storage.getTravelerSteps(travelerId);
   const currentIndex = allSteps.findIndex((s) => s.id === stepId);
   if (currentIndex === 0) {
-    results.push({ key: 'sequence', label: 'Previous step done', passed: true });
+    results.push({
+      key: 'sequence',
+      label: 'Previous step done',
+      passed: true,
+    });
   } else {
     const previousStep = allSteps[currentIndex - 1];
     if (previousStep.status !== 'COMPLETED') {
@@ -486,7 +562,11 @@ export async function evaluateStartGatesDetailed(
         reason: `Step ${previousStep.stepNumber} (${previousStep.departmentName}) must be completed first.`,
       });
     } else {
-      results.push({ key: 'sequence', label: 'Previous step done', passed: true });
+      results.push({
+        key: 'sequence',
+        label: 'Previous step done',
+        passed: true,
+      });
     }
   }
 
@@ -507,7 +587,8 @@ export async function evaluateStartGatesDetailed(
         key: 'training',
         label: 'Training verified',
         passed: false,
-        reason: 'Cannot verify training authorization — identity required first.',
+        reason:
+          'Cannot verify training authorization — identity required first.',
       });
     }
   } else {
@@ -518,10 +599,28 @@ export async function evaluateStartGatesDetailed(
     // Grandfather: only enforce when at least one authorization exists for this part.
     if (traveler.partNumber && prospectiveAuthorizationEnforcementEnabled()) {
       try {
-        await requireApplicableAuthorization({ employeeId: verifiedEmployeeId, type: 'WORK', program: 'P2', partNumber: traveler.partNumber, department: step.departmentName, operation: step.departmentName, actionType: 'TRAVELER_START', evidence: { travelerId, travelerStepId: stepId } });
-        results.push({ key: 'training', label: 'Work authorization', passed: true });
+        await requireApplicableAuthorization({
+          employeeId: verifiedEmployeeId,
+          type: 'WORK',
+          program: 'P2',
+          partNumber: traveler.partNumber,
+          department: step.departmentName,
+          operation: step.departmentName,
+          actionType: 'TRAVELER_START',
+          evidence: { travelerId, travelerStepId: stepId },
+        });
+        results.push({
+          key: 'training',
+          label: 'Work authorization',
+          passed: true,
+        });
       } catch (error: any) {
-        results.push({ key: 'training', label: 'Work authorization', passed: false, reason: error.message });
+        results.push({
+          key: 'training',
+          label: 'Work authorization',
+          passed: false,
+          reason: error.message,
+        });
       }
     } else if (traveler.partNumber) {
       const [anyAuth] = await db
@@ -557,7 +656,11 @@ export async function evaluateStartGatesDetailed(
             reason: `${name} does not have a training authorization for part ${traveler.partNumber}.`,
           });
         } else {
-          results.push({ key: 'training', label: 'Training verified', passed: true });
+          results.push({
+            key: 'training',
+            label: 'Training verified',
+            passed: true,
+          });
         }
       }
     }
@@ -572,8 +675,11 @@ export async function evaluateStartGatesDetailed(
     if (routingOp) {
       // Gate 2b: Operation certification
       if (routingOp.certificationId) {
-        const cert = await storage.getCertificationById(routingOp.certificationId);
-        const certName = cert?.name ?? `Certification #${routingOp.certificationId}`;
+        const cert = await storage.getCertificationById(
+          routingOp.certificationId
+        );
+        const certName =
+          cert?.name ?? `Certification #${routingOp.certificationId}`;
         if (!options.employeeId) {
           results.push({
             key: 'operation_cert',
@@ -582,11 +688,13 @@ export async function evaluateStartGatesDetailed(
             reason: `Employee identity is required to verify the ${certName} certification for this routing step.`,
           });
         } else {
-          const name = options.employeeName || `Employee #${options.employeeId}`;
-          const hasCert = await storage.checkEmployeeHasValidTrainingCertificationForCert(
-            options.employeeId,
-            routingOp.certificationId
-          );
+          const name =
+            options.employeeName || `Employee #${options.employeeId}`;
+          const hasCert =
+            await storage.checkEmployeeHasValidTrainingCertificationForCert(
+              options.employeeId,
+              routingOp.certificationId
+            );
           if (!hasCert) {
             results.push({
               key: 'operation_cert',
@@ -595,21 +703,31 @@ export async function evaluateStartGatesDetailed(
               reason: `${name} does not hold a valid, non-expired ${certName} certification required by this routing step.`,
             });
           } else {
-            results.push({ key: 'operation_cert', label: `Operation cert: ${certName}`, passed: true });
+            results.push({
+              key: 'operation_cert',
+              label: `Operation cert: ${certName}`,
+              passed: true,
+            });
           }
         }
       }
 
       if (options.employeeId) {
-        const activeQuals = await storage.getActiveEmployeeMachineQualificationsForEmployee(
-          options.employeeId
-        );
+        const activeQuals =
+          await storage.getActiveEmployeeMachineQualificationsForEmployee(
+            options.employeeId
+          );
 
         // Gate 2c: Machine-class qualification
-        const cncOp = await storage.getRoutingCncOperationForRoutingOp(routingOp.id);
+        const cncOp = await storage.getRoutingCncOperationForRoutingOp(
+          routingOp.id
+        );
         if (cncOp?.machineClass) {
-          const hasMachineQual = activeQuals.some((q) => q.machineClass === cncOp.machineClass);
-          const name = options.employeeName || `Employee #${options.employeeId}`;
+          const hasMachineQual = activeQuals.some(
+            (q) => q.machineClass === cncOp.machineClass
+          );
+          const name =
+            options.employeeName || `Employee #${options.employeeId}`;
           results.push({
             key: 'machine_class',
             label: `Machine class: ${cncOp.machineClass}`,
@@ -624,8 +742,11 @@ export async function evaluateStartGatesDetailed(
         // specifies an operationType.
         if (routingOp.operationType) {
           {
-            const hasOpTypeQual = activeQuals.some((q) => q.operationType === routingOp.operationType);
-            const name = options.employeeName || `Employee #${options.employeeId}`;
+            const hasOpTypeQual = activeQuals.some(
+              (q) => q.operationType === routingOp.operationType
+            );
+            const name =
+              options.employeeName || `Employee #${options.employeeId}`;
             results.push({
               key: 'operation_type',
               label: `Operation type: ${routingOp.operationType}`,
@@ -662,7 +783,9 @@ export async function evaluateStartGatesDetailed(
   }
 
   // Gate 3: Material
-  const hasMaterialOnTraveler = !!(traveler.lotNumber || traveler.internalControlNumber);
+  const hasMaterialOnTraveler = !!(
+    traveler.lotNumber || traveler.internalControlNumber
+  );
   if (!hasMaterialOnTraveler) {
     const [consumption] = await db
       .select({ id: travelerMaterialConsumption.id })
@@ -675,10 +798,15 @@ export async function evaluateStartGatesDetailed(
         key: 'material',
         label: 'Material assigned',
         passed: false,
-        reason: 'No material (lot number or ICN) has been allocated to this traveler.',
+        reason:
+          'No material (lot number or ICN) has been allocated to this traveler.',
       });
     } else {
-      results.push({ key: 'material', label: 'Material assigned', passed: true });
+      results.push({
+        key: 'material',
+        label: 'Material assigned',
+        passed: true,
+      });
     }
   } else {
     results.push({ key: 'material', label: 'Material assigned', passed: true });
@@ -695,7 +823,9 @@ export async function evaluateStartGatesDetailed(
  *
  * @param stepId UUID of the step being finished
  */
-export async function evaluateTravelerFinishGates(stepId: string): Promise<GateResult> {
+export async function evaluateTravelerFinishGates(
+  stepId: string
+): Promise<GateResult> {
   const tasks = await storage.getTravelerTasks(stepId);
 
   const isCompletionGate = (t: { taskType: string }) =>

--- a/server/src/lib/travelerGates.ts
+++ b/server/src/lib/travelerGates.ts
@@ -1,6 +1,7 @@
 import { storage } from '../../storage';
 import { db } from '../../db';
 import { calibrationAssets, calibrationUseLogs, productionWorkOrders, travelerAuthorizations, travelerMaterialConsumption } from '../../schema';
+import { prospectiveAuthorizationEnforcementEnabled, requireApplicableAuthorization } from '../services/certificationAuthorizationService';
 import { eq, and, inArray } from 'drizzle-orm';
 
 export interface GateResult {
@@ -294,6 +295,22 @@ export async function evaluateTravelerStartGates(
   // Grandfather: only enforce once at least one authorization has been set up for
   // this part (avoids blocking everyone when the system is newly deployed).
   if (traveler.partNumber) {
+    if (prospectiveAuthorizationEnforcementEnabled()) {
+      try {
+        await requireApplicableAuthorization({
+          employeeId: options.employeeId,
+          type: 'WORK',
+          program: 'P2',
+          partNumber: traveler.partNumber,
+          department: step.departmentName,
+          operation: step.departmentName,
+          actionType: 'TRAVELER_START',
+          evidence: { travelerId, travelerStepId: stepId },
+        });
+      } catch (error: any) {
+        return { allowed: false, reason: error.message };
+      }
+    } else {
     const [anyAuth] = await db
       .select({ id: travelerAuthorizations.id })
       .from(travelerAuthorizations)
@@ -325,6 +342,7 @@ export async function evaluateTravelerStartGates(
           reason: `${name} does not have a training authorization for part ${traveler.partNumber}. An authorization record must be created before work can begin.`,
         };
       }
+    }
     }
   }
 
@@ -483,7 +501,14 @@ export async function evaluateStartGatesDetailed(
       reason: identityReason,
     });
     // Cannot evaluate part-auth or op-cert without identity; record them as pending.
-    if (traveler.partNumber) {
+    if (traveler.partNumber && prospectiveAuthorizationEnforcementEnabled()) {
+      try {
+        await requireApplicableAuthorization({ employeeId: options.employeeId, type: 'WORK', program: 'P2', partNumber: traveler.partNumber, department: step.departmentName, operation: step.departmentName, actionType: 'TRAVELER_START', evidence: { travelerId, travelerStepId: stepId } });
+        results.push({ key: 'training', label: 'Work authorization', passed: true });
+      } catch (error: any) {
+        results.push({ key: 'training', label: 'Work authorization', passed: false, reason: error.message });
+      }
+    } else if (traveler.partNumber) {
       results.push({
         key: 'training',
         label: 'Training verified',

--- a/server/src/routes/certificationAuthorizations.ts
+++ b/server/src/routes/certificationAuthorizations.ts
@@ -1,0 +1,78 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { pool } from '../../db';
+import { requirePermission } from '../../middleware/requirePermission';
+
+const router = Router();
+const programs = z.enum(['P1','P2','DESIGN','GENERAL','OTHER']);
+const types = z.enum(['WORK','QC_INSPECTION','ROUTING_RELEASE','FINAL_QC','FINAL_PRODUCT_RELEASE','COC_APPROVAL']);
+const statuses = z.enum(['DRAFT','ACTIVE','SUSPENDED','EXPIRED','REVOKED']);
+const draft = z.object({
+  employeeId: z.number().int().positive(), employeeUserId: z.number().int().positive().nullable().optional(),
+  program: programs, partNumber: z.string().trim().min(1).nullable().optional(), productFamily: z.string().trim().min(1).nullable().optional(),
+  department: z.string().trim().min(1).nullable().optional(), operationScope: z.string().trim().min(1).nullable().optional(),
+  authorizationType: types, effectiveDate: z.string().datetime().nullable().optional(), expirationDate: z.string().datetime().nullable().optional(),
+  qualificationMethod: z.string().trim().min(1), evidenceReference: z.string().trim().min(1), notes: z.string().nullable().optional(), limitations: z.string().nullable().optional(),
+}).refine(v => v.partNumber || v.productFamily || ['GENERAL','OTHER'].includes(v.program), 'Part number or product family is required.');
+
+function actor(req: Request) {
+  if (!req.user?.id) throw Object.assign(new Error('Authenticated identity required.'), { status: 401 });
+  return { userId: Number(req.user.id), employeeId: req.user.employeeId ? Number(req.user.employeeId) : null };
+}
+function fail(res: Response, error: any) {
+  if (error instanceof z.ZodError) return res.status(400).json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error?.code === '23505') return res.status(409).json({ error: 'OVERLAPPING_ACTIVE_AUTHORIZATION' });
+  return res.status(error?.status || 500).json({ error: error?.message || 'Authorization action failed.' });
+}
+
+router.get('/', requirePermission('training.authorization.view'), async (req, res) => {
+  try {
+    const values: unknown[] = []; const where: string[] = [];
+    for (const [queryKey, column] of [['employeeId','a.employee_id'],['program','a.program'],['partNumber','a.part_number'],['productFamily','a.product_family'],['department','a.department'],['authorizationType','a.authorization_type'],['status','a.status'],['approverId','a.approved_by_user_id']] as const) {
+      const value = req.query[queryKey]; if (value) { values.push(value); where.push(`${column}=$${values.length}`); }
+    }
+    if (req.query.expiration === 'expired') where.push(`a.expiration_date <= now()`);
+    if (req.query.expiration === 'soon') where.push(`a.expiration_date > now() AND a.expiration_date <= now() + interval '60 days'`);
+    const rows = await pool.query(`SELECT a.*, e.employee_id AS employee_number, e.name AS employee_name,
+      au.username AS approver_username FROM certification_authorizations a JOIN employees e ON e.id=a.employee_id
+      LEFT JOIN users au ON au.id=a.approved_by_user_id ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
+      ORDER BY a.employee_id,a.authorization_type,a.updated_at DESC`, values);
+    res.json(rows);
+  } catch (error) { fail(res, error); }
+});
+
+router.get('/:id/history', requirePermission('training.authorization.view'), async (req, res) => {
+  try { res.json(await pool.query(`SELECT * FROM certification_authorization_events WHERE authorization_id=$1 ORDER BY revision DESC`, [req.params.id])); }
+  catch (error) { fail(res, error); }
+});
+
+router.post('/', requirePermission('training.authorization.grant'), async (req, res) => {
+  try {
+    const body = draft.parse(req.body); const a = actor(req);
+    const rows = await pool.query(`INSERT INTO certification_authorizations
+      (employee_id,employee_user_id,program,part_number,product_family,department,operation_scope,authorization_type,status,effective_date,expiration_date,qualification_method,evidence_reference,notes,limitations,created_by_user_id,updated_by_user_id)
+      VALUES($1,$2,$3,$4,$5,$6,$7,$8,'DRAFT',$9,$10,$11,$12,$13,$14,$15,$15) RETURNING *`,
+      [body.employeeId,body.employeeUserId??null,body.program,body.partNumber??null,body.productFamily??null,body.department??null,body.operationScope??null,body.authorizationType,body.effectiveDate??null,body.expirationDate??null,body.qualificationMethod,body.evidenceReference,body.notes??null,body.limitations??null,a.userId]);
+    const row=(rows as any[])[0]; await pool.query(`INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,actor_user_id,actor_employee_id) VALUES($1,1,'CREATED',$2::jsonb,$3,$4)`,[row.id,JSON.stringify(row),a.userId,a.employeeId]);
+    res.status(201).json(row);
+  } catch (error) { fail(res, error); }
+});
+
+router.post('/:id/approve', requirePermission('training.authorization.approve'), async (req, res) => {
+  try {
+    const body=z.object({signatureMeaning:z.string().min(1),effectiveDate:z.string().datetime(),expirationDate:z.string().datetime().nullable().optional()}).parse(req.body); const a=actor(req);
+    const rows=await pool.query(`UPDATE certification_authorizations SET status='ACTIVE',revision=revision+1,effective_date=$2,expiration_date=$3,approved_by_user_id=$4,approved_by_employee_id=$5,approved_at=now(),signature_meaning=$6,updated_by_user_id=$4,updated_at=now() WHERE id=$1 AND status IN ('DRAFT','SUSPENDED','EXPIRED') RETURNING *`,[req.params.id,body.effectiveDate,body.expirationDate??null,a.userId,a.employeeId,body.signatureMeaning]);
+    if (!(rows as any[]).length) return res.status(409).json({error:'INVALID_STATUS_TRANSITION'}); const row=(rows as any[])[0];
+    await pool.query(`INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,actor_user_id,actor_employee_id) VALUES($1,$2,'APPROVED',$3::jsonb,$4,$5)`,[row.id,row.revision,JSON.stringify(row),a.userId,a.employeeId]); res.json(row);
+  } catch(error){fail(res,error);}
+});
+
+router.post('/:id/status', requirePermission('training.authorization.change_status'), async (req,res)=>{
+  try { const body=z.object({status:statuses.extract(['SUSPENDED','REVOKED']),reason:z.string().min(1)}).parse(req.body); const a=actor(req);
+    const rows=await pool.query(`UPDATE certification_authorizations SET status=$2,revision=revision+1,updated_by_user_id=$3,updated_at=now() WHERE id=$1 AND status <> 'REVOKED' RETURNING *`,[req.params.id,body.status,a.userId]);
+    if (!(rows as any[]).length) return res.status(409).json({error:'INVALID_STATUS_TRANSITION'}); const row=(rows as any[])[0];
+    await pool.query(`INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,reason,actor_user_id,actor_employee_id) VALUES($1,$2,$3,$4::jsonb,$5,$6,$7)`,[row.id,row.revision,body.status,JSON.stringify(row),body.reason,a.userId,a.employeeId]); res.json(row);
+  } catch(error){fail(res,error);}
+});
+
+export default router;

--- a/server/src/routes/certificationAuthorizations.ts
+++ b/server/src/routes/certificationAuthorizations.ts
@@ -4,75 +4,238 @@ import { pool } from '../../db';
 import { requirePermission } from '../../middleware/requirePermission';
 
 const router = Router();
-const programs = z.enum(['P1','P2','DESIGN','GENERAL','OTHER']);
-const types = z.enum(['WORK','QC_INSPECTION','ROUTING_RELEASE','FINAL_QC','FINAL_PRODUCT_RELEASE','COC_APPROVAL']);
-const statuses = z.enum(['DRAFT','ACTIVE','SUSPENDED','EXPIRED','REVOKED']);
-const draft = z.object({
-  employeeId: z.number().int().positive(), employeeUserId: z.number().int().positive().nullable().optional(),
-  program: programs, partNumber: z.string().trim().min(1).nullable().optional(), productFamily: z.string().trim().min(1).nullable().optional(),
-  department: z.string().trim().min(1).nullable().optional(), operationScope: z.string().trim().min(1).nullable().optional(),
-  authorizationType: types, effectiveDate: z.string().datetime().nullable().optional(), expirationDate: z.string().datetime().nullable().optional(),
-  qualificationMethod: z.string().trim().min(1), evidenceReference: z.string().trim().min(1), notes: z.string().nullable().optional(), limitations: z.string().nullable().optional(),
-}).refine(v => v.partNumber || v.productFamily || ['GENERAL','OTHER'].includes(v.program), 'Part number or product family is required.');
+const programs = z.enum(['P1', 'P2', 'DESIGN', 'GENERAL', 'OTHER']);
+const types = z.enum([
+  'WORK',
+  'QC_INSPECTION',
+  'ROUTING_RELEASE',
+  'FINAL_QC',
+  'FINAL_PRODUCT_RELEASE',
+  'COC_APPROVAL',
+]);
+const statuses = z.enum(['DRAFT', 'ACTIVE', 'SUSPENDED', 'EXPIRED', 'REVOKED']);
+const draft = z
+  .object({
+    employeeId: z.number().int().positive(),
+    employeeUserId: z.number().int().positive().nullable().optional(),
+    program: programs,
+    partNumber: z.string().trim().min(1).nullable().optional(),
+    productFamily: z.string().trim().min(1).nullable().optional(),
+    department: z.string().trim().min(1).nullable().optional(),
+    operationScope: z.string().trim().min(1).nullable().optional(),
+    authorizationType: types,
+    effectiveDate: z.string().datetime().nullable().optional(),
+    expirationDate: z.string().datetime().nullable().optional(),
+    qualificationMethod: z.string().trim().min(1),
+    evidenceReference: z.string().trim().min(1),
+    notes: z.string().nullable().optional(),
+    limitations: z.string().nullable().optional(),
+  })
+  .refine(
+    (v) =>
+      v.partNumber ||
+      v.productFamily ||
+      ['GENERAL', 'OTHER'].includes(v.program),
+    'Part number or product family is required.'
+  );
 
 function actor(req: Request) {
-  if (!req.user?.id) throw Object.assign(new Error('Authenticated identity required.'), { status: 401 });
-  return { userId: Number(req.user.id), employeeId: req.user.employeeId ? Number(req.user.employeeId) : null };
+  if (!req.user?.id)
+    throw Object.assign(new Error('Authenticated identity required.'), {
+      status: 401,
+    });
+  return {
+    userId: Number(req.user.id),
+    employeeId: req.user.employeeId ? Number(req.user.employeeId) : null,
+  };
 }
 function fail(res: Response, error: any) {
-  if (error instanceof z.ZodError) return res.status(400).json({ error: 'INVALID_INPUT', details: error.flatten() });
-  if (error?.code === '23505') return res.status(409).json({ error: 'OVERLAPPING_ACTIVE_AUTHORIZATION' });
-  return res.status(error?.status || 500).json({ error: error?.message || 'Authorization action failed.' });
+  if (error instanceof z.ZodError)
+    return res
+      .status(400)
+      .json({ error: 'INVALID_INPUT', details: error.flatten() });
+  if (error?.code === '23505')
+    return res.status(409).json({ error: 'OVERLAPPING_ACTIVE_AUTHORIZATION' });
+  return res
+    .status(error?.status || 500)
+    .json({ error: error?.message || 'Authorization action failed.' });
 }
 
-router.get('/', requirePermission('training.authorization.view'), async (req, res) => {
-  try {
-    const values: unknown[] = []; const where: string[] = [];
-    for (const [queryKey, column] of [['employeeId','a.employee_id'],['program','a.program'],['partNumber','a.part_number'],['productFamily','a.product_family'],['department','a.department'],['authorizationType','a.authorization_type'],['status','a.status'],['approverId','a.approved_by_user_id']] as const) {
-      const value = req.query[queryKey]; if (value) { values.push(value); where.push(`${column}=$${values.length}`); }
-    }
-    if (req.query.expiration === 'expired') where.push(`a.expiration_date <= now()`);
-    if (req.query.expiration === 'soon') where.push(`a.expiration_date > now() AND a.expiration_date <= now() + interval '60 days'`);
-    const rows = await pool.query(`SELECT a.*, e.employee_id AS employee_number, e.name AS employee_name,
+router.get(
+  '/',
+  requirePermission('training.authorization.view'),
+  async (req, res) => {
+    try {
+      const values: unknown[] = [];
+      const where: string[] = [];
+      for (const [queryKey, column] of [
+        ['employeeId', 'a.employee_id'],
+        ['program', 'a.program'],
+        ['partNumber', 'a.part_number'],
+        ['productFamily', 'a.product_family'],
+        ['department', 'a.department'],
+        ['authorizationType', 'a.authorization_type'],
+        ['status', 'a.status'],
+        ['approverId', 'a.approved_by_user_id'],
+      ] as const) {
+        const value = req.query[queryKey];
+        if (value) {
+          values.push(value);
+          where.push(`${column}=$${values.length}`);
+        }
+      }
+      if (req.query.expiration === 'expired')
+        where.push(`a.expiration_date <= now()`);
+      if (req.query.expiration === 'soon')
+        where.push(
+          `a.expiration_date > now() AND a.expiration_date <= now() + interval '60 days'`
+        );
+      const rows = await pool.query(
+        `SELECT a.*, e.employee_id AS employee_number, e.name AS employee_name,
       au.username AS approver_username FROM certification_authorizations a JOIN employees e ON e.id=a.employee_id
       LEFT JOIN users au ON au.id=a.approved_by_user_id ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
-      ORDER BY a.employee_id,a.authorization_type,a.updated_at DESC`, values);
-    res.json(rows);
-  } catch (error) { fail(res, error); }
-});
+      ORDER BY a.employee_id,a.authorization_type,a.updated_at DESC`,
+        values
+      );
+      res.json(rows);
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
 
-router.get('/:id/history', requirePermission('training.authorization.view'), async (req, res) => {
-  try { res.json(await pool.query(`SELECT * FROM certification_authorization_events WHERE authorization_id=$1 ORDER BY revision DESC`, [req.params.id])); }
-  catch (error) { fail(res, error); }
-});
+router.get(
+  '/:id/history',
+  requirePermission('training.authorization.view'),
+  async (req, res) => {
+    try {
+      res.json(
+        await pool.query(
+          `SELECT * FROM certification_authorization_events WHERE authorization_id=$1 ORDER BY revision DESC`,
+          [req.params.id]
+        )
+      );
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
 
-router.post('/', requirePermission('training.authorization.grant'), async (req, res) => {
-  try {
-    const body = draft.parse(req.body); const a = actor(req);
-    const rows = await pool.query(`INSERT INTO certification_authorizations
+router.post(
+  '/',
+  requirePermission('training.authorization.grant'),
+  async (req, res) => {
+    try {
+      const body = draft.parse(req.body);
+      const a = actor(req);
+      const rows = await pool.query(
+        `INSERT INTO certification_authorizations
       (employee_id,employee_user_id,program,part_number,product_family,department,operation_scope,authorization_type,status,effective_date,expiration_date,qualification_method,evidence_reference,notes,limitations,created_by_user_id,updated_by_user_id)
       VALUES($1,$2,$3,$4,$5,$6,$7,$8,'DRAFT',$9,$10,$11,$12,$13,$14,$15,$15) RETURNING *`,
-      [body.employeeId,body.employeeUserId??null,body.program,body.partNumber??null,body.productFamily??null,body.department??null,body.operationScope??null,body.authorizationType,body.effectiveDate??null,body.expirationDate??null,body.qualificationMethod,body.evidenceReference,body.notes??null,body.limitations??null,a.userId]);
-    const row=(rows as any[])[0]; await pool.query(`INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,actor_user_id,actor_employee_id) VALUES($1,1,'CREATED',$2::jsonb,$3,$4)`,[row.id,JSON.stringify(row),a.userId,a.employeeId]);
-    res.status(201).json(row);
-  } catch (error) { fail(res, error); }
-});
+        [
+          body.employeeId,
+          body.employeeUserId ?? null,
+          body.program,
+          body.partNumber ?? null,
+          body.productFamily ?? null,
+          body.department ?? null,
+          body.operationScope ?? null,
+          body.authorizationType,
+          body.effectiveDate ?? null,
+          body.expirationDate ?? null,
+          body.qualificationMethod,
+          body.evidenceReference,
+          body.notes ?? null,
+          body.limitations ?? null,
+          a.userId,
+        ]
+      );
+      const row = (rows as any[])[0];
+      await pool.query(
+        `INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,actor_user_id,actor_employee_id) VALUES($1,1,'CREATED',$2::jsonb,$3,$4)`,
+        [row.id, JSON.stringify(row), a.userId, a.employeeId]
+      );
+      res.status(201).json(row);
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
 
-router.post('/:id/approve', requirePermission('training.authorization.approve'), async (req, res) => {
-  try {
-    const body=z.object({signatureMeaning:z.string().min(1),effectiveDate:z.string().datetime(),expirationDate:z.string().datetime().nullable().optional()}).parse(req.body); const a=actor(req);
-    const rows=await pool.query(`UPDATE certification_authorizations SET status='ACTIVE',revision=revision+1,effective_date=$2,expiration_date=$3,approved_by_user_id=$4,approved_by_employee_id=$5,approved_at=now(),signature_meaning=$6,updated_by_user_id=$4,updated_at=now() WHERE id=$1 AND status IN ('DRAFT','SUSPENDED','EXPIRED') RETURNING *`,[req.params.id,body.effectiveDate,body.expirationDate??null,a.userId,a.employeeId,body.signatureMeaning]);
-    if (!(rows as any[]).length) return res.status(409).json({error:'INVALID_STATUS_TRANSITION'}); const row=(rows as any[])[0];
-    await pool.query(`INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,actor_user_id,actor_employee_id) VALUES($1,$2,'APPROVED',$3::jsonb,$4,$5)`,[row.id,row.revision,JSON.stringify(row),a.userId,a.employeeId]); res.json(row);
-  } catch(error){fail(res,error);}
-});
+router.post(
+  '/:id/approve',
+  requirePermission('training.authorization.approve'),
+  async (req, res) => {
+    try {
+      const body = z
+        .object({
+          signatureMeaning: z.string().min(1),
+          effectiveDate: z.string().datetime(),
+          expirationDate: z.string().datetime().nullable().optional(),
+        })
+        .parse(req.body);
+      const a = actor(req);
+      const rows = await pool.query(
+        `UPDATE certification_authorizations SET status='ACTIVE',revision=revision+1,effective_date=$2,expiration_date=$3,approved_by_user_id=$4,approved_by_employee_id=$5,approved_at=now(),signature_meaning=$6,updated_by_user_id=$4,updated_at=now() WHERE id=$1 AND status IN ('DRAFT','SUSPENDED','EXPIRED') RETURNING *`,
+        [
+          req.params.id,
+          body.effectiveDate,
+          body.expirationDate ?? null,
+          a.userId,
+          a.employeeId,
+          body.signatureMeaning,
+        ]
+      );
+      if (!(rows as any[]).length)
+        return res.status(409).json({ error: 'INVALID_STATUS_TRANSITION' });
+      const row = (rows as any[])[0];
+      await pool.query(
+        `INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,actor_user_id,actor_employee_id) VALUES($1,$2,'APPROVED',$3::jsonb,$4,$5)`,
+        [row.id, row.revision, JSON.stringify(row), a.userId, a.employeeId]
+      );
+      res.json(row);
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
 
-router.post('/:id/status', requirePermission('training.authorization.change_status'), async (req,res)=>{
-  try { const body=z.object({status:statuses.extract(['SUSPENDED','REVOKED']),reason:z.string().min(1)}).parse(req.body); const a=actor(req);
-    const rows=await pool.query(`UPDATE certification_authorizations SET status=$2,revision=revision+1,updated_by_user_id=$3,updated_at=now() WHERE id=$1 AND status <> 'REVOKED' RETURNING *`,[req.params.id,body.status,a.userId]);
-    if (!(rows as any[]).length) return res.status(409).json({error:'INVALID_STATUS_TRANSITION'}); const row=(rows as any[])[0];
-    await pool.query(`INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,reason,actor_user_id,actor_employee_id) VALUES($1,$2,$3,$4::jsonb,$5,$6,$7)`,[row.id,row.revision,body.status,JSON.stringify(row),body.reason,a.userId,a.employeeId]); res.json(row);
-  } catch(error){fail(res,error);}
-});
+router.post(
+  '/:id/status',
+  requirePermission('training.authorization.change_status'),
+  async (req, res) => {
+    try {
+      const body = z
+        .object({
+          status: statuses.extract(['SUSPENDED', 'REVOKED']),
+          reason: z.string().min(1),
+        })
+        .parse(req.body);
+      const a = actor(req);
+      const rows = await pool.query(
+        `UPDATE certification_authorizations SET status=$2,revision=revision+1,updated_by_user_id=$3,updated_at=now() WHERE id=$1 AND status <> 'REVOKED' RETURNING *`,
+        [req.params.id, body.status, a.userId]
+      );
+      if (!(rows as any[]).length)
+        return res.status(409).json({ error: 'INVALID_STATUS_TRANSITION' });
+      const row = (rows as any[])[0];
+      await pool.query(
+        `INSERT INTO certification_authorization_events(authorization_id,revision,event_type,snapshot,reason,actor_user_id,actor_employee_id) VALUES($1,$2,$3,$4::jsonb,$5,$6,$7)`,
+        [
+          row.id,
+          row.revision,
+          body.status,
+          JSON.stringify(row),
+          body.reason,
+          a.userId,
+          a.employeeId,
+        ]
+      );
+      res.json(row);
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
 
 export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier -- Legacy aggregate route registry is not Prettier-clean; avoid an unrelated whole-file rewrite. */
 /*
 EPOCH USER IDENTITY STANDARD
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -102,7 +102,8 @@ import metalAccessoriesRoutes from './metalAccessories';
 import featureSelectionsRoutes from './featureSelections';
 import calendarRoutes from './calendar';
 import documentIntelligenceRoutes from './documentIntelligence';
-import trainingRoutes from './training';
+  import trainingRoutes from './training';
+  import certificationAuthorizationRoutes from './certificationAuthorizations';
 import magicLinkRoutes from './magicLink';
 import certificationsRoutes from './certifications';
 import globalSearchRoutes from './globalSearch';
@@ -1559,6 +1560,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   // Training management routes
   app.use('/api/training', trainingRoutes);
+  app.use('/api/training/certification-authorizations', certificationAuthorizationRoutes);
 
   // Certifications management routes
   app.use('/api/certifications', certificationsRoutes);

--- a/server/src/routes/projectQualityRelease.ts
+++ b/server/src/routes/projectQualityRelease.ts
@@ -18,6 +18,7 @@ import {
   ProjectPilotControlError,
   requireActivePilotForAction,
 } from '../services/projectPilotControlService';
+import { requireApplicableAuthorization } from '../services/certificationAuthorizationService';
 
 const router = Router({ mergeParams: true });
 const expected = z.object({ expectedLockVersion: z.number().int().positive() });
@@ -218,6 +219,8 @@ router.post('/releases', async (req, res) => {
       idempotencyKey: body.idempotencyKey,
       confirmation: body.pilotConfirmation,
     });
+    if (!user.employeeId) throw new ProjectQualityReleaseError('EMPLOYEE_IDENTITY_REQUIRED','An employee identity is required for Final Product Release.',403);
+    await requireApplicableAuthorization({ employeeId:user.employeeId, userId:user.userId, type:'FINAL_PRODUCT_RELEASE', program:'P2', partNumber:body.partNumber, actionType:'FINAL_PRODUCT_RELEASE', evidence:{ projectId:id(req), poLineId:body.poLineId, quantity:body.quantity, serialNumbers:body.serialNumbers, batchLots:body.batchLots } });
     res.status(201).json(await releaseProduct(id(req), body, user));
   } catch (error) {
     fail(res, error);

--- a/server/src/routes/projectQualityRelease.ts
+++ b/server/src/routes/projectQualityRelease.ts
@@ -219,8 +219,27 @@ router.post('/releases', async (req, res) => {
       idempotencyKey: body.idempotencyKey,
       confirmation: body.pilotConfirmation,
     });
-    if (!user.employeeId) throw new ProjectQualityReleaseError('EMPLOYEE_IDENTITY_REQUIRED','An employee identity is required for Final Product Release.',403);
-    await requireApplicableAuthorization({ employeeId:user.employeeId, userId:user.userId, type:'FINAL_PRODUCT_RELEASE', program:'P2', partNumber:body.partNumber, actionType:'FINAL_PRODUCT_RELEASE', evidence:{ projectId:id(req), poLineId:body.poLineId, quantity:body.quantity, serialNumbers:body.serialNumbers, batchLots:body.batchLots } });
+    if (!user.employeeId)
+      throw new ProjectQualityReleaseError(
+        'EMPLOYEE_IDENTITY_REQUIRED',
+        'An employee identity is required for Final Product Release.',
+        403
+      );
+    await requireApplicableAuthorization({
+      employeeId: user.employeeId,
+      userId: user.userId,
+      type: 'FINAL_PRODUCT_RELEASE',
+      program: 'P2',
+      partNumber: body.partNumber,
+      actionType: 'FINAL_PRODUCT_RELEASE',
+      evidence: {
+        projectId: id(req),
+        poLineId: body.poLineId,
+        quantity: body.quantity,
+        serialNumbers: body.serialNumbers,
+        batchLots: body.batchLots,
+      },
+    });
     res.status(201).json(await releaseProduct(id(req), body, user));
   } catch (error) {
     fail(res, error);

--- a/server/src/services/certificationAuthorizationService.ts
+++ b/server/src/services/certificationAuthorizationService.ts
@@ -1,0 +1,53 @@
+import { pool } from '../../db';
+
+export type AuthorizationType = 'WORK' | 'QC_INSPECTION' | 'ROUTING_RELEASE' | 'FINAL_QC' | 'FINAL_PRODUCT_RELEASE' | 'COC_APPROVAL';
+
+export function prospectiveAuthorizationEnforcementEnabled() {
+  return process.env.CERTIFICATION_AUTHORIZATION_ENFORCEMENT === 'true';
+}
+
+export async function requireApplicableAuthorization(input: {
+  employeeId: number;
+  userId?: number | null;
+  type: AuthorizationType;
+  program: string;
+  partNumber?: string | null;
+  productFamily?: string | null;
+  department?: string | null;
+  operation?: string | null;
+  actionType: 'TRAVELER_START' | 'QC_ACCEPTANCE' | 'ROUTING_RELEASE' | 'FINAL_PRODUCT_RELEASE' | 'COC_APPROVAL';
+  evidence?: Record<string, unknown>;
+}) {
+  if (!prospectiveAuthorizationEnforcementEnabled()) return null;
+  const result = await pool.query(
+    `SELECT a.*
+       FROM certification_authorizations a
+      WHERE a.employee_id=$1 AND a.authorization_type=$2 AND a.program=$3
+        AND a.status='ACTIVE' AND a.effective_date <= now()
+        AND (a.expiration_date IS NULL OR a.expiration_date > now())
+        AND (a.part_number IS NULL OR a.part_number=$4)
+        AND (a.product_family IS NULL OR a.product_family=$5)
+        AND (a.department IS NULL OR lower(a.department)=lower($6))
+        AND (a.operation_scope IS NULL OR lower(a.operation_scope)=lower($7))
+      ORDER BY a.part_number NULLS LAST, a.operation_scope NULLS LAST
+      LIMIT 1`,
+    [input.employeeId, input.type, input.program, input.partNumber ?? null, input.productFamily ?? null, input.department ?? null, input.operation ?? null]
+  );
+  const authorization = (result as any[])[0];
+  if (!authorization) {
+    const error: any = new Error(`Active ${input.type} authorization is required for this employee and exact scope.`);
+    error.code = 'CERTIFICATION_AUTHORIZATION_REQUIRED';
+    error.status = 403;
+    throw error;
+  }
+  await pool.query(
+    `INSERT INTO certification_authorization_use_snapshots
+      (authorization_id,authorization_revision,action_type,employee_id,user_id,part_number,product_family,
+       qualification_status,effective_date,expiration_date,approver_user_id,evidence)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,'ACTIVE',$8,$9,$10,$11::jsonb)`,
+    [authorization.id, authorization.revision, input.actionType, input.employeeId, input.userId ?? null,
+     input.partNumber ?? null, input.productFamily ?? null, authorization.effective_date,
+     authorization.expiration_date, authorization.approved_by_user_id, JSON.stringify(input.evidence ?? {})]
+  );
+  return authorization;
+}

--- a/server/src/services/certificationAuthorizationService.ts
+++ b/server/src/services/certificationAuthorizationService.ts
@@ -1,6 +1,12 @@
 import { pool } from '../../db';
 
-export type AuthorizationType = 'WORK' | 'QC_INSPECTION' | 'ROUTING_RELEASE' | 'FINAL_QC' | 'FINAL_PRODUCT_RELEASE' | 'COC_APPROVAL';
+export type AuthorizationType =
+  | 'WORK'
+  | 'QC_INSPECTION'
+  | 'ROUTING_RELEASE'
+  | 'FINAL_QC'
+  | 'FINAL_PRODUCT_RELEASE'
+  | 'COC_APPROVAL';
 
 export function prospectiveAuthorizationEnforcementEnabled() {
   return process.env.CERTIFICATION_AUTHORIZATION_ENFORCEMENT === 'true';
@@ -15,7 +21,12 @@ export async function requireApplicableAuthorization(input: {
   productFamily?: string | null;
   department?: string | null;
   operation?: string | null;
-  actionType: 'TRAVELER_START' | 'QC_ACCEPTANCE' | 'ROUTING_RELEASE' | 'FINAL_PRODUCT_RELEASE' | 'COC_APPROVAL';
+  actionType:
+    | 'TRAVELER_START'
+    | 'QC_ACCEPTANCE'
+    | 'ROUTING_RELEASE'
+    | 'FINAL_PRODUCT_RELEASE'
+    | 'COC_APPROVAL';
   evidence?: Record<string, unknown>;
 }) {
   if (!prospectiveAuthorizationEnforcementEnabled()) return null;
@@ -31,11 +42,21 @@ export async function requireApplicableAuthorization(input: {
         AND (a.operation_scope IS NULL OR lower(a.operation_scope)=lower($7))
       ORDER BY a.part_number NULLS LAST, a.operation_scope NULLS LAST
       LIMIT 1`,
-    [input.employeeId, input.type, input.program, input.partNumber ?? null, input.productFamily ?? null, input.department ?? null, input.operation ?? null]
+    [
+      input.employeeId,
+      input.type,
+      input.program,
+      input.partNumber ?? null,
+      input.productFamily ?? null,
+      input.department ?? null,
+      input.operation ?? null,
+    ]
   );
   const authorization = (result as any[])[0];
   if (!authorization) {
-    const error: any = new Error(`Active ${input.type} authorization is required for this employee and exact scope.`);
+    const error: any = new Error(
+      `Active ${input.type} authorization is required for this employee and exact scope.`
+    );
     error.code = 'CERTIFICATION_AUTHORIZATION_REQUIRED';
     error.status = 403;
     throw error;
@@ -45,9 +66,19 @@ export async function requireApplicableAuthorization(input: {
       (authorization_id,authorization_revision,action_type,employee_id,user_id,part_number,product_family,
        qualification_status,effective_date,expiration_date,approver_user_id,evidence)
      VALUES ($1,$2,$3,$4,$5,$6,$7,'ACTIVE',$8,$9,$10,$11::jsonb)`,
-    [authorization.id, authorization.revision, input.actionType, input.employeeId, input.userId ?? null,
-     input.partNumber ?? null, input.productFamily ?? null, authorization.effective_date,
-     authorization.expiration_date, authorization.approved_by_user_id, JSON.stringify(input.evidence ?? {})]
+    [
+      authorization.id,
+      authorization.revision,
+      input.actionType,
+      input.employeeId,
+      input.userId ?? null,
+      input.partNumber ?? null,
+      input.productFamily ?? null,
+      authorization.effective_date,
+      authorization.expiration_date,
+      authorization.approved_by_user_id,
+      JSON.stringify(input.evidence ?? {}),
+    ]
   );
   return authorization;
 }


### PR DESCRIPTION
## Summary
- add one Training-owned certification and authorization register with immutable revision and use evidence
- expose the same component from Training and P2 Control Center with P2/ACTIVE defaults
- conservatively backfill legacy P2 competency records as DRAFT Work authorizations only
- keep prospective server enforcement disabled by default while wiring traveler Work and final product-release checks

## Validation
- git diff --check
- static architecture assertions: PASS
- focused Vitest and TypeScript: BLOCKED because clean worktree dependencies attempted registry downloads and failed with EACCES
- PostgreSQL migration replay: NOT RUN; no disposable database was supplied

## Controlled rollout
Do not merge or enable CERTIFICATION_AUTHORIZATION_ENFORCEMENT until migration replay, authorization setup, remaining QC/routing/CoC enforcement integration, and full negative-path certification are complete.