### PR TITLE
Emergency fix P2 contact migration boot failure

### DIFF
--- a/migrations/0284_p2_customer_contacts.sql
+++ b/migrations/0284_p2_customer_contacts.sql
@@ -10,12 +10,14 @@ CREATE TABLE IF NOT EXISTS p2_customer_contacts (
   phone text,
   is_primary boolean DEFAULT false,
   created_at timestamp DEFAULT now(),
-  updated_at timestamp DEFAULT now(),
-  CONSTRAINT p2_customer_contacts_customer_id_p2_customers_id_fk
-    FOREIGN KEY (customer_id)
-    REFERENCES p2_customers(id)
-    ON DELETE CASCADE
+  updated_at timestamp DEFAULT now()
 );
+
+-- Production contains a legacy p2_customers layout where the numeric id is
+-- not guaranteed by a database-level unique constraint. The application uses
+-- that stable numeric id to address customers, but adding a foreign key to it
+-- would fail migration 0284 and prevent startup. Keep the lookup indexed and
+-- enforce customer existence in the authenticated API route.
 
 CREATE INDEX IF NOT EXISTS p2_customer_contacts_customer_id_idx
   ON p2_customer_contacts (customer_id);

--- a/server/__tests__/p2CustomerContactsMigration.test.ts
+++ b/server/__tests__/p2CustomerContactsMigration.test.ts
@@ -21,16 +21,29 @@ describe('P2 customer contacts migration', () => {
     ).not.toThrow();
   });
 
-  it('creates the expected table, customer relationship, and lookup index', () => {
+  it('creates the expected table and lookup index without a legacy-incompatible foreign key', () => {
     expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS p2_customer_contacts/i);
-    expect(sql).toMatch(/REFERENCES p2_customers\s*\(id\)/i);
-    expect(sql).toMatch(/ON DELETE CASCADE/i);
+    expect(sql).not.toMatch(/REFERENCES p2_customers\s*\(id\)/i);
+    expect(sql).not.toMatch(/FOREIGN KEY\s*\(customer_id\)/i);
     expect(sql).toMatch(/p2_customer_contacts_customer_id_idx/i);
   });
 
-  it('is registered as a required production boot migration', () => {
+  it('runs at production boot without being allowed to take the ERP offline', () => {
     const migrationName = '0284_p2_customer_contacts.sql';
     expect(safeMigrationFiles).toContain(migrationName);
-    expect(criticalMigrationFiles.has(migrationName)).toBe(true);
+    expect(criticalMigrationFiles.has(migrationName)).toBe(false);
+  });
+
+  it('enforces customer existence in the contact API instead of a legacy-incompatible FK', () => {
+    const routes = fs.readFileSync(
+      path.resolve(process.cwd(), 'server/src/routes/index.ts'),
+      'utf8'
+    );
+    const createRoute = routes.slice(
+      routes.indexOf("app.post('/api/p2/customers/:customerId/contacts'"),
+      routes.indexOf("app.put('/api/p2/customers/:customerId/contacts/:contactId'")
+    );
+    expect(createRoute).toContain('storage.getP2Customer(customerId)');
+    expect(createRoute).toContain("res.status(404).json({ error: 'P2 customer not found' })");
   });
 });

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -6241,9 +6241,7 @@ export const p2Customers = pgTable('p2_customers', {
 // P2 Customer Contacts - Additional contacts for P2 customers
 export const p2CustomerContacts = pgTable('p2_customer_contacts', {
   id: serial('id').primaryKey(),
-  customerId: integer('customer_id')
-    .references(() => p2Customers.id, { onDelete: 'cascade' })
-    .notNull(),
+  customerId: integer('customer_id').notNull(),
   name: text('name').notNull(),
   title: text('title'),
   email: text('email'),

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -438,7 +438,6 @@ export const criticalMigrationFiles = new Set([
   '0281_contain_shipped_p1_auto_populate_regression.sql',
   '0282_car_form_data.sql',
   '0283_remove_legacy_rma_change_control_projections.sql',
-  '0284_p2_customer_contacts.sql',
   '0285_p2_material_deposits_and_payment_settlements.sql',
   '0287_p2_deposit_invoice_clin_contact.sql',
   '0289_correct_po00021498_customer_line_numbers.sql',

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2607,6 +2607,13 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
     try {
       const { storage } = await import('../../storage');
       const customerId = parseInt(req.params.customerId, 10);
+      if (!Number.isInteger(customerId)) {
+        return res.status(400).json({ error: 'Invalid P2 customer ID' });
+      }
+      const customer = await storage.getP2Customer(customerId);
+      if (!customer) {
+        return res.status(404).json({ error: 'P2 customer not found' });
+      }
       const contact = await storage.createP2CustomerContact({ ...req.body, customerId });
       res.json(contact);
     } catch (_error: any) {


### PR DESCRIPTION
## Root cause
Migration 0284 referenced p2_customers.id, but the production legacy table does not expose that column as a database-level unique key. PostgreSQL rejected the foreign key and, because 0284 was marked critical, route registration and login returned 503.

## Fix
- removes the production-incompatible foreign key while retaining the indexed numeric customer link used by the application
- validates customer existence in the authenticated contact-create API
- keeps migration 0284 in the boot list but makes this auxiliary feature noncritical so it cannot take the ERP offline again
- updates regression coverage for the actual production mismatch

## Validation
- P2 customer contacts migration suite: 4 tests passed
- full TypeScript check passed
- migration safety scanner passed
- git diff --check passed