### PR TITLE
Authorize persisted P2 execution demand

### DIFF
--- a/migrations/0271_p2_execution_authorization_event.sql
+++ b/migrations/0271_p2_execution_authorization_event.sql
@@ -1,0 +1,11 @@
+-- Admit the planning-to-floor authorization bridge event without weakening
+-- the immutable Production Launch event ledger.
+ALTER TABLE project_production_launch_events
+  DROP CONSTRAINT IF EXISTS project_production_launch_events_event_type_check;
+
+ALTER TABLE project_production_launch_events
+  ADD CONSTRAINT project_production_launch_events_event_type_check
+  CHECK (event_type IN (
+    'RECURSIVE_DEMAND_GRAPH_PERSISTED',
+    'EXECUTION_AUTHORIZED'
+  ));

--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -73,6 +73,7 @@ import {
   persistProductionLaunch,
   persistProductionLaunchForCertification,
 } from '../src/services/productionLaunchPersistenceService';
+import { authorizeProductionExecution } from '../src/services/productionExecutionAuthorizationService';
 import { getProductionLaunchPreview } from '../src/services/productionLaunchPreviewService';
 
 // This established lifecycle suite certifies immutable definition v2. The
@@ -1188,6 +1189,66 @@ describe('recursive Production Launch persistence against PostgreSQL', () => {
     expect(evidence.rows[0].demands).toBeGreaterThan(0);
     expect(evidence.rows[0].events).toBe(1);
     expect(evidence.rows[0].execution_links).toBe(0);
+  });
+
+  it('authorizes persisted MAKE demand against the released WAD without floor records', async () => {
+    const fixture = await createFixture(
+      '00000000-0000-4000-8000-000000000823',
+      'RECURSIVE-AUTHORIZATION'
+    );
+    const preview = await prepareRecursivePersistenceFixture(fixture);
+    const launch = await persistProductionLaunch(
+      fixture.projectId,
+      {
+        idempotencyKey: 'recursive-authorization-launch',
+        expectedPreviewDigest: preview.resultChecksum,
+        signatureMeaning: 'Persist synthetic planning evidence',
+      },
+      actor
+    );
+    process.env.P2_V2_EXECUTION_AUTHORIZATION_ENABLED = 'true';
+    const input = {
+      idempotencyKey: 'recursive-execution-authorization',
+      expectedLaunchDigest: preview.resultChecksum,
+      signatureMeaning: 'Authorize synthetic MAKE demand against released WAD',
+    };
+    const first = await authorizeProductionExecution(
+      fixture.projectId,
+      String(launch.launch.id),
+      input,
+      actor
+    );
+    const replay = await authorizeProductionExecution(
+      fixture.projectId,
+      String(launch.launch.id),
+      input,
+      actor
+    );
+    expect(first.replayed).toBe(false);
+    expect(replay.replayed).toBe(true);
+    const evidence = await query<{
+      authorized_demands: number;
+      wad_links: number;
+      floor_links: number;
+      floor_records: number;
+    }>(
+      `SELECT
+        (SELECT count(*)::int FROM project_production_demands
+          WHERE project_id=$1 AND disposition='MAKE' AND demand_status='AUTHORIZED') authorized_demands,
+        (SELECT count(*)::int FROM project_production_demand_execution_links
+          WHERE project_id=$1 AND link_type='WAD') wad_links,
+        (SELECT count(*)::int FROM project_production_demand_execution_links
+          WHERE project_id=$1 AND link_type<>'WAD') floor_links,
+        ((SELECT count(*)::int FROM p2_production_orders WHERE project_id=$1)
+          +(SELECT count(*)::int FROM travelers WHERE project_id=$1)) floor_records`,
+      [fixture.projectId]
+    );
+    expect(evidence.rows[0].authorized_demands).toBeGreaterThan(0);
+    expect(evidence.rows[0].wad_links).toBe(
+      evidence.rows[0].authorized_demands
+    );
+    expect(evidence.rows[0].floor_links).toBe(0);
+    expect(evidence.rows[0].floor_records).toBe(0);
   });
 });
 

