### PR TITLE
Fix P1 layup schedule print pagination

### DIFF
--- a/client/src/__tests__/layupSchedulePreview.component.test.tsx
+++ b/client/src/__tests__/layupSchedulePreview.component.test.tsx
@@ -161,4 +161,62 @@ describe('LayupSchedulePreview printing', () => {
       'Schedule saved, but the barcode was not ready to print. Reprint it from Schedule History.'
     );
   });
+
+  it('prints every Thursday order across deterministic continuation pages', async () => {
+    const writes: string[] = [];
+    const printWindow = {
+      document: {
+        write: vi.fn((value: string) => writes.push(value)),
+        open: vi.fn(),
+        close: vi.fn(),
+      },
+      close: vi.fn(),
+      print: vi.fn(),
+      onload: null as null | (() => void),
+    };
+    vi.spyOn(window, 'open').mockReturnValue(printWindow as unknown as Window);
+
+    const thursdayItems = Array.from({ length: 25 }, (_, index) => ({
+      ...scheduledItems[0],
+      orderId: `THURSDAY-${String(index + 1).padStart(2, '0')}`,
+      scheduledDate: '2026-07-23',
+      dayOfWeek: 4,
+      dayName: 'Thursday',
+    }));
+
+    render(
+      <LayupSchedulePreview
+        open
+        onClose={vi.fn()}
+        scheduledItems={thursdayItems}
+        overflowItems={[]}
+        weekStart="2026-07-20"
+        totalItems={thursdayItems.length}
+        onApprove={vi.fn().mockResolvedValue({ entriesSaved: thursdayItems.length })}
+        isApproving={false}
+      />
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector('svg rect')).not.toBeNull()
+    );
+    fireEvent.click(screen.getByTestId('button-print-schedule'));
+
+    await waitFor(() =>
+      expect(writes.some((value) => value.startsWith('<!DOCTYPE html>'))).toBe(
+        true
+      )
+    );
+
+    const printHtml = writes.find((value) => value.startsWith('<!DOCTYPE html>')) || '';
+    expect(printHtml.match(/data-print-day="Thursday"/g)).toHaveLength(3);
+    expect(printHtml).toContain('Thursday (continued)');
+    expect(printHtml).toContain('page 3 of 3');
+    expect(printHtml).toContain('overflow: visible');
+    expect(printHtml).not.toContain('page-break-inside: avoid; \n      margin-bottom');
+
+    for (const item of thursdayItems) {
+      expect(printHtml.match(new RegExp(item.orderId, 'g'))).toHaveLength(1);
+    }
+  });
 });

--- a/client/src/components/LayupSchedulePreview.tsx
+++ b/client/src/components/LayupSchedulePreview.tsx
@@ -50,6 +50,16 @@ function stockModelLabel(item: {
   return item.stockModelDisplayName || item.stockModel || item.originalRef || 'Unresolved stock model';
 }
 
+const PRINT_ITEMS_PER_PAGE = 12;
+
+function chunkItems<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
 interface LayupSchedulePreviewProps {
   open: boolean;
   onClose: () => void;
@@ -229,6 +239,16 @@ export function LayupSchedulePreview({
   const generatePrintHTML = (barcodeDataURL: string) => {
     const dayNames = ['', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
     const scheduledDays = [1, 2, 3, 4, 5].filter(day => itemsByDay[day]?.length > 0);
+    const printableDayPages = scheduledDays.flatMap((day) => {
+      const dayItems = itemsByDay[day] || [];
+      return chunkItems(dayItems, PRINT_ITEMS_PER_PAGE).map((items, pageIndex, pages) => ({
+        day,
+        items,
+        pageIndex,
+        pageCount: pages.length,
+        totalForDay: dayItems.length,
+      }));
+    });
     
     return `<!DOCTYPE html>
 <html>
@@ -307,12 +327,21 @@ export function LayupSchedulePreview({
       font-weight: 700;
       color: #2c3e50;
     }
+    .day-page {
+      break-after: page;
+      page-break-after: always;
+    }
+    .day-page:last-child {
+      break-after: auto;
+      page-break-after: auto;
+    }
     .day-section { 
-      page-break-inside: avoid; 
+      break-inside: auto;
+      page-break-inside: auto;
       margin-bottom: 10px;
       border: 1px solid #dee2e6; 
       border-radius: 4px;
-      overflow: hidden;
+      overflow: visible;
       box-shadow: 0 1px 2px rgba(0,0,0,0.05);
     }
     .day-header { 
@@ -451,7 +480,11 @@ export function LayupSchedulePreview({
     }
     @media print { 
       body { padding: 0; }
+      .day-page { break-after: page; page-break-after: always; }
+      .day-page:last-child { break-after: auto; page-break-after: auto; }
+      .day-header { break-after: avoid; page-break-after: avoid; }
       .order-item { break-inside: avoid; }
+      .signature { break-inside: avoid; page-break-inside: avoid; }
     }
   </style>
 </head>
@@ -482,14 +515,15 @@ export function LayupSchedulePreview({
     </div>
   </div>
   
-  ${scheduledDays.map(day => `
+  ${printableDayPages.map(({ day, items, pageIndex, pageCount, totalForDay }) => `
+    <div class="day-page" data-print-day="${dayNames[day]}" data-print-page="${pageIndex + 1}">
     <div class="day-section">
       <div class="day-header">
-        <span>${dayNames[day]}</span>
-        <span class="count">${itemsByDay[day]?.length || 0} items</span>
+        <span>${dayNames[day]}${pageIndex > 0 ? ' (continued)' : ''}</span>
+        <span class="count">${totalForDay} items${pageCount > 1 ? ` • page ${pageIndex + 1} of ${pageCount}` : ''}</span>
       </div>
       <div class="day-content">
-        ${itemsByDay[day]?.map(item => `
+        ${items.map(item => `
           <div class="order-item">
             <div class="checkbox"></div>
             <div class="order-details">
@@ -532,7 +566,7 @@ export function LayupSchedulePreview({
             })()}
           </div>
         `).join('')}
-        <div class="signature">
+        ${pageIndex === pageCount - 1 ? `<div class="signature">
           <div class="sig-field">
             <div class="sig-label">Completed By</div>
             <div class="sig-line"></div>
@@ -541,8 +575,9 @@ export function LayupSchedulePreview({
             <div class="sig-label">Date</div>
             <div class="sig-line"></div>
           </div>
-        </div>
+        </div>` : ''}
       </div>
+    </div>
     </div>
   `).join('')}
 </body>


### PR DESCRIPTION
## What changed

- split each P1 layup schedule day into deterministic 12-order print pages
- repeat the day heading on continuation pages
- remove the unbreakable, clipped day container that could omit an oversized Thursday section
- keep the completion signature on the final page for each day
- add a 25-order Thursday regression that verifies three pages and every order exactly once

## Why

A production schedule printed on August 17, 2026 omitted the final Thursday page. The print stylesheet treated the entire day as an unbreakable container and hid overflow, allowing Chromium to clip or drop a day that exceeded one landscape page.

The branch is based on current `origin/main`, which already contains the persistence-first `Approve, Save & Print` behavior needed for Schedule History. The existing component tests continue to verify that the schedule saves before printing and remains recoverable when popup or barcode preparation fails.

## Validation

- `vitest run --config vitest.config.component.ts client/src/__tests__/layupSchedulePreview.component.test.tsx` — 4/4 passed
- `git diff --check` — passed

## Deployment

Not deployed. Production verification remains required after merge and publish.