### PR TITLE
Fix Design Control schema-readiness certification drift

### DIFF
--- a/server/__tests__/designControlSchemaHardening.test.ts
+++ b/server/__tests__/designControlSchemaHardening.test.ts
@@ -23,17 +23,9 @@ import {
 } from '../src/services/designControlSchemaReadiness';
 
 const root = process.cwd();
-const migrationFiles = [
-  'migrations/0189_design_control_workflow.sql',
-  'migrations/0190_design_control_requirement_applicability.sql',
-  'migrations/0191_engineering_releases.sql',
-  'migrations/0192_engineering_packages.sql',
-  'migrations/0207_design_control_authority_foundation.sql',
-  'migrations/0208_design_control_authenticated_approvals.sql',
-  'migrations/0248_design_project_manufacturing_configuration.sql',
-  'migrations/0251_design_project_configuration_workspace.sql',
-  'migrations/0258_design_control_structured_lifecycle.sql',
-];
+const migrationFiles = requiredDesignControlMigrations.map(
+  (file) => `migrations/${file}`
+);
 
 const originalDatabaseUrl = process.env.DATABASE_URL;
 const originalForceDatabaseUrl = process.env.FORCE_DATABASE_URL;
@@ -230,6 +222,8 @@ describe('Design Control schema hardening', () => {
             { object_name: 'design_control_step_approvals_valid_slot_unique' },
             { object_name: 'prevent_design_control_step_version_delete' },
             { object_name: 'prevent_design_control_step_approval_delete' },
+            { object_name: 'dc_step_approval_assignments_version_slot_uq' },
+            { object_name: 'prevent_design_control_assignment_delete' },
           ];
         }
         return [];


### PR DESCRIPTION
## Certification obstruction

The complete P2 V2 certification reached the Design Control lifecycle step and failed two assertions in `designControlSchemaHardening.test.ts`:

- `covers every required Design Control and Engineering Package table in migrations`
- `allows readiness when required schema SELECT checks succeed`

The failures reported the migration 0275 assignment table as absent from the test's inspected migration set and reported `dc_step_approval_assignments_version_slot_uq` plus `prevent_design_control_assignment_delete` as absent from the success fixture.

## Root cause

Commit `f70883e91` added migration `0275_design_control_verified_approval_assignments.sql`, registered it for safe/critical boot, and made its table, index, and trigger required by the runtime readiness service. The schema-hardening test retained a manually duplicated migration list ending at 0258 and a mock response containing only the four earlier approval structures.

The authoritative migration and runtime readiness behavior are correct. This PR aligns only the stale certification fixture.

## Correction

- Derive the migration files inspected by the test from `requiredDesignControlMigrations` so the certification inventory cannot silently drift from runtime readiness.
- Include migration 0275's unique assignment index and delete-prevention trigger in the successful readiness fixture.

No migration, schema, route, service, permission, lifecycle, historical record, feature flag, Phase 3 behavior, or Phase 4 WAD authority behavior changes.

## Preservation evidence

- No database migration or backfill is added.
- Existing Design Control records and lifecycle evidence are untouched.
- The change is test-only and cannot create or mutate production, inventory, traveler, work-order, queue, scheduling, barcode, Receiving, material-consumption, manufactured-output, or Genealogy records.
- Local Design Control and Phase 3/4 non-database regression suite: 214/214 passed.
- The focused schema-hardening suite: 8/8 passed, including both reproduced failures.
- Focused ESLint, Prettier, and `git diff --check`: passed.
- Local PostgreSQL suites could not start without a disposable `DATABASE_URL`; required GitHub PostgreSQL certification must pass before merge.

## Rollback

Revert the single test-only commit. No database rollback or data repair is required.

## Boundaries

This is a certification-unblocking correction only. Do not merge until required checks complete successfully. Do not deploy, enable flags, or begin Phase 5 or Phase 6 from this PR.
