### PR TITLE
Exclude finished P2 POs from packet demand

### DIFF
--- a/server/__tests__/cuttingCompletedP2PoDemand.test.ts
+++ b/server/__tests__/cuttingCompletedP2PoDemand.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('weekly cutting queue P2 demand lifecycle', () => {
+  const routeSource = readFileSync(
+    join(process.cwd(), 'server/src/routes/cuttingTable.ts'),
+    'utf8'
+  );
+
+  it('excludes demand whose parent P2 purchase order is finished', () => {
+    expect(routeSource).toMatch(
+      /COALESCE\(UPPER\(p2\.status\), ''\) NOT IN \(\s*'CLOSED', 'COMPLETE', 'COMPLETED', 'SHIPPED', 'CANCELLED', 'CANCELED'\s*\)/
+    );
+  });
+});

--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -2475,6 +2475,11 @@ router.get('/weekly-cutting-queue', async (req, res) => {
                 )
               )
               WHERE COALESCE(UPPER(po.status), '') NOT IN ('CANCELLED', 'CANCELED')
+                -- A finished parent PO is no longer an open customer demand,
+                -- even when historical production-order quantities remain.
+                AND COALESCE(UPPER(p2.status), '') NOT IN (
+                  'CLOSED', 'COMPLETE', 'COMPLETED', 'SHIPPED', 'CANCELLED', 'CANCELED'
+                )
                 AND (
                   inv.is_packet = true
                   OR bom.id IS NOT NULL


### PR DESCRIPTION
## What changed

- Exclude finished parent P2 purchase orders from the weekly cutting queue demand read model.
- Treat `CLOSED`, `COMPLETE`, `COMPLETED`, `SHIPPED`, `CANCELLED`, and `CANCELED` as terminal for packet demand.
- Preserve historical production-order, shipment, and fulfillment records.
- Add a regression test protecting the parent-PO lifecycle gate.

## Why

The P2 PO Packet Demand card calculated remaining packet demand from historical production-order quantities without checking whether the parent purchase order was already finished. That allowed completed POs to continue appearing as actionable demand.

## Validation

- Focused Vitest regression: 1 test passed.
- `git diff --check`: passed.
- Full TypeScript check was attempted at 2 GB and 4 GB heaps but exhausted memory before completion.

## Deployment

Source change only. No database mutation, migration, or production deployment is included.