### PR TITLE
Correct serialized unit PostgreSQL certification

### DIFF
--- a/server/__tests__/p2V2PostgresCertification.test.ts
+++ b/server/__tests__/p2V2PostgresCertification.test.ts
@@ -1314,7 +1314,7 @@ describe('recursive Production Launch persistence against PostgreSQL', () => {
           WHERE project_id=$1 AND link_type='P2_PRODUCTION_ORDER') p2_links,
         (SELECT count(*)::int FROM p2_production_orders WHERE project_id=$1) p2_orders,
         (SELECT count(*)::int FROM p2_serialized_items si
-          JOIN p2_purchase_orders po ON po.id=si.po_id WHERE po.project_id=$1) serialized_items,
+          JOIN projects p ON p.po_id=si.po_id WHERE p.id=$1) serialized_items,
         (SELECT count(*)::int FROM travelers WHERE project_id=$1) travelers`,
       [fixture.projectId]
     );
@@ -1389,6 +1389,7 @@ describe('recursive Production Launch persistence against PostgreSQL', () => {
       root_quantity: number;
       serialized_items: number;
       serialized_links: number;
+      wrong_project_items: number;
       non_root_links: number;
       travelers: number;
     }>(
@@ -1396,10 +1397,16 @@ describe('recursive Production Launch persistence against PostgreSQL', () => {
         (SELECT sum(shortage_quantity)::int FROM project_production_demands
           WHERE project_id=$1 AND parent_demand_id IS NULL AND path_depth=0
             AND classification='MANUFACTURED' AND disposition='MAKE') root_quantity,
-        (SELECT count(*)::int FROM p2_serialized_items si
-          JOIN p2_purchase_orders po ON po.id=si.po_id WHERE po.project_id=$1) serialized_items,
+        (SELECT count(*)::int FROM project_production_demand_serialized_units su
+          JOIN p2_serialized_items si ON si.id=su.serialized_item_id
+          WHERE su.project_id=$1) serialized_items,
         (SELECT count(*)::int FROM project_production_demand_serialized_units
           WHERE project_id=$1) serialized_links,
+        (SELECT count(*)::int FROM project_production_demand_serialized_units su
+          JOIN p2_serialized_items si ON si.id=su.serialized_item_id
+          WHERE su.project_id=$1 AND NOT EXISTS (
+            SELECT 1 FROM projects p WHERE p.id=su.project_id AND p.po_id=si.po_id
+          )) wrong_project_items,
         (SELECT count(*)::int FROM project_production_demand_serialized_units su
           JOIN project_production_demands d ON d.id=su.demand_id
           WHERE su.project_id=$1 AND (d.parent_demand_id IS NOT NULL OR d.path_depth<>0)) non_root_links,
@@ -1412,6 +1419,7 @@ describe('recursive Production Launch persistence against PostgreSQL', () => {
     expect(evidence.rows[0].serialized_links).toBe(
       evidence.rows[0].root_quantity
     );
+    expect(evidence.rows[0].wrong_project_items).toBe(0);
     expect(evidence.rows[0].non_root_links).toBe(0);
     expect(evidence.rows[0].travelers).toBe(0);
   });

--- a/server/__tests__/serializedUnitPostgresCertificationQuery.test.ts
+++ b/server/__tests__/serializedUnitPostgresCertificationQuery.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const certification = readFileSync(
+  join(process.cwd(), 'server/__tests__/p2V2PostgresCertification.test.ts'),
+  'utf8'
+);
+
+describe('serialized-unit PostgreSQL certification identity', () => {
+  it('counts project units through the immutable serialized-unit audit link', () => {
+    expect(certification).toContain(
+      'JOIN p2_serialized_items si ON si.id=su.serialized_item_id'
+    );
+    expect(certification).toContain('WHERE su.project_id=$1');
+  });
+
+  it('proves PO ownership through projects.po_id rather than PO-local project metadata', () => {
+    expect(certification).toContain('p.id=su.project_id AND p.po_id=si.po_id');
+    expect(certification).not.toContain(
+      'JOIN p2_purchase_orders po ON po.id=si.po_id WHERE po.project_id=$1'
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- correct the P2 PostgreSQL lifecycle queries that counted serialized units through nonexistent PO-local project identity
- count provisioned units through the immutable project-to-serialized-unit audit bridge
- verify each linked serialized unit belongs to the project's authoritative `projects.po_id`
- repair the earlier zero-serial assertion so it also uses the actual project-to-PO relationship
- add a static regression guard for both identity rules

## Root cause

The merged lifecycle test joined `p2_serialized_items` to `p2_purchase_orders` and filtered on `p2_purchase_orders.project_id`. The certification fixture and application model establish project ownership through `projects.po_id`, so committed serialized rows were incorrectly reported as zero.

No application persistence behavior changed.

## Validation

- 16 focused serialized-unit tests passed after rebasing onto current main
- focused ESLint passed
- formatting and `git diff --check` passed
- PostgreSQL lifecycle CI is required to confirm the corrected database assertion
