### PR TITLE
Provision P2 component work orders

### DIFF
--- a/migrations/0276_p2_work_order_provisioning.sql
+++ b/migrations/0276_p2_work_order_provisioning.sql
@@ -1,0 +1,20 @@
+ALTER TABLE project_production_demand_execution_links
+  DROP CONSTRAINT IF EXISTS project_production_demand_execution_links_link_type_check;
+
+ALTER TABLE project_production_demand_execution_links
+  ADD CONSTRAINT project_production_demand_execution_links_link_type_check
+  CHECK (link_type IN (
+    'P2_PRODUCTION_ORDER','WAD','WORK_ORDER','TRAVELER','CNC_JOB',
+    'MANUFACTURING_QUEUE','CUTTING_DEMAND'
+  ));
+
+ALTER TABLE project_production_launch_events
+  DROP CONSTRAINT IF EXISTS project_production_launch_events_event_type_check;
+
+ALTER TABLE project_production_launch_events
+  ADD CONSTRAINT project_production_launch_events_event_type_check
+  CHECK (event_type IN (
+    'RECURSIVE_DEMAND_GRAPH_PERSISTED','EXECUTION_AUTHORIZED',
+    'P2_PRODUCTION_ORDERS_PROVISIONED','P2_SERIALIZED_UNITS_PROVISIONED',
+    'P2_DRAFT_TRAVELERS_PROVISIONED','P2_WORK_ORDERS_PROVISIONED'
+  ));

--- a/server/__tests__/workOrderProvisioningFeatureGate.test.ts
+++ b/server/__tests__/workOrderProvisioningFeatureGate.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isP2V2WorkOrderProvisioningEnabled } from '../src/lib/featureFlags';
+
+describe('P2 V2 work-order provisioning feature gate', () => {
+  afterEach(() => delete process.env.P2_V2_WORK_ORDER_PROVISIONING_ENABLED);
+
+  it.each([undefined, '', 'false', 'TRUE', '1', ' true '])(
+    'fails closed for %s',
+    (value) => {
+      if (value === undefined)
+        delete process.env.P2_V2_WORK_ORDER_PROVISIONING_ENABLED;
+      else process.env.P2_V2_WORK_ORDER_PROVISIONING_ENABLED = value;
+      expect(isP2V2WorkOrderProvisioningEnabled()).toBe(false);
+    }
+  );
+
+  it('enables only exact lowercase true', () => {
+    process.env.P2_V2_WORK_ORDER_PROVISIONING_ENABLED = 'true';
+    expect(isP2V2WorkOrderProvisioningEnabled()).toBe(true);
+  });
+});

