### PR TITLE
Apply P2 deposit migrations during production boot

### DIFF
--- a/client/src/components/p2/P2ProjectDepositsCard.tsx
+++ b/client/src/components/p2/P2ProjectDepositsCard.tsx
@@ -40,6 +40,9 @@ export default function P2ProjectDepositsCard({ projectId }: { projectId: string
   const deposits = workspace.data?.deposits || [];
   const finalInvoices = workspace.data?.finalInvoices || [];
   const clins = workspace.data?.clins || [];
+  const workspaceError = workspace.error instanceof Error
+    ? workspace.error.message
+    : 'The material-deposit workspace could not be loaded.';
   const updateAllocationClin = (index: number, clinId: string) => {
     const selectedClin = clins.find((clin: any) => String(clin.id) === clinId);
     setAllocations(allocations.map((row, rowIndex) => rowIndex === index ? {
@@ -137,7 +140,13 @@ export default function P2ProjectDepositsCard({ projectId }: { projectId: string
             <div className="md:col-span-2 rounded-md border p-3"><p className="mb-3 font-medium">Point of Contact</p><div className="grid gap-3 md:grid-cols-3"><div><Label>Name *</Label><Input value={form.pointOfContactName} onChange={(e) => setForm({ ...form, pointOfContactName: e.target.value })} /></div><div><Label>Phone *</Label><Input value={form.pointOfContactPhone} onChange={(e) => setForm({ ...form, pointOfContactPhone: e.target.value })} /></div><div><Label>Email *</Label><Input type="email" value={form.pointOfContactEmail} onChange={(e) => setForm({ ...form, pointOfContactEmail: e.target.value })} /></div></div></div>
             <div className="md:col-span-2 space-y-3 rounded-md border p-3">
               <div className="flex items-center justify-between"><div><p className="font-medium">CLIN Allocations</p><p className="text-xs text-muted-foreground">Allocate this deposit by fixed amount or as a percentage of the CLIN contract value.</p></div><Button type="button" size="sm" variant="outline" onClick={() => setAllocations([...allocations, emptyAllocation()])}>Add CLIN</Button></div>
-              {clins.length === 0 && <p className="rounded bg-amber-50 p-2 text-sm text-amber-900">No PO lines are available for this project. Link an active customer PO with line items before creating a deposit invoice.</p>}
+              {workspace.isError ? (
+                <p className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-800">
+                  Unable to load PO lines: {workspaceError}
+                </p>
+              ) : clins.length === 0 ? (
+                <p className="rounded bg-amber-50 p-2 text-sm text-amber-900">No PO lines are available for this project. Link an active customer PO with line items before creating a deposit invoice.</p>
+              ) : null}
               {allocations.map((allocation, index) => <div key={index} className="grid gap-2 rounded border p-3 md:grid-cols-6">
                 <div className="md:col-span-2"><Label>PO line / CLIN *</Label><Select value={allocation.clinId} onValueChange={(value) => updateAllocationClin(index, value)}><SelectTrigger><SelectValue placeholder="Select PO line" /></SelectTrigger><SelectContent>{clins.map((clin: any) => <SelectItem key={clin.id} value={String(clin.id)}>Line {clin.clinNumber}{clin.description ? ` - ${clin.description}` : ''}{Number(clin.contractLineValue || 0) > 0 ? ` (${money(clin.contractLineValue)})` : ''}</SelectItem>)}</SelectContent></Select></div>
                 <div className="md:col-span-2"><Label>Method *</Label><Select value={allocation.calculationMethod} onValueChange={(value: 'FIXED_AMOUNT' | 'PERCENTAGE') => setAllocations(allocations.map((row, rowIndex) => rowIndex === index ? { ...row, calculationMethod: value } : row))}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="FIXED_AMOUNT">Fixed amount</SelectItem><SelectItem value="PERCENTAGE">Percentage</SelectItem></SelectContent></Select></div>

--- a/server/__tests__/p2MaterialDepositsAndSettlements.test.ts
+++ b/server/__tests__/p2MaterialDepositsAndSettlements.test.ts
@@ -13,12 +13,18 @@ describe('P2 material deposits and customer payment settlements', () => {
   const invoicePdf = read('server/utils/pdf/arInvoicePdf.ts');
   const invoiceRoutes = read('server/src/routes/arInvoices.ts');
   const invoiceDetail = read('client/src/pages/InvoiceDetailPage.tsx');
+  const safeBootMigrations = read('server/scripts/migrations/runSafeBootMigrations.ts');
 
   it('uses an additive migration accepted by the safety scanner', () => {
     expect(() => runMigrationSafetyCheck(migration, '0285_p2_material_deposits_and_payment_settlements.sql')).not.toThrow();
     expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS p2_deposit_applications/i);
     expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS ar_payment_settlements/i);
     expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS ar_payment_settlement_items/i);
+  });
+
+  it('applies the deposit schema during every production boot', () => {
+    expect(safeBootMigrations).toContain("'0285_p2_material_deposits_and_payment_settlements.sql'");
+    expect(safeBootMigrations).toContain("'0287_p2_deposit_invoice_clin_contact.sql'");
   });
 
   it('posts deposit invoices and applications through Customer Deposits', () => {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -344,6 +344,8 @@ export const safeMigrationFiles = [
   '0281_contain_shipped_p1_auto_populate_regression.sql',
   '0282_car_form_data.sql',
   '0283_remove_legacy_rma_change_control_projections.sql',
+  '0285_p2_material_deposits_and_payment_settlements.sql',
+  '0287_p2_deposit_invoice_clin_contact.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -432,6 +434,8 @@ export const criticalMigrationFiles = new Set([
   '0281_contain_shipped_p1_auto_populate_regression.sql',
   '0282_car_form_data.sql',
   '0283_remove_legacy_rma_change_control_projections.sql',
+  '0285_p2_material_deposits_and_payment_settlements.sql',
+  '0287_p2_deposit_invoice_clin_contact.sql',
 ]);
 
 export async function runSafeBootMigrations() {


### PR DESCRIPTION
## Root cause
The material-deposit endpoint was live, but production boot did not include migrations 0285 and 0287. The live API failed with elation p2_deposit_applications does not exist, and the modal misleadingly displayed that as no PO lines.

## What changed
- Add the P2 material-deposit schema migrations to the mandatory safe production boot sequence.
- Mark both migrations critical so deployment fails visibly instead of serving a partially installed workflow.
- Show the actual workspace API error in the deposit modal instead of an incorrect no-PO message.

## Validation
- 12 focused server tests passed.
- Migration safety checks passed.
- Production Vite build completed successfully.
- Live browser inspection confirmed the missing production relation was the active failure.