### PR TITLE
Connect generated documents to controlled review

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -280,11 +280,30 @@ export default function MasterDocumentRegister() {
     null
   );
   const { toast } = useToast();
+  const handledLinkedDocumentId = useRef<string | null>(null);
 
   // Fetch controlled documents
   const { data: documents = [], isLoading } = useQuery<
     ControlledDocumentView[]
   >({ queryKey: ['/api/controlled-documents'] });
+
+  useEffect(() => {
+    if (isLoading || documents.length === 0) return;
+    const documentId = new URLSearchParams(window.location.search).get('documentId');
+    if (!documentId || handledLinkedDocumentId.current === documentId) return;
+    handledLinkedDocumentId.current = documentId;
+    const linkedDocument = documents.find((doc) => doc.id === documentId);
+    if (!linkedDocument) {
+      toast({
+        title: 'Controlled document not found',
+        description: 'The builder record is not connected to an accessible Master Document Register record.',
+        variant: 'destructive',
+      });
+      return;
+    }
+    setSearchQuery(linkedDocument.documentNumber);
+    setSelectedDocument(linkedDocument);
+  }, [documents, isLoading, toast]);
 
   const {
     data: designControlTemplates = [],

--- a/client/src/pages/RoutingDocumentManagement.tsx
+++ b/client/src/pages/RoutingDocumentManagement.tsx
@@ -36,7 +36,8 @@ import {
   MoreHorizontal,
   Plus,
   X,
-  ChevronsUpDown
+  ChevronsUpDown,
+  ExternalLink
 } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
@@ -56,6 +57,10 @@ interface RoutingDocument {
   aiProcessedAt: string | null;
   isTemplate: boolean;
   createdAt: string;
+  controlledDocumentId: string | null;
+  controlledDocumentNumber: string | null;
+  controlledLifecycleStatus: string | null;
+  controlledRevisionChecksumStatus: string | null;
 }
 
 interface DocumentTemplate {
@@ -397,6 +402,10 @@ export default function RoutingDocumentManagement() {
       aiProcessedAt: doc.ai_processed_at ?? doc.aiProcessedAt,
       isTemplate: doc.is_template ?? doc.isTemplate ?? false,
       createdAt: doc.created_at ?? doc.createdAt,
+      controlledDocumentId: doc.controlled_document_id ?? doc.controlledDocumentId ?? null,
+      controlledDocumentNumber: doc.controlled_document_number ?? doc.controlledDocumentNumber ?? null,
+      controlledLifecycleStatus: doc.controlled_lifecycle_status ?? doc.controlledLifecycleStatus ?? null,
+      controlledRevisionChecksumStatus: doc.controlled_revision_checksum_status ?? doc.controlledRevisionChecksumStatus ?? null,
     })),
   });
 
