### PR TITLE
Restore one-page FO Form 11 RFQ PDFs

### DIFF
--- a/server/__tests__/blankRfqRiskAssessmentPdf.test.ts
+++ b/server/__tests__/blankRfqRiskAssessmentPdf.test.ts
@@ -2,14 +2,38 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { PDFDocument } from 'pdf-lib';
-import { generateBlankRfqRiskAssessmentPdf } from '../src/services/blankRfqRiskAssessmentPdf';
+import {
+  generateBlankRfqRiskAssessmentPdf,
+  generateRfqRiskAssessmentPdf,
+} from '../src/services/blankRfqRiskAssessmentPdf';
 
 describe('blank RFQ risk assessment PDF', () => {
-  it('produces a compact two-page printable form', async () => {
+  it('produces the original compact one-page printable form', async () => {
     const bytes = await generateBlankRfqRiskAssessmentPdf();
     const document = await PDFDocument.load(bytes);
-    expect(document.getPageCount()).toBe(2);
-    expect(bytes.byteLength).toBeGreaterThan(4_000);
+    expect(document.getPageCount()).toBe(1);
+    expect(bytes.byteLength).toBeGreaterThan(3_000);
+  });
+
+  it('uses the same one-page form for a completed assessment', async () => {
+    const bytes = await generateRfqRiskAssessmentPdf({
+      rfqNumber: 'AEV260017',
+      formData: {
+        trainedStaff: 'low',
+        equipmentRequirements: 'medium',
+        internalSubtotal: 1,
+        externalSubtotal: 0,
+        mitigationActionA: 'Cross-train an additional operator',
+        printedName: 'Glenn Jones',
+        date: '08/19/2026',
+      },
+      totalOverallPoints: 1,
+      adjustedRiskLevel: 1,
+      riskDetermination: 'Low Risk',
+      bidDecision: 'accept',
+    });
+    const document = await PDFDocument.load(bytes);
+    expect(document.getPageCount()).toBe(1);
   });
 
   it('routes blank print and export through the PDF endpoint instead of browser page printing', () => {
@@ -19,6 +43,7 @@ describe('blank RFQ risk assessment PDF', () => {
     expect(page).toContain("'/api/customers/rfq-assessments/blank/pdf'");
     expect(page).toContain('onClick={handleViewPdf}');
     expect(routes).toContain("router.get('/rfq-assessments/blank/pdf'");
+    expect(routes).toContain('generateRfqRiskAssessmentPdf(assessment as any)');
     expect(routes.indexOf("router.get('/rfq-assessments/blank/pdf'")).toBeLessThan(
       routes.indexOf("router.get('/rfq-assessments/:id/pdf'")
     );

--- a/server/src/routes/customers.ts
+++ b/server/src/routes/customers.ts
@@ -594,6 +594,29 @@ router.get('/rfq-assessments/:id/pdf', async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     const assessment = await storage.getRFQRiskAssessmentById(id);
+
+    if (!assessment) {
+      return res.status(404).json({ error: 'RFQ Risk Assessment not found' });
+    }
+
+    const { generateRfqRiskAssessmentPdf } = await import('../services/blankRfqRiskAssessmentPdf');
+    const pdfBytes = await generateRfqRiskAssessmentPdf(assessment as any);
+    const safeRfqNumber = String(assessment.rfqNumber || 'Assessment').replace(/[^a-zA-Z0-9_-]/g, '_');
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `inline; filename="RFQ_${safeRfqNumber}_Risk_Assessment.pdf"`);
+    res.setHeader('Cache-Control', 'no-store');
+    res.send(Buffer.from(pdfBytes));
+  } catch (error) {
+    console.error('Generate RFQ PDF error:', error);
+    res.status(500).json({ error: 'Failed to generate PDF' });
+  }
+});
+
+// Retained temporarily for direct comparison while the unified FO Form 11 renderer is adopted.
+router.get('/rfq-assessments/:id/pdf-legacy', async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id);
+    const assessment = await storage.getRFQRiskAssessmentById(id);
     
     if (!assessment) {
       return res.status(404).json({ error: 'RFQ Risk Assessment not found' });

--- a/server/src/services/blankRfqRiskAssessmentPdf.ts
+++ b/server/src/services/blankRfqRiskAssessmentPdf.ts
@@ -2,165 +2,221 @@ import { PDFDocument, StandardFonts, rgb, type PDFPage, type PDFFont } from 'pdf
 
 const PAGE_WIDTH = 612;
 const PAGE_HEIGHT = 792;
-const MARGIN = 42;
-const CONTENT_WIDTH = PAGE_WIDTH - (MARGIN * 2);
-const BLUE = rgb(0.08, 0.25, 0.44);
-const LIGHT_BLUE = rgb(0.91, 0.95, 0.98);
-const LIGHT_GRAY = rgb(0.96, 0.97, 0.98);
-const MID_GRAY = rgb(0.42, 0.46, 0.50);
-const BLACK = rgb(0.08, 0.09, 0.10);
+const LEFT = 36;
+const RIGHT = 576;
+const BLACK = rgb(0, 0, 0);
+const GRAY = rgb(0.93, 0.93, 0.93);
 
-type Fonts = { regular: PDFFont; bold: PDFFont };
+type AssessmentInput = {
+  rfqNumber?: string | null;
+  customerName?: string | null;
+  description?: string | null;
+  formData?: Record<string, any> | null;
+  totalOverallPoints?: number | null;
+  adjustedRiskLevel?: number | null;
+  riskDetermination?: string | null;
+  bidDecision?: string | null;
+};
 
-function text(page: PDFPage, value: string, x: number, y: number, size: number, font: PDFFont, color = BLACK) {
-  page.drawText(value, { x, y, size, font, color });
+type Fonts = { regular: PDFFont; bold: PDFFont; italic: PDFFont };
+
+const internalRisks = [
+  ['trainedStaff', 'Availability of properly trained staff'],
+  ['equipmentRequirements', 'Equipment requirements / capability'],
+  ['manufacturingSpace', 'Manufacturing space / capacity'],
+  ['regulatoryRequirements', 'Regulatory requirements'],
+  ['conflictingPriorities', 'Conflicting priorities'],
+  ['customerConcentration', 'Customer concentration'],
+  ['climateEnvironmental', 'Climate / environmental requirements'],
+] as const;
+
+const externalRisks = [
+  ['supplyChainDisruptions', 'Supply chain disruptions'],
+  ['supplierVariability', 'Supplier variability'],
+  ['contractProvisions', 'Contract provisions'],
+  ['timelines', 'Required timelines'],
+  ['qualityExpectations', 'Quality expectations'],
+] as const;
+
+function drawText(page: PDFPage, value: unknown, x: number, y: number, size: number, font: PDFFont) {
+  page.drawText(String(value ?? ''), { x, y, size, font, color: BLACK });
 }
 
-function line(page: PDFPage, x1: number, y1: number, x2: number, y2: number, color = MID_GRAY, thickness = 0.7) {
-  page.drawLine({ start: { x: x1, y: y1 }, end: { x: x2, y: y2 }, color, thickness });
+function drawLine(page: PDFPage, x1: number, y1: number, x2: number, y2: number, thickness = 0.65) {
+  page.drawLine({ start: { x: x1, y: y1 }, end: { x: x2, y: y2 }, thickness, color: BLACK });
 }
 
-function fieldLine(page: PDFPage, label: string, x: number, y: number, width: number, fonts: Fonts) {
-  text(page, label, x, y + 3, 9, fonts.bold);
-  const labelWidth = fonts.bold.widthOfTextAtSize(label, 9) + 8;
-  line(page, x + labelWidth, y, x + width, y);
+function centered(page: PDFPage, value: string, y: number, size: number, font: PDFFont) {
+  const width = font.widthOfTextAtSize(value, size);
+  drawText(page, value, (PAGE_WIDTH - width) / 2, y, size, font);
 }
 
-function header(page: PDFPage, fonts: Fonts, pageNumber: number) {
-  page.drawRectangle({ x: 0, y: PAGE_HEIGHT - 76, width: PAGE_WIDTH, height: 76, color: BLUE });
-  text(page, 'A G COMPOSITES', MARGIN, PAGE_HEIGHT - 34, 16, fonts.bold, rgb(1, 1, 1));
-  text(page, 'RFQ RISK ASSESSMENT', MARGIN, PAGE_HEIGHT - 57, 13, fonts.bold, rgb(1, 1, 1));
-  text(page, 'FO Form 11', PAGE_WIDTH - MARGIN - 62, PAGE_HEIGHT - 34, 9, fonts.bold, rgb(1, 1, 1));
-  text(page, `Page ${pageNumber} of 2`, PAGE_WIDTH - MARGIN - 62, PAGE_HEIGHT - 53, 8, fonts.regular, rgb(1, 1, 1));
-}
-
-function footer(page: PDFPage, fonts: Fonts) {
-  line(page, MARGIN, 31, PAGE_WIDTH - MARGIN, 31, rgb(0.75, 0.77, 0.79), 0.5);
-  text(page, 'FO Form 11 - Version 1.4 - Uncontrolled when printed', MARGIN, 18, 7.5, fonts.regular, MID_GRAY);
-  text(page, 'Blank assessment form', PAGE_WIDTH - MARGIN - 84, 18, 7.5, fonts.regular, MID_GRAY);
-}
-
-function sectionTitle(page: PDFPage, title: string, y: number, fonts: Fonts) {
-  page.drawRectangle({ x: MARGIN, y: y - 4, width: CONTENT_WIDTH, height: 22, color: LIGHT_BLUE });
-  text(page, title, MARGIN + 8, y + 3, 10, fonts.bold, BLUE);
-}
-
-function checkbox(page: PDFPage, x: number, y: number) {
-  page.drawRectangle({ x, y, width: 9, height: 9, borderColor: MID_GRAY, borderWidth: 0.7 });
-}
-
-function riskTable(page: PDFPage, yTop: number, title: string, factors: string[], fonts: Fonts): number {
-  sectionTitle(page, title, yTop, fonts);
-  const top = yTop - 12;
-  const rowHeight = 31;
-  const columns = [MARGIN, MARGIN + 196, MARGIN + 246, MARGIN + 296, MARGIN + 346, MARGIN + 396, PAGE_WIDTH - MARGIN];
-
-  page.drawRectangle({ x: MARGIN, y: top - 24, width: CONTENT_WIDTH, height: 24, color: LIGHT_GRAY });
-  ['Assessment factor', 'Low', 'Med.', 'High', 'Extreme', 'Notes / evidence'].forEach((label, index) => {
-    text(page, label, columns[index] + 5, top - 16, index === 0 || index === 5 ? 7.5 : 7, fonts.bold, BLUE);
-  });
-  line(page, MARGIN, top, PAGE_WIDTH - MARGIN, top, BLUE, 0.8);
-  line(page, MARGIN, top - 24, PAGE_WIDTH - MARGIN, top - 24, MID_GRAY, 0.6);
-
-  let rowTop = top - 24;
-  for (const factor of factors) {
-    const rowBottom = rowTop - rowHeight;
-    text(page, factor, MARGIN + 5, rowBottom + 11, 8, fonts.regular);
-    [columns[1], columns[2], columns[3], columns[4]].forEach((columnX) => checkbox(page, columnX + 19, rowBottom + 11));
-    line(page, MARGIN, rowBottom, PAGE_WIDTH - MARGIN, rowBottom, rgb(0.78, 0.80, 0.82), 0.5);
-    rowTop = rowBottom;
+function checkbox(page: PDFPage, x: number, y: number, checked: boolean) {
+  page.drawRectangle({ x, y, width: 9, height: 9, borderColor: BLACK, borderWidth: 0.7 });
+  if (checked) {
+    drawLine(page, x + 1.5, y + 1.5, x + 7.5, y + 7.5, 1.2);
+    drawLine(page, x + 7.5, y + 1.5, x + 1.5, y + 7.5, 1.2);
   }
-  columns.forEach((columnX) => line(page, columnX, top, columnX, rowTop, rgb(0.72, 0.74, 0.76), 0.5));
-  return rowTop;
 }
 
-export async function generateBlankRfqRiskAssessmentPdf(): Promise<Uint8Array> {
+function normalizeRisk(value: unknown): string {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (normalized === 'med') return 'medium';
+  return normalized;
+}
+
+function sectionBar(page: PDFPage, number: string, title: string, y: number, fonts: Fonts) {
+  page.drawRectangle({ x: LEFT, y: y - 3, width: RIGHT - LEFT, height: 16, color: GRAY, borderColor: BLACK, borderWidth: 0.7 });
+  drawText(page, `${number}. ${title}`, LEFT + 5, y + 1, 8.5, fonts.bold);
+}
+
+function riskTable(
+  page: PDFPage,
+  yTop: number,
+  rows: ReadonlyArray<readonly [string, string]>,
+  formData: Record<string, any>,
+  fonts: Fonts,
+): number {
+  const labelRight = 365;
+  const columnWidth = (RIGHT - labelRight) / 4;
+  const rowHeight = 19;
+  const headerBottom = yTop - 18;
+  const bottom = headerBottom - (rows.length * rowHeight);
+  const levels = ['extreme', 'high', 'medium', 'low'];
+  const labels = ['Extreme', 'High', 'Medium', 'Low'];
+
+  page.drawRectangle({ x: LEFT, y: headerBottom, width: RIGHT - LEFT, height: 18, borderColor: BLACK, borderWidth: 0.7 });
+  drawText(page, 'Risk Factor', LEFT + 5, headerBottom + 5, 7.5, fonts.bold);
+  labels.forEach((label, index) => {
+    const x = labelRight + (index * columnWidth);
+    const width = fonts.bold.widthOfTextAtSize(label, 6.8);
+    drawText(page, label, x + ((columnWidth - width) / 2), headerBottom + 5, 6.8, fonts.bold);
+  });
+
+  rows.forEach(([key, label], rowIndex) => {
+    const rowBottom = headerBottom - ((rowIndex + 1) * rowHeight);
+    drawText(page, label, LEFT + 5, rowBottom + 6, 7.3, fonts.regular);
+    const selected = normalizeRisk(formData[key]);
+    levels.forEach((level, columnIndex) => {
+      const x = labelRight + (columnIndex * columnWidth) + ((columnWidth - 9) / 2);
+      checkbox(page, x, rowBottom + 5, selected === level);
+    });
+    drawLine(page, LEFT, rowBottom, RIGHT, rowBottom, 0.45);
+  });
+
+  [LEFT, labelRight, ...[1, 2, 3].map((i) => labelRight + (i * columnWidth)), RIGHT].forEach((x) => {
+    drawLine(page, x, yTop, x, bottom, 0.55);
+  });
+  return bottom;
+}
+
+function valueOrBlank(value: unknown): string {
+  return value === null || value === undefined || value === '' ? '' : String(value);
+}
+
+function mitigationLine(page: PDFPage, letter: string, action: unknown, reduction: unknown, y: number, fonts: Fonts) {
+  drawText(page, `${letter}.`, LEFT + 4, y, 7.5, fonts.bold);
+  const actionText = valueOrBlank(action);
+  if (actionText) drawText(page, actionText.slice(0, 93), LEFT + 18, y, 7, fonts.regular);
+  drawLine(page, LEFT + 17, y - 2, 474, y - 2, 0.45);
+  drawText(page, 'Score Adj.', 480, y, 6.8, fonts.bold);
+  drawLine(page, 525, y - 2, RIGHT, y - 2, 0.45);
+  if (valueOrBlank(reduction)) drawText(page, reduction, 539, y, 7, fonts.regular);
+}
+
+async function drawSignature(page: PDFPage, document: PDFDocument, signature: unknown, x: number, y: number) {
+  if (typeof signature !== 'string' || !signature.startsWith('data:image/png;base64,')) return;
+  try {
+    const image = await document.embedPng(Buffer.from(signature.split(',')[1], 'base64'));
+    const scale = Math.min(120 / image.width, 23 / image.height);
+    page.drawImage(image, { x, y, width: image.width * scale, height: image.height * scale });
+  } catch {
+    // Older records may contain incomplete signature data. The remaining audit fields still render.
+  }
+}
+
+export async function generateRfqRiskAssessmentPdf(input: AssessmentInput = {}): Promise<Uint8Array> {
   const document = await PDFDocument.create();
   const fonts: Fonts = {
     regular: await document.embedFont(StandardFonts.Helvetica),
     bold: await document.embedFont(StandardFonts.HelveticaBold),
+    italic: await document.embedFont(StandardFonts.HelveticaOblique),
   };
+  const page = document.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
+  const formData = input.formData || {};
 
-  const page1 = document.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
-  header(page1, fonts, 1);
-  footer(page1, fonts);
+  centered(page, 'AG', 756, 28, fonts.bold);
+  centered(page, 'COMPOSITES LLC', 744, 7.2, fonts.bold);
+  centered(page, 'ENGINEERED FOR PERFORMANCE', 734, 5.8, fonts.italic);
+  centered(page, `RFQ Risk Assessment # ${valueOrBlank(input.rfqNumber) || '________________'}`, 708, 14, fonts.bold);
 
-  fieldLine(page1, 'RFQ Number', MARGIN, 686, 245, fonts);
-  fieldLine(page1, 'Date', 318, 686, 252, fonts);
-  fieldLine(page1, 'Customer', MARGIN, 661, CONTENT_WIDTH, fonts);
-  text(page1, 'Description / scope:', MARGIN, 638, 9, fonts.bold);
-  line(page1, MARGIN, 622, PAGE_WIDTH - MARGIN, 622);
-  line(page1, MARGIN, 606, PAGE_WIDTH - MARGIN, 606);
+  sectionBar(page, '1', 'Internal Risks', 682, fonts);
+  let y = riskTable(page, 661, internalRisks, formData, fonts);
+  drawText(page, 'Subtotal Internal Risk Points:', 395, y - 14, 7.3, fonts.bold);
+  drawLine(page, 523, y - 16, RIGHT, y - 16);
+  drawText(page, valueOrBlank(formData.internalSubtotal), 539, y - 14, 7.3, fonts.regular);
 
-  page1.drawRectangle({ x: MARGIN, y: 567, width: CONTENT_WIDTH, height: 27, color: LIGHT_GRAY });
-  text(page1, 'Score each factor:  Low = 0     Medium = 1     High = 3     Extreme = 17', MARGIN + 8, 578, 8.5, fonts.bold, BLUE);
+  y -= 38;
+  sectionBar(page, '2', 'External Risks', y, fonts);
+  y = riskTable(page, y - 21, externalRisks, formData, fonts);
+  drawText(page, 'Subtotal External Risk Points:', 395, y - 14, 7.3, fonts.bold);
+  drawLine(page, 523, y - 16, RIGHT, y - 16);
+  drawText(page, valueOrBlank(formData.externalSubtotal), 539, y - 14, 7.3, fonts.regular);
 
-  riskTable(page1, 547, '1. INTERNAL RISKS', [
-    'Trained staff',
-    'Equipment requirements',
-    'Manufacturing space',
-    'Regulatory requirements',
-    'Conflicting priorities',
-    'Customer concentration',
-    'Climate / environmental',
-  ], fonts);
-  fieldLine(page1, 'Internal subtotal', MARGIN + 330, 282, 198, fonts);
-  text(page1, 'Use notes/evidence to identify assumptions, constraints, or required follow-up.', MARGIN, 255, 8, fonts.regular, MID_GRAY);
+  y -= 38;
+  sectionBar(page, '3', 'Mitigation Actions and Score Adjustment', y, fonts);
+  y -= 20;
+  mitigationLine(page, 'a', formData.mitigationActionA, formData.mitigationReductionA, y, fonts);
+  mitigationLine(page, 'b', formData.mitigationActionB, formData.mitigationReductionB, y - 20, fonts);
+  mitigationLine(page, 'c', formData.mitigationActionC, formData.mitigationReductionC, y - 40, fonts);
+  drawText(page, 'Total Overall Points:', 407, y - 61, 7.5, fonts.bold);
+  drawLine(page, 503, y - 63, RIGHT, y - 63);
+  drawText(page, valueOrBlank(input.totalOverallPoints ?? formData.totalOverallPoints), 535, y - 61, 7.3, fonts.regular);
 
-  const page2 = document.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
-  header(page2, fonts, 2);
-  footer(page2, fonts);
-
-  let y = riskTable(page2, 682, '2. EXTERNAL RISKS', [
-    'Supply chain disruptions',
-    'Supplier variability',
-    'Contract provisions',
-    'Timelines',
-    'Quality expectations',
-  ], fonts);
-  fieldLine(page2, 'External subtotal', MARGIN + 330, y - 22, 198, fonts);
-
-  y -= 58;
-  sectionTitle(page2, '3. MITIGATION ACTIONS', y, fonts);
-  y -= 22;
-  ['A', 'B', 'C'].forEach((letter) => {
-    text(page2, `${letter}.`, MARGIN + 4, y - 8, 9, fonts.bold);
-    line(page2, MARGIN + 22, y - 10, MARGIN + 395, y - 10);
-    text(page2, 'Reduction:', MARGIN + 405, y - 8, 8, fonts.bold);
-    line(page2, MARGIN + 455, y - 10, PAGE_WIDTH - MARGIN, y - 10);
-    y -= 31;
+  y -= 84;
+  sectionBar(page, '4', 'Overall Risk Determination', y, fonts);
+  y -= 24;
+  const determination = normalizeRisk(input.riskDetermination ?? formData.riskDetermination);
+  drawText(page, 'Overall Risk:', LEFT + 5, y, 7.5, fonts.bold);
+  [['High', 'high'], ['Medium', 'medium'], ['Low', 'low']].forEach(([label, value], index) => {
+    const x = LEFT + 79 + (index * 85);
+    checkbox(page, x, y - 2, determination.includes(value));
+    drawText(page, label, x + 14, y, 7.3, fonts.regular);
   });
+  drawText(page, 'Adjusted Score:', 402, y, 7.3, fonts.bold);
+  drawLine(page, 472, y - 2, RIGHT, y - 2);
+  drawText(page, valueOrBlank(input.adjustedRiskLevel ?? formData.adjustedRiskLevel), 526, y, 7.3, fonts.regular);
 
-  sectionTitle(page2, '4. RISK SUMMARY AND BID DECISION', y, fonts);
-  y -= 29;
-  fieldLine(page2, 'Total overall points', MARGIN + 4, y, 220, fonts);
-  fieldLine(page2, 'Less mitigation', MARGIN + 270, y, 252, fonts);
-  y -= 27;
-  fieldLine(page2, 'Adjusted risk level', MARGIN + 4, y, 220, fonts);
-  text(page2, 'Risk determination:', MARGIN + 270, y + 3, 9, fonts.bold);
-  ['Low', 'Medium', 'High'].forEach((label, index) => {
-    checkbox(page2, MARGIN + 365 + (index * 55), y - 2);
-    text(page2, label, MARGIN + 378 + (index * 55), y, 8, fonts.regular);
-  });
   y -= 31;
-  text(page2, 'Bid decision:', MARGIN + 4, y + 3, 9, fonts.bold);
-  ['Bid', 'No bid', 'Conditional / management review'].forEach((label, index) => {
-    const x = [MARGIN + 78, MARGIN + 150, MARGIN + 240][index];
-    checkbox(page2, x, y - 2);
-    text(page2, label, x + 13, y, 8, fonts.regular);
-  });
+  const bidDecision = String(input.bidDecision ?? formData.bidDecision ?? '').toLowerCase();
+  checkbox(page, LEFT + 5, y - 2, bidDecision === 'accept' || bidDecision === 'bid');
+  drawText(page, 'By submitting a bid, I acknowledge and accept the risks associated with this RFQ.', LEFT + 21, y, 7.3, fonts.regular);
+  y -= 20;
+  checkbox(page, LEFT + 5, y - 2, bidDecision === 'abstain' || bidDecision === 'no bid');
+  drawText(page, 'Due to risk, I choose to abstain from submitting a bid.', LEFT + 21, y, 7.3, fonts.regular);
 
-  y -= 43;
-  sectionTitle(page2, '5. APPROVAL', y, fonts);
-  y -= 32;
-  fieldLine(page2, 'Printed name', MARGIN + 4, y, 245, fonts);
-  fieldLine(page2, 'Date', MARGIN + 285, y, 237, fonts);
   y -= 35;
-  fieldLine(page2, 'Signature', MARGIN + 4, y, CONTENT_WIDTH - 4, fonts);
-  text(page2, 'High-risk assessments require authorized executive approval.', MARGIN + 4, y - 24, 8, fonts.regular, MID_GRAY);
+  drawText(page, 'Date:', LEFT + 5, y, 7.5, fonts.bold);
+  drawLine(page, LEFT + 32, y - 2, 177, y - 2);
+  drawText(page, valueOrBlank(formData.date), LEFT + 36, y, 7.3, fonts.regular);
+  drawText(page, 'Printed Name:', 200, y, 7.5, fonts.bold);
+  drawLine(page, 267, y - 2, 390, y - 2);
+  drawText(page, valueOrBlank(formData.printedName), 271, y, 7.3, fonts.regular);
+  drawText(page, 'Signature:', 408, y, 7.5, fonts.bold);
+  drawLine(page, 456, y - 2, RIGHT, y - 2);
+  await drawSignature(page, document, formData.signature, 458, y - 5);
 
-  document.setTitle('Blank RFQ Risk Assessment');
-  document.setSubject('Printable blank RFQ risk assessment form');
+  drawLine(page, LEFT, 31, RIGHT, 31, 0.45);
+  drawText(page, 'FO Form 11', LEFT, 20, 6.7, fonts.regular);
+  centered(page, 'Version 1.4 10/23/2024', 20, 6.7, fonts.regular);
+  drawText(page, 'Page 1 of 1', 529, 20, 6.7, fonts.regular);
+
+  document.setTitle(input.rfqNumber ? `RFQ Risk Assessment ${input.rfqNumber}` : 'Blank RFQ Risk Assessment');
+  document.setSubject('FO Form 11 RFQ Risk Assessment');
   document.setCreator('EPOCH Manufacturing ERP');
   return document.save();
+}
+
+export async function generateBlankRfqRiskAssessmentPdf(): Promise<Uint8Array> {
+  return generateRfqRiskAssessmentPdf();
 }


### PR DESCRIPTION
## What changed
- Restores the compact one-page FO Form 11 layout for blank RFQ risk assessments.
- Uses the same renderer for saved/completed assessments, populating risk selections, totals, mitigation actions, bid decision, date, name, and signature.
- Adds regression coverage proving both blank and completed PDFs remain one page and share the unified route.

## Why
The blank form had been unnecessarily redesigned as a two-page document while completed assessments used a separate report layout. This restores the familiar paper form and removes that inconsistency.

## Validation
- Server Vitest: 3 tests passed
- TypeScript: tsc --noEmit passed
- Visual render QA completed for blank and populated samples