### PR TITLE
Auto-resolve Design Control IDs for native changes

### DIFF
--- a/client/src/pages/QMSChangeControlPage.tsx
+++ b/client/src/pages/QMSChangeControlPage.tsx
@@ -70,6 +70,11 @@ type PreviewRow = {
   data: Record<string, unknown>;
 };
 
+type DesignProjectOption = {
+  id: string;
+  projectName: string;
+};
+
 const TYPES = [
   'NCR',
   'CAR',
@@ -101,6 +106,9 @@ const initialHistorical = {
 export default function QMSChangeControlPage() {
   const { can } = usePermissions();
   const [rows, setRows] = useState<ChangeRow[]>([]);
+  const [designProjects, setDesignProjects] = useState<DesignProjectOption[]>(
+    []
+  );
   const [cards, setCards] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -127,7 +135,6 @@ export default function QMSChangeControlPage() {
   const [preview, setPreview] = useState<PreviewRow[]>([]);
   const [native, setNative] = useState({
     designControlProjectId: '',
-    designControlRecordId: '',
     changeType: 'ECR',
     title: '',
     description: '',
@@ -210,6 +217,18 @@ export default function QMSChangeControlPage() {
   useEffect(() => {
     void load();
   }, [query]);
+
+  useEffect(() => {
+    const loadDesignProjects = async () => {
+      const response = await fetch('/api/rd-projects', {
+        credentials: 'include',
+      });
+      if (!response.ok) return;
+      const payload = await response.json().catch(() => []);
+      setDesignProjects(Array.isArray(payload) ? payload : []);
+    };
+    void loadDesignProjects();
+  }, []);
 
   const openDetails = async (id: string) => {
     const response = await fetch(`/api/change-control/${id}`, {
@@ -770,20 +789,33 @@ export default function QMSChangeControlPage() {
             authenticated signatures.
           </div>
           <div className="grid gap-3 md:grid-cols-2">
-            <Field
-              label="Design Control project ID"
-              value={native.designControlProjectId}
-              onChange={(value) =>
-                setNative({ ...native, designControlProjectId: value })
-              }
-            />
-            <Field
-              label="Design Control record ID"
-              value={native.designControlRecordId}
-              onChange={(value) =>
-                setNative({ ...native, designControlRecordId: value })
-              }
-            />
+            <div className="space-y-2">
+              <Label>Design Project</Label>
+              <Select
+                value={native.designControlProjectId}
+                onValueChange={(value) =>
+                  setNative({ ...native, designControlProjectId: value })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select an R&amp;D Design Project" />
+                </SelectTrigger>
+                <SelectContent>
+                  {designProjects.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {project.projectName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Design Control record</Label>
+              <div className="flex min-h-10 items-center rounded-md border bg-muted/30 px-3 text-sm text-muted-foreground">
+                Selected automatically from the project&apos;s authoritative
+                record
+              </div>
+            </div>
             <TypeSelect
               value={native.changeType}
               onChange={(value) => setNative({ ...native, changeType: value })}
@@ -826,7 +858,12 @@ export default function QMSChangeControlPage() {
             }
           />
           <DialogFooter>
-            <Button onClick={() => void createNative()}>
+            <Button
+              onClick={() => void createNative()}
+              disabled={
+                !native.designControlProjectId || !native.title.trim()
+              }
+            >
               Create Controlled Draft
             </Button>
           </DialogFooter>

--- a/server/__tests__/qmsChangeControl.test.ts
+++ b/server/__tests__/qmsChangeControl.test.ts
@@ -30,6 +30,16 @@ const service = readFileSync(
   path.join(root, 'server', 'src', 'services', 'changeControlService.ts'),
   'utf8'
 );
+const ecrService = readFileSync(
+  path.join(
+    root,
+    'server',
+    'src',
+    'services',
+    'engineeringChangeRequestService.ts'
+  ),
+  'utf8'
+);
 const page = readFileSync(
   path.join(root, 'client', 'src', 'pages', 'QMSChangeControlPage.tsx'),
   'utf8'
@@ -64,6 +74,18 @@ describe('QMS Change Control architecture', () => {
     );
     expect(service).not.toMatch(
       /INSERT INTO engineering_change_notice_approvals/
+    );
+  });
+
+  it('selects the Design Project without exposing internal IDs and resolves its authoritative record', () => {
+    expect(page).toContain('Select an R&amp;D Design Project');
+    expect(page).toContain(
+      "Selected automatically from the project&apos;s authoritative"
+    );
+    expect(page).not.toContain('label="Design Control project ID"');
+    expect(page).not.toContain('label="Design Control record ID"');
+    expect(ecrService).toContain(
+      "dcr.authority_status = 'authoritative'"
     );
   });
 

--- a/server/src/services/engineeringChangeRequestService.ts
+++ b/server/src/services/engineeringChangeRequestService.ts
@@ -99,6 +99,7 @@ async function loadAuthority(
        FROM rd_projects rp
        JOIN design_control_records dcr ON dcr.rd_project_id = rp.id
       WHERE rp.id = $1
+        AND dcr.authority_status = 'authoritative'
         AND ($2::uuid IS NULL OR dcr.id = $2::uuid)
       ORDER BY dcr.created_at DESC LIMIT 1`,
     [projectId, recordId ?? null]


### PR DESCRIPTION
## What changed

- replace raw Design Control project and record ID inputs with an R&D Design Project selector
- resolve the linked Design Control record automatically on the server
- require the resolved record to be the project's authoritative record
- prevent draft creation until a project and title are selected

## Why

Users were being asked to manually enter internal identifiers in the Create New EPOCH Change dialog. This was error-prone and could link a change to the wrong or historical Design Control record.

## Impact

Users now select the existing Design Project by name. The internal project identifier is supplied by the selector, and the authoritative Design Control record is bound automatically.

## Validation

- focused `qmsChangeControl` regression suite
- focused `engineeringChangeRequests` regression suite
- `git diff --check`
- clean three-file compare against current `origin/main`
- conflict-free `git merge-tree --write-tree origin/main HEAD`