### PR TITLE
Provision draft travelers for P2 serialized units

### DIFF
--- a/migrations/0274_p2_traveler_provisioning.sql
+++ b/migrations/0274_p2_traveler_provisioning.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS project_production_serialized_unit_travelers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+  serialized_unit_link_id UUID NOT NULL REFERENCES project_production_demand_serialized_units(id) ON DELETE RESTRICT,
+  traveler_id VARCHAR(255) NOT NULL REFERENCES travelers(id) ON DELETE RESTRICT,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  UNIQUE (serialized_unit_link_id),
+  UNIQUE (traveler_id)
+);
+
+ALTER TABLE project_production_launch_events
+  DROP CONSTRAINT IF EXISTS project_production_launch_events_event_type_check;
+
+ALTER TABLE project_production_launch_events
+  ADD CONSTRAINT project_production_launch_events_event_type_check
+  CHECK (event_type IN (
+    'RECURSIVE_DEMAND_GRAPH_PERSISTED',
+    'EXECUTION_AUTHORIZED',
+    'P2_PRODUCTION_ORDERS_PROVISIONED',
+    'P2_SERIALIZED_UNITS_PROVISIONED',
+    'P2_DRAFT_TRAVELERS_PROVISIONED'
+  ));

--- a/server/__tests__/travelerProvisioningFeatureGate.test.ts
+++ b/server/__tests__/travelerProvisioningFeatureGate.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isP2V2TravelerProvisioningEnabled } from '../src/lib/featureFlags';
+
+describe('P2 traveler provisioning feature gate', () => {
+  afterEach(() => delete process.env.P2_V2_TRAVELER_PROVISIONING_ENABLED);
+
+  for (const value of [undefined, '', 'false', 'TRUE', '1', 'yes']) {
+    it(`is disabled for ${String(value)}`, () => {
+      if (value === undefined)
+        delete process.env.P2_V2_TRAVELER_PROVISIONING_ENABLED;
+      else process.env.P2_V2_TRAVELER_PROVISIONING_ENABLED = value;
+      expect(isP2V2TravelerProvisioningEnabled()).toBe(false);
+    });
+  }
+
+  it('is enabled only by exact lowercase true', () => {
+    process.env.P2_V2_TRAVELER_PROVISIONING_ENABLED = 'true';
+    expect(isP2V2TravelerProvisioningEnabled()).toBe(true);
+  });
+});

