### PR TITLE
Connect Design Control evidence upload prompts

### DIFF
--- a/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
+++ b/client/src/__tests__/designControlUnifiedStepEditor.client.test.ts
@@ -106,10 +106,15 @@ describe('unified Design Control step editor', () => {
     expect(editor).toContain('Select an active project assignment');
     expect(editor).toContain('Enter another accountable person');
     expect(editor).toContain('Enter another customer or order link');
+    expect(editor).toContain('Open evidence upload');
+    expect(editor).toContain('design-control-evidence-step-');
     expect(editor).not.toContain('<datalist');
     expect(forms).toContain("window.addEventListener('beforeunload'");
     expect(forms).toContain('/attachments`');
     expect(forms).toContain('Objective evidence attached');
+    expect(forms).toContain(
+      'No controlled step-form template is available for this checkpoint'
+    );
     expect(release).toContain('/engineering-release-preview`');
     expect(release).toContain('/engineering-release`');
     expect(release).toContain('disabled={!preview.ready || busy}');

--- a/client/src/components/design-control/ProjectFormInstancesPanel.tsx
+++ b/client/src/components/design-control/ProjectFormInstancesPanel.tsx
@@ -357,7 +357,10 @@ export function ProjectFormInstancesPanel({
   };
 
   return (
-    <Card>
+    <Card
+      id={stepKey ? `design-control-evidence-step-${stepKey}` : undefined}
+      className="scroll-mt-4"
+    >
       <CardHeader className="flex flex-row items-start justify-between gap-4">
         <div>
           <CardTitle>Controlled Form Instances</CardTitle>
@@ -383,6 +386,13 @@ export function ProjectFormInstancesPanel({
         {message && (
           <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
             {message}
+          </div>
+        )}
+        {visibleCatalog.length === 0 && (
+          <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+            No controlled step-form template is available for this checkpoint,
+            so evidence upload cannot start. Contact Document Control to release
+            the required template.
           </div>
         )}
         {visibleCatalog.map((definition) => {

--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -525,7 +525,9 @@ export function DesignControlStepEditor({
             return (
               <div
                 className={`space-y-1.5 ${
-                  presentation.kind === 'textarea' ? 'md:col-span-2' : ''
+                  ['textarea', 'attachment'].includes(presentation.kind)
+                    ? 'md:col-span-2'
+                    : ''
                 }`}
                 key={field.key}
               >
@@ -535,7 +537,39 @@ export function DesignControlStepEditor({
                     *
                   </span>
                 </Label>
-                {presentation.kind === 'textarea' ? (
+                {presentation.kind === 'attachment' ? (
+                  <div className="space-y-2 rounded-md border p-3">
+                    <Input
+                      aria-describedby={`${fieldId}-help`}
+                      aria-invalid={missing}
+                      id={fieldId}
+                      placeholder={presentation.placeholder}
+                      value={value}
+                      onChange={(event) => update(event.target.value)}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() =>
+                        document
+                          .getElementById(
+                            `design-control-evidence-step-${definition.key}`
+                          )
+                          ?.scrollIntoView({
+                            behavior: 'smooth',
+                            block: 'start',
+                          })
+                      }
+                    >
+                      Open evidence upload
+                    </Button>
+                    <p className="text-xs text-muted-foreground">
+                      Create or open the controlled step form below, then select
+                      Attach evidence. The file is retained with that form; this
+                      field records its controlled reference.
+                    </p>
+                  </div>
+                ) : presentation.kind === 'textarea' ? (
                   <Textarea
                     aria-describedby={`${fieldId}-help`}
                     aria-invalid={missing}

--- a/client/src/features/design-control/designControlFieldPresentation.ts
+++ b/client/src/features/design-control/designControlFieldPresentation.ts
@@ -18,11 +18,7 @@ export type DesignControlFieldPresentation = {
 };
 
 export type StructuredDesignControlRecordType =
-  | 'REQUIREMENT'
-  | 'RISK'
-  | 'REVIEW'
-  | 'VERIFICATION'
-  | 'VALIDATION';
+  'REQUIREMENT' | 'RISK' | 'REVIEW' | 'VERIFICATION' | 'VALIDATION';
 
 export const STRUCTURED_RECORD_TYPE_BY_STEP: Partial<
   Record<string, StructuredDesignControlRecordType>
@@ -114,7 +110,7 @@ export function getDesignControlFieldPresentation(
   if (attachmentPattern.test(label)) {
     return {
       kind: 'attachment',
-      help: 'Identify the controlled artifact here, then upload objective evidence in the controlled-form evidence section below.',
+      help: 'Enter the controlled artifact reference, then use Open evidence upload to attach the file to this step form.',
       placeholder: 'Document number, revision, or retained evidence reference',
     };
   }


### PR DESCRIPTION
## Summary

- render Design Control attachment-style fields as controlled-reference inputs with an explicit **Open evidence upload** action
- jump directly from the field prompt to the current checkpoint's controlled form-instance panel
- explain that the file is retained with the controlled form while the workflow field records its document/revision reference
- show an explicit Document Control template blocker when no controlled step-form template is available instead of rendering an empty panel

## Root cause

The shared field presentation correctly classified `Photos` and the Design Verification/Validation `Evidence attachment` fields as attachment evidence. The editor, however, had no attachment rendering branch, so those fields fell through to a generic text input. Its help text referred to an upload section below without a link or action, and the form-instance panel displayed an empty card when no matching catalog entry was available.

The authoritative upload workflow already exists on the controlled Project Form Instance through **Attach evidence**. This change connects the prompts to that existing workflow rather than introducing duplicate file storage.

## User impact

For every attachment-style Design Control field, users can now:

1. record the controlled document/revision reference;
2. select **Open evidence upload**;
3. create or open the checkpoint's controlled form; and
4. select **Attach evidence** to upload the retained file.

If Document Control has not made the required template available, the page identifies that exact blocker.

## Validation

- focused Design Control client suite: 5 passed
- `git diff --check origin/main...HEAD`: passed
- `git merge-tree --write-tree origin/main HEAD`: passed (`acd4ed621ee7ab45e663df53b2bbd0a12e6c2f5a`)
- rebased onto `main` after PR #1758 merged

## Rollout boundary

This PR does not deploy or upload files. Existing controlled-form permissions, template-release requirements, evidence retention, and server upload controls remain authoritative.