### PR TITLE
Route the CAR placeholder to the new workspace

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1638,6 +1638,10 @@ function App() {
                           component={QMSCorrectiveActionsPage}
                         />
                         <Route
+                          path="/qms/corrective-actions"
+                          component={QMSCorrectiveActionsPage}
+                        />
+                        <Route
                           path="/my-quality-actions"
                           component={MyQualityActionsPage}
                         />

--- a/client/src/components/qms/QualityActionWorkspace.tsx
+++ b/client/src/components/qms/QualityActionWorkspace.tsx
@@ -235,7 +235,7 @@ export default function QualityActionWorkspace({
 
   const recommendationHref = (code: string) => {
     if (code.includes('NCR')) return '/nonconformance';
-    if (code.includes('CAR')) return '/qms/corrective-actions';
+    if (code.includes('CAR')) return '/qms/cars';
     if (code.includes('PCR')) return '/my-quality-actions';
     if (code.includes('ECR') || code.includes('ECN'))
       return '/qms/design-control';

--- a/server/__tests__/qmsCarWorkflow.test.ts
+++ b/server/__tests__/qmsCarWorkflow.test.ts
@@ -10,8 +10,13 @@ describe('QMS CAR workflow', () => {
   it('routes the QMS CAR navbar item to the template-based workspace', () => {
     const app = read('client/src/App.tsx');
     const page = read('client/src/pages/QMSCorrectiveActionsPage.tsx');
+    const workspace = read(
+      'client/src/components/qms/QualityActionWorkspace.tsx'
+    );
     expect(app).toContain('path="/qms/cars"');
+    expect(app).toContain('path="/qms/corrective-actions"');
     expect(app).toContain('QMSCorrectiveActionsPage');
+    expect(workspace).toContain("return '/qms/cars'");
     for (const section of [
       'Problem and scope',
       'Containment and correction',


### PR DESCRIPTION
## Summary

- route the existing `/qms/cars` placeholder directly to the new CAR workspace
- keep `/qms/corrective-actions` as a compatibility alias to the same UI
- update Quality Action CAR recommendations to open `/qms/cars`
- add regression assertions covering both entry points

## Why

The original CAR UI PR replaced the navbar route, but a stale Quality Action link still opened a generic placeholder under `/qms/corrective-actions`. This follow-up makes every CAR entry point resolve to the same template-based CAR UI.

## Validation

- `git diff --check`
- TypeScript syntax transpilation for the three touched TypeScript/TSX files
- focused route/source assertions

## State

PR #1746 containing the main CAR UI was already merged before this routing correction was pushed. This PR contains the follow-up route correction.