### PR TITLE
Honor WAD traveler selection for manufactured items

### DIFF
--- a/server/__tests__/componentTravelerProvisioningFoundation.test.ts
+++ b/server/__tests__/componentTravelerProvisioningFoundation.test.ts
@@ -31,6 +31,9 @@ describe('P2 component traveler provisioning boundary', () => {
   });
 
   it('requires exact draft work-order and frozen-routing evidence', () => {
+    expect(service).toContain('resolveWadTravelerRequired');
+    expect(service).toContain('WAD_TRAVELER_SELECTION_REQUIRED');
+    expect(service).toContain('travelerRequired: false');
     expect(service).toContain("target.work_order_status !== 'PLANNED'");
     expect(service).toContain("target.work_order_wad_status !== 'DRAFT'");
     expect(service).toContain('work_order_part_number');

--- a/server/__tests__/componentTravelerProvisioningService.test.ts
+++ b/server/__tests__/componentTravelerProvisioningService.test.ts
@@ -21,7 +21,10 @@ vi.mock('../src/lib/featureFlags', () => ({
   isP2V2ComponentTravelerProvisioningEnabled: mocks.enabled,
 }));
 
-import { provisionP2ComponentTravelers } from '../src/services/componentTravelerProvisioningService';
+import {
+  provisionP2ComponentTravelers,
+  resolveWadTravelerRequired,
+} from '../src/services/componentTravelerProvisioningService';
 
 const input = {
   idempotencyKey: 'synthetic-key',
@@ -40,6 +43,22 @@ describe('P2 component traveler provisioning service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.enabled.mockReturnValue(true);
+  });
+
+  it('uses only an explicit, unambiguous WAD traveler selection', () => {
+    expect(
+      resolveWadTravelerRequired({ step6: { travelerRequired: true } })
+    ).toBe(true);
+    expect(
+      resolveWadTravelerRequired({ step6: { travelerRequired: false } })
+    ).toBe(false);
+    expect(resolveWadTravelerRequired({})).toBeNull();
+    expect(
+      resolveWadTravelerRequired({
+        travelerRequired: true,
+        step6: { travelerRequired: false },
+      })
+    ).toBeNull();
   });
 
   it('performs no database or storage work while disabled', async () => {
@@ -64,6 +83,7 @@ describe('P2 component traveler provisioning service', () => {
           preview_digest: input.expectedLaunchDigest,
           wad_status: 'RELEASED',
           work_order_wad_status: 'APPROVED',
+          wad_wizard_data: { step6: { travelerRequired: true } },
         },
       ],
       [],
@@ -115,6 +135,62 @@ describe('P2 component traveler provisioning service', () => {
         productionWorkOrderId: 'wo-1',
       })
     );
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('records a WAD no-traveler selection without generating travelers', async () => {
+    const client = { query: vi.fn(), release: vi.fn() };
+    mocks.connect.mockResolvedValue(client);
+    const responses: unknown[] = [
+      [
+        {
+          id: 'launch-1',
+          status: 'COMPLETE',
+          preview_digest: input.expectedLaunchDigest,
+          wad_status: 'RELEASED',
+          work_order_wad_status: 'APPROVED',
+          wad_wizard_data: { step6: { travelerRequired: false } },
+        },
+      ],
+      [],
+      [{ id: 'work-order-event' }],
+      [],
+    ];
+    mocks.execute.mockImplementation(async () => responses.shift() ?? []);
+    await expect(
+      provisionP2ComponentTravelers('project-1', 'launch-1', input, actor)
+    ).resolves.toMatchObject({
+      replayed: false,
+      travelerRequired: false,
+      travelerIds: [],
+    });
+    expect(mocks.generate).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('blocks when the released WAD has no traveler selection', async () => {
+    const client = { query: vi.fn(), release: vi.fn() };
+    mocks.connect.mockResolvedValue(client);
+    const responses: unknown[] = [
+      [
+        {
+          id: 'launch-1',
+          status: 'COMPLETE',
+          preview_digest: input.expectedLaunchDigest,
+          wad_status: 'RELEASED',
+          work_order_wad_status: 'APPROVED',
+          wad_wizard_data: {},
+        },
+      ],
+      [],
+      [{ id: 'work-order-event' }],
+    ];
+    mocks.execute.mockImplementation(async () => responses.shift() ?? []);
+    await expect(
+      provisionP2ComponentTravelers('project-1', 'launch-1', input, actor)
+    ).rejects.toMatchObject({ code: 'WAD_TRAVELER_SELECTION_REQUIRED' });
+    expect(mocks.generate).not.toHaveBeenCalled();
     expect(client.release).toHaveBeenCalledOnce();
   });
 });

--- a/server/src/services/componentTravelerProvisioningService.ts
+++ b/server/src/services/componentTravelerProvisioningService.ts
@@ -15,6 +15,24 @@ const rows = (value: unknown): Row[] =>
 const digest = (value: unknown) =>
   createHash('sha256').update(JSON.stringify(value)).digest('hex');
 
+export function resolveWadTravelerRequired(value: unknown): boolean | null {
+  const wizard = value && typeof value === 'object' ? (value as Row) : {};
+  const step6 =
+    wizard.step6 && typeof wizard.step6 === 'object'
+      ? (wizard.step6 as Row).travelerRequired
+      : undefined;
+  const legacy = wizard.travelerRequired;
+  const decisions = [step6, legacy].filter(
+    (decision): decision is boolean => typeof decision === 'boolean'
+  );
+  if (
+    !decisions.length ||
+    decisions.some((decision) => decision !== decisions[0])
+  )
+    return null;
+  return decisions[0];
+}
+
 export type ComponentTravelerProvisioningInput = {
   idempotencyKey: string;
   expectedLaunchDigest: string;
@@ -59,7 +77,7 @@ export async function provisionP2ComponentTravelers(
     const launch = rows(
       await db.execute(sql`
       SELECT pl.id,pl.status,pl.preview_digest,wa.status AS wad_status,
-        pwo.wad_status AS work_order_wad_status
+        pwo.wad_status AS work_order_wad_status,pwo.wizard_data AS wad_wizard_data
       FROM project_production_launches pl
       JOIN projects p ON p.id=pl.project_id AND p.workflow_version='p2_v2'
       JOIN project_wad_authorizations wa ON wa.id=pl.wad_authorization_id
@@ -111,6 +129,38 @@ export async function provisionP2ComponentTravelers(
         'WORK_ORDER_PROVISIONING_REQUIRED',
         'Component work orders must be provisioned first.'
       );
+    const travelerRequired = resolveWadTravelerRequired(launch.wad_wizard_data);
+    if (travelerRequired === null)
+      throw new ComponentTravelerProvisioningError(
+        'WAD_TRAVELER_SELECTION_REQUIRED',
+        'Select whether travelers are required in WAD Step 6 before creating manufacturing work orders.'
+      );
+    if (!travelerRequired) {
+      const eventId = randomUUID();
+      const evidence = {
+        launchId,
+        travelerRequired: false,
+        travelerIds: [],
+        reason: 'Released WAD Step 6 does not require travelers.',
+        createsCncJobs: false,
+        createsQueues: false,
+        releasesFloorWork: false,
+      };
+      await db.execute(sql`
+        INSERT INTO project_production_launch_events
+          (id,project_id,production_launch_id,event_type,request_hash,evidence_digest,
+           created_record_ids,evidence_snapshot,actor_user_id,actor_display_name,actor_role,signature_meaning)
+        VALUES (${eventId},${projectId},${launchId},'P2_COMPONENT_TRAVELERS_PROVISIONED',
+          ${requestHash},${digest(evidence)},${JSON.stringify({ travelerIds: [] })}::jsonb,
+          ${JSON.stringify(evidence)}::jsonb,${actor.userId},${actor.displayName},${actor.role},${input.signatureMeaning.trim()})`);
+      return {
+        replayed: false,
+        eventId,
+        travelerRequired: false,
+        travelerIds: [],
+        provisionedDemandIds: [],
+      };
+    }
 
     const targets = rows(
       await db.execute(sql`
@@ -231,6 +281,7 @@ export async function provisionP2ComponentTravelers(
     const eventId = randomUUID();
     const evidence = {
       launchId,
+      travelerRequired: true,
       demandIds: targets.map((target) => target.demand_id),
       workOrderIds: targets.map((target) => target.production_work_order_id),
       travelerIds,


### PR DESCRIPTION
## Correction

PR #1728 generated draft travelers for every manufactured child. That is too broad. The released WAD must decide whether travelers are required.

## Behavior

- WAD Step 6 `travelerRequired = true`: generate draft travelers for manufactured child work orders
- WAD Step 6 `travelerRequired = false`: create no travelers and record the controlled no-traveler result
- missing or contradictory WAD traveler evidence: block with an actionable WAD Step 6 correction message
- production-plan traveler preferences are not substituted for the released WAD decision
- purchased items remain traveler-free

## Safety

- reads the exact WAD linked to the Production Launch
- preserves idempotency and immutable event evidence
- makes no CNC jobs, department queues, cutting jobs, or floor releases
- does not change existing historical travelers

## Validation

- 17/17 focused corrective tests passed
- focused ESLint passed
- `git diff --check` passed