### PR TITLE
Expose stored draft PDFs in Master Document Register

### DIFF
--- a/client/src/pages/MasterDocumentRegister.tsx
+++ b/client/src/pages/MasterDocumentRegister.tsx
@@ -1809,20 +1809,69 @@ export default function MasterDocumentRegister() {
                                 </Button>
                               </>
                             ) : (
-                              <Badge
-                                variant={
-                                  doc.currentReleasedRevisionId
-                                    ? 'destructive'
-                                    : 'outline'
-                                }
-                                title={
-                                  doc.currentReleasedRevisionId
-                                    ? 'The released revision is not verified and available for controlled use. Use Document File Recovery.'
-                                    : 'A document becomes available for controlled use only after approval and release.'
-                                }
-                              >
-                                {getReleasedFileTypeLabel(doc)}
-                              </Badge>
+                              <>
+                                <Badge
+                                  variant={
+                                    doc.currentReleasedRevisionId
+                                      ? 'destructive'
+                                      : 'outline'
+                                  }
+                                  title={
+                                    doc.currentReleasedRevisionId
+                                      ? 'The released revision is not verified and available for controlled use. Use Document File Recovery.'
+                                      : 'A document becomes available for controlled use only after approval and release.'
+                                  }
+                                >
+                                  {getReleasedFileTypeLabel(doc)}
+                                </Badge>
+                                {!doc.currentReleasedRevisionId &&
+                                  doc.currentRevisionId &&
+                                  doc.currentRevisionHasFile && (
+                                    <>
+                                      {doc.currentRevisionIsPdf && (
+                                        <Button
+                                          size="sm"
+                                          variant="outline"
+                                          className="h-8 gap-1 border-amber-300 px-2 text-amber-800 hover:bg-amber-50"
+                                          title="Preview draft PDF — not released for controlled use"
+                                          disabled={openingDocumentId === doc.id}
+                                          onClick={() =>
+                                            openDocumentFile(
+                                              doc,
+                                              'view',
+                                              undefined,
+                                              `/api/controlled-documents/${doc.id}/revisions/${doc.currentRevisionId}/view`
+                                            )
+                                          }
+                                          data-testid={`button-preview-draft-${doc.id}`}
+                                        >
+                                          <Eye className="h-3.5 w-3.5" />
+                                          {openingDocumentId === doc.id
+                                            ? 'Opening'
+                                            : 'Draft PDF'}
+                                        </Button>
+                                      )}
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        className="h-8 w-8 p-0"
+                                        title="Download draft revision — not released for controlled use"
+                                        disabled={openingDocumentId === doc.id}
+                                        onClick={() =>
+                                          openDocumentFile(
+                                            doc,
+                                            'download',
+                                            null,
+                                            `/api/controlled-documents/${doc.id}/revisions/${doc.currentRevisionId}/download`
+                                          )
+                                        }
+                                        data-testid={`button-download-draft-${doc.id}`}
+                                      >
+                                        <Download className="h-4 w-4" />
+                                      </Button>
+                                    </>
+                                  )}
+                              </>
                             )}
                             <Button
                               size="sm"

--- a/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
+++ b/server/__tests__/controlledDocumentReleasedRevisionAccess.test.ts
@@ -93,6 +93,19 @@ describe('Master Document Register released-revision access', () => {
     expect(client).toContain('Preview Exact Revision Before Approval');
   });
 
+  it('exposes the stored working draft PDF from the register without treating it as released', () => {
+    expect(client).toContain('button-preview-draft-${doc.id}');
+    expect(client).toContain('button-download-draft-${doc.id}');
+    expect(client).toContain(
+      '/api/controlled-documents/${doc.id}/revisions/${doc.currentRevisionId}/view'
+    );
+    expect(client).toContain('Draft PDF');
+    expect(client).toContain('not released for controlled use');
+    expect(client).toMatch(
+      /!doc\.currentReleasedRevisionId\s*&&\s*doc\.currentRevisionId\s*&&\s*doc\.currentRevisionHasFile/
+    );
+  });
+
   it('does not expose draft revision metadata through general document history', () => {
     expect(route).toContain('authorizedRevisionHistory');
     expect(route).toMatch(


### PR DESCRIPTION
## What changed

- show a clearly labeled **Draft PDF** preview action directly in the Master Document Register for unreleased documents with stored revision bytes
- add a draft revision download action for printing or offline review
- keep normal controlled-use View/Download strictly tied to the released, verified revision
- route draft access through the existing exact-revision permission and checksum controls

## Root cause

Form & Document Builder correctly generated and stored FDT-2026-002 as revision 1.0, but the register row rendered only **Not released**. The draft PDF was reachable only through Version History, so users reasonably interpreted the document as unavailable.

## User impact

Authorized users can open, print, or download the generated draft PDF directly from the register while the UI continues to state that it is not released for controlled use.

## Validation

- `controlledDocumentReleasedRevisionAccess.test.ts`
- `controlledDocumentPhase1ACompatibility.test.ts`
- 23 focused tests passed
- `git diff --check` passed
- production FDT-2026-002 revision 1.0 preview was verified through the signed-in application session