### PR TITLE
Add controlled material review to planning wizard

### DIFF
--- a/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
@@ -31,6 +31,7 @@ const model = {
     },
     {
       id: 'leaf',
+      inventory_item_id: 20,
       assembly_path: 'root:1/line:2',
       part_number: 'BUY-20',
       part_name: 'Purchased fastener',
@@ -41,6 +42,7 @@ const model = {
       extended_project_quantity: '8',
       bom_release_status: 'NOT_REQUIRED_APPROVED',
       routing_release_status: 'NOT_REQUIRED_APPROVED',
+      specification_references: ['AMS-QQ-A-200'],
     },
   ],
   history: [
@@ -193,6 +195,18 @@ describe('P2V2ProductionPlanning', () => {
     expect(screen.getByTestId('routing-review')).toHaveTextContent('Released');
     expect(screen.getAllByTestId('routing-review-item')).toHaveLength(1);
     expect(screen.getAllByTestId('production-plan-item')).toHaveLength(1);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Page 4: Check Materials' })
+    );
+    expect(screen.getByTestId('material-review')).toHaveTextContent(
+      'Controlled material definition'
+    );
+    expect(screen.getByTestId('material-review')).toHaveTextContent('BUY-20');
+    expect(screen.getByTestId('material-review')).toHaveTextContent(
+      'AMS-QQ-A-200'
+    );
+    expect(screen.getByText('Inventory linked')).toBeInTheDocument();
+    expect(screen.getAllByTestId('material-review-item')).toHaveLength(1);
     fireEvent.click(
       screen.getByRole('button', { name: 'Page 10: Review and Approve' })
     );

--- a/client/src/components/projects/P2V2ProductionPlanning.tsx
+++ b/client/src/components/projects/P2V2ProductionPlanning.tsx
@@ -102,11 +102,6 @@ const wizardPages = [
 ] as const;
 
 const reviewPageFields: Record<number, Array<[string, string]>> = {
-  3: [
-    ['Required quantity', 'extended_project_quantity'],
-    ['Planning classification', 'planning_classification'],
-    ['Material specification', 'specification_references'],
-  ],
   4: [
     ['Required tooling', 'tooling_requirements'],
     ['Computer numerical control programs', 'cnc_program_requirements'],
@@ -411,7 +406,10 @@ export default function P2V2ProductionPlanning({
                     ))}
                 </section>
               )}
-              {currentPage >= 3 && currentPage <= 7 && (
+              {currentPage === 3 && !!data?.items.length && (
+                <MaterialReview items={data.items} />
+              )}
+              {currentPage >= 4 && currentPage <= 7 && (
                 <ReviewByExceptionPanel
                   items={data?.items ?? []}
                   fields={reviewPageFields[currentPage] ?? []}
@@ -730,6 +728,88 @@ function RoutingReview({
           </article>
         );
       })}
+    </section>
+  );
+}
+
+function MaterialReview({ items }: { items: Row[] }) {
+  const components = items.filter((item) =>
+    Boolean(value(item, 'parent_part_number'))
+  );
+  return (
+    <section className="space-y-3" data-testid="material-review">
+      <div className="rounded border p-4">
+        <h3 className="font-semibold">Controlled material definition</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Component identity and quantity come from the saved assembly baseline.
+          This page reviews material definition only; it does not claim that
+          inventory is available, reserved, allocated, or purchased.
+        </p>
+      </div>
+      {components.map((item) => {
+        const classification =
+          value(item, 'planning_classification') ||
+          value(item, 'make_buy') ||
+          (item.is_manufactured ? 'MAKE' : 'BUY');
+        const inventoryLinked = Boolean(value(item, 'inventory_item_id'));
+        const specifications = displayValue(item, 'specification_references');
+        return (
+          <article
+            className="rounded border p-4"
+            data-testid="material-review-item"
+            key={value(item, 'id')}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <h4 className="font-semibold">
+                  {value(item, 'part_number') || 'Information Missing'} —{' '}
+                  {value(item, 'part_name') || 'Information Missing'}
+                </h4>
+                <p className="text-sm text-muted-foreground">
+                  Used by {value(item, 'parent_part_number')}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Badge variant="outline">
+                  {classification.replaceAll('_', ' ')}
+                </Badge>
+                <Badge variant={inventoryLinked ? 'default' : 'destructive'}>
+                  {inventoryLinked
+                    ? 'Inventory linked'
+                    : 'Inventory link missing'}
+                </Badge>
+              </div>
+            </div>
+            <dl className="mt-3 grid gap-3 text-sm md:grid-cols-4">
+              <OrderFact
+                label="Quantity per parent"
+                current={item.quantity_per_parent}
+              />
+              <OrderFact
+                label="Required project quantity"
+                current={item.extended_project_quantity}
+              />
+              <OrderFact
+                label="Inventory record"
+                current={item.inventory_item_id}
+              />
+              <OrderFact label="BOM status" current={item.bom_release_status} />
+            </dl>
+            <div className="mt-3 text-sm">
+              <p className="text-muted-foreground">Material specifications</p>
+              <p className={specifications ? '' : 'font-medium text-amber-700'}>
+                {specifications || 'Information Missing'}
+              </p>
+            </div>
+          </article>
+        );
+      })}
+      {!components.length && (
+        <p className="rounded border border-amber-300 bg-amber-50 p-3 text-sm">
+          No component material lines are present in the saved assembly
+          baseline.
+        </p>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## What changed

- replace the generic Page 4 field list with a controlled material-definition review
- show component identity, parent assembly, make/buy classification, required quantities, inventory linkage, BOM status, and material specifications
- explicitly distinguish material-definition review from live inventory availability, reservation, allocation, or purchasing
- add focused component coverage for the material review

## Why

Production planners need a clear review of the material baseline before proceeding to tooling and quality. The prior generic list did not make component relationships or inventory-master linkage visible and could be mistaken for an availability check.

## Validation

- focused Vitest component suite: 3 tests passed
- Prettier check passed
- `git diff --check` passed

## Deployment boundary

This PR changes source and focused tests only. It does not add a live inventory availability calculation and has not been deployed or verified against production data.
