### PR TITLE
Fix Design Control approver dropdowns and reassignment

### DIFF
--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -95,6 +95,7 @@ type EligibleApprovers = {
     accountRole: string;
     accountStatus: string;
     eligibleApprovalKeys: string[];
+    eligibleApprovalRoles: string[];
   }>;
 };
 
@@ -145,6 +146,9 @@ export function DesignControlStepEditor({
   const [approvalAssignments, setApprovalAssignments] = useState<
     Record<string, string>
   >({});
+  const [reassignmentRole, setReassignmentRole] = useState<string | null>(null);
+  const [reassignmentSelection, setReassignmentSelection] = useState('');
+  const [reassignmentReason, setReassignmentReason] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
@@ -239,7 +243,7 @@ export function DesignControlStepEditor({
           { credentials: 'include' }
         )
       ),
-    enabled: step?.status !== 'submitted_for_approval',
+    enabled: true,
   });
 
   const refresh = async () => {
@@ -356,6 +360,12 @@ export function DesignControlStepEditor({
   const editable = !readOnly && can('design.control.edit') && !underReview;
   const canSubmit = !readOnly && can('design.control.submit') && !underReview;
   const canApprove = !readOnly && can('design.control.approve') && underReview;
+  const canRouteApprovers =
+    !readOnly &&
+    !underReview &&
+    (can('design.control.edit') || can('design.control.submit'));
+  const canReassignApprovers =
+    !readOnly && underReview && can('design.control.admin');
   const missingFields = definition.fields.filter(
     (field) => !String(formData[field.key] ?? '').trim()
   );
@@ -373,6 +383,41 @@ export function DesignControlStepEditor({
       return;
     navigate();
   };
+
+  const reassignApprover = (slot: ApprovalSlot) =>
+    run(async () => {
+      const selected = (eligibleApproversQuery.data?.employees ?? []).find(
+        (employee) =>
+          `${employee.employeeId}:${employee.userId}` === reassignmentSelection
+      );
+      const contentVersionId = approvalQuery.data?.currentContentVersion?.id;
+      if (!selected || !contentVersionId || !reassignmentReason.trim())
+        throw new Error(
+          'Select an active employee and enter a reassignment reason.'
+        );
+      return responsePayload(
+        await fetch(
+          `/api/qms/design-control/${encodeURIComponent(recordId)}/steps/${encodeURIComponent(definition.key)}/assignments/${encodeURIComponent(slot.key)}/reassign`,
+          {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              contentVersionId,
+              employeeId: selected.employeeId,
+              userId: selected.userId,
+              reason: reassignmentReason.trim(),
+            }),
+          }
+        )
+      );
+    }, `${slot.label} reassigned with an audit record.`).then((saved) => {
+      if (saved) {
+        setReassignmentRole(null);
+        setReassignmentSelection('');
+        setReassignmentReason('');
+      }
+    });
 
   return (
     <div className="space-y-5">
@@ -729,7 +774,7 @@ export function DesignControlStepEditor({
             </Button>
           </>
         )}
-        {canSubmit && (
+        {canRouteApprovers && (
           <div className="w-full space-y-3 rounded-md border p-3">
             <h3 className="font-semibold">Assign verified approvers</h3>
             <p className="text-sm text-muted-foreground">
@@ -747,10 +792,9 @@ export function DesignControlStepEditor({
                   <Label htmlFor={`approval-assignee-${slot.key}`}>
                     {slot.label}
                   </Label>
-                  <Input
+                  <select
+                    className="h-10 w-full rounded-md border bg-background px-3 text-sm"
                     id={`approval-assignee-${slot.key}`}
-                    list={`approval-assignee-options-${slot.key}`}
-                    placeholder="Search active employees by name, code, title, department, or role"
                     value={approvalAssignments[slot.key] ?? ''}
                     onChange={(event) =>
                       setApprovalAssignments((current) => ({
@@ -758,8 +802,8 @@ export function DesignControlStepEditor({
                         [slot.key]: event.target.value,
                       }))
                     }
-                  />
-                  <datalist id={`approval-assignee-options-${slot.key}`}>
+                  >
+                    <option value="">Select an active employee...</option>
                     {candidates.map((employee) => (
                       <option
                         key={`${employee.employeeId}:${employee.userId}`}
@@ -773,10 +817,10 @@ export function DesignControlStepEditor({
                           employee.department ||
                           'Role not recorded'}{' '}
                         | Account {employee.accountStatus} |{' '}
-                        {employee.accountRole}
+                        {employee.eligibleApprovalRoles.join(', ')}
                       </option>
                     ))}
-                  </datalist>
+                  </select>
                 </div>
               );
             })}
@@ -845,6 +889,87 @@ export function DesignControlStepEditor({
                       ? 'Independent reviewer required'
                       : 'Authenticated reviewer required'}
                   </p>
+                  {canReassignApprovers &&
+                    slot.assignment?.status === 'PENDING' && (
+                      <Button
+                        className="mt-2"
+                        onClick={() => {
+                          setReassignmentRole(slot.key);
+                          setReassignmentSelection('');
+                          setReassignmentReason('');
+                        }}
+                        size="sm"
+                        type="button"
+                        variant="outline"
+                      >
+                        Change approver
+                      </Button>
+                    )}
+                  {reassignmentRole === slot.key && (
+                    <div className="mt-3 space-y-2 rounded-md border p-3">
+                      <Label htmlFor={`reassign-${slot.key}`}>
+                        New verified employee
+                      </Label>
+                      <select
+                        className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                        id={`reassign-${slot.key}`}
+                        value={reassignmentSelection}
+                        onChange={(event) =>
+                          setReassignmentSelection(event.target.value)
+                        }
+                      >
+                        <option value="">Select an active employee...</option>
+                        {(eligibleApproversQuery.data?.employees ?? [])
+                          .filter((employee) =>
+                            employee.eligibleApprovalKeys.includes(slot.key)
+                          )
+                          .map((employee) => (
+                            <option
+                              key={`${employee.employeeId}:${employee.userId}`}
+                              value={`${employee.employeeId}:${employee.userId}`}
+                            >
+                              {employee.displayName} |{' '}
+                              {employee.employeeCode ||
+                                `Employee ${employee.employeeId}`}{' '}
+                              |{' '}
+                              {employee.jobTitle ||
+                                employee.department ||
+                                'Role not recorded'}
+                            </option>
+                          ))}
+                      </select>
+                      <Input
+                        aria-label="Reassignment reason"
+                        placeholder="Reason for changing this submitted-version assignment"
+                        value={reassignmentReason}
+                        onChange={(event) =>
+                          setReassignmentReason(event.target.value)
+                        }
+                      />
+                      <div className="flex gap-2">
+                        <Button
+                          disabled={
+                            busy ||
+                            !reassignmentSelection ||
+                            !reassignmentReason.trim()
+                          }
+                          onClick={() => reassignApprover(slot)}
+                          size="sm"
+                          type="button"
+                        >
+                          Save reassignment
+                        </Button>
+                        <Button
+                          onClick={() => setReassignmentRole(null)}
+                          size="sm"
+                          type="button"
+                          variant="ghost"
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    </div>
+                  )}
                   <p className="text-xs text-muted-foreground">
                     {slot.assignment
                       ? `${slot.assignment.approverNameSnapshot} (${slot.assignment.employeeCodeSnapshot || `Employee ${slot.assignment.employeeId}`}) · ${slot.assignment.jobTitleSnapshot || slot.assignment.departmentSnapshot || 'Role not recorded'} · Account ${slot.assignment.accountStatusSnapshot}`

--- a/server/__tests__/designControlAuthenticatedApprovals.test.ts
+++ b/server/__tests__/designControlAuthenticatedApprovals.test.ts
@@ -151,4 +151,21 @@ describe('authenticated Design Control approvals', () => {
     expect(service).toContain("'LEGACY_UNVERIFIED_APPROVAL_EVIDENCE'");
     expect(service).toContain('satisfiesAuthenticatedGate: false');
   });
+
+  it('uses Design Control capabilities rather than login-role names for employee eligibility', () => {
+    const service = readRepoFile(
+      'server/src/services/designControlApprovalService.ts'
+    );
+    const editor = readRepoFile(
+      'client/src/features/design-control/DesignControlStepEditor.tsx'
+    );
+    expect(service).toContain(
+      'permissions.permissionSet.has(slot.requiredCapability!)'
+    );
+    expect(service).not.toContain('APPROVER_ROLE_MISMATCH');
+    expect(editor).toContain('Select an active employee...');
+    expect(editor).toContain('canRouteApprovers');
+    expect(editor).toContain('Change approver');
+    expect(editor).toContain('/reassign');
+  });
 });

--- a/server/src/services/designControlApprovalService.ts
+++ b/server/src/services/designControlApprovalService.ts
@@ -94,13 +94,6 @@ async function verifiedApprover(
       'APPROVER_NOT_AUTHORIZED',
       `${candidate.employeeName} is not authorized for ${slot.label}`
     );
-  const normalizedRole = candidate.userRole.toUpperCase();
-  if (!(slot.allowedRoles ?? []).includes(normalizedRole))
-    throw new DesignControlApprovalError(
-      422,
-      'APPROVER_ROLE_MISMATCH',
-      `${candidate.employeeName} does not hold an allowed account role for ${slot.label}`
-    );
   return candidate;
 }
 
@@ -145,14 +138,15 @@ export async function listEligibleDesignControlApprovers(
         return {
           ...row,
           eligibleApprovalKeys: context.definition.approvals
-            .filter(
-              (slot) =>
-                permissions.permissionSet.has(slot.requiredCapability!) &&
-                (slot.allowedRoles ?? []).includes(
-                  row.accountRole.toUpperCase()
-                )
+            .filter((slot) =>
+              permissions.permissionSet.has(slot.requiredCapability!)
             )
             .map((slot) => slot.key),
+          eligibleApprovalRoles: context.definition.approvals
+            .filter((slot) =>
+              permissions.permissionSet.has(slot.requiredCapability!)
+            )
+            .map((slot) => slot.label),
         };
       })
   );
@@ -910,18 +904,6 @@ export async function decideDesignControlStepApproval(
       slot,
       tx as Client
     );
-    const normalizedRole = input.actor.role.toUpperCase();
-    if (
-      normalizedRole !== 'ADMIN' &&
-      normalizedRole !== 'OWNER' &&
-      !(slot.allowedRoles ?? []).includes(normalizedRole)
-    ) {
-      throw new DesignControlApprovalError(
-        403,
-        'APPROVAL_ROLE_MISMATCH',
-        'Actor role cannot satisfy this approval slot'
-      );
-    }
     const [version] = await tx
       .select()
       .from(designControlStepContentVersions)


### PR DESCRIPTION
## Summary

- show verified approver dropdowns to Design Control users who can edit or submit a draft
- populate employee choices using the required Design Control capability instead of comparing functional approval roles with generic login-role names
- keep eligible employees loaded for pending submissions
- add a reason-required **Change approver** control wired to the immutable audited reassignment endpoint

## Root cause

The initial implementation rendered assignment controls only for users with `design.control.submit`, so editors could not select or change approvers. It also compared approval roles such as Engineering and Quality to the authentication account role, which filtered ordinary employee accounts out of the selector even when they held the required Design Control capability. The pending-approval view had no UI for the existing authorized reassignment API.

## Validation

- rebased onto current `main` at `a3637494461551cfe5631db808a14441bbc85654`
- compare contains one follow-up commit and three scoped files
- Prettier completed on all touched files
- TypeScript syntax transpile passed for all three touched files
- focused source-contract assertions passed
- `git diff --check origin/main...HEAD` passed

## Boundary

The active employee/account checks, exact-version binding, server-side assigned-user enforcement, required capabilities, independence rules, and audited reassignment history remain fail closed. This PR is not deployed.