### PR TITLE
Bind Design Control approvals to verified employees

### DIFF
--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -47,9 +47,20 @@ type ApprovalSlot = {
     decidedBySnapshot?: { username?: string; role?: string } | null;
     decidedAt?: string | null;
   } | null;
+  assignment?: {
+    employeeId: number;
+    userId: number;
+    employeeCodeSnapshot?: string | null;
+    approverNameSnapshot: string;
+    jobTitleSnapshot?: string | null;
+    departmentSnapshot?: string | null;
+    accountStatusSnapshot: string;
+    status: string;
+  } | null;
 };
 
 type ApprovalState = {
+  currentUserId?: number | null;
   currentContentVersion?: { id: string; contentVersion: number } | null;
   versions: Array<{
     id: string;
@@ -71,6 +82,20 @@ type ApprovalState = {
     status: string;
   }>;
   approvalSlots: ApprovalSlot[];
+};
+
+type EligibleApprovers = {
+  employees: Array<{
+    employeeId: number;
+    employeeCode?: string | null;
+    displayName: string;
+    jobTitle?: string | null;
+    department?: string | null;
+    userId: number;
+    accountRole: string;
+    accountStatus: string;
+    eligibleApprovalKeys: string[];
+  }>;
 };
 
 type Props = {
@@ -117,6 +142,9 @@ export function DesignControlStepEditor({
   const [checklist, setChecklist] = useState<Record<string, unknown>>({});
   const [changeReason, setChangeReason] = useState('');
   const [decisionComment, setDecisionComment] = useState('');
+  const [approvalAssignments, setApprovalAssignments] = useState<
+    Record<string, string>
+  >({});
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
@@ -196,6 +224,23 @@ export function DesignControlStepEditor({
         )
       ),
   });
+  const eligibleApproversQuery = useQuery<EligibleApprovers>({
+    queryKey: [
+      '/api/qms/design-control',
+      recordId,
+      'steps',
+      definition.key,
+      'eligible-approvers',
+    ],
+    queryFn: async () =>
+      responsePayload(
+        await fetch(
+          `/api/qms/design-control/${encodeURIComponent(recordId)}/steps/${encodeURIComponent(definition.key)}/eligible-approvers`,
+          { credentials: 'include' }
+        )
+      ),
+    enabled: step?.status !== 'submitted_for_approval',
+  });
 
   const refresh = async () => {
     await Promise.all([
@@ -260,6 +305,20 @@ export function DesignControlStepEditor({
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             contentVersionId: step?.currentContentVersionId ?? null,
+            assignments: definition.approvals.map((slot) => {
+              const selected = (
+                eligibleApproversQuery.data?.employees ?? []
+              ).find(
+                (employee) =>
+                  `${employee.employeeId}:${employee.userId}` ===
+                  approvalAssignments[slot.key]
+              );
+              return {
+                approvalKey: slot.key,
+                employeeId: selected?.employeeId,
+                userId: selected?.userId,
+              };
+            }),
           }),
         }
       );
@@ -484,7 +543,9 @@ export function DesignControlStepEditor({
                         {value && value !== projectId && (
                           <option value={value}>Existing value: {value}</option>
                         )}
-                        <option value={projectId}>Linked project: {projectId}</option>
+                        <option value={projectId}>
+                          Linked project: {projectId}
+                        </option>
                         <option value="__MANUAL__">
                           Enter another customer or order link…
                         </option>
@@ -518,9 +579,7 @@ export function DesignControlStepEditor({
                       className="h-10 w-full rounded-md border bg-background px-3 text-sm"
                       id={fieldId}
                       value={
-                        manualPersonFields.has(field.key)
-                          ? '__MANUAL__'
-                          : value
+                        manualPersonFields.has(field.key) ? '__MANUAL__' : value
                       }
                       onChange={(event) => {
                         if (event.target.value === '__MANUAL__') {
@@ -671,9 +730,67 @@ export function DesignControlStepEditor({
           </>
         )}
         {canSubmit && (
+          <div className="w-full space-y-3 rounded-md border p-3">
+            <h3 className="font-semibold">Assign verified approvers</h3>
+            <p className="text-sm text-muted-foreground">
+              Only active employees with active, authorized EPOCH accounts are
+              available. Assignments are locked to the submitted version.
+            </p>
+            {definition.approvals.map((slot) => {
+              const candidates = (
+                eligibleApproversQuery.data?.employees ?? []
+              ).filter((employee) =>
+                employee.eligibleApprovalKeys.includes(slot.key)
+              );
+              return (
+                <div className="space-y-1" key={slot.key}>
+                  <Label htmlFor={`approval-assignee-${slot.key}`}>
+                    {slot.label}
+                  </Label>
+                  <Input
+                    id={`approval-assignee-${slot.key}`}
+                    list={`approval-assignee-options-${slot.key}`}
+                    placeholder="Search active employees by name, code, title, department, or role"
+                    value={approvalAssignments[slot.key] ?? ''}
+                    onChange={(event) =>
+                      setApprovalAssignments((current) => ({
+                        ...current,
+                        [slot.key]: event.target.value,
+                      }))
+                    }
+                  />
+                  <datalist id={`approval-assignee-options-${slot.key}`}>
+                    {candidates.map((employee) => (
+                      <option
+                        key={`${employee.employeeId}:${employee.userId}`}
+                        value={`${employee.employeeId}:${employee.userId}`}
+                      >
+                        {employee.displayName} |{' '}
+                        {employee.employeeCode ||
+                          `Employee ${employee.employeeId}`}{' '}
+                        |{' '}
+                        {employee.jobTitle ||
+                          employee.department ||
+                          'Role not recorded'}{' '}
+                        | Account {employee.accountStatus} |{' '}
+                        {employee.accountRole}
+                      </option>
+                    ))}
+                  </datalist>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        {canSubmit && (
           <Button
             disabled={
-              busy || dirty || !approvalQuery.data?.currentContentVersion?.id
+              busy ||
+              dirty ||
+              !approvalQuery.data?.currentContentVersion?.id ||
+              definition.approvals.some(
+                (slot) => !approvalAssignments[slot.key]
+              )
             }
             onClick={submit}
             type="button"
@@ -728,6 +845,11 @@ export function DesignControlStepEditor({
                       ? 'Independent reviewer required'
                       : 'Authenticated reviewer required'}
                   </p>
+                  <p className="text-xs text-muted-foreground">
+                    {slot.assignment
+                      ? `${slot.assignment.approverNameSnapshot} (${slot.assignment.employeeCodeSnapshot || `Employee ${slot.assignment.employeeId}`}) · ${slot.assignment.jobTitleSnapshot || slot.assignment.departmentSnapshot || 'Role not recorded'} · Account ${slot.assignment.accountStatusSnapshot}`
+                      : 'Unverified legacy assignment or no verified assignee'}
+                  </p>
                 </div>
                 <div className="flex items-center gap-2">
                   <Badge
@@ -735,36 +857,39 @@ export function DesignControlStepEditor({
                   >
                     {slot.status.toLowerCase()}
                   </Badge>
-                  {canApprove && slot.status !== 'APPROVED' && (
-                    <>
-                      <Button
-                        disabled={busy || !decisionComment.trim()}
-                        onClick={() => decide(slot, 'APPROVED')}
-                        size="sm"
-                        type="button"
-                      >
-                        Approve
-                      </Button>
-                      <Button
-                        disabled={busy || !decisionComment.trim()}
-                        onClick={() => decide(slot, 'RETURNED_FOR_REVISION')}
-                        size="sm"
-                        type="button"
-                        variant="outline"
-                      >
-                        Return
-                      </Button>
-                      <Button
-                        disabled={busy}
-                        onClick={() => decide(slot, 'REJECTED')}
-                        size="sm"
-                        type="button"
-                        variant="destructive"
-                      >
-                        Reject
-                      </Button>
-                    </>
-                  )}
+                  {canApprove &&
+                    slot.status !== 'APPROVED' &&
+                    slot.assignment?.userId ===
+                      approvalQuery.data?.currentUserId && (
+                      <>
+                        <Button
+                          disabled={busy || !decisionComment.trim()}
+                          onClick={() => decide(slot, 'APPROVED')}
+                          size="sm"
+                          type="button"
+                        >
+                          Approve
+                        </Button>
+                        <Button
+                          disabled={busy || !decisionComment.trim()}
+                          onClick={() => decide(slot, 'RETURNED_FOR_REVISION')}
+                          size="sm"
+                          type="button"
+                          variant="outline"
+                        >
+                          Return
+                        </Button>
+                        <Button
+                          disabled={busy}
+                          onClick={() => decide(slot, 'REJECTED')}
+                          size="sm"
+                          type="button"
+                          variant="destructive"
+                        >
+                          Reject
+                        </Button>
+                      </>
+                    )}
                 </div>
               </div>
             ))}

--- a/migrations/0275_design_control_verified_approval_assignments.sql
+++ b/migrations/0275_design_control_verified_approval_assignments.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS design_control_step_approval_assignments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rd_project_id text NOT NULL REFERENCES rd_projects(id) ON DELETE RESTRICT,
+  design_control_record_id uuid NOT NULL REFERENCES design_control_records(id) ON DELETE RESTRICT,
+  design_control_step_id uuid NOT NULL REFERENCES design_control_steps(id) ON DELETE RESTRICT,
+  step_content_version_id uuid NOT NULL REFERENCES design_control_step_content_versions(id) ON DELETE RESTRICT,
+  approval_key text NOT NULL,
+  approval_role_snapshot text NOT NULL,
+  employee_id integer NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+  user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  employee_code_snapshot text,
+  approver_name_snapshot text NOT NULL,
+  job_title_snapshot text,
+  department_snapshot text,
+  account_status_snapshot text NOT NULL,
+  required_capability_snapshot text NOT NULL,
+  status text NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING','APPROVED','RETURNED','REJECTED','REASSIGNED')),
+  decision_id uuid REFERENCES design_control_step_approvals(id) ON DELETE RESTRICT,
+  assigned_by_user_id integer NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  assigned_at timestamptz NOT NULL DEFAULT now(),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE UNIQUE INDEX IF NOT EXISTS dc_step_approval_assignments_version_slot_uq
+ON design_control_step_approval_assignments(step_content_version_id, approval_key)
+WHERE status <> 'REASSIGNED';
+CREATE INDEX IF NOT EXISTS dc_step_approval_assignments_version_idx ON design_control_step_approval_assignments(step_content_version_id);
+
+CREATE OR REPLACE FUNCTION prevent_design_control_assignment_delete() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN RAISE EXCEPTION 'Design Control approval assignments are immutable'; END $$;
+DROP TRIGGER IF EXISTS prevent_design_control_assignment_delete ON design_control_step_approval_assignments;
+CREATE TRIGGER prevent_design_control_assignment_delete BEFORE DELETE ON design_control_step_approval_assignments
+FOR EACH ROW EXECUTE FUNCTION prevent_design_control_assignment_delete();
+
+COMMENT ON TABLE design_control_step_approval_assignments IS
+'Immutable submitted-version assignments. Legacy name-only values remain unverified and never satisfy this gate.';
+
+COMMIT;

--- a/server/__tests__/designControlAuthenticatedApprovals.test.ts
+++ b/server/__tests__/designControlAuthenticatedApprovals.test.ts
@@ -120,4 +120,35 @@ describe('authenticated Design Control approvals', () => {
       );
     }
   });
+
+  it('binds submitted approval roles to verified employee accounts without name matching', () => {
+    const migration = readRepoFile(
+      'migrations/0275_design_control_verified_approval_assignments.sql'
+    );
+    const service = readRepoFile(
+      'server/src/services/designControlApprovalService.ts'
+    );
+    expect(migration).toContain('design_control_step_approval_assignments');
+    expect(migration).toContain(
+      'employee_id integer NOT NULL REFERENCES employees'
+    );
+    expect(migration).toContain('user_id integer NOT NULL REFERENCES users');
+    expect(migration).toContain("WHERE status <> 'REASSIGNED'");
+    expect(service).toContain('eq(users.employeeId, selection.employeeId)');
+    expect(service).toContain("eq(employees.employmentStatus, 'ACTIVE')");
+    expect(service).toContain("'APPROVER_NOT_ASSIGNED'");
+    expect(service).toContain("'INDEPENDENCE_REQUIRED'");
+    expect(service).toContain("'ADMIN_APPROVAL_BYPASS_FORBIDDEN'");
+    expect(service).not.toMatch(/employeeName\s*===\s*/);
+  });
+
+  it('provides audited exact-version reassignment while preserving legacy evidence as unverified', () => {
+    const service = readRepoFile(
+      'server/src/services/designControlApprovalService.ts'
+    );
+    expect(service).toContain("'DESIGN_CONTROL_APPROVER_REASSIGNED'");
+    expect(service).toContain("'AUDITED_AUTHORIZED_REASSIGNMENT'");
+    expect(service).toContain("'LEGACY_UNVERIFIED_APPROVAL_EVIDENCE'");
+    expect(service).toContain('satisfiesAuthenticatedGate: false');
+  });
 });

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -6364,9 +6364,14 @@ export const p2CustomerDemandQuantityEvents = pgTable(
       .notNull()
       .references(() => p2PurchaseOrderItems.id, { onDelete: 'restrict' }),
     eventType: text('event_type').notNull(),
-    quantityDelta: numeric('quantity_delta', { precision: 18, scale: 6 }).notNull(),
+    quantityDelta: numeric('quantity_delta', {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
     unitOfMeasure: text('unit_of_measure').notNull(),
-    effectiveAt: timestamp('effective_at', { withTimezone: true }).defaultNow().notNull(),
+    effectiveAt: timestamp('effective_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
     customerEvidenceReference: text('customer_evidence_reference'),
     reason: text('reason').notNull(),
     idempotencyKey: text('idempotency_key').notNull(),
@@ -6377,7 +6382,9 @@ export const p2CustomerDemandQuantityEvents = pgTable(
     }),
     recordedByDisplayName: text('recorded_by_display_name').notNull(),
     recordedByRole: text('recorded_by_role').notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
   },
   (table) => ({
     // Named unique constraints — match the names in migration 0262.
@@ -6394,7 +6401,10 @@ export const p2CustomerDemandQuantityEvents = pgTable(
     itemIdentityFk: foreignKey({
       name: 'p2_demand_event_item_identity_fk',
       columns: [table.poItemId, table.demandLineIdentity],
-      foreignColumns: [p2PurchaseOrderItems.id, p2PurchaseOrderItems.demandLineIdentity],
+      foreignColumns: [
+        p2PurchaseOrderItems.id,
+        p2PurchaseOrderItems.demandLineIdentity,
+      ],
     }).onDelete('restrict'),
   })
 );
@@ -22948,6 +22958,68 @@ export const designControlStepApprovals = pgTable(
     ),
     projectIdx: index('design_control_step_approvals_project_idx').on(
       table.rdProjectId
+    ),
+  })
+);
+
+export const designControlStepApprovalAssignments = pgTable(
+  'design_control_step_approval_assignments',
+  {
+    id: uuid('id')
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    rdProjectId: text('rd_project_id')
+      .notNull()
+      .references(() => rdProjects.id, { onDelete: 'restrict' }),
+    designControlRecordId: uuid('design_control_record_id')
+      .notNull()
+      .references(() => designControlRecords.id, { onDelete: 'restrict' }),
+    designControlStepId: uuid('design_control_step_id')
+      .notNull()
+      .references(() => designControlSteps.id, { onDelete: 'restrict' }),
+    stepContentVersionId: uuid('step_content_version_id')
+      .notNull()
+      .references(() => designControlStepContentVersions.id, {
+        onDelete: 'restrict',
+      }),
+    approvalKey: text('approval_key').notNull(),
+    approvalRoleSnapshot: text('approval_role_snapshot').notNull(),
+    employeeId: integer('employee_id')
+      .notNull()
+      .references(() => employees.id, { onDelete: 'restrict' }),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    employeeCodeSnapshot: text('employee_code_snapshot'),
+    approverNameSnapshot: text('approver_name_snapshot').notNull(),
+    jobTitleSnapshot: text('job_title_snapshot'),
+    departmentSnapshot: text('department_snapshot'),
+    accountStatusSnapshot: text('account_status_snapshot').notNull(),
+    requiredCapabilitySnapshot: text('required_capability_snapshot').notNull(),
+    status: text('status').notNull().default('PENDING'),
+    decisionId: uuid('decision_id').references(
+      () => designControlStepApprovals.id,
+      { onDelete: 'restrict' }
+    ),
+    assignedByUserId: integer('assigned_by_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    assignedAt: timestamp('assigned_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    metadata: jsonb('metadata')
+      .$type<Record<string, unknown>>()
+      .default(sql`'{}'::jsonb`)
+      .notNull(),
+  },
+  (table) => ({
+    versionSlotUnique: uniqueIndex(
+      'dc_step_approval_assignments_version_slot_uq'
+    )
+      .on(table.stepContentVersionId, table.approvalKey)
+      .where(sql`${table.status} <> 'REASSIGNED'`),
+    versionIdx: index('dc_step_approval_assignments_version_idx').on(
+      table.stepContentVersionId
     ),
   })
 );

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -335,6 +335,7 @@ export const safeMigrationFiles = [
   '0272_p2_production_order_provisioning_event.sql',
   '0273_p2_serialized_unit_provisioning.sql',
   '0274_p2_traveler_provisioning.sql',
+  '0275_design_control_verified_approval_assignments.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -415,6 +416,7 @@ export const criticalMigrationFiles = new Set([
   '0272_p2_production_order_provisioning_event.sql',
   '0273_p2_serialized_unit_provisioning.sql',
   '0274_p2_traveler_provisioning.sql',
+  '0275_design_control_verified_approval_assignments.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/qmsDesignControl.ts
+++ b/server/src/routes/qmsDesignControl.ts
@@ -59,7 +59,9 @@ import {
   decideDesignControlStepApproval,
   DesignControlApprovalError,
   getDesignControlStepApprovalState,
+  listEligibleDesignControlApprovers,
   reopenDesignControlStep,
+  reassignDesignControlStepApprover,
   saveDesignControlStepDraft,
   submitDesignControlStep,
   type DesignControlApprovalActor,
@@ -601,6 +603,36 @@ router.get(
   }
 );
 
+router.post(
+  '/:id/steps/:stepKey/assignments/:approvalKey/reassign',
+  authenticateToken,
+  requirePermission('design.control.admin'),
+  enforceDesignControlProjectAssignment,
+  async (req: Request, res: Response) => {
+    try {
+      res.json(
+        await reassignDesignControlStepApprover({
+          recordId: req.params.id,
+          stepKey: req.params.stepKey,
+          contentVersionId: String(req.body?.contentVersionId ?? ''),
+          approvalKey: req.params.approvalKey,
+          employeeId: Number(req.body?.employeeId),
+          userId: Number(req.body?.userId),
+          reason: String(req.body?.reason ?? ''),
+          actor: approvalActorFromRequest(req),
+          requestMetadata: requestMetadata(req),
+        })
+      );
+    } catch (error) {
+      sendApprovalError(
+        res,
+        error,
+        'Failed to reassign Design Control approver'
+      );
+    }
+  }
+);
+
 router.get(
   '/oversight/projects',
   requireDesignControlView,
@@ -938,10 +970,38 @@ router.post(
             : undefined,
         actor: approvalActorFromRequest(req),
         requestMetadata: requestMetadata(req),
+        assignments: Array.isArray(req.body?.assignments)
+          ? req.body.assignments.map((assignment: any) => ({
+              approvalKey: String(assignment?.approvalKey ?? ''),
+              employeeId: Number(assignment?.employeeId),
+              userId: Number(assignment?.userId),
+            }))
+          : [],
       });
       res.json(result);
     } catch (error) {
       sendApprovalError(res, error, 'Failed to submit Design Control step');
+    }
+  }
+);
+
+router.get(
+  '/:id/steps/:stepKey/eligible-approvers',
+  authenticateToken,
+  async (req: Request, res: Response) => {
+    try {
+      res.json(
+        await listEligibleDesignControlApprovers(
+          req.params.id,
+          req.params.stepKey
+        )
+      );
+    } catch (error) {
+      sendApprovalError(
+        res,
+        error,
+        'Failed to load eligible Design Control approvers'
+      );
     }
   }
 );
@@ -995,12 +1055,13 @@ router.get(
   authenticateToken,
   async (req: Request, res: Response) => {
     try {
-      res.json(
-        await getDesignControlStepApprovalState(
+      res.json({
+        ...(await getDesignControlStepApprovalState(
           req.params.id,
           req.params.stepKey
-        )
-      );
+        )),
+        currentUserId: req.user?.id ?? null,
+      });
     } catch (error) {
       sendApprovalError(res, error, 'Failed to load Design Control approvals');
     }

--- a/server/src/services/designControlApprovalService.ts
+++ b/server/src/services/designControlApprovalService.ts
@@ -5,9 +5,12 @@ import { and, asc, eq, sql } from 'drizzle-orm';
 import { db } from '../../db';
 import {
   designControlRecords,
+  designControlStepApprovalAssignments,
   designControlStepApprovals,
   designControlStepContentVersions,
   designControlSteps,
+  employees,
+  users,
 } from '../../schema';
 import {
   DESIGN_CONTROL_WORKFLOW,
@@ -32,6 +35,134 @@ export type DesignControlRequestMetadata = {
   ipAddress?: string | null;
   userAgent?: string | null;
 };
+
+export type DesignControlApprovalSelection = {
+  approvalKey: string;
+  employeeId: number;
+  userId: number;
+};
+
+async function verifiedApprover(
+  selection: DesignControlApprovalSelection,
+  slot: DesignControlWorkflowItem,
+  client: Client
+) {
+  const [candidate] = await client
+    .select({
+      employeeId: employees.id,
+      employeeCode: employees.employeeCode,
+      employeeName: employees.name,
+      jobTitle: employees.jobTitle,
+      department: employees.department,
+      userId: users.id,
+      username: users.username,
+      userRole: users.role,
+      accessStatus: users.accessStatus,
+    })
+    .from(users)
+    .innerJoin(employees, eq(employees.id, users.employeeId))
+    .where(
+      and(
+        eq(users.id, selection.userId),
+        eq(users.employeeId, selection.employeeId),
+        eq(users.isActive, true),
+        eq(users.accessStatus, 'ACTIVE'),
+        eq(employees.isActive, true),
+        eq(employees.employmentStatus, 'ACTIVE')
+      )
+    )
+    .limit(1);
+  if (!candidate)
+    throw new DesignControlApprovalError(
+      422,
+      'APPROVER_NOT_ACTIVE_OR_LINKED',
+      'Each approver must be an active employee with an active linked EPOCH account'
+    );
+  if (candidate.userRole === 'ADMIN' || candidate.userRole === 'OWNER')
+    throw new DesignControlApprovalError(
+      422,
+      'ADMIN_APPROVAL_BYPASS_FORBIDDEN',
+      'Administrative account status does not confer Design Control approval authority'
+    );
+  const permissions = await getUserPermissions(
+    candidate.userId,
+    candidate.userRole
+  );
+  if (!permissions.permissionSet.has(slot.requiredCapability!))
+    throw new DesignControlApprovalError(
+      422,
+      'APPROVER_NOT_AUTHORIZED',
+      `${candidate.employeeName} is not authorized for ${slot.label}`
+    );
+  const normalizedRole = candidate.userRole.toUpperCase();
+  if (!(slot.allowedRoles ?? []).includes(normalizedRole))
+    throw new DesignControlApprovalError(
+      422,
+      'APPROVER_ROLE_MISMATCH',
+      `${candidate.employeeName} does not hold an allowed account role for ${slot.label}`
+    );
+  return candidate;
+}
+
+export async function listEligibleDesignControlApprovers(
+  recordId: string,
+  stepKey: string,
+  client: Client = db
+) {
+  const context = await loadStepContext(recordId, stepKey, client, false);
+  const rows = await client
+    .select({
+      employeeId: employees.id,
+      employeeCode: employees.employeeCode,
+      displayName: employees.name,
+      jobTitle: employees.jobTitle,
+      department: employees.department,
+      userId: users.id,
+      username: users.username,
+      accountRole: users.role,
+      accountStatus: users.accessStatus,
+    })
+    .from(users)
+    .innerJoin(employees, eq(employees.id, users.employeeId))
+    .where(
+      and(
+        eq(users.isActive, true),
+        eq(users.accessStatus, 'ACTIVE'),
+        eq(employees.isActive, true),
+        eq(employees.employmentStatus, 'ACTIVE')
+      )
+    );
+  const candidates = await Promise.all(
+    rows
+      .filter(
+        (row) => row.accountRole !== 'ADMIN' && row.accountRole !== 'OWNER'
+      )
+      .map(async (row) => {
+        const permissions = await getUserPermissions(
+          row.userId,
+          row.accountRole
+        );
+        return {
+          ...row,
+          eligibleApprovalKeys: context.definition.approvals
+            .filter(
+              (slot) =>
+                permissions.permissionSet.has(slot.requiredCapability!) &&
+                (slot.allowedRoles ?? []).includes(
+                  row.accountRole.toUpperCase()
+                )
+            )
+            .map((slot) => slot.key),
+        };
+      })
+  );
+  return {
+    approvalSlots: context.definition.approvals,
+    employees: candidates.filter(
+      (candidate) => candidate.eligibleApprovalKeys.length > 0
+    ),
+  };
+}
 
 export class DesignControlApprovalError extends Error {
   constructor(
@@ -507,6 +638,7 @@ export async function submitDesignControlStep(
     expectedContentVersionId?: string | null;
     actor: DesignControlApprovalActor;
     requestMetadata?: DesignControlRequestMetadata;
+    assignments: DesignControlApprovalSelection[];
   },
   client: Client = db
 ) {
@@ -565,6 +697,69 @@ export async function submitDesignControlStep(
       );
     }
     const now = new Date();
+    const selections = new Map(
+      input.assignments.map((assignment) => [
+        assignment.approvalKey,
+        assignment,
+      ])
+    );
+    if (selections.size !== context.definition.approvals.length)
+      throw new DesignControlApprovalError(
+        422,
+        'APPROVAL_ASSIGNMENTS_REQUIRED',
+        'Select one verified employee account for every required approval role'
+      );
+    const assignedUserIds = new Set<number>();
+    for (const slot of context.definition.approvals) {
+      const selection = selections.get(slot.key);
+      if (!selection)
+        throw new DesignControlApprovalError(
+          422,
+          'APPROVAL_ASSIGNMENTS_REQUIRED',
+          `Select an approver for ${slot.label}`
+        );
+      if (
+        slot.requiresIndependentReviewer &&
+        selection.userId === input.actor.id
+      )
+        throw new DesignControlApprovalError(
+          409,
+          'INDEPENDENCE_REQUIRED',
+          'The submitter cannot be assigned to an independent approval'
+        );
+      if (
+        slot.requiresIndependentReviewer &&
+        assignedUserIds.has(selection.userId)
+      )
+        throw new DesignControlApprovalError(
+          409,
+          'SEGREGATION_OF_DUTIES',
+          'One employee cannot satisfy multiple independent approvals'
+        );
+      const candidate = await verifiedApprover(selection, slot, tx as Client);
+      assignedUserIds.add(candidate.userId);
+      await tx.insert(designControlStepApprovalAssignments).values({
+        rdProjectId: context.record.rdProjectId!,
+        designControlRecordId: context.record.id,
+        designControlStepId: context.step.id,
+        stepContentVersionId: version.id,
+        approvalKey: slot.key,
+        approvalRoleSnapshot: slot.label,
+        employeeId: candidate.employeeId,
+        userId: candidate.userId,
+        employeeCodeSnapshot: candidate.employeeCode,
+        approverNameSnapshot: candidate.employeeName,
+        jobTitleSnapshot: candidate.jobTitle,
+        departmentSnapshot: candidate.department,
+        accountStatusSnapshot: candidate.accessStatus,
+        requiredCapabilitySnapshot: slot.requiredCapability!,
+        assignedByUserId: input.actor.id,
+        metadata: {
+          evidenceHash: version.contentChecksum,
+          provenance: 'VERIFIED_EMPLOYEE_ACCOUNT_ASSIGNMENT',
+        },
+      });
+    }
     await tx
       .update(designControlStepContentVersions)
       .set({
@@ -682,6 +877,39 @@ export async function decideDesignControlStepApproval(
       input.actor,
       slot.requiredCapability
     );
+    const [assignment] = await tx
+      .select()
+      .from(designControlStepApprovalAssignments)
+      .where(
+        and(
+          eq(
+            designControlStepApprovalAssignments.stepContentVersionId,
+            input.contentVersionId
+          ),
+          eq(
+            designControlStepApprovalAssignments.approvalKey,
+            input.approvalKey
+          ),
+          eq(designControlStepApprovalAssignments.userId, input.actor.id),
+          eq(designControlStepApprovalAssignments.status, 'PENDING')
+        )
+      )
+      .limit(1);
+    if (!assignment)
+      throw new DesignControlApprovalError(
+        403,
+        'APPROVER_NOT_ASSIGNED',
+        'The authenticated user is not assigned to this approval role'
+      );
+    await verifiedApprover(
+      {
+        approvalKey: assignment.approvalKey,
+        employeeId: assignment.employeeId,
+        userId: assignment.userId,
+      },
+      slot,
+      tx as Client
+    );
     const normalizedRole = input.actor.role.toUpperCase();
     if (
       normalizedRole !== 'ADMIN' &&
@@ -772,6 +1000,22 @@ export async function decideDesignControlStepApproval(
         metadata: { provenance: 'AUTHENTICATED_VERSION_BOUND_APPROVAL' },
       })
       .returning();
+    await tx
+      .update(designControlStepApprovalAssignments)
+      .set({
+        status:
+          input.decision === 'APPROVED'
+            ? 'APPROVED'
+            : input.decision === 'REJECTED'
+              ? 'REJECTED'
+              : 'RETURNED',
+        decisionId: decision.id,
+        metadata: {
+          ...(assignment.metadata ?? {}),
+          decidedEvidenceHash: version.contentChecksum,
+        },
+      })
+      .where(eq(designControlStepApprovalAssignments.id, assignment.id));
 
     const approvals = await tx
       .select()
@@ -854,6 +1098,146 @@ export async function decideDesignControlStepApproval(
       input.stepKey,
       tx as Client
     );
+  });
+}
+
+export async function reassignDesignControlStepApprover(
+  input: {
+    recordId: string;
+    stepKey: string;
+    contentVersionId: string;
+    approvalKey: string;
+    employeeId: number;
+    userId: number;
+    reason: string;
+    actor: DesignControlApprovalActor;
+    requestMetadata?: DesignControlRequestMetadata;
+  },
+  client: Client = db
+) {
+  if (!input.reason.trim())
+    throw new DesignControlApprovalError(
+      422,
+      'REASSIGNMENT_REASON_REQUIRED',
+      'Authorized reassignment requires a reason'
+    );
+  await requireActorCapability(input.actor, 'design.control.admin');
+  return client.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${`${input.recordId}:${input.stepKey}`}))`
+    );
+    const context = await loadStepContext(
+      input.recordId,
+      input.stepKey,
+      tx as Client
+    );
+    if (
+      context.step.status !== 'submitted_for_approval' ||
+      context.step.currentContentVersionId !== input.contentVersionId
+    )
+      throw new DesignControlApprovalError(
+        409,
+        'STALE_CONTENT_VERSION',
+        'Reassignment must target the exact pending submitted version'
+      );
+    const slot = context.definition.approvals.find(
+      (candidate) => candidate.key === input.approvalKey
+    );
+    if (!slot?.requiredCapability)
+      throw new DesignControlApprovalError(
+        400,
+        'INVALID_APPROVAL_SLOT',
+        'Unknown approval slot'
+      );
+    const [prior] = await tx
+      .select()
+      .from(designControlStepApprovalAssignments)
+      .where(
+        and(
+          eq(
+            designControlStepApprovalAssignments.stepContentVersionId,
+            input.contentVersionId
+          ),
+          eq(
+            designControlStepApprovalAssignments.approvalKey,
+            input.approvalKey
+          ),
+          eq(designControlStepApprovalAssignments.status, 'PENDING')
+        )
+      )
+      .limit(1);
+    if (!prior)
+      throw new DesignControlApprovalError(
+        409,
+        'ASSIGNMENT_NOT_PENDING',
+        'Only a pending assignment may be reassigned'
+      );
+    const candidate = await verifiedApprover(
+      {
+        approvalKey: input.approvalKey,
+        employeeId: input.employeeId,
+        userId: input.userId,
+      },
+      slot,
+      tx as Client
+    );
+    await tx
+      .update(designControlStepApprovalAssignments)
+      .set({
+        status: 'REASSIGNED',
+        metadata: {
+          ...(prior.metadata ?? {}),
+          reassignedByUserId: input.actor.id,
+          reassignedAt: new Date().toISOString(),
+          reassignmentReason: input.reason.trim(),
+        },
+      })
+      .where(eq(designControlStepApprovalAssignments.id, prior.id));
+    const [replacement] = await tx
+      .insert(designControlStepApprovalAssignments)
+      .values({
+        rdProjectId: context.record.rdProjectId!,
+        designControlRecordId: context.record.id,
+        designControlStepId: context.step.id,
+        stepContentVersionId: input.contentVersionId,
+        approvalKey: slot.key,
+        approvalRoleSnapshot: slot.label,
+        employeeId: candidate.employeeId,
+        userId: candidate.userId,
+        employeeCodeSnapshot: candidate.employeeCode,
+        approverNameSnapshot: candidate.employeeName,
+        jobTitleSnapshot: candidate.jobTitle,
+        departmentSnapshot: candidate.department,
+        accountStatusSnapshot: candidate.accessStatus,
+        requiredCapabilitySnapshot: slot.requiredCapability,
+        assignedByUserId: input.actor.id,
+        metadata: {
+          evidenceHash: prior.metadata?.evidenceHash,
+          provenance: 'AUDITED_AUTHORIZED_REASSIGNMENT',
+          priorAssignmentId: prior.id,
+          reason: input.reason.trim(),
+        },
+      })
+      .returning();
+    await recordAuditEvent(
+      {
+        ...auditBase(context, input.actor, input.requestMetadata ?? {}),
+        eventType: 'DESIGN_CONTROL_APPROVER_REASSIGNED',
+        reason: input.reason.trim(),
+        fieldsChanged: {
+          assignedUserId: { before: prior.userId, after: replacement.userId },
+        },
+        payload: {
+          approvalKey: slot.key,
+          contentVersionId: input.contentVersionId,
+          employeeId: replacement.employeeId,
+          userId: replacement.userId,
+          priorAssignmentId: prior.id,
+        },
+      },
+      tx
+    );
+    return replacement;
   });
 }
 
@@ -945,6 +1329,17 @@ export async function getDesignControlStepApprovalState(
     .from(designControlStepApprovals)
     .where(eq(designControlStepApprovals.designControlStepId, context.step.id))
     .orderBy(asc(designControlStepApprovals.createdAt));
+  const assignments = context.step.currentContentVersionId
+    ? await client
+        .select()
+        .from(designControlStepApprovalAssignments)
+        .where(
+          eq(
+            designControlStepApprovalAssignments.stepContentVersionId,
+            context.step.currentContentVersionId
+          )
+        )
+    : [];
   const currentApprovals = approvals.filter(
     (approval) =>
       approval.stepContentVersionId === context.step.currentContentVersionId &&
@@ -963,6 +1358,7 @@ export async function getDesignControlStepApprovalState(
       ) ?? null,
     versions,
     approvals,
+    assignments,
     approvalSlots: context.definition.approvals.map((slot) => ({
       key: slot.key,
       label: slot.label,
@@ -975,6 +1371,9 @@ export async function getDesignControlStepApprovalState(
         currentApprovals.find(
           (approval) => approval.approvalKey === slot.key
         ) ?? null,
+      assignment:
+        assignments.find((assignment) => assignment.approvalKey === slot.key) ??
+        null,
     })),
     legacyEvidence: {
       provenance: 'LEGACY_UNVERIFIED_APPROVAL_EVIDENCE',

--- a/server/src/services/designControlSchemaReadiness.ts
+++ b/server/src/services/designControlSchemaReadiness.ts
@@ -12,6 +12,7 @@ export const requiredDesignControlMigrations = [
   '0248_design_project_manufacturing_configuration.sql',
   '0251_design_project_configuration_workspace.sql',
   '0258_design_control_structured_lifecycle.sql',
+  '0275_design_control_verified_approval_assignments.sql',
 ] as const;
 
 export const requiredDesignControlTables = [
@@ -19,6 +20,7 @@ export const requiredDesignControlTables = [
   'design_control_steps',
   'design_control_step_content_versions',
   'design_control_step_approvals',
+  'design_control_step_approval_assignments',
   'design_control_requirements',
   'design_control_risks',
   'design_control_reviews',
@@ -249,7 +251,8 @@ export async function assertDesignControlSchemaReady(
       WHERE schemaname = 'public'
         AND indexname IN (
           'design_control_step_content_versions_step_version_unique',
-          'design_control_step_approvals_valid_slot_unique'
+          'design_control_step_approvals_valid_slot_unique',
+          'dc_step_approval_assignments_version_slot_uq'
         )
       UNION ALL
       SELECT tgname AS object_name
@@ -257,7 +260,8 @@ export async function assertDesignControlSchemaReady(
       WHERE NOT tgisinternal
         AND tgname IN (
           'prevent_design_control_step_version_delete',
-          'prevent_design_control_step_approval_delete'
+          'prevent_design_control_step_approval_delete',
+          'prevent_design_control_assignment_delete'
         )
     `);
     const structureRows = ((approvalStructures as any)?.rows ??
@@ -272,6 +276,8 @@ export async function assertDesignControlSchemaReady(
       'design_control_step_approvals_valid_slot_unique',
       'prevent_design_control_step_version_delete',
       'prevent_design_control_step_approval_delete',
+      'dc_step_approval_assignments_version_slot_uq',
+      'prevent_design_control_assignment_delete',
     ];
     const missingStructures = requiredStructures.filter(
       (name) => !presentStructures.has(name)


### PR DESCRIPTION
## Summary

- replace unauthenticated name-based Design Control approval routing with searchable active-employee/account assignments
- bind each assignment and decision to the exact submitted content version and evidence hash
- enforce assigned-user, account-active, role/capability, independence, and segregation-of-duties checks on the server
- preserve legacy name-only evidence as unverified and add reason-required, audited reassignment
- add migration `0275_design_control_verified_approval_assignments.sql` with immutable assignment history and uniqueness constraints

## Root cause

The existing authenticated decision ledger recorded the deciding user, but submission created no immutable named assignment. Any broadly authorized user could attempt a decision, while UI person fields still represented people primarily as display names.

## Validation

- rebased onto current `main` at `754396cb7d6d6961f4597ea8573d8a056ffd2df4`
- migration sequence verified through upstream `0274`; this change uses `0275`
- `git diff --check origin/main...HEAD` passed
- focused source-contract assertions passed
- formatting completed for touched TypeScript and TSX files
- full TypeScript check was attempted but exceeded the default heap, then timed out with a 6 GB heap
- focused Vitest startup was blocked by Windows/esbuild access through the shared dependency junction
- disposable PostgreSQL replay and browser acceptance testing remain required before rollout

## Rollout boundary

This PR does not deploy or enable production behavior and does not modify production data. Apply migration `0275`, run PostgreSQL replay and the synthetic heated-pitot browser scenario, then review feature activation separately.