### PR TITLE
Prevent MDR print footer from covering document content

### DIFF
--- a/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
+++ b/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
@@ -47,9 +47,13 @@ describe('Master Document Register released-revision access', () => {
 
   it('keeps stamped footer control information inside the printable page area', () => {
     expect(route).toContain('page.getCropBox()');
-    expect(route).toContain('const bottomInset = 24');
-    expect(route).toContain('y: pageY + bottomInset');
-    expect(route).toContain('y: pageY + bottomInset + 8');
+    expect(route).toContain('const footerAreaHeight = 48');
+    expect(route).toContain('const bottomInset = 18');
+    expect(route).toContain('const footerAreaY = pageY - footerAreaHeight');
+    expect(route).toContain('page.setMediaBox(');
+    expect(route).toContain('page.setCropBox(');
+    expect(route).toContain('y: footerAreaY + bottomInset');
+    expect(route).toContain('y: footerAreaY + bottomInset + 8');
     expect(route).not.toMatch(/page\.drawText\(text, \{[\s\S]*?y: 8,/);
   });
 

--- a/server/src/routes/controlledDocuments.ts
+++ b/server/src/routes/controlledDocuments.ts
@@ -952,11 +952,15 @@ const addControlledDocumentFooter = async (
   const footerText = `Doc #: ${doc.documentNumber || 'N/A'} | Version: ${revision.versionNumber || 'N/A'} | Effective: ${footerDate} | Status: ${lifecycleStatus}`;
 
   for (const page of pages) {
-    const { x: pageX, y: pageY, width } = page.getCropBox();
+    const { x: pageX, y: pageY, width, height } = page.getCropBox();
+    const mediaBox = page.getMediaBox();
     const marginX = 36;
-    const bottomInset = 24;
+    const footerAreaHeight = 48;
+    const bottomInset = 18;
     const footerHeight = 24;
     const fontSize = 8;
+    const footerAreaY = pageY - footerAreaHeight;
+    const mediaBottom = Math.min(mediaBox.y, footerAreaY);
     const text = truncateTextToWidth(
       footerText,
       width - marginX * 2,
@@ -964,9 +968,19 @@ const addControlledDocumentFooter = async (
       fontSize
     );
 
+    // Give the control footer its own printable strip below the original page
+    // instead of covering document content near the existing bottom edge.
+    page.setMediaBox(
+      mediaBox.x,
+      mediaBottom,
+      mediaBox.width,
+      mediaBox.y + mediaBox.height - mediaBottom
+    );
+    page.setCropBox(pageX, footerAreaY, width, height + footerAreaHeight);
+
     page.drawRectangle({
       x: pageX,
-      y: pageY + bottomInset,
+      y: footerAreaY + bottomInset,
       width,
       height: footerHeight,
       color: rgb(1, 1, 1),
@@ -975,18 +989,18 @@ const addControlledDocumentFooter = async (
     page.drawLine({
       start: {
         x: pageX + marginX,
-        y: pageY + bottomInset + footerHeight,
+        y: footerAreaY + bottomInset + footerHeight,
       },
       end: {
         x: pageX + width - marginX,
-        y: pageY + bottomInset + footerHeight,
+        y: footerAreaY + bottomInset + footerHeight,
       },
       thickness: 0.5,
       color: rgb(0.72, 0.72, 0.72),
     });
     page.drawText(text, {
       x: pageX + marginX,
-      y: pageY + bottomInset + 8,
+      y: footerAreaY + bottomInset + 8,
       size: fontSize,
       font,
       color: rgb(0.2, 0.2, 0.2),


### PR DESCRIPTION
## What changed

- add a dedicated 48-point footer strip below each PDF page's original content area
- preserve an 18-point printer-safe bottom margin within that strip
- anchor the expanded page and footer geometry to each page's crop and media boxes
- update regression coverage for the dedicated footer area and safe positioning

## Why

The first fix moved the MDR footer away from the physical page edge so printers would not cut it off. The supplied print preview showed that the raised footer could cover existing form fields near the bottom of a source document. This follow-up gives the footer its own added page space below the original content, avoiding both clipping and overlap.

## Impact

Controlled PDFs keep the same control metadata on every page. Existing source-document content remains at its original coordinates and is no longer obscured by the footer.

## Validation

- pdf-lib save/reload check confirmed the expanded crop-box geometry persists
- focused footer regression assertions passed
- `git diff --check` passed
- `git merge-tree --write-tree origin/main HEAD` completed without conflicts
- full Vitest execution remains unavailable because dependencies are not installed in the isolated worktree and registry access is restricted