### PR TITLE
Fix department schema safe boot migration

### DIFF
--- a/server/__tests__/departmentRoutingAuthorityPhase1.test.ts
+++ b/server/__tests__/departmentRoutingAuthorityPhase1.test.ts
@@ -11,6 +11,7 @@ describe('department routing authority Phase 1 foundation', () => {
   const flags = read('server/src/lib/featureFlags.ts');
   const sharedRoute = read('server/src/routes/sharedDepartments.ts');
   const routingRoute = read('server/src/routes/partRoutings.ts');
+  const safeBootRunner = read('server/scripts/migrations/runSafeBootMigrations.ts');
 
   it('is additive and performs no historical data mutation', () => {
     expect(migration).not.toMatch(/\bUPDATE\b|\bDELETE\s+FROM\b|\bTRUNCATE\b|\bDROP\b/i);
@@ -35,6 +36,17 @@ describe('department routing authority Phase 1 foundation', () => {
     expect(migration).not.toMatch(/ADD COLUMN IF NOT EXISTS default_department_id\s+INTEGER\s+NOT NULL/i);
     expect(migration).not.toMatch(/ADD COLUMN IF NOT EXISTS inventory_item_fk\s+INTEGER\s+NOT NULL/i);
     expect(migration).not.toMatch(/ADD COLUMN IF NOT EXISTS department_id\s+INTEGER\s+NOT NULL/i);
+  });
+
+  it('applies the schema before routes become ready and treats failure as fatal', () => {
+    const migrationName = '0294_shared_department_routing_authority_phase1.sql';
+    expect(safeBootRunner.match(new RegExp(migrationName, 'g'))).toHaveLength(2);
+    expect(safeBootRunner).toMatch(
+      /safeMigrationFiles\s*=\s*\[[\s\S]*0294_shared_department_routing_authority_phase1\.sql/
+    );
+    expect(safeBootRunner).toMatch(
+      /criticalMigrationFiles\s*=\s*new Set\(\[[\s\S]*0294_shared_department_routing_authority_phase1\.sql/
+    );
   });
 
   it('keeps all Phase 1 flags disabled by default', () => {

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -352,6 +352,7 @@ export const safeMigrationFiles = [
   '0290_p2_po_line_and_clin_distinction.sql',
   '0291_renumber_astrion_material_deposit_invoice.sql',
   '0292_vendor_po_final_compliance_confirmation.sql',
+  '0294_shared_department_routing_authority_phase1.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -446,6 +447,7 @@ export const criticalMigrationFiles = new Set([
   '0289_correct_po00021498_customer_line_numbers.sql',
   '0290_p2_po_line_and_clin_distinction.sql',
   '0292_vendor_po_final_compliance_confirmation.sql',
+  '0294_shared_department_routing_authority_phase1.sql',
 ]);
 
 export async function runSafeBootMigrations() {


### PR DESCRIPTION
## Summary
- register migration 0294_shared_department_routing_authority_phase1.sql in the safe boot migration list
- mark the migration critical so routes do not become ready against an incompatible schema
- add regression coverage for both registrations

## Production symptom fixed
- POST /api/inventory/items returned 400 because inventory_items.default_department_id did not exist
- GET /api/inventory/departments returned 500 from the same partially deployed department schema

## Validation
- bundled Node syntax checks passed for both touched TypeScript files
- git diff --check passed
- full Vitest execution unavailable because the isolated worktree has no installed dependencies

## Deployment verification
After merge and redeploy, confirm migration 0294 completes before routes are marked ready, GET /api/inventory/departments returns 200, and AG part 26389 can be created.