### PR TITLE
Fix retired migration 0253 safe-boot regression

### DIFF
--- a/scripts/sync-safe-migrations.js
+++ b/scripts/sync-safe-migrations.js
@@ -83,6 +83,9 @@ while ((m = entryRegex.exec(arrayBody)) !== null) {
 // boot once the repair has been applied or the target row state has changed.
 // List them here so the sync script never re-adds them automatically.
 const INTENTIONALLY_EXCLUDED = new Set([
+  // One-off controlled validation-package correction. It is certified by the
+  // dedicated migration-0253 workflow and must not replay during safe boot.
+  '0253_void_duplicate_epoch_validation_packages.sql',
   // One-off row-level data repair for PO-P18380-46-1.  Its fail-closed guard
   // raises an exception when the target production_orders row is not in the
   // exact legacy mismatch state it was authored against (CANCELLED / Shipping QC),

--- a/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
+++ b/server/__tests__/epochSoftwareValidationDuplicateCleanupArchitecture.test.ts
@@ -15,6 +15,15 @@ const safeBoot = fs.readFileSync(
   path.join(root, 'server/scripts/migrations/runSafeBootMigrations.ts'),
   'utf8'
 );
+const safeBootEntries =
+  safeBoot
+    .match(/safeMigrationFiles\s*=\s*\[([\s\S]*?)\];/)?.[1]
+    .match(/'[^']+\.sql'/g)
+    ?.map((entry) => entry.slice(1, -1)) ?? [];
+const migrationSync = fs.readFileSync(
+  path.join(root, 'scripts/sync-safe-migrations.js'),
+  'utf8'
+);
 const certification = fs.readFileSync(
   path.join(root, '.github/workflows/p2-v2-postgres-certification.yml'),
   'utf8'
@@ -74,8 +83,11 @@ describe('EPOCH validation duplicate cleanup', () => {
   });
 
   it('keeps retired migration 0253 out of recurring safe boot', () => {
-    expect(safeBoot).not.toContain(
+    expect(safeBootEntries).not.toContain(
       '0253_void_duplicate_epoch_validation_packages.sql'
+    );
+    expect(migrationSync).toMatch(
+      /INTENTIONALLY_EXCLUDED\s*=\s*new Set\(\[[\s\S]*?'0253_void_duplicate_epoch_validation_packages\.sql'/
     );
   });
 

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -307,7 +307,9 @@ export const safeMigrationFiles = [
   '0250_epoch_validation_wizard_phase1.sql',
   '0251_design_project_configuration_workspace.sql',
   '0252_potential_order_duplicate_reviews.sql',
-  '0253_void_duplicate_epoch_validation_packages.sql',
+  // 0253_void_duplicate_epoch_validation_packages.sql is intentionally
+  // excluded. It is a one-off controlled data correction certified by the
+  // dedicated migration-0253 workflow, not a recurring safe-boot migration.
   '0254_controlled_document_reconciliation_certification_controls.sql',
   '0255_p2_v2_definition_v3_handoff.sql',
   '0256_controlled_document_atomic_approval_release.sql',


### PR DESCRIPTION
## Scope

Corrects only the validation-certification regression exposed after PR #1812.

- Removes the retired one-off migration 0253 from the executable recurring safe-boot list.
- Records migration 0253 in the sync script's intentional-exclusion set so automation cannot re-register it.
- Makes the architecture regression inspect executable safeMigrationFiles entries rather than prohibiting an explanatory filename comment.

## Evidence

- Focused duplicate-cleanup architecture tests: 5/5 passed.
- Static migration-safety tests: 10/10 passed; 9 database-only cases intentionally excluded locally because no disposable DATABASE_URL was supplied.
- Affected-scope ESLint: passed.
- Affected-scope Prettier: passed.
- git diff --check: passed.

## Boundaries

This PR contains no Phase 4 authority correction and no Phase 5 implementation. It changes no application routes, permissions, WAD behavior, traceability, BOM, routing, historical records, production execution, inventory balances, barcode, Receiving, or Genealogy behavior. Feature flags remain disabled by default.

This draft requires authorized review, disposable PostgreSQL certification, and merge before the separate Phase 4 authority correction can begin.