### PR TITLE
Isolate production launch route certification

### DIFF
--- a/server/__tests__/productionLaunchPreviewRoute.test.ts
+++ b/server/__tests__/productionLaunchPreviewRoute.test.ts
@@ -43,6 +43,22 @@ vi.mock('../src/services/productionLaunchPreviewService', () => ({
 vi.mock('../src/services/productionLaunchPersistenceService', () => ({
   persistProductionLaunch: mocks.persistProductionLaunch,
 }));
+vi.mock('../src/services/productionExecutionAuthorizationService', () => ({
+  authorizeProductionExecution: vi.fn(),
+  ProductionExecutionAuthorizationError: class extends Error {},
+}));
+vi.mock('../src/services/productionOrderProvisioningService', () => ({
+  provisionP2ProductionOrders: vi.fn(),
+  ProductionOrderProvisioningError: class extends Error {},
+}));
+vi.mock('../src/services/serializedUnitProvisioningService', () => ({
+  provisionP2SerializedUnits: vi.fn(),
+  SerializedUnitProvisioningError: class extends Error {},
+}));
+vi.mock('../src/services/travelerProvisioningService', () => ({
+  provisionP2DraftTravelers: vi.fn(),
+  TravelerProvisioningError: class extends Error {},
+}));
 
 import projectProductionPlanningRouter from '../src/routes/projectProductionPlanning';
 


### PR DESCRIPTION
## What changed

- isolate the Production Launch preview route certification from all execution and provisioning service imports
- mock execution authorization, production-order provisioning, serialized-unit provisioning, and traveler provisioning at the route boundary
- prevent route test collection from initializing the real database

## Root cause

The route gained new execution/provisioning imports after the original preview-route test was written. Those unmocked modules imported the database during test collection, causing the otherwise database-independent permission and request-contract suite to fail before running any tests.

## Main synchronization

The branch was rebased onto current `origin/main`, including the P2 work-order hierarchy changes. Its final compare is one commit and one test file.

## Validation

- Phase 13 focused matrix before rebase: 60 tests passed across 10 files
- affected route suite after rebase: 4 tests passed
- production client build passed: 6,415 modules transformed
- changed-file ESLint passed
- Prettier check passed
- `git diff --check origin/main...HEAD` passed
- `git merge-tree --write-tree origin/main HEAD` passed

## Explicit limitations

- full TypeScript did not complete locally: a 4 GB run exhausted memory and an 8 GB run exceeded five minutes without diagnostics
- PostgreSQL replay and legacy database suites were not run because this environment has neither `DATABASE_URL` nor Docker
- no authenticated browser session, deployment, production configuration, or production data was used
