### PR TITLE
Add resumable P2 order drafts and audited line-item corrections

### DIFF
--- a/client/src/components/P2POItemsManager.tsx
+++ b/client/src/components/P2POItemsManager.tsx
@@ -50,6 +50,7 @@ interface P2POItemsManagerProps {
   poId: number;
   poNumber: string;
   onBack: () => void;
+  correctionReason?: string;
 }
 
 interface P2POItem {
@@ -69,6 +70,7 @@ export function P2POItemsManager({
   poId,
   poNumber,
   onBack,
+  correctionReason,
 }: P2POItemsManagerProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<P2POItem | null>(null);
@@ -135,7 +137,7 @@ export function P2POItemsManager({
     mutationFn: (data: typeof formData) =>
       apiRequest(`/api/p2/purchase-orders/${poId}/items`, {
         method: 'POST',
-        body: data,
+        body: { ...data, correctionReason },
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -194,7 +196,7 @@ export function P2POItemsManager({
     mutationFn: ({ itemId, data }) =>
       apiRequest(`/api/p2/purchase-orders/${poId}/items/${itemId}`, {
         method: 'PUT',
-        body: data,
+        body: { ...data, correctionReason },
       }) as Promise<UpdateResponse>,
     onSuccess: (data) => {
       queryClient.invalidateQueries({
@@ -250,6 +252,7 @@ export function P2POItemsManager({
     mutationFn: (itemId: number) =>
       apiRequest(`/api/p2/purchase-orders/${poId}/items/${itemId}`, {
         method: 'DELETE',
+        body: { correctionReason },
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/client/src/components/p2/P2POCreationWizard.tsx
+++ b/client/src/components/p2/P2POCreationWizard.tsx
@@ -27,6 +27,7 @@ import {
   Trash2,
   AlertCircle,
   GitBranch,
+  Save,
 } from 'lucide-react';
 import { apiRequest, queryClient } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
@@ -68,6 +69,7 @@ export interface SourcePO {
   poNumber: string;
   customerId: string;
   expectedDelivery?: string | null;
+  poDate?: string | null;
   toleranceAuthorizerId?: number | null;
   notes?: string | null;
   assignedToId?: number | null;
@@ -100,6 +102,7 @@ const customerSchema = z.object({
 
 const detailsSchema = z.object({
   customerPONumber: z.string().min(1, 'Customer PO number is required'),
+  poDate: z.string().min(1, 'PO date is required'),
   dueDate: z.string().min(1, 'Due date is required'),
   toleranceAuthorizer: z.string().min(1, 'Tolerance authorizer is required for quality control'),
   assignedTo: z.string().optional(),
@@ -146,6 +149,7 @@ export default function P2POCreationWizard({
     internalName: '',
   });
   const [sourcePrefilled, setSourcePrefilled] = useState(false);
+  const [draftRestored, setDraftRestored] = useState(false);
   const { toast } = useToast();
   const qc = useQueryClient();
 
@@ -245,6 +249,7 @@ export default function P2POCreationWizard({
     resolver: zodResolver(detailsSchema),
     defaultValues: {
       customerPONumber: '',
+      poDate: new Date().toISOString().slice(0, 10),
       dueDate: '',
       toleranceAuthorizer: '',
       assignedTo: '',
@@ -253,6 +258,12 @@ export default function P2POCreationWizard({
       projectId: initialProjectId || NO_PROJECT_VALUE,
       projectName: '',
     },
+  });
+
+  const draftQuery = useQuery<any>({
+    queryKey: ['/api/projects', initialProjectId, 'p2-order-draft'],
+    queryFn: () => apiRequest(`/api/projects/${initialProjectId}/p2-order-draft`),
+    enabled: !!initialProjectId && !isReviseMode,
   });
 
   useEffect(() => {
@@ -268,6 +279,37 @@ export default function P2POCreationWizard({
     setSelectedCustomer((current: any) => current || customer);
   }, [customerForm, initialCustomerId, p2Customers]);
 
+  useEffect(() => {
+    const draft = draftQuery.data;
+    if (!draft || draftRestored || p2Customers.length === 0 || projects.length === 0) return;
+    const savedCustomer = draft.draftData?.customerForm || {};
+    const savedDetails = draft.draftData?.detailsForm || {};
+    customerForm.reset({ customerId: String(savedCustomer.customerId || '') });
+    detailsForm.reset({
+      customerPONumber: String(savedDetails.customerPONumber || ''),
+      poDate: String(savedDetails.poDate || new Date().toISOString().slice(0, 10)),
+      dueDate: String(savedDetails.dueDate || ''),
+      toleranceAuthorizer: String(savedDetails.toleranceAuthorizer || ''),
+      assignedTo: String(savedDetails.assignedTo || ''),
+      productionLead: String(savedDetails.productionLead || ''),
+      notes: String(savedDetails.notes || ''),
+      projectId: String(savedDetails.projectId || initialProjectId || NO_PROJECT_VALUE),
+      projectName: String(savedDetails.projectName || ''),
+    });
+    const customer = p2Customers.find((candidate: any) => String(candidate.id) === String(savedCustomer.customerId || ''));
+    setSelectedCustomer(customer || null);
+    const selectedProject = projects.find((project) => project.id === (savedDetails.projectId || initialProjectId));
+    setPODetails({
+      ...savedDetails,
+      projectId: selectedProject?.id || initialProjectId || '',
+      projectName: selectedProject ? renderProjectLabel(selectedProject) : String(savedDetails.projectName || ''),
+    } as z.infer<typeof detailsSchema>);
+    setLineItems(Array.isArray(draft.draftData?.lineItems) ? draft.draftData.lineItems : []);
+    setCurrentStep(Math.max(0, Math.min(3, Number(draft.currentStep || 0))));
+    setDraftRestored(true);
+    toast({ title: 'Saved P2 order restored', description: 'Continue where you left off.' });
+  }, [customerForm, detailsForm, draftQuery.data, draftRestored, initialProjectId, p2Customers, projects, toast]);
+
   // Pre-populate from sourcePO (revise mode) — wait for all data to load
   useEffect(() => {
     if (!editableSourcePO || sourcePrefilled || p2Customers.length === 0 || employees.length === 0) return;
@@ -282,6 +324,9 @@ export default function P2POCreationWizard({
     // PO Details — strip any -RX revision suffix from PO number for the new revision
     const basePONumber = existingPoId ? editableSourcePO.poNumber : editableSourcePO.poNumber.replace(/-R[A-Z]+$/, '');
     detailsForm.setValue('customerPONumber', basePONumber);
+    if (editableSourcePO.poDate) {
+      detailsForm.setValue('poDate', editableSourcePO.poDate.split('T')[0]);
+    }
     if (editableSourcePO.expectedDelivery) {
       detailsForm.setValue('dueDate', editableSourcePO.expectedDelivery.split('T')[0]);
     }
@@ -327,6 +372,30 @@ export default function P2POCreationWizard({
     setLineItems(items);
   }, [editableSourcePO, loadedRevisionPO, sourcePOItems]);
 
+  const saveDraftMutation = useMutation({
+    mutationFn: async () => {
+      const projectId = initialProjectId || detailsForm.getValues('projectId');
+      if (!projectId || projectId === NO_PROJECT_VALUE) throw new Error('Select a project before saving this draft');
+      return apiRequest(`/api/projects/${projectId}/p2-order-draft`, {
+        method: 'PUT',
+        body: {
+          currentStep,
+          draftData: {
+            customerForm: customerForm.getValues(),
+            detailsForm: detailsForm.getValues(),
+            lineItems,
+          },
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/projects', initialProjectId, 'p2-order-draft'] });
+      toast({ title: 'P2 order draft saved', description: 'You can reopen this project and continue later.' });
+      onCancel();
+    },
+    onError: (error: Error) => toast({ title: 'Unable to save draft', description: error.message, variant: 'destructive' }),
+  });
+
   const createPOMutation = useMutation({
     mutationFn: async (data: any) => {
       const po = await apiRequest('/api/p2-purchase-orders-bypass', {
@@ -339,7 +408,10 @@ export default function P2POCreationWizard({
       });
       return po;
     },
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
+      if (initialProjectId) {
+        await apiRequest(`/api/projects/${initialProjectId}/p2-order-draft`, { method: 'DELETE' }).catch(() => undefined);
+      }
       queryClient.invalidateQueries({ queryKey: ['/api/p2-purchase-orders-bypass'] });
       queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center'] });
       toast({
@@ -470,6 +542,7 @@ export default function P2POCreationWizard({
     return {
       customerId: selectedCustomer.customerId,
       customerPONumber: poDetails?.customerPONumber,
+      poDate: poDetails?.poDate,
       dueDate: poDetails?.dueDate,
       toleranceAuthorizerId: selectedAuthorizer?.id || null,
       toleranceAuthorizerName: getEmployeeName(selectedAuthorizer),
@@ -524,9 +597,14 @@ export default function P2POCreationWizard({
               Step {currentStep + 1} of {steps.length}: {steps[currentStep].title}
             </CardDescription>
           </div>
-          <Button variant="ghost" onClick={onCancel}>
-            Cancel
-          </Button>
+          <div className="flex items-center gap-2">
+            {!isReviseMode && (
+              <Button variant="outline" onClick={() => saveDraftMutation.mutate()} disabled={saveDraftMutation.isPending} data-testid="button-save-p2-draft">
+                <Save className="mr-2 h-4 w-4" /> {saveDraftMutation.isPending ? 'Saving...' : 'Save Draft'}
+              </Button>
+            )}
+            <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+          </div>
         </div>
 
         {isReviseMode && (
@@ -634,6 +712,20 @@ export default function P2POCreationWizard({
                       <FormLabel>Customer PO Number</FormLabel>
                       <FormControl>
                         <Input {...field} placeholder="e.g., PO-2024-001" data-testid="input-customer-po" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={detailsForm.control}
+                  name="poDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>PO Date</FormLabel>
+                      <FormControl>
+                        <Input type="date" {...field} data-testid="input-po-date" />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -961,6 +1053,7 @@ export default function P2POCreationWizard({
                 </CardHeader>
                 <CardContent className="space-y-1">
                   <p><span className="text-muted-foreground">Customer PO:</span> {poDetails?.customerPONumber}</p>
+                  <p><span className="text-muted-foreground">PO Date:</span> {poDetails?.poDate}</p>
                   <p><span className="text-muted-foreground">Due Date:</span> {poDetails?.dueDate}</p>
                   {isReviseMode && (
                     <p><span className="text-muted-foreground">New Revision:</span>{' '}

--- a/client/src/components/p2/P2StatusDashboard.tsx
+++ b/client/src/components/p2/P2StatusDashboard.tsx
@@ -25,6 +25,7 @@ import { format } from 'date-fns';
 interface P2StatusDashboardProps {
   onStartBOM: (poId: number) => void;
   onViewPO?: (poId: number) => void;
+  onManageItems?: (poId: number, poNumber: string) => void;
   selectedPOIds?: number[];
 }
 
@@ -57,7 +58,7 @@ interface POStatus {
   p2WadConnectionLabel?: string;
 }
 
-export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds = [] }: P2StatusDashboardProps) {
+export default function P2StatusDashboard({ onStartBOM, onViewPO, onManageItems, selectedPOIds = [] }: P2StatusDashboardProps) {
   const [activeSortBy, setActiveSortBy] = useState<'default' | 'project_asc' | 'project_desc'>('default');
 
   const {
@@ -377,6 +378,17 @@ export default function P2StatusDashboard({ onStartBOM, onViewPO, selectedPOIds 
                       </div>
 
                       <div className="flex flex-col gap-2">
+                        {(po.shippedItems ?? 0) === 0 && po.scheduledItems === 0 && po.inProductionItems === 0 && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => onManageItems?.(po.id, po.poNumber)}
+                            data-testid={`button-manage-po-items-${po.id}`}
+                          >
+                            <Package className="h-4 w-4 mr-1" />
+                            Manage Line Items
+                          </Button>
+                        )}
                         {po.projectId && (
                           <Link href={`/pm-control-center?project=${po.projectId}`}>
                             <Button

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -47,6 +47,7 @@ import RoutingDocumentManagement from './RoutingDocumentManagement';
 import P2ChangesTab from '@/components/p2/P2ChangesTab';
 import P2ShippingTab from '@/components/p2/P2ShippingTab';
 import P2NonconformingTab from '@/components/p2/P2ScrappedItemsTab';
+import { P2POItemsManager } from '@/components/P2POItemsManager';
 import { TravelerCapturedDataById } from '@/components/p2/TravelerCapturedData';
 import ProgramManufacturingOrchestration from '@/components/p2/ProgramManufacturingOrchestration';
 import { queryClient, apiRequest } from '@/lib/queryClient';
@@ -137,6 +138,9 @@ export default function P2ControlCenter() {
   const [selectedPOForBOM, setSelectedPOForBOM] = useState<number | null>(null);
   const [selectedPOIds, setSelectedPOIds] = useState<number[]>([]);
   const [editingPOId, setEditingPOId] = useState<number | null>(editPoIdFromUrl);
+  const [lineItemCorrection, setLineItemCorrection] = useState<{ poId: number; poNumber: string } | null>(null);
+  const [pendingLineItemCorrection, setPendingLineItemCorrection] = useState<{ poId: number; poNumber: string } | null>(null);
+  const [lineItemCorrectionReason, setLineItemCorrectionReason] = useState('');
 
   const { data: stats } = useQuery<P2Stats>({
     queryKey: ['/api/p2/control-center/stats'],
@@ -191,6 +195,36 @@ export default function P2ControlCenter() {
     queryKey: ['/api/p2/control-center/po-statuses'],
     refetchInterval: 30000,
   });
+
+  const startLineItemCorrection = useMutation({
+    mutationFn: ({ poId, reason }: { poId: number; reason: string }) =>
+      apiRequest(`/api/p2/purchase-orders/${poId}/line-item-correction/start`, {
+        method: 'POST',
+        body: { reason },
+      }),
+    onSuccess: () => {
+      if (pendingLineItemCorrection) setLineItemCorrection(pendingLineItemCorrection);
+      setPendingLineItemCorrection(null);
+      toast({ title: 'Correction opened', description: 'The PO is temporarily unlocked and the reason was audited.' });
+    },
+    onError: (error: Error) => toast({ title: 'Cannot edit this PO', description: error.message, variant: 'destructive' }),
+  });
+
+  const finishLineItemCorrection = async () => {
+    if (!lineItemCorrection) return;
+    try {
+      await apiRequest(`/api/p2/purchase-orders/${lineItemCorrection.poId}/line-item-correction/complete`, {
+        method: 'POST',
+        body: { reason: lineItemCorrectionReason },
+      });
+      queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/po-statuses'] });
+      toast({ title: 'Correction completed', description: 'The PO was relocked and the correction was audited.' });
+      setLineItemCorrection(null);
+      setLineItemCorrectionReason('');
+    } catch (error) {
+      toast({ title: 'Could not relock PO', description: error instanceof Error ? error.message : 'Unknown error', variant: 'destructive' });
+    }
+  };
 
   const openPOs = useMemo(
     () => allPOStatuses.filter((po) => po.status !== 'completed'),
@@ -339,6 +373,19 @@ export default function P2ControlCenter() {
             setShowBOMWizard(false);
             setSelectedPOForBOM(null);
           }}
+        />
+      </div>
+    );
+  }
+
+  if (lineItemCorrection) {
+    return (
+      <div className="container mx-auto p-6">
+        <P2POItemsManager
+          poId={lineItemCorrection.poId}
+          poNumber={lineItemCorrection.poNumber}
+          correctionReason={lineItemCorrectionReason}
+          onBack={finishLineItemCorrection}
         />
       </div>
     );
@@ -823,6 +870,10 @@ export default function P2ControlCenter() {
             onViewPO={(poId) => {
               navigate(`/p2/purchase-orders/${poId}/preview`);
             }}
+            onManageItems={(poId, poNumber) => {
+              setPendingLineItemCorrection({ poId, poNumber });
+              setLineItemCorrectionReason('');
+            }}
             selectedPOIds={selectedPOIds}
           />
         </TabsContent>
@@ -933,6 +984,46 @@ export default function P2ControlCenter() {
           <P2NonconformingTab selectedPOIds={selectedPOIds} />
         </TabsContent>
       </Tabs>
+
+      <Dialog
+        open={!!pendingLineItemCorrection}
+        onOpenChange={(open) => {
+          if (!open && !startLineItemCorrection.isPending) setPendingLineItemCorrection(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Correct PO line items</DialogTitle>
+            <DialogDescription>
+              This is for correcting the original PO before production begins. The PO will be temporarily unlocked and every change will retain this audit reason.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="line-item-correction-reason">Correction reason</Label>
+            <Input
+              id="line-item-correction-reason"
+              value={lineItemCorrectionReason}
+              onChange={(event) => setLineItemCorrectionReason(event.target.value)}
+              placeholder="Example: Add omitted shipping line from original customer PO"
+              data-testid="input-line-item-correction-reason"
+            />
+            <p className="text-xs text-muted-foreground">At least 10 characters are required.</p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingLineItemCorrection(null)}>Cancel</Button>
+            <Button
+              disabled={lineItemCorrectionReason.trim().length < 10 || startLineItemCorrection.isPending}
+              onClick={() => pendingLineItemCorrection && startLineItemCorrection.mutate({
+                poId: pendingLineItemCorrection.poId,
+                reason: lineItemCorrectionReason.trim(),
+              })}
+              data-testid="button-start-line-item-correction"
+            >
+              {startLineItemCorrection.isPending ? 'Opening...' : 'Open audited correction'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/migrations/0288_p2_order_draft_progress.sql
+++ b/migrations/0288_p2_order_draft_progress.sql
@@ -1,0 +1,18 @@
+-- Project-scoped, non-production drafts for the resumable P2 order wizard.
+-- Drafts are deliberately separate from p2_purchase_orders so incomplete work
+-- cannot enter scheduling, BOM, contract review, or production workflows.
+
+CREATE TABLE IF NOT EXISTS p2_order_drafts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  current_step integer NOT NULL DEFAULT 0 CHECK (current_step BETWEEN 0 AND 3),
+  draft_data jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_by text,
+  updated_by text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT p2_order_drafts_project_unique UNIQUE (project_id)
+);
+
+CREATE INDEX IF NOT EXISTS p2_order_drafts_project_idx
+  ON p2_order_drafts (project_id);

--- a/server/__tests__/p2OrderDraftProgress.test.ts
+++ b/server/__tests__/p2OrderDraftProgress.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runMigrationSafetyCheck } from '../utils/migrationSafetyCheck';
+
+const read = (relative: string) => fs.readFileSync(path.resolve(process.cwd(), relative), 'utf8');
+
+describe('resumable P2 order wizard drafts', () => {
+  it('uses a separate additive draft table outside production POs', () => {
+    const migration = read('migrations/0288_p2_order_draft_progress.sql');
+    expect(() => runMigrationSafetyCheck(migration, '0288_p2_order_draft_progress.sql')).not.toThrow();
+    expect(migration).toContain('CREATE TABLE IF NOT EXISTS p2_order_drafts');
+    expect(migration).toContain('CONSTRAINT p2_order_drafts_project_unique UNIQUE (project_id)');
+    expect(migration).not.toMatch(/\bDROP\b|\bTRUNCATE\b/i);
+  });
+
+  it('supports load, upsert, and delete for a project draft', () => {
+    const routes = read('server/src/routes/projects.ts');
+    expect(routes).toContain("router.get('/:id/p2-order-draft'");
+    expect(routes).toContain("router.put('/:id/p2-order-draft'");
+    expect(routes).toContain("router.delete('/:id/p2-order-draft'");
+    expect(routes).toContain('ON CONFLICT (project_id) DO UPDATE');
+  });
+
+  it('keeps PO date distinct from committed due date', () => {
+    const wizard = read('client/src/components/p2/P2POCreationWizard.tsx');
+    expect(wizard).toContain("poDate: z.string().min(1, 'PO date is required')");
+    expect(wizard).toContain('data-testid="input-po-date"');
+    expect(wizard).toContain('data-testid="input-due-date"');
+    expect(wizard).toContain('data-testid="button-save-p2-draft"');
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -6361,6 +6361,26 @@ export const p2PurchaseOrderItems = pgTable(
   })
 );
 
+export const p2OrderDrafts = pgTable(
+  'p2_order_drafts',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references((): AnyPgColumn => projects.id, { onDelete: 'cascade' }),
+    currentStep: integer('current_step').notNull().default(0),
+    draftData: jsonb('draft_data').notNull().default(sql`'{}'::jsonb`),
+    createdBy: text('created_by'),
+    updatedBy: text('updated_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    projectUnique: unique('p2_order_drafts_project_unique').on(table.projectId),
+    projectIdx: index('p2_order_drafts_project_idx').on(table.projectId),
+  })
+);
+
 // P2 customer-demand quantity event ledger. Migration 0262 is the database
 // authority for immutability triggers and CHECK constraints; this schema
 // entry exists so Drizzle's schema-diff produces the correct composite FK

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -7651,6 +7651,71 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   });
 
   // P2 Purchase Order Items routes
+  const assertP2LineItemCorrectionAllowed = async (poId: number) => {
+    const { pool } = await import('../../db');
+    const result = await pool.query(
+      `SELECT po.id, po.po_number, po.locked_at, po.is_current_revision,
+              (SELECT COUNT(*)::int FROM p2_serialized_items psi WHERE psi.po_id = po.id) AS serialized_count,
+              (SELECT COUNT(*)::int FROM p2_production_orders ppo WHERE ppo.p2_po_id = po.id) AS production_count
+         FROM p2_purchase_orders po
+        WHERE po.id = $1`,
+      [poId],
+    );
+    const po = result.rows[0];
+    if (!po) throw Object.assign(new Error('P2 purchase order not found'), { status: 404 });
+    if (po.is_current_revision === false) {
+      throw Object.assign(new Error('Superseded revisions cannot be corrected'), { status: 409 });
+    }
+    if (Number(po.serialized_count) > 0 || Number(po.production_count) > 0) {
+      throw Object.assign(new Error('This PO has entered production. Use the formal revision process instead.'), { status: 409 });
+    }
+    return po;
+  };
+
+  app.post('/api/p2/purchase-orders/:poId/line-item-correction/start', softAuth, requireAdminOrOwner, async (req, res) => {
+    try {
+      const poId = parseInt(req.params.poId);
+      const reason = String(req.body?.reason || '').trim();
+      if (reason.length < 10) return res.status(400).json({ error: 'A correction reason of at least 10 characters is required' });
+      const po = await assertP2LineItemCorrectionAllowed(poId);
+      const { pool } = await import('../../db');
+      await pool.query('UPDATE p2_purchase_orders SET locked_at = NULL, locked_by = NULL, updated_at = NOW() WHERE id = $1', [poId]);
+      const user = (req as any).user;
+      await auditService.logEvent({
+        entityType: 'p2_order', entityId: String(poId), action: 'P2_PO_LINE_ITEM_CORRECTION_STARTED', reason,
+        actor: { id: user?.id, username: user?.username || user?.email, role: user?.role },
+        ipAddress: req.ip, userAgent: req.get('user-agent') || undefined,
+        meta: { poNumber: po.po_number },
+      });
+      res.json({ success: true, poId, poNumber: po.po_number });
+    } catch (error) {
+      const status = Number((error as any).status) || 500;
+      res.status(status).json({ error: (error as Error).message || 'Failed to open PO correction' });
+    }
+  });
+
+  app.post('/api/p2/purchase-orders/:poId/line-item-correction/complete', softAuth, requireAdminOrOwner, async (req, res) => {
+    try {
+      const poId = parseInt(req.params.poId);
+      const reason = String(req.body?.reason || '').trim();
+      if (reason.length < 10) return res.status(400).json({ error: 'A correction reason of at least 10 characters is required' });
+      const po = await assertP2LineItemCorrectionAllowed(poId);
+      const { pool } = await import('../../db');
+      const user = (req as any).user;
+      await pool.query('UPDATE p2_purchase_orders SET locked_at = NOW(), locked_by = $1, updated_at = NOW() WHERE id = $2', [user?.id || null, poId]);
+      await auditService.logEvent({
+        entityType: 'p2_order', entityId: String(poId), action: 'P2_PO_LINE_ITEM_CORRECTION_COMPLETED', reason,
+        actor: { id: user?.id, username: user?.username || user?.email, role: user?.role },
+        ipAddress: req.ip, userAgent: req.get('user-agent') || undefined,
+        meta: { poNumber: po.po_number },
+      });
+      res.json({ success: true, poId });
+    } catch (error) {
+      const status = Number((error as any).status) || 500;
+      res.status(status).json({ error: (error as Error).message || 'Failed to complete PO correction' });
+    }
+  });
+
   app.get('/api/p2/purchase-orders/:poId/items', async (req, res) => {
     try {
       const { poId } = req.params;
@@ -7666,6 +7731,11 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   app.post('/api/p2/purchase-orders/:poId/items', async (req, res) => {
     try {
       const { poId } = req.params;
+      const correctionReason = String(req.body?.correctionReason || '').trim();
+      if (correctionReason) {
+        if (correctionReason.length < 10) return res.status(400).json({ error: 'A valid correction reason is required' });
+        await assertP2LineItemCorrectionAllowed(parseInt(poId));
+      }
       const { storage } = await import('../../storage');
       const { insertP2PurchaseOrderItemSchema } = await import('../../schema');
       
@@ -7689,6 +7759,15 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       console.log('📦 P2 PO Item Create - Final data to storage:', createData);
       
       const item = await storage.createP2PurchaseOrderItem(createData);
+      if (correctionReason) {
+        const user = (req as any).user;
+        await auditService.logEvent({
+          entityType: 'p2_order', entityId: poId, action: 'P2_PO_LINE_ITEM_ADDED', reason: correctionReason,
+          actor: { id: user?.id, username: user?.username || user?.email, role: user?.role },
+          ipAddress: req.ip, userAgent: req.get('user-agent') || undefined,
+          fieldsChanged: { lineItem: { before: null, after: item } },
+        });
+      }
       
       console.log('📦 P2 PO Item Create - Created item:', item);
       
@@ -7724,6 +7803,11 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const itemIdNum = parseInt(itemId);
       const { storage } = await import('../../storage');
       const { insertP2PurchaseOrderItemSchema } = await import('../../schema');
+      const correctionReason = String(req.body?.correctionReason || '').trim();
+      if (correctionReason) {
+        if (correctionReason.length < 10) return res.status(400).json({ error: 'A valid correction reason is required' });
+        await assertP2LineItemCorrectionAllowed(poIdNum);
+      }
 
       const itemData = insertP2PurchaseOrderItemSchema
         .partial()
@@ -7746,6 +7830,14 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
         itemData,
         actor,
       );
+
+      if (correctionReason) {
+        await auditService.logEvent({
+          entityType: 'p2_order', entityId: String(poIdNum), action: 'P2_PO_LINE_ITEM_UPDATED', reason: correctionReason,
+          actor, ipAddress: req.ip, userAgent: req.get('user-agent') || undefined,
+          meta: { itemId: itemIdNum, updatedItem: result.item, sync: result.sync },
+        });
+      }
 
       res.json({ ...result.item, sync: result.sync });
     } catch (error) {
@@ -7798,9 +7890,25 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   app.delete('/api/p2/purchase-orders/:poId/items/:itemId', async (req, res) => {
     try {
-      const { itemId } = req.params;
+      const { poId, itemId } = req.params;
+      const correctionReason = String(req.body?.correctionReason || '').trim();
+      if (correctionReason) {
+        if (correctionReason.length < 10) return res.status(400).json({ error: 'A valid correction reason is required' });
+        await assertP2LineItemCorrectionAllowed(parseInt(poId));
+      }
       const { storage } = await import('../../storage');
+      const existingItems = correctionReason ? await storage.getP2PurchaseOrderItems(parseInt(poId)) : [];
+      const deletedItem = existingItems.find((item: any) => Number(item.id) === parseInt(itemId));
       await storage.deleteP2PurchaseOrderItem(parseInt(itemId));
+      if (correctionReason) {
+        const user = (req as any).user;
+        await auditService.logEvent({
+          entityType: 'p2_order', entityId: poId, action: 'P2_PO_LINE_ITEM_DELETED', reason: correctionReason,
+          actor: { id: user?.id, username: user?.username || user?.email, role: user?.role },
+          ipAddress: req.ip, userAgent: req.get('user-agent') || undefined,
+          fieldsChanged: { lineItem: { before: deletedItem || { id: parseInt(itemId) }, after: null } },
+        });
+      }
       res.json({ success: true });
     } catch (error) {
       console.error('Delete P2 purchase order item error:', error);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -599,6 +599,69 @@ const projectClinBodySchema = z.object({
   active: z.boolean().optional(),
 });
 
+const p2OrderDraftBodySchema = z.object({
+  currentStep: z.number().int().min(0).max(3),
+  draftData: z.object({
+    customerForm: z.record(z.unknown()).optional(),
+    detailsForm: z.record(z.unknown()).optional(),
+    lineItems: z.array(z.record(z.unknown())).optional(),
+  }),
+});
+
+router.get('/:id/p2-order-draft', async (req, res) => {
+  try {
+    const projectId = uuidStringSchema.parse(req.params.id);
+    const rows = await pool.query(
+      `SELECT id, project_id AS "projectId", current_step AS "currentStep",
+              draft_data AS "draftData", created_by AS "createdBy",
+              updated_by AS "updatedBy", created_at AS "createdAt",
+              updated_at AS "updatedAt"
+         FROM p2_order_drafts
+        WHERE project_id = $1
+        LIMIT 1`,
+      [projectId]
+    );
+    res.json(rows[0] || null);
+  } catch (error) {
+    res.status(error instanceof z.ZodError ? 400 : 500).json({ message: 'Failed to load P2 order draft' });
+  }
+});
+
+router.put('/:id/p2-order-draft', async (req: Request, res: Response) => {
+  try {
+    const projectId = uuidStringSchema.parse(req.params.id);
+    const input = p2OrderDraftBodySchema.parse(req.body);
+    const actor = String((req as any).user?.username || (req as any).user?.email || 'unknown');
+    const rows = await pool.query(
+      `INSERT INTO p2_order_drafts (project_id, current_step, draft_data, created_by, updated_by)
+       VALUES ($1, $2, $3::jsonb, $4, $4)
+       ON CONFLICT (project_id) DO UPDATE
+         SET current_step = EXCLUDED.current_step,
+             draft_data = EXCLUDED.draft_data,
+             updated_by = EXCLUDED.updated_by,
+             updated_at = now()
+       RETURNING id, project_id AS "projectId", current_step AS "currentStep",
+                 draft_data AS "draftData", created_by AS "createdBy",
+                 updated_by AS "updatedBy", created_at AS "createdAt",
+                 updated_at AS "updatedAt"`,
+      [projectId, input.currentStep, JSON.stringify(input.draftData), actor]
+    );
+    res.json(rows[0]);
+  } catch (error) {
+    res.status(error instanceof z.ZodError ? 400 : 500).json({ message: 'Failed to save P2 order draft' });
+  }
+});
+
+router.delete('/:id/p2-order-draft', async (req: Request, res: Response) => {
+  try {
+    const projectId = uuidStringSchema.parse(req.params.id);
+    await pool.query('DELETE FROM p2_order_drafts WHERE project_id = $1', [projectId]);
+    res.status(204).send();
+  } catch (error) {
+    res.status(error instanceof z.ZodError ? 400 : 500).json({ message: 'Failed to delete P2 order draft' });
+  }
+});
+
 async function getNextProjectRevisionNumber(
   projectId: string
 ): Promise<number> {


### PR DESCRIPTION
## What changed

- Adds resumable draft saving to the P2 order creation wizard and captures the customer PO date.
- Adds a **Manage Line Items** action to eligible P2 orders in the Control Center.
- Requires an audit reason before correcting an original PO.
- Prevents the correction workflow after serialized units or production orders exist.
- Audits correction start, line additions/updates/deletions, completion, actor, IP address, and user agent.
- Relocks the PO when the correction is completed.

## Why

PO00021498 was missing its shipping line, but the prior P2 item-management screen was no longer reachable from the deployed Control Center. A formal revision is unnecessary before production begins, while unrestricted editing would weaken traceability.

## User impact

Administrators and owners can correct omitted lines on untouched P2 POs without creating a revision. Once production has begun, EPOCH directs the user to the formal revision workflow.

## Validation

- `npx tsc --noEmit --pretty false`
- `git diff --check`
- Branch rebased onto current `origin/main` before push.