### PR TITLE
Contain shipped P1 orders and restore fulfillment

### DIFF
--- a/migrations/0281_contain_shipped_p1_auto_populate_regression.sql
+++ b/migrations/0281_contain_shipped_p1_auto_populate_regression.sql
@@ -1,0 +1,124 @@
+-- Remove shipped P1 orders from every active manufacturing department and
+-- restore the canonical completed state: FULFILLED / Shipping Management.
+--
+-- Durable shipment evidence is authoritative. The affected row is captured
+-- before repair so the physical floor-removal population remains auditable.
+
+CREATE TABLE IF NOT EXISTS p1_shipped_order_containment_audit (
+  order_id text PRIMARY KEY,
+  detected_at timestamp NOT NULL DEFAULT NOW(),
+  last_floor_update_at timestamp,
+  status_before text,
+  department_before text NOT NULL,
+  shipped_date timestamp,
+  shipping_completed_at timestamp,
+  tracking_number text,
+  restored_at timestamp,
+  floor_removal_required boolean NOT NULL DEFAULT TRUE,
+  containment_reason text NOT NULL DEFAULT 'SHIPPED_ORDER_FOUND_IN_MANUFACTURING'
+);
+
+CREATE TEMP TABLE tmp_shipped_manufacturing_containment ON COMMIT DROP AS
+SELECT DISTINCT ON (ao.order_id)
+  ao.order_id,
+  ao.status AS status_before,
+  ao.current_department AS department_before,
+  ao.shipped_date,
+  ao.shipping_completed_at,
+  ao.tracking_number,
+  ao.updated_at AS last_floor_update_at
+FROM all_orders ao
+WHERE ao.current_department IN (
+    'P1 Production Queue', 'Layup/Plugging', 'Barcode', 'CNC',
+    'Gunsmith', 'Finish', 'Finish QC', 'Paint', 'Shipping QC'
+  )
+  AND ao.is_cancelled IS DISTINCT FROM TRUE
+  AND ao.status NOT IN ('CANCELLED', 'CANCELED', 'SCRAPPED')
+  AND (
+    ao.shipped_date IS NOT NULL
+    OR ao.shipping_completed_at IS NOT NULL
+    OR NULLIF(TRIM(COALESCE(ao.tracking_number, '')), '') IS NOT NULL
+    OR UPPER(COALESCE(ao.status, '')) IN ('FULFILLED', 'SHIPPED')
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM order_activity_events repaired
+    WHERE repaired.order_id = ao.order_id
+      AND repaired.reason_code = 'CONTAIN_SHIPPED_MANUFACTURING_ORDER'
+  )
+ORDER BY ao.order_id, ao.updated_at DESC NULLS LAST;
+
+INSERT INTO p1_shipped_order_containment_audit (
+  order_id, last_floor_update_at, status_before, department_before,
+  shipped_date, shipping_completed_at, tracking_number
+)
+SELECT
+  order_id, last_floor_update_at, status_before, department_before,
+  shipped_date, shipping_completed_at, tracking_number
+FROM tmp_shipped_manufacturing_containment
+ON CONFLICT (order_id) DO NOTHING;
+
+INSERT INTO order_activity_events (
+  order_id, event_type, event_category, occurred_at, actor_type,
+  actor_display_name, source, source_route, reason_code, reason_text,
+  status_from, status_to, department_from, department_to, field_diff, metadata
+)
+SELECT
+  repair.order_id,
+  'STATUS_DEPARTMENT_RESTORED',
+  'admin',
+  NOW(),
+  'system',
+  'migration 0281',
+  'migration',
+  'migrations/0281_contain_shipped_p1_auto_populate_regression.sql',
+  'CONTAIN_SHIPPED_MANUFACTURING_ORDER',
+  'Removed a shipped order from manufacturing and restored Shipping Management.',
+  repair.status_before,
+  'FULFILLED',
+  repair.department_before,
+  'Shipping Management',
+  jsonb_build_object(
+    'status', jsonb_build_object('before', repair.status_before, 'after', 'FULFILLED', 'label', 'Order Status'),
+    'currentDepartment', jsonb_build_object('before', repair.department_before, 'after', 'Shipping Management', 'label', 'Current Department')
+  ),
+  jsonb_build_object(
+    'migration', '0281_contain_shipped_p1_auto_populate_regression',
+    'cause', 'shipped_order_in_active_manufacturing_department',
+    'lastFloorUpdateAt', repair.last_floor_update_at,
+    'shippedDate', repair.shipped_date,
+    'shippingCompletedAt', repair.shipping_completed_at,
+    'trackingNumber', repair.tracking_number,
+    'floorRemovalRequired', true
+  )
+FROM tmp_shipped_manufacturing_containment repair;
+
+UPDATE all_orders ao
+SET
+  status = 'FULFILLED',
+  current_department = 'Shipping Management',
+  updated_at = NOW()
+FROM tmp_shipped_manufacturing_containment repair
+WHERE ao.order_id = repair.order_id
+  AND ao.current_department = repair.department_before;
+
+UPDATE production_orders po
+SET
+  current_department = 'Shipping Management',
+  production_status = 'SHIPPED',
+  is_fulfilled = true,
+  shipped_at = COALESCE(po.shipped_at, repair.shipped_date, repair.shipping_completed_at, NOW()),
+  fulfilled_date = COALESCE(po.fulfilled_date, po.shipped_at, repair.shipped_date, repair.shipping_completed_at, NOW()),
+  updated_at = NOW()
+FROM tmp_shipped_manufacturing_containment repair
+WHERE po.order_id = repair.order_id
+  AND po.current_department IN (
+    'P1 Production Queue', 'Layup/Plugging', 'Barcode', 'CNC',
+    'Gunsmith', 'Finish', 'Finish QC', 'Paint', 'Shipping QC'
+  );
+
+UPDATE p1_shipped_order_containment_audit audit
+SET restored_at = NOW()
+FROM tmp_shipped_manufacturing_containment repair
+WHERE audit.order_id = repair.order_id
+  AND audit.restored_at IS NULL;

