### PR TITLE
Verified fix: P2 correction eligibility and Vendor PO issuance

### DIFF
--- a/client/src/components/inventory/VendorPOManager.tsx
+++ b/client/src/components/inventory/VendorPOManager.tsx
@@ -2839,7 +2839,7 @@ export default function VendorPOManager({
       setNoEmailConfirmed(false);
     },
     onError: (error: any) => {
-      toast.error(error?.message || 'Failed to issue PO');
+      toast.error(error?.message || 'Failed to issue PO', { duration: 12000 });
     },
   });
 

--- a/server/__tests__/p2LineItemCorrectionEligibility.test.ts
+++ b/server/__tests__/p2LineItemCorrectionEligibility.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const routes = fs.readFileSync(path.resolve(process.cwd(), 'server/src/routes/index.ts'), 'utf8');
+
+describe('P2 audited line-item correction eligibility', () => {
+  it('does not treat pending setup placeholders as production activity', () => {
+    expect(routes).toContain("COALESCE(UPPER(psi.status), 'PENDING') <> 'PENDING'");
+    expect(routes).toContain("COALESCE(UPPER(ppo.status), 'PENDING') NOT IN ('PENDING', 'CANCELLED', 'CANCELED')");
+  });
+
+  it('blocks after scheduling, starting, or manufacturing activity', () => {
+    expect(routes).toContain('ppo.scheduled_layup_date IS NOT NULL');
+    expect(routes).toContain('ppo.started_at IS NOT NULL');
+    expect(routes).toContain('COALESCE(ppo.quantity_manufactured, 0) > 0');
+  });
+});

