### PR TITLE
Improve P2 invoice email layout

### DIFF
--- a/server/__tests__/arInvoiceEmailPreviewParity.test.ts
+++ b/server/__tests__/arInvoiceEmailPreviewParity.test.ts
@@ -12,7 +12,7 @@ describe('AR invoice email preview parity', () => {
     const envelope = buildInvoiceEmailEnvelope({
       invoiceNumber: 'MI26-300',
       invoiceType: 'MATERIAL_DEPOSIT',
-      totalAmount: '25000.00',
+      totalAmount: '242500.00',
       dueDate: '2026-09-17',
       customerMessage: 'Deposit for PO Line 1.',
       isP1: false,
@@ -24,12 +24,32 @@ describe('AR invoice email preview parity', () => {
     const sent = toSendGridInvoiceMessage(envelope);
 
     expect(preview.subject).toBe('Material Deposit Invoice MI26-300');
+    expect(preview.text).toContain('Amount due: $242,500.00');
+    expect(preview.html).toContain('$242,500.00');
+    expect(preview.html).toContain('Invoice summary');
+    expect(preview.html).not.toContain('Please find attached');
+    expect(preview.html.indexOf('Deposit for PO Line 1.')).toBeLessThan(preview.html.indexOf('Invoice summary'));
     expect(preview.to).toBe(sent.to);
     expect(preview.cc).toEqual(sent.cc);
     expect(preview.subject).toBe(sent.subject);
     expect(preview.text).toBe(sent.text);
     expect(preview.html).toBe(sent.html);
     expect(preview.attachments.map((item) => item.filename)).toEqual(sent.attachments.map((item) => item.filename));
+  });
+
+  it('uses the attachment sentence only when no customer message is provided', () => {
+    const envelope = buildInvoiceEmailEnvelope({
+      invoiceNumber: 'AST26-0001',
+      invoiceType: 'MATERIAL_DEPOSIT',
+      totalAmount: 242500,
+      dueDate: '2026-09-17',
+      isP1: false,
+      to: 'ap@example.com',
+      attachments: [],
+    });
+
+    expect(envelope.html).toContain('Please find attached material deposit invoice AST26-0001.');
+    expect(envelope.html).toContain('$242,500.00');
   });
 
   it('routes both preview and send through the same server preparation function', () => {

--- a/server/src/services/arInvoiceEmailService.ts
+++ b/server/src/services/arInvoiceEmailService.ts
@@ -30,6 +30,14 @@ export function invoiceDocumentLabel(invoiceType: string | null | undefined): st
   return invoiceType === 'MATERIAL_DEPOSIT' ? 'Material Deposit Invoice' : 'Invoice';
 }
 
+function formatInvoiceCurrency(value: string | number | null | undefined): string {
+  const amount = Number(value || 0);
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number.isFinite(amount) ? amount : 0);
+}
+
 export function buildInvoiceEmailEnvelope(input: {
   invoiceNumber: string;
   invoiceType?: string | null;
@@ -44,21 +52,25 @@ export function buildInvoiceEmailEnvelope(input: {
 }): InvoiceEmailEnvelope {
   const label = invoiceDocumentLabel(input.invoiceType);
   const message = String(input.customerMessage || input.customerVisibleNotes || '').trim();
-  const amountDue = Number(input.totalAmount || 0).toFixed(2);
+  const amountDue = formatInvoiceCurrency(input.totalAmount);
   const dueDate = input.dueDate ? String(input.dueDate) : '';
-  const opening = `Please find attached ${label.toLowerCase()} ${input.invoiceNumber}.`;
+  const defaultMessage = `Please find attached ${label.toLowerCase()} ${input.invoiceNumber}.`;
+  const bodyMessage = message || defaultMessage;
   const text = [
-    opening,
-    message,
+    bodyMessage,
     '',
+    'Invoice summary',
     `Amount due: $${amountDue}`,
     dueDate ? `Due date: ${dueDate}` : '',
   ].filter(Boolean).join('\n');
   const html = [
-    `<p>Please find attached <strong>${escapeHtml(label)} ${escapeHtml(input.invoiceNumber)}</strong>.</p>`,
-    message ? `<p>${escapeHtml(message).replace(/\n/g, '<br/>')}</p>` : '',
-    `<p><strong>Amount due:</strong> $${amountDue}</p>`,
-    dueDate ? `<p><strong>Due date:</strong> ${escapeHtml(dueDate)}</p>` : '',
+    `<div style="white-space:normal;line-height:1.5">${escapeHtml(bodyMessage).replace(/\n/g, '<br/>')}</div>`,
+    '<div style="margin-top:24px;padding-top:12px;border-top:1px solid #d1d5db">',
+    '<div style="margin-bottom:6px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:#6b7280">Invoice summary</div>',
+    '<table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:collapse">',
+    `<tr><td style="padding:2px 18px 2px 0;font-weight:600">Amount due</td><td style="padding:2px 0">$${amountDue}</td></tr>`,
+    dueDate ? `<tr><td style="padding:2px 18px 2px 0;font-weight:600">Due date</td><td style="padding:2px 0">${escapeHtml(dueDate)}</td></tr>` : '',
+    '</table></div>',
   ].filter(Boolean).join('');
 
   return {


### PR DESCRIPTION
## What changed
- makes the editable customer message the primary email body
- suppresses the redundant attachment sentence when a custom message exists
- separates amount due and due date into a clearly spaced invoice-summary block
- formats invoice amounts with thousands separators and two decimal places
- preserves exact preview/send parity

## Validation
- AR invoice email preview parity suite: 4 tests passed
- git diff --check passed