### PR TITLE
P2 V2: unblock projects route certification lint

### DIFF
--- a/server/__tests__/p2OrderDraftProgress.test.ts
+++ b/server/__tests__/p2OrderDraftProgress.test.ts
@@ -1,16 +1,23 @@
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
+
 import { runMigrationSafetyCheck } from '../utils/migrationSafetyCheck';
 
-const read = (relative: string) => fs.readFileSync(path.resolve(process.cwd(), relative), 'utf8');
+const read = (relative: string) =>
+  fs.readFileSync(path.resolve(process.cwd(), relative), 'utf8');
 
 describe('resumable P2 order wizard drafts', () => {
   it('uses a separate additive draft table outside production POs', () => {
     const migration = read('migrations/0288_p2_order_draft_progress.sql');
-    expect(() => runMigrationSafetyCheck(migration, '0288_p2_order_draft_progress.sql')).not.toThrow();
+    expect(() =>
+      runMigrationSafetyCheck(migration, '0288_p2_order_draft_progress.sql')
+    ).not.toThrow();
     expect(migration).toContain('CREATE TABLE IF NOT EXISTS p2_order_drafts');
-    expect(migration).toContain('CONSTRAINT p2_order_drafts_project_unique UNIQUE (project_id)');
+    expect(migration).toContain(
+      'CONSTRAINT p2_order_drafts_project_unique UNIQUE (project_id)'
+    );
     expect(migration).not.toMatch(/\bDROP\b|\bTRUNCATE\b/i);
   });
 
@@ -20,11 +27,19 @@ describe('resumable P2 order wizard drafts', () => {
     expect(routes).toContain("router.put('/:id/p2-order-draft'");
     expect(routes).toContain("router.delete('/:id/p2-order-draft'");
     expect(routes).toContain('ON CONFLICT (project_id) DO UPDATE');
+    expect(routes).toContain(
+      "draftActor?.username || draftActor?.email || 'unknown'"
+    );
+    expect(routes).toContain(
+      "pool.query('DELETE FROM p2_order_drafts WHERE project_id = $1'"
+    );
   });
 
   it('keeps PO date distinct from committed due date', () => {
     const wizard = read('client/src/components/p2/P2POCreationWizard.tsx');
-    expect(wizard).toContain("poDate: z.string().min(1, 'PO date is required')");
+    expect(wizard).toContain(
+      "poDate: z.string().min(1, 'PO date is required')"
+    );
     expect(wizard).toContain('data-testid="input-po-date"');
     expect(wizard).toContain('data-testid="input-due-date"');
     expect(wizard).toContain('data-testid="button-save-p2-draft"');

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -623,7 +623,9 @@ router.get('/:id/p2-order-draft', async (req, res) => {
     );
     res.json(rows[0] || null);
   } catch (error) {
-    res.status(error instanceof z.ZodError ? 400 : 500).json({ message: 'Failed to load P2 order draft' });
+    res
+      .status(error instanceof z.ZodError ? 400 : 500)
+      .json({ message: 'Failed to load P2 order draft' });
   }
 });
 
@@ -631,7 +633,10 @@ router.put('/:id/p2-order-draft', async (req: Request, res: Response) => {
   try {
     const projectId = uuidStringSchema.parse(req.params.id);
     const input = p2OrderDraftBodySchema.parse(req.body);
-    const actor = String((req as any).user?.username || (req as any).user?.email || 'unknown');
+    const draftActor = req.user as typeof req.user & { email?: string };
+    const actor = String(
+      draftActor?.username || draftActor?.email || 'unknown'
+    );
     const rows = await pool.query(
       `INSERT INTO p2_order_drafts (project_id, current_step, draft_data, created_by, updated_by)
        VALUES ($1, $2, $3::jsonb, $4, $4)
@@ -648,17 +653,23 @@ router.put('/:id/p2-order-draft', async (req: Request, res: Response) => {
     );
     res.json(rows[0]);
   } catch (error) {
-    res.status(error instanceof z.ZodError ? 400 : 500).json({ message: 'Failed to save P2 order draft' });
+    res
+      .status(error instanceof z.ZodError ? 400 : 500)
+      .json({ message: 'Failed to save P2 order draft' });
   }
 });
 
 router.delete('/:id/p2-order-draft', async (req: Request, res: Response) => {
   try {
     const projectId = uuidStringSchema.parse(req.params.id);
-    await pool.query('DELETE FROM p2_order_drafts WHERE project_id = $1', [projectId]);
+    await pool.query('DELETE FROM p2_order_drafts WHERE project_id = $1', [
+      projectId,
+    ]);
     res.status(204).send();
   } catch (error) {
-    res.status(error instanceof z.ZodError ? 400 : 500).json({ message: 'Failed to delete P2 order draft' });
+    res
+      .status(error instanceof z.ZodError ? 400 : 500)
+      .json({ message: 'Failed to delete P2 order draft' });
   }
 });
 
@@ -3965,7 +3976,9 @@ router.get('/:id/p2-hub', async (req, res) => {
     const orderedQuantityByRootPart = new Map<string, number>();
     assemblySourceItems.forEach((item: LegacyProjectValue) => {
       const rootPartNumber = String(
-        poInventoryPartById.get(Number(item.inventory_item_id)) || item.part_number || ''
+        poInventoryPartById.get(Number(item.inventory_item_id)) ||
+          item.part_number ||
+          ''
       )
         .trim()
         .toLowerCase();


### PR DESCRIPTION
## Scope

Certification-only correction for required P2 V2 workflow run 32876519646.

- Formats the six reported Prettier findings in server/src/routes/projects.ts.
- Replaces two no-explicit-any casts with the existing authenticated request-user type plus a typed optional legacy email fallback.
- Preserves routes, SQL, status handling, permissions, and actor fallback behavior.
- Extends the focused P2 order-draft regression.

## Origin

All findings predate Phase 3 and Phase 4. Lines 626, 634, 651, 658, and 661 originated in f3aefd6dca (2026-08-17); line 3968 originated in d08d343c34 (2026-08-13). PR #1811 did not modify projects.ts.

## Validation

- P2 order-draft, Phase 3, and Phase 4 focused tests: 14/14 passed.
- Affected-scope Prettier: passed.
- Affected-scope ESLint: passed with zero warnings.
- git diff --check: passed.
- Repository-wide local TypeScript has extensive preexisting baseline errors; the bounded GitHub comparison is authoritative.

## Boundaries

No Phase 4 logic, migration, feature flag, permission, database behavior, production transition, or Phase 5 implementation changes.

The Phase 4 post-merge review separately identified unresolved coverage-identity, retry-idempotency, and batch-coverage validation concerns. This lint-only PR does not correct them.

Do not merge, deploy, enable flags, or begin Phase 5 based solely on this PR.