### PR TITLE
Fix Design Control autofill follow-up

### DIFF
--- a/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
+++ b/client/src/__tests__/designControlStructuredWorkspace.client.test.tsx
@@ -47,9 +47,11 @@ function renderWithQuery(ui: ReactElement) {
 
 describe('Design Control structured workspaces', () => {
   let failDraftSave = false;
+  let projectTeamAssignments: Array<Record<string, unknown>> = [];
 
   beforeEach(() => {
     failDraftSave = false;
+    projectTeamAssignments = [];
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: unknown, init?: globalThis.RequestInit) => {
@@ -226,7 +228,11 @@ describe('Design Control structured workspaces', () => {
           );
         if (url.endsWith('/project-team'))
           return new Response(
-            JSON.stringify({ activated: false, assignments: [], history: [] }),
+            JSON.stringify({
+              activated: false,
+              assignments: projectTeamAssignments,
+              history: [],
+            }),
             { status: 200 }
           );
         return new Response(JSON.stringify({ message: 'Unexpected request' }), {
@@ -351,6 +357,102 @@ describe('Design Control structured workspaces', () => {
         })
       )
     );
+  });
+
+  it('suggests authoritative project and team values only for blank fields', async () => {
+    projectTeamAssignments = [
+      {
+        userId: 42,
+        username: 'heated-pitot-engineer',
+        firstName: 'Heated',
+        lastName: 'Engineer',
+        projectRole: 'RESPONSIBLE_ENGINEER',
+        status: 'ACTIVE',
+      },
+    ];
+    const definition = DESIGN_CONTROL_WORKFLOW[0];
+    renderWithQuery(
+      <DesignControlStepEditor
+        definition={definition}
+        hasNext
+        hasPrevious={false}
+        onChanged={vi.fn(async () => undefined)}
+        onNext={vi.fn()}
+        onPrevious={vi.fn()}
+        projectId="heated-pitot-project"
+        readOnly={false}
+        recordId="record-1"
+        step={{ stepKey: definition.key, status: 'draft' }}
+      />
+    );
+
+    expect(
+      await screen.findByLabelText('Project / customer / order link', {
+        exact: false,
+      })
+    ).toHaveValue('heated-pitot-project');
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText('Responsible engineer', { exact: false })
+      ).toHaveValue('Heated Engineer')
+    );
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('design-control-missing-summary')
+    ).toHaveTextContent(/required item/i);
+    expect(
+      screen.queryByText(/Authenticated approval is recorded/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('never overwrites existing saved values with authoritative suggestions', async () => {
+    projectTeamAssignments = [
+      {
+        userId: 42,
+        username: 'new-engineer',
+        firstName: 'New',
+        lastName: 'Engineer',
+        projectRole: 'RESPONSIBLE_ENGINEER',
+        status: 'ACTIVE',
+      },
+    ];
+    const definition = DESIGN_CONTROL_WORKFLOW[0];
+    const projectField = definition.fields.find((field) =>
+      field.label.includes('Project / customer')
+    )!;
+    const engineerField = definition.fields.find((field) =>
+      field.label.includes('Responsible engineer')
+    )!;
+    renderWithQuery(
+      <DesignControlStepEditor
+        definition={definition}
+        hasNext
+        hasPrevious={false}
+        onChanged={vi.fn(async () => undefined)}
+        onNext={vi.fn()}
+        onPrevious={vi.fn()}
+        projectId="new-project"
+        readOnly={false}
+        recordId="record-1"
+        step={{
+          stepKey: definition.key,
+          status: 'draft',
+          formData: {
+            [projectField.key]: 'saved-project',
+            [engineerField.key]: 'Saved Engineer',
+          },
+        }}
+      />
+    );
+
+    expect(
+      await screen.findByLabelText('Project / customer / order link', {
+        exact: false,
+      })
+    ).toHaveValue('saved-project');
+    expect(
+      screen.getByLabelText('Responsible engineer', { exact: false })
+    ).toHaveValue('Saved Engineer');
   });
 
   it('can focus the stage workspace on the matching authoritative register', async () => {

--- a/client/src/features/design-control/DesignControlStepEditor.tsx
+++ b/client/src/features/design-control/DesignControlStepEditor.tsx
@@ -240,10 +240,9 @@ export function DesignControlStepEditor({
   );
 
   useEffect(() => {
-    if (dirtyRef.current) return;
     const suggestions: Record<string, string> = {};
     for (const field of definition.fields) {
-      if (String(step?.formData?.[field.key] ?? '').trim()) continue;
+      if (String(formData[field.key] ?? '').trim()) continue;
       const presentation = getDesignControlFieldPresentation(
         definition.key,
         field
@@ -276,9 +275,17 @@ export function DesignControlStepEditor({
       }
     }
     if (Object.keys(suggestions).length === 0) return;
-    setFormData((current) => ({ ...suggestions, ...current }));
-    setDirty(true);
-  }, [definition, projectId, step?.formData, teamQuery.data?.assignments]);
+    setFormData((current) => {
+      const applicable = Object.fromEntries(
+        Object.entries(suggestions).filter(
+          ([key]) => !String(current[key] ?? '').trim()
+        )
+      );
+      if (Object.keys(applicable).length === 0) return current;
+      setDirty(true);
+      return { ...current, ...applicable };
+    });
+  }, [definition, formData, projectId, teamQuery.data?.assignments]);
 
   const approvalQuery = useQuery<ApprovalState>({
     queryKey: approvalQueryKey,

--- a/client/src/features/design-control/DesignControlWorkspace.tsx
+++ b/client/src/features/design-control/DesignControlWorkspace.tsx
@@ -10,7 +10,6 @@ import { expandDesignControlTerm } from '@shared/designControlTerminology';
 import {
   AlertTriangle,
   CheckCircle2,
-  Circle,
   FileSearch,
   LockKeyhole,
 } from 'lucide-react';
@@ -533,40 +532,6 @@ export function DesignControlWorkspace({
         </details>
 
         <TabsContent value="lifecycle" className="space-y-4">
-          <nav
-            className="hidden"
-            aria-hidden="true"
-            aria-label="Controlled Design Control checkpoints"
-          >
-            {DESIGN_CONTROL_WORKFLOW.map((definition) => {
-              const step = stepByKey.get(definition.key);
-              const selected = definition.key === activeStep;
-              return (
-                <button
-                  aria-current={selected ? 'step' : undefined}
-                  className="flex w-full items-start gap-2 rounded-md border p-3 text-left hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  key={definition.key}
-                  onClick={() => setActiveStep(definition.key)}
-                  type="button"
-                >
-                  {step?.status === 'approved' ? (
-                    <CheckCircle2 className="mt-0.5 h-4 w-4" />
-                  ) : (
-                    <Circle className="mt-0.5 h-4 w-4" />
-                  )}
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-sm font-medium">
-                      {definition.order}. {definition.title}
-                    </span>
-                    <span className="block text-xs text-muted-foreground">
-                      {displayStatus(step?.status)} · generation{' '}
-                      {step?.contentVersion || 0}
-                    </span>
-                  </span>
-                </button>
-              );
-            })}
-          </nav>
           <Card>
             <CardHeader>
               <div className="flex flex-wrap items-start justify-between gap-2">

--- a/server/__tests__/designControlWorkspacePhase11.test.ts
+++ b/server/__tests__/designControlWorkspacePhase11.test.ts
@@ -76,9 +76,7 @@ describe('Phase 11 unified Design Control workspace', () => {
       'setActiveStep(phaseEntryStep(phase.stepKeys))'
     );
     expect(workspace).toContain('Record Details');
-    expect(workspace).toContain(
-      'aria-label="Controlled Design Control checkpoints"'
-    );
+    expect(workspace).not.toContain('Controlled Design Control checkpoints');
   });
 
   it('gives every phase the same guided, correctable layout', () => {
@@ -200,7 +198,7 @@ describe('Phase 11 unified Design Control workspace', () => {
 
   it('distinguishes Revision A and Revision B+', () => {
     expect(workspace).toContain('Revision A establishes the initial baseline');
-    expect(workspace).toContain('Revision B+');
+    expect(workspace).toMatch(/Revision\s+B\+/);
   });
 
   it('reuses controlled forms, copies, and DHF panels', () => {
@@ -237,14 +235,13 @@ describe('Phase 11 unified Design Control workspace', () => {
   });
 
   it('provides labeled and keyboard-accessible controls', () => {
-    expect(workspace).toContain('aria-label="Design Control steps"');
-    expect(workspace).toContain("aria-current={selected ? 'step'");
+    expect(workspace).toContain('aria-label="Six Design Control phases"');
     expect(workspace).toContain('focus-visible:ring-2');
     expect(qms).toContain('<Label>');
   });
 
   it('communicates status with text rather than color alone', () => {
-    expect(workspace).toContain('{displayStatus(step?.status)}');
+    expect(workspace).toContain('phaseStatus(phase.stepKeys)');
     expect(qms).toContain('{statusText(row.designControlStatus)}');
   });
 


### PR DESCRIPTION
## What changed

- Fixes the blank-field auto-fill race introduced by the six-phase Design Control simplification: linked project data may populate first, then later-arriving active project-team data can populate only the remaining blank accountable-person fields.
- Preserves existing saved values and unsaved user entries.
- Adds Heated Pitot-focused synthetic regression fixtures proving project/team suggestions remain unsaved suggestions, do not overwrite saved values, and do not create checklist or approval evidence.
- Removes the hidden duplicate 12-checkpoint navigation so the six phases are the only workflow navigation presented; the underlying twelve controlled stages and records remain intact.
- Updates source-shape assertions for the visible six-phase navigation and preserved Revision A / Revision B+ distinction.

## Context

PR #1770 was merged before this follow-up work began. This PR contains only the post-merge corrections and is based on current `main`.

## Validation

- Focused Design Control client suites: **16/16 passed**
- Focused Design Control server/workspace assertions: **23/23 passed**
- Touched-file ESLint: **passed** (`ESLINT_EXIT=0`)
- Prettier on touched files: **passed**
- `git diff --check origin/main...HEAD`: **passed**
- `git merge-tree --write-tree origin/main HEAD`: **passed**
- Repository-wide TypeScript: default 2 GB run exited `134` with heap exhaustion; a scoped 4 GB retry consumed approximately 4.25 GB and terminated without a captured successful exit or TypeScript diagnostic. It is **not reported as passed**.
- Production Vite build reached transformation but exited without producing `dist` or a captured successful exit. It is **not reported as passed**.
- PostgreSQL-backed tests were not run because no database behavior or migration changed.

No Heated Pitot or other Design Control data was deleted; the correction did not require it. Nothing was deployed, enabled, or written to production.