### PR TITLE
Correct PO00021498 customer line order

### DIFF
--- a/migrations/0289_correct_po00021498_customer_line_numbers.sql
+++ b/migrations/0289_correct_po00021498_customer_line_numbers.sql
@@ -1,0 +1,89 @@
+-- Add an explicit customer PO line / CLIN to P2 PO items, then correct the
+-- first two lines of Astrion PO00021498 without changing item identities.
+
+ALTER TABLE p2_purchase_order_items
+  ADD COLUMN IF NOT EXISTS customer_po_line text;
+
+DO $$
+DECLARE
+  before_rows jsonb;
+  after_rows jsonb;
+BEGIN
+  SELECT jsonb_agg(
+           jsonb_build_object(
+             'id', poi.id,
+             'partNumber', poi.part_number,
+             'customerPoLine', poi.customer_po_line
+           ) ORDER BY poi.id
+         )
+    INTO before_rows
+    FROM p2_purchase_order_items poi
+    JOIN p2_purchase_orders po ON po.id = poi.po_id
+   WHERE po.po_number = 'PO00021498'
+     AND (
+       poi.part_number LIKE 'AG-PRIV-01%'
+       OR poi.part_number LIKE 'AG-LAUN-01%'
+     );
+
+  IF EXISTS (
+    SELECT 1
+      FROM p2_purchase_order_items poi
+      JOIN p2_purchase_orders po ON po.id = poi.po_id
+     WHERE po.po_number = 'PO00021498'
+       AND (
+         (poi.part_number LIKE 'AG-PRIV-01%' AND poi.customer_po_line IS DISTINCT FROM '1')
+         OR (poi.part_number LIKE 'AG-LAUN-01%' AND poi.customer_po_line IS DISTINCT FROM '2')
+       )
+  ) THEN
+    UPDATE p2_purchase_order_items poi
+       SET customer_po_line = CASE
+         WHEN poi.part_number LIKE 'AG-PRIV-01%' THEN '1'
+         WHEN poi.part_number LIKE 'AG-LAUN-01%' THEN '2'
+         ELSE poi.customer_po_line
+       END,
+       updated_at = now()
+      FROM p2_purchase_orders po
+     WHERE po.id = poi.po_id
+       AND po.po_number = 'PO00021498'
+       AND (
+         poi.part_number LIKE 'AG-PRIV-01%'
+         OR poi.part_number LIKE 'AG-LAUN-01%'
+       );
+
+    SELECT jsonb_agg(
+             jsonb_build_object(
+               'id', poi.id,
+               'partNumber', poi.part_number,
+               'customerPoLine', poi.customer_po_line
+             ) ORDER BY poi.id
+           )
+      INTO after_rows
+      FROM p2_purchase_order_items poi
+      JOIN p2_purchase_orders po ON po.id = poi.po_id
+     WHERE po.po_number = 'PO00021498'
+       AND (
+         poi.part_number LIKE 'AG-PRIV-01%'
+         OR poi.part_number LIKE 'AG-LAUN-01%'
+       );
+
+    INSERT INTO schema_change_log (
+      actor,
+      action_type,
+      table_name,
+      column_name,
+      before_state,
+      after_state,
+      approved_by,
+      override_reason
+    ) VALUES (
+      'migration:0289',
+      'OVERRIDE',
+      'p2_purchase_order_items',
+      'customer_po_line',
+      before_rows,
+      after_rows,
+      'Glenn Jones',
+      'Correct PO00021498 customer line order: AG-PRIV-01 is Line 1 and AG-LAUN-01 is Line 2.'
+    );
+  END IF;
+END $$;

