### PR TITLE
Handle fabric delete conflicts and storage IAM outages

### DIFF
--- a/client/src/pages/FabricInventoryPage.tsx
+++ b/client/src/pages/FabricInventoryPage.tsx
@@ -416,8 +416,12 @@ export default function FabricInventoryPage() {
       setIsDeleteDialogOpen(false);
       setSelectedItem(null);
     },
-    onError: () => {
-      toast({ title: "Error", description: "Failed to delete fabric inventory item", variant: "destructive" });
+    onError: (error: Error) => {
+      toast({
+        title: "Unable to delete fabric roll",
+        description: error.message || "Failed to delete fabric inventory item",
+        variant: "destructive",
+      });
     },
   });
 

--- a/server/__tests__/fabricInventoryDeletion.test.ts
+++ b/server/__tests__/fabricInventoryDeletion.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FABRIC_INVENTORY_IN_USE_MESSAGE,
+  getFabricInventoryDeleteErrorResponse,
+} from '../src/services/fabricInventoryDeletion';
+
+describe('fabric inventory deletion errors', () => {
+  it('returns an actionable conflict for a referenced traceability record', () => {
+    expect(
+      getFabricInventoryDeleteErrorResponse({
+        code: '23503',
+        constraint: 'cutting_fabric_inventory_transactions_fabric_inventory_id_fkey',
+      }),
+    ).toEqual({
+      status: 409,
+      body: {
+        error: 'FABRIC_INVENTORY_IN_USE',
+        message: FABRIC_INVENTORY_IN_USE_MESSAGE,
+      },
+    });
+  });
+
+  it('leaves unrelated database errors for the generic handler', () => {
+    expect(getFabricInventoryDeleteErrorResponse({ code: '42P01' })).toBeNull();
+  });
+});

--- a/server/__tests__/fileStorageProviderErrors.test.ts
+++ b/server/__tests__/fileStorageProviderErrors.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { getStorageErrorResponse } from '../src/services/fileStorageErrors';
+
+describe('file storage provider errors', () => {
+  it('reports provider IAM failures as storage outages instead of user authorization failures', () => {
+    const response = getStorageErrorResponse(
+      new Error(
+        "deployment-service-account does not have storage.objects.create access. Permission 'storage.objects.create' denied",
+      ),
+    );
+
+    expect(response).toEqual({
+      status: 503,
+      reason: 'storage_provider_permission_denied',
+      message:
+        'Central file storage is not writable. Reconnect the configured storage bucket to this deployment and try again.',
+    });
+  });
+
+  it('preserves true application authorization errors', () => {
+    const error = new Error('Upload token signature is invalid.');
+    Object.assign(error, { status: 403, reason: 'invalid_upload_token' });
+
+    expect(getStorageErrorResponse(error)).toEqual({
+      status: 403,
+      reason: 'invalid_upload_token',
+      message: 'Upload token signature is invalid.',
+    });
+  });
+});

--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -40,6 +40,7 @@ import {
   insertCuttingPacketBOMCutSchema,
   type CuttingFabricInventoryTransaction,
 } from '../../schema';
+import { getFabricInventoryDeleteErrorResponse } from '../services/fabricInventoryDeletion';
 
 const router = Router();
 
@@ -1087,6 +1088,10 @@ router.delete('/fabric-inventory/:id', async (req, res) => {
     res.json({ success: true });
   } catch (error) {
     console.error('Error deleting fabric inventory:', error);
+    const deleteError = getFabricInventoryDeleteErrorResponse(error);
+    if (deleteError) {
+      return res.status(deleteError.status).json(deleteError.body);
+    }
     res.status(500).json({ error: 'Failed to delete fabric inventory' });
   }
 });

--- a/server/src/services/fabricInventoryDeletion.ts
+++ b/server/src/services/fabricInventoryDeletion.ts
@@ -1,0 +1,16 @@
+export const FABRIC_INVENTORY_IN_USE_MESSAGE =
+  'This fabric roll has traceability or transaction history and cannot be deleted. Mark it depleted instead.';
+
+export function getFabricInventoryDeleteErrorResponse(error: unknown) {
+  const dbError = error as { code?: string };
+
+  if (dbError?.code !== '23503') return null;
+
+  return {
+    status: 409,
+    body: {
+      error: 'FABRIC_INVENTORY_IN_USE',
+      message: FABRIC_INVENTORY_IN_USE_MESSAGE,
+    },
+  };
+}

