### PR TITLE
Add tooling resource review to planning wizard

### DIFF
--- a/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
@@ -28,6 +28,10 @@ const model = {
       routing_id: 'routing-100-rev-4',
       routing_revision: '4',
       routing_release_status: 'RELEASED',
+      tooling_requirements: ['Assembly fixture AF-100'],
+      cnc_program_requirements: [],
+      special_process_source: 'EXTERNAL_APPROVED_SUPPLIER',
+      special_process_requirements: ['Type II anodize'],
     },
     {
       id: 'leaf',
@@ -207,6 +211,24 @@ describe('P2V2ProductionPlanning', () => {
     );
     expect(screen.getByText('Inventory linked')).toBeInTheDocument();
     expect(screen.getAllByTestId('material-review-item')).toHaveLength(1);
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Page 5: Check Tooling and Resources',
+      })
+    );
+    expect(screen.getByTestId('tooling-resource-review')).toHaveTextContent(
+      'Tooling and resource requirements'
+    );
+    expect(screen.getByTestId('tooling-resource-review')).toHaveTextContent(
+      'Assembly fixture AF-100'
+    );
+    expect(screen.getByTestId('tooling-resource-review')).toHaveTextContent(
+      'Type II anodize'
+    );
+    expect(screen.getByText('Requirements recorded')).toBeInTheDocument();
+    expect(screen.getAllByTestId('tooling-resource-review-item')).toHaveLength(
+      1
+    );
     fireEvent.click(
       screen.getByRole('button', { name: 'Page 10: Review and Approve' })
     );

--- a/client/src/components/projects/P2V2ProductionPlanning.tsx
+++ b/client/src/components/projects/P2V2ProductionPlanning.tsx
@@ -102,11 +102,6 @@ const wizardPages = [
 ] as const;
 
 const reviewPageFields: Record<number, Array<[string, string]>> = {
-  4: [
-    ['Required tooling', 'tooling_requirements'],
-    ['Computer numerical control programs', 'cnc_program_requirements'],
-    ['Special process source', 'special_process_source'],
-  ],
   5: [
     ['Inspection extent', 'inspection_extent'],
     ['First Article Inspection', 'fai_requirement'],
@@ -409,7 +404,13 @@ export default function P2V2ProductionPlanning({
               {currentPage === 3 && !!data?.items.length && (
                 <MaterialReview items={data.items} />
               )}
-              {currentPage >= 4 && currentPage <= 7 && (
+              {currentPage === 4 && !!data?.items.length && (
+                <ToolingResourceReview
+                  items={data.items}
+                  blockers={data.readiness.blockers}
+                />
+              )}
+              {currentPage >= 5 && currentPage <= 7 && (
                 <ReviewByExceptionPanel
                   items={data?.items ?? []}
                   fields={reviewPageFields[currentPage] ?? []}
@@ -810,6 +811,106 @@ function MaterialReview({ items }: { items: Row[] }) {
           baseline.
         </p>
       )}
+    </section>
+  );
+}
+
+function ToolingResourceReview({
+  items,
+  blockers,
+}: {
+  items: Row[];
+  blockers: string[];
+}) {
+  const manufacturedItems = items.filter((item) => item.is_manufactured);
+  return (
+    <section className="space-y-3" data-testid="tooling-resource-review">
+      <div className="rounded border p-4">
+        <h3 className="font-semibold">Tooling and resource requirements</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          These requirements come from the saved Production Planning baseline.
+          This review does not establish physical availability, calibration,
+          program release, machine capacity, or supplier approval.
+        </p>
+      </div>
+      {manufacturedItems.map((item) => {
+        const partNumber = value(item, 'part_number');
+        const tooling = displayValue(item, 'tooling_requirements');
+        const programs = displayValue(item, 'cnc_program_requirements');
+        const specialProcessSource = value(item, 'special_process_source');
+        const specialProcesses = displayValue(
+          item,
+          'special_process_requirements'
+        );
+        const decisionsComplete =
+          Array.isArray(item.tooling_requirements) &&
+          Array.isArray(item.cnc_program_requirements) &&
+          Boolean(specialProcessSource) &&
+          (specialProcessSource === 'NONE' || Boolean(specialProcesses));
+        const itemBlockers = blockers.filter((blocker) =>
+          blocker.startsWith(`${partNumber}:`)
+        );
+        return (
+          <article
+            className="rounded border p-4"
+            data-testid="tooling-resource-review-item"
+            key={value(item, 'id')}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <h4 className="font-semibold">
+                  {partNumber || 'Information Missing'} —{' '}
+                  {value(item, 'part_name') || 'Information Missing'}
+                </h4>
+                <p className="text-sm text-muted-foreground">
+                  Routing revision{' '}
+                  {value(item, 'routing_revision') || 'Information Missing'}
+                </p>
+              </div>
+              <Badge variant={decisionsComplete ? 'default' : 'destructive'}>
+                {decisionsComplete
+                  ? 'Requirements recorded'
+                  : 'Decision missing'}
+              </Badge>
+            </div>
+            <dl className="mt-3 grid gap-3 text-sm md:grid-cols-3">
+              <OrderFact
+                label="Required tooling"
+                current={tooling || 'None recorded'}
+              />
+              <OrderFact
+                label="CNC programs"
+                current={programs || 'None recorded'}
+              />
+              <OrderFact
+                label="Special-process source"
+                current={specialProcessSource}
+              />
+            </dl>
+            {specialProcessSource && specialProcessSource !== 'NONE' && (
+              <div className="mt-3 text-sm">
+                <p className="text-muted-foreground">
+                  Special-process requirements
+                </p>
+                <p
+                  className={
+                    specialProcesses ? '' : 'font-medium text-amber-700'
+                  }
+                >
+                  {specialProcesses || 'Information Missing'}
+                </p>
+              </div>
+            )}
+            {!!itemBlockers.length && (
+              <ul className="mt-3 list-disc pl-5 text-sm text-amber-800">
+                {itemBlockers.map((blocker) => (
+                  <li key={blocker}>{blocker}</li>
+                ))}
+              </ul>
+            )}
+          </article>
+        );
+      })}
     </section>
   );
 }


### PR DESCRIPTION
## What changed

- replace Page 5's generic field list with a controlled tooling and resource requirements review
- show each manufactured item's routing revision, tooling requirements, CNC program requirements, special-process source, and special-process requirements
- surface relevant planning blockers and distinguish complete decisions from missing decisions
- explicitly avoid implying physical availability, calibration, program release, machine capacity, or supplier approval
- add focused component coverage for the new review

## Why

Production planners need to verify the resource requirements captured in the controlled planning baseline before moving to quality review. The prior generic list did not clearly separate recorded requirements from operational availability or readiness.

## Validation

- focused Vitest component suite: 3 tests passed
- Prettier check passed
- `git diff --check` passed

## Deployment boundary

This PR changes source and focused tests only. It does not verify live tool availability, calibration, CNC program release, machine capacity, or approved-supplier status, and it has not been deployed.