--- a/server/__tests__/p2DepositClinTermsContact.test.ts
+++ b/server/__tests__/p2DepositClinTermsContact.test.ts
@@ -30,11 +30,24 @@ describe('P2 material deposit CLIN, terms, and contact enhancement', () => {
     expect(service).toContain('FROM p2_billing_allocations');
     expect(service).toContain('FROM p2_purchase_order_items');
     expect(service).toContain('quantity::numeric * unit_price::numeric');
+    expect(service).toContain("NULLIF(BTRIM(customer_po_line), '')");
     expect(service).toContain('onConflictDoUpdate');
     expect(service).toContain('clin.contractLineValue ?? allocation.contractLineValue');
     expect(component).toContain('updateAllocationClin');
     expect(component).toContain('Full PO line value');
     expect(component).toContain('Quantity × unit price from the selected PO line.');
+  });
+
+  it('installs the audited PO00021498 line-number correction at boot', () => {
+    const migration = read('migrations/0289_correct_po00021498_customer_line_numbers.sql');
+    const boot = read('server/scripts/migrations/runSafeBootMigrations.ts');
+    expect(() => runMigrationSafetyCheck(migration, '0289_correct_po00021498_customer_line_numbers.sql')).not.toThrow();
+    expect(migration).toContain("po.po_number = 'PO00021498'");
+    expect(migration).toContain("AG-PRIV-01%' THEN '1'");
+    expect(migration).toContain("AG-LAUN-01%' THEN '2'");
+    expect(migration).toContain('INSERT INTO schema_change_log');
+    expect(migration).toContain("'OVERRIDE'");
+    expect(boot).toContain("'0289_correct_po00021498_customer_line_numbers.sql'");
   });
 
   it('supports a PO linked from the PO side when projects.po_id is empty', () => {

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -6341,6 +6341,7 @@ export const p2PurchaseOrderItems = pgTable(
     ), // FK to inventory_items
     partNumber: text('part_number').notNull(), // P2-specific part number
     partName: text('part_name').notNull(), // Display name for the part
+    customerPoLine: text('customer_po_line'), // Customer-assigned PO line / CLIN
     quantity: integer('quantity').notNull(),
     demandLineIdentity: uuid('demand_line_identity').defaultRandom().notNull(),
     dueDate: date('due_date'),

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -346,6 +346,7 @@ export const safeMigrationFiles = [
   '0283_remove_legacy_rma_change_control_projections.sql',
   '0285_p2_material_deposits_and_payment_settlements.sql',
   '0287_p2_deposit_invoice_clin_contact.sql',
+  '0289_correct_po00021498_customer_line_numbers.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -436,6 +437,7 @@ export const criticalMigrationFiles = new Set([
   '0283_remove_legacy_rma_change_control_projections.sql',
   '0285_p2_material_deposits_and_payment_settlements.sql',
   '0287_p2_deposit_invoice_clin_contact.sql',
+  '0289_correct_po00021498_customer_line_numbers.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/services/p2ProjectDepositService.ts
+++ b/server/src/services/p2ProjectDepositService.ts
@@ -101,7 +101,10 @@ export async function getP2ProjectDepositWorkspace(projectId: string) {
          AND NULLIF(BTRIM(customer_po_line), '') IS NOT NULL
        GROUP BY NULLIF(BTRIM(customer_po_line), '')
     ), po_item_clins AS (
-      SELECT ROW_NUMBER() OVER (ORDER BY id)::text AS "clinNumber",
+      SELECT COALESCE(
+               NULLIF(BTRIM(customer_po_line), ''),
+               ROW_NUMBER() OVER (ORDER BY id)::text
+             ) AS "clinNumber",
              CONCAT(part_number, CASE WHEN NULLIF(BTRIM(part_name), '') IS NOT NULL THEN ' - ' || part_name ELSE '' END) AS description,
              COALESCE(total_price::numeric, quantity::numeric * unit_price::numeric, 0)::numeric AS "contractLineValue",
              2 AS source_priority


### PR DESCRIPTION
## What changed
- Adds an explicit customer PO line/CLIN field to P2 PO items so CLIN identity is no longer inferred solely from database insertion order.
- Applies an idempotent one-time correction for Astrion PO00021498:
  - AG-PRIV-01 Rev A → Line 1
  - AG-LAUN-01 Rev A → Line 2
- Updates material-deposit CLIN choices to prefer the explicit customer PO line.
- Records the affected rows' before/after state in schema_change_log with Glenn Jones as approver.

## Safety
- Does not change item IDs, quantities, prices, demand identities, or the third PO line.
- Re-running the migration is a no-op after the desired line mapping exists.

## Validation
- 13 focused deposit/CLIN tests passed.
- Migration safety checks passed.
- Production Vite build completed successfully.