--- a/server/__tests__/workOrderProvisioningFoundation.test.ts
+++ b/server/__tests__/workOrderProvisioningFoundation.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+const service = read('server/src/services/workOrderProvisioningService.ts');
+const route = read('server/src/routes/projectProductionPlanning.ts');
+const migration = read('migrations/0276_p2_work_order_provisioning.sql');
+const runner = read('server/scripts/migrations/runSafeBootMigrations.ts');
+
+describe('P2 work-order provisioning boundary', () => {
+  it('is independently disabled and capability protected', () => {
+    expect(service).toContain('isP2V2WorkOrderProvisioningEnabled()');
+    expect(route).toContain("'/launch/:launchId/provision-work-orders'");
+    expect(route).toContain("'projects.production_launch.launch'");
+  });
+
+  it('uses the released WAD as the exact single root assembly work order', () => {
+    expect(service).toContain('SINGLE_ROOT_ASSEMBLY_REQUIRED');
+    expect(service).toContain('ROOT_WAD_MISMATCH');
+    expect(service).toContain('demand.id !== root.id');
+    expect(service).toContain("'WORK_ORDER'");
+  });
+
+  it('creates draft child work orders only for authorized MAKE shortages', () => {
+    expect(service).toContain("d.disposition='MAKE'");
+    expect(service).toContain("demand.demand_status !== 'IN_PROCESS'");
+    expect(service).toContain('INSERT INTO production_work_orders');
+    expect(service).toContain("'PLANNED','DRAFT'");
+    expect(service).not.toContain('INSERT INTO travelers');
+    expect(service).not.toContain('INSERT INTO cnc_jobs');
+    expect(service).not.toContain('INSERT INTO manufacturing_queue');
+    expect(service).not.toContain('INSERT INTO cutting_packet_schedule');
+  });
+
+  it('is transactional, idempotent, and preserves audit evidence', () => {
+    expect(service).toContain('db.transaction');
+    expect(service).toContain('pg_advisory_xact_lock');
+    expect(service).toContain("event_type='P2_WORK_ORDERS_PROVISIONED'");
+    expect(service).toContain('WORK_ORDER_PROVISIONING_IDEMPOTENCY_CONFLICT');
+    expect(service).toContain('EXISTING_WORK_ORDERS_REQUIRE_RECONCILIATION');
+    expect(service).toContain('releasesFloorWork: false');
+  });
+
+  it('registers the additive migration in both safe-boot lists', () => {
+    expect(migration).toContain("'WORK_ORDER'");
+    expect(migration).toContain("'P2_WORK_ORDERS_PROVISIONED'");
+    expect(runner.match(/0276_p2_work_order_provisioning\.sql/g)).toHaveLength(
+      2
+    );
+  });
+});

