### PR TITLE
Show all purchased BOM parts in project Material

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -4133,8 +4133,8 @@ export default function ProjectDetailPage() {
             <CardContent className="space-y-4">
               <div className="grid gap-3 md:grid-cols-4">
                 <div className="rounded-md border bg-muted/30 p-3">
-                  <p className="text-xs text-muted-foreground">PO Parts</p>
-                  <p className="font-medium">{Array.isArray(hubMaterial.parts) ? hubMaterial.parts.length : 0}</p>
+                  <p className="text-xs text-muted-foreground">BOM Purchased Parts</p>
+                  <p className="font-medium">{hubMaterial.summary?.purchasedBomPartCount ?? (Array.isArray(hubMaterial.parts) ? hubMaterial.parts.length : 0)}</p>
                 </div>
                 <div className="rounded-md border bg-muted/30 p-3">
                   <p className="text-xs text-muted-foreground">Parts Requests</p>
@@ -4221,7 +4221,12 @@ export default function ProjectDetailPage() {
                 </div>
               )}
               {Array.isArray(hubMaterial.parts) && hubMaterial.parts.length > 0 && (
-                <div className="space-y-2">
+                <div className="rounded-md border p-4">
+                  <div className="mb-3">
+                    <h3 className="text-base font-semibold">BOM Purchased Parts</h3>
+                    <p className="text-sm text-muted-foreground">All purchased components required by the active assembly BOM, extended by the ordered assembly quantity.</p>
+                  </div>
+                  <div className="space-y-2">
                   {hubMaterial.parts.map((part: any) => (
                     <div key={part.id} className="flex items-center justify-between rounded-md border p-3">
                       <div>
@@ -4231,6 +4236,7 @@ export default function ProjectDetailPage() {
                       <Badge variant="outline">Qty {part.quantity}</Badge>
                     </div>
                   ))}
+                  </div>
                 </div>
               )}
             </CardContent>

--- a/server/__tests__/projectBomAssembly.test.ts
+++ b/server/__tests__/projectBomAssembly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildProjectBomAssemblyTree, type ProjectBomAssemblyRow } from '../src/services/projectBomAssembly';
+import { buildProjectBomAssemblyTree, collectPurchasedBomParts, type ProjectBomAssemblyRow } from '../src/services/projectBomAssembly';
 
 const row = (overrides: Partial<ProjectBomAssemblyRow>): ProjectBomAssemblyRow => ({
   node_key: ['root:1000'],
@@ -68,5 +68,28 @@ describe('buildProjectBomAssemblyTree', () => {
   it('treats a part with a BOM as manufactured when inventory classification is absent', () => {
     const tree = buildProjectBomAssemblyTree([row({ item_type: null })]);
     expect(tree[0]).toMatchObject({ isManufactured: true, hasBom: true });
+  });
+
+  it('collects every purchased BOM component and extends quantities through the assembly tree', () => {
+    const tree = buildProjectBomAssemblyTree([
+      row({}),
+      row({
+        node_key: ['root:1000', 'line:1'], parent_key: ['root:1000'], part_number: '2000',
+        part_name: 'Manufactured child', item_type: 'MANUFACTURED', qty_per: 2, depth: 1, bom_id: 'bom-child',
+      }),
+      row({
+        node_key: ['root:1000', 'line:1', 'line:2'], parent_key: ['root:1000', 'line:1'], part_number: 'BUY-1',
+        part_name: 'Fastener', item_type: 'PURCHASED', qty_per: 3, depth: 2, bom_id: null,
+      }),
+      row({
+        node_key: ['root:1000', 'line:3'], parent_key: ['root:1000'], part_number: 'BUY-1',
+        part_name: 'Fastener', item_type: 'PURCHASED', qty_per: 1, depth: 1, bom_id: null,
+      }),
+    ]);
+
+    expect(collectPurchasedBomParts(tree, new Map([['1000', 10]]))).toEqual([{
+      id: 'bom-purchased:buy-1', part_number: 'BUY-1', part_name: 'Fastener',
+      quantity: 70, bom_occurrence_count: 2,
+    }]);
   });
 });

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -40,6 +40,7 @@ import { getQuoteContractReviewGate } from '../services/quoteContractService';
 import { getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
 import {
   buildProjectBomAssemblyTree,
+  collectPurchasedBomParts,
   type ProjectBomAssemblyRow,
 } from '../services/projectBomAssembly';
 import { buildProjectProductionHierarchy } from '../services/projectProductionHierarchy';
@@ -3898,6 +3899,25 @@ router.get('/:id/p2-hub', async (req, res) => {
           )
         : [];
     const assemblyTree = buildProjectBomAssemblyTree(assemblyRows);
+    const orderedQuantityByRootPart = new Map<string, number>();
+    assemblySourceItems.forEach((item: LegacyProjectValue) => {
+      const rootPartNumber = String(
+        poInventoryPartById.get(Number(item.inventory_item_id)) || item.part_number || ''
+      )
+        .trim()
+        .toLowerCase();
+      if (!rootPartNumber) return;
+      const quantity = Number(item.quantity ?? 0);
+      orderedQuantityByRootPart.set(
+        rootPartNumber,
+        (orderedQuantityByRootPart.get(rootPartNumber) ?? 0) +
+          (Number.isFinite(quantity) ? quantity : 0)
+      );
+    });
+    const purchasedBomParts = collectPurchasedBomParts(
+      assemblyTree,
+      orderedQuantityByRootPart
+    );
     const recursiveBomRecords = Array.from(
       new Map(
         assemblyRows
@@ -4722,12 +4742,13 @@ router.get('/:id/p2-hub', async (req, res) => {
         },
         material: {
           summary: {
+            purchasedBomPartCount: purchasedBomParts.length,
             partsRequestCount: partsRequests.length,
             receivedMaterialCount: receivedMaterials.length,
             materialBudget,
             receivedMaterialCost,
           },
-          parts: poItems,
+          parts: purchasedBomParts,
           partsRequests,
           receivedMaterials,
         },

--- a/server/src/services/projectBomAssembly.ts
+++ b/server/src/services/projectBomAssembly.ts
@@ -34,6 +34,14 @@ export type ProjectBomAssemblyNode = {
   children: ProjectBomAssemblyNode[];
 };
 
+export type ProjectPurchasedBomPart = {
+  id: string;
+  part_number: string;
+  part_name: string | null;
+  quantity: number;
+  bom_occurrence_count: number;
+};
+
 const keyFor = (segments: string[]) => segments.join('/');
 
 export function buildProjectBomAssemblyTree(rows: ProjectBomAssemblyRow[]): ProjectBomAssemblyNode[] {
@@ -79,4 +87,43 @@ export function buildProjectBomAssemblyTree(rows: ProjectBomAssemblyRow[]): Proj
   });
 
   return roots;
+}
+
+export function collectPurchasedBomParts(
+  roots: ProjectBomAssemblyNode[],
+  orderedQuantityByRootPart: ReadonlyMap<string, number>
+): ProjectPurchasedBomPart[] {
+  const purchasedByPart = new Map<string, ProjectPurchasedBomPart>();
+
+  const visit = (node: ProjectBomAssemblyNode, extendedParentQuantity: number) => {
+    const requiredQuantity = extendedParentQuantity * node.quantityPerParent;
+    if (!node.isManufactured) {
+      const normalizedPartNumber = node.partNumber.trim().toLowerCase();
+      const existing = purchasedByPart.get(normalizedPartNumber);
+      if (existing) {
+        existing.quantity += requiredQuantity;
+        existing.bom_occurrence_count += 1;
+      } else {
+        purchasedByPart.set(normalizedPartNumber, {
+          id: `bom-purchased:${normalizedPartNumber}`,
+          part_number: node.partNumber,
+          part_name: node.partName,
+          quantity: requiredQuantity,
+          bom_occurrence_count: 1,
+        });
+      }
+      return;
+    }
+
+    node.children.forEach((child) => visit(child, requiredQuantity));
+  };
+
+  roots.forEach((root) => {
+    const orderedQuantity = orderedQuantityByRootPart.get(root.partNumber.trim().toLowerCase()) ?? 0;
+    root.children.forEach((child) => visit(child, orderedQuantity));
+  });
+
+  return Array.from(purchasedByPart.values()).sort((left, right) =>
+    left.part_number.localeCompare(right.part_number)
+  );
 }


### PR DESCRIPTION
## What changed

- replace the Material tab's customer PO-line list with recursively derived purchased BOM components
- extend required quantities through nested BOM multipliers and the active ordered assembly quantity
- aggregate duplicate purchased parts into one Material-tab row
- label the summary and list as BOM Purchased Parts

## Why

The Material tab was reading `poItems`, so it showed the customer assembly line instead of all purchased components required by that assembly's BOM. This made the project material view incomplete and unsuitable for checking BOM-backed purchasing demand.

## Impact

Project Material now shows the complete purchased-component demand from the active assembly BOM, including nested components and rolled-up quantities. Existing parts-request, receiving, and material-budget data remain unchanged.

## Validation

- `vitest run --root . server/__tests__/projectBomAssembly.test.ts` — 3 tests passed
- `git diff --cached --check` — passed
- `git merge-tree --write-tree HEAD origin/main` — passed after refreshing `origin/main`

## Validation boundaries

- repository-wide TypeScript validation exhausted the available Node heap before diagnostics
- targeted ESLint did not complete within the timeout
- not browser-tested, deployed, or validated against production data
