### PR TITLE
P2 Phase 4: correct WAD authority enforcement

### DIFF
--- a/.github/workflows/p2-wad-traveler-authority-postgres.yml
+++ b/.github/workflows/p2-wad-traveler-authority-postgres.yml
@@ -60,12 +60,12 @@ jobs:
           SELECT 'travelers|'||count(*) FROM travelers;
           SELECT 'transactions|'||count(*) FROM inventory_transactions;
           SELECT 'decisions|'||count(*) FROM p2_wad_traveler_decisions;
+          SELECT 'inventory_items_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM inventory_items t;
+          SELECT 'work_orders_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM production_work_orders t;
+          SELECT 'travelers_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM travelers t;
+          SELECT 'transactions_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM inventory_transactions t;
+          SELECT 'decisions_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM p2_wad_traveler_decisions t;
           SQL
-          pg_dump "$DATABASE_URL" --data-only --column-inserts \
-            --table=inventory_items --table=production_work_orders \
-            --table=travelers --table=inventory_transactions \
-            --table=p2_wad_traveler_decisions > /tmp/before-data.sql
-          sha256sum /tmp/before-data.sql > /tmp/before-data.sha256
           npm run maintenance:safe-migrations
           psql "$DATABASE_URL" -At -v ON_ERROR_STOP=1 <<'SQL' > /tmp/after.txt
           SELECT 'inventory_items|'||count(*) FROM inventory_items;
@@ -73,14 +73,13 @@ jobs:
           SELECT 'travelers|'||count(*) FROM travelers;
           SELECT 'transactions|'||count(*) FROM inventory_transactions;
           SELECT 'decisions|'||count(*) FROM p2_wad_traveler_decisions;
+          SELECT 'inventory_items_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM inventory_items t;
+          SELECT 'work_orders_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM production_work_orders t;
+          SELECT 'travelers_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM travelers t;
+          SELECT 'transactions_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM inventory_transactions t;
+          SELECT 'decisions_checksum|'||md5(COALESCE(string_agg(md5(row_to_json(t)::text),'' ORDER BY md5(row_to_json(t)::text)),'')) FROM p2_wad_traveler_decisions t;
           SQL
-          pg_dump "$DATABASE_URL" --data-only --column-inserts \
-            --table=inventory_items --table=production_work_orders \
-            --table=travelers --table=inventory_transactions \
-            --table=p2_wad_traveler_decisions > /tmp/after-data.sql
-          sha256sum /tmp/after-data.sql | sed 's#/tmp/after-data.sql#/tmp/before-data.sql#' > /tmp/after-data.sha256
           diff -u /tmp/before.txt /tmp/after.txt
-          diff -u /tmp/before-data.sha256 /tmp/after-data.sha256
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
           BEGIN;
           ALTER TABLE p2_wad_traveler_decisions ADD COLUMN rollback_probe boolean;

--- a/.github/workflows/p2-wad-traveler-authority-postgres.yml
+++ b/.github/workflows/p2-wad-traveler-authority-postgres.yml
@@ -3,7 +3,9 @@ name: P2 WAD Traveler Authority PostgreSQL Certification
 on:
   workflow_dispatch:
   push:
-    branches: [codex/p2-wad-traveler-authority-completion]
+    branches:
+      - codex/p2-wad-traveler-authority-completion
+      - codex/p2-phase4-authority-correction
 
 permissions:
   contents: read
@@ -42,7 +44,7 @@ jobs:
           test -z "${VITE_P2_WAD_TRAVELER_DECISION_READS_ENABLED:-}"
           test -z "${VITE_P2_WAD_TRAVELER_DECISION_WRITES_ENABLED:-}"
       - name: Focused Phase 4 contract tests
-        run: npx vitest run --config vitest.config.server.ts server/__tests__/p2WadTravelerAuthorityFoundation.test.ts --reporter=verbose
+        run: npx vitest run --config vitest.config.server.ts server/__tests__/p2WadTravelerAuthorityFoundation.test.ts server/__tests__/p2WadTravelerAuthorityCorrection.test.ts server/__tests__/p2ProjectControlledConfigurationFoundation.test.ts server/__tests__/projectWadAuthorization.test.ts --reporter=verbose
       - name: Create clean application schema
         run: |
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE SEQUENCE rts_item_number_seq"
@@ -59,6 +61,11 @@ jobs:
           SELECT 'transactions|'||count(*) FROM inventory_transactions;
           SELECT 'decisions|'||count(*) FROM p2_wad_traveler_decisions;
           SQL
