### PR TITLE
Fix P2 correction for Active / Pending Layup units

### DIFF
--- a/server/__tests__/p2LineItemCorrectionEligibility.test.ts
+++ b/server/__tests__/p2LineItemCorrectionEligibility.test.ts
@@ -6,7 +6,8 @@ const routes = fs.readFileSync(path.resolve(process.cwd(), 'server/src/routes/in
 
 describe('P2 audited line-item correction eligibility', () => {
   it('does not treat pending setup placeholders as production activity', () => {
-    expect(routes).toContain("COALESCE(UPPER(psi.status), 'PENDING') <> 'PENDING'");
+    expect(routes).toContain("NOT IN ('', 'PENDING LAYUP', 'INVENTORY', 'SHIPPED', 'SHIPPING', 'CLOSED')");
+    expect(routes).toContain("NOT IN ('PENDING', 'SCHEDULED', 'COMPLETE', 'COMPLETED', 'CLOSED', 'SHIPPED', 'SCRAP', 'SCRAPPED', 'CANCELED', 'CANCELLED', 'VOID')");
     expect(routes).toContain("COALESCE(UPPER(ppo.status), 'PENDING') NOT IN ('PENDING', 'CANCELLED', 'CANCELED')");
   });
 
@@ -14,5 +15,7 @@ describe('P2 audited line-item correction eligibility', () => {
     expect(routes).toContain('ppo.scheduled_layup_date IS NOT NULL');
     expect(routes).toContain('ppo.started_at IS NOT NULL');
     expect(routes).toContain('COALESCE(ppo.quantity_manufactured, 0) > 0');
+    expect(routes).toContain("IN ('LAYUP', 'SCHEDULED')");
+    expect(routes).toContain('psi.finalized_at IS NOT NULL');
   });
 });

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -7658,7 +7658,14 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
               (SELECT COUNT(*)::int
                  FROM p2_serialized_items psi
                 WHERE psi.po_id = po.id
-                  AND COALESCE(UPPER(psi.status), 'PENDING') <> 'PENDING') AS active_serialized_count,
+                  AND (
+                    psi.finalized_at IS NOT NULL
+                    OR UPPER(TRIM(COALESCE(psi.current_department, ''))) IN ('LAYUP', 'SCHEDULED')
+                    OR (
+                      UPPER(TRIM(COALESCE(psi.current_department, ''))) NOT IN ('', 'PENDING LAYUP', 'INVENTORY', 'SHIPPED', 'SHIPPING', 'CLOSED')
+                      AND UPPER(TRIM(COALESCE(psi.status, ''))) NOT IN ('PENDING', 'SCHEDULED', 'COMPLETE', 'COMPLETED', 'CLOSED', 'SHIPPED', 'SCRAP', 'SCRAPPED', 'CANCELED', 'CANCELLED', 'VOID')
+                    )
+                  )) AS active_serialized_count,
               (SELECT COUNT(*)::int
                  FROM p2_production_orders ppo
                 WHERE ppo.p2_po_id = po.id


### PR DESCRIPTION
## Exact production-state fix
PO00021498 has serialized placeholders stored as `status = ACTIVE`, `current_department = Pending Layup`. The Control Center correctly displays these as available to schedule, but the prior correction guard blocked every `ACTIVE` row.

This change makes the audited-correction guard use the same status-plus-department semantics as the Control Center ledger:
- `ACTIVE / PENDING LAYUP` remains correctable
- scheduled Layup, finalized units, started work, and actual production activity remain blocked

## Verification
- existing ledger test explicitly verifies `ACTIVE / Pending Layup` is available capacity
- updated correction eligibility regression test
- 7 focused tests passed
- full TypeScript check passed
- no migration required

This PR contains the final status-alignment commit that was pushed after PR #1768 had already merged.