### PR TITLE
Reconcile template fields by Part List label

### DIFF
--- a/server/__tests__/routingDocumentTemplatePartListCompatibility.test.ts
+++ b/server/__tests__/routingDocumentTemplatePartListCompatibility.test.ts
@@ -29,9 +29,24 @@ describe('document-from-template legacy part-list compatibility', () => {
     expect(result.partsList).toBe('canonical');
   });
 
+  it('reconciles browser and server field names that share the Part List label', () => {
+    const result = normalizeTemplateFieldValues(
+      { selectedInventoryParts: '1 | 26246 | Body, Heated Pitot' },
+      [
+        { fieldName: 'selectedInventoryParts', fieldLabel: 'Part List' },
+        { field_name: 'requiredMaterials', field_label: 'Part List' },
+      ],
+    );
+
+    expect(result.requiredMaterials).toBe('1 | 26246 | Body, Heated Pitot');
+    expect(result.partList).toBe('1 | 26246 | Body, Heated Pitot');
+  });
+
   it('normalizes submitted values before required-field validation and PDF rendering', () => {
-    expect(handler).toContain('const values = normalizeTemplateFieldValues(fieldValues)');
-    expect(handler.indexOf('normalizeTemplateFieldValues(fieldValues)')).toBeLessThan(
+    expect(handler).toContain(
+      'const values = normalizeTemplateFieldValues(fieldValues, [...defaultFields, ...templateFields])',
+    );
+    expect(handler.indexOf('normalizeTemplateFieldValues(fieldValues,')).toBeLessThan(
       handler.indexOf('for (const field of templateFields)'),
     );
     expect(handler).toContain('fieldValues: values');

--- a/server/src/routes/routingDocuments.ts
+++ b/server/src/routes/routingDocuments.ts
@@ -2530,7 +2530,7 @@ const createDocumentFromTemplate = async (req: Request, res: Response) => {
       };
     });
 
-    const values = normalizeTemplateFieldValues(fieldValues);
+    const values = normalizeTemplateFieldValues(fieldValues, [...defaultFields, ...templateFields]);
     for (const field of templateFields) {
       const fieldValue = values[field.fieldName];
       if (field.isRequired && (fieldValue == null || fieldValue === '' || (Array.isArray(fieldValue) && fieldValue.length < (field.minimumRows || 1)))) {

--- a/server/src/utils/templateFieldValueCompatibility.ts
+++ b/server/src/utils/templateFieldValueCompatibility.ts
@@ -3,7 +3,23 @@ const hasSubmittedValue = (value: unknown) =>
 
 const normalizeFieldKey = (key: string) => key.toLowerCase().replace(/[^a-z0-9]/g, '');
 
-export const normalizeTemplateFieldValues = (fieldValues: unknown) => {
+type TemplateFieldIdentity = {
+  fieldName?: unknown;
+  field_name?: unknown;
+  fieldLabel?: unknown;
+  field_label?: unknown;
+};
+
+const isPartListIdentity = (value: unknown) => {
+  if (typeof value !== 'string') return false;
+  const normalizedValue = normalizeFieldKey(value);
+  return normalizedValue === 'partlist' || normalizedValue === 'partslist';
+};
+
+export const normalizeTemplateFieldValues = (
+  fieldValues: unknown,
+  fieldDefinitions: TemplateFieldIdentity[] = [],
+) => {
   const values = fieldValues && typeof fieldValues === 'object'
     ? { ...(fieldValues as Record<string, unknown>) }
     : {};
@@ -11,20 +27,34 @@ export const normalizeTemplateFieldValues = (fieldValues: unknown) => {
   // Work Instructions templates have used partList, partsList, parts_list,
   // and display-label keys over time. Resolve any populated Part List variant
   // to both names still consumed by validation and legacy PDF rendering.
-  const submittedPartListKey = Object.keys(values).find((key) => {
-    const normalizedKey = normalizeFieldKey(key);
-    return (
-      (normalizedKey === 'partlist' || normalizedKey === 'partslist') &&
-      hasSubmittedValue(values[key])
-    );
-  });
+  const partListKeys = new Set(['partList', 'partsList']);
+  for (const key of Object.keys(values)) {
+    if (isPartListIdentity(key)) {
+      partListKeys.add(key);
+    }
+  }
+  for (const field of fieldDefinitions) {
+    const fieldName = field.fieldName ?? field.field_name;
+    const fieldLabel = field.fieldLabel ?? field.field_label;
+    if (
+      typeof fieldName === 'string' &&
+      (isPartListIdentity(fieldName) || isPartListIdentity(fieldLabel))
+    ) {
+      partListKeys.add(fieldName);
+    }
+  }
+
+  const submittedPartListKey = Array.from(partListKeys).find((key) =>
+    hasSubmittedValue(values[key]),
+  );
   const submittedPartList = submittedPartListKey ? values[submittedPartListKey] : undefined;
 
-  if (!hasSubmittedValue(values.partList) && hasSubmittedValue(submittedPartList)) {
-    values.partList = submittedPartList;
-  }
-  if (!hasSubmittedValue(values.partsList) && hasSubmittedValue(submittedPartList)) {
-    values.partsList = submittedPartList;
+  if (hasSubmittedValue(submittedPartList)) {
+    for (const key of partListKeys) {
+      if (!hasSubmittedValue(values[key])) {
+        values[key] = submittedPartList;
+      }
+    }
   }
 
   return values;


### PR DESCRIPTION
## What changed

- reconcile browser `default_fields` and canonical `template_fields` by their shared Part List label
- copy the populated inventory selection into the exact server-required field name before validation
- retain support for singular, plural, snake-case, and display-label payload keys
- add executable coverage for mismatched browser/server field names

## Root cause

Production template `d191e6fe-da82-4af8-bfa9-f5efc91102b9` has field-name drift between its browser metadata and canonical validation rows. Normalizing only common spellings could not populate an unrelated canonical field name even though both definitions are labeled Part List.

## Impact

Recovered Work Instructions can submit for review without re-entering parts. No database migration or production-data mutation is included.

## Validation

- 2 focused test files passed
- 10 focused tests passed
- `git diff --check` passed