### PR TITLE
Add simple manufacturing work order action

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -157,6 +157,13 @@ function ProductionHierarchyNode({ node, isRoot = false }: { node: any; isRoot?:
   );
 }
 
+function hasMissingManufacturingWorkOrder(node: any): boolean {
+  if (!node) return false;
+  const required = node.sourceType !== 'PURCHASED_MATERIAL';
+  if (required && (!Array.isArray(node.workOrders) || node.workOrders.length === 0)) return true;
+  return Array.isArray(node.children) && node.children.some(hasMissingManufacturingWorkOrder);
+}
+
 const ROM_CATEGORY_CONFIG = [
   { key: 'labor', label: 'Labor', field: 'quotedHours', kind: 'hours', detail: 'Direct labor estimate from ROM/quote feedback' },
   { key: 'material', label: 'Material', field: 'budgetAmount', kind: 'currency', detail: 'Material budget that will seed the WAD' },
@@ -900,6 +907,37 @@ export default function ProjectDetailPage() {
     queryKey: ['/api/projects', id, 'p2-hub'],
     queryFn: () => fetch(`/api/projects/${id}/p2-hub`).then(r => r.json()),
     enabled: !!id,
+  });
+
+  const createManufacturingWorkOrders = useMutation({
+    mutationFn: async () => {
+      const action = p2Hub?.tabs?.production?.manufacturingWorkOrderAction;
+      if (!action?.launchId || !action?.expectedLaunchDigest)
+        throw new Error('Complete Production Launch before creating manufacturing work orders.');
+      if (!action.enabled)
+        throw new Error('Manufacturing work-order creation is not enabled for this deployment yet.');
+      return apiRequest(
+        `/api/projects/${id}/workflow-v2/production-planning/launch/${action.launchId}/create-manufacturing-work-orders`,
+        {
+          method: 'POST',
+          body: {
+            idempotencyKey: `manufacturing-work-orders:${action.launchId}`,
+            expectedLaunchDigest: action.expectedLaunchDigest,
+            signatureMeaning: 'Create manufacturing work orders from the released BOM and routing.',
+          },
+        }
+      );
+    },
+    onSuccess: (result: any) => {
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', id, 'p2-hub'] });
+      toast({ title: result?.message || 'Manufacturing work orders created' });
+    },
+    onError: (error: any) =>
+      toast({
+        title: 'Work orders could not be created',
+        description: error?.message || 'Check the released BOM, routing, and WAD information.',
+        variant: 'destructive',
+      }),
   });
 
   interface GateStatus {
@@ -3970,7 +4008,19 @@ export default function ProjectDetailPage() {
                         <div className="mt-3 rounded-md border bg-muted/20 p-3">
                           <div className="mb-2 flex items-center justify-between gap-2">
                             <p className="text-sm font-medium">Manufacturing Structure</p>
-                            <Badge variant="secondary">BOM driven</Badge>
+                            <div className="flex items-center gap-2">
+                              <Badge variant="secondary">BOM driven</Badge>
+                              {hasMissingManufacturingWorkOrder(line.manufacturingHierarchy) && (
+                                <Button
+                                  size="sm"
+                                  disabled={createManufacturingWorkOrders.isPending}
+                                  onClick={() => createManufacturingWorkOrders.mutate()}
+                                  data-testid="create-manufacturing-work-orders"
+                                >
+                                  {createManufacturingWorkOrders.isPending ? 'Creating...' : 'Create Manufacturing Work Orders'}
+                                </Button>
+                              )}
+                            </div>
                           </div>
                           {line.manufacturingHierarchy ? (
                             <ProductionHierarchyNode node={line.manufacturingHierarchy} isRoot />

--- a/server/__tests__/simpleManufacturingWorkOrderAction.test.ts
+++ b/server/__tests__/simpleManufacturingWorkOrderAction.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const route = readFileSync(
+  join(process.cwd(), 'server/src/routes/projectProductionPlanning.ts'),
+  'utf8'
+);
+const hub = readFileSync(
+  join(process.cwd(), 'server/src/routes/projects.ts'),
+  'utf8'
+);
+const ui = readFileSync(
+  join(process.cwd(), 'client/src/pages/ProjectDetailPage.tsx'),
+  'utf8'
+);
+
+describe('simple manufacturing work-order action', () => {
+  it('exposes one operator action backed by the controlled sequence', () => {
+    expect(route).toContain(
+      "'/launch/:launchId/create-manufacturing-work-orders'"
+    );
+    expect(route).toContain('authorizeProductionExecution(');
+    expect(route).toContain('provisionP2ProductionOrders(');
+    expect(route).toContain('provisionP2WorkOrders(');
+    expect(route).toContain("'projects.production_launch.launch'");
+  });
+
+  it('uses a deterministic retry key and server-owned quantities', () => {
+    expect(route).toContain('manufacturing-work-orders:${req.params.launchId}');
+    expect(route).not.toContain('req.body.quantity');
+    expect(route).not.toContain('req.body.partNumber');
+  });
+
+  it('exposes only enabled launch identity in the read model', () => {
+    expect(hub).toContain('manufacturingWorkOrderAction');
+    expect(hub).toContain('isP2V2ExecutionAuthorizationEnabled()');
+    expect(hub).toContain('isP2V2ProductionOrderProvisioningEnabled()');
+    expect(hub).toContain('isP2V2WorkOrderProvisioningEnabled()');
+  });
+
+  it('shows one plain-language button only while work orders are missing', () => {
+    expect(ui).toContain('Create Manufacturing Work Orders');
+    expect(ui).toContain('hasMissingManufacturingWorkOrder');
+    expect(ui).toContain(
+      'Complete Production Launch before creating manufacturing work orders.'
+    );
+    expect(ui).not.toContain('Authorize Execution</Button>');
+    expect(ui).not.toContain('Provision P2 Orders</Button>');
+  });
+});

--- a/server/src/routes/projectProductionPlanning.ts
+++ b/server/src/routes/projectProductionPlanning.ts
@@ -326,6 +326,48 @@ router.post('/launch/:launchId/provision-work-orders', async (req, res) => {
     fail(res, error);
   }
 });
+router.post(
+  '/launch/:launchId/create-manufacturing-work-orders',
+  async (req, res) => {
+    try {
+      const user = await requireCapability(
+        req,
+        'projects.production_launch.launch'
+      );
+      const input = workOrderProvisioningSchema.parse(req.body);
+      const sharedInput = {
+        ...input,
+        idempotencyKey: `manufacturing-work-orders:${req.params.launchId}`,
+      };
+      await authorizeProductionExecution(
+        projectId(req),
+        req.params.launchId,
+        sharedInput,
+        user
+      );
+      await provisionP2ProductionOrders(
+        projectId(req),
+        req.params.launchId,
+        sharedInput,
+        user
+      );
+      const result = await provisionP2WorkOrders(
+        projectId(req),
+        req.params.launchId,
+        sharedInput,
+        user
+      );
+      res.status(result.replayed ? 200 : 201).json({
+        ...result,
+        message: result.replayed
+          ? 'Manufacturing work orders already exist.'
+          : 'Manufacturing work orders created.',
+      });
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
 router.post('/', async (req, res) => {
   try {
     const user = await requireCapability(

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -29,6 +29,11 @@ import { ensureProjectHasWAD } from '../lib/wadHelper';
 import { evaluateDocumentationRequirements } from '../lib/documentationRequirementsEngine';
 import { cancelWadWorkOrdersSupersededByP2 } from '../services/wadSupersedeService';
 import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
+import {
+  isP2V2ExecutionAuthorizationEnabled,
+  isP2V2ProductionOrderProvisioningEnabled,
+  isP2V2WorkOrderProvisioningEnabled,
+} from '../lib/featureFlags';
 import { resolveCustomersIntegerId } from '../lib/customerResolver';
 import { getQuoteContractReviewGate } from '../services/quoteContractService';
 import { getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
@@ -4171,6 +4176,25 @@ router.get('/:id/p2-hub', async (req, res) => {
         unreleasedQuantity: 0,
       }
     );
+    const manufacturingWorkOrderLaunch =
+      (
+        await pool.query(
+          `SELECT id, preview_digest AS "previewDigest", status
+           FROM project_production_launches
+          WHERE project_id = $1 AND status = 'COMPLETE'
+          ORDER BY launched_at DESC
+          LIMIT 1`,
+          [id]
+        )
+      ).rows[0] ?? null;
+    const manufacturingWorkOrderAction = {
+      launchId: manufacturingWorkOrderLaunch?.id ?? null,
+      expectedLaunchDigest: manufacturingWorkOrderLaunch?.previewDigest ?? null,
+      enabled:
+        isP2V2ExecutionAuthorizationEnabled() &&
+        isP2V2ProductionOrderProvisioningEnabled() &&
+        isP2V2WorkOrderProvisioningEnabled(),
+    };
     const laborBudgetHours = workOrders.reduce(
       (sum: number, workOrder: LegacyProjectValue) => {
         const hours = Number(workOrder.totalBudgetHours ?? 0);
@@ -4679,6 +4703,7 @@ router.get('/:id/p2-hub', async (req, res) => {
             ...productionTotals,
           },
           poLinePlacements,
+          manufacturingWorkOrderAction,
           productionOrders,
           serializedItems,
           assemblyTree: {


### PR DESCRIPTION
## What changed

- adds one **Create Manufacturing Work Orders** action to the BOM-driven manufacturing structure
- shows the action only while required assembly or manufactured-child work orders are missing
- exposes the current completed Production Launch identity and digest through the existing project read model
- performs execution authorization, P2 demand-order creation, and canonical work-order creation behind one server action
- uses a deterministic launch-based retry key so repeated clicks do not create duplicate work orders

## Why

The manufacturing structure correctly identified missing work orders, but operators had no direct way to create them. The underlying controlled services existed as separate technical steps. This PR keeps the operator experience simple while retaining those safety checks behind one action.

## Behavior

- the released BOM and server-owned quantities determine which work orders are created
- manufactured assemblies and components receive quantity-based work orders
- purchased materials remain purchase demand and receive no production work order
- incomplete Production Launch or disabled deployment flags produce a plain-language blocker
- the client cannot submit authoritative parts, classifications, routings, or quantities

## Safety boundaries

- requires `projects.production_launch.launch`
- retains the existing disabled-by-default execution, P2-order, and work-order feature flags
- preserves existing routing, WAD, launch-digest, reconciliation, and idempotency checks
- creates no travelers, CNC jobs, cutting demand, manufacturing queues, or floor release
- does not rewrite historical records

## Validation

- 18/18 focused Vitest tests passed
- focused server lint passed
- `git diff --check` passed
- the legacy ProjectDetailPage formatting was preserved; its unrelated repository-wide formatting lint debt was not rewritten