### PR TITLE
Allow repeated Master Document Register revisions

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -175,6 +175,9 @@ const nextRevisionVersion = (version: string | null | undefined) => {
   return `${major}.${minor + 1}`;
 };
 
+const revisionBaseVersion = (document: ControlledDocument) =>
+  document.currentRevisionVersion || document.currentVersion;
+
 type DesignControlTemplateRevisionView = {
   id: string;
   documentVersionHistoryId: string;
@@ -995,7 +998,7 @@ export default function MasterDocumentRegister() {
     if (createNewVersion) {
       formData.append(
         'revisionValue',
-        nextRevisionVersion(selectedDocument.currentVersion)
+        nextRevisionVersion(revisionBaseVersion(selectedDocument))
       );
       formData.append(
         'reason',
@@ -2291,11 +2294,12 @@ export default function MasterDocumentRegister() {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm font-medium">
-                        Current Version: {selectedDocument.currentVersion}
+                        Current Version:{' '}
+                        {revisionBaseVersion(selectedDocument)}
                       </p>
                       <p className="text-xs text-gray-600">
                         {createNewVersion
-                          ? `Next revision: ${nextRevisionVersion(selectedDocument.currentVersion)}`
+                          ? `Next revision: ${nextRevisionVersion(revisionBaseVersion(selectedDocument))}`
                           : 'Updating current version'}
                       </p>
                     </div>
@@ -2311,7 +2315,9 @@ export default function MasterDocumentRegister() {
                           Next Version
                         </div>
                         <div className="font-mono text-lg">
-                          {nextRevisionVersion(selectedDocument.currentVersion)}
+                          {nextRevisionVersion(
+                            revisionBaseVersion(selectedDocument)
+                          )}
                         </div>
                       </div>
 

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -2105,6 +2105,7 @@ router.put(
             message: 'A revision reason is required',
           });
         }
+        const revisionState = await getControlledDocumentState(existingDoc.id);
         const filePath = await persistControlledDocumentUpload(
           req.file,
           existingDoc.id
@@ -2117,7 +2118,10 @@ router.put(
               : undefined,
           revisionValue: String(
             req.body.revisionValue ||
-              nextRevisionVersion(existingDoc.currentVersion)
+              nextRevisionVersion(
+                revisionState.currentRevision?.versionNumber ||
+                  existingDoc.currentVersion
+              )
           ),
           reason: String(changeDescription),
           file: {


### PR DESCRIPTION
## What changed

- derive the next MDR revision number from the actual current revision record
- show the current working revision in the revision dialog
- align the compatibility update route with the same latest-revision behavior

## Why

When a revision remained unreleased or was rejected, the document-level released version stayed unchanged. A later revision attempt therefore reused the same version number and failed with a revision-value conflict.

## Impact

Authorized users can continue revising a controlled document as many times as needed. Released document pointers and immutable revision history remain unchanged.

## Validation

- `git diff --check`
- focused server tests: 36 passed across `controlledDocumentLifecycleHardening.test.ts` and `controlledDocumentPhase1BReconciliation.test.ts`