--- a/server/__tests__/productionExecutionAuthorizationFeatureGate.test.ts
+++ b/server/__tests__/productionExecutionAuthorizationFeatureGate.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isP2V2ExecutionAuthorizationEnabled } from '../src/lib/featureFlags';
+
+describe('P2 V2 execution authorization feature gate', () => {
+  afterEach(() => delete process.env.P2_V2_EXECUTION_AUTHORIZATION_ENABLED);
+
+  it.each([undefined, '', 'false', 'TRUE', '1', ' true '])(
+    'fails closed for %s',
+    (value) => {
+      if (value === undefined)
+        delete process.env.P2_V2_EXECUTION_AUTHORIZATION_ENABLED;
+      else process.env.P2_V2_EXECUTION_AUTHORIZATION_ENABLED = value;
+      expect(isP2V2ExecutionAuthorizationEnabled()).toBe(false);
+    }
+  );
+
+  it('enables only exact lowercase true', () => {
+    process.env.P2_V2_EXECUTION_AUTHORIZATION_ENABLED = 'true';
+    expect(isP2V2ExecutionAuthorizationEnabled()).toBe(true);
+  });
+});

--- a/server/__tests__/productionExecutionAuthorizationFoundation.test.ts
+++ b/server/__tests__/productionExecutionAuthorizationFoundation.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const service = readFileSync(
+  join(
+    process.cwd(),
+    'server/src/services/productionExecutionAuthorizationService.ts'
+  ),
+  'utf8'
+);
+const route = readFileSync(
+  join(process.cwd(), 'server/src/routes/projectProductionPlanning.ts'),
+  'utf8'
+);
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/0271_p2_execution_authorization_event.sql'),
+  'utf8'
+);
+const migrationRunner = readFileSync(
+  join(process.cwd(), 'server/scripts/migrations/runSafeBootMigrations.ts'),
+  'utf8'
+);
+
+describe('Production execution authorization foundation', () => {
+  it('is independently fail-closed and server-authorized', () => {
+    expect(service).toContain('isP2V2ExecutionAuthorizationEnabled()');
+    expect(route).toContain("'projects.production_launch.launch'");
+    expect(route).toContain("'/launch/:launchId/authorize-execution'");
+  });
+
+  it('links MAKE demand only to the exact released WAD', () => {
+    expect(service).toContain("demand.disposition === 'MAKE'");
+    expect(service).toContain('wa.status AS wad_status');
+    expect(service).toContain('pwo.wad_status AS work_order_wad_status');
+    expect(service).toContain("'WAD'");
+    expect(service).toContain("demand_status='AUTHORIZED'");
+  });
+
+  it('creates no floor execution records in this phase', () => {
+    for (const forbidden of [
+      'INSERT INTO p2_production_orders',
+      'INSERT INTO travelers',
+      'INSERT INTO traveler_steps',
+      'INSERT INTO cnc_jobs',
+      'INSERT INTO manufacturing_queue',
+      'INSERT INTO cutting_packet_schedule',
+      'INSERT INTO production_work_orders',
+    ])
+      expect(service).not.toContain(forbidden);
+    expect(service).toContain('createsFloorRecords: false');
+  });
+
+  it('uses one transaction, locking, idempotency, and reconciliation blockers', () => {
+    expect(service).toContain('db.transaction');
+    expect(service).toContain('pg_advisory_xact_lock');
+    expect(service).toContain("event_type='EXECUTION_AUTHORIZED'");
+    expect(service).toContain('EXECUTION_AUTHORIZATION_IDEMPOTENCY_CONFLICT');
+    expect(service).toContain('EXISTING_EXECUTION_REQUIRES_RECONCILIATION');
+  });
+
+  it('registers the authorization event without opening arbitrary event types', () => {
+    expect(migration).toContain("'RECURSIVE_DEMAND_GRAPH_PERSISTED'");
+    expect(migration).toContain("'EXECUTION_AUTHORIZED'");
+    expect(migration).toContain(
+      'project_production_launch_events_event_type_check'
+    );
+    expect(
+      migrationRunner.match(/0271_p2_execution_authorization_event\.sql/g)
+    ).toHaveLength(2);
+  });
+});