+          pg_dump "$DATABASE_URL" --data-only --column-inserts \
+            --table=inventory_items --table=production_work_orders \
+            --table=travelers --table=inventory_transactions \
+            --table=p2_wad_traveler_decisions > /tmp/before-data.sql
+          sha256sum /tmp/before-data.sql > /tmp/before-data.sha256
           npm run maintenance:safe-migrations
           psql "$DATABASE_URL" -At -v ON_ERROR_STOP=1 <<'SQL' > /tmp/after.txt
           SELECT 'inventory_items|'||count(*) FROM inventory_items;
@@ -67,7 +74,13 @@ jobs:
           SELECT 'transactions|'||count(*) FROM inventory_transactions;
           SELECT 'decisions|'||count(*) FROM p2_wad_traveler_decisions;
           SQL
+          pg_dump "$DATABASE_URL" --data-only --column-inserts \
+            --table=inventory_items --table=production_work_orders \
+            --table=travelers --table=inventory_transactions \
+            --table=p2_wad_traveler_decisions > /tmp/after-data.sql
+          sha256sum /tmp/after-data.sql | sed 's#/tmp/after-data.sql#/tmp/before-data.sql#' > /tmp/after-data.sha256
           diff -u /tmp/before.txt /tmp/after.txt
+          diff -u /tmp/before-data.sha256 /tmp/after-data.sha256
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
           BEGIN;
           ALTER TABLE p2_wad_traveler_decisions ADD COLUMN rollback_probe boolean;
@@ -78,16 +91,47 @@ jobs:
             END IF;
           END $$;
           SQL
-      - name: Verify lifecycle, audit, concurrency, and immutability schema
+      - name: Verify authority, batch coverage, audit, concurrency, and immutability
         run: |
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
-          SELECT concurrency_version,status,content_checksum FROM p2_wad_traveler_decisions LIMIT 0;
-          SELECT actor_user_id,actor_display_name,actor_role,signature_meaning FROM p2_wad_traveler_decision_events LIMIT 0;
+          SELECT concurrency_version,status,content_checksum,batch_approved_quantity,batch_coverage_scope,
+                 created_by_employee_id,validated_by_employee_id
+          FROM p2_wad_traveler_decisions LIMIT 0;
+          SELECT actor_user_id,actor_employee_id,actor_display_name,actor_role,signature_meaning
+          FROM p2_wad_traveler_decision_events LIMIT 0;
           SELECT tgname FROM pg_trigger WHERE tgname='p2_wad_traveler_decision_immutable' \gset
           \if :{?tgname}
           \else
             \quit 1
           \endif
+          SELECT tgname FROM pg_trigger WHERE tgname='p2_released_wad_authorization_immutable' \gset
+          \if :{?tgname}
+          \else
+            \quit 1
+          \endif
+
+          CREATE TEMP TABLE phase4_wad_immutability_probe (
+            status text,
+            payload text,
+            superseded_at timestamptz,
+            superseded_by_authorization_id uuid,
+            updated_at timestamptz
+          );
+          CREATE TRIGGER phase4_wad_immutability_probe_trigger
+            BEFORE UPDATE OR DELETE ON phase4_wad_immutability_probe
+            FOR EACH ROW EXECUTE FUNCTION p2_released_wad_authorization_immutable();
+          INSERT INTO phase4_wad_immutability_probe(status,payload,updated_at)
+            VALUES ('RELEASED','authoritative',now());
+          DO $$ BEGIN
+            BEGIN
+              UPDATE phase4_wad_immutability_probe SET payload='tampered';
+              RAISE EXCEPTION 'released WAD mutation unexpectedly succeeded';
+            EXCEPTION WHEN raise_exception THEN
+              IF SQLERRM = 'released WAD mutation unexpectedly succeeded' THEN
+                RAISE;
+              END IF;
+            END;
+          END $$;
           SQL
       - name: Diff hygiene
         run: git diff --check HEAD^ HEAD

