### PR TITLE
Add background job safety controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Database
 DATABASE_URL="postgresql://username:password@localhost:5432/database_name"
 
+# Background-job safety controls. Existing deployments default to enabled when
+# these are omitted. Set the master switch to false for a fully passive server.
+BACKGROUND_JOBS_ENABLED="true"
+# Gates scheduled email/reminder delivery and anomaly email escalation.
+OUTBOUND_NOTIFICATIONS_ENABLED="true"
+# Gates bulk or workflow-changing jobs (annual vendor reset and approval escalation).
+HIGH_IMPACT_JOBS_ENABLED="true"
+
 # Phase 1 read-only recursive P2 Production Launch preview. Keep disabled until validated.
 P2_V2_PRODUCTION_LAUNCH_PREVIEW_ENABLED="false"
 P2_V2_PRODUCTION_LAUNCH_PERSISTENCE_ENABLED="false"

--- a/server/__tests__/backgroundJobControls.test.ts
+++ b/server/__tests__/backgroundJobControls.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  areBackgroundJobsEnabled,
+  areHighImpactJobsEnabled,
+  areOutboundNotificationsEnabled,
+  shouldRunBackgroundJob,
+} from '../config/backgroundJobControls';
+
+const original = {
+  BACKGROUND_JOBS_ENABLED: process.env.BACKGROUND_JOBS_ENABLED,
+  OUTBOUND_NOTIFICATIONS_ENABLED: process.env.OUTBOUND_NOTIFICATIONS_ENABLED,
+  HIGH_IMPACT_JOBS_ENABLED: process.env.HIGH_IMPACT_JOBS_ENABLED,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(original)) {
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('background job controls', () => {
+  it('preserves existing behavior when no switches are configured', () => {
+    delete process.env.BACKGROUND_JOBS_ENABLED;
+    delete process.env.OUTBOUND_NOTIFICATIONS_ENABLED;
+    delete process.env.HIGH_IMPACT_JOBS_ENABLED;
+
+    expect(areBackgroundJobsEnabled()).toBe(true);
+    expect(areOutboundNotificationsEnabled()).toBe(true);
+    expect(areHighImpactJobsEnabled()).toBe(true);
+  });
+
+  it('uses the master switch to disable every category', () => {
+    process.env.BACKGROUND_JOBS_ENABLED = 'false';
+    process.env.OUTBOUND_NOTIFICATIONS_ENABLED = 'true';
+    process.env.HIGH_IMPACT_JOBS_ENABLED = 'true';
+
+    expect(shouldRunBackgroundJob('standard')).toBe(false);
+    expect(shouldRunBackgroundJob('outbound')).toBe(false);
+    expect(shouldRunBackgroundJob('high-impact')).toBe(false);
+  });
+
+  it('allows standard jobs while independently pausing outbound and high-impact jobs', () => {
+    process.env.BACKGROUND_JOBS_ENABLED = 'true';
+    process.env.OUTBOUND_NOTIFICATIONS_ENABLED = 'off';
+    process.env.HIGH_IMPACT_JOBS_ENABLED = '0';
+
+    expect(shouldRunBackgroundJob('standard')).toBe(true);
+    expect(shouldRunBackgroundJob('outbound')).toBe(false);
+    expect(shouldRunBackgroundJob('high-impact')).toBe(false);
+  });
+});

--- a/server/config/backgroundJobControls.ts
+++ b/server/config/backgroundJobControls.ts
@@ -1,0 +1,34 @@
+export type BackgroundJobCategory = 'standard' | 'outbound' | 'high-impact';
+
+function envFlag(name: string, defaultValue = true): boolean {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') return defaultValue;
+  return !['0', 'false', 'no', 'off', 'disabled'].includes(raw.trim().toLowerCase());
+}
+
+export function areBackgroundJobsEnabled(): boolean {
+  return envFlag('BACKGROUND_JOBS_ENABLED');
+}
+
+export function areOutboundNotificationsEnabled(): boolean {
+  return areBackgroundJobsEnabled() && envFlag('OUTBOUND_NOTIFICATIONS_ENABLED');
+}
+
+export function areHighImpactJobsEnabled(): boolean {
+  return areBackgroundJobsEnabled() && envFlag('HIGH_IMPACT_JOBS_ENABLED');
+}
+
+export function shouldRunBackgroundJob(category: BackgroundJobCategory = 'standard'): boolean {
+  if (!areBackgroundJobsEnabled()) return false;
+  if (category === 'outbound') return areOutboundNotificationsEnabled();
+  if (category === 'high-impact') return areHighImpactJobsEnabled();
+  return true;
+}
+
+export function logBackgroundJobControls(): void {
+  console.log('[BackgroundJobs] controls', {
+    backgroundJobsEnabled: areBackgroundJobsEnabled(),
+    outboundNotificationsEnabled: areOutboundNotificationsEnabled(),
+    highImpactJobsEnabled: areHighImpactJobsEnabled(),
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,10 @@ import {
   shouldRunLegacyStartupDbMaintenance,
 } from './bootstrap/startupMaintenance';
 import { LEGACY_STARTUP_REPAIR_STEPS } from './src/services/projectWorkflowRegistry';
+import {
+  logBackgroundJobControls,
+  shouldRunBackgroundJob,
+} from './config/backgroundJobControls';
 
 // Build version marker - change this to verify deployment updates
 const BUILD_VERSION = '2026-01-27-v2';
@@ -512,6 +516,7 @@ process.on('SIGINT',  () => gracefulShutdown('SIGINT'));
 async function initializeBackgroundServices() {
   bootState.backgroundServices.status = 'running';
   bootState.backgroundServices.startedAt = new Date().toISOString();
+  logBackgroundJobControls();
   try {
     // Test database connection (non-blocking)
     console.log('Initializing database connection...');
@@ -6256,6 +6261,7 @@ async function initializeBackgroundServices() {
     // Recovery net: creates CNC jobs for any IN_PROGRESS CNC steps that missed
     // the real-time hook (e.g. server was down when step was started).
     cron.schedule('*/30 * * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const result = await pool.query(`
           SELECT
@@ -6310,6 +6316,7 @@ async function initializeBackgroundServices() {
 
     // Set up annual vendor evaluation reset (runs on Jan 1)
     cron.schedule('1 0 1 1 *', async () => {
+      if (!shouldRunBackgroundJob('high-impact')) return;
       try {
         console.log('🔄 Running annual vendor evaluation reset...');
         const { vendors } = await import('./schema');
@@ -6336,6 +6343,7 @@ async function initializeBackgroundServices() {
 
     // Set up daily follow-up order reminder check
     cron.schedule('0 9 * * *', async () => {
+      if (!shouldRunBackgroundJob('outbound')) return;
       try {
         console.log('📧 Running daily follow-up order reminder check...');
         const { sendReminderForOverdueOrders } = await import('./utils/followupOrderReminder.js');
@@ -6350,6 +6358,7 @@ async function initializeBackgroundServices() {
 
     // Set up ticket stale reminder check (runs daily at 10:00 AM)
     cron.schedule('0 10 * * *', async () => {
+      if (!shouldRunBackgroundJob('outbound')) return;
       try {
         console.log('🎫 Running daily ticket stale reminder check...');
         const { sendStaleTicketReminders } = await import('./utils/ticketReminder.js');
@@ -6365,7 +6374,7 @@ async function initializeBackgroundServices() {
     // Start model stats aggregator (rebuilds model-department cycle time stats every 4 hours)
     try {
       const { startModelStatsAggregator } = await import('./services/modelStatsAggregator');
-      startModelStatsAggregator();
+      if (shouldRunBackgroundJob()) startModelStatsAggregator();
     } catch (aggErr: any) {
       console.warn('⚠️ Model stats aggregator failed to start:', aggErr.message);
     }
@@ -6373,6 +6382,7 @@ async function initializeBackgroundServices() {
     // Set up dynamic health checks scheduler (checks every minute if it's time to run)
     // This allows the scheduled time to be changed via the UI without restarting the server
     cron.schedule('* * * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { runAllEnabledChecks, getHealthCheckConfig } = await import('./utils/healthCheckService');
         
@@ -6418,6 +6428,7 @@ async function initializeBackgroundServices() {
     console.log('🏥 Daily system health checks scheduler active (runs at configured time from UI)');
 
     cron.schedule('0 2 * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { rebuildModelDepartmentStats } = await import('./src/services/cycleTimeLearning');
         const report = await rebuildModelDepartmentStats();
@@ -6432,6 +6443,7 @@ async function initializeBackgroundServices() {
     // Task #85: persist a tamper-evident checkpoint of the chain head every
     // night so the verifier has stable known-good waypoints for DCAA evidence.
     cron.schedule('15 2 * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { writeAnchor } = await import('./src/services/auditLedgerService');
         const anchor = await writeAnchor({
@@ -6451,6 +6463,7 @@ async function initializeBackgroundServices() {
     // survive the trigger's RAISE) and mirrors each attempt into the unified
     // hash-chained ledger as an AUDIT_DML_BLOCKED event with sequence + hash.
     cron.schedule('*/5 * * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { drainTamperAttempts } = await import('./src/services/auditLedgerService');
         const n = await drainTamperAttempts(500);
@@ -6467,6 +6480,7 @@ async function initializeBackgroundServices() {
     // emit notifications. Deduped per (detector_key, dedup_key) while OPEN.
     const anomalyCron = process.env.INVENTORY_ANOMALY_CRON ?? '*/15 * * * *';
     cron.schedule(anomalyCron, async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { runAnomalyDetectionJob } = await import(
           './src/services/inventoryAnomalyDetectionService'
@@ -6501,6 +6515,7 @@ async function initializeBackgroundServices() {
         anomaly: { id: string; detectorKey: string; severity: string; summary: string; agPartNumber: string | null },
         recipients: number[],
       ) => {
+        if (!shouldRunBackgroundJob('outbound')) return;
         if (!recipients || recipients.length === 0) return;
         try {
           const recips = await db
@@ -6585,6 +6600,7 @@ async function initializeBackgroundServices() {
     // mismatch records an AUDIT_CHAIN_INTEGRITY_FAILED event so the
     // compliance dashboard surfaces tamper evidence between nightly anchors.
     cron.schedule('*/30 * * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { verifyRecentChain, recordAuditEvent } = await import('./src/services/auditLedgerService');
         const result = await verifyRecentChain(5000);
@@ -6627,6 +6643,7 @@ async function initializeBackgroundServices() {
       return edriCronDefault;
     })();
     cron.schedule(edriCronSchedule, async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { computeEdriSnapshot } = await import('./src/services/edriScoringService');
         const result = await computeEdriSnapshot(undefined, 'scheduled-refresh');
@@ -6641,6 +6658,7 @@ async function initializeBackgroundServices() {
     // Verifies docs/policies/*.md content hashes match the latest published in-repo
     // policy versions. Drift is logged and visible at /api/policies/admin/drift.
     cron.schedule('30 2 * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { runPoliciesDriftCheck } = await import('./src/jobs/policiesDriftCheck');
         await runPoliciesDriftCheck();
@@ -6656,6 +6674,7 @@ async function initializeBackgroundServices() {
     // last_reminded_at is updated after each successful reminder so the same
     // request is never nagged more than once per 2-day window.
     cron.schedule('0 9 * * *', async () => {
+      if (!shouldRunBackgroundJob('outbound')) return;
       try {
         console.log('[RefundReminder] Checking for pending refund requests due for reminder...');
         const { refundRequests: rr, customers: cust } = await import('./schema');
@@ -6728,6 +6747,7 @@ async function initializeBackgroundServices() {
     // The scheduled time is configurable via the Admin UI without a server restart.
     // Defaults to 2:30 AM. Admins can change or disable it from the EDRI dashboard.
     cron.schedule('* * * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { runScheduledForensicScan, getForensicAuditScheduleConfig } = await import('./src/jobs/forensicAuditScheduler');
         const config = getForensicAuditScheduleConfig();
@@ -6752,6 +6772,7 @@ async function initializeBackgroundServices() {
     // Idempotent and safe to run on multiple instances — `escalateExpired`
     // re-reads each candidate row under FOR UPDATE SKIP LOCKED.
     cron.schedule('* * * * *', async () => {
+      if (!shouldRunBackgroundJob('high-impact')) return;
       try {
         const { escalateExpired } = await import('./src/services/escalationService');
         const result = await escalateExpired(new Date());
@@ -6769,7 +6790,7 @@ async function initializeBackgroundServices() {
     // Queue integrity background monitor
     try {
       const { startQueueIntegrityService } = await import('./src/services/queueIntegrityService');
-      startQueueIntegrityService();
+      if (shouldRunBackgroundJob()) startQueueIntegrityService();
     } catch (svcError) {
       console.warn('⚠️ Queue integrity service failed to start:', svcError);
     }
@@ -8063,7 +8084,7 @@ async function initializeBackgroundServices() {
     // DCAA Forensic Scan → EDRI baseline (sequenced): scan must complete first so
     // dcaa_audit_findings is populated before EDRI reads it for the startup score.
     // Both steps run fire-and-forget to avoid blocking other startup work.
-    (async () => {
+    if (shouldRunBackgroundJob()) (async () => {
       try {
         const { runForensicScan } = await import('./src/services/dcaaForensicEngine');
         const summary = await runForensicScan();
@@ -8084,6 +8105,7 @@ async function initializeBackgroundServices() {
 
     // DCAA Forensic Scan: re-scan every 6 hours to keep dcaa_audit_findings current
     cron.schedule('0 */6 * * *', async () => {
+      if (!shouldRunBackgroundJob()) return;
       try {
         const { runForensicScan } = await import('./src/services/dcaaForensicEngine');
         const summary = await runForensicScan();
@@ -8095,6 +8117,7 @@ async function initializeBackgroundServices() {
     console.log('🔍 DCAA forensic findings scanner scheduled (every 6 hours)');
     // Training certification expiration digest (runs daily at 8:00 AM)
     cron.schedule('0 8 * * *', async () => {
+      if (!shouldRunBackgroundJob('outbound')) return;
       try {
         console.log('🎓 Running daily training certification expiration digest...');
         const { sendTrainingExpirationDigest } = await import('./utils/trainingAlertReminder.js');


### PR DESCRIPTION
## What changed
- Added a master `BACKGROUND_JOBS_ENABLED` switch for scheduled/background work.
- Added independent `OUTBOUND_NOTIFICATIONS_ENABLED` and `HIGH_IMPACT_JOBS_ENABLED` switches.
- Applied the controls to EPOCH's cron jobs, recurring aggregators, startup DCAA/EDRI work, notification reminders, annual vendor reset, and approval escalation.
- Documented all three variables in `.env.example`.
- Added focused tests for defaults, master shutdown, and category-specific shutdown.

## Why
This lets the Railway copy stay available for testing without duplicating outbound messages or running workflow-changing jobs before cutover. Existing deployments remain unchanged when the variables are omitted.

## Recommended Railway test settings
```
BACKGROUND_JOBS_ENABLED=true
OUTBOUND_NOTIFICATIONS_ENABLED=false
HIGH_IMPACT_JOBS_ENABLED=false
```
Use `BACKGROUND_JOBS_ENABLED=false` if a completely passive test server is preferred.

## Verification
- `vitest --config vitest.config.server.ts server/__tests__/backgroundJobControls.test.ts`: 3 tests passed.
- `git diff --check`: passed.
- Full-project TypeScript check was stopped after producing no output for over 90 seconds on the Windows checkout.