--- a/scripts/audits/p1_shipped_order_floor_removal.sql
+++ b/scripts/audits/p1_shipped_order_floor_removal.sql
@@ -1,0 +1,30 @@
+-- READ ONLY: shipped orders currently assigned to an active P1 manufacturing
+-- department. Run against the authoritative production application database.
+
+SELECT DISTINCT ON (ao.order_id)
+  ao.order_id,
+  ao.customer_id,
+  ao.customer_po,
+  ao.model_id,
+  ao.due_date,
+  ao.status AS current_status,
+  ao.current_department,
+  ao.tracking_number,
+  ao.shipped_date,
+  ao.shipping_completed_at,
+  ao.updated_at AS last_floor_update_at,
+  'REMOVE FROM PRODUCTION FLOOR - ALREADY SHIPPED' AS required_floor_action
+FROM all_orders ao
+WHERE ao.current_department IN (
+    'P1 Production Queue', 'Layup/Plugging', 'Barcode', 'CNC',
+    'Gunsmith', 'Finish', 'Finish QC', 'Paint', 'Shipping QC'
+  )
+  AND ao.is_cancelled IS DISTINCT FROM TRUE
+  AND ao.status NOT IN ('CANCELLED', 'CANCELED', 'SCRAPPED')
+  AND (
+    ao.shipped_date IS NOT NULL
+    OR ao.shipping_completed_at IS NOT NULL
+    OR NULLIF(TRIM(COALESCE(ao.tracking_number, '')), '') IS NOT NULL
+    OR UPPER(COALESCE(ao.status, '')) IN ('FULFILLED', 'SHIPPED')
+  )
+ORDER BY ao.order_id, ao.updated_at DESC NULLS LAST;

