### PR TITLE
Add schedule capacity review to planning wizard

### DIFF
--- a/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
+++ b/client/src/__tests__/P2V2ProductionPlanning.component.test.tsx
@@ -286,6 +286,22 @@ describe('P2V2ProductionPlanning', () => {
       screen.getAllByTestId('controlled-document-review-item')
     ).toHaveLength(1);
     fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Page 8: Check Schedule and Capacity',
+      })
+    );
+    expect(screen.getByTestId('schedule-capacity-review')).toHaveTextContent(
+      'Scheduling inputs and capacity boundary'
+    );
+    expect(screen.getByTestId('schedule-capacity-review')).toHaveTextContent(
+      '2026-10-01'
+    );
+    expect(screen.getByTestId('schedule-capacity-review')).toHaveTextContent(
+      'Not evaluated in this baseline'
+    );
+    expect(screen.getAllByTestId('schedule-order-line')).toHaveLength(1);
+    expect(screen.getAllByTestId('schedule-manufactured-item')).toHaveLength(1);
+    fireEvent.click(
       screen.getByRole('button', { name: 'Page 10: Review and Approve' })
     );
     expect(screen.getByText(/engineering approval/i)).toBeInTheDocument();

--- a/client/src/components/projects/P2V2ProductionPlanning.tsx
+++ b/client/src/components/projects/P2V2ProductionPlanning.tsx
@@ -101,14 +101,6 @@ const wizardPages = [
   'Review and Approve',
 ] as const;
 
