### PR TITLE
Remove unrelated RMA projections from Change Control

### DIFF
--- a/migrations/0283_remove_legacy_rma_change_control_projections.sql
+++ b/migrations/0283_remove_legacy_rma_change_control_projections.sql
@@ -1,0 +1,68 @@
+-- Remove legacy customer-return/RMA rows from the Quality Action register.
+--
+-- `nonconformance_records` is the historical customer RMA/repair workflow. It
+-- is not the authoritative P1 (`non_conforming_items`) or P2
+-- (`p2_nonconforming_dispositions`) production nonconformance workflow. The
+-- Quality Action migration accidentally projected every historical RMA into
+-- `change_control_records` as an NCR.
+--
+-- Preserve the source RMA records and fail closed if a projected row has
+-- acquired controlled Change Control evidence. Only the derived register rows
+-- are removed.
+
+DROP TRIGGER IF EXISTS sync_ncr_quality_action_register_trigger
+  ON nonconformance_records;
+DROP FUNCTION IF EXISTS sync_ncr_quality_action_register();
+
+DO $$
+DECLARE
+  protected_projection_count integer;
+  remaining_projection_count integer;
+BEGIN
+  SELECT count(*)::integer
+    INTO protected_projection_count
+    FROM change_control_records r
+   WHERE r.authoritative_record_type = 'NCR'
+     AND EXISTS (
+       SELECT 1
+         FROM nonconformance_records n
+        WHERE n.id::text = r.authoritative_record_id
+     )
+     AND (
+       EXISTS (SELECT 1 FROM change_control_record_links l WHERE l.change_control_record_id = r.id)
+       OR EXISTS (SELECT 1 FROM change_control_evidence e WHERE e.change_control_record_id = r.id)
+       OR EXISTS (SELECT 1 FROM change_control_historical_approvals a WHERE a.change_control_record_id = r.id)
+       OR EXISTS (SELECT 1 FROM change_control_audit_events a WHERE a.change_control_record_id = r.id)
+       OR EXISTS (SELECT 1 FROM change_control_assessments a WHERE a.change_control_record_id = r.id)
+     );
+
+  IF protected_projection_count <> 0 THEN
+    RAISE EXCEPTION
+      '0283 refused to remove % legacy RMA Change Control projection(s) with controlled evidence',
+      protected_projection_count;
+  END IF;
+
+  DELETE FROM change_control_records r
+   WHERE r.authoritative_record_type = 'NCR'
+     AND EXISTS (
+       SELECT 1
+         FROM nonconformance_records n
+        WHERE n.id::text = r.authoritative_record_id
+     );
+
+  SELECT count(*)::integer
+    INTO remaining_projection_count
+    FROM change_control_records r
+   WHERE r.authoritative_record_type = 'NCR'
+     AND EXISTS (
+       SELECT 1
+         FROM nonconformance_records n
+        WHERE n.id::text = r.authoritative_record_id
+     );
+
+  IF remaining_projection_count <> 0 THEN
+    RAISE EXCEPTION
+      '0283 expected no legacy RMA Change Control projections after cleanup; found %',
+      remaining_projection_count;
+  END IF;
+END $$;

--- a/server/__tests__/legacyRmaChangeControlCleanup.test.ts
+++ b/server/__tests__/legacyRmaChangeControlCleanup.test.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(__dirname, '../..');
+const migration = fs.readFileSync(
+  path.join(
+    root,
+    'migrations',
+    '0283_remove_legacy_rma_change_control_projections.sql'
+  ),
+  'utf8'
+);
+const safeBoot = fs.readFileSync(
+  path.join(root, 'server/scripts/migrations/runSafeBootMigrations.ts'),
+  'utf8'
+);
+
+describe('legacy RMA Change Control cleanup', () => {
+  it('stops projecting the legacy customer-return table as Quality Action NCRs', () => {
+    expect(migration).toMatch(
+      /DROP TRIGGER IF EXISTS sync_ncr_quality_action_register_trigger\s+ON nonconformance_records/i
+    );
+    expect(migration).toMatch(
+      /DROP FUNCTION IF EXISTS sync_ncr_quality_action_register\(\)/i
+    );
+  });
+
+  it('deletes only derived register rows backed by the legacy RMA table', () => {
+    expect(migration).toMatch(/DELETE FROM change_control_records r/i);
+    expect(migration).toMatch(/r\.authoritative_record_type = 'NCR'/i);
+    expect(migration).toMatch(
+      /FROM nonconformance_records n\s+WHERE n\.id::text = r\.authoritative_record_id/i
+    );
+    expect(migration).not.toMatch(/DELETE FROM nonconformance_records/i);
+    expect(migration).not.toMatch(/DELETE FROM non_conforming_items/i);
+    expect(migration).not.toMatch(/DELETE FROM p2_nonconforming_dispositions/i);
+  });
+
+  it('fails closed when a projected row has controlled workflow evidence', () => {
+    for (const table of [
+      'change_control_record_links',
+      'change_control_evidence',
+      'change_control_historical_approvals',
+      'change_control_audit_events',
+      'change_control_assessments',
+    ]) {
+      expect(migration).toContain(`FROM ${table}`);
+    }
+    expect(migration).toContain('RAISE EXCEPTION');
+  });
+
+  it('is registered as both a safe and critical migration', () => {
+    const references = safeBoot.match(
+      /0283_remove_legacy_rma_change_control_projections\.sql/g
+    );
+    expect(references).toHaveLength(2);
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -343,6 +343,7 @@ export const safeMigrationFiles = [
   '0280_move_forward.sql',
   '0281_contain_shipped_p1_auto_populate_regression.sql',
   '0282_car_form_data.sql',
+  '0283_remove_legacy_rma_change_control_projections.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -430,6 +431,7 @@ export const criticalMigrationFiles = new Set([
   '0279_vendor_international_contact_fields.sql',
   '0281_contain_shipped_p1_auto_populate_regression.sql',
   '0282_car_form_data.sql',
+  '0283_remove_legacy_rma_change_control_projections.sql',
 ]);
 
 export async function runSafeBootMigrations() {


### PR DESCRIPTION
## What changed

- add migration `0283_remove_legacy_rma_change_control_projections.sql`
- stop projecting legacy `nonconformance_records` customer-return/RMA rows into the Quality Action register as NCRs
- remove only the derived Change Control projections while preserving the underlying RMA records
- fail closed if any projected row has controlled links, evidence, approvals, audit events, or assessments
- register the cleanup in both safe and critical boot migration lists
- add regression coverage for the cleanup boundary

## Why

The Quality Action migration broadly treated every historical customer RMA/repair record as an NCR. Those rows are unrelated to the authoritative P1 `non_conforming_items` and P2 `p2_nonconforming_dispositions` workflows, so the live Change Control register displayed unrelated RMA history.

## Impact

After this migration runs, unrelated historical RMA projections no longer appear in Quality Action → Change Control, and future legacy RMAs are not automatically projected there. Source RMA history and actual P1/P2 nonconforming data remain untouched.

## Validation

- cleanup contract assertions passed
- Prettier check passed for changed TypeScript files
- `git diff --check origin/main...HEAD` passed
- `git merge-tree --write-tree origin/main HEAD` completed cleanly
- focused Vitest execution was attempted but the isolated worktree lacks its dependency links; the available shared runner could not load the worktree PostCSS/Tailwind dependencies
- migration was not executed against a live database