### PR TITLE
Simplify Design Control into six guided phases

### DIFF
--- a/client/src/__tests__/designControlAuthority.client.test.ts
+++ b/client/src/__tests__/designControlAuthority.client.test.ts
@@ -85,7 +85,7 @@ describe('Design Control client authority foundation', () => {
     expect(editorSource).toContain('You have unsaved changes');
     expect(editorSource).toContain('Last saved');
     expect(editorSource).toContain('Next action');
-    expect(editorSource).toContain('Submit current version');
+    expect(editorSource).toContain('Submit for Approval');
     expect(editorSource).toContain('Previous stage');
     expect(editorSource).toContain('Next stage');
     expect(editorSource).toContain("can('design.control.edit')");

--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -239,6 +239,47 @@ export function DesignControlStepEditor({
     [teamQuery.data?.assignments]
   );
 
+  useEffect(() => {
+    if (dirtyRef.current) return;
+    const suggestions: Record<string, string> = {};
+    for (const field of definition.fields) {
+      if (String(step?.formData?.[field.key] ?? '').trim()) continue;
+      const presentation = getDesignControlFieldPresentation(
+        definition.key,
+        field
+      );
+      if (presentation.kind === 'project' && projectId) {
+        suggestions[field.key] = projectId;
+        continue;
+      }
+      if (presentation.kind !== 'person') continue;
+      const wantedRole = field.label.toLowerCase();
+      const assignment = (teamQuery.data?.assignments ?? []).find(
+        (candidate) => {
+          if (candidate.status !== 'ACTIVE') return false;
+          const role = candidate.projectRole.replaceAll('_', ' ').toLowerCase();
+          return (
+            wantedRole.includes(role) ||
+            (wantedRole.includes('engineer') && role.includes('engineer')) ||
+            (wantedRole.includes('quality') && role.includes('quality')) ||
+            (wantedRole.includes('manufacturing') &&
+              role.includes('manufacturing')) ||
+            (wantedRole.includes('manager') && role.includes('manager'))
+          );
+        }
+      );
+      if (assignment) {
+        suggestions[field.key] =
+          [assignment.firstName, assignment.lastName]
+            .filter(Boolean)
+            .join(' ') || assignment.username;
+      }
+    }
+    if (Object.keys(suggestions).length === 0) return;
+    setFormData((current) => ({ ...suggestions, ...current }));
+    setDirty(true);
+  }, [definition, projectId, step?.formData, teamQuery.data?.assignments]);
+
   const approvalQuery = useQuery<ApprovalState>({
     queryKey: approvalQueryKey,
     queryFn: async () =>
@@ -827,6 +868,7 @@ export function DesignControlStepEditor({
               disabled={busy || !dirty}
               onClick={() => saveDraft()}
               type="button"
+              variant="outline"
             >
               Save Draft
             </Button>
@@ -834,7 +876,9 @@ export function DesignControlStepEditor({
               disabled={busy || !dirty}
               onClick={() => saveDraft(true)}
               type="button"
-              variant="secondary"
+              variant={
+                definition.approvals.length > 0 ? 'secondary' : 'default'
+              }
             >
               Save and Continue
             </Button>
@@ -904,9 +948,9 @@ export function DesignControlStepEditor({
             }
             onClick={submit}
             type="button"
-            variant="secondary"
+            variant="default"
           >
-            Submit current version
+            Submit for Approval
           </Button>
         )}
         {canSubmit && dirty && (

--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -236,15 +236,13 @@ export function DesignControlWorkspace({
     DESIGN_CONTROL_WORKFLOW.find((step) => step.key === activeStep) ??
     DESIGN_CONTROL_WORKFLOW[0];
   const selectedStep = stepByKey.get(selectedDefinition.key);
-  const completed = detail.steps.filter((step) =>
-    ['approved', 'complete', 'completed'].includes(step.status || '')
-  ).length;
   const selectedIndex = DESIGN_CONTROL_WORKFLOW.findIndex(
     (step) => step.key === selectedDefinition.key
   );
   const structuredRecordType =
     STRUCTURED_RECORD_TYPE_BY_STEP[selectedDefinition.key];
-  const activePhase = designControlPhaseForStep(selectedDefinition.key)!;
+  const selectedPhase = designControlPhaseForStep(selectedDefinition.key)!;
+  const released = Boolean(detail.record.releasedAt);
   const phaseStatus = (stepKeys: readonly string[]) => {
     const statuses = stepKeys.map(
       (key) => stepByKey.get(key)?.status?.toLowerCase() || 'not_started'
@@ -273,17 +271,44 @@ export function DesignControlWorkspace({
     stepKeys.find((key) => {
       const status = stepByKey.get(key)?.status?.toLowerCase();
       return !['approved', 'complete', 'completed'].includes(status || '');
-    }) ?? stepKeys[stepKeys.length - 1];
+    }) ??
+    stepKeys[stepKeys.length - 1] ??
+    '12';
+  const correctionDefinition = DESIGN_CONTROL_WORKFLOW.find((definition) => {
+    const status = stepByKey.get(definition.key)?.status?.toLowerCase();
+    return [
+      'returned',
+      'returned_for_revision',
+      'rejected',
+      'blocked',
+    ].includes(status || '');
+  });
   const firstIncompleteDefinition =
+    correctionDefinition ??
     DESIGN_CONTROL_WORKFLOW.find((definition) => {
       const status = stepByKey.get(definition.key)?.status?.toLowerCase();
       return !['approved', 'complete', 'completed'].includes(status || '');
-    }) ?? DESIGN_CONTROL_WORKFLOW[DESIGN_CONTROL_WORKFLOW.length - 1];
+    }) ??
+    DESIGN_CONTROL_WORKFLOW[DESIGN_CONTROL_WORKFLOW.length - 1];
+  const currentPhase = released
+    ? DESIGN_CONTROL_PHASES[5]
+    : (designControlPhaseForStep(firstIncompleteDefinition.key) ??
+      DESIGN_CONTROL_PHASES[0]);
+  const currentStep = stepByKey.get(firstIncompleteDefinition.key);
+  const waitingForApproval = ['submitted', 'submitted_for_approval'].includes(
+    currentStep?.status?.toLowerCase() || ''
+  );
   const nextActionLabel = readOnly
     ? 'View Current Design Phase'
-    : completed === DESIGN_CONTROL_WORKFLOW.length
-      ? 'Review Release Readiness'
-      : 'Continue Design';
+    : released
+      ? 'Start Design Change'
+      : waitingForApproval
+        ? 'Awaiting Approval'
+        : correctionDefinition
+          ? 'Resolve Returned Work'
+          : firstIncompleteDefinition.key === '12'
+            ? 'Resolve Release Blockers'
+            : 'Continue Design';
   const selectedFormData = selectedStep?.formData ?? {};
   const selectedExample =
     'examples' in selectedDefinition
@@ -305,6 +330,12 @@ export function DesignControlWorkspace({
       : [];
     return total + actions.length;
   }, 0);
+  const responsibleField = firstIncompleteDefinition.fields.find((field) =>
+    /responsible|owner|manager|representative|engineer/i.test(field.label)
+  );
+  const responsiblePerson = responsibleField
+    ? String(currentStep?.formData?.[responsibleField.key] || '')
+    : '';
 
   return (
     <section className="space-y-4" aria-label="Design Control workspace">
@@ -314,8 +345,8 @@ export function DesignControlWorkspace({
             <div>
               <CardTitle>{detail.record.title}</CardTitle>
               <CardDescription>
-                Record {detail.record.recordNumber || detail.record.id} ·
-                generation {detail.record.recordVersion || 1}
+                Follow the current phase and complete the one action shown
+                below.
               </CardDescription>
               <p className="mt-1 text-sm">
                 R&amp;D project:{' '}
@@ -328,15 +359,9 @@ export function DesignControlWorkspace({
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <Badge variant="outline">
-                Authority: {displayStatus(detail.record.authorityStatus)}
-              </Badge>
-              <Badge variant="outline">
-                Status: {displayStatus(detail.record.status)}
-              </Badge>
-              <Badge variant="outline">Progress: {completed}/12</Badge>
-              <Badge variant="outline">
-                Phase {activePhase.order}: {activePhase.title}
+              <Badge variant="secondary">
+                {currentPhase.title} ·{' '}
+                {released ? 'Released' : phaseStatus(currentPhase.stepKeys)}
               </Badge>
               {readOnly && (
                 <Badge variant="secondary">
@@ -349,50 +374,62 @@ export function DesignControlWorkspace({
         </CardHeader>
         <CardContent className="space-y-4">
           <div
-            className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+            className="grid gap-3 sm:grid-cols-3"
             aria-label="Project guidance summary"
           >
             <div className="rounded-md border p-3">
               <span className="text-xs text-muted-foreground">
                 Current phase
               </span>
-              <p className="font-medium">{activePhase.title}</p>
+              <p className="font-medium">{currentPhase.title}</p>
             </div>
             <div className="rounded-md border p-3">
               <span className="text-xs text-muted-foreground">
                 Overall progress
               </span>
               <p className="font-medium">
-                {Math.round((completed / DESIGN_CONTROL_WORKFLOW.length) * 100)}
-                % complete
+                {
+                  DESIGN_CONTROL_PHASES.filter(
+                    (phase) =>
+                      phase.stepKeys.length > 0 &&
+                      phaseStatus(phase.stepKeys) === 'Approved'
+                  ).length
+                }{' '}
+                of 6 phases complete
               </p>
-            </div>
-            <div className="rounded-md border p-3">
-              <span className="text-xs text-muted-foreground">Open risks</span>
-              <p className="font-medium">{openRiskCount}</p>
             </div>
             <div className="rounded-md border p-3">
               <span className="text-xs text-muted-foreground">
-                Open review actions
+                Responsible for the next action
               </span>
-              <p className="font-medium">{openActionCount}</p>
+              <p className="font-medium">
+                {responsiblePerson ||
+                  (waitingForApproval ? 'Assigned approver' : 'Project team')}
+              </p>
             </div>
           </div>
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-muted/30 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border-2 border-primary/40 bg-primary/5 p-5">
             <div>
               <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                Next required action
+                Do This Next
               </p>
               <p className="font-semibold">{firstIncompleteDefinition.title}</p>
               <p className="text-sm text-muted-foreground">
-                {firstIncompleteDefinition.purpose}
+                {waitingForApproval
+                  ? 'This exact saved version is waiting for the assigned approver. You may continue after it is approved or returned.'
+                  : firstIncompleteDefinition.purpose}
               </p>
             </div>
             <Button
+              disabled={!readOnly && waitingForApproval}
               onClick={() => {
-                setActiveTab('lifecycle');
-                setActiveStep(firstIncompleteDefinition.key);
+                if (released) setActiveTab('changes');
+                else {
+                  setActiveTab('lifecycle');
+                  setActiveStep(firstIncompleteDefinition.key);
+                }
               }}
+              size="lg"
             >
               {nextActionLabel}
             </Button>
@@ -403,15 +440,20 @@ export function DesignControlWorkspace({
           >
             {DESIGN_CONTROL_PHASES.map((phase) => (
               <li
-                className={`rounded-md border p-3 text-sm ${phase.key === activePhase.key ? 'border-primary bg-primary/5' : ''}`}
+                className={`rounded-md border p-3 text-sm ${phase.key === currentPhase.key ? 'border-primary bg-primary/5' : ''}`}
                 key={phase.key}
               >
                 <button
                   className="w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   onClick={() => {
+                    if (phase.key === 'control-changes') {
+                      if (released) setActiveTab('changes');
+                      return;
+                    }
                     setActiveTab('lifecycle');
                     setActiveStep(phaseEntryStep(phase.stepKeys));
                   }}
+                  disabled={phase.key === 'control-changes' && !released}
                   type="button"
                 >
                   <span className="flex items-start justify-between gap-2">
@@ -419,7 +461,11 @@ export function DesignControlWorkspace({
                       {phase.order}. {phase.title}
                     </span>
                     <Badge variant="outline">
-                      {phaseStatus(phase.stepKeys)}
+                      {phase.key === 'control-changes'
+                        ? released
+                          ? 'Available'
+                          : 'After release'
+                        : phaseStatus(phase.stepKeys)}
                     </Badge>
                   </span>
                   <span className="mt-1 block text-xs text-muted-foreground">
@@ -433,29 +479,58 @@ export function DesignControlWorkspace({
             Follow the six phases in order. Controlled approvals, versions, and
             audit history are preserved automatically.
           </p>
-          <p className="mt-3 text-sm text-muted-foreground">
-            Revision A establishes the initial baseline. Released designs use
-            {expandDesignControlTerm('ECR')} approval and{' '}
-            {expandDesignControlTerm('ECN')} implementation before a Revision B+
-            baseline is released.
-          </p>
+          <details className="rounded-md border p-3 text-sm">
+            <summary className="cursor-pointer font-medium">
+              Record Details
+            </summary>
+            <div className="mt-3 flex flex-wrap gap-2 text-muted-foreground">
+              <Badge variant="outline">
+                Record {detail.record.recordNumber || detail.record.id}
+              </Badge>
+              <Badge variant="outline">
+                Version {detail.record.recordVersion || 1}
+              </Badge>
+              <Badge variant="outline">
+                Authority {displayStatus(detail.record.authorityStatus)}
+              </Badge>
+              <Badge variant="outline">
+                Status {displayStatus(detail.record.status)}
+              </Badge>
+              <Badge variant="outline">Open risks {openRiskCount}</Badge>
+              <Badge variant="outline">
+                Open review actions {openActionCount}
+              </Badge>
+            </div>
+            <p className="mt-3 text-muted-foreground">
+              Revision A establishes the initial baseline. Released designs use
+              {expandDesignControlTerm('ECR')} approval and{' '}
+              {expandDesignControlTerm('ECN')} implementation before a Revision
+              B+ baseline is released.
+            </p>
+          </details>
         </CardContent>
       </Card>
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList className="h-auto flex-wrap justify-start">
-          <TabsTrigger value="lifecycle">Design phases</TabsTrigger>
-          <TabsTrigger value="evidence">Evidence registers</TabsTrigger>
-          <TabsTrigger value="traceability">Traceability</TabsTrigger>
-          <TabsTrigger value="final-review">Final review</TabsTrigger>
-          <TabsTrigger value="team">Project team</TabsTrigger>
-          <TabsTrigger value="configuration">Configuration</TabsTrigger>
-          <TabsTrigger value="changes">Engineering changes</TabsTrigger>
-          <TabsTrigger value="documents">Forms &amp; copies</TabsTrigger>
-          <TabsTrigger value="dhf">
-            {expandDesignControlTerm('DHF')} &amp; package
-          </TabsTrigger>
+          <TabsTrigger value="lifecycle">Current work</TabsTrigger>
         </TabsList>
+
+        <details className="mt-3 rounded-md border p-3">
+          <summary className="cursor-pointer text-sm font-medium">
+            Evidence, team, changes &amp; history
+          </summary>
+          <TabsList className="mt-3 h-auto flex-wrap justify-start">
+            <TabsTrigger value="evidence">Evidence</TabsTrigger>
+            <TabsTrigger value="traceability">Traceability</TabsTrigger>
+            <TabsTrigger value="final-review">Approval readiness</TabsTrigger>
+            <TabsTrigger value="team">Project team</TabsTrigger>
+            <TabsTrigger value="configuration">Project setup</TabsTrigger>
+            <TabsTrigger value="changes">Design changes</TabsTrigger>
+            <TabsTrigger value="documents">Forms &amp; copies</TabsTrigger>
+            <TabsTrigger value="dhf">History &amp; package</TabsTrigger>
+          </TabsList>
+        </details>
 
         <TabsContent value="lifecycle" className="space-y-4">
           <nav
@@ -497,7 +572,7 @@ export function DesignControlWorkspace({
               <div className="flex flex-wrap items-start justify-between gap-2">
                 <div>
                   <p className="text-sm font-medium text-primary">
-                    Phase {activePhase.order}: {activePhase.title}
+                    Phase {selectedPhase.order}: {selectedPhase.title}
                   </p>
                   <CardTitle>{selectedDefinition.title}</CardTitle>
                 </div>

--- a/server/__tests__/designControlWorkspacePhase11.test.ts
+++ b/server/__tests__/designControlWorkspacePhase11.test.ts
@@ -49,18 +49,18 @@ const phases = fs.readFileSync(
 describe('Phase 11 unified Design Control workspace', () => {
   it('uses the canonical twelve-step definition', () => {
     expect(workspace).toContain('import { DESIGN_CONTROL_WORKFLOW }');
-    expect(workspace).toContain('Progress: {completed}/12');
+    expect(workspace).toContain('DESIGN_CONTROL_WORKFLOW.find');
     expect(workspace).not.toMatch(/const\s+workflowSteps\s*=/);
   });
 
   it('presents six plain-language phases while preserving all twelve stages', () => {
     for (const title of [
-      'Define the Project',
-      'Requirements and Risks',
-      'Develop the Design',
-      'Build, Review, and Test',
-      'Final Design Approval',
-      'Release to Manufacturing',
+      'Start & Plan',
+      'Requirements & Risks',
+      'Design Outputs',
+      'Review, Verify & Validate',
+      'Approve & Release',
+      'Control Changes',
     ]) {
       expect(phases).toContain(title);
     }
@@ -69,13 +69,13 @@ describe('Phase 11 unified Design Control workspace', () => {
     }
     expect(workspace).toContain('Six Design Control phases');
     expect(workspace).toContain('Controlled approvals, versions, and');
-    expect(workspace).toContain('Design phases');
-    expect(workspace).toContain('Next required action');
+    expect(workspace).toContain('Current work');
+    expect(workspace).toContain('Do This Next');
     expect(workspace).toContain('Continue Design');
-    expect(workspace).toContain('setActiveStep(phaseEntryStep(phase.stepKeys))');
     expect(workspace).toContain(
-      'Controlled checkpoint {selectedDefinition.order} of 12'
+      'setActiveStep(phaseEntryStep(phase.stepKeys))'
     );
+    expect(workspace).toContain('Record Details');
     expect(workspace).toContain(
       'aria-label="Controlled Design Control checkpoints"'
     );
@@ -93,6 +93,9 @@ describe('Phase 11 unified Design Control workspace', () => {
     }
     expect(workspace).toContain('.getElementById(');
     expect(workspace).toContain('You can save an incomplete draft');
+    expect(workspace).toContain('Responsible for the next action');
+    expect(workspace).toContain('Awaiting Approval');
+    expect(workspace).toContain('Resolve Returned Work');
   });
 
   it('is shared by R&D project mode and QMS oversight mode', () => {

--- a/shared/designControlPhases.ts
+++ b/shared/designControlPhases.ts
@@ -1,51 +1,51 @@
 export const DESIGN_CONTROL_PHASES = [
   {
-    key: 'define-project',
+    key: 'start-plan',
     order: 1,
-    title: 'Define the Project',
+    title: 'Start & Plan',
     stepKeys: ['1', '2'],
     explanation:
-      'Describe the project, its purpose, responsibilities, plan, and required evidence.',
+      'Define the project, responsibility, schedule, required activities, and resources.',
   },
   {
     key: 'requirements-risks',
     order: 2,
-    title: 'Requirements and Risks',
+    title: 'Requirements & Risks',
     stepKeys: ['3', '4', '5'],
     explanation:
       'Confirm what the design must do, resolve unclear requirements, and control design risk.',
   },
   {
-    key: 'develop-design',
+    key: 'design-outputs',
     order: 3,
-    title: 'Develop the Design',
+    title: 'Design Outputs',
     stepKeys: ['6', '7'],
     explanation:
-      'Review the design direction and create controlled outputs that satisfy the requirements.',
+      'Review the design direction and link the drawings, bill of materials, specifications, and other authoritative outputs.',
   },
   {
-    key: 'build-review-test',
+    key: 'review-verify-validate',
     order: 4,
-    title: 'Build, Review, and Test',
+    title: 'Review, Verify & Validate',
     stepKeys: ['8', '9', '10'],
     explanation:
-      'Build the correct configuration and retain separate verification and validation evidence.',
+      'Review readiness, verify that the design is correct, and validate that it works for its intended use.',
   },
   {
-    key: 'final-approval',
+    key: 'approve-release',
     order: 5,
-    title: 'Final Design Approval',
-    stepKeys: ['11'],
+    title: 'Approve & Release',
+    stepKeys: ['11', '12'],
     explanation:
-      'Resolve readiness blockers and obtain an authenticated final design decision.',
+      'Resolve readiness blockers, obtain the required approvals, and create the Engineering Release baseline.',
   },
   {
-    key: 'manufacturing-release',
+    key: 'control-changes',
     order: 6,
-    title: 'Release to Manufacturing',
-    stepKeys: ['12'],
+    title: 'Control Changes',
+    stepKeys: [],
     explanation:
-      'Create the separately approved, immutable Engineering Release baseline.',
+      'After Engineering Release, use approved change requests and change notices to revise the controlled baseline.',
   },
 ] as const;
 


### PR DESCRIPTION
## What changed

- Renames the user-facing workflow to six plain-language phases: Start & Plan, Requirements & Risks, Design Outputs, Review, Verify & Validate, Approve & Release, and Control Changes.
- Makes the first returned, rejected, blocked, or incomplete controlled action the prominent **Do This Next** action.
- Shows current phase, phase status, responsibility, approval-waiting guidance, missing information, and six-phase progress before technical record details.
- Moves identifiers, versions, risk/action counts, secondary evidence workspaces, team setup, changes, forms, and history behind progressive disclosure.
- Removes the hidden duplicate 12-checkpoint navigation; the twelve controlled backend stages and records remain preserved underneath the six phases.
- Routes post-release work into the existing ECR/ECN change-control workspace.
- Suggests authoritative linked-project and active project-team values only for fields that are still blank, including when team data arrives after project data.
- Preserves existing saved and unsaved values; suggestions require an explicit controlled save and never create checklist, approval, test-result, or completion evidence.
- Keeps verified employee approver selectors, version-bound approvals, structured registers, final-review readiness, Engineering Release gating, audit history, and authoritative module ownership intact.

## Why

The connected Design Control workspace exposed the underlying twelve checkpoints, technical record metadata, and many secondary tabs too prominently. Employees could not immediately tell where the project was, what to do next, who was responsible, or whether approval was blocking progress.

## Validation

- Focused Design Control client suites: **16/16 passed**
- Focused Design Control server/workspace assertions: **23/23 passed**
- Touched-file ESLint: **passed** (`ESLINT_EXIT=0`)
- Prettier 3.6.2 check/format on touched files: **passed**
- `git diff --check`: **passed**
- `git merge-tree --write-tree origin/main HEAD`: **passed** before publication
- Repository-wide TypeScript: default 2 GB run exited `134` with heap exhaustion; a scoped 4 GB retry also consumed approximately 4.25 GB and terminated without a captured successful exit or TypeScript diagnostic. It is **not reported as passed**.
- Production Vite build reached transformation but exited without producing `dist` or a captured successful exit. It is **not reported as passed**.
- PostgreSQL-backed tests were not run because no database behavior or migration changed.

No Heated Pitot or other Design Control record was deleted; the fix was additive and did not require data removal. This PR remains draft pending CI and any required interactive/browser review. Nothing was deployed, enabled, merged, or written to production.