### PR TITLE
Emergency: fix P2 audited correction and vendor PO issuance

### DIFF
--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -201,6 +201,7 @@ export default function P2ControlCenter() {
       apiRequest(`/api/p2/purchase-orders/${poId}/line-item-correction/start`, {
         method: 'POST',
         body: { reason },
+        timeout: 15000,
       }),
     onSuccess: () => {
       if (pendingLineItemCorrection) setLineItemCorrection(pendingLineItemCorrection);
@@ -1008,6 +1009,13 @@ export default function P2ControlCenter() {
               data-testid="input-line-item-correction-reason"
             />
             <p className="text-xs text-muted-foreground">At least 10 characters are required.</p>
+            {startLineItemCorrection.isError && (
+              <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive" role="alert">
+                {startLineItemCorrection.error instanceof Error
+                  ? startLineItemCorrection.error.message
+                  : 'The correction could not be opened. Please try again.'}
+              </p>
+            )}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setPendingLineItemCorrection(null)}>Cancel</Button>

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -7672,9 +7672,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     return po;
   };
 
-  app.post('/api/p2/purchase-orders/:poId/line-item-correction/start', softAuth, requireAdminOrOwner, async (req, res) => {
+  app.post('/api/p2/purchase-orders/:poId/line-item-correction/start', requireAdminOrOwner, async (req, res) => {
     try {
       const poId = parseInt(req.params.poId);
+      if (!Number.isInteger(poId)) return res.status(400).json({ error: 'Invalid P2 purchase order ID' });
       const reason = String(req.body?.reason || '').trim();
       if (reason.length < 10) return res.status(400).json({ error: 'A correction reason of at least 10 characters is required' });
       const po = await assertP2LineItemCorrectionAllowed(poId);
@@ -7683,34 +7684,39 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
       const user = (req as any).user;
       await auditService.logEvent({
         entityType: 'p2_order', entityId: String(poId), action: 'P2_PO_LINE_ITEM_CORRECTION_STARTED', reason,
-        actor: { id: user?.id, username: user?.username || user?.email, role: user?.role },
+        // audit_events.actor_id is an employees.id foreign key.  The auth user
+        // id belongs to users.id and must never be written into that column.
+        actor: { id: user?.employeeId ?? undefined, username: user?.username || user?.email, role: user?.role },
         ipAddress: req.ip, userAgent: req.get('user-agent') || undefined,
         meta: { poNumber: po.po_number },
       });
       res.json({ success: true, poId, poNumber: po.po_number });
     } catch (error) {
+      console.error('Open P2 PO line-item correction error:', error);
       const status = Number((error as any).status) || 500;
       res.status(status).json({ error: (error as Error).message || 'Failed to open PO correction' });
     }
   });
 
-  app.post('/api/p2/purchase-orders/:poId/line-item-correction/complete', softAuth, requireAdminOrOwner, async (req, res) => {
+  app.post('/api/p2/purchase-orders/:poId/line-item-correction/complete', requireAdminOrOwner, async (req, res) => {
     try {
       const poId = parseInt(req.params.poId);
+      if (!Number.isInteger(poId)) return res.status(400).json({ error: 'Invalid P2 purchase order ID' });
       const reason = String(req.body?.reason || '').trim();
       if (reason.length < 10) return res.status(400).json({ error: 'A correction reason of at least 10 characters is required' });
       const po = await assertP2LineItemCorrectionAllowed(poId);
       const { pool } = await import('../../db');
       const user = (req as any).user;
-      await pool.query('UPDATE p2_purchase_orders SET locked_at = NOW(), locked_by = $1, updated_at = NOW() WHERE id = $2', [user?.id || null, poId]);
+      await pool.query('UPDATE p2_purchase_orders SET locked_at = NOW(), locked_by = $1, updated_at = NOW() WHERE id = $2', [user?.employeeId ?? null, poId]);
       await auditService.logEvent({
         entityType: 'p2_order', entityId: String(poId), action: 'P2_PO_LINE_ITEM_CORRECTION_COMPLETED', reason,
-        actor: { id: user?.id, username: user?.username || user?.email, role: user?.role },
+        actor: { id: user?.employeeId ?? undefined, username: user?.username || user?.email, role: user?.role },
         ipAddress: req.ip, userAgent: req.get('user-agent') || undefined,
         meta: { poNumber: po.po_number },
       });
       res.json({ success: true, poId });
     } catch (error) {
+      console.error('Complete P2 PO line-item correction error:', error);
       const status = Number((error as any).status) || 500;
       res.status(status).json({ error: (error as Error).message || 'Failed to complete PO correction' });
     }

--- a/server/src/routes/vendorPOs.ts
+++ b/server/src/routes/vendorPOs.ts
@@ -2681,8 +2681,11 @@ router.post('/:id/issue', requirePermission('purchasing.approve_po'), async (req
 
     const performedBy = String((req as any).user?.username ?? (req as any).user?.id ?? 'unknown');
     const performedByEmail = (req as any).user?.email as string | undefined;
+    // audit_events.actor_id references employees.id, not users.id.  Passing the
+    // authenticated application-user id causes a foreign-key failure for users
+    // whose user and employee records do not share the same numeric id.
     const actor = {
-      id: (req as any).user?.id,
+      id: (req as any).user?.employeeId ?? undefined,
       username: (req as any).user?.username,
       role: (req as any).user?.role,
     };


### PR DESCRIPTION
## Summary
- use the authenticated employee ID—not the application user ID—for audit ledger actor foreign keys
- use the employee ID when relocking corrected P2 POs
- remove duplicate authentication middleware from the correction endpoints
- surface correction failures inline and cap the request wait at 15 seconds
- add server logging and invalid-ID validation

## Production symptoms fixed
- Vendor PO Draft #180 reports `Failed to issue vendor PO`
- `Open audited correction` on PO00021498 appears to do nothing

## Verification
- `npx tsc --noEmit --pretty false`
- `git diff --check`