### PR TITLE
Fix legacy template part list submission

### DIFF
--- a/server/__tests__/routingDocumentTemplatePartListCompatibility.test.ts
+++ b/server/__tests__/routingDocumentTemplatePartListCompatibility.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('document-from-template legacy part-list compatibility', () => {
+  const route = readFileSync(join(process.cwd(), 'server/src/routes/routingDocuments.ts'), 'utf8');
+  const normalizationStart = route.indexOf('const normalizeTemplateFieldValues');
+  const handlerStart = route.indexOf('const createDocumentFromTemplate');
+  const handlerEnd = route.indexOf("router.post('/documents/from-template'", handlerStart);
+  const normalization = route.slice(normalizationStart, handlerStart);
+  const handler = route.slice(handlerStart, handlerEnd);
+
+  it('copies the legacy plural partsList value to the canonical partList key', () => {
+    expect(normalizationStart).toBeGreaterThan(-1);
+    expect(normalization).toContain('values.partList = values.partsList');
+  });
+
+  it('also keeps current partList values available to legacy renderers', () => {
+    expect(normalization).toContain('values.partsList = values.partList');
+  });
+
+  it('normalizes submitted values before required-field validation and PDF rendering', () => {
+    expect(handler).toContain('const values = normalizeTemplateFieldValues(fieldValues)');
+    expect(handler.indexOf('normalizeTemplateFieldValues(fieldValues)')).toBeLessThan(
+      handler.indexOf('for (const field of templateFields)'),
+    );
+    expect(handler).toContain('fieldValues: values');
+  });
+});

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -2468,6 +2468,32 @@ router.post('/spec-sheets/complete-upload', async (req: Request, res: Response) 
 
 // Fill any reusable template, save the finished PDF in central storage, register it in MDR,
 // and optionally attach it directly to a project.
+const normalizeTemplateFieldValues = (fieldValues: unknown) => {
+  const values = fieldValues && typeof fieldValues === 'object'
+    ? { ...(fieldValues as Record<string, unknown>) }
+    : {};
+
+  // Older Work Instructions templates stored the browser field as `partsList`
+  // while their canonical template_fields row uses `partList`. Preserve the
+  // authored selection under the canonical key before required-field validation.
+  if (
+    (values.partList == null || values.partList === '') &&
+    values.partsList != null &&
+    values.partsList !== ''
+  ) {
+    values.partList = values.partsList;
+  }
+  if (
+    (values.partsList == null || values.partsList === '') &&
+    values.partList != null &&
+    values.partList !== ''
+  ) {
+    values.partsList = values.partList;
+  }
+
+  return values;
+};
+
 const createDocumentFromTemplate = async (req: Request, res: Response) => {
   let creationStage = 'validating request';
   try {
@@ -2529,7 +2555,7 @@ const createDocumentFromTemplate = async (req: Request, res: Response) => {
       };
     });
 
-    const values = fieldValues && typeof fieldValues === 'object' ? fieldValues : {};
+    const values = normalizeTemplateFieldValues(fieldValues);
     for (const field of templateFields) {
       const fieldValue = values[field.fieldName];
       if (field.isRequired && (fieldValue == null || fieldValue === '' || (Array.isArray(fieldValue) && fieldValue.length < (field.minimumRows || 1)))) {


### PR DESCRIPTION
## What changed

- normalize legacy `partsList` template submissions to the canonical `partList` key before required-field validation
- keep canonical `partList` values available to legacy PDF renderers
- add regression coverage for both mappings and validation ordering

## Why

The Form & Document Builder visibly retained inventory selections, but older Work Instructions templates used `partsList` in browser metadata while the canonical `template_fields` row required `partList`. The POST therefore failed with `Part List is required` even when users selected parts from inventory search.

## Impact

Selected inventory parts now survive validation and are passed into PDF generation for legacy and current Work Instructions templates. No database migration or production-data mutation is included.

## Validation

- focused compatibility assertions passed
- `git diff --check` passed
- Vitest could not start locally because this clean worktree had no installed dependencies and sandboxed package installation could not reach the registry