### PR TITLE
P2 Phase 1.1: harden shared Department management permission

### DIFF
--- a/client/src/__tests__/departmentAuthorityPermissionHardening.client.test.ts
+++ b/client/src/__tests__/departmentAuthorityPermissionHardening.client.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '../../..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+
+describe('Department management client permission boundary', () => {
+  const inventory = read('client/src/components/inventory/InventoryItemsCard.tsx');
+  const routing = read('client/src/components/PartRoutingWizard.tsx');
+
+  it('requires the dedicated permission in both management surfaces', () => {
+    for (const source of [inventory, routing]) {
+      expect(source).toContain("can('inventory.departments.manage')");
+      expect(source).toContain('canManageDepartments');
+      expect(source).toContain('Department management permission is required');
+    }
+  });
+
+  it('does not use inventory.adjust or a VITE flag alone as management authority', () => {
+    expect(inventory).not.toContain("can('inventory.adjust')");
+    expect(routing).not.toContain("can('inventory.adjust')");
+    expect(routing).toContain(
+      "sharedDepartmentWritesEnabled && can('inventory.departments.manage')"
+    );
+  });
+
+  it('continues to expose existing Department selection without management permission', () => {
+    expect(inventory).toContain('sortedDepartments.map');
+    expect(inventory).toContain('onMultiSelectChange');
+    expect(routing).toContain('onClick={() => toggleDepartment(dept)}');
+    expect(routing).toContain('deptRecord && canManageDepartments');
+  });
+});

--- a/client/src/components/PartRoutingWizard.tsx
+++ b/client/src/components/PartRoutingWizard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
+import { usePermissions } from '@/hooks/usePermissions';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -342,6 +343,12 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
     import.meta.env.VITE_SHARED_INVENTORY_DEPARTMENT_READS_ENABLED === 'true';
   const operationDepartmentIdsEnabled =
     import.meta.env.VITE_ROUTING_OPERATION_DEPARTMENT_IDS_ENABLED === 'true';
+  const sharedDepartmentWritesEnabled =
+    import.meta.env.VITE_SHARED_INVENTORY_DEPARTMENT_WRITES_ENABLED === 'true';
+  const { can } = usePermissions();
+  const canManageDepartments =
+    !sharedDepartmentsEnabled ||
+    (sharedDepartmentWritesEnabled && can('inventory.departments.manage'));
   const [step, setStep] = useState(1);
   const [selectedItemId, setSelectedItemId] = useState<string>(editRouting?.inventoryItemId || '');
   const [selectedProjectId, setSelectedProjectId] = useState<string>(editRouting?.projectId || '');
@@ -1973,7 +1980,7 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
                             <ChevronRight className="mr-2 h-4 w-4" />
                             {deptRecord?.departmentCode ? `${deptRecord.departmentCode} — ` : ''}{dept}
                           </Button>
-                          {deptRecord && (
+                          {deptRecord && canManageDepartments && (
                             <Button
                               variant="ghost"
                               size="sm"
@@ -1986,7 +1993,7 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
                         </div>
                       );
                     })}