@@ -1313,6 +1322,7 @@ export default function RoutingDocumentManagement() {
                       <TableHead>Type</TableHead>
                       <TableHead>Part Number</TableHead>
                       <TableHead>Department</TableHead>
+                      <TableHead>Document Control</TableHead>
                       <TableHead>AI Analyzed</TableHead>
                       <TableHead>Actions</TableHead>
                     </TableRow>
@@ -1338,6 +1348,20 @@ export default function RoutingDocumentManagement() {
                         </TableCell>
                         <TableCell>{doc.partNumber || '-'}</TableCell>
                         <TableCell>{doc.departmentName || '-'}</TableCell>
+                        <TableCell>
+                          {doc.controlledDocumentId ? (
+                            <div className="space-y-1">
+                              <Badge variant="outline">
+                                {doc.controlledLifecycleStatus || 'DRAFT'}
+                              </Badge>
+                              <div className="text-xs text-muted-foreground">
+                                {doc.controlledDocumentNumber}
+                              </div>
+                            </div>
+                          ) : (
+                            <Badge variant="secondary">Not registered</Badge>
+                          )}
+                        </TableCell>
                         <TableCell>
                           {doc.aiProcessedAt ? (
                             <Badge className="bg-green-100 text-green-800">
@@ -1375,6 +1399,14 @@ export default function RoutingDocumentManagement() {
                                   <Pencil className="h-4 w-4 mr-2" />
                                   Edit Details
                                 </DropdownMenuItem>
+                                {doc.controlledDocumentId && (
+                                  <DropdownMenuItem onClick={() => {
+                                    window.location.assign(`/master-document-register?documentId=${encodeURIComponent(doc.controlledDocumentId!)}`);
+                                  }}>
+                                    <ExternalLink className="h-4 w-4 mr-2" />
+                                    Review / View Controlled PDF
+                                  </DropdownMenuItem>
+                                )}
                                 <DropdownMenuItem onClick={() => {
                                   setSelectedDocument(doc);
                                   setShowParseDialog(true);
@@ -1407,7 +1439,7 @@ export default function RoutingDocumentManagement() {
                     ))}
                     {documents.length === 0 && (
                       <TableRow>
-                        <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
+                        <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
                           No documents uploaded yet. Upload your first document to get started.
                         </TableCell>
                       </TableRow>
@@ -2462,6 +2494,23 @@ export default function RoutingDocumentManagement() {
                     <Badge variant="secondary">Not Analyzed</Badge>
                   )}
                 </div>
+                <div className="space-y-2">
+                  <Label className="text-muted-foreground">Controlled Document</Label>
+                  <div>{selectedDocument.controlledDocumentNumber || 'Not registered'}</div>
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-muted-foreground">Control Status</Label>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">
+                      {selectedDocument.controlledLifecycleStatus || 'Unavailable'}
+                    </Badge>
+                    {selectedDocument.controlledRevisionChecksumStatus && (
+                      <span className="text-xs text-muted-foreground">
+                        Checksum {selectedDocument.controlledRevisionChecksumStatus}
+                      </span>
+                    )}
+                  </div>
+                </div>
               </div>
 
               {selectedDocument.aiExtractedContent && Object.keys(selectedDocument.aiExtractedContent).length > 0 && (
@@ -2600,6 +2649,14 @@ export default function RoutingDocumentManagement() {
           )}
           <DialogFooter className="flex gap-2">
             <Button variant="outline" onClick={() => setShowViewDialog(false)}>Close</Button>
+            {selectedDocument?.controlledDocumentId && (
+              <Button variant="outline" onClick={() => {
+                window.location.assign(`/master-document-register?documentId=${encodeURIComponent(selectedDocument.controlledDocumentId!)}`);
+              }}>
+                <ExternalLink className="h-4 w-4 mr-2" />
+                Review / View Controlled PDF
+              </Button>
+            )}
             {selectedDocument && !selectedDocument.aiProcessedAt && (
               <Button onClick={() => {
                 setShowViewDialog(false);

--- a/migrations/0276_routing_document_controlled_link.sql
+++ b/migrations/0276_routing_document_controlled_link.sql
@@ -1,0 +1,41 @@
+-- Connect Form & Document Builder records to their authoritative MDR records.
+-- The file-path backfill is intentionally limited to unique matches so ambiguous
+-- historical records remain unlinked and cannot be approved by inference.
+
+ALTER TABLE routing_documents
+  ADD COLUMN IF NOT EXISTS controlled_document_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'routing_documents_controlled_document_id_fkey'
+  ) THEN
+    ALTER TABLE routing_documents
+      ADD CONSTRAINT routing_documents_controlled_document_id_fkey
+      FOREIGN KEY (controlled_document_id)
+      REFERENCES controlled_documents(id)
+      ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS routing_documents_controlled_document_idx
+  ON routing_documents(controlled_document_id);
+
+WITH unique_file_matches AS (
+  SELECT rd.id AS routing_document_id, MIN(cd.id::text)::uuid AS controlled_document_id
+  FROM routing_documents rd
+  JOIN controlled_documents cd
+    ON cd.file_path = rd.file_url
+  WHERE rd.controlled_document_id IS NULL
+    AND rd.file_url IS NOT NULL
+    AND rd.file_url <> ''
+  GROUP BY rd.id
+  HAVING COUNT(*) = 1
+)
+UPDATE routing_documents rd
+SET controlled_document_id = matches.controlled_document_id,
+    updated_at = NOW()
+FROM unique_file_matches matches
+WHERE rd.id = matches.routing_document_id;

--- a/server/__tests__/routingDocumentControlledLink.test.ts
+++ b/server/__tests__/routingDocumentControlledLink.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('Form & Document Builder controlled-document linkage', () => {
+  const route = readFileSync(join(process.cwd(), 'server/src/routes/routingDocuments.ts'), 'utf8');
+  const migration = readFileSync(
+    join(process.cwd(), 'migrations/0276_routing_document_controlled_link.sql'),
+    'utf8'
+  );
+  const client = readFileSync(
+    join(process.cwd(), 'client/src/pages/RoutingDocumentManagement.tsx'),
+    'utf8'
+  );
+
+  it('returns authoritative MDR identity and revision evidence with builder rows', () => {
+    expect(route).toContain('LEFT JOIN controlled_documents cd ON cd.id = rd.controlled_document_id');
+    expect(route).toContain('controlled_revision_checksum_status');
+    expect(route).toContain('controlled_working_draft_revision_id');
+  });
+
+  it('persists the MDR identity for newly generated and imported documents', () => {
+    expect(route).toContain('SET controlled_document_id = ${controlledDocument.id}');
+    expect(route).toContain('controlledDocumentId: controlledDocument.id');
+  });
+
+  it('backfills only unambiguous historical file matches', () => {
+    expect(migration).toContain('HAVING COUNT(*) = 1');
+    expect(migration).toContain('WHERE rd.controlled_document_id IS NULL');
+    expect(migration).toContain('ON DELETE RESTRICT');
+  });
+
+  it('routes review and viewing through the controlled MDR workflow', () => {
+    expect(client).toContain('Review / View Controlled PDF');
+    expect(client).toContain('/master-document-register?documentId=');
+    expect(client).not.toContain('window.open(doc.fileUrl');
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -17517,6 +17517,10 @@ export const routingDocuments = pgTable(
     fileName: varchar('file_name', { length: 500 }),
     fileType: varchar('file_type', { length: 100 }),
     fileSize: integer('file_size'),
+    controlledDocumentId: uuid('controlled_document_id').references(
+      () => controlledDocuments.id,
+      { onDelete: 'restrict' }
+    ),
 
     extractedText: text('extracted_text'),
     aiExtractedContent: jsonb('ai_extracted_content'),
@@ -17543,6 +17547,9 @@ export const routingDocuments = pgTable(
     ),
     departmentIdx: index('routing_documents_department_idx').on(
       table.departmentName
+    ),
+    controlledDocumentIdx: index('routing_documents_controlled_document_idx').on(
+      table.controlledDocumentId
     ),
   })
 );

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -336,6 +336,7 @@ export const safeMigrationFiles = [
   '0273_p2_serialized_unit_provisioning.sql',
   '0274_p2_traveler_provisioning.sql',
   '0275_design_control_verified_approval_assignments.sql',
+  '0276_routing_document_controlled_link.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -417,6 +418,7 @@ export const criticalMigrationFiles = new Set([
   '0273_p2_serialized_unit_provisioning.sql',
   '0274_p2_traveler_provisioning.sql',
   '0275_design_control_verified_approval_assignments.sql',
+  '0276_routing_document_controlled_link.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -838,7 +838,27 @@ router.get('/', async (req: Request, res: Response) => {
     const { partNumber, departmentName, documentType, isTemplate } = req.query;
     
     // Use raw SQL template to avoid Neon HTTP driver issues with empty tables
-    const results = await db.execute(sql`SELECT * FROM routing_documents WHERE is_active = true ORDER BY created_at DESC`);
+    const results = await db.execute(sql`
+      SELECT
+        rd.*,
+        cd.document_number AS controlled_document_number,
+        cd.lifecycle_status AS controlled_lifecycle_status,
+        cd.status AS controlled_status,
+        cd.current_revision_id AS controlled_current_revision_id,
+        cd.working_draft_revision_id AS controlled_working_draft_revision_id,
+        revision.checksum_status AS controlled_revision_checksum_status,
+        revision.file_path AS controlled_revision_file_path
+      FROM routing_documents rd
+      LEFT JOIN controlled_documents cd ON cd.id = rd.controlled_document_id
+      LEFT JOIN document_version_history revision
+        ON revision.id = COALESCE(
+          cd.working_draft_revision_id,
+          cd.current_revision_id,
+          cd.current_released_revision_id
+        )
+      WHERE rd.is_active = true
+      ORDER BY rd.created_at DESC
+    `);
     
     // Extract rows from the raw result and transform UUIDs
     const rows = (results as any)?.rows || results || [];
@@ -1703,6 +1723,12 @@ router.post('/upload-template-to-register', async (req: Request, res: Response) 
           status = 'draft'
       WHERE id = ${controlledDocument.id}
     `);
+    await db.execute(sql`
+      UPDATE routing_documents
+      SET controlled_document_id = ${controlledDocument.id},
+          updated_at = NOW()
+      WHERE id = ${routingDocument.id}
+    `);
 
     res.status(201).json({
       document: routingDocument,
@@ -2115,6 +2141,10 @@ ${templateContent ? `\nTemplate:\n${templateContent}` : ''}`;
       lifecycleStatus: 'DRAFT',
       status: 'draft',
     }).where(eq(controlledDocuments.id, controlledDocument.id));
+    await db.update(routingDocuments).set({
+      controlledDocumentId: controlledDocument.id,
+      updatedAt: new Date(),
+    }).where(eq(routingDocuments.id, newDocument.id));
     if (specSheet && specActor) {
       const snapshot = {
         documentNumber,


### PR DESCRIPTION
## What changed
- adds an explicit controlled-document link for Form & Document Builder records
- backfills only historical rows with one unambiguous matching MDR file reference
- exposes MDR lifecycle and checksum status in Routing Document Management
- adds a Review / View Controlled PDF handoff to the exact Master Document Register record
- preserves the existing step-up, permission, revision, and checksum approval gates

## Root cause
Generated work instructions and spec sheets were stored in `routing_documents`, while viewing and approval live in the controlled-document workflow. The UI only displayed builder metadata and had no durable MDR identity to hand off, leaving generated PDFs difficult or impossible to review and approve.

## Validation
- focused Vitest: 4 files, 14 tests passed
- `git diff --cached --check` passed before commit
- full repository TypeScript check attempted but exceeded the Node 2 GB heap limit before producing type errors