### PR TITLE
Exclude completed P2 POs from cutting demand

### DIFF
--- a/server/__tests__/p2CuttingDemand.test.ts
+++ b/server/__tests__/p2CuttingDemand.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { reconcileP2CuttingDemandWithShipmentLedger } from '../src/lib/p2CuttingDemand';
+
+describe('P2 cutting demand shipment reconciliation', () => {
+  it('removes a completed PO line when the shipment ledger accounts for every unit', () => {
+    const rows = reconcileP2CuttingDemandWithShipmentLedger([{
+      poItemId: 64,
+      originalQuantity: 87,
+      shippedQuantity: 0,
+      committedQuantity: 0,
+    }], new Map([[64, 87]]));
+
+    expect(rows).toEqual([]);
+  });
+
+  it('leaves partially shipped demand to the existing line-level calculation', () => {
+    const rows = reconcileP2CuttingDemandWithShipmentLedger([{
+      poItemId: 64,
+      originalQuantity: 87,
+      shippedQuantity: 2,
+      committedQuantity: 5,
+    }], new Map([[64, 80]]));
+
+    expect(rows).toEqual([{
+      poItemId: 64,
+      originalQuantity: 87,
+      shippedQuantity: 2,
+      committedQuantity: 5,
+    }]);
+  });
+});

--- a/server/src/lib/p2CuttingDemand.ts
+++ b/server/src/lib/p2CuttingDemand.ts
@@ -1,0 +1,26 @@
+export type P2CuttingDemandRow = {
+  poItemId: unknown;
+  originalQuantity: unknown;
+  shippedQuantity: unknown;
+  committedQuantity: unknown;
+  [key: string]: unknown;
+};
+
+export function reconcileP2CuttingDemandWithShipmentLedger<T extends P2CuttingDemandRow>(
+  rows: readonly T[],
+  shippedByPoItem: ReadonlyMap<number, number>,
+): T[] {
+  return rows.flatMap((row) => {
+    const poItemId = Number(row.poItemId);
+    const originalQuantity = Math.max(0, Number(row.originalQuantity) || 0);
+    const ledgerShippedQuantity = Number.isFinite(poItemId)
+      ? Math.max(0, shippedByPoItem.get(poItemId) || 0)
+      : 0;
+    if (originalQuantity > 0 && ledgerShippedQuantity >= originalQuantity) return [];
+
+    // Keep the existing line-level calculation for partially shipped demand. Shipment
+    // membership and packet commitment can temporarily refer to the same active unit,
+    // so combining them here would risk subtracting one unit twice.
+    return [row];
+  });
+}

--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -40,6 +40,8 @@ import {
   insertCuttingPacketBOMCutSchema,
   type CuttingFabricInventoryTransaction,
 } from '../../schema';
+import { P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL } from '../lib/p2ShipmentEvidence';
+import { reconcileP2CuttingDemandWithShipmentLedger } from '../lib/p2CuttingDemand';
 import { getFabricInventoryDeleteErrorResponse } from '../services/fabricInventoryDeletion';
 
 const router = Router();
@@ -2697,7 +2699,30 @@ router.get('/weekly-cutting-queue', async (req, res) => {
             ORDER BY pg.id, pg."dueDate" ASC
           `, [startDate.toISOString().split('T')[0], endDate.toISOString().split('T')[0]]);
 
-      const p2Rows = Array.isArray(p2Result) ? p2Result : (p2Result as any).rows || [];
+      const rawP2Rows = Array.isArray(p2Result) ? p2Result : (p2Result as any).rows || [];
+      const p2PoIds = Array.from(new Set(
+        rawP2Rows.map((row: any) => Number(row.poId)).filter(Number.isFinite)
+      ));
+      const shippedByPoItem = new Map<number, number>();
+      if (p2PoIds.length > 0) {
+        const shipmentMembershipResult = await pool.query(`
+          SELECT
+            si.po_item_id AS "poItemId",
+            COUNT(DISTINCT membership."serializedItemId")::int AS "shippedQuantity"
+          FROM (${P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL}) membership
+          JOIN p2_serialized_items si
+            ON LOWER(si.id::text) = LOWER(membership."serializedItemId")
+          WHERE si.po_item_id IS NOT NULL
+          GROUP BY si.po_item_id
+        `, [p2PoIds]);
+        const shipmentMembershipRows = Array.isArray(shipmentMembershipResult)
+          ? shipmentMembershipResult
+          : (shipmentMembershipResult as any).rows || [];
+        for (const row of shipmentMembershipRows as any[]) {
+          shippedByPoItem.set(Number(row.poItemId), Number(row.shippedQuantity) || 0);
+        }
+      }
+      const p2Rows = reconcileP2CuttingDemandWithShipmentLedger(rawP2Rows, shippedByPoItem);
       const p2MaterialCache: Record<string, string> = {};
       for (const item of p2Rows) {
         const matchingBomId = item.matchedBomId;


### PR DESCRIPTION
## What changed

- Reconcile P2 weekly cutting demand with the authoritative shipment-membership ledger.
- Remove a P2 packet-demand line when shipment evidence accounts for its full ordered quantity.
- Preserve the existing calculation for partially shipped lines to avoid double-subtracting units that may also have packet commitments.
- Add focused regression coverage for fully completed and partially shipped PO lines.

## Why

The weekly cutting queue previously relied on limited shipment fields and the raw parent PO status. P2 Control Center derives completion from serialized shipment evidence, so a PO could display as completed there while still appearing as open packet demand in Cutting Table.

## Impact

Completed P2 POs such as FC064 no longer contribute false packet demand. Genuine partially open demand remains visible.

## Validation

- `vitest --config vitest.config.server.ts server/__tests__/p2CuttingDemand.test.ts server/__tests__/cuttingCompletedP2PoDemand.test.ts` — 3 tests passed.
- `git diff --check origin/main...HEAD` — passed.
- Non-destructive merge-tree verification against `origin/main` — passed.
