### PR TITLE
Fix P2 BOM-driven work order hierarchy

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -104,6 +104,59 @@ function BomAssemblyTreeNode({ node, isRoot = false }: { node: any; isRoot?: boo
   );
 }
 
+function ProductionHierarchyNode({ node, isRoot = false }: { node: any; isRoot?: boolean }) {
+  const workOrders = Array.isArray(node.workOrders) ? node.workOrders : [];
+  const demand = node.productionDemand ?? {};
+  const departments = Array.isArray(demand.departments) ? demand.departments : [];
+  const isPurchased = node.sourceType === 'PURCHASED_MATERIAL';
+  const typeLabel = node.sourceType === 'ASSEMBLY_WORK_ORDER'
+    ? 'Assembly work order'
+    : isPurchased
+      ? 'Purchased material'
+      : `${departments.join(' / ') || 'Manufactured'} work order`;
+
+  return (
+    <div className={isRoot ? '' : 'ml-4 border-l pl-4'}>
+      <div className="rounded-md border bg-background p-3">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="font-mono text-sm font-semibold">{node.partNumber}</p>
+            <p className="truncate text-xs text-muted-foreground">{node.partName || 'No part description'}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant={isPurchased ? 'secondary' : 'default'}>{typeLabel}</Badge>
+            <Badge variant="outline">Required {Number(node.requiredQuantity ?? 0).toLocaleString()}</Badge>
+          </div>
+        </div>
+        {isPurchased ? (
+          <p className="mt-2 text-xs text-muted-foreground">Purchase demand only - no production work order.</p>
+        ) : workOrders.length > 0 ? (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {workOrders.map((wo: any) => (
+              <Badge key={wo.id ?? wo.workOrderNumber ?? wo.work_order_number} variant="outline">
+                {wo.workOrderNumber ?? wo.work_order_number} - Qty {Number(wo.quantity ?? 0).toLocaleString()}
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-2 text-xs font-medium text-amber-700">Required work order has not been provisioned.</p>
+        )}
+        {!isPurchased && Number(demand.recordCount ?? 0) > 0 && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Production demand: {Number(demand.totalQuantity ?? 0).toLocaleString()}
+            {demand.legacyUnitRows ? ` (${Number(demand.recordCount).toLocaleString()} historical unit rows collapsed for display)` : ''}
+          </p>
+        )}
+      </div>
+      {Array.isArray(node.children) && node.children.length > 0 && (
+        <div className="mt-2 space-y-2">
+          {node.children.map((child: any) => <ProductionHierarchyNode key={child.key} node={child} />)}
+        </div>
+      )}
+    </div>
+  );
+}
+
 const ROM_CATEGORY_CONFIG = [
   { key: 'labor', label: 'Labor', field: 'quotedHours', kind: 'hours', detail: 'Direct labor estimate from ROM/quote feedback' },
   { key: 'material', label: 'Material', field: 'budgetAmount', kind: 'currency', detail: 'Material budget that will seed the WAD' },
@@ -3819,7 +3872,6 @@ export default function ProjectDetailPage() {
                 ) : (
                   productionLinePlacements.map((line: any) => {
                     const lineWorkOrders = Array.isArray(line.workOrders) ? line.workOrders : [];
-                    const lineProductionOrders = Array.isArray(line.productionOrders) ? line.productionOrders : [];
                     const lineSerializedItems = Array.isArray(line.serializedItems) ? line.serializedItems : [];
                     const inProductionQuantity = Math.max(0, Number(line.serializedQuantity ?? 0) - Number(line.completedQuantity ?? 0));
 
@@ -3861,7 +3913,7 @@ export default function ProjectDetailPage() {
                           )}
                         </div>
 
-                        <div className="mt-4 grid gap-3 xl:grid-cols-3">
+                        <div className="mt-4 grid gap-3 xl:grid-cols-2">
                           <div className="rounded-md border bg-muted/20 p-3">
                             <div className="mb-2 flex items-center justify-between gap-2">
                               <p className="text-sm font-medium">Serialized / Traveler Status</p>
@@ -3913,29 +3965,18 @@ export default function ProjectDetailPage() {
                             )}
                           </div>
 
-                          <div className="rounded-md border bg-muted/20 p-3">
-                            <div className="mb-2 flex items-center justify-between gap-2">
-                              <p className="text-sm font-medium">Production Orders</p>
-                              <Badge variant="secondary">{formatQuantityLabel(lineProductionOrders.length)}</Badge>
-                            </div>
-                            {lineProductionOrders.length === 0 ? (
-                              <p className="text-sm text-muted-foreground">No generated production-order rows are linked to this PO line.</p>
-                            ) : (
-                              <div className="space-y-2">
-                                {lineProductionOrders.slice(0, 5).map((order: any) => (
-                                  <div key={order.id} className="rounded-md border bg-background p-2">
-                                    <div className="flex items-center justify-between gap-2">
-                                      <p className="truncate font-medium">{order.order_id}</p>
-                                      <Badge variant="outline">{order.status ?? 'Unknown'}</Badge>
-                                    </div>
-                                    <p className="text-xs text-muted-foreground">
-                                      Qty {formatQuantityLabel(order.quantity)} - Made {formatQuantityLabel(order.quantity_manufactured)}
-                                    </p>
-                                  </div>
-                                ))}
-                              </div>
-                            )}
+                        </div>
+
+                        <div className="mt-3 rounded-md border bg-muted/20 p-3">
+                          <div className="mb-2 flex items-center justify-between gap-2">
+                            <p className="text-sm font-medium">Manufacturing Structure</p>
+                            <Badge variant="secondary">BOM driven</Badge>
                           </div>
+                          {line.manufacturingHierarchy ? (
+                            <ProductionHierarchyNode node={line.manufacturingHierarchy} isRoot />
+                          ) : (
+                            <p className="text-sm text-muted-foreground">No released BOM hierarchy is linked to this PO line.</p>
+                          )}
                         </div>
                       </div>
                     );

--- a/server/__tests__/projectProductionHierarchy.test.ts
+++ b/server/__tests__/projectProductionHierarchy.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { ProjectBomAssemblyNode } from '../src/services/projectBomAssembly';
+import { buildProjectProductionHierarchy } from '../src/services/projectProductionHierarchy';
+
+const node = (
+  key: string,
+  partNumber: string,
+  isManufactured: boolean,
+  children: ProjectBomAssemblyNode[] = []
+): ProjectBomAssemblyNode => ({
+  key,
+  partNumber,
+  partName: partNumber,
+  quantityPerParent: 1,
+  operationSequence: null,
+  depth: key.split('/').length - 1,
+  isManufactured,
+  hasBom: children.length > 0,
+  bomId: children.length > 0 ? `${partNumber}-bom` : null,
+  bomCode: null,
+  revisionId: null,
+  revisionCode: null,
+  children,
+});
+
+describe('buildProjectProductionHierarchy', () => {
+  it('separates the assembly, manufactured children, and purchased material', () => {
+    const root = node('pitot', 'HEATED-PITOT', true, [
+      node('pitot/body', 'PITOT-BODY', true),
+      node('pitot/manifold', 'MANIFOLD', true),
+      node('pitot/heater', 'HEATER-CARTRIDGE', false),
+    ]);
+    const productionOrders = [
+      ...Array.from({ length: 150 }, (_, index) => ({
+        id: `body-${index}`,
+        sku: 'PITOT-BODY',
+        quantity: 1,
+        quantity_manufactured: 0,
+        department: 'CNC',
+      })),
+      ...Array.from({ length: 150 }, (_, index) => ({
+        id: `manifold-${index}`,
+        sku: 'MANIFOLD',
+        quantity: 1,
+        quantity_manufactured: 0,
+        department: 'CNC',
+      })),
+    ];
+
+    const result = buildProjectProductionHierarchy({
+      root,
+      orderedQuantity: 150,
+      workOrders: [{ id: 1, partNumber: 'HEATED-PITOT', quantity: 150 }],
+      productionOrders,
+    });
+
+    expect(result?.sourceType).toBe('ASSEMBLY_WORK_ORDER');
+    expect(result?.requiredQuantity).toBe(150);
+    expect(result?.workOrders).toHaveLength(1);
+    expect(result?.children).toMatchObject([
+      {
+        partNumber: 'PITOT-BODY',
+        sourceType: 'MANUFACTURED_WORK_ORDER',
+        requiredQuantity: 150,
+        productionDemand: {
+          recordCount: 150,
+          totalQuantity: 150,
+          legacyUnitRows: true,
+          departments: ['CNC'],
+        },
+      },
+      {
+        partNumber: 'MANIFOLD',
+        sourceType: 'MANUFACTURED_WORK_ORDER',
+        requiredQuantity: 150,
+        productionDemand: {
+          recordCount: 150,
+          totalQuantity: 150,
+          legacyUnitRows: true,
+          departments: ['CNC'],
+        },
+      },
+      {
+        partNumber: 'HEATER-CARTRIDGE',
+        sourceType: 'PURCHASED_MATERIAL',
+        requiredQuantity: 150,
+        productionDemand: { recordCount: 0 },
+      },
+    ]);
+  });
+
+  it('multiplies nested BOM quantities without inventing work orders', () => {
+    const child = node('assembly/child', 'CHILD', true);
+    child.quantityPerParent = 2;
+    const result = buildProjectProductionHierarchy({
+      root: node('assembly', 'ASSEMBLY', true, [child]),
+      orderedQuantity: 10,
+      workOrders: [],
+      productionOrders: [],
+    });
+
+    expect(result?.children[0].requiredQuantity).toBe(20);
+    expect(result?.children[0].workOrders).toEqual([]);
+  });
+});

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -36,6 +36,7 @@ import {
   buildProjectBomAssemblyTree,
   type ProjectBomAssemblyRow,
 } from '../services/projectBomAssembly';
+import { buildProjectProductionHierarchy } from '../services/projectProductionHierarchy';
 import {
   getActiveWorkflowInstanceForProject,
   getWorkflowReadModel,
@@ -4130,6 +4131,20 @@ router.get('/:id/p2-hub', async (req, res) => {
         placementCounts,
         productionOrders: lineProductionOrders,
         workOrders: lineWorkOrders,
+        manufacturingHierarchy: buildProjectProductionHierarchy({
+          root:
+            assemblyTree.find(
+              (root) =>
+                normalizeProductionKey(root.partNumber) ===
+                normalizeProductionKey(
+                  poInventoryPartById.get(Number(item.inventory_item_id)) ??
+                    item.part_number
+                )
+            ) ?? null,
+          orderedQuantity,
+          workOrders,
+          productionOrders: lineProductionOrders,
+        }),
         serializedItems: lineSerializedItems.map(
           (serializedItem: LegacyProjectValue) => ({
             ...serializedItem,

--- a/server/src/services/projectProductionHierarchy.ts
+++ b/server/src/services/projectProductionHierarchy.ts
@@ -1,0 +1,113 @@
+import type { ProjectBomAssemblyNode } from './projectBomAssembly';
+
+type ProductionRecord = Record<string, unknown>;
+
+export type ProjectProductionHierarchyNode = {
+  key: string;
+  partNumber: string;
+  partName: string | null;
+  sourceType:
+    | 'ASSEMBLY_WORK_ORDER'
+    | 'MANUFACTURED_WORK_ORDER'
+    | 'PURCHASED_MATERIAL';
+  quantityPerParent: number;
+  requiredQuantity: number;
+  workOrders: ProductionRecord[];
+  productionDemand: {
+    recordCount: number;
+    totalQuantity: number;
+    quantityManufactured: number;
+    legacyUnitRows: boolean;
+    departments: string[];
+  };
+  children: ProjectProductionHierarchyNode[];
+};
+
+const normalized = (value: unknown) =>
+  String(value ?? '')
+    .trim()
+    .toLowerCase();
+const finiteQuantity = (value: unknown) => {
+  const quantity = Number(value ?? 0);
+  return Number.isFinite(quantity) ? quantity : 0;
+};
+
+export function buildProjectProductionHierarchy(input: {
+  root: ProjectBomAssemblyNode | null;
+  orderedQuantity: number;
+  workOrders: ProductionRecord[];
+  productionOrders: ProductionRecord[];
+}): ProjectProductionHierarchyNode | null {
+  if (!input.root) return null;
+  const workOrdersByPart = new Map<string, ProductionRecord[]>();
+  input.workOrders.forEach((record) => {
+    const key = normalized(record.partNumber ?? record.part_number);
+    if (!key) return;
+    workOrdersByPart.set(key, [...(workOrdersByPart.get(key) ?? []), record]);
+  });
+  const productionOrdersByPart = new Map<string, ProductionRecord[]>();
+  input.productionOrders.forEach((record) => {
+    const key = normalized(record.sku ?? record.part_number);
+    if (!key) return;
+    productionOrdersByPart.set(key, [
+      ...(productionOrdersByPart.get(key) ?? []),
+      record,
+    ]);
+  });
+
+  const visit = (
+    node: ProjectBomAssemblyNode,
+    parentRequiredQuantity: number,
+    root = false
+  ): ProjectProductionHierarchyNode => {
+    const requiredQuantity = root
+      ? Math.max(0, input.orderedQuantity)
+      : parentRequiredQuantity * Math.max(0, node.quantityPerParent);
+    const key = normalized(node.partNumber);
+    const demandRows = productionOrdersByPart.get(key) ?? [];
+    const totalQuantity = demandRows.reduce(
+      (total, record) => total + finiteQuantity(record.quantity),
+      0
+    );
+    const quantityManufactured = demandRows.reduce(
+      (total, record) =>
+        total +
+        finiteQuantity(
+          record.quantityManufactured ?? record.quantity_manufactured
+        ),
+      0
+    );
+    const departments = Array.from(
+      new Set(
+        demandRows
+          .map((record) => String(record.department ?? '').trim())
+          .filter(Boolean)
+      )
+    );
+    return {
+      key: node.key,
+      partNumber: node.partNumber,
+      partName: node.partName,
+      sourceType: root
+        ? 'ASSEMBLY_WORK_ORDER'
+        : node.isManufactured
+          ? 'MANUFACTURED_WORK_ORDER'
+          : 'PURCHASED_MATERIAL',
+      quantityPerParent: root ? 1 : node.quantityPerParent,
+      requiredQuantity,
+      workOrders: workOrdersByPart.get(key) ?? [],
+      productionDemand: {
+        recordCount: demandRows.length,
+        totalQuantity,
+        quantityManufactured,
+        legacyUnitRows:
+          demandRows.length > 1 &&
+          demandRows.every((record) => finiteQuantity(record.quantity) === 1),
+        departments,
+      },
+      children: node.children.map((child) => visit(child, requiredQuantity)),
+    };
+  };
+
+  return visit(input.root, input.orderedQuantity, true);
+}


### PR DESCRIPTION
## What changed

- replaces the raw per-unit production-order list with a BOM-driven manufacturing hierarchy
- represents the heated pitot as the parent assembly work order
- separates manufactured component work-order requirements from purchased-material demand
- collapses historical quantity-one production rows into auditable demand totals
- surfaces manufactured requirements whose work orders have not yet been provisioned

## Root cause

The project P2 read model attached every `p2_production_orders` row to the customer PO line, and the UI rendered those rows individually. For two manufactured components at quantity 150, this appeared as 300 separate production orders and obscured the actual parent/child manufacturing structure.

## Impact

The production view now follows the released BOM: the parent assembly, manufactured child requirements, and purchased components are distinct. Existing historical records are preserved; this PR changes their read-model presentation and does not delete or rewrite production data.

## Validation

- focused hierarchy assertions passed for assembly quantity 150, two CNC children, and one purchased heater cartridge
- `git diff --check` passed
- full Vitest was blocked by the isolated worktree dependency-junction environment
- full TypeScript checking exceeded the available 2 GB Node heap