### PR TITLE
Create draft travelers with P2 work orders

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -4010,7 +4010,9 @@ export default function ProjectDetailPage() {
                             <p className="text-sm font-medium">Manufacturing Structure</p>
                             <div className="flex items-center gap-2">
                               <Badge variant="secondary">BOM driven</Badge>
-                              {hasMissingManufacturingWorkOrder(line.manufacturingHierarchy) && (
+                              {!hubProduction.manufacturingWorkOrderAction?.completed &&
+                                (hasMissingManufacturingWorkOrder(line.manufacturingHierarchy) ||
+                                  Boolean(line.manufacturingHierarchy)) && (
                                 <Button
                                   size="sm"
                                   disabled={createManufacturingWorkOrders.isPending}

--- a/migrations/0278_p2_component_traveler_provisioning.sql
+++ b/migrations/0278_p2_component_traveler_provisioning.sql
@@ -1,0 +1,11 @@
+ALTER TABLE project_production_launch_events
+  DROP CONSTRAINT IF EXISTS project_production_launch_events_event_type_check;
+
+ALTER TABLE project_production_launch_events
+  ADD CONSTRAINT project_production_launch_events_event_type_check
+  CHECK (event_type IN (
+    'RECURSIVE_DEMAND_GRAPH_PERSISTED','EXECUTION_AUTHORIZED',
+    'P2_PRODUCTION_ORDERS_PROVISIONED','P2_SERIALIZED_UNITS_PROVISIONED',
+    'P2_DRAFT_TRAVELERS_PROVISIONED','P2_WORK_ORDERS_PROVISIONED',
+    'P2_COMPONENT_TRAVELERS_PROVISIONED'
+  ));

--- a/server/__tests__/componentTravelerProvisioningFeatureGate.test.ts
+++ b/server/__tests__/componentTravelerProvisioningFeatureGate.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isP2V2ComponentTravelerProvisioningEnabled } from '../src/lib/featureFlags';
+
+describe('P2 V2 component traveler provisioning feature gate', () => {
+  afterEach(
+    () => delete process.env.P2_V2_COMPONENT_TRAVELER_PROVISIONING_ENABLED
+  );
+
+  it.each([undefined, '', 'false', 'TRUE', '1', ' true '])(
+    'fails closed for %s',
+    (value) => {
+      if (value === undefined)
+        delete process.env.P2_V2_COMPONENT_TRAVELER_PROVISIONING_ENABLED;
+      else process.env.P2_V2_COMPONENT_TRAVELER_PROVISIONING_ENABLED = value;
+      expect(isP2V2ComponentTravelerProvisioningEnabled()).toBe(false);
+    }
+  );
+
+  it('enables only exact lowercase true', () => {
+    process.env.P2_V2_COMPONENT_TRAVELER_PROVISIONING_ENABLED = 'true';
+    expect(isP2V2ComponentTravelerProvisioningEnabled()).toBe(true);
+  });
+});

--- a/server/__tests__/componentTravelerProvisioningFoundation.test.ts
+++ b/server/__tests__/componentTravelerProvisioningFoundation.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+const service = read(
+  'server/src/services/componentTravelerProvisioningService.ts'
+);
+const route = read('server/src/routes/projectProductionPlanning.ts');
+const migration = read(
+  'migrations/0278_p2_component_traveler_provisioning.sql'
+);
+const runner = read('server/scripts/migrations/runSafeBootMigrations.ts');
+
+describe('P2 component traveler provisioning boundary', () => {
+  it('is independently disabled and capability protected', () => {
+    expect(service).toContain('isP2V2ComponentTravelerProvisioningEnabled()');
+    expect(route).toContain(
+      "'/launch/:launchId/provision-component-travelers'"
+    );
+    expect(route).toContain("'projects.production_launch.launch'");
+  });
+
+  it('targets manufactured children only after work-order provisioning', () => {
+    expect(service).toContain("event_type='P2_WORK_ORDERS_PROVISIONED'");
+    expect(service).toContain("d.disposition='MAKE'");
+    expect(service).toContain('d.parent_demand_id IS NOT NULL');
+    expect(service).toContain("wo.link_type='WORK_ORDER'");
+    expect(service).toContain('WORK_ORDER_PROVISIONING_REQUIRED');
+  });
+
+  it('requires exact draft work-order and frozen-routing evidence', () => {
+    expect(service).toContain("target.work_order_status !== 'PLANNED'");
+    expect(service).toContain("target.work_order_wad_status !== 'DRAFT'");
+    expect(service).toContain('work_order_part_number');
+    expect(service).toContain('routing_first_department');
+    expect(service).toContain('first_department_snapshot');
+  });
+
+  it('creates draft travelers without downstream execution records', () => {
+    expect(service).toContain('generateTravelerFromRouting');
+    expect(service).toContain("status: 'DRAFT'");
+    expect(service).toContain("'TRAVELER'");
+    for (const forbidden of [
+      'INSERT INTO cnc_jobs',
+      'INSERT INTO manufacturing_queue',
+      'INSERT INTO cutting_packet_schedule',
+    ])
+      expect(service).not.toContain(forbidden);
+    expect(service).toContain('createsCncJobs: false');
+    expect(service).toContain('releasesFloorWork: false');
+  });
+
+  it('uses locking, idempotency, reconciliation guards, and registered audit evidence', () => {
+    expect(service).toContain('pg_advisory_lock');
+    expect(service).toContain('COMPONENT_TRAVELER_IDEMPOTENCY_CONFLICT');
+    expect(service).toContain(
+      'EXISTING_COMPONENT_TRAVELER_REQUIRES_RECONCILIATION'
+    );
+    expect(migration).toContain("'P2_COMPONENT_TRAVELERS_PROVISIONED'");
+    expect(
+      runner.match(/0278_p2_component_traveler_provisioning\.sql/g)
+    ).toHaveLength(2);
+  });
+});

--- a/server/__tests__/componentTravelerProvisioningService.test.ts
+++ b/server/__tests__/componentTravelerProvisioningService.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  enabled: vi.fn(() => true),
+  connect: vi.fn(),
+  execute: vi.fn(),
+  generate: vi.fn(),
+  update: vi.fn(),
+}));
+vi.mock('../db', () => ({
+  db: { execute: mocks.execute },
+  pgPool: { connect: mocks.connect },
+}));
+vi.mock('../storage', () => ({
+  storage: {
+    generateTravelerFromRouting: mocks.generate,
+    updateTraveler: mocks.update,
+  },
+}));
+vi.mock('../src/lib/featureFlags', () => ({
+  isP2V2ComponentTravelerProvisioningEnabled: mocks.enabled,
+}));
+
+import { provisionP2ComponentTravelers } from '../src/services/componentTravelerProvisioningService';
+
+const input = {
+  idempotencyKey: 'synthetic-key',
+  expectedLaunchDigest: 'a'.repeat(64),
+  signatureMeaning: 'Provision component travelers.',
+};
+const actor = {
+  userId: 1,
+  employeeId: 2,
+  username: 'operator',
+  displayName: 'Synthetic Operator',
+  role: 'OPERATIONS',
+};
+
+describe('P2 component traveler provisioning service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.enabled.mockReturnValue(true);
+  });
+
+  it('performs no database or storage work while disabled', async () => {
+    mocks.enabled.mockReturnValue(false);
+    await expect(
+      provisionP2ComponentTravelers('project-1', 'launch-1', input, actor)
+    ).rejects.toMatchObject({
+      code: 'P2_V2_COMPONENT_TRAVELER_PROVISIONING_DISABLED',
+    });
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(mocks.generate).not.toHaveBeenCalled();
+  });
+
+  it('creates one draft batch traveler for a manufactured child work order', async () => {
+    const client = { query: vi.fn(), release: vi.fn() };
+    mocks.connect.mockResolvedValue(client);
+    const responses: unknown[] = [
+      [
+        {
+          id: 'launch-1',
+          status: 'COMPLETE',
+          preview_digest: input.expectedLaunchDigest,
+          wad_status: 'RELEASED',
+          work_order_wad_status: 'APPROVED',
+        },
+      ],
+      [],
+      [{ id: 'work-order-event' }],
+      [
+        {
+          demand_id: 'body-demand',
+          assembly_path: 'root/body',
+          part_number: 'PITOT-BODY',
+          routing_id: 'routing-1',
+          first_department_snapshot: 'CNC',
+          shortage_quantity: '150',
+          demand_status: 'IN_PROCESS',
+          production_work_order_id: 'wo-1',
+          work_order_number: 'P2WO-body',
+          work_order_part_number: 'PITOT-BODY',
+          work_order_quantity: 150,
+          work_order_status: 'PLANNED',
+          work_order_wad_status: 'DRAFT',
+          assigned_department: 'CNC',
+          traveler_id: null,
+          routing_first_department: 'CNC',
+        },
+      ],
+      [],
+      [],
+      [],
+      [],
+    ];
+    mocks.execute.mockImplementation(async () => responses.shift() ?? []);
+    mocks.generate.mockResolvedValue({ id: 'traveler-1' });
+    mocks.update.mockResolvedValue({ id: 'traveler-1', status: 'DRAFT' });
+
+    await expect(
+      provisionP2ComponentTravelers('project-1', 'launch-1', input, actor)
+    ).resolves.toMatchObject({
+      replayed: false,
+      travelerIds: ['traveler-1'],
+      provisionedDemandIds: ['body-demand'],
+    });
+    expect(mocks.generate).toHaveBeenCalledWith(
+      'routing-1',
+      expect.objectContaining({ lotNumber: 'P2WO-body', quantity: 150 })
+    );
+    expect(mocks.update).toHaveBeenCalledWith(
+      'traveler-1',
+      expect.objectContaining({
+        status: 'DRAFT',
+        productionWorkOrderId: 'wo-1',
+      })
+    );
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+});