--- a/server/__tests__/workOrderProvisioningService.test.ts
+++ b/server/__tests__/workOrderProvisioningService.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  enabled: vi.fn(() => true),
+  transaction: vi.fn(),
+}));
+vi.mock('../db', () => ({ db: { transaction: mocks.transaction } }));
+vi.mock('../src/lib/featureFlags', () => ({
+  isP2V2WorkOrderProvisioningEnabled: mocks.enabled,
+}));
+
+import { provisionP2WorkOrders } from '../src/services/workOrderProvisioningService';
+
+describe('P2 work-order provisioning service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.enabled.mockReturnValue(true);
+  });
+
+  it('performs no transaction while disabled', async () => {
+    mocks.enabled.mockReturnValue(false);
+    await expect(
+      provisionP2WorkOrders(
+        'project-1',
+        'launch-1',
+        {
+          idempotencyKey: 'synthetic-key',
+          expectedLaunchDigest: 'a'.repeat(64),
+          signatureMeaning: 'Provision work orders.',
+        },
+        {
+          userId: 1,
+          employeeId: 2,
+          username: 'operator',
+          displayName: 'Synthetic Operator',
+          role: 'OPERATIONS',
+        }
+      )
+    ).rejects.toMatchObject({ code: 'P2_V2_WORK_ORDER_PROVISIONING_DISABLED' });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it('reuses the exact root WAD and creates one draft manufactured child work order', async () => {
+    const launchDigest = 'a'.repeat(64);
+    const shared = {
+      demand_status: 'IN_PROCESS',
+      wad_link_id: 'wad-link',
+      p2_order_link_id: 'p2-link',
+      routing_id: 'routing-1',
+      routing_first_department: 'CNC',
+      first_department_snapshot: 'CNC',
+      shortage_quantity: '150',
+    };
+    const responses: unknown[] = [
+      [],
+      [
+        {
+          id: 'launch-1',
+          status: 'COMPLETE',
+          preview_digest: launchDigest,
+          wad_status: 'RELEASED',
+          wad_work_order_id: 'wad-1',
+          work_order_number: 'WAD-1',
+          wad_part_number: 'HEATED-PITOT',
+          wad_quantity: 150,
+          work_order_wad_status: 'APPROVED',
+        },
+      ],
+      [],
+      [
+        {
+          ...shared,
+          id: 'root-demand',
+          parent_demand_id: null,
+          part_number: 'HEATED-PITOT',
+          assembly_path: 'root',
+        },
+        {
+          ...shared,
+          id: 'body-demand',
+          parent_demand_id: 'root-demand',
+          part_number: 'PITOT-BODY',
+          assembly_path: 'root/body',
+        },
+      ],
+      [],
+      [],
+      [{ id: 'body-work-order' }],
+      [],
+      [],
+    ];
+    const execute = vi.fn(async () => responses.shift() ?? []);
+    mocks.transaction.mockImplementation(async (callback) =>
+      callback({ execute })
+    );
+
+    await expect(
+      provisionP2WorkOrders(
+        'project-1',
+        'launch-1',
+        {
+          idempotencyKey: 'synthetic-key',
+          expectedLaunchDigest: launchDigest,
+          signatureMeaning: 'Provision controlled work orders.',
+        },
+        {
+          userId: 1,
+          employeeId: 2,
+          username: 'operator',
+          displayName: 'Synthetic Operator',
+          role: 'OPERATIONS',
+        }
+      )
+    ).resolves.toMatchObject({
+      replayed: false,
+      workOrderIds: ['wad-1', 'body-work-order'],
+    });
+
+    expect(execute).toHaveBeenCalledTimes(9);
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -336,6 +336,7 @@ export const safeMigrationFiles = [
   '0273_p2_serialized_unit_provisioning.sql',
   '0274_p2_traveler_provisioning.sql',
   '0275_design_control_verified_approval_assignments.sql',
+  '0276_p2_work_order_provisioning.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -417,6 +418,7 @@ export const criticalMigrationFiles = new Set([
   '0273_p2_serialized_unit_provisioning.sql',
   '0274_p2_traveler_provisioning.sql',
   '0275_design_control_verified_approval_assignments.sql',
+  '0276_p2_work_order_provisioning.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -83,6 +83,11 @@ export function isP2V2TravelerProvisioningEnabled(): boolean {
   return process.env.P2_V2_TRAVELER_PROVISIONING_ENABLED === 'true';
 }
 
+/** Gates canonical assembly/component work-order links from authorized MAKE demand. */
+export function isP2V2WorkOrderProvisioningEnabled(): boolean {
+  return process.env.P2_V2_WORK_ORDER_PROVISIONING_ENABLED === 'true';
+}
+
 /**
  * Cutover date for the punch_ledger migration.
  * For pay periods starting ON or AFTER this date, hour computations read

--- a/server/src/routes/projectProductionPlanning.ts
+++ b/server/src/routes/projectProductionPlanning.ts
@@ -33,6 +33,10 @@ import {
   provisionP2DraftTravelers,
   TravelerProvisioningError,
 } from '../services/travelerProvisioningService';
+import {
+  provisionP2WorkOrders,
+  WorkOrderProvisioningError,
+} from '../services/workOrderProvisioningService';
 
 const router = Router({ mergeParams: true });
 const headerSchema = z.object({
@@ -66,6 +70,7 @@ const executionAuthorizationSchema = z
 const productionOrderProvisioningSchema = executionAuthorizationSchema;
 const serializedUnitProvisioningSchema = executionAuthorizationSchema;
 const travelerProvisioningSchema = executionAuthorizationSchema;
+const workOrderProvisioningSchema = executionAuthorizationSchema;
 const itemSchema = z
   .object({
     drawing_number: z.string().nullable().optional(),
@@ -190,6 +195,10 @@ function fail(res: Response, error: unknown) {
     return res
       .status(error.status)
       .json({ error: error.code, message: error.message, ...error.details });
+  if (error instanceof WorkOrderProvisioningError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
   console.error('P2 V2 Production Planning error:', error);
   return res.status(500).json({
     error: 'PRODUCTION_PLANNING_FAILED',
@@ -293,6 +302,23 @@ router.post('/launch/:launchId/provision-draft-travelers', async (req, res) => {
       projectId(req),
       req.params.launchId,
       travelerProvisioningSchema.parse(req.body),
+      user
+    );
+    res.status(result.replayed ? 200 : 201).json(result);
+  } catch (error) {
+    fail(res, error);
+  }
+});
+router.post('/launch/:launchId/provision-work-orders', async (req, res) => {
+  try {
+    const user = await requireCapability(
+      req,
+      'projects.production_launch.launch'
+    );
+    const result = await provisionP2WorkOrders(
+      projectId(req),
+      req.params.launchId,
+      workOrderProvisioningSchema.parse(req.body),
       user
     );
     res.status(result.replayed ? 200 : 201).json(result);

--- a/server/src/services/workOrderProvisioningService.ts
+++ b/server/src/services/workOrderProvisioningService.ts
@@ -1,0 +1,230 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db } from '../../db';
+import { isP2V2WorkOrderProvisioningEnabled } from '../lib/featureFlags';
+import type { PlanningActor } from './projectProductionPlanningService';
+
+type Row = Record<string, unknown>;
+const rows = (value: unknown): Row[] =>
+  Array.isArray(value)
+    ? (value as Row[])
+    : ((value as { rows?: Row[] } | null)?.rows ?? []);
+const digest = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+export type WorkOrderProvisioningInput = {
+  idempotencyKey: string;
+  expectedLaunchDigest: string;
+  signatureMeaning: string;
+};
+
+export class WorkOrderProvisioningError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 409,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+
+export async function provisionP2WorkOrders(
+  projectId: string,
+  launchId: string,
+  input: WorkOrderProvisioningInput,
+  actor: PlanningActor
+) {
+  if (!isP2V2WorkOrderProvisioningEnabled())
+    throw new WorkOrderProvisioningError(
+      'P2_V2_WORK_ORDER_PROVISIONING_DISABLED',
+      'P2 work-order provisioning is disabled.',
+      503
+    );
+  const requestHash = digest({
+    projectId,
+    launchId,
+    idempotencyKey: input.idempotencyKey.trim(),
+    expectedLaunchDigest: input.expectedLaunchDigest,
+  });
+
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${projectId}:p2-work-order-provisioning`},0))`
+    );
+    const launch = rows(
+      await tx.execute(sql`
+      SELECT pl.id,pl.status,pl.preview_digest,wa.status AS wad_status,
+        wa.wad_work_order_id,pwo.work_order_number,pwo.part_number AS wad_part_number,
+        pwo.quantity AS wad_quantity,pwo.wad_status AS work_order_wad_status
+      FROM project_production_launches pl
+      JOIN projects p ON p.id=pl.project_id AND p.workflow_version='p2_v2'
+      JOIN project_wad_authorizations wa ON wa.id=pl.wad_authorization_id
+      JOIN production_work_orders pwo ON pwo.id=wa.wad_work_order_id
+      WHERE pl.id=${launchId} AND pl.project_id=${projectId}
+      FOR UPDATE OF pl,p,wa,pwo`)
+    )[0];
+    if (!launch)
+      throw new WorkOrderProvisioningError(
+        'PRODUCTION_LAUNCH_NOT_FOUND',
+        'The completed Production Launch was not found.',
+        404
+      );
+    if (
+      launch.status !== 'COMPLETE' ||
+      launch.wad_status !== 'RELEASED' ||
+      launch.work_order_wad_status !== 'APPROVED'
+    )
+      throw new WorkOrderProvisioningError(
+        'EXECUTION_AUTHORITY_NOT_RELEASED',
+        'The launch and exact WAD authority must remain complete and released.'
+      );
+    if (String(launch.preview_digest) !== input.expectedLaunchDigest)
+      throw new WorkOrderProvisioningError(
+        'STALE_PRODUCTION_LAUNCH',
+        'The expected Production Launch digest is stale.'
+      );
+
+    const priorEvent = rows(
+      await tx.execute(sql`
+      SELECT * FROM project_production_launch_events
+      WHERE production_launch_id=${launchId} AND event_type='P2_WORK_ORDERS_PROVISIONED' LIMIT 1`)
+    )[0];
+    if (priorEvent) {
+      if (String(priorEvent.request_hash) !== requestHash)
+        throw new WorkOrderProvisioningError(
+          'WORK_ORDER_PROVISIONING_IDEMPOTENCY_CONFLICT',
+          'Work orders were already provisioned with different evidence.'
+        );
+      return { replayed: true, event: priorEvent };
+    }
+
+    const demands = rows(
+      await tx.execute(sql`
+      SELECT d.*,wl.id AS wad_link_id,pol.id AS p2_order_link_id,
+        ro.department_name AS routing_first_department
+      FROM project_production_demands d
+      LEFT JOIN project_production_demand_execution_links wl
+        ON wl.demand_id=d.id AND wl.link_type='WAD'
+        AND wl.production_work_order_id=${String(launch.wad_work_order_id)}
+      LEFT JOIN project_production_demand_execution_links pol
+        ON pol.demand_id=d.id AND pol.link_type='P2_PRODUCTION_ORDER'
+      LEFT JOIN LATERAL (
+        SELECT department_name FROM routing_operations
+        WHERE part_routing_id=d.routing_id ORDER BY step_number,id LIMIT 1
+      ) ro ON true
+      WHERE d.project_id=${projectId} AND d.production_launch_id=${launchId}
+        AND d.disposition='MAKE' AND d.shortage_quantity>0
+      ORDER BY d.path_depth,d.assembly_path FOR UPDATE OF d`)
+    );
+    if (!demands.length)
+      throw new WorkOrderProvisioningError(
+        'AUTHORIZED_MAKE_DEMAND_REQUIRED',
+        'No shortage-backed MAKE demand is available for work-order provisioning.'
+      );
+    const roots = demands.filter((demand) => !demand.parent_demand_id);
+    if (roots.length !== 1)
+      throw new WorkOrderProvisioningError(
+        'SINGLE_ROOT_ASSEMBLY_REQUIRED',
+        'The current WAD authority must resolve to exactly one root assembly.',
+        409,
+        { rootPaths: roots.map((demand) => demand.assembly_path) }
+      );
+    const invalid = demands.filter(
+      (demand) =>
+        demand.demand_status !== 'IN_PROCESS' ||
+        !demand.wad_link_id ||
+        !demand.p2_order_link_id ||
+        !demand.routing_id ||
+        !demand.routing_first_department ||
+        String(demand.routing_first_department).trim() !==
+          String(demand.first_department_snapshot ?? '').trim() ||
+        !Number.isSafeInteger(Number(demand.shortage_quantity)) ||
+        Number(demand.shortage_quantity) <= 0
+    );
+    if (invalid.length)
+      throw new WorkOrderProvisioningError(
+        'WORK_ORDER_DEMAND_NOT_PROVISIONABLE',
+        'Every MAKE demand must retain authorized P2 demand, released WAD, and frozen routing evidence.',
+        409,
+        { paths: invalid.map((demand) => demand.assembly_path) }
+      );
+    const root = roots[0];
+    if (
+      String(root.part_number).trim().toLowerCase() !==
+        String(launch.wad_part_number).trim().toLowerCase() ||
+      Number(root.shortage_quantity) !== Number(launch.wad_quantity)
+    )
+      throw new WorkOrderProvisioningError(
+        'ROOT_WAD_MISMATCH',
+        'The released WAD does not exactly represent the root assembly part and quantity.'
+      );
+
+    const existing = rows(
+      await tx.execute(sql`
+      SELECT l.demand_id FROM project_production_demand_execution_links l
+      JOIN project_production_demands d ON d.id=l.demand_id
+      WHERE d.production_launch_id=${launchId} AND l.link_type='WORK_ORDER'`)
+    );
+    if (existing.length)
+      throw new WorkOrderProvisioningError(
+        'EXISTING_WORK_ORDERS_REQUIRE_RECONCILIATION',
+        'Work-order links already exist and require explicit reconciliation.'
+      );
+
+    const workOrderIds: string[] = [];
+    const linkIds: string[] = [];
+    for (const demand of demands) {
+      let workOrderId = String(launch.wad_work_order_id);
+      if (demand.id !== root.id) {
+        const workOrderNumber = `P2WO-${String(demand.id)}`;
+        const created = rows(
+          await tx.execute(sql`
+          INSERT INTO production_work_orders
+            (work_order_number,project_id,part_number,description,quantity,status,
+             wad_status,due_date,assigned_department,wizard_data)
+          VALUES (${workOrderNumber},${projectId},${String(demand.part_number)},
+            ${String(demand.description ?? demand.part_number)},${Number(demand.shortage_quantity)},
+            'PLANNED','DRAFT',${demand.required_by_date ?? null},
+            ${String(demand.routing_first_department).trim()},
+            ${JSON.stringify({ source: 'P2_V2_PRODUCTION_DEMAND', launchId, demandId: demand.id, parentDemandId: demand.parent_demand_id, routingId: demand.routing_id, assemblyPath: demand.assembly_path })}::jsonb)
+          RETURNING id`)
+        )[0];
+        workOrderId = String(created.id);
+      }
+      workOrderIds.push(workOrderId);
+      const linkId = randomUUID();
+      linkIds.push(linkId);
+      await tx.execute(sql`
+        INSERT INTO project_production_demand_execution_links
+          (id,project_id,demand_id,production_work_order_id,link_type)
+        VALUES (${linkId},${projectId},${String(demand.id)},${workOrderId},'WORK_ORDER')`);
+    }
+
+    const eventId = randomUUID();
+    const evidence = {
+      launchId,
+      rootDemandId: root.id,
+      rootWorkOrderId: launch.wad_work_order_id,
+      demandIds: demands.map((demand) => demand.id),
+      workOrderIds,
+      createsTravelers: false,
+      releasesFloorWork: false,
+    };
+    await tx.execute(sql`
+      INSERT INTO project_production_launch_events
+        (id,project_id,production_launch_id,event_type,request_hash,evidence_digest,
+         created_record_ids,evidence_snapshot,actor_user_id,actor_display_name,actor_role,signature_meaning)
+      VALUES (${eventId},${projectId},${launchId},'P2_WORK_ORDERS_PROVISIONED',${requestHash},
+        ${digest(evidence)},${JSON.stringify({ workOrderIds, linkIds })}::jsonb,
+        ${JSON.stringify(evidence)}::jsonb,${actor.userId},${actor.displayName},${actor.role},${input.signatureMeaning.trim()})`);
+    return {
+      replayed: false,
+      eventId,
+      workOrderIds,
+      provisionedDemandIds: evidence.demandIds,
+    };
+  });
+}


### PR DESCRIPTION
## What changed

- adds disabled-by-default canonical work-order provisioning for authorized recursive P2 `MAKE` demand
- treats the exact released WAD as the single top-level assembly work order
- creates one `PLANNED` / `DRAFT` work order for each manufactured child shortage
- links root and child work orders to their authoritative production-demand nodes
- records immutable provisioning evidence and supports exact idempotent replay
- adds migration and safe-boot registration for `WORK_ORDER` execution links and the provisioning audit event

## Why

P2 Production Launch already persists recursive demand and provisions P2 demand rows, serialized root units, and draft travelers. It did not create canonical `production_work_orders` for manufactured BOM children, leaving the assembly view disconnected from the work-order spine used by manufacturing.

## Safety boundaries

- independently fail-closed behind `P2_V2_WORK_ORDER_PROVISIONING_ENABLED`
- requires a complete launch, released/approved WAD, authorized P2 demand link, whole-unit shortage, and exact frozen routing department
- fails closed if the WAD does not exactly match the single root assembly part and quantity
- purchased demand receives no production work order
- child work orders remain `PLANNED` / `DRAFT`
- creates no travelers, CNC jobs, manufacturing queues, cutting demand, purchasing records, or floor authorization
- does not rewrite historical records

## Validation

- 14/14 focused Vitest tests passed
- focused ESLint passed
- `git diff --check` passed
- PostgreSQL migration replay remains pending CI or a disposable PostgreSQL runtime