-                    {editingDeptId && (
+                    {canManageDepartments && editingDeptId && (
                       <div className="flex gap-2 p-2 border rounded bg-blue-50 dark:bg-blue-950">
                         <Input
                           className="text-sm flex-1"
@@ -2060,6 +2067,7 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
                         </Button>
                       </div>
                     )}
+                    {canManageDepartments ? <>
                     <Separator className="my-2" />
                     <div className="flex gap-2">
                       <Input
@@ -2105,6 +2113,11 @@ export default function PartRoutingWizard({ open, onOpenChange, editRouting, poI
                         {deptSaving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />} Add
                       </Button>
                     </div>
+                    </> : sharedDepartmentsEnabled ? (
+                      <p className="text-xs text-muted-foreground" data-testid="routing-department-management-forbidden">
+                        You can select existing departments, but Department management permission is required to add or edit them.
+                      </p>
+                    ) : null}
                   </div>
                 </div>
 

--- a/client/src/components/inventory/InventoryItemsCard.tsx
+++ b/client/src/components/inventory/InventoryItemsCard.tsx
@@ -78,6 +78,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useLocation } from 'wouter';
 import { calculateCOGS } from '@/lib/unitConversion';
 import { parseLeadTimeToDays } from '@/utils/leadTimeUtils';
+import { usePermissions } from '@/hooks/usePermissions';
 
 type TraceabilityVisibility = 'required' | 'optional' | 'hidden';
 type TraceabilityFieldConfig = Record<string, TraceabilityVisibility>;
@@ -465,6 +466,9 @@ const InventoryForm = ({
 }) => {
   const sharedDepartmentPhase1 =
     import.meta.env.VITE_SHARED_INVENTORY_DEPARTMENT_WRITES_ENABLED === 'true';
+  const { can } = usePermissions();
+  const canManageDepartments =
+    !sharedDepartmentPhase1 || can('inventory.departments.manage');
   const queryClient = useQueryClient();
   const [duplicateWarning, setDuplicateWarning] = useState<string | null>(null);
   const [isCheckingDuplicate, setIsCheckingDuplicate] = useState(false);
@@ -547,6 +551,10 @@ const InventoryForm = ({
   });
 
   const handleAddDepartment = () => {
+    if (!canManageDepartments) {
+      toast.error('Department management permission is required.');
+      return;
+    }
     const departmentName = newDepartmentName.trim();
     if (!departmentName) {
       toast.error('Enter a department name');
@@ -1375,7 +1383,7 @@ const InventoryForm = ({
               </div>
             ))}
           </div>
-          <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+          {canManageDepartments ? <div className="mt-3 flex flex-col gap-2 sm:flex-row">
             <Input
               value={newDepartmentName}
               onChange={(event) => setNewDepartmentName(event.target.value)}
@@ -1398,7 +1406,11 @@ const InventoryForm = ({
               <Plus className="h-4 w-4 mr-2" />
               {createDepartmentMutation.isPending ? 'Adding...' : 'Add Department'}
             </Button>
-          </div>
+          </div> : sharedDepartmentPhase1 ? (
+            <p className="text-xs text-muted-foreground mt-3" data-testid="department-management-forbidden">
+              You can select existing departments, but Department management permission is required to add one.
+            </p>
+          ) : null}
           {formData.assignedDepartments.length > 0 && (
             <div className="flex flex-wrap gap-2 mt-2">
               {formData.assignedDepartments.map((dept) => (

--- a/server/__tests__/departmentAuthorityPermissionHardening.test.ts
+++ b/server/__tests__/departmentAuthorityPermissionHardening.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getUserPermissions } = vi.hoisted(() => ({
+  getUserPermissions: vi.fn(),
+}));
+vi.mock('../src/services/permissionService', () => ({ getUserPermissions }));
+vi.mock('../src/services/auditLedgerService', () => ({ recordAuditEvent: vi.fn() }));
+
+import { requirePermission } from '../middleware/requirePermission';
+
+const root = resolve(import.meta.dirname, '../..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+
+function response() {
+  const res: any = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+}
+
+describe('shared Department management permission hardening', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('denies a direct API request from a user with only inventory.adjust', async () => {
+    getUserPermissions.mockResolvedValue({
+      permissionSet: new Set(['inventory.adjust']),
+    });
+    const req: any = { user: { id: 42, role: 'INVENTORY_MANAGER' } };
+    const res = response();
+    const next = vi.fn();
+
+    await requirePermission('inventory.departments.manage')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Forbidden',
+      requiredCapability: 'inventory.departments.manage',
+    });
+  });
+
+  it('allows an authenticated user with the dedicated permission', async () => {
+    getUserPermissions.mockResolvedValue({
+      permissionSet: new Set(['inventory.departments.manage']),
+    });
+    const req: any = { user: { id: 7, role: 'INVENTORY_MANAGER' } };
+    const res = response();
+    const next = vi.fn();
+
+    await requirePermission('inventory.departments.manage')(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('uses the dedicated permission for every shared mutation surface', () => {
+    const shared = read('server/src/routes/sharedDepartments.ts');
+    const inventory = read('server/src/routes/inventory.ts');
+    const routing = read('server/src/routes/partRoutings.ts');
+
+    expect(shared.match(/requirePermission\('inventory\.departments\.manage'\)/g)).toHaveLength(3);
+    expect(inventory.match(/requirePermission\('inventory\.departments\.manage'\)/g)).toHaveLength(3);
+    expect(routing.match(/requirePermission\('inventory\.departments\.manage'\)/g)).toHaveLength(3);
+    expect(shared).not.toContain("requirePermission('inventory.adjust')");
+  });
+
+  it('defines the permission but does not broaden manager role grants', () => {
+    const index = read('server/index.ts');
+    expect(index).toContain("key: 'inventory.departments.manage'");
+    const managerBlock = index.slice(
+      index.indexOf('const managerCaps = ['),
+      index.indexOf('const inventoryManagerCaps = [')
+    );
+    const inventoryManagerBlock = index.slice(
+      index.indexOf('const inventoryManagerCaps = ['),
+      index.indexOf("WHERE pr.name = 'PURCHASING_BUYER'")
+    );
+    expect(managerBlock).not.toContain('inventory.departments.manage');
+    expect(inventoryManagerBlock).not.toContain('inventory.departments.manage');
+    expect(index).toContain("for (const roleName of ['ADMIN', 'OWNER'])");
+  });
+
+  it('keeps viewing and selection separate from Department management', () => {
+    const shared = read('server/src/routes/sharedDepartments.ts');
+    const routing = read('server/src/routes/partRoutings.ts');
+    expect(shared).toContain("router.get('/', async");
+    expect(routing).toContain("router.get('/departments/list', async");
+    expect(routing).toContain('listSharedDepartments({ routingOnly: true })');
+  });
+
+  it('hides shared Department management controls without hiding selection', () => {
+    const inventoryUi = read('client/src/components/inventory/InventoryItemsCard.tsx');
+    const routingUi = read('client/src/components/PartRoutingWizard.tsx');
+    for (const source of [inventoryUi, routingUi]) {
+      expect(source).toContain("can('inventory.departments.manage')");
+      expect(source).toContain('canManageDepartments');
+      expect(source).toContain('Department management permission is required');
+    }
+    expect(inventoryUi).toContain('sortedDepartments.map');
+    expect(routingUi).toContain('onClick={() => toggleDepartment(dept)}');
+  });
+
+  it('retains authenticated actor identity in Department audit events', () => {
+    const service = read('server/src/services/sharedDepartmentService.ts');
+    expect(service.match(/actor,/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(service).toContain("eventType: 'SHARED_DEPARTMENT_CREATED'");
+    expect(service).toContain("eventType: 'SHARED_DEPARTMENT_UPDATED'");
+    expect(service).toContain("eventType: 'SHARED_DEPARTMENT_DEACTIVATED'");
+  });
+
+  it('does not enable any Phase 1 feature flag', () => {
+    const flags = read('server/src/lib/featureFlags.ts');
+    for (const key of [
+      'SHARED_INVENTORY_DEPARTMENT_READS_ENABLED',
+      'SHARED_INVENTORY_DEPARTMENT_WRITES_ENABLED',
+      'STABLE_ROUTING_INVENTORY_ITEM_FK_ENABLED',
+      'ROUTING_OPERATION_DEPARTMENT_IDS_ENABLED',
+    ]) expect(flags).toContain(`envBool('${key}', false)`);
+  });
+});

--- a/server/__tests__/departmentRoutingAuthorityPhase1.test.ts
+++ b/server/__tests__/departmentRoutingAuthorityPhase1.test.ts
@@ -61,7 +61,7 @@ describe('department routing authority Phase 1 foundation', () => {
   });
 
   it('protects department mutations with permission checks and audit events', () => {
-    expect(sharedRoute.match(/requirePermission\('inventory\.adjust'\)/g)?.length).toBe(3);
+    expect(sharedRoute.match(/requirePermission\('inventory\.departments\.manage'\)/g)?.length).toBe(3);
     const service = read('server/src/services/sharedDepartmentService.ts');
     expect(service).toContain('SHARED_DEPARTMENT_CREATED');
     expect(service).toContain('SHARED_DEPARTMENT_UPDATED');

--- a/server/index.ts
+++ b/server/index.ts
@@ -4691,6 +4691,7 @@ async function initializeBackgroundServices() {
 
           // Inventory
           { key: 'inventory.adjust', description: 'Update and delete inventory items and balances', category: 'inventory' },
+          { key: 'inventory.departments.manage', description: 'Create, edit, deactivate, and reactivate controlled inventory departments', category: 'inventory' },
           { key: 'inventory.manage_requests', description: 'Receive or reject inventory parts requests', category: 'inventory' },
           { key: 'inventory.approve_parts_requests', description: 'Approve inventory parts requests before they enter RFQ or Vendor PO flow', category: 'inventory' },
 

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -3813,27 +3813,31 @@ router.get('/departments', async (req: Request, res: Response) => {
   }
 });
 
-router.post('/departments', requireRole('ADMIN', 'OWNER'), async (req: Request, res: Response) => {
+router.post('/departments', async (req: Request, res: Response) => {
   try {
     if (areSharedInventoryDepartmentWritesEnabled()) {
-      const user = req.user as any;
-      return res.status(201).json(await createSharedDepartment(
-        {
-          name: String(req.body?.name || ''),
-          departmentCode: String(req.body?.departmentCode || ''),
-          routingEnabled: req.body?.routingEnabled,
-          productionEnabled: req.body?.productionEnabled,
-          schedulingEnabled: req.body?.schedulingEnabled,
-          sortOrder: req.body?.sortOrder,
-        },
-        { id: Number(user?.id) || null, username: user?.username, role: user?.role }
-      ));
+      return requirePermission('inventory.departments.manage')(req, res, async () => {
+        const user = req.user as any;
+        return res.status(201).json(await createSharedDepartment(
+          {
+            name: String(req.body?.name || ''),
+            departmentCode: String(req.body?.departmentCode || ''),
+            routingEnabled: req.body?.routingEnabled,
+            productionEnabled: req.body?.productionEnabled,
+            schedulingEnabled: req.body?.schedulingEnabled,
+            sortOrder: req.body?.sortOrder,
+          },
+          { id: Number(user?.id) || null, username: user?.username, role: user?.role }
+        ));
+      });
     }
-    const { inventoryDepartments, insertInventoryDepartmentSchema } = await import('../../schema');
-    const { db } = await import('../../db');
-    const departmentData = insertInventoryDepartmentSchema.parse(req.body);
-    const [newDepartment] = await db.insert(inventoryDepartments).values(departmentData).returning();
-    res.status(201).json(newDepartment);
+    return requireRole('ADMIN', 'OWNER')(req, res, async () => {
+      const { inventoryDepartments, insertInventoryDepartmentSchema } = await import('../../schema');
+      const { db } = await import('../../db');
+      const departmentData = insertInventoryDepartmentSchema.parse(req.body);
+      const [newDepartment] = await db.insert(inventoryDepartments).values(departmentData).returning();
+      return res.status(201).json(newDepartment);
+    });
   } catch (error) {
     console.error('Create department error:', error);
     if (error instanceof Error) {
@@ -3843,28 +3847,32 @@ router.post('/departments', requireRole('ADMIN', 'OWNER'), async (req: Request, 
   }
 });
 
-router.put('/departments/:id', requireRole('ADMIN', 'OWNER'), async (req: Request, res: Response) => {
+router.put('/departments/:id', async (req: Request, res: Response) => {
   try {
     const departmentId = parseInt(req.params.id);
     if (areSharedInventoryDepartmentWritesEnabled()) {
-      const user = req.user as any;
-      return res.json(await updateSharedDepartment(
-        departmentId,
-        req.body,
-        { id: Number(user?.id) || null, username: user?.username, role: user?.role }
-      ));
+      return requirePermission('inventory.departments.manage')(req, res, async () => {
+        const user = req.user as any;
+        return res.json(await updateSharedDepartment(
+          departmentId,
+          req.body,
+          { id: Number(user?.id) || null, username: user?.username, role: user?.role }
+        ));
+      });
     }
-    const { inventoryDepartments, insertInventoryDepartmentSchema } = await import('../../schema');
-    const { eq } = await import('drizzle-orm');
-    const { db } = await import('../../db');
-    const updates = insertInventoryDepartmentSchema.partial().parse(req.body);
-    const [updatedDepartment] = await db
-      .update(inventoryDepartments)
-      .set(updates)
-      .where(eq(inventoryDepartments.id, departmentId))
-      .returning();
-    if (!updatedDepartment) return res.status(404).json({ error: 'Department not found' });
-    res.json(updatedDepartment);
+    return requireRole('ADMIN', 'OWNER')(req, res, async () => {
+      const { inventoryDepartments, insertInventoryDepartmentSchema } = await import('../../schema');
+      const { eq } = await import('drizzle-orm');
+      const { db } = await import('../../db');
+      const updates = insertInventoryDepartmentSchema.partial().parse(req.body);
+      const [updatedDepartment] = await db
+        .update(inventoryDepartments)
+        .set(updates)
+        .where(eq(inventoryDepartments.id, departmentId))
+        .returning();
+      if (!updatedDepartment) return res.status(404).json({ error: 'Department not found' });
+      return res.json(updatedDepartment);
+    });
   } catch (error) {
     console.error('Update department error:', error);
     if (error instanceof Error) {
@@ -3874,18 +3882,22 @@ router.put('/departments/:id', requireRole('ADMIN', 'OWNER'), async (req: Reques
   }
 });
 
-router.delete('/departments/:id', requireRole('ADMIN', 'OWNER'), async (req: Request, res: Response) => {
+router.delete('/departments/:id', async (req: Request, res: Response) => {
   try {
     const departmentId = parseInt(req.params.id);
     if (areSharedInventoryDepartmentWritesEnabled()) {
-      const user = req.user as any;
-      return res.json(await deactivateUnreferencedDepartment(
-        departmentId,
-        { id: Number(user?.id) || null, username: user?.username, role: user?.role }
-      ));
+      return requirePermission('inventory.departments.manage')(req, res, async () => {
+        const user = req.user as any;
+        return res.json(await deactivateUnreferencedDepartment(
+          departmentId,
+          { id: Number(user?.id) || null, username: user?.username, role: user?.role }
+        ));
+      });
     }
-    await storage.deleteDepartment(departmentId);
-    res.status(204).end();
+    return requireRole('ADMIN', 'OWNER')(req, res, async () => {
+      await storage.deleteDepartment(departmentId);
+      return res.status(204).end();
+    });
   } catch (error) {
     console.error('Delete department error:', error);
     res.status(500).json({ error: 'Failed to delete department' });

--- a/server/src/routes/partRoutings.ts
+++ b/server/src/routes/partRoutings.ts
@@ -13,7 +13,9 @@ import {
 } from '../lib/featureFlags';
 import {
   createSharedDepartment,
+  deactivateUnreferencedDepartment,
   listSharedDepartments,
+  updateSharedDepartment,
 } from '../services/sharedDepartmentService';
 import { requirePermission } from '../../middleware/requirePermission';
 import OpenAI from 'openai';
@@ -490,7 +492,7 @@ router.get('/departments/list', async (_req: Request, res: Response) => {
 router.post('/departments', async (req: Request, res: Response) => {
   try {
     if (areSharedInventoryDepartmentWritesEnabled()) {
-      return requirePermission('inventory.adjust')(req, res, async () => {
+      return requirePermission('inventory.departments.manage')(req, res, async () => {
         try {
           const name = String(req.body?.name || '').trim();
           const departmentCode = String(req.body?.departmentCode || '').trim();
@@ -529,6 +531,28 @@ router.post('/departments', async (req: Request, res: Response) => {
 
 router.patch('/departments/:id', async (req: Request, res: Response) => {
   try {
+    if (areSharedInventoryDepartmentWritesEnabled()) {
+      return requirePermission('inventory.departments.manage')(req, res, async () => {
+        try {
+          const user = req.user as any;
+          return res.json(await updateSharedDepartment(
+            z.coerce.number().int().positive().parse(req.params.id),
+            z.object({
+              name: z.string().trim().min(1).max(120).optional(),
+              departmentCode: z.string().trim().min(1).max(40).regex(/^[A-Za-z0-9_-]+$/).optional(),
+              routingEnabled: z.boolean().optional(),
+              productionEnabled: z.boolean().optional(),
+              schedulingEnabled: z.boolean().optional(),
+              sortOrder: z.number().int().optional(),
+              isActive: z.boolean().optional(),
+            }).parse(req.body),
+            { id: Number(user?.id) || null, username: user?.username, role: user?.role }
+          ));
+        } catch (error: any) {
+          return res.status(error.status || 400).json({ error: error.code || error.message });
+        }
+      });
+    }
     const deptId = req.params.id;
     const { name } = req.body;
 
@@ -556,6 +580,19 @@ router.patch('/departments/:id', async (req: Request, res: Response) => {
 
 router.delete('/departments/:id', async (req: Request, res: Response) => {
   try {
+    if (areSharedInventoryDepartmentWritesEnabled()) {
+      return requirePermission('inventory.departments.manage')(req, res, async () => {
+        try {
+          const user = req.user as any;
+          return res.json(await deactivateUnreferencedDepartment(
+            z.coerce.number().int().positive().parse(req.params.id),
+            { id: Number(user?.id) || null, username: user?.username, role: user?.role }
+          ));
+        } catch (error: any) {
+          return res.status(error.status || 400).json({ error: error.code || error.message });
+        }
+      });
+    }
     const rows = await pool.query(
       `UPDATE p2_routing_departments SET is_active = false, updated_at = NOW()
        WHERE id = $1

--- a/server/src/routes/sharedDepartments.ts
+++ b/server/src/routes/sharedDepartments.ts
@@ -56,19 +56,19 @@ router.get('/', async (req, res) => {
   } catch (error) { failure(res, error); }
 });
 
-router.post('/', requirePermission('inventory.adjust'), async (req, res) => {
+router.post('/', requirePermission('inventory.departments.manage'), async (req, res) => {
   if (!enabled(res, 'write')) return;
   try { res.status(201).json(await createSharedDepartment(writeSchema.parse(req.body), actor(req))); }
   catch (error) { failure(res, error); }
 });
 
-router.patch('/:id', requirePermission('inventory.adjust'), async (req, res) => {
+router.patch('/:id', requirePermission('inventory.departments.manage'), async (req, res) => {
   if (!enabled(res, 'write')) return;
   try { res.json(await updateSharedDepartment(z.coerce.number().int().positive().parse(req.params.id), updateSchema.parse(req.body), actor(req))); }
   catch (error) { failure(res, error); }
 });
 
-router.delete('/:id', requirePermission('inventory.adjust'), async (req, res) => {
+router.delete('/:id', requirePermission('inventory.departments.manage'), async (req, res) => {
   if (!enabled(res, 'write')) return;
   try { res.json(await deactivateUnreferencedDepartment(z.coerce.number().int().positive().parse(req.params.id), actor(req))); }
   catch (error) { failure(res, error); }


### PR DESCRIPTION
## Summary

- adds the dedicated `inventory.departments.manage` capability for controlled shared Department creation, editing, deactivation, and reactivation
- removes `inventory.adjust` as shared Department administration authority across the shared, inventory, and routing API surfaces
- gates Inventory Item Master and routing Department-management controls while retaining Department viewing and selection
- preserves authenticated actor audit attribution

## Authority and compatibility

- ADMIN and OWNER remain the default roles with Department-management authority
- MANAGER and INVENTORY_MANAGER retain `inventory.adjust` but do not receive the new capability
- legacy Department behavior is unchanged while shared-write flags are disabled
- no migration, data backfill, historical-record mutation, or Phase 2 behavior is included

## Feature flags

All remain disabled by default:

- `SHARED_INVENTORY_DEPARTMENT_READS_ENABLED`
- `SHARED_INVENTORY_DEPARTMENT_WRITES_ENABLED`
- `STABLE_ROUTING_INVENTORY_ITEM_FK_ENABLED`
- `ROUTING_OPERATION_DEPARTMENT_IDS_ENABLED`
- corresponding client `VITE_` flags

## Validation

- server focused suites: 17 passed
- client focused suite: 3 passed
- `git diff --check origin/main...HEAD`
- clean non-conflicting merge tree against current `origin/main` (`317e53aad`)

Full repository TypeScript validation remains affected by the existing current-main error backlog; the focused permission and Phase 1 contracts pass.

## Scope boundary

This is foundation-only security hardening. It does not enable any feature flag, change inventory balances, create work orders or travelers, implement Receiving barcodes or Genealogy, modify historical records, deploy, or begin Phase 2.