--- a/server/__tests__/p1ShippedOrderContainment.test.ts
+++ b/server/__tests__/p1ShippedOrderContainment.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const migrationName = '0281_contain_shipped_p1_auto_populate_regression.sql';
+
+describe('P1 shipped-order containment', () => {
+  it('persists fulfilled shipping state when an order ships', () => {
+    const source = readFileSync(
+      path.join(root, 'server/src/routes/shipping.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain("status: 'FULFILLED'");
+    expect(source).toContain("currentDepartment: 'Shipping Management'");
+    expect(source.match(/status: 'FULFILLED'/g)?.length).toBeGreaterThanOrEqual(4);
+    expect(
+      source.match(/currentDepartment: 'Shipping Management'/g)?.length
+    ).toBeGreaterThanOrEqual(4);
+  });
+
+  it('fulfills shipping completions from bulk and badge progression paths', () => {
+    const indexRoute = readFileSync(
+      path.join(root, 'server/src/routes/index.ts'),
+      'utf8'
+    );
+    const badgeRoute = readFileSync(
+      path.join(root, 'server/src/routes/employeeBadges.ts'),
+      'utf8'
+    );
+
+    expect(indexRoute).toContain("const completingShipping = currentOrder.currentDepartment === 'Shipping'");
+    expect(indexRoute).toContain("? 'FULFILLED'");
+    expect(indexRoute).toContain("updateData.productionStatus = 'SHIPPED'");
+    expect(badgeRoute).toContain("updateData.status = 'FULFILLED'");
+    expect(badgeRoute).toContain("productionStatus: 'SHIPPED'");
+  });
+
+  it('fails closed before auto-populating any order with shipment evidence', () => {
+    const source = readFileSync(
+      path.join(root, 'server/src/routes/productionQueue.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain("NOT IN ('FULFILLED', 'SHIPPED')");
+    expect(source).toContain("'Shipping Management', 'Fulfilled', 'Shipped'");
+    expect(source).toContain('AND o.shipped_date IS NULL');
+    expect(source).toContain('AND o.shipping_completed_at IS NULL');
+    expect(source).toContain(
+      "NULLIF(TRIM(COALESCE(o.tracking_number, '')), '') IS NULL"
+    );
+    expect(source).toContain("router.get('/shipped-regression-audit'");
+    expect(source).toContain('p1_shipped_order_containment_audit');
+    expect(source).toContain('p1-shipped-order-floor-removal-audit.csv');
+  });
+
+  it('blocks shipped orders at canonical progression and transfer seams', () => {
+    const storage = readFileSync(path.join(root, 'server/storage.ts'), 'utf8');
+    const ordersRoute = readFileSync(
+      path.join(root, 'server/src/routes/orders.ts'),
+      'utf8'
+    );
+
+    expect(storage).toContain('SHIPPED_ORDER_MANUFACTURING_BLOCK');
+    expect(storage).toContain('hasDurableShipmentEvidence');
+    expect(storage.match(/recordsShipmentCompletion/g)?.length).toBeGreaterThanOrEqual(4);
+    expect(storage).toContain("updateData.status = 'FULFILLED'");
+    expect(storage).toContain("updateData.currentDepartment = 'Shipping Management'");
+    expect(ordersRoute).toContain("code: 'SHIPPED_ORDER_MANUFACTURING_BLOCK'");
+    expect(ordersRoute).toContain("requiredDepartment: 'Shipping Management'");
+    expect(ordersRoute).toContain("updateData.currentDepartment = 'Shipping Management'");
+  });
+
+  it('registers an auditable all-department restoration migration', () => {
+    const sql = readFileSync(
+      path.join(root, 'migrations', migrationName),
+      'utf8'
+    );
+    const registry = readFileSync(
+      path.join(root, 'server/scripts/migrations/runSafeBootMigrations.ts'),
+      'utf8'
+    );
+
+    expect(registry.match(new RegExp(migrationName, 'g'))).toHaveLength(2);
+    expect(sql).toContain('p1_shipped_order_containment_audit');
+    expect(sql).toContain("'Gunsmith', 'Finish', 'Finish QC', 'Paint', 'Shipping QC'");
+    expect(sql).toContain("reason_code = 'CONTAIN_SHIPPED_MANUFACTURING_ORDER'");
+    expect(sql).toContain('ao.shipped_date IS NOT NULL');
+    expect(sql).toContain("current_department = 'Shipping Management'");
+    expect(sql).toContain("production_status = 'SHIPPED'");
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -341,6 +341,7 @@ export const safeMigrationFiles = [
   '0278_p2_component_traveler_provisioning.sql',
   '0279_vendor_international_contact_fields.sql',
   '0280_move_forward.sql',
+  '0281_contain_shipped_p1_auto_populate_regression.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -426,6 +427,7 @@ export const criticalMigrationFiles = new Set([
   '0277_routing_document_controlled_link.sql',
   '0278_p2_component_traveler_provisioning.sql',
   '0279_vendor_international_contact_fields.sql',
+  '0281_contain_shipped_p1_auto_populate_regression.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/employeeBadges.ts
+++ b/server/src/routes/employeeBadges.ts
@@ -373,9 +373,12 @@ router.post('/execute-badge-action', async (req, res) => {
             const fromDepartment = order.currentDepartment;
             const toDepartment = actionConfig.toDepartment;
             const currentTimestamp = new Date();
+            const completingShipping =
+              fromDepartment === 'Shipping' ||
+              fromDepartment === 'Shipping Management';
             
             // Skip no-op moves
-            if (fromDepartment === toDepartment) {
+            if (fromDepartment === toDepartment && !completingShipping) {
               executionResult = { success: true, message: `Order already in ${toDepartment}` };
               break;
             }
@@ -416,13 +419,16 @@ router.post('/execute-badge-action', async (req, res) => {
             } else if (fromDepartment === 'QC' || fromDepartment === 'QC Shipping Queue') {
               updateData.qcCompletedAt = currentTimestamp;
             } else if (fromDepartment === 'Shipping' || fromDepartment === 'Shipping Management') {
+              updateData.status = 'FULFILLED';
+              updateData.currentDepartment = 'Shipping Management';
+              updateData.shippedDate = currentTimestamp;
               updateData.shippingCompletedAt = currentTimestamp;
             }
             
             await recordBadgeScanTransition(
               order.orderId,
               fromDepartment ?? '',
-              toDepartment,
+              updateData.currentDepartment,
               updateData,
               {
                 actorDisplayName: employeeCode,
@@ -475,15 +481,21 @@ router.post('/execute-badge-action', async (req, res) => {
             // Update each matched production_order row using its own actual currentDepartment
             for (const poOrder of poMatches) {
               const rowFromDepartment = poOrder.currentDepartment;
+              const completingShipping =
+                rowFromDepartment === 'Shipping' ||
+                rowFromDepartment === 'Shipping Management';
+              const rowToDepartment = completingShipping
+                ? 'Shipping Management'
+                : toDepartment;
 
               // Skip no-op: this unit is already in the target department
-              if (rowFromDepartment === toDepartment) continue;
+              if (rowFromDepartment === rowToDepartment && !completingShipping) continue;
 
               const existingHistory = (poOrder as any).departmentHistory || [];
               const departmentHistory = Array.isArray(existingHistory) ? [...existingHistory] : [];
               departmentHistory.push({
                 fromDepartment: rowFromDepartment,
-                toDepartment,
+                toDepartment: rowToDepartment,
                 timestamp: currentTimestamp.toISOString(),
                 progressedBy: employeeCode,
                 scanMethod: 'badge',
@@ -492,7 +504,15 @@ router.post('/execute-badge-action', async (req, res) => {
               await db
                 .update(productionOrders)
                 .set({
-                  currentDepartment: toDepartment,
+                  currentDepartment: rowToDepartment,
+                  ...(completingShipping
+                    ? {
+                        productionStatus: 'SHIPPED',
+                        isFulfilled: true,
+                        shippedAt: currentTimestamp,
+                        fulfilledDate: currentTimestamp,
+                      }
+                    : {}),
                   updatedAt: currentTimestamp,
                   ...completionFields(rowFromDepartment),
                   departmentHistory,
@@ -509,6 +529,12 @@ router.post('/execute-badge-action', async (req, res) => {
             // Sync corresponding all_orders rows once per unique (poNumber, fromDepartment) pair
             for (const [syncKey, rowFromDepartment] of allOrdersSyncKeys) {
               const poNumber = syncKey.split('|')[0];
+              const completingShipping =
+                rowFromDepartment === 'Shipping' ||
+                rowFromDepartment === 'Shipping Management';
+              const rowToDepartment = completingShipping
+                ? 'Shipping Management'
+                : toDepartment;
               const correspondingAllOrders = await db
                 .select()
                 .from(allOrders)
@@ -524,7 +550,7 @@ router.post('/execute-badge-action', async (req, res) => {
                 const aoDepartmentHistory = Array.isArray(aoExistingHistory) ? [...aoExistingHistory] : [];
                 aoDepartmentHistory.push({
                   fromDepartment: rowFromDepartment,
-                  toDepartment,
+                  toDepartment: rowToDepartment,
                   timestamp: currentTimestamp.toISOString(),
                   progressedBy: employeeCode,
                   scanMethod: 'badge',
@@ -533,9 +559,16 @@ router.post('/execute-badge-action', async (req, res) => {
                 await recordBadgeScanTransition(
                   aoOrder.orderId,
                   rowFromDepartment ?? '',
-                  toDepartment,
+                  rowToDepartment,
                   {
-                    currentDepartment: toDepartment,
+                    currentDepartment: rowToDepartment,
+                    ...(completingShipping
+                      ? {
+                          status: 'FULFILLED',
+                          shippedDate: currentTimestamp,
+                          shippingCompletedAt: currentTimestamp,
+                        }
+                      : {}),
                     updatedAt: currentTimestamp,
                     ...completionFields(rowFromDepartment),
                     departmentHistory: aoDepartmentHistory,

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -11856,17 +11856,26 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
           // If the destination is a real production department (not an initial queue),
           // always force status to IN_PROGRESS regardless of what the caller sent.
-          const resolvedStatus =
-            INITIAL_QUEUE_DEPARTMENTS.includes(department)
+          const completingShipping = currentOrder.currentDepartment === 'Shipping';
+          const resolvedDepartment = completingShipping
+            ? 'Shipping Management'
+            : department;
+          const resolvedStatus = completingShipping
+            ? 'FULFILLED'
+            : INITIAL_QUEUE_DEPARTMENTS.includes(department)
               ? (status || 'IN_PROGRESS')
               : 'IN_PROGRESS';
 
           // Prepare update data
           const updateData: any = {
-            currentDepartment: department,
+            currentDepartment: resolvedDepartment,
             status: resolvedStatus,
             ...completionUpdates,
           };
+          if (completingShipping) {
+            updateData.shippingCompletedAt = now;
+            if (!isProductionOrder) updateData.shippedDate = now;
+          }
 
           // Add technician assignment if provided
           if (assignedTechnician) {
@@ -11877,13 +11886,16 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           let updatedOrder;
           if (isProductionOrder) {
             const productionStatus = deriveP1ProductionStatus({
-              currentDepartment: department,
-              isFulfilled: (currentOrder as any).isFulfilled,
+              currentDepartment: resolvedDepartment,
+              isFulfilled: completingShipping || (currentOrder as any).isFulfilled,
               currentStatus: (currentOrder as any).productionStatus,
             });
             const productionUpdateData = {
               ...updateData,
               productionStatus,
+              ...(completingShipping
+                ? { isFulfilled: true, shippedAt: now, fulfilledDate: now }
+                : {}),
               updatedAt: now,
             };
             delete (productionUpdateData as any).status;
@@ -12688,7 +12700,17 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
           } else if (currentDept === 'QC' || currentDept === 'QC Shipping Queue') {
             updateData.qcCompletedAt = currentTimestamp;
           } else if (currentDept === 'Shipping' || currentDept === 'Shipping Management') {
+            updateData.currentDepartment = 'Shipping Management';
             updateData.shippingCompletedAt = currentTimestamp;
+            if (isProductionOrder) {
+              updateData.productionStatus = 'SHIPPED';
+              updateData.isFulfilled = true;
+              updateData.shippedAt = currentTimestamp;
+              updateData.fulfilledDate = currentTimestamp;
+            } else {
+              updateData.status = 'FULFILLED';
+              updateData.shippedDate = currentTimestamp;
+            }
           }
 
           // Capture BEFORE state for audit

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -2416,6 +2416,17 @@ router.post('/:id/progress', async (req: Request, res: Response) => {
     res.json(updatedOrder);
   } catch (error) {
     console.error('Progress order error:', error);
+    if (
+      error instanceof Error &&
+      error.message.includes('SHIPPED_ORDER_MANUFACTURING_BLOCK')
+    ) {
+      return res.status(409).json({
+        error: 'Shipped orders cannot progress through manufacturing',
+        code: 'SHIPPED_ORDER_MANUFACTURING_BLOCK',
+        requiredStatus: 'FULFILLED',
+        requiredDepartment: 'Shipping Management',
+      });
+    }
     res.status(500).json({ error: 'Failed to progress order' });
   }
 });
@@ -3102,12 +3113,12 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
 
     if (!targetDepartment) {
       // Special case: Shipping is the final department
-      // When progressing from Shipping, set status to FULFILLED and clear department
+      // When progressing from Shipping, preserve the completed Shipping Management bucket.
       if (existingOrder.currentDepartment === 'Shipping') {
         shouldMarkFulfilled = true;
-        targetDepartment = null; // Clear department
+        targetDepartment = 'Shipping Management';
         console.log(
-          `📦 Order ${orderId} completing Shipping - will be marked as FULFILLED with no department`
+          `📦 Order ${orderId} completing Shipping - will be marked as FULFILLED in Shipping Management`
         );
       }
       // Orders with no stock model should skip manufacturing departments
@@ -3184,8 +3195,8 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
     if (shouldMarkFulfilled) {
       updateData.status = 'FULFILLED';
       updateData.shippedDate = now;
-      updateData.currentDepartment = undefined; // Clear department when fulfilled
-      console.log(`📦 Marking order as FULFILLED with no department`);
+      updateData.currentDepartment = 'Shipping Management';
+      console.log(`📦 Marking order as FULFILLED in Shipping Management`);
     } else {
       updateData.currentDepartment = targetDepartment;
       if (
@@ -3259,6 +3270,11 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
 
         if (shouldMarkFulfilled) {
           fieldDiff['status'] = { before: existingOrder.status ?? null, after: 'FULFILLED', label: 'Order Status' };
+          fieldDiff['currentDepartment'] = {
+            before: existingOrder.currentDepartment ?? null,
+            after: 'Shipping Management',
+            label: 'Current Department',
+          };
         } else {
           fieldDiff['currentDepartment'] = {
             before: existingOrder.currentDepartment ?? null,
@@ -3287,7 +3303,7 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
           statusFrom: existingOrder.status ?? null,
           statusTo: shouldMarkFulfilled ? 'FULFILLED' : (after.status ?? null),
           departmentFrom: existingOrder.currentDepartment ?? null,
-          departmentTo: shouldMarkFulfilled ? null : (targetDepartment ?? null),
+          departmentTo: shouldMarkFulfilled ? 'Shipping Management' : (targetDepartment ?? null),
           fieldDiff,
         });
 
@@ -4204,6 +4220,28 @@ router.patch(
           previousDepartment = (productionOrder as any).currentDepartment || null;
         }
       }
+    }
+
+    const normalizedExistingStatus = String(
+      existingOrder?.status ?? existingOrder?.productionStatus ?? ''
+    ).toUpperCase();
+    const hasDurableShipmentEvidence = Boolean(
+      existingOrder?.shippedDate ||
+      existingOrder?.shippedAt ||
+      existingOrder?.shippingCompletedAt ||
+      String(existingOrder?.trackingNumber || '').trim() ||
+      existingOrder?.isFulfilled === true ||
+      normalizedExistingStatus === 'FULFILLED' ||
+      normalizedExistingStatus === 'SHIPPED'
+    );
+    if (hasDurableShipmentEvidence) {
+      return res.status(409).json({
+        error: 'Shipped orders cannot be transferred into manufacturing',
+        code: 'SHIPPED_ORDER_MANUFACTURING_BLOCK',
+        orderId,
+        requiredStatus: 'FULFILLED',
+        requiredDepartment: 'Shipping Management',
+      });
     }
 
     const shouldResetStatusToInProgress = shouldResetReadyForShippingToInProgress(

--- a/server/src/routes/productionQueue.ts
+++ b/server/src/routes/productionQueue.ts
@@ -152,7 +152,11 @@ router.post('/auto-populate', async (req: Request, res: Response) => {
       FROM all_orders o
       WHERE (o.status = 'FINALIZED' OR (o.status = 'IN_PROGRESS' AND o.current_department = 'P1 Production Queue'))
         AND (o.is_cancelled IS NULL OR o.is_cancelled = false)
-        AND o.current_department NOT IN ('Shipping', 'Layup/Plugging', 'Barcode', 'CNC', 'Finish', 'Gunsmith', 'Paint', 'Shipping QC')
+        AND UPPER(COALESCE(o.status, '')) NOT IN ('FULFILLED', 'SHIPPED')
+        AND COALESCE(o.current_department, '') NOT IN ('Shipping', 'Shipping Management', 'Fulfilled', 'Shipped', 'Layup/Plugging', 'Barcode', 'CNC', 'Finish', 'Gunsmith', 'Paint', 'Shipping QC')
+        AND o.shipped_date IS NULL
+        AND o.shipping_completed_at IS NULL
+        AND NULLIF(TRIM(COALESCE(o.tracking_number, '')), '') IS NULL
         AND (o.model_id IS NOT NULL AND o.model_id != '' AND o.model_id != 'None' 
              AND LOWER(o.model_id) != 'no stock' AND LOWER(o.model_id) != 'no_stock')
       ORDER BY o.due_date ASC, o.created_at ASC
@@ -320,6 +324,69 @@ router.get('/p1-queue', async (req: Request, res: Response) => {
       error: 'Failed to fetch P1 production queue',
       details: error instanceof Error ? error.message : 'Unknown error',
     });
+  }
+});
+
+// Incident population captured before migration 0281 restores canonical state.
+router.get('/shipped-regression-audit', async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(`
+      SELECT
+        audit.order_id AS "orderId",
+        ao.customer_id AS "customerId",
+        ao.customer_po AS "customerPo",
+        ao.model_id AS "modelId",
+        ao.due_date AS "dueDate",
+        audit.tracking_number AS "trackingNumber",
+        audit.shipped_date AS "shippedDate",
+        audit.shipping_completed_at AS "shippingCompletedAt",
+        audit.last_floor_update_at AS "lastFloorUpdateAt",
+        audit.detected_at AS "detectedAt",
+        audit.restored_at AS "restoredAt",
+        audit.floor_removal_required AS "floorRemovalRequired",
+        audit.containment_reason AS "containmentReason"
+      FROM p1_shipped_order_containment_audit audit
+      LEFT JOIN all_orders ao ON ao.order_id = audit.order_id
+      ORDER BY audit.last_floor_update_at DESC NULLS LAST, audit.order_id ASC
+    `);
+
+    const rows = Array.isArray(result) ? result : result.rows || [];
+    res.set('Cache-Control', 'no-store');
+
+    if (req.query.format === 'csv') {
+      const csvCell = (value: unknown) => {
+        const raw = value == null ? '' : String(value);
+        const safe = /^[=+\-@]/.test(raw) ? `'${raw}` : raw;
+        return `"${safe.replace(/"/g, '""')}"`;
+      };
+      const fields = [
+        'orderId', 'customerId', 'customerPo', 'modelId', 'dueDate',
+        'trackingNumber', 'shippedDate', 'shippingCompletedAt',
+        'lastFloorUpdateAt', 'detectedAt', 'restoredAt', 'floorRemovalRequired',
+      ];
+      const csv = [
+        fields.join(','),
+        ...rows.map((row: any) =>
+          fields.map(field => csvCell(row[field])).join(',')
+        ),
+      ].join('\r\n');
+
+      res.set({
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': 'attachment; filename="p1-shipped-order-floor-removal-audit.csv"',
+      });
+      return res.send(csv);
+    }
+
+    res.json({
+      incident: 'SHIPPED_ORDER_FOUND_IN_MANUFACTURING',
+      floorRemovalRequired: true,
+      count: rows.length,
+      orders: rows,
+    });
+  } catch (error) {
+    console.error('Failed to fetch shipped-order regression audit:', error);
+    res.status(500).json({ error: 'Failed to fetch shipped-order regression audit' });
   }
 });
 

--- a/server/src/routes/shipping.ts
+++ b/server/src/routes/shipping.ts
@@ -408,7 +408,8 @@ router.post('/mark-shipped/:orderId', requirePermission('shipping.mark_shipped')
 
     // Update order with shipping information
     const updateData = {
-      currentDepartment: 'Fulfilled',
+      status: 'FULFILLED',
+      currentDepartment: 'Shipping Management',
       trackingNumber,
       shippingCarrier,
       shippingMethod,
@@ -626,7 +627,11 @@ router.post('/update-tracking/:orderId', async (req: Request, res: Response) => 
     }
 
     // If order doesn't have a shipped date, set it now
-    updateData.shippedDate = new Date();
+    const shippedAt = new Date();
+    updateData.status = 'FULFILLED';
+    updateData.currentDepartment = 'Shipping Management';
+    updateData.shippedDate = shippedAt;
+    updateData.shippingCompletedAt = shippedAt;
 
     // Update in allOrders table via canonical audit service
     await recordShippingUpdate(
@@ -1072,6 +1077,8 @@ router.post('/create-label', requirePermission('shipping.create_label'), async (
       if (order) {
         try {
           const updateData = {
+            status: 'FULFILLED',
+            currentDepartment: 'Shipping Management',
             trackingNumber,
             shippingCarrier: 'UPS',
             shippingMethod: getServiceName(serviceType || '03'),
@@ -1080,6 +1087,7 @@ router.post('/create-label', requirePermission('shipping.create_label'), async (
             shippingLabelGenerated: true,
             labelGeneratedAt: new Date(),
             shippedDate: new Date(),
+            shippingCompletedAt: new Date(),
           };
 
           // Try updating finalized order first, fall back to draft
@@ -2057,11 +2065,14 @@ router.post('/bulk/create-consolidated-label', async (req: Request, res: Respons
 
       // Update ALL orders with the same tracking number
       const updateData = {
+        status: 'FULFILLED',
+        currentDepartment: 'Shipping Management',
         trackingNumber,
         shippingCarrier: 'UPS',
         shippingMethod: getServiceName(serviceCode || '03'),
         shippingCost: shipmentCost ? parseFloat(shipmentCost) : null,
         shippedDate: new Date(),
+        shippingCompletedAt: new Date(),
         shippingLabelGenerated: true,
         labelGeneratedAt: new Date(),
       };
@@ -2683,10 +2694,13 @@ router.post('/bulk/create-labels', async (req: Request, res: Response) => {
           // Update order with tracking number
           try {
             const updateData = {
+              status: 'FULFILLED',
+              currentDepartment: 'Shipping Management',
               trackingNumber,
               shippingCarrier: 'UPS',
               shippingMethod: getServiceName(serviceCode || '03'),
               shippedDate: new Date(),
+              shippingCompletedAt: new Date(),
               shippingLabelGenerated: true,
             };
             

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -3858,9 +3858,17 @@ export class DatabaseStorage implements IStorage {
     orderId: string,
     data: Partial<InsertOrderDraft>
   ): Promise<OrderDraft> {
+    const updateData: Partial<InsertOrderDraft> = { ...data };
+    const recordsShipmentCompletion = Boolean(
+      updateData.shippedDate || updateData.shippingCompletedAt
+    );
+    if (recordsShipmentCompletion) {
+      updateData.status = 'FULFILLED';
+      updateData.currentDepartment = 'Shipping Management';
+    }
     const [draft] = await db
       .update(orderDrafts)
-      .set(data)
+      .set(updateData)
       .where(eq(orderDrafts.orderId, orderId))
       .returning();
 
@@ -14789,6 +14797,11 @@ export class DatabaseStorage implements IStorage {
           currentOrder = {
             orderId: productionOrderRecord.orderId,
             currentDepartment: productionOrderRecord.currentDepartment,
+            status: productionOrderRecord.productionStatus,
+            shippedDate: productionOrderRecord.shippedAt,
+            shippingCompletedAt: productionOrderRecord.shippingCompletedAt,
+            trackingNumber: (productionOrderRecord as any).trackingNumber,
+            isFulfilled: productionOrderRecord.isFulfilled,
             departmentHistory: productionOrderRecord.departmentHistory || [],
             features: parsedFeatures,
             isFlattop: false,
@@ -14799,6 +14812,21 @@ export class DatabaseStorage implements IStorage {
 
       if (!currentOrder) {
         throw new Error(`Order ${orderId} not found`);
+      }
+
+      const normalizedStatus = String((currentOrder as any).status || '').toUpperCase();
+      const hasDurableShipmentEvidence = Boolean(
+        (currentOrder as any).shippedDate ||
+        (currentOrder as any).shippingCompletedAt ||
+        String((currentOrder as any).trackingNumber || '').trim() ||
+        (currentOrder as any).isFulfilled === true ||
+        normalizedStatus === 'FULFILLED' ||
+        normalizedStatus === 'SHIPPED'
+      );
+      if (hasDurableShipmentEvidence) {
+        throw new Error(
+          `SHIPPED_ORDER_MANUFACTURING_BLOCK: Order ${orderId} has shipment evidence and cannot progress through manufacturing`
+        );
       }
 
       // Department progression logic
@@ -14829,7 +14857,8 @@ export class DatabaseStorage implements IStorage {
         Array.isArray(features?.other_options) &&
         features.other_options.includes('tripod_tap');
 
-      let nextDept = nextDepartment;
+      const completingShipping = currentOrder.currentDepartment === 'Shipping';
+      let nextDept = completingShipping ? 'Shipping Management' : nextDepartment;
       if (!nextDept) {
         // Flat top orders skip CNC and go directly to Finish after Layup/Plugging
         if (isFlatTop && currentOrder.currentDepartment === 'Layup/Plugging') {
@@ -14922,6 +14951,11 @@ export class DatabaseStorage implements IStorage {
           isFulfilled: (productionOrderRecord as any).isFulfilled,
           currentStatus: productionOrderRecord.productionStatus,
         });
+        if (completingShipping) {
+          productionCompletionUpdates.productionStatus = 'SHIPPED';
+          productionCompletionUpdates.isFulfilled = true;
+          productionCompletionUpdates.fulfilledDate = now;
+        }
         
         // Map completion timestamps for production orders (using schema column names)
         // Schema columns: barcodeCompletedAt, layupCompletedAt, cncCompletedAt, 
@@ -15001,11 +15035,25 @@ export class DatabaseStorage implements IStorage {
       } else if (isFinalized) {
         updatedOrder = await this.updateFinalizedOrder(orderId, {
           currentDepartment: nextDept,
+          ...(completingShipping
+            ? {
+                status: 'FULFILLED',
+                shippedDate: now,
+                shippingCompletedAt: now,
+              }
+            : {}),
           ...completionUpdates,
         });
       } else {
         updatedOrder = await this.updateOrderDraft(orderId, {
           currentDepartment: nextDept,
+          ...(completingShipping
+            ? {
+                status: 'FULFILLED',
+                shippedDate: now,
+                shippingCompletedAt: now,
+              }
+            : {}),
           ...completionUpdates,
           updatedAt: now,
         });
@@ -23012,6 +23060,13 @@ export class DatabaseStorage implements IStorage {
   ): Promise<AllOrder> {
     try {
       const updateData: Partial<InsertAllOrder> = { ...data };
+      const recordsShipmentCompletion = Boolean(
+        updateData.shippedDate || updateData.shippingCompletedAt
+      );
+      if (recordsShipmentCompletion) {
+        updateData.status = 'FULFILLED';
+        updateData.currentDepartment = 'Shipping Management';
+      }
       if (!options.allowDueDateUpdate && Object.prototype.hasOwnProperty.call(updateData, 'dueDate')) {
         delete updateData.dueDate;
       }
@@ -23046,9 +23101,29 @@ export class DatabaseStorage implements IStorage {
         // sync it within the same transaction so getAllOrders deduplication
         // (which prefers production_orders) always returns the correct department.
         if (updateData.currentDepartment !== undefined && productionRecord) {
-          await tx.execute(
-            sql`UPDATE production_orders SET current_department = ${updateData.currentDepartment}, updated_at = NOW() WHERE order_id = ${orderId}`
-          );
+          if (recordsShipmentCompletion) {
+            await tx
+              .update(productionOrders)
+              .set({
+                currentDepartment: 'Shipping Management',
+                productionStatus: 'SHIPPED',
+                isFulfilled: true,
+                shippedAt:
+                  updateData.shippedDate ||
+                  updateData.shippingCompletedAt ||
+                  new Date(),
+                fulfilledDate:
+                  updateData.shippedDate ||
+                  updateData.shippingCompletedAt ||
+                  new Date(),
+                updatedAt: new Date(),
+              })
+              .where(eq(productionOrders.orderId, orderId));
+          } else {
+            await tx.execute(
+              sql`UPDATE production_orders SET current_department = ${updateData.currentDepartment}, updated_at = NOW() WHERE order_id = ${orderId}`
+            );
+          }
           console.log(`[updateFinalizedOrder] Synced production_orders.current_department for ${orderId} → ${updateData.currentDepartment}`);
         }
 


### PR DESCRIPTION
## What changed
- Enforce `FULFILLED` / `Shipping Management` for every P1 shipment-completion path.
- Add a storage-level shipment invariant and block shipped orders from manufacturing progression.
- Restore shipment-evidenced orders from active manufacturing departments through audited migration 0281.
- Add a read-only floor-removal audit query for operations.

## Root cause
Some P1 shipping paths wrote shipment evidence such as `shippedDate`, tracking, or `shippingCompletedAt` but did not also set `status = FULFILLED`. P1 auto-population could then select those remaining `FINALIZED` rows, and downstream progression could move some of them farther through manufacturing.

## Existing-order containment
Migration 0281 first captures every affected row in `p1_shipped_order_containment_audit` and records an immutable `CONTAIN_SHIPPED_MANUFACTURING_ORDER` activity event. It then restores `all_orders` to `FULFILLED` / `Shipping Management` and synchronizes matching production rows to `SHIPPED` / `Shipping Management` with fulfilled fields populated.

The live authenticated audit found 58 shipment-evidenced orders in active manufacturing departments at review time. The migration determines the deployment-time set from shipment evidence, so it also catches any additional affected rows created before rollout.

## Validation
- Focused Vitest regression suite: 5/5 passed.
- Shipment invariant source assertions passed.
- `git diff --cached --check` passed before commit.

## Deployment note
This PR is draft and is not deployed. Existing production records are restored only after merge/deployment runs safe-boot migration 0281.