### PR TITLE
Add quality requirements review to planning wizard

### DIFF
--- a/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
@@ -32,6 +32,13 @@ const model = {
       cnc_program_requirements: [],
       special_process_source: 'EXTERNAL_APPROVED_SUPPLIER',
       special_process_requirements: ['Type II anodize'],
+      inspection_extent: 'APPROVED_SAMPLING',
+      sampling_plan_id: 'SP-100',
+      sampling_plan_status: 'APPROVED',
+      fai_requirement: 'PARTIAL',
+      traceability_level: 'SERIAL',
+      required_certifications: ['Certificate of Conformance'],
+      required_test_records: ['Final inspection report'],
     },
     {
       id: 'leaf',
@@ -229,6 +236,26 @@ describe('P2V2ProductionPlanning', () => {
     expect(screen.getAllByTestId('tooling-resource-review-item')).toHaveLength(
       1
     );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Page 6: Check Quality Requirements',
+      })
+    );
+    expect(screen.getByTestId('quality-requirement-review')).toHaveTextContent(
+      'Controlled quality requirements'
+    );
+    expect(screen.getByTestId('quality-requirement-review')).toHaveTextContent(
+      'SP-100'
+    );
+    expect(screen.getByTestId('quality-requirement-review')).toHaveTextContent(
+      'Certificate of Conformance'
+    );
+    expect(screen.getByTestId('quality-requirement-review')).toHaveTextContent(
+      'Final inspection report'
+    );
+    expect(
+      screen.getAllByTestId('quality-requirement-review-item')
+    ).toHaveLength(1);
     fireEvent.click(
       screen.getByRole('button', { name: 'Page 10: Review and Approve' })
     );