--- a/server/__tests__/productionExecutionAuthorizationService.test.ts
+++ b/server/__tests__/productionExecutionAuthorizationService.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  enabled: vi.fn(() => true),
+  transaction: vi.fn(),
+}));
+vi.mock('../db', () => ({ db: { transaction: mocks.transaction } }));
+vi.mock('../src/lib/featureFlags', () => ({
+  isP2V2ExecutionAuthorizationEnabled: mocks.enabled,
+}));
+
+import { authorizeProductionExecution } from '../src/services/productionExecutionAuthorizationService';
+
+const digest = 'a'.repeat(64);
+const input = {
+  idempotencyKey: 'synthetic-execution-key',
+  expectedLaunchDigest: digest,
+  signatureMeaning: 'I authorize the released plan against its WAD.',
+};
+const actor = {
+  userId: 7,
+  employeeId: 8,
+  username: 'operator',
+  displayName: 'Synthetic Operator',
+  role: 'OPERATIONS',
+};
+
+describe('Production execution authorization service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.enabled.mockReturnValue(true);
+  });
+
+  it('does not open a transaction while disabled', async () => {
+    mocks.enabled.mockReturnValue(false);
+    await expect(
+      authorizeProductionExecution('project-1', 'launch-1', input, actor)
+    ).rejects.toMatchObject({ code: 'P2_V2_EXECUTION_AUTHORIZATION_DISABLED' });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it('authorizes MAKE demand against the released WAD atomically', async () => {
+    const responses: unknown[] = [
+      [],
+      [
+        {
+          id: 'launch-1',
+          project_id: 'project-1',
+          status: 'COMPLETE',
+          preview_digest: digest,
+          wad_authorization_id: 'wad-auth-1',
+          wad_status: 'RELEASED',
+          wad_work_order_id: 'wad-work-order-1',
+          work_order_status: 'RELEASED',
+          work_order_wad_status: 'APPROVED',
+        },
+      ],
+      [],
+      [
+        {
+          id: 'demand-1',
+          disposition: 'MAKE',
+          shortage_quantity: 2,
+          demand_status: 'PLANNED',
+          routing_id: 'routing-1',
+          wad_authorization_id: 'wad-auth-1',
+          assembly_path: 'root:1',
+        },
+      ],
+      [],
+      [],
+      [],
+      [],
+    ];
+    const execute = vi.fn(async () => responses.shift() ?? []);
+    mocks.transaction.mockImplementation(async (callback) =>
+      callback({ execute })
+    );
+
+    await expect(
+      authorizeProductionExecution('project-1', 'launch-1', input, actor)
+    ).resolves.toMatchObject({
+      replayed: false,
+      authorizedDemandIds: ['demand-1'],
+    });
+    expect(execute).toHaveBeenCalledTimes(8);
+    const statements = execute.mock.calls.map(([query]) =>
+      query.queryChunks?.map((chunk: unknown) => String(chunk)).join('')
+    );
+    expect(statements.join('\n')).not.toMatch(
+      /INSERT INTO (?:p2_production_orders|production_work_orders|travelers|cnc_jobs|manufacturing_queue)/
+    );
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -299,6 +299,7 @@ export const safeMigrationFiles = [
   '0268_replit_p2_demand_composite_fk_repair.sql',
   '0269_repair_composite_po_item_demand_fks.sql',
   '0270_certification_authorization_matrix.sql',
+  '0271_p2_execution_authorization_event.sql',
 ];
 
 export const criticalMigrationFiles = new Set([
@@ -374,6 +375,7 @@ export const criticalMigrationFiles = new Set([
   '0268_replit_p2_demand_composite_fk_repair.sql',
   '0269_repair_composite_po_item_demand_fks.sql',
   '0270_certification_authorization_matrix.sql',
+  '0271_p2_execution_authorization_event.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -63,6 +63,11 @@ export function isP2V2ProductionLaunchPersistenceEnabled(): boolean {
   return process.env.P2_V2_PRODUCTION_LAUNCH_PERSISTENCE_ENABLED === 'true';
 }
 
+/** Gates the planning-to-floor authorization bridge; disabled unless exact lowercase true. */
+export function isP2V2ExecutionAuthorizationEnabled(): boolean {
+  return process.env.P2_V2_EXECUTION_AUTHORIZATION_ENABLED === 'true';
+}
+
 /**
  * Cutover date for the punch_ledger migration.
  * For pay periods starting ON or AFTER this date, hour computations read

--- a/server/src/routes/projectProductionPlanning.ts
+++ b/server/src/routes/projectProductionPlanning.ts
@@ -17,6 +17,10 @@ import {
 } from '../services/projectProductionPlanningService';
 import { getProductionLaunchPreview } from '../services/productionLaunchPreviewService';
 import { persistProductionLaunch } from '../services/productionLaunchPersistenceService';
+import {
+  authorizeProductionExecution,
+  ProductionExecutionAuthorizationError,
+} from '../services/productionExecutionAuthorizationService';
 
 const router = Router({ mergeParams: true });
 const headerSchema = z.object({
@@ -37,6 +41,13 @@ const launchSchema = z
   .object({
     idempotencyKey: z.string().trim().min(8).max(200),
     expectedPreviewDigest: z.string().regex(/^[0-9a-f]{64}$/),
+    signatureMeaning: z.string().trim().min(1).max(500),
+  })
+  .strict();
+const executionAuthorizationSchema = z
+  .object({
+    idempotencyKey: z.string().trim().min(8).max(200),
+    expectedLaunchDigest: z.string().regex(/^[0-9a-f]{64}$/),
     signatureMeaning: z.string().trim().min(1).max(500),
   })
   .strict();
@@ -148,6 +159,10 @@ function fail(res: Response, error: unknown) {
     return res
       .status(error.status)
       .json({ error: error.code, message: error.message, ...error.details });
+  if (error instanceof ProductionExecutionAuthorizationError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
   console.error('P2 V2 Production Planning error:', error);
   return res.status(500).json({
     error: 'PRODUCTION_PLANNING_FAILED',
@@ -180,6 +195,23 @@ router.post('/launch', async (req, res) => {
     const result = await persistProductionLaunch(
       projectId(req),
       launchSchema.parse(req.body),
+      user
+    );
+    res.status(result.replayed ? 200 : 201).json(result);
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/launch/:launchId/authorize-execution', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_launch.launch'
+    );
+    const result = await authorizeProductionExecution(
+      projectId(req),
+      req.params.launchId,
+      executionAuthorizationSchema.parse(req.body),
       user
     );
     res.status(result.replayed ? 200 : 201).json(result);

--- a/server/src/services/productionExecutionAuthorizationService.ts
+++ b/server/src/services/productionExecutionAuthorizationService.ts
@@ -1,0 +1,185 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { isP2V2ExecutionAuthorizationEnabled } from '../lib/featureFlags';
+import type { PlanningActor } from './projectProductionPlanningService';
+
+type Row = Record<string, unknown>;
+const rows = (value: unknown): Row[] =>
+  Array.isArray(value)
+    ? (value as Row[])
+    : ((value as { rows?: Row[] } | null)?.rows ?? []);
+const digest = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+export type ExecutionAuthorizationInput = {
+  idempotencyKey: string;
+  expectedLaunchDigest: string;
+  signatureMeaning: string;
+};
+
+export class ProductionExecutionAuthorizationError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 409,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+
+export async function authorizeProductionExecution(
+  projectId: string,
+  launchId: string,
+  input: ExecutionAuthorizationInput,
+  actor: PlanningActor
+) {
+  if (!isP2V2ExecutionAuthorizationEnabled())
+    throw new ProductionExecutionAuthorizationError(
+      'P2_V2_EXECUTION_AUTHORIZATION_DISABLED',
+      'Production execution authorization is disabled.',
+      503
+    );
+  const requestHash = digest({
+    projectId,
+    launchId,
+    idempotencyKey: input.idempotencyKey.trim(),
+    expectedLaunchDigest: input.expectedLaunchDigest,
+  });
+
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${projectId}:execution-authorization`},0))`
+    );
+    const context = rows(
+      await tx.execute(sql`
+        SELECT pl.id,pl.project_id,pl.status,pl.preview_digest,
+          pl.configuration_baseline_id,pl.wad_authorization_id,
+          wa.status AS wad_status,wa.wad_work_order_id,
+          pwo.status AS work_order_status,pwo.wad_status AS work_order_wad_status
+        FROM project_production_launches pl
+        JOIN projects p ON p.id=pl.project_id AND p.workflow_version='p2_v2'
+        JOIN project_wad_authorizations wa ON wa.id=pl.wad_authorization_id
+        JOIN production_work_orders pwo ON pwo.id=wa.wad_work_order_id
+        WHERE pl.id=${launchId} AND pl.project_id=${projectId}
+        FOR UPDATE OF pl,p,wa,pwo`)
+    )[0];
+    if (!context)
+      throw new ProductionExecutionAuthorizationError(
+        'PRODUCTION_LAUNCH_NOT_FOUND',
+        'The completed Production Launch was not found.',
+        404
+      );
+    if (
+      context.status !== 'COMPLETE' ||
+      context.wad_status !== 'RELEASED' ||
+      context.work_order_wad_status !== 'APPROVED'
+    )
+      throw new ProductionExecutionAuthorizationError(
+        'EXECUTION_AUTHORITY_NOT_RELEASED',
+        'The launch and exact WAD authority must be complete and released.'
+      );
+    if (String(context.preview_digest) !== input.expectedLaunchDigest)
+      throw new ProductionExecutionAuthorizationError(
+        'STALE_PRODUCTION_LAUNCH',
+        'The expected Production Launch digest is stale.'
+      );
+
+    const priorEvent = rows(
+      await tx.execute(sql`
+        SELECT * FROM project_production_launch_events
+        WHERE production_launch_id=${launchId} AND event_type='EXECUTION_AUTHORIZED'
+        LIMIT 1`)
+    )[0];
+    if (priorEvent) {
+      if (String(priorEvent.request_hash) !== requestHash)
+        throw new ProductionExecutionAuthorizationError(
+          'EXECUTION_AUTHORIZATION_IDEMPOTENCY_CONFLICT',
+          'Execution was already authorized with different evidence.'
+        );
+      return { replayed: true, event: priorEvent };
+    }
+
+    const demands = rows(
+      await tx.execute(sql`
+        SELECT * FROM project_production_demands
+        WHERE project_id=${projectId} AND production_launch_id=${launchId}
+        ORDER BY path_depth,assembly_path FOR UPDATE`)
+    );
+    const makeDemands = demands.filter(
+      (demand) =>
+        demand.disposition === 'MAKE' && Number(demand.shortage_quantity) > 0
+    );
+    if (!makeDemands.length)
+      throw new ProductionExecutionAuthorizationError(
+        'MAKE_DEMAND_REQUIRED',
+        'No shortage-backed MAKE demand is available for authorization.'
+      );
+    const invalid = makeDemands.filter(
+      (demand) =>
+        demand.demand_status !== 'PLANNED' ||
+        !demand.routing_id ||
+        !demand.wad_authorization_id ||
+        String(demand.wad_authorization_id) !==
+          String(context.wad_authorization_id)
+    );
+    if (invalid.length)
+      throw new ProductionExecutionAuthorizationError(
+        'DEMAND_NOT_AUTHORIZABLE',
+        'Every MAKE demand must be planned and retain the frozen routing and WAD authority.',
+        409,
+        { paths: invalid.map((demand) => demand.assembly_path) }
+      );
+    const existingFloorLinks = rows(
+      await tx.execute(sql`
+        SELECT l.demand_id,l.link_type FROM project_production_demand_execution_links l
+        JOIN project_production_demands d ON d.id=l.demand_id
+        WHERE d.production_launch_id=${launchId} AND l.link_type<>'WAD'`)
+    );
+    if (existingFloorLinks.length)
+      throw new ProductionExecutionAuthorizationError(
+        'EXISTING_EXECUTION_REQUIRES_RECONCILIATION',
+        'Execution records already exist and require explicit reconciliation.'
+      );
+
+    const linkIds: string[] = [];
+    for (const demand of makeDemands) {
+      const linkId = randomUUID();
+      linkIds.push(linkId);
+      await tx.execute(sql`
+        INSERT INTO project_production_demand_execution_links
+          (id,project_id,demand_id,production_work_order_id,link_type)
+        VALUES (${linkId},${projectId},${String(demand.id)},${String(context.wad_work_order_id)},'WAD')
+        ON CONFLICT DO NOTHING`);
+    }
+    await tx.execute(sql`
+      UPDATE project_production_demands SET demand_status='AUTHORIZED',
+        status_reason='Authorized against released WAD',updated_at=now()
+      WHERE production_launch_id=${launchId} AND project_id=${projectId}
+        AND disposition='MAKE' AND shortage_quantity>0 AND demand_status='PLANNED'`);
+    const eventId = randomUUID();
+    const evidence = {
+      launchId,
+      wadAuthorizationId: context.wad_authorization_id,
+      wadWorkOrderId: context.wad_work_order_id,
+      demandIds: makeDemands.map((demand) => demand.id),
+      createsFloorRecords: false,
+    };
+    await tx.execute(sql`
+      INSERT INTO project_production_launch_events
+        (id,project_id,production_launch_id,event_type,request_hash,evidence_digest,
+         created_record_ids,evidence_snapshot,actor_user_id,actor_display_name,actor_role,signature_meaning)
+      VALUES (${eventId},${projectId},${launchId},'EXECUTION_AUTHORIZED',${requestHash},
+        ${digest(evidence)},${JSON.stringify({ linkIds })}::jsonb,${JSON.stringify(evidence)}::jsonb,
+        ${actor.userId},${actor.displayName},${actor.role},${input.signatureMeaning.trim()})
+      RETURNING *`);
+    return {
+      replayed: false,
+      eventId,
+      authorizedDemandIds: evidence.demandIds,
+    };
+  });
+}


### PR DESCRIPTION
## What changed

- add a disabled-by-default P2 execution-authorization feature gate
- authorize persisted shortage-backed MAKE demands against the exact released WAD authority
- create demand-to-WAD execution links and immutable `EXECUTION_AUTHORIZED` launch events
- enforce transaction locking, evidence-based replay idempotency, and conflict detection
- register migration `0271_p2_execution_authorization_event.sql` after main's `0269` FK repair and `0270` certification authorization matrix
- add focused service/foundation/feature-gate coverage and PostgreSQL certification coverage

## Why

The persisted recursive demand graph needs a controlled authorization boundary before any shop-floor execution records are provisioned. This phase establishes that bridge without fabricating department/routing ownership or bypassing WAD release controls.

## Impact

When `P2_V2_EXECUTION_AUTHORIZATION_ENABLED` is explicitly enabled, eligible persisted MAKE demands can move from `PLANNED` to `AUTHORIZED` and link to their exact approved WAD. The feature remains disabled by default.

This PR intentionally creates no P2 production orders, production work orders, travelers, CNC jobs, queues, cutting records, serialized items, reservations, or other floor records.

## Validation

- rebased onto current `main` at `de271ab06`
- 17/17 focused feature-gate, foundation, service, and persistence tests passed after conflict resolution
- focused ESLint passed
- `git diff --check origin/main...HEAD` passed
- `git merge-tree --write-tree origin/main HEAD` completed cleanly
- earlier full P2 V2 PostgreSQL certification passed 28/28; PostgreSQL was not rerun during this conflict-only reconciliation
