### PR TITLE
Preserve saved Design Control drafts

### DIFF
--- a/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
+++ b/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
@@ -93,6 +93,22 @@ describe('Design Control structured workspaces', () => {
             }),
             { status: 409 }
           );
+        if (init?.method === 'PATCH' && url.endsWith('/steps/1')) {
+          const body = JSON.parse(String(init.body));
+          return new Response(
+            JSON.stringify({
+              step: {
+                stepKey: '1',
+                status: 'draft',
+                formData: body.formData,
+                checklist: body.checklist,
+                currentContentVersionId: 'version-2',
+                updatedAt: '2026-08-12T12:00:00.000Z',
+              },
+            }),
+            { status: 200 }
+          );
+        }
         if (url.endsWith('/structured/REQUIREMENT'))
           return new Response(JSON.stringify({ records: [] }), { status: 200 });
         if (url.endsWith('/structured/VALIDATION'))
@@ -300,6 +316,41 @@ describe('Design Control structured workspaces', () => {
       await screen.findByText('Synthetic save rejected: stale version')
     ).toBeInTheDocument();
     expect(field).toHaveValue('SYNTHETIC-PROJECT-1');
+  });
+
+  it('hydrates the workspace from the committed PATCH row after saving', async () => {
+    const definition = DESIGN_CONTROL_WORKFLOW[0];
+    const onChanged = vi.fn(async () => undefined);
+    renderWithQuery(
+      <DesignControlStepEditor
+        definition={definition}
+        hasNext
+        hasPrevious={false}
+        onChanged={onChanged}
+        onNext={vi.fn()}
+        onPrevious={vi.fn()}
+        readOnly={false}
+        recordId="record-1"
+        step={{ stepKey: definition.key, status: 'draft' }}
+      />
+    );
+
+    const field = await screen.findByLabelText(definition.fields[0].label, {
+      exact: false,
+    });
+    fireEvent.change(field, { target: { value: 'PERSISTED-PROJECT-1' } });
+    fireEvent.click(await screen.findByRole('button', { name: 'Save Draft' }));
+
+    await waitFor(() =>
+      expect(onChanged).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentContentVersionId: 'version-2',
+          formData: expect.objectContaining({
+            [definition.fields[0].key]: 'PERSISTED-PROJECT-1',
+          }),
+        })
+      )
+    );
   });
 
   it('can focus the stage workspace on the matching authoritative register', async () => {

--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -105,7 +105,7 @@ type Props = {
   definition: DesignControlWorkflowStep;
   step?: StepRow;
   readOnly: boolean;
-  onChanged: () => Promise<unknown>;
+  onChanged: (savedStep?: StepRow) => Promise<unknown>;
   onPrevious: () => void;
   onNext: () => void;
   hasPrevious: boolean;
@@ -246,55 +246,66 @@ export function DesignControlStepEditor({
     enabled: true,
   });
 
-  const refresh = async () => {
+  const refresh = async (savedStep?: StepRow) => {
     await Promise.all([
-      onChanged(),
+      onChanged(savedStep),
       queryClient.invalidateQueries({ queryKey: approvalQueryKey }),
     ]);
   };
 
-  const run = async (action: () => Promise<unknown>, success: string) => {
+  const run = async <T,>(
+    action: () => Promise<T>,
+    success: string,
+    savedStepFromResult?: (result: T) => StepRow | undefined
+  ) => {
     setBusy(true);
     setError('');
     setMessage('');
     try {
-      await action();
+      const result = await action();
       setMessage(success);
       setDirty(false);
-      await refresh();
-      return true;
+      await refresh(savedStepFromResult?.(result));
+      return result;
     } catch (actionError) {
       setError(
         actionError instanceof Error
           ? actionError.message
           : 'The controlled action failed.'
       );
-      return false;
+      return null;
     } finally {
       setBusy(false);
     }
   };
 
   const saveDraft = async (continueAfterSave = false) => {
-    const saved = await run(async () => {
-      const response = await fetch(
-        `/api/qms/design-control/${encodeURIComponent(recordId)}/steps/${encodeURIComponent(definition.key)}`,
-        {
-          method: 'PATCH',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            formData,
-            checklist,
-            attachments: step?.attachments ?? [],
-            contentVersionId: step?.currentContentVersionId ?? null,
-            changeReason:
-              changeReason.trim() || 'Design Control step draft saved',
-          }),
-        }
-      );
-      return responsePayload(response);
-    }, 'Draft saved as a controlled content version.');
+    const saved = await run(
+      async () => {
+        const response = await fetch(
+          `/api/qms/design-control/${encodeURIComponent(recordId)}/steps/${encodeURIComponent(definition.key)}`,
+          {
+            method: 'PATCH',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              formData,
+              checklist,
+              attachments: step?.attachments ?? [],
+              contentVersionId: step?.currentContentVersionId ?? null,
+              changeReason:
+                changeReason.trim() || 'Design Control step draft saved',
+            }),
+          }
+        );
+        return responsePayload(response);
+      },
+      'Draft saved as a controlled content version.',
+      (result) =>
+        result && typeof result === 'object' && 'step' in result
+          ? (result.step as StepRow)
+          : undefined
+    );
     if (saved) setLastSavedAt(new Date().toISOString());
     if (saved && continueAfterSave && hasNext) onNext();
   };

--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'wouter';
 import { DESIGN_CONTROL_WORKFLOW } from '@shared/designControlWorkflow';
 import {
@@ -165,6 +165,7 @@ export function DesignControlWorkspace({
   releaseId?: string | null;
   mode?: WorkspaceMode;
 }) {
+  const queryClient = useQueryClient();
   const readOnly = mode === 'auditor';
   const params = useMemo(() => new URLSearchParams(window.location.search), []);
   const initialStep =
@@ -456,10 +457,7 @@ export function DesignControlWorkspace({
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent
-          value="lifecycle"
-          className="space-y-4"
-        >
+        <TabsContent value="lifecycle" className="space-y-4">
           <nav
             className="hidden"
             aria-hidden="true"
@@ -600,7 +598,29 @@ export function DesignControlWorkspace({
                 definition={selectedDefinition}
                 hasNext={selectedIndex < DESIGN_CONTROL_WORKFLOW.length - 1}
                 hasPrevious={selectedIndex > 0}
-                onChanged={() => detailQuery.refetch()}
+                onChanged={async (savedStep) => {
+                  if (!savedStep) {
+                    await detailQuery.refetch();
+                    return;
+                  }
+                  // The PATCH response is the authoritative committed row. Use
+                  // it directly so a lagging read cannot restore the user's
+                  // pre-save values in the editor.
+                  queryClient.setQueryData<Detail>(
+                    ['/api/qms/design-control', recordId],
+                    (current) =>
+                      current
+                        ? {
+                            ...current,
+                            steps: current.steps.map((candidate) =>
+                              candidate.stepKey === savedStep.stepKey
+                                ? { ...candidate, ...savedStep }
+                                : candidate
+                            ),
+                          }
+                        : current
+                  );
+                }}
                 onNext={() =>
                   setActiveStep(DESIGN_CONTROL_WORKFLOW[selectedIndex + 1].key)
                 }


### PR DESCRIPTION
## What changed

- propagate the committed Design Control step returned by the save endpoint back into the workspace cache
- retain the server-issued content-version ID and saved form/checklist values after a successful save
- add regression coverage proving that the committed PATCH row hydrates the UI

## Why

After saving a Design Control draft, the UI immediately refetched the whole record. A lagging read could replace the committed PATCH response with older step data, making entered values appear not to have been saved and leaving the editor with a stale content-version ID.

The PATCH response is the authoritative committed database row, so the workspace now applies that row directly. Other controlled actions continue to use the normal record refresh path.

## User impact

Entered Design Control form and checklist data remains visible after Save Draft or Save and Continue, and subsequent saves use the current server-issued version identity.

## Validation

- `vitest run client/src/__tests__/designControlStructuredWorkspace.client.test.tsx --config vitest.config.client.ts --reporter=verbose`
- 1 test file passed
- 11 tests passed
- `git diff --check`

This is source and focused-test validation only; it has not been deployed or verified against the live production database.
