### PR TITLE
P2 Phase 4: WAD traveler-decision authority foundation

### DIFF
--- a/migrations/0297_p2_wad_traveler_authority_foundation.sql
+++ b/migrations/0297_p2_wad_traveler_authority_foundation.sql
@@ -1,0 +1,45 @@
+-- Phase 4 foundation: prospective WAD traveler decisions against released master policy.
+-- Additive only; no historical WAD, traveler, work-order or Inventory record is changed.
+CREATE TABLE IF NOT EXISTS p2_wad_traveler_decisions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  wad_authorization_id UUID NOT NULL REFERENCES project_wad_authorizations(id) ON DELETE RESTRICT,
+  project_configuration_id UUID NOT NULL REFERENCES p2_project_controlled_configurations(id) ON DELETE RESTRICT,
+  inventory_item_id INTEGER NOT NULL REFERENCES inventory_items(id) ON DELETE RESTRICT,
+  assembly_path_identity TEXT NOT NULL,
+  required_quantity NUMERIC(18,6) NOT NULL CHECK (required_quantity > 0),
+  traveler_requirement TEXT NOT NULL CHECK (traveler_requirement IN ('REQUIRED','NOT_REQUIRED_APPROVED')),
+  traveler_type TEXT CHECK (traveler_type IN ('INDIVIDUAL','BATCH')),
+  traceability_policy_id UUID NOT NULL REFERENCES inventory_item_traceability_policies(id) ON DELETE RESTRICT,
+  traceability_policy_revision INTEGER NOT NULL,
+  traceability_policy_type_snapshot TEXT NOT NULL,
+  traceability_requirements_snapshot JSONB NOT NULL,
+  inspection_requirements_snapshot JSONB NOT NULL,
+  exception_required BOOLEAN NOT NULL DEFAULT false,
+  exception_reason TEXT,
+  exception_effectivity JSONB,
+  exception_approved_by INTEGER,
+  exception_approver_display_name TEXT,
+  exception_signature_meaning TEXT,
+  exception_approved_at TIMESTAMPTZ,
+  content_checksum TEXT NOT NULL,
+  created_by INTEGER NOT NULL,
+  created_by_display_name TEXT NOT NULL,
+  created_by_role TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(wad_authorization_id,inventory_item_id,assembly_path_identity),
+  CHECK (traveler_requirement='REQUIRED' OR (exception_required AND exception_reason IS NOT NULL)),
+  CHECK (traveler_requirement<>'REQUIRED' OR traveler_type IS NOT NULL)
+);
+CREATE INDEX IF NOT EXISTS p2_wad_traveler_decisions_configuration_idx ON p2_wad_traveler_decisions(project_configuration_id);
+
+INSERT INTO perm_capabilities(key,description,category) VALUES
+ ('projects.wad_traveler_decisions.manage','Manage controlled WAD traveler decisions','projects'),
+ ('projects.wad_traveler_decisions.exception_approve','Approve a WAD exception that may weaken master traceability','quality')
+ON CONFLICT (key) DO NOTHING;
+INSERT INTO perm_role_capabilities(role_id,capability_id)
+SELECT r.id,c.id FROM perm_roles r CROSS JOIN perm_capabilities c WHERE
+ (r.name IN ('ADMIN','OWNER') AND c.key IN ('projects.wad_traveler_decisions.manage','projects.wad_traveler_decisions.exception_approve')) OR
+ (r.name IN ('PROJECT_MANAGER','PROGRAM_MANAGER') AND c.key='projects.wad_traveler_decisions.manage') OR
+ (r.name IN ('QUALITY','QUALITY_MANAGER') AND c.key='projects.wad_traveler_decisions.exception_approve')
+ON CONFLICT DO NOTHING;

