### PR TITLE
Recover migrated Design Control approval routing

### DIFF
--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -922,7 +922,8 @@ export function DesignControlStepEditor({
                       : 'Authenticated reviewer required'}
                   </p>
                   {canReassignApprovers &&
-                    slot.assignment?.status === 'PENDING' && (
+                    (!slot.assignment ||
+                      slot.assignment.status === 'PENDING') && (
                       <Button
                         className="mt-2"
                         onClick={() => {
@@ -934,7 +935,9 @@ export function DesignControlStepEditor({
                         type="button"
                         variant="outline"
                       >
-                        Change approver
+                        {slot.assignment
+                          ? 'Change approver'
+                          : 'Assign verified approver'}
                       </Button>
                     )}
                   {reassignmentRole === slot.key && (
@@ -972,7 +975,11 @@ export function DesignControlStepEditor({
                       </select>
                       <Input
                         aria-label="Reassignment reason"
-                        placeholder="Reason for changing this submitted-version assignment"
+                        placeholder={
+                          slot.assignment
+                            ? 'Reason for changing this submitted-version assignment'
+                            : 'Reason for assigning this migrated submitted version'
+                        }
                         value={reassignmentReason}
                         onChange={(event) =>
                           setReassignmentReason(event.target.value)
@@ -989,7 +996,9 @@ export function DesignControlStepEditor({
                           size="sm"
                           type="button"
                         >
-                          Save reassignment
+                          {slot.assignment
+                            ? 'Save reassignment'
+                            : 'Save verified assignment'}
                         </Button>
                         <Button
                           onClick={() => setReassignmentRole(null)}

--- a/server/__tests__/designControlAuthenticatedApprovals.test.ts
+++ b/server/__tests__/designControlAuthenticatedApprovals.test.ts
@@ -148,6 +148,10 @@ describe('authenticated Design Control approvals', () => {
     );
     expect(service).toContain("'DESIGN_CONTROL_APPROVER_REASSIGNED'");
     expect(service).toContain("'AUDITED_AUTHORIZED_REASSIGNMENT'");
+    expect(service).toContain("'AUDITED_LEGACY_ASSIGNMENT_RECOVERY'");
+    expect(service).toContain("'DESIGN_CONTROL_APPROVER_ASSIGNED'");
+    expect(service).toContain('recoveredLegacyAssignment: !prior');
+    expect(service).not.toContain("'ASSIGNMENT_NOT_PENDING'");
     expect(service).toContain("'LEGACY_UNVERIFIED_APPROVAL_EVIDENCE'");
     expect(service).toContain('satisfiesAuthenticatedGate: false');
   });
@@ -169,6 +173,8 @@ describe('authenticated Design Control approvals', () => {
     expect(editor).toContain('Select an active employee...');
     expect(editor).toContain('canRouteApprovers');
     expect(editor).toContain('Change approver');
+    expect(editor).toContain('Assign verified approver');
+    expect(editor).toContain('Save verified assignment');
     expect(editor).toContain('/reassign');
   });
 });

--- a/server/src/services/designControlApprovalService.ts
+++ b/server/src/services/designControlApprovalService.ts
@@ -1135,12 +1135,6 @@ export async function reassignDesignControlStepApprover(
         )
       )
       .limit(1);
-    if (!prior)
-      throw new DesignControlApprovalError(
-        409,
-        'ASSIGNMENT_NOT_PENDING',
-        'Only a pending assignment may be reassigned'
-      );
     const candidate = await verifiedApprover(
       {
         approvalKey: input.approvalKey,
@@ -1150,18 +1144,20 @@ export async function reassignDesignControlStepApprover(
       slot,
       tx as Client
     );
-    await tx
-      .update(designControlStepApprovalAssignments)
-      .set({
-        status: 'REASSIGNED',
-        metadata: {
-          ...(prior.metadata ?? {}),
-          reassignedByUserId: input.actor.id,
-          reassignedAt: new Date().toISOString(),
-          reassignmentReason: input.reason.trim(),
-        },
-      })
-      .where(eq(designControlStepApprovalAssignments.id, prior.id));
+    if (prior) {
+      await tx
+        .update(designControlStepApprovalAssignments)
+        .set({
+          status: 'REASSIGNED',
+          metadata: {
+            ...(prior.metadata ?? {}),
+            reassignedByUserId: input.actor.id,
+            reassignedAt: new Date().toISOString(),
+            reassignmentReason: input.reason.trim(),
+          },
+        })
+        .where(eq(designControlStepApprovalAssignments.id, prior.id));
+    }
     const [replacement] = await tx
       .insert(designControlStepApprovalAssignments)
       .values({
@@ -1181,9 +1177,11 @@ export async function reassignDesignControlStepApprover(
         requiredCapabilitySnapshot: slot.requiredCapability,
         assignedByUserId: input.actor.id,
         metadata: {
-          evidenceHash: prior.metadata?.evidenceHash,
-          provenance: 'AUDITED_AUTHORIZED_REASSIGNMENT',
-          priorAssignmentId: prior.id,
+          evidenceHash: prior?.metadata?.evidenceHash,
+          provenance: prior
+            ? 'AUDITED_AUTHORIZED_REASSIGNMENT'
+            : 'AUDITED_LEGACY_ASSIGNMENT_RECOVERY',
+          priorAssignmentId: prior?.id ?? null,
           reason: input.reason.trim(),
         },
       })
@@ -1191,17 +1189,23 @@ export async function reassignDesignControlStepApprover(
     await recordAuditEvent(
       {
         ...auditBase(context, input.actor, input.requestMetadata ?? {}),
-        eventType: 'DESIGN_CONTROL_APPROVER_REASSIGNED',
+        eventType: prior
+          ? 'DESIGN_CONTROL_APPROVER_REASSIGNED'
+          : 'DESIGN_CONTROL_APPROVER_ASSIGNED',
         reason: input.reason.trim(),
         fieldsChanged: {
-          assignedUserId: { before: prior.userId, after: replacement.userId },
+          assignedUserId: {
+            before: prior?.userId ?? null,
+            after: replacement.userId,
+          },
         },
         payload: {
           approvalKey: slot.key,
           contentVersionId: input.contentVersionId,
           employeeId: replacement.employeeId,
           userId: replacement.userId,
-          priorAssignmentId: prior.id,
+          priorAssignmentId: prior?.id ?? null,
+          recoveredLegacyAssignment: !prior,
         },
       },
       tx


### PR DESCRIPTION
## Summary

- allow an authorized Design Control admin to attach the first verified approver when a migrated submitted version has no verified assignment
- retain the existing reassignment workflow when a pending verified assignment already exists
- expose an `Assign verified approver` action for unassigned approval slots under review
- record a reason, selected employee/account snapshots, exact content version, and an explicit recovery provenance in the audit ledger

## Root cause

The verified-approval rollout correctly prevented legacy name-only values from satisfying authenticated approval gates, but the recovery workflow only supported replacing an existing pending verified assignment. Migrated submitted versions have no such assignment, so the UI hid the action and the server returned `ASSIGNMENT_NOT_PENDING`. The step remained read-only under review and could never advance.

## User impact

For a migrated submitted step showing `Unverified legacy assignment or no verified assignee`, an authorized Design Control admin can now:

1. select **Assign verified approver**;
2. choose an active employee with an active linked account and the slot's required capability;
3. provide the controlled recovery reason; and
4. attach that approver to the exact submitted content version.

The selected assignee can then perform the normal authenticated decision. Legacy evidence remains preserved and explicitly unverified; it is not converted into an approval.

## Controls preserved

- exact submitted content-version match
- active employee and active linked EPOCH account
- required approval capability
- server-side assignment and reviewer-independence checks
- reason-required administrative recovery
- immutable legacy evidence and new audit event

## Validation

- client Design Control editor suite: 5 passed
- server authenticated approval suite: 9 passed
- `git diff --check origin/main...HEAD`: passed
- rebased onto `main` at `700d8fe2aa2ad03418be962dc32c458f36a58c98`
- `git merge-tree --write-tree origin/main HEAD`: passed (`6c79a8b19da4c393527e842b0983b33cb0e451f9`)

## Rollout boundary

This follow-up does not deploy the change or mutate existing production records. After deployment, an authorized admin must perform the reasoned assignment recovery for each affected pending slot; the system does not silently infer or backfill approvers.