-const reviewPageFields: Record<number, Array<[string, string]>> = {
-  7: [
-    ['Required quantity', 'extended_project_quantity'],
-    ['Routing revision', 'routing_revision'],
-    ['Effectivity', 'effectivity_reference'],
-  ],
-};
-
 export default function P2V2ProductionPlanning({
   projectId,
 }: {
@@ -410,10 +402,12 @@ export default function P2V2ProductionPlanning({
                   blockers={data.readiness.blockers}
                 />
               )}
-              {currentPage === 7 && (
-                <ReviewByExceptionPanel
-                  items={data?.items ?? []}
-                  fields={reviewPageFields[currentPage] ?? []}
+              {currentPage === 7 && data?.plan && (
+                <ScheduleCapacityReview
+                  plan={data.plan}
+                  items={data.items}
+                  orderConfirmation={data.orderConfirmation}
+                  blockers={data.readiness.blockers}
                 />
               )}
               {currentPage === 8 && (
@@ -1152,6 +1146,107 @@ function ControlledDocumentReview({
   );
 }
 
+function ScheduleCapacityReview({
+  plan,
+  items,
+  orderConfirmation,
+  blockers,
+}: {
+  plan: Row;
+  items: Row[];
+  orderConfirmation: Model['orderConfirmation'];
+  blockers: string[];
+}) {
+  const manufacturedItems = items.filter((item) => item.is_manufactured);
+  return (
+    <section className="space-y-4" data-testid="schedule-capacity-review">
+      <div className="rounded border p-4">
+        <h3 className="font-semibold">
+          Scheduling inputs and capacity boundary
+        </h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          This page reviews controlled demand and timing inputs. The Production
+          Planning baseline does not calculate labor loading, machine calendars,
+          finite capacity, material availability, or a committed production
+          schedule.
+        </p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-4">
+        <OrderFact
+          label="Customer required delivery"
+          current={orderConfirmation.requiredDeliveryDate}
+        />
+        <OrderFact
+          label="Planning effectivity"
+          current={plan.effectivity_reference}
+        />
+        <OrderFact
+          label="Manufactured items"
+          current={manufacturedItems.length}
+        />
+        <OrderFact
+          label="Capacity confirmation"
+          current="Not evaluated in this baseline"
+        />
+      </div>
+      <div className="rounded border p-4">
+        <h3 className="font-semibold">Customer order timing</h3>
+        <div className="mt-3 space-y-2">
+          {orderConfirmation.lines.map((line) => (
+            <div
+              className="grid gap-3 rounded border p-3 text-sm md:grid-cols-4"
+              data-testid="schedule-order-line"
+              key={value(line, 'id')}
+            >
+              <OrderFact
+                label="Customer part"
+                current={line.customer_part_number}
+              />
+              <OrderFact label="AG part" current={line.ag_part_number} />
+              <OrderFact label="Order quantity" current={line.quantity} />
+              <OrderFact label="Due date" current={line.due_date} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <h3 className="font-semibold">Manufactured demand inputs</h3>
+        {manufacturedItems.map((item) => (
+          <article
+            className="grid gap-3 rounded border p-3 text-sm md:grid-cols-4"
+            data-testid="schedule-manufactured-item"
+            key={value(item, 'id')}
+          >
+            <OrderFact label="Part" current={item.part_number} />
+            <OrderFact
+              label="Required quantity"
+              current={item.extended_project_quantity}
+            />
+            <OrderFact
+              label="Routing revision"
+              current={item.routing_revision}
+            />
+            <OrderFact
+              label="Effectivity"
+              current={item.effectivity_reference}
+            />
+          </article>
+        ))}
+      </div>
+      {!!blockers.length && (
+        <div className="rounded border border-amber-300 bg-amber-50 p-3">
+          <h3 className="font-semibold">Inputs still blocking release</h3>
+          <ul className="mt-2 list-disc pl-5 text-sm">
+            {blockers.map((blocker) => (
+              <li key={blocker}>{blocker}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
 function ConfirmOrderSummary({
   confirmation,
   plan,
@@ -1261,54 +1356,6 @@ function OrderFact({ label, current }: { label: string; current: unknown }) {
         {displayed || 'Information Missing'}
       </p>
     </div>
-  );
-}
-
-function ReviewByExceptionPanel({
-  items,
-  fields,
-}: {
-  items: Row[];
-  fields: Array<[string, string]>;
-}) {
-  return (
-    <section className="space-y-3" data-testid="review-by-exception-panel">
-      <div className="rounded border p-4">
-        <h3 className="font-semibold">Completed from existing EPOCH records</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Values below come from the current controlled Production Planning
-          baseline. Missing values remain visible for review and are not
-          silently replaced.
-        </p>
-      </div>
-      {items.map((item) => (
-        <div className="rounded border p-3" key={value(item, 'id')}>
-          <h4 className="font-medium">
-            {value(item, 'part_number')} — {value(item, 'part_name')}
-          </h4>
-          <dl className="mt-2 grid gap-3 text-sm md:grid-cols-2">
-            {fields.map(([label, key]) => {
-              const current = displayValue(item, key);
-              return (
-                <div key={key}>
-                  <dt className="text-muted-foreground">{label}</dt>
-                  <dd className={current ? '' : 'font-medium text-amber-700'}>
-                    {current || 'Information Missing'}
-                  </dd>
-                </div>
-              );
-            })}
-          </dl>
-        </div>
-      ))}
-      {!items.length && (
-        <p className="rounded border border-amber-300 bg-amber-50 p-3 text-sm">
-          No controlled planning items are available. Return to Confirm the
-          Order and build or refresh the draft from the authoritative
-          configuration.
-        </p>
-      )}
-    </section>
   );
 }
 


### PR DESCRIPTION
## What changed

- replace Page 8's generic field list with a scheduling-input and capacity-boundary review
- show customer delivery dates, order-line timing, manufactured demand quantities, routing revisions, effectivity, and release blockers
- explicitly identify that labor loading, machine calendars, finite capacity, material availability, and committed scheduling are not evaluated by this baseline
- remove the now-unused generic review helper
- add focused component coverage for the schedule and capacity review

## Why

Production planners need the controlled timing and demand inputs visible before demand preview, but the planning model does not contain a finite-capacity engine. The prior generic list could imply a capacity check that had not occurred.

## Main synchronization

The branch was rebased onto current `origin/main`, including the P2 traveler-provisioning changes. Its final compare remains one commit and two scoped UI/test files.

## Validation

- focused Vitest component suite: 3 tests passed
- Prettier check passed
- `git diff --check origin/main...HEAD` passed
- `git merge-tree --write-tree origin/main HEAD` passed

## Deployment boundary

This PR changes source and focused tests only. It does not calculate or confirm finite capacity, material availability, or a committed production schedule, and it has not been deployed.