--- a/server/__tests__/vendorPoIssueDeactivatedGates.test.ts
+++ b/server/__tests__/vendorPoIssueDeactivatedGates.test.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = fs.readFileSync(path.resolve(process.cwd(), 'server/src/routes/vendorPOs.ts'), 'utf8');
+
+describe('vendor PO issuance with temporarily deactivated controls', () => {
+  it('guards inactive qualification and compliance queries', () => {
+    const issueRoute = source.slice(
+      source.indexOf("router.post('/:id/issue'"),
+      source.indexOf("router.post('/:id/rfq-transition'"),
+    );
+    const gateStart = issueRoute.indexOf('if (!VENDOR_PO_ISSUE_GATES_DEACTIVATED) {');
+    const qualification = issueRoute.indexOf('getVendorQualificationBlockers');
+    const issueWithoutEmail = issueRoute.indexOf('if (skip)');
+
+    expect(gateStart).toBeGreaterThan(0);
+    expect(qualification).toBeGreaterThan(gateStart);
+    expect(issueWithoutEmail).toBeGreaterThan(qualification);
+    expect(issueRoute.slice(qualification, issueWithoutEmail).trimEnd()).toMatch(/}\s*$/);
+  });
+
+  it('reports the failing issuance stage', () => {
+    expect(source).toContain('`Failed to issue vendor PO during ${issueStage}`');
+  });
+});

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -7655,8 +7655,19 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     const { pool } = await import('../../db');
     const result = await pool.query(
       `SELECT po.id, po.po_number, po.locked_at, po.is_current_revision,
-              (SELECT COUNT(*)::int FROM p2_serialized_items psi WHERE psi.po_id = po.id) AS serialized_count,
-              (SELECT COUNT(*)::int FROM p2_production_orders ppo WHERE ppo.p2_po_id = po.id) AS production_count
+              (SELECT COUNT(*)::int
+                 FROM p2_serialized_items psi
+                WHERE psi.po_id = po.id
+                  AND COALESCE(UPPER(psi.status), 'PENDING') <> 'PENDING') AS active_serialized_count,
+              (SELECT COUNT(*)::int
+                 FROM p2_production_orders ppo
+                WHERE ppo.p2_po_id = po.id
+                  AND (
+                    COALESCE(UPPER(ppo.status), 'PENDING') NOT IN ('PENDING', 'CANCELLED', 'CANCELED')
+                    OR ppo.scheduled_layup_date IS NOT NULL
+                    OR ppo.started_at IS NOT NULL
+                    OR COALESCE(ppo.quantity_manufactured, 0) > 0
+                  )) AS active_production_count
          FROM p2_purchase_orders po
         WHERE po.id = $1`,
       [poId],
@@ -7666,7 +7677,10 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     if (po.is_current_revision === false) {
       throw Object.assign(new Error('Superseded revisions cannot be corrected'), { status: 409 });
     }
-    if (Number(po.serialized_count) > 0 || Number(po.production_count) > 0) {
+    // PENDING serialized units and PENDING production-order placeholders are
+    // setup records, not evidence that manufacturing has begun.  Corrections
+    // remain safe until a unit is scheduled or otherwise enters production.
+    if (Number(po.active_serialized_count) > 0 || Number(po.active_production_count) > 0) {
       throw Object.assign(new Error('This PO has entered production. Use the formal revision process instead.'), { status: 409 });
     }
     return po;

--- a/server/src/routes/vendorPOs.ts
+++ b/server/src/routes/vendorPOs.ts
@@ -2655,6 +2655,7 @@ router.post('/:id/direct-po-exception', requirePermission('purchasing.direct_po_
 
 // POST /api/vendor-pos/:id/issue - Issue a PO, optionally sending email to vendor
 router.post('/:id/issue', requirePermission('purchasing.approve_po'), async (req: Request, res: Response) => {
+  let issueStage = 'request validation';
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -2690,6 +2691,11 @@ router.post('/:id/issue', requirePermission('purchasing.approve_po'), async (req
       role: (req as any).user?.role,
     };
 
+    // A deactivated gate must not execute its supporting queries. Previously
+    // these controls were labelled "deactivated" but their queries and audit
+    // observations could still abort issuance before the PO update.
+    if (!VENDOR_PO_ISSUE_GATES_DEACTIVATED) {
+    issueStage = 'supplier qualification review';
     const supplierQualificationBlockers = await getVendorQualificationBlockers(id, vendorPO.vendorId, vendorPO.productionLine ?? null);
     if (supplierQualificationBlockers.length > 0) {
       await emitProcurementLedgerEvent({
@@ -2882,7 +2888,10 @@ router.post('/:id/issue', requirePermission('purchasing.approve_po'), async (req
     }
 
     // ── PATH A: Issue WITHOUT emailing vendor (legacy/backfill) ──────────────
+    }
+
     if (skip) {
+      issueStage = 'database issuance without email';
       const trimmedReason = typeof reason === 'string' && reason.trim().length >= 10
         ? reason.trim()
         : 'Issued without vendor email during temporary purchasing controls deactivation.';
@@ -3016,9 +3025,11 @@ router.post('/:id/issue', requirePermission('purchasing.approve_po'), async (req
     }
 
     // Atomic transactional issuance: lock row, generate number, update status
+    issueStage = 'database issuance';
     const { vendorPO: issuedPO, poNumber } = await storage.issueVendorPO(id);
     await markLinkedPartsRequestsOrdered(id, performedBy);
 
+    issueStage = 'issuance audit';
     await emitProcurementLedgerEvent({
       action: 'VENDOR_PO_ISSUED',
       entityId: id,
@@ -3057,6 +3068,7 @@ router.post('/:id/issue', requirePermission('purchasing.approve_po'), async (req
       vendor_message_text: normalizedIssueMessage.text,
     };
 
+    issueStage = 'vendor email delivery';
     const emailResult = await sendCommunication({
       templateKey: 'vendor_po_issue',
       context: issueContext,
@@ -3145,9 +3157,9 @@ router.post('/:id/issue', requirePermission('purchasing.approve_po'), async (req
       message: `PO issued successfully. Email sent to ${issueToEmail}.`,
     });
   } catch (error: any) {
-    console.error('Issue vendor PO error:', error);
+    console.error('Issue vendor PO error:', { issueStage, error });
     return sendApiError(res, error, {
-      fallbackMessage: 'Failed to issue vendor PO',
+      fallbackMessage: `Failed to issue vendor PO during ${issueStage}`,
       source: 'vendorPO.issue',
       exposeMessage: true,
     });


### PR DESCRIPTION
## Fixes included

1. **PO00021498 audited line-item correction**
   - pending serialized/setup rows and pending production-order placeholders no longer count as actual production
   - correction remains blocked once scheduling, starting, manufacturing, or another active status occurs

2. **Vendor PO Draft #180 issuance**
   - temporarily deactivated procurement/compliance gates are no longer queried during issuance
   - prevents inactive/missing gate infrastructure from aborting the PO before database issuance
   - errors now identify the exact failing issuance stage and remain visible longer

## Important correction to prior PR
PR #1767 was merged before the later eligibility commit was pushed. This replacement PR contains that missing commit plus the Vendor PO issuance fix.

## Verification performed after synchronizing with current main
- 4 focused regression tests passed
- `npx tsc --noEmit --pretty false` passed
- production `npm run build` passed
- no migration required