--- a/migrations/0299_p2_wad_authority_correction.sql
+++ b/migrations/0299_p2_wad_authority_correction.sql
@@ -1,0 +1,57 @@
+-- Phase 4 authority correction: explicit batch coverage, employee attribution,
+-- and database immutability for released WAD authorizations.
+-- Additive and prospective; no historical rows are updated or reinterpreted.
+ALTER TABLE p2_wad_traveler_decisions
+  ADD COLUMN IF NOT EXISTS batch_approved_quantity NUMERIC(18,6),
+  ADD COLUMN IF NOT EXISTS batch_coverage_scope TEXT,
+  ADD COLUMN IF NOT EXISTS created_by_employee_id INTEGER,
+  ADD COLUMN IF NOT EXISTS validated_by_employee_id INTEGER;
+
+ALTER TABLE p2_wad_traveler_decision_events
+  ADD COLUMN IF NOT EXISTS actor_employee_id INTEGER;
+
+DO $$ BEGIN
+  ALTER TABLE p2_wad_traveler_decisions
+    ADD CONSTRAINT p2_wad_traveler_batch_coverage_check CHECK (
+      traveler_type <> 'BATCH' OR (
+        batch_approved_quantity IS NOT NULL AND
+        batch_approved_quantity > 0 AND
+        batch_approved_quantity >= required_quantity AND
+        batch_coverage_scope IS NOT NULL AND
+        btrim(batch_coverage_scope) <> ''
+      )
+    ) NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE OR REPLACE FUNCTION p2_released_wad_authorization_immutable()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' AND OLD.status IN ('RELEASED','SUPERSEDED') THEN
+    RAISE EXCEPTION 'Released WAD authorization evidence is immutable';
+  END IF;
+  IF TG_OP = 'UPDATE' AND OLD.status = 'RELEASED' THEN
+    IF NEW.status = 'SUPERSEDED' AND
+       (to_jsonb(NEW) - ARRAY['status','superseded_at','superseded_by_authorization_id','updated_at']) =
+       (to_jsonb(OLD) - ARRAY['status','superseded_at','superseded_by_authorization_id','updated_at']) THEN
+      RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'Released WAD authorization evidence is immutable';
+  END IF;
+  IF TG_OP = 'UPDATE' AND OLD.status = 'SUPERSEDED' THEN
+    IF (to_jsonb(NEW) - ARRAY['superseded_by_authorization_id','updated_at']) =
+       (to_jsonb(OLD) - ARRAY['superseded_by_authorization_id','updated_at']) THEN
+      RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'Superseded WAD authorization evidence is immutable';
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END $$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS p2_released_wad_authorization_immutable
+  ON project_wad_authorizations;
+CREATE TRIGGER p2_released_wad_authorization_immutable
+  BEFORE UPDATE OR DELETE ON project_wad_authorizations
+  FOR EACH ROW EXECUTE FUNCTION p2_released_wad_authorization_immutable();

