### PR TITLE
Accept legacy Part List payload keys

### DIFF
--- a/server/__tests__/routingDocumentTemplatePartListCompatibility.test.ts
+++ b/server/__tests__/routingDocumentTemplatePartListCompatibility.test.ts
@@ -1,22 +1,32 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { normalizeTemplateFieldValues } from '../src/utils/templateFieldValueCompatibility';
 
 describe('document-from-template legacy part-list compatibility', () => {
   const route = readFileSync(join(process.cwd(), 'server/src/routes/routingDocuments.ts'), 'utf8');
-  const normalizationStart = route.indexOf('const normalizeTemplateFieldValues');
   const handlerStart = route.indexOf('const createDocumentFromTemplate');
   const handlerEnd = route.indexOf("router.post('/documents/from-template'", handlerStart);
-  const normalization = route.slice(normalizationStart, handlerStart);
   const handler = route.slice(handlerStart, handlerEnd);
 
-  it('copies the legacy plural partsList value to the canonical partList key', () => {
-    expect(normalizationStart).toBeGreaterThan(-1);
-    expect(normalization).toContain('values.partList = values.partsList');
-  });
+  it.each(['partList', 'partsList', 'parts_list', 'Part List'])(
+    'maps a populated %s payload to both supported Part List keys',
+    (fieldName) => {
+      const result = normalizeTemplateFieldValues({ [fieldName]: '1 | 26246 | Body, Heated Pitot' });
 
-  it('also keeps current partList values available to legacy renderers', () => {
-    expect(normalization).toContain('values.partsList = values.partList');
+      expect(result.partList).toBe('1 | 26246 | Body, Heated Pitot');
+      expect(result.partsList).toBe('1 | 26246 | Body, Heated Pitot');
+    },
+  );
+
+  it('does not replace a populated canonical value with a legacy alias', () => {
+    const result = normalizeTemplateFieldValues({
+      partList: 'canonical',
+      parts_list: 'legacy',
+    });
+
+    expect(result.partList).toBe('canonical');
+    expect(result.partsList).toBe('canonical');
   });
 
   it('normalizes submitted values before required-field validation and PDF rendering', () => {

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -44,6 +44,7 @@ import {
   specActorSnapshot,
 } from '../lib/partSpecificationSheetControl';
 import { renderPartSpecificationSheetPdf } from '../lib/partSpecificationSheetPdf';
+import { normalizeTemplateFieldValues } from '../utils/templateFieldValueCompatibility';
 
 const require = createRequire(import.meta.url);
 const TEMPLATE_UPLOAD_TABLES = new Set([
@@ -2468,32 +2469,6 @@ router.post('/spec-sheets/complete-upload', async (req: Request, res: Response) 
 
 // Fill any reusable template, save the finished PDF in central storage, register it in MDR,
 // and optionally attach it directly to a project.
-const normalizeTemplateFieldValues = (fieldValues: unknown) => {
-  const values = fieldValues && typeof fieldValues === 'object'
-    ? { ...(fieldValues as Record<string, unknown>) }
-    : {};
-
-  // Older Work Instructions templates stored the browser field as `partsList`
-  // while their canonical template_fields row uses `partList`. Preserve the
-  // authored selection under the canonical key before required-field validation.
-  if (
-    (values.partList == null || values.partList === '') &&
-    values.partsList != null &&
-    values.partsList !== ''
-  ) {
-    values.partList = values.partsList;
-  }
-  if (
-    (values.partsList == null || values.partsList === '') &&
-    values.partList != null &&
-    values.partList !== ''
-  ) {
-    values.partsList = values.partList;
-  }
-
-  return values;
-};
-
 const createDocumentFromTemplate = async (req: Request, res: Response) => {
   let creationStage = 'validating request';
   try {

--- a/server/src/utils/templateFieldValueCompatibility.ts
+++ b/server/src/utils/templateFieldValueCompatibility.ts
@@ -1,0 +1,31 @@
+const hasSubmittedValue = (value: unknown) =>
+  value != null && value !== '' && (!Array.isArray(value) || value.length > 0);
+
+const normalizeFieldKey = (key: string) => key.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+export const normalizeTemplateFieldValues = (fieldValues: unknown) => {
+  const values = fieldValues && typeof fieldValues === 'object'
+    ? { ...(fieldValues as Record<string, unknown>) }
+    : {};
+
+  // Work Instructions templates have used partList, partsList, parts_list,
+  // and display-label keys over time. Resolve any populated Part List variant
+  // to both names still consumed by validation and legacy PDF rendering.
+  const submittedPartListKey = Object.keys(values).find((key) => {
+    const normalizedKey = normalizeFieldKey(key);
+    return (
+      (normalizedKey === 'partlist' || normalizedKey === 'partslist') &&
+      hasSubmittedValue(values[key])
+    );
+  });
+  const submittedPartList = submittedPartListKey ? values[submittedPartListKey] : undefined;
+
+  if (!hasSubmittedValue(values.partList) && hasSubmittedValue(submittedPartList)) {
+    values.partList = submittedPartList;
+  }
+  if (!hasSubmittedValue(values.partsList) && hasSubmittedValue(submittedPartList)) {
+    values.partsList = submittedPartList;
+  }
+
+  return values;
+};


### PR DESCRIPTION
## What changed

- normalize populated Part List payloads across `partList`, `partsList`, `parts_list`, and display-label key formats
- preserve canonical Part List content for validation and legacy PDF rendering
- move compatibility normalization into a focused utility with executable regression tests

## Why

Production continued returning `Part List is required` after the initial singular/plural compatibility fix. Historical Form & Document Builder templates can submit additional field-key formats, so the server must resolve the populated Part List value by normalized field identity before required-field validation.

## Impact

Users can submit recovered Work Instructions for review without re-entering their selected inventory parts. No database migration or production-data mutation is included.

## Validation

- 2 focused test files passed
- 9 focused tests passed
- `git diff --check` passed