### PR TITLE
Hotfix Astrion invoice renumber migration

### DIFF
--- a/migrations/0291_renumber_astrion_material_deposit_invoice.sql
+++ b/migrations/0291_renumber_astrion_material_deposit_invoice.sql
@@ -5,6 +5,8 @@
 DO $$
 DECLARE
   target_invoice ar_invoices%ROWTYPE;
+  voided_invoice ar_invoices%ROWTYPE;
+  voided_archive_number text;
   target_count integer;
   before_sequence jsonb;
 BEGIN
@@ -44,8 +46,57 @@ BEGIN
     RAISE EXCEPTION '0291 AMBIGUOUS_STOP: AST26-0002 is not an unposted, unsent Astrion material-deposit invoice';
   END IF;
 
-  IF EXISTS (SELECT 1 FROM ar_invoices WHERE invoice_number = 'AST26-0001') THEN
-    RAISE EXCEPTION '0291 AMBIGUOUS_STOP: AST26-0001 is already assigned to another invoice';
+  SELECT invoice.* INTO voided_invoice
+    FROM ar_invoices invoice
+    JOIN p2_customers customer ON customer.customer_id = invoice.customer_id
+   WHERE invoice.invoice_number = 'AST26-0001'
+     AND invoice.status = 'VOID'
+     AND invoice.voided_at IS NOT NULL
+     AND lower(customer.customer_name) LIKE 'astrion%';
+
+  IF EXISTS (SELECT 1 FROM ar_invoices WHERE invoice_number = 'AST26-0001')
+     AND voided_invoice.id IS NULL THEN
+    -- Never reuse a number belonging to a live or ambiguously voided invoice.
+    RAISE NOTICE '0291 SAFE_SKIP: AST26-0001 is assigned to an invoice that is not a confirmed voided Astrion invoice; no data was changed';
+    RETURN;
+  END IF;
+
+  IF voided_invoice.id IS NOT NULL THEN
+    -- Preserve the voided invoice and its UUID-linked history while releasing
+    -- the customer-facing number Glenn explicitly approved for reuse.
+    voided_archive_number := 'AST26-0001-VOID-' || left(voided_invoice.id::text, 8);
+
+    UPDATE ar_invoices
+       SET invoice_number = voided_archive_number,
+           updated_at = now()
+     WHERE id = voided_invoice.id
+       AND status = 'VOID'
+       AND voided_at IS NOT NULL;
+
+    INSERT INTO p2_invoice_number_audit (
+      invoice_id, customer_id, old_invoice_number, new_invoice_number,
+      action, reason, changed_by, metadata
+    ) VALUES (
+      voided_invoice.id,
+      voided_invoice.customer_id,
+      'AST26-0001',
+      voided_archive_number,
+      'VOIDED_NUMBER_RELEASE',
+      'Release the number of Glenn Jones'' confirmed voided Astrion invoice while preserving the voided record and UUID-linked audit history.',
+      'migration:0291 approved by Glenn Jones',
+      jsonb_build_object('invoiceStatus', voided_invoice.status, 'voidedAt', voided_invoice.voided_at)
+    );
+
+    INSERT INTO schema_change_log (
+      actor, action_type, table_name, column_name, before_state, after_state,
+      approved_by, override_reason
+    ) VALUES (
+      'migration:0291', 'OVERRIDE', 'ar_invoices', 'invoice_number',
+      jsonb_build_object('invoiceId', voided_invoice.id, 'invoiceNumber', 'AST26-0001', 'status', voided_invoice.status),
+      jsonb_build_object('invoiceId', voided_invoice.id, 'invoiceNumber', voided_archive_number, 'status', voided_invoice.status),
+      'Glenn Jones',
+      'Preserve the voided invoice under an archival number and release AST26-0001 for the valid first Astrion material-deposit invoice.'
+    );
   END IF;
 
   IF EXISTS (

--- a/server/__tests__/p2DepositClinTermsContact.test.ts
+++ b/server/__tests__/p2DepositClinTermsContact.test.ts
@@ -64,7 +64,14 @@ describe('P2 material deposit CLIN, terms, and contact enhancement', () => {
     expect(migration).toContain('INSERT INTO p2_invoice_number_audit');
     expect(migration).toContain('INSERT INTO schema_change_log');
     expect(migration).toContain('AMBIGUOUS_STOP');
+    expect(migration).toContain("invoice.status = 'VOID'");
+    expect(migration).toContain('invoice.voided_at IS NOT NULL');
+    expect(migration).toContain("'VOIDED_NUMBER_RELEASE'");
+    expect(migration).toContain("'AST26-0001-VOID-' || left(voided_invoice.id::text, 8)");
+    expect(migration).toContain('not a confirmed voided Astrion invoice');
     expect(boot).toContain("'0291_renumber_astrion_material_deposit_invoice.sql'");
+    const criticalSection = boot.slice(boot.indexOf('export const criticalMigrationFiles'));
+    expect(criticalSection).not.toContain("'0291_renumber_astrion_material_deposit_invoice.sql'");
   });
 
   it('installs the audited PO00021498 line-number correction at boot', () => {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -441,7 +441,6 @@ export const criticalMigrationFiles = new Set([
   '0287_p2_deposit_invoice_clin_contact.sql',
   '0289_correct_po00021498_customer_line_numbers.sql',
   '0290_p2_po_line_and_clin_distinction.sql',
-  '0291_renumber_astrion_material_deposit_invoice.sql',
 ]);
 
 export async function runSafeBootMigrations() {


### PR DESCRIPTION
## What changed
- makes migration 0291 nonblocking so an invoice-number conflict cannot prevent EPOCH from starting
- permits AST26-0001 reuse only when the existing Astrion invoice is confirmed VOID with a void timestamp
- preserves the voided invoice under a unique archival number and records both number changes in audit tables
- renumbers the valid AST26-0002 invoice to AST26-0001 and resets the next Astrion 2026 sequence to AST26-0002

## Root cause
PR #1781 treated the one-time data correction as a critical boot migration. The existing voided AST26-0001 triggered its collision guard and aborted route registration.

## Validation
- focused Vitest suite: 8 tests passed
- git diff --check passed