--- a/server/__tests__/p2WadTravelerAuthorityCorrection.test.ts
+++ b/server/__tests__/p2WadTravelerAuthorityCorrection.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { evaluateWadTravelerCoverage } from '../src/services/p2WadTravelerCoverage';
+
+const root = resolve(__dirname, '../..');
+const migration = readFileSync(
+  resolve(root, 'migrations/0299_p2_wad_authority_correction.sql'),
+  'utf8'
+);
+const service = readFileSync(
+  resolve(root, 'server/src/services/p2WadTravelerDecisionService.ts'),
+  'utf8'
+);
+const routes = readFileSync(
+  resolve(root, 'server/src/routes/projectWadAuthorization.ts'),
+  'utf8'
+);
+const wadService = readFileSync(
+  resolve(root, 'server/src/services/projectWadAuthorizationService.ts'),
+  'utf8'
+);
+const registry = readFileSync(
+  resolve(root, 'server/scripts/migrations/runSafeBootMigrations.ts'),
+  'utf8'
+);
+
+const manufactured = (path: string, quantity = 10) => ({
+  is_manufactured: true,
+  inventory_item_id: path === 'A' ? 101 : 102,
+  assembly_path: path,
+  extended_project_quantity: quantity,
+});
+const decision = (path: string, quantity = 10) => ({
+  inventory_item_id: path === 'A' ? 101 : 102,
+  assembly_path_identity: path,
+  required_quantity: quantity,
+  traveler_type: 'INDIVIDUAL',
+  status: 'VALIDATED',
+});
+
+describe('Phase 4 WAD authority correction', () => {
+  it('blocks A plus duplicate A when released manufactured path B is missing', () => {
+    expect(
+      evaluateWadTravelerCoverage(
+        [manufactured('A'), manufactured('B')],
+        [decision('A'), decision('A')]
+      )
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('101::A: exactly one'),
+        expect.stringContaining('102::B: exactly one'),
+      ])
+    );
+  });
+
+  it('blocks batch coverage below released demand', () => {
+    expect(
+      evaluateWadTravelerCoverage(
+        [manufactured('A', 10)],
+        [
+          {
+            ...decision('A', 10),
+            traveler_type: 'BATCH',
+            batch_approved_quantity: 6,
+            batch_coverage_scope: 'Assembly A demand',
+          },
+        ]
+      )
+    ).toContain(
+      '101::A: approved batch coverage does not cover released demand 10.'
+    );
+  });
+
+  it('returns an identical create replay without inserting a duplicate event', () => {
+    expect(service).toContain(
+      'existing.rows[0].content_checksum === checksum(content)'
+    );
+    expect(service).toMatch(
+      /content_checksum === checksum\(content\)[\s\S]*?COMMIT[\s\S]*?return existing\.rows\[0\]/
+    );
+    expect(service).toContain('DECISION_CREATE_CONFLICT');
+  });
+
+  it('adds database rejection for direct released-WAD evidence changes', () => {
+    expect(migration).toContain(
+      'CREATE TRIGGER p2_released_wad_authorization_immutable'
+    );
+    expect(migration).toContain("OLD.status IN ('RELEASED','SUPERSEDED')");
+    expect(migration).toContain(
+      "IF TG_OP = 'UPDATE' AND OLD.status = 'RELEASED'"
+    );
+  });
+
+  it('requires explicit prospective batch coverage without historical backfill', () => {
+    expect(migration).toContain('batch_approved_quantity >= required_quantity');
+    expect(migration).toContain('NOT VALID');
+    expect(migration).not.toMatch(/^[ \t]*(UPDATE|DELETE|TRUNCATE)\b/im);
+  });
+
+  it('registers the additive correction after Phase 4 completion', () => {
+    expect(
+      registry.match(/0299_p2_wad_authority_correction\.sql/g)
+    ).toHaveLength(2);
+    expect(registry.indexOf('0298_p2_wad')).toBeLessThan(
+      registry.indexOf('0299_p2_wad')
+    );
+  });
+
+  it('uses dedicated WAD permissions and authenticated employee identity', () => {
+    for (const capability of [
+      'projects.wad_traveler_decisions.manage',
+      'projects.wad_traveler_decisions.exception_approve',
+      'projects.wad_authorization.manage',
+      'projects.wad_authorization.release',
+    ])
+      expect(routes).toContain(capability);
+    expect(routes).toContain('ACTOR_EMPLOYEE_REQUIRED');
+    expect(routes).not.toMatch(/inventory\.adjust|projects\.edit/);
+    expect(service).toContain('created_by_employee_id');
+    expect(service).toContain('actor_employee_id');
+  });
+
+  it('separates creator, functional approvers, and releaser', () => {
+    expect(wadService).toContain(
+      'The WAD creator cannot approve the same controlled revision.'
+    );
+    expect(wadService).toContain(
+      'WAD release requires an independent employee who neither created nor approved the revision.'
+    );
+    expect(wadService).toContain(
+      'evidence.some((entry) => entry.actor_user_id === actor.userId)'
+    );
+  });
+});

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -360,6 +360,7 @@ export const safeMigrationFiles = [
   '0296_p2_project_controlled_configuration_foundation.sql',
   '0297_p2_wad_traveler_authority_foundation.sql',
   '0298_p2_wad_traveler_authority_completion.sql',
+  '0299_p2_wad_authority_correction.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -460,6 +461,7 @@ export const criticalMigrationFiles = new Set([
   '0296_p2_project_controlled_configuration_foundation.sql',
   '0297_p2_wad_traveler_authority_foundation.sql',
   '0298_p2_wad_traveler_authority_completion.sql',
+  '0299_p2_wad_authority_correction.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/projectWadAuthorization.ts
+++ b/server/src/routes/projectWadAuthorization.ts
@@ -66,6 +66,8 @@ const travelerDecisionSchema = z.object({
   inventoryItemId: z.number().int().positive(),
   assemblyPathIdentity: z.string().min(1),
   requiredQuantity: z.number().positive(),
+  batchApprovedQuantity: z.number().positive().nullable().optional(),
+  batchCoverageScope: z.string().min(1).nullable().optional(),
   travelerRequirement: z.enum(['REQUIRED', 'NOT_REQUIRED_APPROVED']),
   travelerType: z.enum(['INDIVIDUAL', 'BATCH']).nullable().optional(),
   inspectionRequirements: z.record(z.unknown()),
@@ -84,6 +86,12 @@ function actor(req: Request): WadAuthorizationActor {
       'ACTOR_REQUIRED',
       'Authenticated actor identity is required.',
       401
+    );
+  if (!req.user.employeeId)
+    throw new ProjectWadAuthorizationError(
+      'ACTOR_EMPLOYEE_REQUIRED',
+      'An authenticated employee identity is required for controlled WAD actions.',
+      403
     );
   return {
     userId: req.user.id,

--- a/server/src/services/p2WadTravelerCoverage.ts
+++ b/server/src/services/p2WadTravelerCoverage.ts
@@ -1,0 +1,56 @@
+const clean = (value: unknown) => String(value ?? '').trim();
+
+export function evaluateWadTravelerCoverage(
+  manufacturedItems: Array<Record<string, unknown>>,
+  decisions: Array<Record<string, unknown>>
+) {
+  const expected = manufacturedItems.filter(
+    (item) => item.is_manufactured === true
+  );
+  const key = (itemId: unknown, path: unknown) =>
+    `${String(itemId)}::${clean(path)}`;
+  const expectedKeys = new Set(
+    expected.map((item) => key(item.inventory_item_id, item.assembly_path))
+  );
+  const byIdentity = new Map<string, Array<Record<string, unknown>>>();
+  for (const decision of decisions) {
+    const identity = key(
+      decision.inventory_item_id,
+      decision.assembly_path_identity
+    );
+    byIdentity.set(identity, [...(byIdentity.get(identity) ?? []), decision]);
+  }
+  const blockers: string[] = [];
+  for (const item of expected) {
+    const identity = key(item.inventory_item_id, item.assembly_path);
+    const matches = byIdentity.get(identity) ?? [];
+    if (matches.length !== 1) {
+      blockers.push(
+        `${identity}: exactly one traveler decision is required; found ${matches.length}.`
+      );
+      continue;
+    }
+    const decision = matches[0];
+    const required = Number(item.extended_project_quantity);
+    if (decision.status !== 'VALIDATED')
+      blockers.push(`${identity}: traveler decision is not validated.`);
+    if (Number(decision.required_quantity) !== required)
+      blockers.push(
+        `${identity}: traveler decision quantity does not match released demand ${required}.`
+      );
+    if (
+      decision.traveler_type === 'BATCH' &&
+      (Number(decision.batch_approved_quantity) < required ||
+        !clean(decision.batch_coverage_scope))
+    )
+      blockers.push(
+        `${identity}: approved batch coverage does not cover released demand ${required}.`
+      );
+  }
+  for (const identity of byIdentity.keys())
+    if (!expectedKeys.has(identity))
+      blockers.push(
+        `${identity}: traveler decision is outside the released manufactured-demand set.`
+      );
+  return blockers;
+}

--- a/server/src/services/p2WadTravelerCoverage.ts
+++ b/server/src/services/p2WadTravelerCoverage.ts
@@ -47,7 +47,7 @@ export function evaluateWadTravelerCoverage(
         `${identity}: approved batch coverage does not cover released demand ${required}.`
       );
   }
-  for (const identity of byIdentity.keys())
+  for (const identity of Array.from(byIdentity.keys()))
     if (!expectedKeys.has(identity))
       blockers.push(
         `${identity}: traveler decision is outside the released manufactured-demand set.`

--- a/server/src/services/p2WadTravelerDecisionService.ts
+++ b/server/src/services/p2WadTravelerDecisionService.ts
@@ -1,9 +1,11 @@
 import { createHash } from 'crypto';
 
 import { pool } from '../../db';
+import { evaluateWadTravelerCoverage } from './p2WadTravelerCoverage';
 
 export type WadTravelerActor = {
   userId: number;
+  employeeId: number | null;
   displayName: string;
   role: string;
 };
@@ -40,6 +42,8 @@ export async function saveWadTravelerDecision(
     inventoryItemId: number;
     assemblyPathIdentity: string;
     requiredQuantity: number;
+    batchApprovedQuantity?: number | null;
+    batchCoverageScope?: string | null;
     travelerRequirement: 'REQUIRED' | 'NOT_REQUIRED_APPROVED';
     travelerType?: 'INDIVIDUAL' | 'BATCH' | null;
     inspectionRequirements: Record<string, unknown>;
@@ -101,6 +105,15 @@ export async function saveWadTravelerDecision(
         'TRAVELER_TYPE_REQUIRED',
         'Required travelers need an INDIVIDUAL or BATCH type.'
       );
+    if (
+      input.travelerType === 'BATCH' &&
+      (!(Number(input.batchApprovedQuantity) >= input.requiredQuantity) ||
+        !clean(input.batchCoverageScope))
+    )
+      throw new WadTravelerDecisionError(
+        'BATCH_COVERAGE_REQUIRED',
+        'A batch decision must explicitly cover the complete released demand quantity and scope.'
+      );
     if (weak && !clean(input.exceptionReason))
       throw new WadTravelerDecisionError(
         'EXCEPTION_REASON_REQUIRED',
@@ -111,6 +124,8 @@ export async function saveWadTravelerDecision(
       inventoryItemId: input.inventoryItemId,
       assemblyPathIdentity: clean(input.assemblyPathIdentity),
       requiredQuantity: input.requiredQuantity,
+      batchApprovedQuantity: input.batchApprovedQuantity ?? null,
+      batchCoverageScope: clean(input.batchCoverageScope) || null,
       travelerRequirement: input.travelerRequirement,
       travelerType: input.travelerType ?? null,
       policyId: row.policy_id,
@@ -131,22 +146,33 @@ export async function saveWadTravelerDecision(
     );
     let saved;
     if (existing.rows[0]) {
-      if (
-        input.expectedVersion == null ||
-        existing.rows[0].concurrency_version !== input.expectedVersion
-      )
+      if (input.expectedVersion == null) {
+        if (existing.rows[0].content_checksum === checksum(content)) {
+          await client.query('COMMIT');
+          return existing.rows[0];
+        }
+        throw new WadTravelerDecisionError(
+          'DECISION_CREATE_CONFLICT',
+          'A traveler decision already exists for this identity with different controlled content.',
+          409
+        );
+      }
+      if (existing.rows[0].concurrency_version !== input.expectedVersion)
         throw new WadTravelerDecisionError(
           'STALE_DECISION',
           'Traveler decision was changed by another user.',
           409
         );
       saved = await client.query(
-        `UPDATE p2_wad_traveler_decisions SET required_quantity=$2,traveler_requirement=$3,traveler_type=$4,
-        inspection_requirements_snapshot=$5::jsonb,exception_required=$6,exception_reason=$7,exception_effectivity=$8::jsonb,
-        status=$9,content_checksum=$10,concurrency_version=concurrency_version+1,updated_at=now() WHERE id=$1 RETURNING *`,
+        `UPDATE p2_wad_traveler_decisions SET required_quantity=$2,batch_approved_quantity=$3,batch_coverage_scope=$4,
+        traveler_requirement=$5,traveler_type=$6,inspection_requirements_snapshot=$7::jsonb,exception_required=$8,
+        exception_reason=$9,exception_effectivity=$10::jsonb,status=$11,content_checksum=$12,
+        concurrency_version=concurrency_version+1,updated_at=now() WHERE id=$1 RETURNING *`,
         [
           existing.rows[0].id,
           input.requiredQuantity,
+          input.batchApprovedQuantity ?? null,
+          clean(input.batchCoverageScope) || null,
           input.travelerRequirement,
           input.travelerType ?? null,
           JSON.stringify(input.inspectionRequirements),
@@ -160,17 +186,19 @@ export async function saveWadTravelerDecision(
     } else {
       saved = await client.query(
         `INSERT INTO p2_wad_traveler_decisions (wad_authorization_id,project_configuration_id,inventory_item_id,
-        assembly_path_identity,required_quantity,traveler_requirement,traveler_type,traceability_policy_id,traceability_policy_revision,
+        assembly_path_identity,required_quantity,batch_approved_quantity,batch_coverage_scope,traveler_requirement,traveler_type,traceability_policy_id,traceability_policy_revision,
         traceability_policy_type_snapshot,traceability_requirements_snapshot,inspection_requirements_snapshot,exception_required,
-        exception_reason,exception_effectivity,status,content_checksum,created_by,created_by_display_name,created_by_role,
-        validated_at,validated_by,validated_by_display_name) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12::jsonb,$13,$14,$15::jsonb,$16,$17,$18,$19,$20,
-        CASE WHEN $16='VALIDATED' THEN now() END,CASE WHEN $16='VALIDATED' THEN $18 END,CASE WHEN $16='VALIDATED' THEN $19 END) RETURNING *`,
+        exception_reason,exception_effectivity,status,content_checksum,created_by,created_by_employee_id,created_by_display_name,created_by_role,
+        validated_at,validated_by,validated_by_employee_id,validated_by_display_name) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::jsonb,$14::jsonb,$15,$16,$17::jsonb,$18,$19,$20,$21,$22,$23,
+        CASE WHEN $18='VALIDATED' THEN now() END,CASE WHEN $18='VALIDATED' THEN $20 END,CASE WHEN $18='VALIDATED' THEN $21 END,CASE WHEN $18='VALIDATED' THEN $22 END) RETURNING *`,
         [
           input.authorizationId,
           row.configuration_id,
           input.inventoryItemId,
           clean(input.assemblyPathIdentity),
           input.requiredQuantity,
+          input.batchApprovedQuantity ?? null,
+          clean(input.batchCoverageScope) || null,
           input.travelerRequirement,
           input.travelerType ?? null,
           row.policy_id,
@@ -190,18 +218,20 @@ export async function saveWadTravelerDecision(
           weak ? 'EXCEPTION_PENDING' : 'VALIDATED',
           checksum(content),
           actor.userId,
+          actor.employeeId,
           actor.displayName,
           actor.role,
         ]
       );
     }
     await client.query(
-      `INSERT INTO p2_wad_traveler_decision_events(decision_id,event_type,actor_user_id,actor_display_name,actor_role,evidence)
-      VALUES($1,$2,$3,$4,$5,$6::jsonb)`,
+      `INSERT INTO p2_wad_traveler_decision_events(decision_id,event_type,actor_user_id,actor_employee_id,actor_display_name,actor_role,evidence)
+      VALUES($1,$2,$3,$4,$5,$6,$7::jsonb)`,
       [
         saved.rows[0].id,
         weak ? 'EXCEPTION_REQUESTED' : 'VALIDATED',
         actor.userId,
+        actor.employeeId,
         actor.displayName,
         actor.role,
         JSON.stringify({
@@ -240,7 +270,7 @@ export async function approveWadTravelerException(
     const result = await client.query(
       `UPDATE p2_wad_traveler_decisions d SET status='VALIDATED',exception_approved_by=$5,
       exception_approver_display_name=$6,exception_signature_meaning=$7,exception_approved_at=now(),validated_at=now(),validated_by=$5,
-      validated_by_display_name=$6,concurrency_version=concurrency_version+1,updated_at=now()
+      validated_by_employee_id=$8,validated_by_display_name=$6,concurrency_version=concurrency_version+1,updated_at=now()
       FROM project_wad_authorizations w WHERE d.id=$3 AND d.wad_authorization_id=w.id AND w.id=$2 AND w.project_id=$1
       AND w.status='DRAFT' AND d.status='EXCEPTION_PENDING' AND d.concurrency_version=$4 AND d.created_by<>$5 RETURNING d.*`,
       [
@@ -251,6 +281,7 @@ export async function approveWadTravelerException(
         actor.userId,
         actor.displayName,
         signatureMeaning,
+        actor.employeeId,
       ]
     );
     if (!result.rows[0])
@@ -260,10 +291,11 @@ export async function approveWadTravelerException(
         409
       );
     await client.query(
-      `INSERT INTO p2_wad_traveler_decision_events(decision_id,event_type,actor_user_id,actor_display_name,actor_role,signature_meaning,evidence) VALUES($1,'EXCEPTION_APPROVED',$2,$3,$4,$5,$6::jsonb)`,
+      `INSERT INTO p2_wad_traveler_decision_events(decision_id,event_type,actor_user_id,actor_employee_id,actor_display_name,actor_role,signature_meaning,evidence) VALUES($1,'EXCEPTION_APPROVED',$2,$3,$4,$5,$6,$7::jsonb)`,
       [
         decisionId,
         actor.userId,
+        actor.employeeId,
         actor.displayName,
         actor.role,
         signatureMeaning,
@@ -286,26 +318,14 @@ export async function wadTravelerDecisionBlockers(
 ) {
   const result = await pool.query(
     `SELECT w.inherited_requirements_snapshot,
-    (SELECT count(*)::int FROM p2_wad_traveler_decisions d WHERE d.wad_authorization_id=w.id AND d.status='VALIDATED') validated_count,
-    (SELECT count(*)::int FROM p2_wad_traveler_decisions d WHERE d.wad_authorization_id=w.id AND d.status<>'VALIDATED') open_count
+    COALESCE((SELECT jsonb_agg(to_jsonb(d)) FROM p2_wad_traveler_decisions d WHERE d.wad_authorization_id=w.id),'[]'::jsonb) decisions
     FROM project_wad_authorizations w WHERE w.project_id=$1 AND w.id=$2`,
     [projectId, authorizationId]
   );
   const row = result.rows[0];
   if (!row) return ['WAD traveler decision authority is missing.'];
-  const expected = (
-    row.inherited_requirements_snapshot?.manufacturedItems ?? []
-  ).filter(
-    (item: Record<string, unknown>) => item.is_manufactured === true
-  ).length;
-  const blockers: string[] = [];
-  if (Number(row.validated_count) < expected)
-    blockers.push(
-      `Validated traveler decisions cover ${row.validated_count} of ${expected} manufactured items.`
-    );
-  if (Number(row.open_count) > 0)
-    blockers.push(
-      `${row.open_count} traveler decision exception(s) remain unresolved.`
-    );
-  return blockers;
+  return evaluateWadTravelerCoverage(
+    row.inherited_requirements_snapshot?.manufacturedItems ?? [],
+    row.decisions ?? []
+  );
 }

--- a/server/src/services/p2WadTravelerDecisionService.ts
+++ b/server/src/services/p2WadTravelerDecisionService.ts
@@ -5,7 +5,7 @@ import { evaluateWadTravelerCoverage } from './p2WadTravelerCoverage';
 
 export type WadTravelerActor = {
   userId: number;
-  employeeId: number | null;
+  employeeId?: number | null;
   displayName: string;
   role: string;
 };
@@ -53,6 +53,12 @@ export async function saveWadTravelerDecision(
   },
   actor: WadTravelerActor
 ) {
+  if (!actor.employeeId)
+    throw new WadTravelerDecisionError(
+      'ACTOR_EMPLOYEE_REQUIRED',
+      'An authenticated employee identity is required for controlled WAD decisions.',
+      403
+    );
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
@@ -259,6 +265,12 @@ export async function approveWadTravelerException(
   signatureMeaning: string,
   actor: WadTravelerActor
 ) {
+  if (!actor.employeeId)
+    throw new WadTravelerDecisionError(
+      'ACTOR_EMPLOYEE_REQUIRED',
+      'An authenticated employee identity is required for controlled WAD exception approval.',
+      403
+    );
   if (!clean(signatureMeaning))
     throw new WadTravelerDecisionError(
       'SIGNATURE_REQUIRED',

--- a/server/src/services/projectWadAuthorizationService.ts
+++ b/server/src/services/projectWadAuthorizationService.ts
@@ -660,6 +660,12 @@ export async function recordWadDecision(
         `${capacity} approval is not required for this revision.`,
         409
       );
+    if (authorization.created_by === actor.userId)
+      throw new ProjectWadAuthorizationError(
+        'SEGREGATION_OF_DUTIES',
+        'The WAD creator cannot approve the same controlled revision.',
+        403
+      );
     const existing = await approvals(authorization, tx);
     if (existing.some((entry) => entry.approval_type === `WAD_${capacity}`))
       throw new ProjectWadAuthorizationError(
@@ -799,6 +805,15 @@ export async function releaseWadAuthorization(
         'All required WAD approvals must be recorded.',
         409,
         { missingApprovals: missing }
+      );
+    if (
+      authorization.created_by === actor.userId ||
+      evidence.some((entry) => entry.actor_user_id === actor.userId)
+    )
+      throw new ProjectWadAuthorizationError(
+        'SEGREGATION_OF_DUTIES',
+        'WAD release requires an independent employee who neither created nor approved the revision.',
+        403
       );
     const wizardApprovals = evidence.map((entry) => ({
       role: String(entry.approval_type).replace(/^WAD_/, '').toLowerCase(),


### PR DESCRIPTION
## Scope

Corrects the four authority defects identified in the Phase 4 post-merge review. This PR is Phase 4-only and contains no Phase 5 implementation.

- Requires exact Inventory Item plus assembly-path coverage for every released manufactured demand identity; missing, duplicate, extra, open, or quantity-mismatched decisions fail closed.
- Makes equivalent decision-create retries idempotent while rejecting materially different same-identity content.
- Adds explicit approved batch quantity and controlled coverage scope, with service and database enforcement against released demand quantity.
- Adds database immutability for released and superseded WAD authorization evidence while preserving the controlled RELEASED-to-SUPERSEDED lifecycle.
- Requires authenticated employee identity and records it in decisions and audit events.
- Separates WAD creator, functional approvers, and releaser and retains dedicated WAD permissions.

## Migration

