### PR TITLE
Add foam and 3D cutting inventory categories

### DIFF
--- a/client/src/components/inventory/InventoryItemsCard.tsx
+++ b/client/src/components/inventory/InventoryItemsCard.tsx
@@ -720,6 +720,8 @@ const InventoryForm = ({
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="PACKET">Packet</SelectItem>
+                  <SelectItem value="FOAM_CUTTING">Foam Cutting</SelectItem>
+                  <SelectItem value="THREE_D_PRINTING_CUTTING">3d Printing/Cutting</SelectItem>
                   <SelectItem value="KIT">Kitting</SelectItem>
                   <SelectItem value="MACHINED_PART">Machined Part</SelectItem>
                   <SelectItem value="CORE">Core</SelectItem>
@@ -1698,7 +1700,7 @@ const inventoryFormSchema = z.object({
   agPartNumber: z.string().min(1, 'AG Part# is required'),
   name: z.string().min(1, 'Name is required'),
   itemType: z.enum(['PURCHASED', 'MANUFACTURED']).optional().nullable(),
-  manufacturedCategory: z.enum(['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT']).optional().nullable(),
+  manufacturedCategory: z.enum(['PACKET', 'FOAM_CUTTING', 'THREE_D_PRINTING_CUTTING', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT']).optional().nullable(),
 }).refine(
   (data) => {
     if (data.itemType === 'MANUFACTURED') return !!data.manufacturedCategory;
@@ -2731,7 +2733,7 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
         type: formData.type || 'Purchased',
         itemType: (formData.itemType || (formData.type === 'Manufactured' ? 'MANUFACTURED' : 'PURCHASED')) as 'PURCHASED' | 'MANUFACTURED',
         manufacturedCategory: (formData.itemType === 'MANUFACTURED' || formData.type === 'Manufactured') && formData.manufacturedCategory
-          ? formData.manufacturedCategory as 'PACKET' | 'KIT' | 'MACHINED_PART' | 'CORE' | 'SUB_ASSEMBLY' | 'ASSEMBLY' | 'FINAL_ASSEMBLY' | 'COMPOSITE' | 'COMPONENT'
+          ? formData.manufacturedCategory as 'PACKET' | 'FOAM_CUTTING' | 'THREE_D_PRINTING_CUTTING' | 'KIT' | 'MACHINED_PART' | 'CORE' | 'SUB_ASSEMBLY' | 'ASSEMBLY' | 'FINAL_ASSEMBLY' | 'COMPOSITE' | 'COMPONENT'
           : null,
         manufacturingLevel: (formData.itemType === 'MANUFACTURED' || formData.type === 'Manufactured') && formData.manufacturingLevel
           ? formData.manufacturingLevel as 'COMPONENT' | 'INTERMEDIATE' | 'FINAL'

--- a/client/src/lib/inventoryConstants.ts
+++ b/client/src/lib/inventoryConstants.ts
@@ -2,6 +2,8 @@ import type { ManufacturedCategory, SupplySourceDashboard } from '@shared/schema
 
 export const MANUFACTURED_CATEGORY_ORDER: ManufacturedCategory[] = [
   'PACKET',
+  'FOAM_CUTTING',
+  'THREE_D_PRINTING_CUTTING',
   'KIT',
   'MACHINED_PART',
   'CORE',
@@ -14,6 +16,8 @@ export const MANUFACTURED_CATEGORY_ORDER: ManufacturedCategory[] = [
 
 export const CATEGORY_DISPLAY_NAMES: Record<ManufacturedCategory, string> = {
   PACKET: 'Packet',
+  FOAM_CUTTING: 'Foam Cutting',
+  THREE_D_PRINTING_CUTTING: '3d Printing/Cutting',
   KIT: 'Kitting',
   MACHINED_PART: 'Machined Part',
   CORE: 'Core',

--- a/migrations/0293_inventory_foam_and_3d_cutting_categories.sql
+++ b/migrations/0293_inventory_foam_and_3d_cutting_categories.sql
@@ -1,0 +1,3 @@
+-- Add dedicated cutting categories for manufactured inventory items.
+ALTER TYPE inventory_manufactured_category ADD VALUE IF NOT EXISTS 'FOAM_CUTTING';
+ALTER TYPE inventory_manufactured_category ADD VALUE IF NOT EXISTS 'THREE_D_PRINTING_CUTTING';

--- a/server/index.ts
+++ b/server/index.ts
@@ -2383,7 +2383,7 @@ async function initializeBackgroundServices() {
         await db.execute(sqlInvClass`
           DO $$ BEGIN
             IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'inventory_manufactured_category') THEN
-              CREATE TYPE inventory_manufactured_category AS ENUM ('PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT');
+              CREATE TYPE inventory_manufactured_category AS ENUM ('PACKET', 'FOAM_CUTTING', 'THREE_D_PRINTING_CUTTING', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT');
             END IF;
           END $$
         `);

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -721,6 +721,8 @@ export const inventoryManufacturedCategoryEnum = pgEnum(
   'inventory_manufactured_category',
   [
     'PACKET',
+    'FOAM_CUTTING',
+    'THREE_D_PRINTING_CUTTING',
     'KIT',
     'MACHINED_PART',
     'CORE',
@@ -3003,6 +3005,8 @@ export const insertInventoryItemSchema = createInsertSchema(inventoryItems)
     manufacturedCategory: z
       .enum([
         'PACKET',
+        'FOAM_CUTTING',
+        'THREE_D_PRINTING_CUTTING',
         'KIT',
         'MACHINED_PART',
         'CORE',

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -80,7 +80,7 @@ const draftBuilderInventoryItemSchema = z.object({
   department: z.string().optional().nullable(),
   isManufactured: z.boolean().default(false),
   manufacturedCategory: z
-    .enum(['PACKET', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT'])
+    .enum(['PACKET', 'FOAM_CUTTING', 'THREE_D_PRINTING_CUTTING', 'KIT', 'MACHINED_PART', 'CORE', 'SUB_ASSEMBLY', 'ASSEMBLY', 'FINAL_ASSEMBLY', 'COMPOSITE', 'COMPONENT'])
     .optional()
     .nullable(),
   project: z.string().optional().nullable(),

--- a/shared/utils/manufacturingRouting.ts
+++ b/shared/utils/manufacturingRouting.ts
@@ -1,5 +1,7 @@
 export type ManufacturedCategory =
   | 'PACKET'
+  | 'FOAM_CUTTING'
+  | 'THREE_D_PRINTING_CUTTING'
   | 'KIT'
   | 'MACHINED_PART'
   | 'CORE'
@@ -54,6 +56,26 @@ export const MANUFACTURING_ROUTE_DEFINITIONS: Record<ManufacturedCategory, Manuf
   PACKET: {
     category: 'PACKET',
     displayName: 'Packet',
+    dashboard: 'CUTTING_TABLE',
+    queueType: 'CUTTING_TABLE',
+    swimlane: 'CUTTING_TABLE_DEMAND',
+    department: 'Cutting Table',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  FOAM_CUTTING: {
+    category: 'FOAM_CUTTING',
+    displayName: 'Foam Cutting',
+    dashboard: 'CUTTING_TABLE',
+    queueType: 'CUTTING_TABLE',
+    swimlane: 'CUTTING_TABLE_DEMAND',
+    department: 'Cutting Table',
+    canRelease: true,
+    includeInBomExplosion: true,
+  },
+  THREE_D_PRINTING_CUTTING: {
+    category: 'THREE_D_PRINTING_CUTTING',
+    displayName: '3d Printing/Cutting',
     dashboard: 'CUTTING_TABLE',
     queueType: 'CUTTING_TABLE',
     swimlane: 'CUTTING_TABLE_DEMAND',


### PR DESCRIPTION
## Summary
- add Foam Cutting and 3d Printing/Cutting as manufactured inventory categories
- route both categories through the existing Cutting Table dashboard, queue, and BOM-explosion path
- accept the categories consistently in the inventory form, API validation, schema, and boot-time enum fallback
- add additive migration 0293 for existing PostgreSQL databases

## Validation
- `git diff --cached --check`
- `git diff --check origin/main..HEAD`
- `git merge-tree --write-tree origin/main HEAD`
- audited compare range: one commit, seven scoped files

## Validation boundary
- Full TypeScript check was not run because the isolated worktree has no installed dependencies.