--- a/server/src/services/fileStorageErrors.ts
+++ b/server/src/services/fileStorageErrors.ts
@@ -1,0 +1,26 @@
+export function getStorageErrorResponse(error: unknown) {
+  const err = error as { status?: number; reason?: string; message?: string };
+  const rawMessage = err?.message || 'Storage operation failed';
+  const providerPermissionDenied =
+    /storage\.objects\.(?:create|delete|get|update)/i.test(rawMessage) &&
+    /permission|access|forbidden|denied/i.test(rawMessage);
+  const reason = providerPermissionDenied
+    ? 'storage_provider_permission_denied'
+    : err?.reason || 'storage_error';
+  const message =
+    providerPermissionDenied
+      ? 'Central file storage is not writable. Reconnect the configured storage bucket to this deployment and try again.'
+      : rawMessage.toLowerCase().includes('error code undefined')
+        ? 'File storage is not available. Check the storage provider configuration and try again.'
+        : rawMessage;
+
+  // Provider IAM is a service outage, not an authorization failure by the
+  // signed-in EPOCH user. A 503 also keeps the client auth layer from retrying.
+  const status = providerPermissionDenied
+    ? 503
+    : err?.status && err.status >= 400
+      ? err.status
+      : 500;
+
+  return { status, reason, message };
+}

--- a/server/src/services/fileStorageProvider.ts
+++ b/server/src/services/fileStorageProvider.ts
@@ -2,6 +2,7 @@ import { randomUUID, createHmac, timingSafeEqual } from 'crypto';
 import { Readable } from 'stream';
 import { Response } from 'express';
 import { ObjectStorageService } from '../../replit_integrations/object_storage';
+export { getStorageErrorResponse } from './fileStorageErrors';
 
 export type FileStorageProviderName = 'replit' | 'supabase';
 
@@ -391,16 +392,4 @@ export function isReplitObjectPath(objectPath: string | null | undefined) {
 export async function uploadSupabaseObjectFromSignedToken(token: string, body: Buffer, contentType?: string) {
   const provider = new SupabaseFileStorageProvider();
   return provider.uploadWithToken(token, body, contentType);
-}
-
-export function getStorageErrorResponse(error: unknown) {
-  const err = error as { status?: number; reason?: string; message?: string };
-  const reason = err?.reason || 'storage_error';
-  const rawMessage = err?.message || 'Storage operation failed';
-  const message =
-    rawMessage.toLowerCase().includes('error code undefined')
-      ? 'File storage is not available. Check the storage provider configuration and try again.'
-      : rawMessage;
-  const status = err?.status && err.status >= 400 ? err.status : 500;
-  return { status, reason, message };
 }


### PR DESCRIPTION
## Summary

- return an actionable `409 FABRIC_INVENTORY_IN_USE` response when a fabric roll is protected by traceability or transaction references
- surface the server explanation in the Fabric Inventory UI and direct users to deplete referenced rolls instead of deleting audit history
- classify storage-provider IAM denials as `503 storage_provider_permission_denied`, preventing the client from treating the outage as a user-authentication failure and retrying the upload
- add focused regression coverage for both error classifications

## Root cause

Fabric inventory deletion attempted an unconditional hard delete, so PostgreSQL foreign-key protection surfaced as a generic 500. Controlled-document uploads passed provider-originated Google Cloud Storage permission denials through as HTTP 403, which incorrectly activated the client authentication retry path.

## Validation

- `server/__tests__/fabricInventoryDeletion.test.ts`
- `server/__tests__/fileStorageProviderErrors.test.ts`
- 4 focused tests passed
- `git diff --cached --check` passed
- full TypeScript validation was attempted with 2 GB and 4 GB Node heaps but exhausted memory before completion

## Deployment boundary

This code corrects classification and user guidance. Restoring controlled-document uploads still requires the Replit deployment's central-storage association/IAM to be repaired so its service account has `storage.objects.create`; the application continues to fail closed until that external permission is restored.