### PR TITLE
Fix validation responsibility identity lock

### DIFF
--- a/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationWizardPhase1Architecture.test.ts
@@ -61,6 +61,7 @@ describe('EPOCH validation wizard Phase 1 architecture', () => {
     expect(route).toContain('responsibilityDecisionIdentityError');
     expect(route).toContain('authenticatedEmployeeId');
     expect(route).toContain('WHERE id=$1 FOR SHARE');
+    expect(route).not.toContain('FOR SHARE OF u,e');
     expect(route).toContain('FOR UPDATE OF r`');
     expect(route).not.toContain('FOR UPDATE OF r,e');
     expect(route).toContain('packageRevision: packageRow.revision');

--- a/server/src/routes/epochSoftwareValidation.ts
+++ b/server/src/routes/epochSoftwareValidation.ts
@@ -1192,7 +1192,7 @@ async function decideResponsibility(
       await q(
         `SELECT u.id AS user_id,u.employee_id,e.is_active AS employee_active
            FROM users u JOIN employees e ON e.id=u.employee_id
-           WHERE u.id=$1 AND u.is_active=true FOR SHARE OF u,e`,
+           WHERE u.id=$1 AND u.is_active=true`,
         [a.id]
       )
     )[0];


### PR DESCRIPTION
## Summary

- remove shared row locks from the read-only authenticated user and employee identity lookup
- preserve identity validation, package protection, and the exclusive lock on the responsibility assignment being updated
- add an architecture regression assertion preventing the user/employee shared locks from returning

## Root cause

Selecting **Accept responsibility** started the decision mutation, which disabled the button while the request was pending. The request could block on `FOR SHARE OF u,e` during the read-only identity lookup when concurrent user or employee maintenance held incompatible locks, so the mutation never settled and the button appeared unresponsive.

## Impact

Responsibility acceptance can proceed without waiting on unrelated user or employee row maintenance while retaining the audited assignee identity checks and assignment-row concurrency control.

## Validation

- bundled Node syntax check passed for `server/src/routes/epochSoftwareValidation.ts`
- `git diff --check origin/main...HEAD` passed
- non-destructive `git merge-tree --write-tree HEAD origin/main` passed
- focused Vitest suites could not start in the sandbox: the package manager could not access npm, and the available sibling runtime's esbuild process could not resolve this worktree's Vite config due to filesystem access restrictions