### PR TITLE
Add exact P2 invoice email preview and Astrion renumber

### DIFF
--- a/client/src/pages/InvoiceDetailPage.tsx
+++ b/client/src/pages/InvoiceDetailPage.tsx
@@ -153,6 +153,16 @@ type InvoiceAttachment = {
 type SendInvoicePayload = {
   recipients: string[];
   attachmentMediaIds: string[];
+  customerMessage: string;
+};
+
+type InvoiceEmailPreview = {
+  to: string;
+  cc: string[];
+  subject: string;
+  text: string;
+  html: string;
+  attachments: Array<{ filename: string; type?: string; disposition?: string }>;
 };
 
 function RecipientPickerList({
@@ -235,6 +245,8 @@ export default function InvoiceDetailPage() {
   const [activeTab, setActiveTab] = useState('overview');
   const [selectedAttachmentMediaIds, setSelectedAttachmentMediaIds] = useState<string[]>([]);
   const [isLoadingRecipients, setIsLoadingRecipients] = useState(false);
+  const [customerMessage, setCustomerMessage] = useState('');
+  const [previewCustomerMessage, setPreviewCustomerMessage] = useState('');
   const [voidDialogOpen, setVoidDialogOpen] = useState(false);
   const [voidReason, setVoidReason] = useState('');
   const [selectedDepositId, setSelectedDepositId] = useState('');
@@ -274,6 +286,26 @@ export default function InvoiceDetailPage() {
     setSelectedAttachmentMediaIds(invoiceAttachments.map((item) => item.media.id));
   }, [sendDialogOpen, invoiceAttachments]);
 
+  useEffect(() => {
+    if (!sendDialogOpen) return;
+    const timer = window.setTimeout(() => setPreviewCustomerMessage(customerMessage), 350);
+    return () => window.clearTimeout(timer);
+  }, [customerMessage, sendDialogOpen]);
+
+  const emailPreview = useQuery<InvoiceEmailPreview>({
+    queryKey: ['/api/ar-invoices', id, 'email-preview', selectedRecipients, selectedAttachmentMediaIds, previewCustomerMessage],
+    queryFn: () => apiRequest(`/api/ar-invoices/${id}/email-preview`, {
+      method: 'POST',
+      body: {
+        recipients: selectedRecipients,
+        attachmentMediaIds: selectedAttachmentMediaIds,
+        customerMessage: previewCustomerMessage.trim() || undefined,
+      },
+    }),
+    enabled: sendDialogOpen && !!id && selectedRecipients.length > 0 && !isLoadingRecipients,
+    staleTime: 0,
+  });
+
   const { data: packingSlipInfo } = useQuery<any>({
     queryKey: ['/api/p2/packing-slips', invoice?.packingSlipId],
     queryFn: () => fetch(`/api/p2/packing-slips/${invoice.packingSlipId}`, { credentials: 'include' }).then(r => r.ok ? r.json() : null),
@@ -309,10 +341,10 @@ export default function InvoiceDetailPage() {
   });
 
   const sendInvoiceMutation = useMutation({
-    mutationFn: ({ recipients, attachmentMediaIds }: SendInvoicePayload) =>
+    mutationFn: ({ recipients, attachmentMediaIds, customerMessage }: SendInvoicePayload) =>
       apiRequest(`/api/ar-invoices/${id}/send`, {
         method: 'POST',
-        body: { recipients, attachmentMediaIds },
+        body: { recipients, attachmentMediaIds, customerMessage: customerMessage.trim() || undefined },
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ predicate: (query) =>
@@ -370,6 +402,8 @@ export default function InvoiceDetailPage() {
   };
 
   const handleOpenSendDialog = () => {
+    setCustomerMessage('');
+    setPreviewCustomerMessage('');
     setSendDialogOpen(true);
     queryClient.invalidateQueries({ queryKey: ['/api/media/attachments', 'invoice', id] });
     loadInvoiceRecipients();
@@ -1162,7 +1196,7 @@ export default function InvoiceDetailPage() {
       </Tabs>
 
       <Dialog open={sendDialogOpen} onOpenChange={setSendDialogOpen}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-3xl">
           <DialogHeader>
             <DialogTitle>Send Invoice</DialogTitle>
             <DialogDescription>
@@ -1177,6 +1211,17 @@ export default function InvoiceDetailPage() {
                 selected={selectedRecipients}
                 onChange={setSelectedRecipients}
                 isLoading={isLoadingRecipients}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="invoice-customer-message">Customer Message (optional)</Label>
+              <Textarea
+                id="invoice-customer-message"
+                rows={3}
+                value={customerMessage}
+                onChange={(event) => setCustomerMessage(event.target.value)}
+                placeholder="Leave blank to use the customer-visible notes already saved on the invoice."
               />
             </div>
 
@@ -1264,6 +1309,44 @@ export default function InvoiceDetailPage() {
                 </p>
               )}
             </div>
+
+            <div className="space-y-3 rounded-lg border p-3">
+              <div className="flex items-center justify-between gap-3">
+                <Label className="text-sm font-semibold">Email Preview</Label>
+                {(emailPreview.isFetching || customerMessage !== previewCustomerMessage) && (
+                  <span className="flex items-center gap-1 text-xs text-muted-foreground"><Loader2 className="h-3 w-3 animate-spin" /> Updating</span>
+                )}
+              </div>
+              {emailPreview.isError ? (
+                <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+                  Preview unavailable: {(emailPreview.error as Error).message}
+                </div>
+              ) : !emailPreview.data ? (
+                <div className="flex items-center gap-2 py-3 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Generating the exact customer email...
+                </div>
+              ) : (
+                <div className="space-y-3 text-sm">
+                  <div className="grid gap-2 md:grid-cols-[80px_1fr]">
+                    <span className="font-medium text-muted-foreground">Subject</span><span>{emailPreview.data.subject}</span>
+                    <span className="font-medium text-muted-foreground">To</span><span>{emailPreview.data.to}</span>
+                    <span className="font-medium text-muted-foreground">CC</span><span>{emailPreview.data.cc.length ? emailPreview.data.cc.join(', ') : 'None'}</span>
+                  </div>
+                  <div>
+                    <p className="mb-1 font-medium text-muted-foreground">HTML Body</p>
+                    <div className="rounded-md border bg-white p-3 text-black" dangerouslySetInnerHTML={{ __html: emailPreview.data.html }} />
+                  </div>
+                  <div>
+                    <p className="mb-1 font-medium text-muted-foreground">Attachments</p>
+                    <ul className="space-y-1">
+                      {emailPreview.data.attachments.map((attachment) => (
+                        <li key={attachment.filename} className="flex items-center gap-2"><Paperclip className="h-3.5 w-3.5" /> {attachment.filename}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setSendDialogOpen(false)}>
@@ -1273,8 +1356,9 @@ export default function InvoiceDetailPage() {
               onClick={() => sendInvoiceMutation.mutate({
                 recipients: selectedRecipients,
                 attachmentMediaIds: selectedAttachmentMediaIds,
+                customerMessage,
               })}
-              disabled={sendInvoiceMutation.isPending || isLoadingRecipients || selectedRecipients.length === 0}
+              disabled={sendInvoiceMutation.isPending || isLoadingRecipients || selectedRecipients.length === 0 || emailPreview.isFetching || !emailPreview.data || emailPreview.isError || customerMessage !== previewCustomerMessage}
             >
               {sendInvoiceMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Send Invoice

--- a/client/src/pages/InvoicesPage.tsx
+++ b/client/src/pages/InvoicesPage.tsx
@@ -455,17 +455,6 @@ export default function InvoicesPage() {
     onSettled: () => setPendingId(null),
   });
 
-  const sendMutation = useMutation({
-    mutationFn: (id: string) => apiRequest(`/api/ar-invoices/${id}/send`, { method: 'POST', body: {} }),
-    onMutate: (id) => setPendingId(id),
-    onSuccess: () => {
-      toast({ title: 'Invoice marked as sent' });
-      invalidateAll();
-    },
-    onError: (err: any) => toast({ title: 'Error', description: err.message, variant: 'destructive' }),
-    onSettled: () => setPendingId(null),
-  });
-
   const voidMutation = useMutation({
     mutationFn: ({ id, reason }: { id: string; reason: string }) =>
       apiRequest(`/api/ar-invoices/${id}/void`, { method: 'POST', body: { voidReason: reason } }),
@@ -480,7 +469,7 @@ export default function InvoicesPage() {
   });
 
   const handlePost = (id: string) => postMutation.mutate(id);
-  const handleSend = (id: string) => sendMutation.mutate(id);
+  const handleSend = (id: string) => setLocation(`/finance/invoices/${id}`);
   const handleVoidRequest = (id: string, invoiceNumber: string) =>
     setVoidDialog({ open: true, invoiceId: id, invoiceNumber, reason: '' });
   const handleView = (id: string) => setLocation(`/finance/invoices/${id}`);
@@ -503,7 +492,7 @@ export default function InvoicesPage() {
     onVoidRequest: handleVoidRequest,
     onView: handleView,
     postPending: postMutation.isPending,
-    sendPending: sendMutation.isPending,
+    sendPending: false,
     voidPending: voidMutation.isPending,
     pendingId,
   };

--- a/migrations/0291_renumber_astrion_material_deposit_invoice.sql
+++ b/migrations/0291_renumber_astrion_material_deposit_invoice.sql
@@ -1,0 +1,131 @@
+-- One-time audited correction for Astrion's first P2 material-deposit invoice.
+-- AST26-0002 was reserved before the invoice workflow was finalized; make it
+-- AST26-0001 and leave the 2026 sequence at 1 so the next number is AST26-0002.
+
+DO $$
+DECLARE
+  target_invoice ar_invoices%ROWTYPE;
+  target_count integer;
+  before_sequence jsonb;
+BEGIN
+  SELECT count(*) INTO target_count
+    FROM ar_invoices
+   WHERE invoice_number = 'AST26-0002';
+
+  IF target_count = 0 THEN
+    -- Idempotent success after this correction has already been applied.
+    IF EXISTS (
+      SELECT 1
+        FROM ar_invoices invoice
+        JOIN p2_customers customer ON customer.customer_id = invoice.customer_id
+       WHERE invoice.invoice_number = 'AST26-0001'
+         AND invoice.invoice_type = 'MATERIAL_DEPOSIT'
+         AND lower(customer.customer_name) LIKE 'astrion%'
+    ) THEN
+      RETURN;
+    END IF;
+    RAISE EXCEPTION '0291 AMBIGUOUS_STOP: AST26-0002 was not found and the corrected AST26-0001 does not exist';
+  ELSIF target_count <> 1 THEN
+    RAISE EXCEPTION '0291 AMBIGUOUS_STOP: expected one AST26-0002 invoice, found %', target_count;
+  END IF;
+
+  SELECT invoice.* INTO target_invoice
+    FROM ar_invoices invoice
+    JOIN p2_customers customer ON customer.customer_id = invoice.customer_id
+   WHERE invoice.invoice_number = 'AST26-0002'
+     AND invoice.invoice_type = 'MATERIAL_DEPOSIT'
+     AND invoice.status IN ('DRAFT', 'REVIEW')
+     AND invoice.posted_at IS NULL
+     AND invoice.sent_at IS NULL
+     AND invoice.packing_slip_id IS NULL
+     AND lower(customer.customer_name) LIKE 'astrion%';
+
+  IF target_invoice.id IS NULL THEN
+    RAISE EXCEPTION '0291 AMBIGUOUS_STOP: AST26-0002 is not an unposted, unsent Astrion material-deposit invoice';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM ar_invoices WHERE invoice_number = 'AST26-0001') THEN
+    RAISE EXCEPTION '0291 AMBIGUOUS_STOP: AST26-0001 is already assigned to another invoice';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM ar_invoices
+     WHERE customer_id = target_invoice.customer_id
+       AND id <> target_invoice.id
+       AND invoice_number ~ '^AST26-[0-9]+$'
+  ) OR EXISTS (
+    SELECT 1 FROM p2_packing_slips
+     WHERE customer_id = target_invoice.customer_id
+       AND invoice_number ~ '^AST26-[0-9]+$'
+  ) THEN
+    RAISE EXCEPTION '0291 AMBIGUOUS_STOP: another Astrion 2026 invoice reservation exists; sequence cannot be safely rewound';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM p2_invoice_number_configs
+     WHERE customer_id = target_invoice.customer_id
+       AND prefix = 'AST'
+  ) THEN
+    RAISE EXCEPTION '0291 AMBIGUOUS_STOP: Astrion invoice-number configuration is not prefix AST';
+  END IF;
+
+  SELECT to_jsonb(sequence_row) INTO before_sequence
+    FROM p2_invoice_number_sequences sequence_row
+   WHERE sequence_row.customer_id = target_invoice.customer_id
+     AND sequence_row.year = 2026;
+
+  UPDATE ar_invoices
+     SET invoice_number = 'AST26-0001',
+         updated_at = now()
+   WHERE id = target_invoice.id;
+
+  INSERT INTO p2_invoice_number_sequences (customer_id, prefix, year, last_number, updated_at)
+  VALUES (target_invoice.customer_id, 'AST', 2026, 1, now())
+  ON CONFLICT (customer_id, year)
+  DO UPDATE SET prefix = 'AST', last_number = 1, updated_at = now();
+
+  INSERT INTO p2_invoice_number_audit (
+    invoice_id,
+    customer_id,
+    old_invoice_number,
+    new_invoice_number,
+    action,
+    reason,
+    changed_by,
+    metadata
+  ) VALUES (
+    target_invoice.id,
+    target_invoice.customer_id,
+    'AST26-0002',
+    'AST26-0001',
+    'ONE_TIME_INVOICE_RENUMBER',
+    'Correct Astrion first material-deposit invoice number after the CLIN/PO-line workflow adjustment; reset the 2026 customer sequence so the next invoice is AST26-0002.',
+    'migration:0291 approved by Glenn Jones',
+    jsonb_build_object(
+      'invoiceType', target_invoice.invoice_type,
+      'invoiceStatus', target_invoice.status,
+      'sequenceBefore', before_sequence,
+      'sequenceAfter', jsonb_build_object('prefix', 'AST', 'year', 2026, 'lastNumber', 1)
+    )
+  );
+
+  INSERT INTO schema_change_log (
+    actor,
+    action_type,
+    table_name,
+    column_name,
+    before_state,
+    after_state,
+    approved_by,
+    override_reason
+  ) VALUES (
+    'migration:0291',
+    'OVERRIDE',
+    'ar_invoices',
+    'invoice_number',
+    jsonb_build_object('invoiceId', target_invoice.id, 'invoiceNumber', 'AST26-0002', 'sequence', before_sequence),
+    jsonb_build_object('invoiceId', target_invoice.id, 'invoiceNumber', 'AST26-0001', 'sequence', jsonb_build_object('prefix', 'AST', 'year', 2026, 'lastNumber', 1)),
+    'Glenn Jones',
+    'Renumber the first Astrion material-deposit invoice and safely reset that customer''s 2026 invoice sequence.'
+  );
+END $$;

--- a/server/__tests__/arInvoiceEmailPreviewParity.test.ts
+++ b/server/__tests__/arInvoiceEmailPreviewParity.test.ts
@@ -40,4 +40,10 @@ describe('AR invoice email preview parity', () => {
     expect(sendRoute).toContain('prepareInvoiceEmail(invoice, req.body || {})');
     expect(sendRoute).toContain('toSendGridInvoiceMessage(envelope)');
   });
+
+  it('does not allow the invoice list shortcut to bypass the reviewed send modal', () => {
+    const page = fs.readFileSync(path.join(process.cwd(), 'client/src/pages/InvoicesPage.tsx'), 'utf8');
+    expect(page).not.toContain("apiRequest(`/api/ar-invoices/${id}/send`");
+    expect(page).toContain('const handleSend = (id: string) => setLocation(`/finance/invoices/${id}`)');
+  });
 });

--- a/server/__tests__/arInvoiceEmailPreviewParity.test.ts
+++ b/server/__tests__/arInvoiceEmailPreviewParity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  buildInvoiceEmailEnvelope,
+  toInvoiceEmailPreview,
+  toSendGridInvoiceMessage,
+} from '../src/services/arInvoiceEmailService';
+
+describe('AR invoice email preview parity', () => {
+  it('uses identical recipients, subject, body, and attachment names for preview and delivery', () => {
+    const envelope = buildInvoiceEmailEnvelope({
+      invoiceNumber: 'MI26-300',
+      invoiceType: 'MATERIAL_DEPOSIT',
+      totalAmount: '25000.00',
+      dueDate: '2026-09-17',
+      customerMessage: 'Deposit for PO Line 1.',
+      isP1: false,
+      to: 'ap@example.com',
+      cc: ['buyer@example.com'],
+      attachments: [{ filename: 'Material-Deposit-Invoice-MI26-300.pdf', content: 'base64-pdf', type: 'application/pdf', disposition: 'attachment' }],
+    });
+    const preview = toInvoiceEmailPreview(envelope);
+    const sent = toSendGridInvoiceMessage(envelope);
+
+    expect(preview.subject).toBe('Material Deposit Invoice MI26-300');
+    expect(preview.to).toBe(sent.to);
+    expect(preview.cc).toEqual(sent.cc);
+    expect(preview.subject).toBe(sent.subject);
+    expect(preview.text).toBe(sent.text);
+    expect(preview.html).toBe(sent.html);
+    expect(preview.attachments.map((item) => item.filename)).toEqual(sent.attachments.map((item) => item.filename));
+  });
+
+  it('routes both preview and send through the same server preparation function', () => {
+    const route = fs.readFileSync(path.join(process.cwd(), 'server/src/routes/arInvoices.ts'), 'utf8');
+    const previewRoute = route.slice(route.indexOf("router.post('/:id/email-preview'"), route.indexOf("router.post('/:id/send'"));
+    const sendRoute = route.slice(route.indexOf("router.post('/:id/send'"), route.indexOf("router.post('/:id/void'"));
+    expect(previewRoute).toContain('prepareInvoiceEmail(invoice, req.body || {})');
+    expect(sendRoute).toContain('prepareInvoiceEmail(invoice, req.body || {})');
+    expect(sendRoute).toContain('toSendGridInvoiceMessage(envelope)');
+  });
+});

--- a/server/__tests__/p2DepositClinTermsContact.test.ts
+++ b/server/__tests__/p2DepositClinTermsContact.test.ts
@@ -52,6 +52,21 @@ describe('P2 material deposit CLIN, terms, and contact enhancement', () => {
     expect(boot).toContain("'0290_p2_po_line_and_clin_distinction.sql'");
   });
 
+  it('safely renumbers the first Astrion material-deposit invoice and resets only its sequence', () => {
+    const migration = read('migrations/0291_renumber_astrion_material_deposit_invoice.sql');
+    const boot = read('server/scripts/migrations/runSafeBootMigrations.ts');
+    expect(() => runMigrationSafetyCheck(migration, '0291_renumber_astrion_material_deposit_invoice.sql')).not.toThrow();
+    expect(migration).toContain("invoice_number = 'AST26-0002'");
+    expect(migration).toContain("SET invoice_number = 'AST26-0001'");
+    expect(migration).toContain("invoice.invoice_type = 'MATERIAL_DEPOSIT'");
+    expect(migration).toContain("invoice.status IN ('DRAFT', 'REVIEW')");
+    expect(migration).toContain("last_number = 1");
+    expect(migration).toContain('INSERT INTO p2_invoice_number_audit');
+    expect(migration).toContain('INSERT INTO schema_change_log');
+    expect(migration).toContain('AMBIGUOUS_STOP');
+    expect(boot).toContain("'0291_renumber_astrion_material_deposit_invoice.sql'");
+  });
+
   it('installs the audited PO00021498 line-number correction at boot', () => {
     const migration = read('migrations/0289_correct_po00021498_customer_line_numbers.sql');
     const boot = read('server/scripts/migrations/runSafeBootMigrations.ts');

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -348,6 +348,7 @@ export const safeMigrationFiles = [
   '0287_p2_deposit_invoice_clin_contact.sql',
   '0289_correct_po00021498_customer_line_numbers.sql',
   '0290_p2_po_line_and_clin_distinction.sql',
+  '0291_renumber_astrion_material_deposit_invoice.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -440,6 +441,7 @@ export const criticalMigrationFiles = new Set([
   '0287_p2_deposit_invoice_clin_contact.sql',
   '0289_correct_po00021498_customer_line_numbers.sql',
   '0290_p2_po_line_and_clin_distinction.sql',
+  '0291_renumber_astrion_material_deposit_invoice.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/arInvoices.ts
+++ b/server/src/routes/arInvoices.ts
@@ -39,6 +39,12 @@ import {
   recordP2InvoiceNumberAudit,
   syncP2InvoiceSequenceFromManualNumber,
 } from '../services/p2InvoiceNumberService';
+import {
+  buildInvoiceEmailEnvelope,
+  invoiceDocumentLabel,
+  toInvoiceEmailPreview,
+  toSendGridInvoiceMessage,
+} from '../services/arInvoiceEmailService';
 
 const LOCKED_STATUSES = ['POSTED', 'VOID', 'PAID'];
 
@@ -1995,6 +2001,67 @@ async function getLotFileAttachments(lotId: string | null) {
   return attachments;
 }
 
+async function prepareInvoiceEmail(
+  invoice: typeof arInvoices.$inferSelect,
+  body: {
+    recipients?: unknown;
+    customerMessage?: unknown;
+    attachmentMediaIds?: unknown;
+  } = {},
+) {
+  const selectedInvoiceAttachmentIds = Array.isArray(body.attachmentMediaIds)
+    ? new Set(body.attachmentMediaIds.filter((mediaId: unknown): mediaId is string => typeof mediaId === 'string' && Boolean(mediaId.trim())))
+    : undefined;
+  const customerMessage = typeof body.customerMessage === 'string' ? body.customerMessage : undefined;
+  const isP1 = await isP1Invoice(invoice);
+  const availableRecipients = await getInvoiceEmailRecipients(invoice);
+  const { to, cc: selectedCc } = deriveInvoiceToAndCc(body.recipients, availableRecipients);
+  if (!to) {
+    const error = new Error('No customer email found. Add a customer contact email or provide a recipient.');
+    (error as any).statusCode = 422;
+    throw error;
+  }
+  const cc = appendAccountingInvoiceCc(to, selectedCc);
+  const invoicePdf = await generateArInvoicePdf(invoice.id);
+  const mediaEmailAttachments = await getMediaEmailAttachments([
+    { entityType: 'invoice', entityId: invoice.id },
+    ...(invoice.packingSlipId ? [{ entityType: 'packing_slip', entityId: invoice.packingSlipId }] : []),
+    ...(invoice.lotId ? [{ entityType: 'lot', entityId: invoice.lotId }] : []),
+  ], { invoiceAttachmentMediaIds: selectedInvoiceAttachmentIds });
+  const lotAttachments = await getLotFileAttachments(invoice.lotId);
+  const documentLabel = invoiceDocumentLabel(invoice.invoiceType);
+  const attachments = [
+    {
+      content: invoicePdf.toString('base64'),
+      filename: `${documentLabel.replace(/\s+/g, '-')}-${invoice.invoiceNumber}.pdf`,
+      type: 'application/pdf',
+      disposition: 'attachment',
+    },
+    ...mediaEmailAttachments,
+    ...lotAttachments,
+  ];
+  const envelope = buildInvoiceEmailEnvelope({
+    invoiceNumber: invoice.invoiceNumber,
+    invoiceType: invoice.invoiceType,
+    totalAmount: invoice.totalAmount,
+    dueDate: invoice.dueDate,
+    customerVisibleNotes: invoice.customerVisibleNotes,
+    customerMessage,
+    isP1,
+    to,
+    cc,
+    attachments,
+  });
+
+  return {
+    envelope,
+    availableRecipients,
+    selectedInvoiceAttachmentIds,
+    customerMessage,
+    isP1,
+  };
+}
+
 router.get('/:id/email-recipients', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
@@ -2028,14 +2095,31 @@ router.get('/:id/email-recipients', async (req: Request, res: Response) => {
   }
 });
 
+router.post('/:id/email-preview', requirePermission('finance.post_invoice'), async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const [invoice] = await db.select().from(arInvoices).where(eq(arInvoices.id, id));
+    if (!invoice) return res.status(404).json({ error: 'Invoice not found' });
+    if (!['REVIEW', 'POSTED', 'SENT'].includes(invoice.status)) {
+      return res.status(409).json({ error: `Cannot preview an invoice email with status ${invoice.status}` });
+    }
+    if (invoice.pricingMismatch || invoice.pricingAmbiguous) {
+      return res.status(409).json({ error: 'Invoice pricing must be resolved before previewing or sending' });
+    }
+
+    const prepared = await prepareInvoiceEmail(invoice, req.body || {});
+    res.json(toInvoiceEmailPreview(prepared.envelope));
+  } catch (error: any) {
+    console.error('Failed to preview invoice email:', error);
+    res.status(error?.statusCode || 500).json({ error: error?.message || 'Failed to preview invoice email' });
+  }
+});
+
 router.post('/:id/send', requirePermission('finance.post_invoice'), async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const user = (req as any).user?.username || null;
-    const { recipients: selectedRecipients, customerMessage, attachmentMediaIds } = req.body || {};
-    const selectedInvoiceAttachmentIds = Array.isArray(attachmentMediaIds)
-      ? new Set(attachmentMediaIds.filter((mediaId: unknown): mediaId is string => typeof mediaId === 'string' && Boolean(mediaId.trim())))
-      : undefined;
+    const { recipients: selectedRecipients } = req.body || {};
 
     const [invoice] = await db.select().from(arInvoices).where(eq(arInvoices.id, id));
     if (!invoice) {
@@ -2048,13 +2132,9 @@ router.post('/:id/send', requirePermission('finance.post_invoice'), async (req: 
       return res.status(409).json({ error: 'Invoice pricing must be resolved before sending' });
     }
 
-    const isP1 = await isP1Invoice(invoice);
-    const availableRecipients = await getInvoiceEmailRecipients(invoice);
-    const { to, cc: selectedCc } = deriveInvoiceToAndCc(selectedRecipients, availableRecipients);
-    if (!to) {
-      return res.status(422).json({ error: 'No customer email found. Add a customer contact email or provide a recipient.' });
-    }
-    const cc = appendAccountingInvoiceCc(to, selectedCc);
+    const prepared = await prepareInvoiceEmail(invoice, req.body || {});
+    const { envelope, availableRecipients, selectedInvoiceAttachmentIds, customerMessage, isP1 } = prepared;
+    const { to, cc } = envelope;
 
     const selectedRecipientRecords = availableRecipients.filter((recipient) =>
       [to, ...(Array.isArray(cc) ? cc : cc ? [cc] : [])].includes(recipient.email)
@@ -2081,42 +2161,7 @@ router.post('/:id/send', requirePermission('finance.post_invoice'), async (req: 
       payload: auditPayloadBase,
     });
 
-    const invoicePdf = await generateArInvoicePdf(id);
-    const mediaAttachments = await getMediaEmailAttachments([
-      { entityType: 'invoice', entityId: id },
-      ...(invoice.packingSlipId ? [{ entityType: 'packing_slip', entityId: invoice.packingSlipId }] : []),
-      ...(invoice.lotId ? [{ entityType: 'lot', entityId: invoice.lotId }] : []),
-    ], { invoiceAttachmentMediaIds: selectedInvoiceAttachmentIds });
-    const lotAttachments = await getLotFileAttachments(invoice.lotId);
-
-    const attachments = [
-      {
-        content: invoicePdf.toString('base64'),
-        filename: `Invoice-${invoice.invoiceNumber}.pdf`,
-        type: 'application/pdf',
-        disposition: 'attachment',
-      },
-      ...mediaAttachments,
-      ...lotAttachments,
-    ];
-
-    const text = [
-      `Please find attached invoice ${invoice.invoiceNumber}.`,
-      customerMessage || invoice.customerVisibleNotes || '',
-      '',
-      `Amount due: $${Number(invoice.totalAmount || 0).toFixed(2)}`,
-      invoice.dueDate ? `Due date: ${invoice.dueDate}` : '',
-    ].filter(Boolean).join('\n');
-
-    const result = await sendEmailViaSendGrid({
-      to,
-      cc,
-      fromName: isP1 ? 'AG Composites' : undefined,
-      subject: `Invoice ${invoice.invoiceNumber}`,
-      text,
-      html: `<p>Please find attached invoice <strong>${invoice.invoiceNumber}</strong>.</p>${customerMessage || invoice.customerVisibleNotes ? `<p>${String(customerMessage || invoice.customerVisibleNotes).replace(/\n/g, '<br/>')}</p>` : ''}<p><strong>Amount due:</strong> $${Number(invoice.totalAmount || 0).toFixed(2)}</p>${invoice.dueDate ? `<p><strong>Due date:</strong> ${invoice.dueDate}</p>` : ''}`,
-      attachments,
-    });
+    const result = await sendEmailViaSendGrid(toSendGridInvoiceMessage(envelope));
 
     if (!result.success) {
       await recordInvoiceSendAudit({
@@ -2171,9 +2216,9 @@ router.post('/:id/send', requirePermission('finance.post_invoice'), async (req: 
     });
 
     res.json(updated);
-  } catch (error) {
+  } catch (error: any) {
     console.error('Failed to send invoice:', error);
-    res.status(500).json({ error: 'Failed to send invoice' });
+    res.status(error?.statusCode || 500).json({ error: error?.message || 'Failed to send invoice' });
   }
 });
 

--- a/server/src/services/arInvoiceEmailService.ts
+++ b/server/src/services/arInvoiceEmailService.ts
@@ -1,0 +1,89 @@
+export type InvoiceEmailAttachment = {
+  filename: string;
+  content: string;
+  type?: string;
+  disposition?: string;
+};
+
+export type InvoiceEmailEnvelope = {
+  to: string;
+  cc: string[];
+  fromName?: string;
+  subject: string;
+  text: string;
+  html: string;
+  attachments: InvoiceEmailAttachment[];
+};
+
+export type InvoiceEmailPreview = Omit<InvoiceEmailEnvelope, 'attachments'> & {
+  attachments: Array<{ filename: string; type?: string; disposition?: string }>;
+};
+
+const escapeHtml = (value: string) => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#039;');
+
+export function invoiceDocumentLabel(invoiceType: string | null | undefined): string {
+  return invoiceType === 'MATERIAL_DEPOSIT' ? 'Material Deposit Invoice' : 'Invoice';
+}
+
+export function buildInvoiceEmailEnvelope(input: {
+  invoiceNumber: string;
+  invoiceType?: string | null;
+  totalAmount: string | number | null | undefined;
+  dueDate?: string | Date | null;
+  customerVisibleNotes?: string | null;
+  customerMessage?: string | null;
+  isP1: boolean;
+  to: string;
+  cc?: string[] | string | null;
+  attachments: InvoiceEmailAttachment[];
+}): InvoiceEmailEnvelope {
+  const label = invoiceDocumentLabel(input.invoiceType);
+  const message = String(input.customerMessage || input.customerVisibleNotes || '').trim();
+  const amountDue = Number(input.totalAmount || 0).toFixed(2);
+  const dueDate = input.dueDate ? String(input.dueDate) : '';
+  const opening = `Please find attached ${label.toLowerCase()} ${input.invoiceNumber}.`;
+  const text = [
+    opening,
+    message,
+    '',
+    `Amount due: $${amountDue}`,
+    dueDate ? `Due date: ${dueDate}` : '',
+  ].filter(Boolean).join('\n');
+  const html = [
+    `<p>Please find attached <strong>${escapeHtml(label)} ${escapeHtml(input.invoiceNumber)}</strong>.</p>`,
+    message ? `<p>${escapeHtml(message).replace(/\n/g, '<br/>')}</p>` : '',
+    `<p><strong>Amount due:</strong> $${amountDue}</p>`,
+    dueDate ? `<p><strong>Due date:</strong> ${escapeHtml(dueDate)}</p>` : '',
+  ].filter(Boolean).join('');
+
+  return {
+    to: input.to,
+    cc: Array.isArray(input.cc) ? input.cc : input.cc ? [input.cc] : [],
+    fromName: input.isP1 ? 'AG Composites' : undefined,
+    subject: `${label} ${input.invoiceNumber}`,
+    text,
+    html,
+    attachments: input.attachments,
+  };
+}
+
+export function toInvoiceEmailPreview(envelope: InvoiceEmailEnvelope): InvoiceEmailPreview {
+  return {
+    to: envelope.to,
+    cc: envelope.cc,
+    fromName: envelope.fromName,
+    subject: envelope.subject,
+    text: envelope.text,
+    html: envelope.html,
+    attachments: envelope.attachments.map(({ filename, type, disposition }) => ({ filename, type, disposition })),
+  };
+}
+
+export function toSendGridInvoiceMessage(envelope: InvoiceEmailEnvelope): InvoiceEmailEnvelope {
+  return envelope;
+}


### PR DESCRIPTION
## Summary
- generate P2 invoice email previews from the same server envelope used for SendGrid delivery
- label material-deposit emails clearly and support an editable customer message
- route invoice-list sends through the reviewed send workflow
- renumber the first Astrion material-deposit invoice to AST26-0001 with guarded sequence reset and audit records

## Validation
- focused AR email preview parity tests pass
- P2 deposit migration tests pass
- TypeScript check passes
- production frontend build passes