### PR TITLE
Prevent project detail crash on non-array API responses

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -777,8 +777,8 @@ export default function ProjectDetailPage() {
     enabled: !!id && !!activeLinkPoId,
   });
 
-  const poItemOptions = poLinkOptions?.poItems ?? [];
-  const billingBucketOptions = (poLinkOptions?.billingBuckets ?? []).filter((bucket) => {
+  const poItemOptions = normalizeArray<P2PurchaseOrderItem>(poLinkOptions?.poItems);
+  const billingBucketOptions = normalizeArray<P2BillingBucketOption>(poLinkOptions?.billingBuckets).filter((bucket) => {
     if (!linkPoItemId) return true;
     return !bucket.poItemId || bucket.poItemId === Number(linkPoItemId);
   });
@@ -833,11 +833,12 @@ export default function ProjectDetailPage() {
     });
   };
 
-  const { data: projectRevisions = [] } = useQuery<ProjectRevision[]>({
+  const { data: projectRevisionsRaw } = useQuery<ProjectRevision[]>({
     queryKey: ['/api/projects', id, 'revisions'],
     queryFn: () => fetch(`/api/projects/${id}/revisions`, { credentials: 'include' }).then(r => r.json()),
     enabled: !!id,
   });
+  const projectRevisions = normalizeArray<ProjectRevision>(projectRevisionsRaw);
 
   const createRevisionMutation = useMutation({
     mutationFn: (data: typeof revisionForm) =>
@@ -887,16 +888,18 @@ export default function ProjectDetailPage() {
     queryClient.invalidateQueries({ queryKey: ['/api/p2/control-center/po-statuses'] });
   };
 
-  const { data: projectWorkOrders = [] } = useQuery<ProjectWorkOrder[]>({
+  const { data: projectWorkOrdersRaw } = useQuery<ProjectWorkOrder[]>({
     queryKey: ['/api/work-orders/project', id],
     queryFn: () => fetch(`/api/work-orders/project/${id}`).then(r => r.json()),
     enabled: !!id,
   });
+  const projectWorkOrders = normalizeArray<ProjectWorkOrder>(projectWorkOrdersRaw);
 
-  const { data: allStepAttachments = [] } = useQuery<StepAttachment[]>({
+  const { data: allStepAttachmentsRaw } = useQuery<StepAttachment[]>({
     queryKey: ['/api/project-step-attachments/by-project', id],
     enabled: !!id,
   });
+  const allStepAttachments = normalizeArray<StepAttachment>(allStepAttachmentsRaw);
 
   const { data: traceability, isLoading: isLoadingTraceability } = useQuery<TraceabilityData>({
     queryKey: ['/api/projects', id, 'traceability'],
@@ -1279,11 +1282,12 @@ export default function ProjectDetailPage() {
     { label: 'Profit / Fee', value: formatCurrencyLabel(hubRom.categories?.profitFee?.budgetAmount), detail: 'Quote profit or fee target' },
   ];
 
-  const { data: projectFarFlowdowns = [] } = useQuery<ProjectFarFlowdown[]>({
+  const { data: projectFarFlowdownsRaw } = useQuery<ProjectFarFlowdown[]>({
     queryKey: ['/api/far-flowdown-clauses/project', id],
     queryFn: () => fetch(`/api/far-flowdown-clauses/project/${id}`).then(r => r.json()),
     enabled: !!id,
   });
+  const projectFarFlowdowns = normalizeArray<ProjectFarFlowdown>(projectFarFlowdownsRaw);
 
   const releaseToP2Mutation = useMutation({
     mutationFn: () => apiRequest(`/api/projects/${id}/release-to-p2`, { method: 'POST' }),
@@ -1338,11 +1342,12 @@ export default function ProjectDetailPage() {
   const [pdfPreviewTitle, setPdfPreviewTitle] = useState<string>('');
   const [uploadingExternalPdfSlipId, setUploadingExternalPdfSlipId] = useState<string | null>(null);
 
-  const { data: projectDocs = [] } = useQuery<ProjectDoc[]>({
+  const { data: projectDocsRaw } = useQuery<ProjectDoc[]>({
     queryKey: ['/api/projects', id, 'documents'],
     queryFn: () => fetch(`/api/projects/${id}/documents`).then(r => r.json()),
     enabled: !!id,
   });
+  const projectDocs = normalizeArray<ProjectDoc>(projectDocsRaw);
   const manufacturingProjectDocs = projectDocs.filter((doc) => doc.source === 'work_instruction' || doc.source === 'spec_sheet');
   const manualProjectDocs = projectDocs.filter((doc) => !doc.source || doc.source === 'manual');
 

--- a/server/__tests__/p2DepositClinTermsContact.test.ts
+++ b/server/__tests__/p2DepositClinTermsContact.test.ts
@@ -37,6 +37,13 @@ describe('P2 material deposit CLIN, terms, and contact enhancement', () => {
     expect(component).toContain('Quantity × unit price from the selected PO line.');
   });
 
+  it('supports a PO linked from the PO side when projects.po_id is empty', () => {
+    const service = read('server/src/services/p2ProjectDepositService.ts');
+    expect(service).toContain('po.project_id = ${projectId}::uuid');
+    expect(service).toContain('po.is_current_revision DESC');
+    expect(service).toContain('poId: effectivePo?.id ?? storedProject.poId');
+  });
+
   it('renders the point of contact and CLIN reference on the customer PDF', () => {
     const pdf = read('server/utils/pdf/arInvoicePdf.ts');
     expect(pdf).toContain("'POINT OF CONTACT'");

--- a/server/src/services/p2ProjectDepositService.ts
+++ b/server/src/services/p2ProjectDepositService.ts
@@ -37,7 +37,7 @@ function termsDays(terms: string): number {
 }
 
 export async function getP2ProjectDepositWorkspace(projectId: string) {
-  const [project] = await db
+  const [storedProject] = await db
     .select({
       id: projects.id,
       projectCode: projects.projectCode,
@@ -53,7 +53,34 @@ export async function getP2ProjectDepositWorkspace(projectId: string) {
     .leftJoin(p2PurchaseOrders, eq(projects.poId, p2PurchaseOrders.id))
     .where(eq(projects.id, projectId));
 
-  if (!project) throw new Error('Project not found');
+  if (!storedProject) throw new Error('Project not found');
+
+  // P2 POs can be linked in either direction. Older/project-first records use
+  // projects.po_id, while PO-first records use p2_purchase_orders.project_id.
+  // Resolve the same current revision that the Project Hub displays so deposit
+  // CLINs remain available even when only the PO-side association is populated.
+  const effectivePoResult = await db.execute(sql`
+    WITH linked_root AS (
+      SELECT COALESCE(parent_po_id, id) AS root_id
+        FROM p2_purchase_orders
+       WHERE id = ${storedProject.poId ?? null}
+    )
+    SELECT po.id, po.po_number AS "poNumber"
+      FROM p2_purchase_orders po
+     WHERE po.project_id = ${projectId}::uuid
+        OR po.id = (SELECT root_id FROM linked_root)
+        OR po.parent_po_id = (SELECT root_id FROM linked_root)
+     ORDER BY po.is_current_revision DESC,
+              po.revision_number DESC,
+              po.created_at DESC
+     LIMIT 1
+  `);
+  const effectivePo = effectivePoResult.rows[0] as { id: number; poNumber: string } | undefined;
+  const project = {
+    ...storedProject,
+    poId: effectivePo?.id ?? storedProject.poId,
+    poNumber: effectivePo?.poNumber ?? storedProject.poNumber,
+  };
 
   // Project deposits are created before shipping, so p2_billing_allocations may
   // not exist yet. Build the selectable CLIN list from the linked customer PO:


### PR DESCRIPTION
## What changed
- Normalizes project detail collection responses before filtering or rendering them.
- Covers revisions, work orders, attachments, FAR flowdowns, project documents, PO items, and billing buckets.

## Root cause
The project page assumed each collection endpoint always returned a raw array. At least one production response was an object or response envelope, so calling .filter() crashed the entire page with Rt.filter is not a function.

## Impact
The project page now loads safely even when one collection response is wrapped or unavailable; the affected subsection renders empty instead of taking down the application.

## Validation
- git diff --check`n- Production Vite build completed successfully