--- a/server/__tests__/p2WadTravelerAuthorityFoundation.test.ts
+++ b/server/__tests__/p2WadTravelerAuthorityFoundation.test.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from 'fs'; import { resolve } from 'path'; import { describe,expect,it } from 'vitest';
+const root=resolve(__dirname,'../..'); const read=(p:string)=>readFileSync(resolve(root,p),'utf8');
+describe('Phase 4 WAD traveler authority foundation',()=>{const m=read('migrations/0297_p2_wad_traveler_authority_foundation.sql');const f=read('server/src/lib/featureFlags.ts');const r=read('server/scripts/migrations/runSafeBootMigrations.ts');
+it('is additive and ordered after Phase 3',()=>{expect(m).not.toMatch(/UPDATE|DELETE FROM|TRUNCATE/i);expect(r.match(/0297_p2_wad_traveler_authority_foundation\.sql/g)).toHaveLength(2);expect(r.indexOf('0296_p2_project')).toBeLessThan(r.indexOf('0297_p2_wad'));});
+it('binds decisions to released authority identities and snapshots',()=>{for(const v of ['project_configuration_id','inventory_item_id','assembly_path_identity','traceability_policy_id','traceability_policy_revision','content_checksum'])expect(m).toContain(v);});
+it('requires controlled evidence for traveler-not-required',()=>{expect(m).toContain("traveler_requirement='REQUIRED' OR (exception_required AND exception_reason IS NOT NULL)");expect(m).toContain('exception_signature_meaning');expect(m).toContain('projects.wad_traveler_decisions.exception_approve');});
+it('keeps Phase 4 disabled by default',()=>{expect(f).toContain("envBool('P2_WAD_TRAVELER_DECISION_READS_ENABLED', false)");expect(f).toContain("envBool('P2_WAD_TRAVELER_DECISION_WRITES_ENABLED', false)");});
+it('creates no execution records',()=>{for(const table of ['work_orders','travelers','inventory_transactions','barcodes','genealogy'])expect(m).not.toMatch(new RegExp(`INSERT INTO ${table}`,'i'));});});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -355,6 +355,7 @@ export const safeMigrationFiles = [
   '0294_shared_department_routing_authority_phase1.sql',
   '0295_inventory_traceability_bom_foundation.sql',
   '0296_p2_project_controlled_configuration_foundation.sql',
+  '0297_p2_wad_traveler_authority_foundation.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -452,6 +453,7 @@ export const criticalMigrationFiles = new Set([
   '0294_shared_department_routing_authority_phase1.sql',
   '0295_inventory_traceability_bom_foundation.sql',
   '0296_p2_project_controlled_configuration_foundation.sql',
+  '0297_p2_wad_traveler_authority_foundation.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -144,6 +144,14 @@ export function areP2ProjectControlledConfigurationWritesEnabled(): boolean {
   return envBool('P2_PROJECT_CONTROLLED_CONFIGURATION_WRITES_ENABLED', false);
 }
 
+/** Phase 4 controlled WAD traveler-decision authority; disabled by default. */
+export function areP2WadTravelerDecisionReadsEnabled(): boolean {
+  return envBool('P2_WAD_TRAVELER_DECISION_READS_ENABLED', false);
+}
+export function areP2WadTravelerDecisionWritesEnabled(): boolean {
+  return envBool('P2_WAD_TRAVELER_DECISION_WRITES_ENABLED', false);
+}
+
 /**
  * Cutover date for the punch_ledger migration.
  * For pay periods starting ON or AFTER this date, hour computations read


### PR DESCRIPTION
Starts the additive Phase 4 authority contract for per-manufactured-item WAD traveler decisions. Decisions are linked to the released Phase 3 project configuration, stable Inventory Item identity, assembly path, and released traceability-policy revision. Individual and batch modes are modeled; traveler-not-required requires controlled exception evidence. Dedicated manage and Quality exception-approval permissions are added. Server flags remain disabled by default. No historical backfill, traveler/work-order creation, barcode, inventory transaction, balance change, material consumption, or Genealogy behavior is included. Migration 0297 is registered after 0296. This is an early draft: API/service/UI integration and PostgreSQL certification remain required before review.