### PR TITLE
Fix template field label compatibility

### DIFF
--- a/server/__tests__/routingDocumentTemplatePartListCompatibility.test.ts
+++ b/server/__tests__/routingDocumentTemplatePartListCompatibility.test.ts
@@ -42,6 +42,31 @@ describe('document-from-template legacy part-list compatibility', () => {
     expect(result.partList).toBe('1 | 26246 | Body, Heated Pitot');
   });
 
+  it('reconciles PPE field names that share the same visible label', () => {
+    const result = normalizeTemplateFieldValues(
+      { selectedPpe: 'Safety glasses and nitrile gloves' },
+      [
+        { fieldName: 'selectedPpe', fieldLabel: 'PPE (Personal Protective Equipment)' },
+        { field_name: 'requiredPpe', field_label: 'PPE (Personal Protective Equipment)' },
+      ],
+    );
+
+    expect(result.requiredPpe).toBe('Safety glasses and nitrile gloves');
+  });
+
+  it('does not replace separately populated fields that share a label', () => {
+    const result = normalizeTemplateFieldValues(
+      { browserPpe: 'Safety glasses', storedPpe: 'Face shield' },
+      [
+        { fieldName: 'browserPpe', fieldLabel: 'PPE' },
+        { fieldName: 'storedPpe', fieldLabel: 'PPE' },
+      ],
+    );
+
+    expect(result.browserPpe).toBe('Safety glasses');
+    expect(result.storedPpe).toBe('Face shield');
+  });
+
   it('normalizes submitted values before required-field validation and PDF rendering', () => {
     expect(handler).toContain(
       'const values = normalizeTemplateFieldValues(fieldValues, [...defaultFields, ...templateFields])',

--- a/server/src/utils/templateFieldValueCompatibility.ts
+++ b/server/src/utils/templateFieldValueCompatibility.ts
@@ -24,6 +24,38 @@ export const normalizeTemplateFieldValues = (
     ? { ...(fieldValues as Record<string, unknown>) }
     : {};
 
+  // Browser template metadata and database template metadata can retain
+  // different field names after a template revision even though the visible
+  // label is unchanged. Reconcile those names before required-field
+  // validation so a value entered under either definition reaches every
+  // field with that same label.
+  const fieldNamesByLabel = new Map<string, Set<string>>();
+  for (const field of fieldDefinitions) {
+    const fieldName = field.fieldName ?? field.field_name;
+    const fieldLabel = field.fieldLabel ?? field.field_label;
+    if (typeof fieldName !== 'string' || typeof fieldLabel !== 'string') continue;
+
+    const normalizedLabel = normalizeFieldKey(fieldLabel);
+    if (!normalizedLabel) continue;
+
+    const fieldNames = fieldNamesByLabel.get(normalizedLabel) ?? new Set<string>();
+    fieldNames.add(fieldName);
+    fieldNamesByLabel.set(normalizedLabel, fieldNames);
+  }
+
+  for (const [normalizedLabel, fieldNames] of fieldNamesByLabel) {
+    for (const key of Object.keys(values)) {
+      if (normalizeFieldKey(key) === normalizedLabel) fieldNames.add(key);
+    }
+
+    const submittedKey = Array.from(fieldNames).find((key) => hasSubmittedValue(values[key]));
+    if (!submittedKey) continue;
+
+    for (const fieldName of fieldNames) {
+      if (!hasSubmittedValue(values[fieldName])) values[fieldName] = values[submittedKey];
+    }
+  }
+
   // Work Instructions templates have used partList, partsList, parts_list,
   // and display-label keys over time. Resolve any populated Part List variant
   // to both names still consumed by validation and legacy PDF rendering.


### PR DESCRIPTION
## What changed

- Reconcile submitted template values across browser and database field names that share the same visible label.
- Preserve separately populated values instead of overwriting them.
- Add regression coverage for `PPE (Personal Protective Equipment)` while retaining legacy Part List compatibility.

## Why

The document-from-template endpoint validates combined `default_fields` and `template_fields`. After template revisions, those definitions can have different field names while presenting the same label. The browser submits the filled value under one name, but server validation checks the other name and incorrectly returns `400` such as `PPE (Personal Protective Equipment) is required`.

## Impact

Filled PPE and other same-label template fields are normalized before required-field validation and PDF rendering, preventing false required-field errors without weakening required-field enforcement.

## Validation

- `git diff --check` passed.
- Added focused regression cases for PPE reconciliation and preservation of independently populated values.
- Focused Vitest execution could not start in the clean worktree because dependencies were unavailable and package downloads were denied/timed out; CI remains the runtime validation boundary.