--- a/server/__tests__/simpleManufacturingWorkOrderAction.test.ts
+++ b/server/__tests__/simpleManufacturingWorkOrderAction.test.ts
@@ -24,6 +24,7 @@ describe('simple manufacturing work-order action', () => {
     expect(route).toContain('authorizeProductionExecution(');
     expect(route).toContain('provisionP2ProductionOrders(');
     expect(route).toContain('provisionP2WorkOrders(');
+    expect(route).toContain('provisionP2ComponentTravelers(');
     expect(route).toContain("'projects.production_launch.launch'");
   });
 
@@ -38,6 +39,8 @@ describe('simple manufacturing work-order action', () => {
     expect(hub).toContain('isP2V2ExecutionAuthorizationEnabled()');
     expect(hub).toContain('isP2V2ProductionOrderProvisioningEnabled()');
     expect(hub).toContain('isP2V2WorkOrderProvisioningEnabled()');
+    expect(hub).toContain('isP2V2ComponentTravelerProvisioningEnabled()');
+    expect(hub).toContain("event_type = 'P2_COMPONENT_TRAVELERS_PROVISIONED'");
   });
 
   it('shows one plain-language button only while work orders are missing', () => {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -338,6 +338,7 @@ export const safeMigrationFiles = [
   '0275_design_control_verified_approval_assignments.sql',
   '0276_p2_work_order_provisioning.sql',
   '0277_routing_document_controlled_link.sql',
+  '0278_p2_component_traveler_provisioning.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -421,6 +422,7 @@ export const criticalMigrationFiles = new Set([
   '0275_design_control_verified_approval_assignments.sql',
   '0276_p2_work_order_provisioning.sql',
   '0277_routing_document_controlled_link.sql',
+  '0278_p2_component_traveler_provisioning.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -88,6 +88,11 @@ export function isP2V2WorkOrderProvisioningEnabled(): boolean {
   return process.env.P2_V2_WORK_ORDER_PROVISIONING_ENABLED === 'true';
 }
 
+/** Gates draft batch travelers for manufactured child work orders. */
+export function isP2V2ComponentTravelerProvisioningEnabled(): boolean {
+  return process.env.P2_V2_COMPONENT_TRAVELER_PROVISIONING_ENABLED === 'true';
+}
+
 /**
  * Cutover date for the punch_ledger migration.
  * For pay periods starting ON or AFTER this date, hour computations read

--- a/server/src/routes/projectProductionPlanning.ts
+++ b/server/src/routes/projectProductionPlanning.ts
@@ -37,6 +37,10 @@ import {
   provisionP2WorkOrders,
   WorkOrderProvisioningError,
 } from '../services/workOrderProvisioningService';
+import {
+  provisionP2ComponentTravelers,
+  ComponentTravelerProvisioningError,
+} from '../services/componentTravelerProvisioningService';
 
 const router = Router({ mergeParams: true });
 const headerSchema = z.object({
@@ -71,6 +75,7 @@ const productionOrderProvisioningSchema = executionAuthorizationSchema;
 const serializedUnitProvisioningSchema = executionAuthorizationSchema;
 const travelerProvisioningSchema = executionAuthorizationSchema;
 const workOrderProvisioningSchema = executionAuthorizationSchema;
+const componentTravelerProvisioningSchema = executionAuthorizationSchema;
 const itemSchema = z
   .object({
     drawing_number: z.string().nullable().optional(),
@@ -196,6 +201,10 @@ function fail(res: Response, error: unknown) {
       .status(error.status)
       .json({ error: error.code, message: error.message, ...error.details });
   if (error instanceof WorkOrderProvisioningError)
+    return res
+      .status(error.status)
+      .json({ error: error.code, message: error.message, ...error.details });
+  if (error instanceof ComponentTravelerProvisioningError)
     return res
       .status(error.status)
       .json({ error: error.code, message: error.message, ...error.details });
@@ -351,7 +360,13 @@ router.post(
         sharedInput,
         user
       );
-      const result = await provisionP2WorkOrders(
+      await provisionP2WorkOrders(
+        projectId(req),
+        req.params.launchId,
+        sharedInput,
+        user
+      );
+      const result = await provisionP2ComponentTravelers(
         projectId(req),
         req.params.launchId,
         sharedInput,
@@ -363,6 +378,26 @@ router.post(
           ? 'Manufacturing work orders already exist.'
           : 'Manufacturing work orders created.',
       });
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
+router.post(
+  '/launch/:launchId/provision-component-travelers',
+  async (req, res) => {
+    try {
+      const user = await requireCapability(
+        req,
+        'projects.production_launch.launch'
+      );
+      const result = await provisionP2ComponentTravelers(
+        projectId(req),
+        req.params.launchId,
+        componentTravelerProvisioningSchema.parse(req.body),
+        user
+      );
+      res.status(result.replayed ? 200 : 201).json(result);
     } catch (error) {
       fail(res, error);
     }

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -30,6 +30,7 @@ import { evaluateDocumentationRequirements } from '../lib/documentationRequireme
 import { cancelWadWorkOrdersSupersededByP2 } from '../services/wadSupersedeService';
 import { ensureProductionWorkflowReadSchema } from '../lib/productionWorkflowReadiness';
 import {
+  isP2V2ComponentTravelerProvisioningEnabled,
   isP2V2ExecutionAuthorizationEnabled,
   isP2V2ProductionOrderProvisioningEnabled,
   isP2V2WorkOrderProvisioningEnabled,
@@ -4179,10 +4180,15 @@ router.get('/:id/p2-hub', async (req, res) => {
     const manufacturingWorkOrderLaunch =
       (
         await pool.query(
-          `SELECT id, preview_digest AS "previewDigest", status
-           FROM project_production_launches
-          WHERE project_id = $1 AND status = 'COMPLETE'
-          ORDER BY launched_at DESC
+          `SELECT pl.id, pl.preview_digest AS "previewDigest", pl.status,
+             EXISTS (
+               SELECT 1 FROM project_production_launch_events ple
+               WHERE ple.production_launch_id = pl.id
+                 AND ple.event_type = 'P2_COMPONENT_TRAVELERS_PROVISIONED'
+             ) AS completed
+           FROM project_production_launches pl
+           WHERE pl.project_id = $1 AND pl.status = 'COMPLETE'
+          ORDER BY pl.launched_at DESC
           LIMIT 1`,
           [id]
         )
@@ -4190,7 +4196,9 @@ router.get('/:id/p2-hub', async (req, res) => {
     const manufacturingWorkOrderAction = {
       launchId: manufacturingWorkOrderLaunch?.id ?? null,
       expectedLaunchDigest: manufacturingWorkOrderLaunch?.previewDigest ?? null,
+      completed: Boolean(manufacturingWorkOrderLaunch?.completed),
       enabled:
+        isP2V2ComponentTravelerProvisioningEnabled() &&
         isP2V2ExecutionAuthorizationEnabled() &&
         isP2V2ProductionOrderProvisioningEnabled() &&
         isP2V2WorkOrderProvisioningEnabled(),

--- a/server/src/services/componentTravelerProvisioningService.ts
+++ b/server/src/services/componentTravelerProvisioningService.ts
@@ -1,0 +1,264 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { sql } from 'drizzle-orm';
+
+import { db, pgPool } from '../../db';
+import { storage } from '../../storage';
+import { isP2V2ComponentTravelerProvisioningEnabled } from '../lib/featureFlags';
+import type { PlanningActor } from './projectProductionPlanningService';
+
+type Row = Record<string, unknown>;
+const rows = (value: unknown): Row[] =>
+  Array.isArray(value)
+    ? (value as Row[])
+    : ((value as { rows?: Row[] } | null)?.rows ?? []);
+const digest = (value: unknown) =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+export type ComponentTravelerProvisioningInput = {
+  idempotencyKey: string;
+  expectedLaunchDigest: string;
+  signatureMeaning: string;
+};
+
+export class ComponentTravelerProvisioningError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 409,
+    public details: Record<string, unknown> = {}
+  ) {
+    super(message);
+  }
+}
+
+export async function provisionP2ComponentTravelers(
+  projectId: string,
+  launchId: string,
+  input: ComponentTravelerProvisioningInput,
+  actor: PlanningActor
+) {
+  if (!isP2V2ComponentTravelerProvisioningEnabled())
+    throw new ComponentTravelerProvisioningError(
+      'P2_V2_COMPONENT_TRAVELER_PROVISIONING_DISABLED',
+      'P2 component traveler provisioning is disabled.',
+      503
+    );
+  const requestHash = digest({
+    projectId,
+    launchId,
+    idempotencyKey: input.idempotencyKey.trim(),
+    expectedLaunchDigest: input.expectedLaunchDigest,
+  });
+  const lockClient = await pgPool.connect();
+  try {
+    await lockClient.query(
+      'SELECT pg_advisory_lock(hashtext($1),hashtext($2))',
+      ['p2-v2-component-travelers', projectId]
+    );
+    const launch = rows(
+      await db.execute(sql`
+      SELECT pl.id,pl.status,pl.preview_digest,wa.status AS wad_status,
+        pwo.wad_status AS work_order_wad_status
+      FROM project_production_launches pl
+      JOIN projects p ON p.id=pl.project_id AND p.workflow_version='p2_v2'
+      JOIN project_wad_authorizations wa ON wa.id=pl.wad_authorization_id
+      JOIN production_work_orders pwo ON pwo.id=wa.wad_work_order_id
+      WHERE pl.id=${launchId} AND pl.project_id=${projectId}`)
+    )[0];
+    if (!launch)
+      throw new ComponentTravelerProvisioningError(
+        'PRODUCTION_LAUNCH_NOT_FOUND',
+        'The completed Production Launch was not found.',
+        404
+      );
+    if (
+      launch.status !== 'COMPLETE' ||
+      launch.wad_status !== 'RELEASED' ||
+      launch.work_order_wad_status !== 'APPROVED'
+    )
+      throw new ComponentTravelerProvisioningError(
+        'EXECUTION_AUTHORITY_NOT_RELEASED',
+        'The launch and exact WAD authority must remain complete and released.'
+      );
+    if (String(launch.preview_digest) !== input.expectedLaunchDigest)
+      throw new ComponentTravelerProvisioningError(
+        'STALE_PRODUCTION_LAUNCH',
+        'The expected Production Launch digest is stale.'
+      );
+
+    const priorEvent = rows(
+      await db.execute(sql`
+      SELECT * FROM project_production_launch_events
+      WHERE production_launch_id=${launchId}
+        AND event_type='P2_COMPONENT_TRAVELERS_PROVISIONED' LIMIT 1`)
+    )[0];
+    if (priorEvent) {
+      if (String(priorEvent.request_hash) !== requestHash)
+        throw new ComponentTravelerProvisioningError(
+          'COMPONENT_TRAVELER_IDEMPOTENCY_CONFLICT',
+          'Component travelers were already provisioned with different evidence.'
+        );
+      return { replayed: true, event: priorEvent };
+    }
+    const workOrderEvent = rows(
+      await db.execute(sql`
+      SELECT id FROM project_production_launch_events
+      WHERE production_launch_id=${launchId} AND event_type='P2_WORK_ORDERS_PROVISIONED' LIMIT 1`)
+    )[0];
+    if (!workOrderEvent)
+      throw new ComponentTravelerProvisioningError(
+        'WORK_ORDER_PROVISIONING_REQUIRED',
+        'Component work orders must be provisioned first.'
+      );
+
+    const targets = rows(
+      await db.execute(sql`
+      SELECT d.id AS demand_id,d.assembly_path,d.part_number,d.routing_id,
+        d.first_department_snapshot,d.shortage_quantity,d.demand_status,
+        wo.production_work_order_id,pwo.work_order_number,pwo.part_number AS work_order_part_number,
+        pwo.quantity AS work_order_quantity,pwo.status AS work_order_status,
+        pwo.wad_status AS work_order_wad_status,pwo.assigned_department,
+        tl.traveler_id,ro.department_name AS routing_first_department
+      FROM project_production_demands d
+      JOIN project_production_demand_execution_links wo
+        ON wo.demand_id=d.id AND wo.project_id=d.project_id AND wo.link_type='WORK_ORDER'
+      JOIN production_work_orders pwo ON pwo.id=wo.production_work_order_id
+      LEFT JOIN project_production_demand_execution_links tl
+        ON tl.demand_id=d.id AND tl.project_id=d.project_id AND tl.link_type='TRAVELER'
+      LEFT JOIN LATERAL (
+        SELECT department_name FROM routing_operations
+        WHERE part_routing_id=d.routing_id ORDER BY step_number,id LIMIT 1
+      ) ro ON true
+      WHERE d.project_id=${projectId} AND d.production_launch_id=${launchId}
+        AND d.disposition='MAKE' AND d.shortage_quantity>0
+        AND d.parent_demand_id IS NOT NULL
+      ORDER BY d.path_depth,d.assembly_path`)
+    );
+    if (!targets.length)
+      throw new ComponentTravelerProvisioningError(
+        'MANUFACTURED_CHILD_WORK_ORDERS_REQUIRED',
+        'No manufactured child work orders are available for traveler provisioning.'
+      );
+    const invalid = targets.filter(
+      (target) =>
+        target.demand_status !== 'IN_PROCESS' ||
+        target.work_order_status !== 'PLANNED' ||
+        target.work_order_wad_status !== 'DRAFT' ||
+        target.traveler_id ||
+        !target.routing_id ||
+        String(target.part_number).trim().toLowerCase() !==
+          String(target.work_order_part_number).trim().toLowerCase() ||
+        Number(target.shortage_quantity) !==
+          Number(target.work_order_quantity) ||
+        String(target.routing_first_department ?? '').trim() !==
+          String(target.first_department_snapshot ?? '').trim() ||
+        String(target.assigned_department ?? '').trim() !==
+          String(target.first_department_snapshot ?? '').trim()
+    );
+    if (invalid.length)
+      throw new ComponentTravelerProvisioningError(
+        'COMPONENT_WORK_ORDER_NOT_TRAVELER_READY',
+        'Every manufactured child must retain a draft work order and exact frozen routing evidence.',
+        409,
+        { paths: invalid.map((target) => target.assembly_path) }
+      );
+
+    const existing = rows(
+      await db.execute(sql`
+      SELECT t.id FROM travelers t
+      WHERE t.production_work_order_id IN (${sql.join(
+        targets.map(
+          (target) => sql`${String(target.production_work_order_id)}`
+        ),
+        sql`,`
+      )})
+         OR t.work_order_id IN (${sql.join(
+           targets.map((target) => sql`${String(target.work_order_number)}`),
+           sql`,`
+         )})
+      LIMIT 1`)
+    );
+    if (existing.length)
+      throw new ComponentTravelerProvisioningError(
+        'EXISTING_COMPONENT_TRAVELER_REQUIRES_RECONCILIATION',
+        'An unlinked traveler already exists for a component work order.'
+      );
+
+    const travelerIds: string[] = [];
+    const linkIds: string[] = [];
+    for (const target of targets) {
+      let traveler = await storage.generateTravelerFromRouting(
+        String(target.routing_id),
+        {
+          lotNumber: String(target.work_order_number),
+          quantity: Number(target.work_order_quantity),
+          createdBy: actor.displayName,
+        }
+      );
+      traveler = await storage.updateTraveler(traveler.id, {
+        status: 'DRAFT',
+        projectId,
+        productionWorkOrderId: String(target.production_work_order_id),
+        workOrderId: String(target.work_order_number),
+      });
+      const linkId = randomUUID();
+      await db.execute(sql`
+        INSERT INTO project_production_demand_execution_links
+          (id,project_id,demand_id,traveler_id,link_type)
+        VALUES (${linkId},${projectId},${String(target.demand_id)},${traveler.id},'TRAVELER')`);
+      travelerIds.push(traveler.id);
+      linkIds.push(linkId);
+    }
+    const started = rows(
+      await db.execute(sql`
+      SELECT t.id FROM travelers t
+      JOIN project_production_demand_execution_links l ON l.traveler_id=t.id
+      LEFT JOIN traveler_steps ts ON ts.traveler_id=t.id AND ts.status<>'NOT_STARTED'
+      WHERE l.project_id=${projectId} AND l.link_type='TRAVELER'
+        AND l.demand_id IN (${sql.join(
+          targets.map((target) => sql`${String(target.demand_id)}`),
+          sql`,`
+        )})
+        AND (t.status<>'DRAFT' OR ts.id IS NOT NULL) LIMIT 1`)
+    );
+    if (started.length)
+      throw new ComponentTravelerProvisioningError(
+        'COMPONENT_TRAVELER_ACTIVATION_BOUNDARY_VIOLATED',
+        'Component travelers must remain draft with all steps not started.'
+      );
+
+    const eventId = randomUUID();
+    const evidence = {
+      launchId,
+      demandIds: targets.map((target) => target.demand_id),
+      workOrderIds: targets.map((target) => target.production_work_order_id),
+      travelerIds,
+      createsCncJobs: false,
+      createsQueues: false,
+      releasesFloorWork: false,
+    };
+    await db.execute(sql`
+      INSERT INTO project_production_launch_events
+        (id,project_id,production_launch_id,event_type,request_hash,evidence_digest,
+         created_record_ids,evidence_snapshot,actor_user_id,actor_display_name,actor_role,signature_meaning)
+      VALUES (${eventId},${projectId},${launchId},'P2_COMPONENT_TRAVELERS_PROVISIONED',
+        ${requestHash},${digest(evidence)},${JSON.stringify({ travelerIds, linkIds })}::jsonb,
+        ${JSON.stringify(evidence)}::jsonb,${actor.userId},${actor.displayName},${actor.role},${input.signatureMeaning.trim()})`);
+    return {
+      replayed: false,
+      eventId,
+      travelerIds,
+      provisionedDemandIds: evidence.demandIds,
+    };
+  } finally {
+    try {
+      await lockClient.query(
+        'SELECT pg_advisory_unlock(hashtext($1),hashtext($2))',
+        ['p2-v2-component-travelers', projectId]
+      );
+    } finally {
+      lockClient.release();
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- extends the existing **Create Manufacturing Work Orders** action to conditionally generate draft travelers for manufactured child work orders
- reads the traveler decision from the exact released WAD Step 6 snapshot
- creates one routing-based batch traveler per manufactured child only when the WAD explicitly selects **Traveler Required**
- records a controlled zero-traveler result when the WAD explicitly selects travelers as not required
- blocks with an actionable WAD correction when the traveler selection is missing or contradictory
- keeps the same single operator button available until the combined action finishes

## Why

Operators asked for a simple workflow, but the WAD must remain authoritative. Manufactured items do not automatically require travelers. This PR keeps one operator action while respecting the released WAD traveler selection.

## Behavior

- WAD Step 6 `travelerRequired = true`: manufactured child work orders receive draft routing travelers
- WAD Step 6 `travelerRequired = false`: work orders are created with no travelers
- missing or conflicting WAD traveler evidence: the action blocks instead of guessing
- the root assembly remains on its existing serialized-unit traveler path
- purchased parts receive neither production work orders nor travelers
- traveler quantities come from the controlled child work order, not browser input
- all traveler operations remain `NOT_STARTED`

## Safety boundaries

- independently fail-closed behind `P2_V2_COMPONENT_TRAVELER_PROVISIONING_ENABLED`
- also requires the existing execution, P2-order, and work-order provisioning flags
- requires a completed Production Launch and completed work-order provisioning event
- requires exact WAD, work-order part, quantity, routing, and first-department agreement
- creates no CNC jobs, manufacturing queues, cutting jobs, purchasing records, or floor release
- preserves reconciliation, idempotency, and immutable audit evidence

## Validation

- 23/23 focused Vitest tests passed
- focused server lint passed
- `git diff --check` passed
- PostgreSQL migration replay remains pending CI or a disposable PostgreSQL runtime