--- a/client/src/components/projects/P2V2ProductionPlanning.tsx
+++ b/client/src/components/projects/P2V2ProductionPlanning.tsx
@@ -102,12 +102,6 @@ const wizardPages = [
 ] as const;
 
 const reviewPageFields: Record<number, Array<[string, string]>> = {
-  5: [
-    ['Inspection extent', 'inspection_extent'],
-    ['First Article Inspection', 'fai_requirement'],
-    ['Required certifications', 'required_certifications'],
-    ['Required test records', 'required_test_records'],
-  ],
   6: [
     ['Drawing number', 'drawing_number'],
     ['Drawing revision', 'drawing_revision'],
@@ -410,7 +404,13 @@ export default function P2V2ProductionPlanning({
                   blockers={data.readiness.blockers}
                 />
               )}
-              {currentPage >= 5 && currentPage <= 7 && (
+              {currentPage === 5 && !!data?.items.length && (
+                <QualityRequirementReview
+                  items={data.items}
+                  blockers={data.readiness.blockers}
+                />
+              )}
+              {currentPage >= 6 && currentPage <= 7 && (
                 <ReviewByExceptionPanel
                   items={data?.items ?? []}
                   fields={reviewPageFields[currentPage] ?? []}
@@ -901,6 +901,117 @@ function ToolingResourceReview({
                 </p>
               </div>
             )}
+            {!!itemBlockers.length && (
+              <ul className="mt-3 list-disc pl-5 text-sm text-amber-800">
+                {itemBlockers.map((blocker) => (
+                  <li key={blocker}>{blocker}</li>
+                ))}
+              </ul>
+            )}
+          </article>
+        );
+      })}
+    </section>
+  );
+}
+
+function QualityRequirementReview({
+  items,
+  blockers,
+}: {
+  items: Row[];
+  blockers: string[];
+}) {
+  const manufacturedItems = items.filter((item) => item.is_manufactured);
+  return (
+    <section className="space-y-3" data-testid="quality-requirement-review">
+      <div className="rounded border p-4">
+        <h3 className="font-semibold">Controlled quality requirements</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          These are planning decisions from the saved baseline. They do not
+          record inspection results, completed FAI, accepted product, or
+          released certification and test evidence.
+        </p>
+      </div>
+      {manufacturedItems.map((item) => {
+        const partNumber = value(item, 'part_number');
+        const inspection = value(item, 'inspection_extent');
+        const samplingRequired = inspection === 'APPROVED_SAMPLING';
+        const samplingApproved =
+          !samplingRequired ||
+          (Boolean(value(item, 'sampling_plan_id')) &&
+            value(item, 'sampling_plan_status').toUpperCase() === 'APPROVED');
+        const fai = value(item, 'fai_requirement');
+        const faiComplete =
+          Boolean(fai) &&
+          (fai !== 'NOT_REQUIRED' || Boolean(value(item, 'fai_reason')));
+        const decisionsComplete =
+          Boolean(inspection) &&
+          samplingApproved &&
+          faiComplete &&
+          Boolean(value(item, 'traceability_level')) &&
+          Array.isArray(item.required_certifications) &&
+          Array.isArray(item.required_test_records);
+        const certifications = displayValue(item, 'required_certifications');
+        const testRecords = displayValue(item, 'required_test_records');
+        const itemBlockers = blockers.filter((blocker) =>
+          blocker.startsWith(`${partNumber}:`)
+        );
+        return (
+          <article
+            className="rounded border p-4"
+            data-testid="quality-requirement-review-item"
+            key={value(item, 'id')}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <h4 className="font-semibold">
+                  {partNumber || 'Information Missing'} —{' '}
+                  {value(item, 'part_name') || 'Information Missing'}
+                </h4>
+                <p className="text-sm text-muted-foreground">
+                  Planning quality controls
+                </p>
+              </div>
+              <Badge variant={decisionsComplete ? 'default' : 'destructive'}>
+                {decisionsComplete
+                  ? 'Requirements recorded'
+                  : 'Decision missing'}
+              </Badge>
+            </div>
+            <dl className="mt-3 grid gap-3 text-sm md:grid-cols-3">
+              <OrderFact label="Inspection strategy" current={inspection} />
+              <OrderFact label="FAI requirement" current={fai} />
+              <OrderFact
+                label="Traceability level"
+                current={item.traceability_level}
+              />
+              {samplingRequired && (
+                <>
+                  <OrderFact
+                    label="Sampling plan"
+                    current={item.sampling_plan_id}
+                  />
+                  <OrderFact
+                    label="Sampling status"
+                    current={item.sampling_plan_status}
+                  />
+                </>
+              )}
+              {fai === 'NOT_REQUIRED' && (
+                <OrderFact label="FAI N/A basis" current={item.fai_reason} />
+              )}
+            </dl>
+            <dl className="mt-3 grid gap-3 text-sm md:grid-cols-2">
+              <OrderFact
+                label="Required certifications"
+                current={certifications || 'None recorded'}
+              />
+              <OrderFact
+                label="Required test records"
+                current={testRecords || 'None recorded'}
+              />
+            </dl>
             {!!itemBlockers.length && (
               <ul className="mt-3 list-disc pl-5 text-sm text-amber-800">
                 {itemBlockers.map((blocker) => (


### PR DESCRIPTION
## What changed

- replace Page 6's generic field list with a controlled quality-requirements review
- show inspection strategy, approved-sampling evidence, FAI requirement and N/A basis, traceability level, required certifications, required test records, and relevant blockers
- distinguish recorded planning requirements from completed inspection, FAI execution, product acceptance, or released evidence
- add focused component coverage for the quality review

## Why

Production planners need to verify quality planning decisions before controlled-document and scheduling review. The prior generic list did not expose conditional sampling and FAI evidence clearly and could be mistaken for completed quality execution.

## Main synchronization

The branch is based on current `origin/main` at `3ab5a71c1`, which includes the Replit migration-error repairs and subsequent migration updates. A non-destructive merge-tree check succeeds, and this PR's compare contains only the two scoped UI/test files.

## Validation

- focused Vitest component suite: 3 tests passed
- Prettier check passed
- `git diff --check origin/main...HEAD` passed
- `git merge-tree --write-tree origin/main HEAD` passed

## Deployment boundary

This PR changes source and focused tests only. It does not record completed inspections, FAI execution, product acceptance, or released certification/test evidence, and it has not been deployed.
