### PR TITLE
Fix Design Control approver and saved-content loading

### DIFF
--- a/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
+++ b/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
@@ -96,6 +96,11 @@ describe('unified Design Control step editor', () => {
     );
 
     expect(editor).toContain("window.addEventListener('beforeunload'");
+    expect(editor).toContain('setFormData(step?.formData ?? {})');
+    expect(editor).toContain('setChecklist(step?.checklist ?? {})');
+    expect(editor).toContain(
+      'if (!navigatedToAnotherStep && dirtyRef.current) return'
+    );
     expect(editor).toContain('Save and Continue');
     expect(editor).toContain('payload.message || payload.error');
     expect(editor).toContain('Select an active project assignment');

--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -180,6 +180,27 @@ export function DesignControlStepEditor({
   const lastInitializedKey = useRef(definition.key);
 
   useEffect(() => {
+    const navigatedToAnotherStep =
+      lastInitializedKey.current !== definition.key;
+    if (!navigatedToAnotherStep && dirtyRef.current) return;
+
+    setFormData(step?.formData ?? {});
+    setChecklist(step?.checklist ?? {});
+    setChangeReason('');
+    setManualPersonFields(new Set());
+    setManualProjectFields(new Set());
+    setLastSavedAt(step?.updatedAt ?? null);
+    setDirty(false);
+    lastInitializedKey.current = definition.key;
+  }, [
+    definition.key,
+    step?.currentContentVersionId,
+    step?.formData,
+    step?.checklist,
+    step?.updatedAt,
+  ]);
+
+  useEffect(() => {
     const warnBeforeUnload = (event: BeforeUnloadEvent) => {
       if (!dirty) return;
       event.preventDefault();

--- a/server/__tests__/designControlAuthenticatedApprovals.test.ts
+++ b/server/__tests__/designControlAuthenticatedApprovals.test.ts
@@ -138,7 +138,7 @@ describe('authenticated Design Control approvals', () => {
     expect(service).toContain("eq(employees.employmentStatus, 'ACTIVE')");
     expect(service).toContain("'APPROVER_NOT_ASSIGNED'");
     expect(service).toContain("'INDEPENDENCE_REQUIRED'");
-    expect(service).toContain("'ADMIN_APPROVAL_BYPASS_FORBIDDEN'");
+    expect(service).not.toContain("'ADMIN_APPROVAL_BYPASS_FORBIDDEN'");
     expect(service).not.toMatch(/employeeName\s*===\s*/);
   });
 
@@ -163,6 +163,9 @@ describe('authenticated Design Control approvals', () => {
       'permissions.permissionSet.has(slot.requiredCapability!)'
     );
     expect(service).not.toContain('APPROVER_ROLE_MISMATCH');
+    expect(service).not.toContain(
+      "row.accountRole !== 'ADMIN' && row.accountRole !== 'OWNER'"
+    );
     expect(editor).toContain('Select an active employee...');
     expect(editor).toContain('canRouteApprovers');
     expect(editor).toContain('Change approver');

--- a/server/src/services/designControlApprovalService.ts
+++ b/server/src/services/designControlApprovalService.ts
@@ -78,12 +78,6 @@ async function verifiedApprover(
       'APPROVER_NOT_ACTIVE_OR_LINKED',
       'Each approver must be an active employee with an active linked EPOCH account'
     );
-  if (candidate.userRole === 'ADMIN' || candidate.userRole === 'OWNER')
-    throw new DesignControlApprovalError(
-      422,
-      'ADMIN_APPROVAL_BYPASS_FORBIDDEN',
-      'Administrative account status does not confer Design Control approval authority'
-    );
   const permissions = await getUserPermissions(
     candidate.userId,
     candidate.userRole
@@ -126,29 +120,22 @@ export async function listEligibleDesignControlApprovers(
       )
     );
   const candidates = await Promise.all(
-    rows
-      .filter(
-        (row) => row.accountRole !== 'ADMIN' && row.accountRole !== 'OWNER'
-      )
-      .map(async (row) => {
-        const permissions = await getUserPermissions(
-          row.userId,
-          row.accountRole
-        );
-        return {
-          ...row,
-          eligibleApprovalKeys: context.definition.approvals
-            .filter((slot) =>
-              permissions.permissionSet.has(slot.requiredCapability!)
-            )
-            .map((slot) => slot.key),
-          eligibleApprovalRoles: context.definition.approvals
-            .filter((slot) =>
-              permissions.permissionSet.has(slot.requiredCapability!)
-            )
-            .map((slot) => slot.label),
-        };
-      })
+    rows.map(async (row) => {
+      const permissions = await getUserPermissions(row.userId, row.accountRole);
+      return {
+        ...row,
+        eligibleApprovalKeys: context.definition.approvals
+          .filter((slot) =>
+            permissions.permissionSet.has(slot.requiredCapability!)
+          )
+          .map((slot) => slot.key),
+        eligibleApprovalRoles: context.definition.approvals
+          .filter((slot) =>
+            permissions.permissionSet.has(slot.requiredCapability!)
+          )
+          .map((slot) => slot.label),
+      };
+    })
   );
   return {
     approvalSlots: context.definition.approvals,


### PR DESCRIPTION
## Summary

- include active `ADMIN` and `OWNER` employee accounts in Design Control approver candidates when their resolved permissions contain the approval slot's required capability
- hydrate the step editor from the current saved `formData` and `checklist` instead of rendering blank local state
- preserve dirty local edits during same-step background refreshes while reinitializing correctly when navigating to another step
- add focused source-contract regressions for both behaviors

## Root cause

The eligible-approver service unconditionally filtered out `ADMIN` and `OWNER` accounts even though the workflow approval policies allow those roles and authorization is already verified through resolved capabilities. In environments where the authorized linked accounts use those roles, every approval dropdown was empty.

Separately, the editor declared local form and checklist state but did not synchronize that state from the selected persisted step. Existing saved entries therefore appeared as a blank form.

## User impact

Authorized, active linked employees can now be selected for the approval slots they are permitted to satisfy. Returning to an already completed or saved step shows its committed entry, and an in-progress unsaved edit is not overwritten by a same-step refresh.

Existing active-account, active-employee, capability, exact-version, assignment, and reviewer-independence controls remain enforced.

## Validation

- client Design Control editor suite: 5 passed
- server authenticated approval suite: 9 passed
- `git diff --check origin/main...HEAD`: passed
- rebased onto current `main` at `df7ad73196b0f63033b0d81b7c739222538acdf0`
- `git merge-tree --write-tree origin/main HEAD`: passed (`8e5ff6528077319c8d6fa8f975f471fdb316edff`)

## Rollout boundary

This PR is code-only. It does not deploy the change or modify production data. Deployment and authenticated browser verification remain separate steps.