--- a/server/__tests__/travelerProvisioningFoundation.test.ts
+++ b/server/__tests__/travelerProvisioningFoundation.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const service = readFileSync(
+  join(process.cwd(), 'server/src/services/travelerProvisioningService.ts'),
+  'utf8'
+);
+const route = readFileSync(
+  join(process.cwd(), 'server/src/routes/projectProductionPlanning.ts'),
+  'utf8'
+);
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/0274_p2_traveler_provisioning.sql'),
+  'utf8'
+);
+const runner = readFileSync(
+  join(process.cwd(), 'server/scripts/migrations/runSafeBootMigrations.ts'),
+  'utf8'
+);
+
+describe('P2 draft traveler provisioning boundary', () => {
+  it('is independently gated and capability protected', () => {
+    expect(service).toContain('isP2V2TravelerProvisioningEnabled()');
+    expect(route).toContain("'/launch/:launchId/provision-draft-travelers'");
+    expect(route).toContain("'projects.production_launch.launch'");
+  });
+
+  it('requires audited serial links and exact frozen routing', () => {
+    expect(service).toContain('project_production_demand_serialized_units');
+    expect(service).toContain('project_production_serialized_unit_travelers');
+    expect(service).toContain(
+      'String(target.part_routing_id) !== String(target.routing_id)'
+    );
+    expect(service).toContain('EXISTING_TRAVELER_REQUIRES_RECONCILIATION');
+  });
+
+  it('creates routing-derived travelers but does not activate work', () => {
+    expect(service).toContain('storage.generateTravelerFromRouting');
+    expect(service).toContain("status: 'DRAFT'");
+    expect(service).toContain("ts.status<>'NOT_STARTED'");
+    expect(service).toContain('activatesWork: false');
+    for (const forbidden of [
+      'INSERT INTO cnc_jobs',
+      'INSERT INTO manufacturing_queue',
+      'INSERT INTO cutting_packet_schedule',
+      'INSERT INTO p2_work_tasks',
+    ])
+      expect(service).not.toContain(forbidden);
+  });
+
+  it('registers migration 0274 as safe and critical', () => {
+    expect(migration).toContain('P2_DRAFT_TRAVELERS_PROVISIONED');
+    expect(runner.match(/0274_p2_traveler_provisioning\.sql/g)).toHaveLength(2);
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -28546,6 +28546,33 @@ export const projectProductionDemandSerializedUnits = pgTable(
   })
 );
 
+export const projectProductionSerializedUnitTravelers = pgTable(
+  'project_production_serialized_unit_travelers',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'restrict' }),
+    serializedUnitLinkId: uuid('serialized_unit_link_id')
+      .notNull()
+      .references(() => projectProductionDemandSerializedUnits.id, {
+        onDelete: 'restrict',
+      }),
+    travelerId: varchar('traveler_id', { length: 255 })
+      .notNull()
+      .references(() => travelers.id, { onDelete: 'restrict' }),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+  },
+  (table) => ({
+    serializedUnitUnique: uniqueIndex(
+      'project_production_serialized_unit_travelers_unit_unique'
+    ).on(table.serializedUnitLinkId),
+    travelerUnique: uniqueIndex(
+      'project_production_serialized_unit_travelers_traveler_unique'
+    ).on(table.travelerId),
+  })
+);
+
 export const projectProductionDemandAllocations = pgTable(
   'project_production_demand_allocations',
   {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -334,6 +334,7 @@ export const safeMigrationFiles = [
   '0271_p2_execution_authorization_event.sql',
   '0272_p2_production_order_provisioning_event.sql',
   '0273_p2_serialized_unit_provisioning.sql',
+  '0274_p2_traveler_provisioning.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -413,6 +414,7 @@ export const criticalMigrationFiles = new Set([
   '0271_p2_execution_authorization_event.sql',
   '0272_p2_production_order_provisioning_event.sql',
   '0273_p2_serialized_unit_provisioning.sql',
+  '0274_p2_traveler_provisioning.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -78,6 +78,11 @@ export function isP2V2SerializedUnitProvisioningEnabled(): boolean {
   return process.env.P2_V2_SERIALIZED_UNIT_PROVISIONING_ENABLED === 'true';
 }
 
+/** Gates draft traveler creation from audited serialized root units. */
+export function isP2V2TravelerProvisioningEnabled(): boolean {
+  return process.env.P2_V2_TRAVELER_PROVISIONING_ENABLED === 'true';
+}
+
 /**
  * Cutover date for the punch_ledger migration.
  * For pay periods starting ON or AFTER this date, hour computations read

--- a/server/src/routes/projectProductionPlanning.ts
+++ b/server/src/routes/projectProductionPlanning.ts
@@ -29,6 +29,10 @@ import {
   provisionP2SerializedUnits,
   SerializedUnitProvisioningError,
 } from '../services/serializedUnitProvisioningService';
+import {
+  provisionP2DraftTravelers,
+  TravelerProvisioningError,
+} from '../services/travelerProvisioningService';
 
 const router = Router({ mergeParams: true });
 const headerSchema = z.object({
@@ -61,6 +65,7 @@ const executionAuthorizationSchema = z
   .strict();
 const productionOrderProvisioningSchema = executionAuthorizationSchema;
 const serializedUnitProvisioningSchema = executionAuthorizationSchema;
+const travelerProvisioningSchema = executionAuthorizationSchema;
 const itemSchema = z
   .object({
     drawing_number: z.string().nullable().optional(),
@@ -181,6 +186,10 @@ function fail(res: Response, error: unknown) {
     return res
       .status(error.status)
       .json({ error: error.code, message: error.message, ...error.details });
+  if (error instanceof TravelerProvisioningError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
   console.error('P2 V2 Production Planning error:', error);
   return res.status(500).json({
     error: 'PRODUCTION_PLANNING_FAILED',
@@ -274,6 +283,23 @@ router.post(
     }
   }
 );
+router.post('/launch/:launchId/provision-draft-travelers', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_launch.launch'
+    );
+    const result = await provisionP2DraftTravelers(
+      projectId(req),
+      req.params.launchId,
+      travelerProvisioningSchema.parse(req.body),
+      user
+    );
+    res.status(result.replayed ? 200 : 201).json(result);
+  } catch (error) {
+    fail(res, error);
+  }
+});
 router.post('/', async (req, res) => {
   try {
     const user = await requireCapability(

--- a/server/src/services/travelerProvisioningService.ts
+++ b/server/src/services/travelerProvisioningService.ts
@@ -1,0 +1,227 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db, pgPool } from '../../db';
+import { storage } from '../../storage';
+import { isP2V2TravelerProvisioningEnabled } from '../lib/featureFlags';
+import type { PlanningActor } from './projectProductionPlanningService';
+
+type Row = Record<string, unknown>;
+const rows = (value: unknown): Row[] =>
+  Array.isArray(value)
+    ? (value as Row[])
+    : ((value as { rows?: Row[] } | null)?.rows ?? []);
+const digest = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+export type TravelerProvisioningInput = {
+  idempotencyKey: string;
+  expectedLaunchDigest: string;
+  signatureMeaning: string;
+};
+
+export class TravelerProvisioningError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 409,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+
+export async function provisionP2DraftTravelers(
+  projectId: string,
+  launchId: string,
+  input: TravelerProvisioningInput,
+  actor: PlanningActor
+) {
+  if (!isP2V2TravelerProvisioningEnabled())
+    throw new TravelerProvisioningError(
+      'P2_V2_TRAVELER_PROVISIONING_DISABLED',
+      'P2 draft traveler provisioning is disabled.',
+      503
+    );
+
+  const requestHash = digest({
+    projectId,
+    launchId,
+    idempotencyKey: input.idempotencyKey.trim(),
+    expectedLaunchDigest: input.expectedLaunchDigest,
+  });
+  const lockClient = await pgPool.connect();
+  try {
+    await lockClient.query(
+      'SELECT pg_advisory_lock(hashtext($1),hashtext($2))',
+      ['p2-v2-traveler-provisioning', projectId]
+    );
+
+    const launch = rows(
+      await db.execute(sql`
+        SELECT pl.id,pl.status,pl.preview_digest,wa.status AS wad_status,
+          wa.wad_work_order_id,pwo.wad_status AS work_order_wad_status
+        FROM project_production_launches pl
+        JOIN projects p ON p.id=pl.project_id AND p.workflow_version='p2_v2'
+        JOIN project_wad_authorizations wa ON wa.id=pl.wad_authorization_id
+        JOIN production_work_orders pwo ON pwo.id=wa.wad_work_order_id
+        WHERE pl.id=${launchId} AND pl.project_id=${projectId}`)
+    )[0];
+    if (!launch)
+      throw new TravelerProvisioningError(
+        'PRODUCTION_LAUNCH_NOT_FOUND',
+        'The completed Production Launch was not found.',
+        404
+      );
+    if (
+      launch.status !== 'COMPLETE' ||
+      launch.wad_status !== 'RELEASED' ||
+      launch.work_order_wad_status !== 'APPROVED'
+    )
+      throw new TravelerProvisioningError(
+        'EXECUTION_AUTHORITY_NOT_RELEASED',
+        'The launch and exact WAD authority must remain complete and released.'
+      );
+    if (String(launch.preview_digest) !== input.expectedLaunchDigest)
+      throw new TravelerProvisioningError(
+        'STALE_PRODUCTION_LAUNCH',
+        'The expected Production Launch digest is stale.'
+      );
+
+    const priorEvent = rows(
+      await db.execute(sql`
+        SELECT * FROM project_production_launch_events
+        WHERE production_launch_id=${launchId}
+          AND event_type='P2_DRAFT_TRAVELERS_PROVISIONED' LIMIT 1`)
+    )[0];
+    if (priorEvent) {
+      if (String(priorEvent.request_hash) !== requestHash)
+        throw new TravelerProvisioningError(
+          'TRAVELER_PROVISIONING_IDEMPOTENCY_CONFLICT',
+          'Draft travelers were already provisioned with different evidence.'
+        );
+      return { replayed: true, event: priorEvent };
+    }
+
+    const targets = rows(
+      await db.execute(sql`
+        SELECT su.id AS serialized_unit_link_id,su.demand_id,
+          si.id AS serialized_item_id,si.serial_number,si.po_number,
+          si.part_routing_id,si.part_number,si.status AS serialized_status,
+          d.routing_id,d.demand_status,st.traveler_id
+        FROM project_production_demand_serialized_units su
+        JOIN project_production_demands d ON d.id=su.demand_id
+          AND d.project_id=su.project_id AND d.production_launch_id=${launchId}
+        JOIN p2_serialized_items si ON si.id=su.serialized_item_id
+        LEFT JOIN project_production_serialized_unit_travelers st
+          ON st.serialized_unit_link_id=su.id
+        WHERE su.project_id=${projectId}
+        ORDER BY si.serial_number`)
+    );
+    if (!targets.length)
+      throw new TravelerProvisioningError(
+        'SERIALIZED_ROOT_UNITS_REQUIRED',
+        'No audited serialized root units are available for traveler provisioning.'
+      );
+
+    const invalid = targets.filter(
+      (target) =>
+        target.demand_status !== 'IN_PROCESS' ||
+        target.serialized_status !== 'ACTIVE' ||
+        !target.serial_number ||
+        !target.routing_id ||
+        String(target.part_routing_id) !== String(target.routing_id)
+    );
+    if (invalid.length)
+      throw new TravelerProvisioningError(
+        'SERIALIZED_UNIT_NOT_TRAVELER_READY',
+        'Every serialized unit must retain pending status and its exact frozen routing.',
+        409,
+        {
+          serializedItemIds: invalid.map((target) => target.serialized_item_id),
+        }
+      );
+
+    const travelerIds: string[] = [];
+    for (const target of targets) {
+      if (target.traveler_id) {
+        travelerIds.push(String(target.traveler_id));
+        continue;
+      }
+      const existing = rows(
+        await db.execute(sql`
+          SELECT id FROM travelers
+          WHERE lower(trim(serial_number))=lower(trim(${String(target.serial_number)}))
+          LIMIT 1`)
+      );
+      if (existing.length)
+        throw new TravelerProvisioningError(
+          'EXISTING_TRAVELER_REQUIRES_RECONCILIATION',
+          'An unlinked traveler already exists for a target serialized unit.'
+        );
+
+      let traveler = await storage.generateTravelerFromRouting(
+        String(target.routing_id),
+        {
+          serialNumber: String(target.serial_number),
+          lotNumber: target.po_number ? String(target.po_number) : undefined,
+          quantity: 1,
+          createdBy: actor.displayName,
+        }
+      );
+      traveler = await storage.updateTraveler(traveler.id, {
+        status: 'DRAFT',
+        projectId,
+        productionWorkOrderId: String(launch.wad_work_order_id),
+      });
+      await db.execute(sql`
+        INSERT INTO project_production_serialized_unit_travelers
+          (id,project_id,serialized_unit_link_id,traveler_id)
+        VALUES (${randomUUID()},${projectId},${String(target.serialized_unit_link_id)},${traveler.id})`);
+      travelerIds.push(traveler.id);
+    }
+
+    const activeRecords = rows(
+      await db.execute(sql`
+        SELECT t.id FROM travelers t
+        JOIN project_production_serialized_unit_travelers st ON st.traveler_id=t.id
+        JOIN project_production_demand_serialized_units su ON su.id=st.serialized_unit_link_id
+        LEFT JOIN traveler_steps ts ON ts.traveler_id=t.id AND ts.status<>'NOT_STARTED'
+        WHERE su.project_id=${projectId}
+          AND (t.status<>'DRAFT' OR ts.id IS NOT NULL) LIMIT 1`)
+    );
+    if (activeRecords.length)
+      throw new TravelerProvisioningError(
+        'TRAVELER_ACTIVATION_BOUNDARY_VIOLATED',
+        'Provisioned travelers must remain draft with all steps not started.'
+      );
+
+    const eventId = randomUUID();
+    const evidence = {
+      launchId,
+      travelerIds,
+      createsQueues: false,
+      activatesWork: false,
+    };
+    await db.execute(sql`
+      INSERT INTO project_production_launch_events
+        (id,project_id,production_launch_id,event_type,request_hash,evidence_digest,
+         created_record_ids,evidence_snapshot,actor_user_id,actor_display_name,
+         actor_role,signature_meaning)
+      VALUES (${eventId},${projectId},${launchId},'P2_DRAFT_TRAVELERS_PROVISIONED',
+        ${requestHash},${digest(evidence)},${JSON.stringify({ travelerIds })}::jsonb,
+        ${JSON.stringify(evidence)}::jsonb,${actor.userId},${actor.displayName},
+        ${actor.role},${input.signatureMeaning.trim()})`);
+    return { replayed: false, eventId, travelerIds };
+  } finally {
+    try {
+      await lockClient.query(
+        'SELECT pg_advisory_unlock(hashtext($1),hashtext($2))',
+        ['p2-v2-traveler-provisioning', projectId]
+      );
+    } finally {
+      lockClient.release();
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- provision one routing-derived draft traveler for every audited serialized root unit
- link each traveler to its serialized-unit audit bridge, project, and exact released WAD work order
- require the completed launch, released WAD authority, active serialized unit, and frozen routing to remain exact
- add an independently gated capability-protected provisioning endpoint
- add migration 0274, immutable launch evidence, schema registration, and focused regression coverage

## Safety boundary

This phase creates travelers only in `DRAFT`. Every generated traveler step and task must remain `NOT_STARTED`. It does not create work tasks, manufacturing queues, cutting schedules, CNC jobs, or automatic floor activation. Existing unlinked travelers block provisioning for controlled reconciliation.

The feature remains disabled unless `P2_V2_TRAVELER_PROVISIONING_ENABLED` is exact lowercase `true`.

## Validation

- 11 focused tests passed
- focused ESLint passed
- migration registry synchronization passed with 316 entries
- `git diff --check` and staged diff checks passed
- PostgreSQL lifecycle certification was not run locally because `DATABASE_URL` was unavailable
