### PR TITLE
Fix migration 0171 manufacturing bypass

### DIFF
--- a/migrations/0301_repair_0171_manufacturing_bypass.sql
+++ b/migrations/0301_repair_0171_manufacturing_bypass.sql
@@ -1,0 +1,233 @@
+-- One-time, fail-closed repair for the eight orders conclusively identified by
+-- migration 0257's immutable RESTORE_SHIPPING_QC_AFTER_0171_REPLAY events.
+--
+-- This migration is intentionally excluded from recurring safe boot. It does
+-- not infer manufacturing completion from shipment fields and never deletes
+-- the original 0171/0257 evidence.
+
+CREATE TABLE IF NOT EXISTS p1_0171_manufacturing_bypass_audit (
+  order_id text PRIMARY KEY,
+  restoration_event_id integer NOT NULL,
+  restoration_occurred_at timestamp NOT NULL,
+  shipping_qc_entered_at timestamp,
+  status_observed text,
+  department_observed text,
+  disposition text NOT NULL,
+  audited_at timestamp NOT NULL DEFAULT NOW(),
+  repaired_at timestamp
+);
+
+CREATE TEMP TABLE tmp_0171_confirmed_orders ON COMMIT DROP AS
+SELECT DISTINCT ON (event.order_id)
+  event.order_id,
+  event.id AS restoration_event_id,
+  event.occurred_at AS restoration_occurred_at,
+  NULLIF(event.metadata ->> 'shippingQcEnteredAt', '')::timestamp AS shipping_qc_entered_at
+FROM order_activity_events event
+WHERE event.reason_code = 'RESTORE_SHIPPING_QC_AFTER_0171_REPLAY'
+ORDER BY event.order_id, event.occurred_at DESC;
+
+DO $$
+DECLARE
+  observed_count integer;
+  unexpected_ids text[];
+BEGIN
+  SELECT COUNT(*) INTO observed_count FROM tmp_0171_confirmed_orders;
+  IF observed_count = 0 THEN
+    RAISE NOTICE '0301 repair skipped: no migration-0257 restoration evidence exists in this database';
+    RETURN;
+  END IF;
+
+  SELECT array_agg(order_id ORDER BY order_id) INTO unexpected_ids
+  FROM tmp_0171_confirmed_orders
+  WHERE order_id <> ALL (ARRAY['FD001','FD007','FD690','FD787','FD832','FE039','FE108','FE241']);
+
+  IF observed_count <> 8 OR unexpected_ids IS NOT NULL THEN
+    RAISE EXCEPTION
+      '0301 repair aborted: expected exactly the reviewed eight 0171 orders, found %; unexpected=%',
+      observed_count, COALESCE(unexpected_ids::text, 'none');
+  END IF;
+END $$;
+
+INSERT INTO p1_0171_manufacturing_bypass_audit (
+  order_id, restoration_event_id, restoration_occurred_at,
+  shipping_qc_entered_at, status_observed, department_observed, disposition
+)
+SELECT
+  confirmed.order_id,
+  confirmed.restoration_event_id,
+  confirmed.restoration_occurred_at,
+  confirmed.shipping_qc_entered_at,
+  orders.status,
+  orders.current_department,
+  CASE
+    WHEN confirmed.order_id IN ('FD007','FD690','FE108','FE241')
+      AND orders.status = 'IN_PROGRESS'
+      AND orders.current_department = 'Shipping QC'
+      THEN 'RETURN_TO_P1_MANUFACTURING'
+    WHEN confirmed.order_id = 'FD787'
+      AND orders.status = 'IN_PROGRESS'
+      AND orders.current_department = 'CNC'
+      THEN 'REPAIR_CNC_TRANSITION_LEDGER'
+    ELSE 'AUDIT_ONLY_CURRENT_OPERATIONAL_STATE'
+  END
+FROM tmp_0171_confirmed_orders confirmed
+JOIN all_orders orders ON orders.order_id = confirmed.order_id
+ON CONFLICT (order_id) DO NOTHING;
+
+CREATE TEMP TABLE tmp_0171_return_to_p1 ON COMMIT DROP AS
+SELECT audit.order_id
+FROM p1_0171_manufacturing_bypass_audit audit
+JOIN all_orders orders ON orders.order_id = audit.order_id
+WHERE audit.disposition = 'RETURN_TO_P1_MANUFACTURING'
+  AND audit.repaired_at IS NULL
+  AND orders.status = 'IN_PROGRESS'
+  AND orders.current_department = 'Shipping QC';
+
+INSERT INTO order_activity_events (
+  order_id, event_type, event_category, occurred_at, actor_type,
+  actor_display_name, source, source_route, reason_code, reason_text,
+  status_from, status_to, department_from, department_to, field_diff, metadata
+)
+SELECT
+  repair.order_id,
+  'STATUS_DEPARTMENT_REPAIRED', 'admin', NOW(), 'system', 'migration 0301',
+  'migration', 'migrations/0301_repair_0171_manufacturing_bypass.sql',
+  'REPAIR_0171_MANUFACTURING_BYPASS',
+  'Returned an unmanufactured order from Shipping QC to P1 Production Queue; preserved the 0171 and 0257 audit evidence.',
+  orders.status, orders.status, 'Shipping QC', 'P1 Production Queue',
+  jsonb_build_object(
+    'currentDepartment', jsonb_build_object(
+      'before', 'Shipping QC', 'after', 'P1 Production Queue', 'label', 'Current Department'
+    )
+  ),
+  jsonb_build_object(
+    'cause', '0171_safe_boot_replay_followed_by_0257_restoration',
+    'requiresManufacturing', true,
+    'restorationEventId', audit.restoration_event_id
+  )
+FROM tmp_0171_return_to_p1 repair
+JOIN all_orders orders ON orders.order_id = repair.order_id
+JOIN p1_0171_manufacturing_bypass_audit audit ON audit.order_id = repair.order_id;
+
+UPDATE order_department_transitions transition
+SET exited_at = NOW(),
+    duration_minutes = GREATEST(FLOOR(EXTRACT(EPOCH FROM (NOW() - entered_at)) / 60)::integer, 0),
+    exit_reason = 'REPAIR_0171_MANUFACTURING_BYPASS',
+    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+      'migration', '0301_repair_0171_manufacturing_bypass'
+    )
+FROM tmp_0171_return_to_p1 repair
+WHERE transition.entity_type = 'p1_order'
+  AND transition.entity_id = repair.order_id
+  AND transition.department = 'Shipping QC'
+  AND transition.exited_at IS NULL;
+
+INSERT INTO order_department_transitions (
+  entity_type, entity_id, department, entered_at, metadata
+)
+SELECT
+  'p1_order', repair.order_id, 'P1 Production Queue', NOW(),
+  jsonb_build_object(
+    'migration', '0301_repair_0171_manufacturing_bypass',
+    'reason', 'REPAIR_0171_MANUFACTURING_BYPASS',
+    'requiresManufacturing', true
+  )
+FROM tmp_0171_return_to_p1 repair
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM order_department_transitions open_transition
+  WHERE open_transition.entity_type = 'p1_order'
+    AND open_transition.entity_id = repair.order_id
+    AND open_transition.exited_at IS NULL
+);
+
+UPDATE all_orders orders
+SET current_department = 'P1 Production Queue', updated_at = NOW()
+FROM tmp_0171_return_to_p1 repair
+WHERE orders.order_id = repair.order_id
+  AND orders.status = 'IN_PROGRESS'
+  AND orders.current_department = 'Shipping QC';
+
+-- FD787's canonical CNC state is authoritative. Repair only the reviewed stale
+-- open P1 transition and use the earliest surviving CNC activity timestamp.
+CREATE TEMP TABLE tmp_fd787_transition_repair ON COMMIT DROP AS
+SELECT orders.order_id
+FROM all_orders orders
+JOIN p1_0171_manufacturing_bypass_audit audit ON audit.order_id = orders.order_id
+WHERE orders.order_id = 'FD787'
+  AND orders.status = 'IN_PROGRESS'
+  AND orders.current_department = 'CNC'
+  AND audit.disposition = 'REPAIR_CNC_TRANSITION_LEDGER'
+  AND audit.repaired_at IS NULL
+  AND EXISTS (
+    SELECT 1 FROM order_department_transitions transition
+    WHERE transition.entity_type = 'p1_order'
+      AND transition.entity_id = orders.order_id
+      AND transition.department = 'P1 Production Queue'
+      AND transition.exited_at IS NULL
+  );
+
+UPDATE order_department_transitions transition
+SET exited_at = COALESCE(
+      (SELECT MIN(event.occurred_at) FROM order_activity_events event
+       WHERE event.order_id = 'FD787' AND event.department_to = 'CNC'),
+      NOW()
+    ),
+    exit_reason = 'REPAIR_FD787_STALE_OPEN_TRANSITION',
+    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+      'migration', '0301_repair_0171_manufacturing_bypass'
+    )
+FROM tmp_fd787_transition_repair repair
+WHERE transition.entity_type = 'p1_order'
+  AND transition.entity_id = repair.order_id
+  AND transition.department = 'P1 Production Queue'
+  AND transition.exited_at IS NULL;
+
+INSERT INTO order_department_transitions (
+  entity_type, entity_id, department, entered_at, metadata
+)
+SELECT
+  'p1_order', repair.order_id, 'CNC',
+  COALESCE(
+    (SELECT MIN(event.occurred_at) FROM order_activity_events event
+     WHERE event.order_id = repair.order_id AND event.department_to = 'CNC'),
+    NOW()
+  ),
+  jsonb_build_object(
+    'migration', '0301_repair_0171_manufacturing_bypass',
+    'reason', 'REPAIR_FD787_STALE_OPEN_TRANSITION'
+  )
+FROM tmp_fd787_transition_repair repair
+WHERE NOT EXISTS (
+  SELECT 1 FROM order_department_transitions open_transition
+  WHERE open_transition.entity_type = 'p1_order'
+    AND open_transition.entity_id = repair.order_id
+    AND open_transition.exited_at IS NULL
+);
+
+INSERT INTO order_activity_events (
+  order_id, event_type, event_category, occurred_at, actor_type,
+  actor_display_name, source, source_route, reason_code, reason_text,
+  status_from, status_to, department_from, department_to, field_diff, metadata
+)
+SELECT
+  repair.order_id, 'DEPARTMENT_LEDGER_REPAIRED', 'admin', NOW(), 'system',
+  'migration 0301', 'migration',
+  'migrations/0301_repair_0171_manufacturing_bypass.sql',
+  'REPAIR_FD787_STALE_OPEN_TRANSITION',
+  'Aligned the open department-transition ledger to the authoritative CNC canonical state without changing the order.',
+  'IN_PROGRESS', 'IN_PROGRESS', 'P1 Production Queue', 'CNC',
+  jsonb_build_object(
+    'transitionLedger', jsonb_build_object('before', 'P1 Production Queue', 'after', 'CNC')
+  ),
+  jsonb_build_object('canonicalDepartmentChanged', false)
+FROM tmp_fd787_transition_repair repair;
+
+UPDATE p1_0171_manufacturing_bypass_audit audit
+SET repaired_at = NOW()
+WHERE audit.order_id IN (
+  SELECT order_id FROM tmp_0171_return_to_p1
+  UNION
+  SELECT order_id FROM tmp_fd787_transition_repair
+);

--- a/scripts/sync-safe-migrations.js
+++ b/scripts/sync-safe-migrations.js
@@ -92,6 +92,11 @@ const INTENTIONALLY_EXCLUDED = new Set([
   // which blocks boot after the order state changes.  Idempotency key:
   // migration.0267_reconcile_p18380_persisted_shipment
   '0267_reconcile_p18380_persisted_shipment.sql',
+  // Historical row-level corrections. These are applied once by the tracked
+  // migration runner and must never replay on application boot.
+  '0257_restore_shipping_qc_after_0171_replay.sql',
+  '0281_contain_shipped_p1_auto_populate_regression.sql',
+  '0301_repair_0171_manufacturing_bypass.sql',
 ]);
 
 const missing = diskFiles.filter(

--- a/server/__tests__/migration0171ManufacturingBypassRepair.test.ts
+++ b/server/__tests__/migration0171ManufacturingBypassRepair.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { safeMigrationFiles } from '../scripts/migrations/runSafeBootMigrations';
+
+const root = process.cwd();
+const migration = '0301_repair_0171_manufacturing_bypass.sql';
+const affectedOrders = ['FD001', 'FD007', 'FD690', 'FD787', 'FD832', 'FE039', 'FE108', 'FE241'];
+
+describe('migration 0171 manufacturing-bypass containment', () => {
+  it('uses the immutable 0257 ledger and fail-closes to the reviewed eight orders', () => {
+    const sql = readFileSync(path.join(root, 'migrations', migration), 'utf8');
+    expect(sql).toContain("reason_code = 'RESTORE_SHIPPING_QC_AFTER_0171_REPLAY'");
+    expect(sql).toContain('expected exactly the reviewed eight 0171 orders');
+    for (const orderId of affectedOrders) expect(sql).toContain(`'${orderId}'`);
+  });
+
+  it('returns only the four unmanufactured Shipping QC orders to P1', () => {
+    const sql = readFileSync(path.join(root, 'migrations', migration), 'utf8');
+    expect(sql).toContain("IN ('FD007','FD690','FE108','FE241')");
+    expect(sql).toContain("THEN 'RETURN_TO_P1_MANUFACTURING'");
+    expect(sql).toContain("current_department = 'P1 Production Queue'");
+    expect(sql).toContain("'REPAIR_0171_MANUFACTURING_BYPASS'");
+    expect(sql).not.toContain('shipment_accounting_snapshots');
+    expect(sql).not.toContain("current_department = 'Shipping Management'");
+  });
+
+  it('repairs FD787 transition history without changing its canonical CNC state', () => {
+    const sql = readFileSync(path.join(root, 'migrations', migration), 'utf8');
+    expect(sql).toContain("orders.order_id = 'FD787'");
+    expect(sql).toContain("orders.current_department = 'CNC'");
+    expect(sql).toContain("'REPAIR_FD787_STALE_OPEN_TRANSITION'");
+    expect(sql).toContain("'canonicalDepartmentChanged', false");
+  });
+
+  it('keeps every historical row repair out of recurring safe boot', () => {
+    expect(safeMigrationFiles).not.toContain('0257_restore_shipping_qc_after_0171_replay.sql');
+    expect(safeMigrationFiles).not.toContain('0281_contain_shipped_p1_auto_populate_regression.sql');
+    expect(safeMigrationFiles).not.toContain(migration);
+  });
+});
+
+describe('Shipping QC manufacturing gate', () => {
+  const orders = readFileSync(path.join(root, 'server/src/routes/orders.ts'), 'utf8');
+  const productionQueue = readFileSync(path.join(root, 'server/src/routes/productionQueue.ts'), 'utf8');
+
+  it('blocks direct progression from P1 Production Queue to Shipping QC', () => {
+    expect(orders).toContain("code: 'SHIPPING_QC_MANUFACTURING_EVIDENCE_REQUIRED'");
+    expect(orders).toContain("existingOrder.currentDepartment !== 'Paint'");
+    expect(orders).toContain("existingOrder.currentDepartment !== 'Finish QC'");
+    expect(orders).not.toContain('has no stock model - routing directly to Shipping QC');
+  });
+
+  it('keeps invalid stock models in P1 for attention and performs no auto-move', () => {
+    expect(productionQueue).toContain('no departments were changed');
+    expect(productionQueue).not.toContain('AUTO-MOVING');
+    expect(productionQueue).not.toContain("currentDepartment: 'Shipping QC'");
+  });
+
+  it('writes finalized canonical and transition state in one transaction', () => {
+    expect(orders).toContain('UPDATE order_department_transitions');
+    expect(orders).toContain('INSERT INTO order_department_transitions');
+    expect(orders).toContain('if (!isFinalized)');
+  });
+});

--- a/server/__tests__/p1ShippedOrderContainment.test.ts
+++ b/server/__tests__/p1ShippedOrderContainment.test.ts
@@ -72,7 +72,7 @@ describe('P1 shipped-order containment', () => {
     expect(ordersRoute).toContain("updateData.currentDepartment = 'Shipping Management'");
   });
 
-  it('registers an auditable all-department restoration migration', () => {
+  it('keeps the historical containment migration retired from recurring boot', () => {
     const sql = readFileSync(
       path.join(root, 'migrations', migrationName),
       'utf8'
@@ -82,7 +82,7 @@ describe('P1 shipped-order containment', () => {
       'utf8'
     );
 
-    expect(registry.match(new RegExp(migrationName, 'g'))).toHaveLength(2);
+    expect(registry).not.toContain(`'${migrationName}'`);
     expect(sql).toContain('p1_shipped_order_containment_audit');
     expect(sql).toContain("'Gunsmith', 'Finish', 'Finish QC', 'Paint', 'Shipping QC'");
     expect(sql).toContain("reason_code = 'CONTAIN_SHIPPED_MANUFACTURING_ORDER'");

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -307,13 +307,11 @@ export const safeMigrationFiles = [
   '0250_epoch_validation_wizard_phase1.sql',
   '0251_design_project_configuration_workspace.sql',
   '0252_potential_order_duplicate_reviews.sql',
-  // 0253_void_duplicate_epoch_validation_packages.sql is intentionally
-  // excluded. It is a one-off controlled data correction certified by the
-  // dedicated migration-0253 workflow, not a recurring safe-boot migration.
+  // 0253 and 0257 are one-time controlled data corrections intentionally
+  // excluded from recurring safe boot; see scripts/sync-safe-migrations.js.
   '0254_controlled_document_reconciliation_certification_controls.sql',
   '0255_p2_v2_definition_v3_handoff.sql',
   '0256_controlled_document_atomic_approval_release.sql',
-  '0257_restore_shipping_qc_after_0171_replay.sql',
   '0258_design_control_structured_lifecycle.sql',
   '0259_design_control_form_template_database_artifacts.sql',
   '0260_controlled_document_source_recovery.sql',
@@ -323,13 +321,7 @@ export const safeMigrationFiles = [
   '0264_p2_recursive_production_demand_foundation.sql',
   '0265_p2_demand_planning_foundation.sql',
   '0266_p2_production_launch_persistence.sql',
-  // 0267_reconcile_p18380_persisted_shipment.sql is intentionally excluded.
-  // It is a one-off row-level data repair (no DDL) whose fail-closed guard
-  // raises an exception when the target order is not in the exact legacy
-  // mismatch state it was authored against, blocking boot once the order
-  // state changes.  Excluded from sync-safe-migrations.js via
-  // INTENTIONALLY_EXCLUDED.  Idempotency key:
-  // migration.0267_reconcile_p18380_persisted_shipment
+  // 0267 is a guarded one-time row repair intentionally excluded from boot.
   '0268_replit_p2_demand_composite_fk_repair.sql',
   '0269_repair_composite_po_item_demand_fks.sql',
   '0270_certification_authorization_matrix.sql',
@@ -343,7 +335,8 @@ export const safeMigrationFiles = [
   '0278_p2_component_traveler_provisioning.sql',
   '0279_vendor_international_contact_fields.sql',
   '0280_move_forward.sql',
-  '0281_contain_shipped_p1_auto_populate_regression.sql',
+  // 0281 and 0301 are one-time order-state reconciliations intentionally
+  // excluded from recurring safe boot; see scripts/sync-safe-migrations.js.
   '0282_car_form_data.sql',
   '0283_remove_legacy_rma_change_control_projections.sql',
   '0284_p2_customer_contacts.sql',
@@ -447,7 +440,6 @@ export const criticalMigrationFiles = new Set([
   '0277_routing_document_controlled_link.sql',
   '0278_p2_component_traveler_provisioning.sql',
   '0279_vendor_international_contact_fields.sql',
-  '0281_contain_shipped_p1_auto_populate_regression.sql',
   '0282_car_form_data.sql',
   '0283_remove_legacy_rma_change_control_projections.sql',
   '0285_p2_material_deposits_and_payment_settlements.sql',

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -3093,10 +3093,6 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
       }
     }
 
-    // Special handling for orders with no stock model - they bypass manufacturing and go to Shipping QC
-    const hasNoStockModel =
-      !existingOrder.modelId || existingOrder.modelId.trim() === '';
-
     // Special handling for flat top orders - they bypass CNC and go directly to Finish
     const isFlatTop = existingOrder.isFlattop || false;
 
@@ -3119,16 +3115,6 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
         targetDepartment = 'Shipping Management';
         console.log(
           `📦 Order ${orderId} completing Shipping - will be marked as FULFILLED in Shipping Management`
-        );
-      }
-      // Orders with no stock model should skip manufacturing departments
-      else if (
-        hasNoStockModel &&
-        existingOrder.currentDepartment === 'P1 Production Queue'
-      ) {
-        targetDepartment = 'Shipping QC';
-        console.log(
-          `🚀 Order ${orderId} has no stock model - routing directly to Shipping QC`
         );
       }
       // Flat top orders skip CNC and go directly to Finish after Layup/Plugging
@@ -3166,6 +3152,24 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
             });
         }
       }
+    }
+
+    // Shipping QC is a downstream manufacturing gate. A missing stock model,
+    // migration, or explicit API target must never bypass the manufacturing
+    // route. Normal progression reaches this gate from Paint; Finish QC is
+    // retained for approved no-paint routings.
+    if (
+      targetDepartment === 'Shipping QC' &&
+      existingOrder.currentDepartment !== 'Paint' &&
+      existingOrder.currentDepartment !== 'Finish QC'
+    ) {
+      return res.status(409).json({
+        error: 'Shipping QC requires completed manufacturing',
+        code: 'SHIPPING_QC_MANUFACTURING_EVIDENCE_REQUIRED',
+        orderId,
+        currentDepartment: existingOrder.currentDepartment,
+        allowedPriorDepartments: ['Paint', 'Finish QC'],
+      });
     }
 
     console.log(`🎯 Target department: ${targetDepartment}`);
@@ -3307,6 +3311,32 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
           fieldDiff,
         });
 
+        if (!shouldMarkFulfilled && targetDepartment) {
+          await tx.execute(sql`
+            UPDATE order_department_transitions
+            SET exited_at = ${now},
+                duration_minutes = GREATEST(FLOOR(EXTRACT(EPOCH FROM (${now} - entered_at)) / 60)::integer, 0),
+                exit_reason = 'NORMAL_PROGRESSION'
+            WHERE entity_type = 'p1_order'
+              AND entity_id = ${orderId}
+              AND exited_at IS NULL
+          `);
+          await tx.execute(sql`
+            INSERT INTO order_department_transitions (
+              entity_type, entity_id, department, entered_at,
+              entered_by_user_id, metadata
+            ) VALUES (
+              'p1_order', ${orderId}, ${targetDepartment}, ${now},
+              ${canonicalActorId},
+              ${JSON.stringify({
+                source: 'department-transition',
+                fromDepartment: existingOrder.currentDepartment,
+                progressedBy,
+              })}::jsonb
+            )
+          `);
+        }
+
         return after;
       });
 
@@ -3355,17 +3385,20 @@ router.post('/:orderId/progress', async (req: Request, res: Response) => {
         );
       }
 
-      // Record department transition for timing tracking
-      await auditService.recordDepartmentEntry({
-        entityType: 'p1_order',
-        entityId: orderId,
-        department: targetDepartment,
-        enteredByUserId: (req as any).user?.id,
-        metadata: {
-          fromDepartment: existingOrder.currentDepartment,
-          progressedBy: progressedBy,
-        },
-      });
+      // Finalized orders record the transition in the same transaction as the
+      // canonical state. Draft paths retain the legacy audit-service write.
+      if (!isFinalized) {
+        await auditService.recordDepartmentEntry({
+          entityType: 'p1_order',
+          entityId: orderId,
+          department: targetDepartment,
+          enteredByUserId: (req as any).user?.id,
+          metadata: {
+            fromDepartment: existingOrder.currentDepartment,
+            progressedBy: progressedBy,
+          },
+        });
+      }
     }
 
     res.json({ success: true, order: updatedOrder });

--- a/server/src/routes/productionQueue.ts
+++ b/server/src/routes/productionQueue.ts
@@ -26,8 +26,6 @@ async function autoMoveInvalidStockModelOrders(storage: any) {
   try {
     const allOrders = await storage.getAllOrders();
 
-    // Split orders into two categories: those to move to Shipping QC vs those needing attention
-    const ordersToMoveToShipping = [];
     const ordersNeedingAttention = [];
 
     for (const order of allOrders) {
@@ -40,14 +38,16 @@ async function autoMoveInvalidStockModelOrders(storage: any) {
         continue;
       }
 
-      // Orders with "no_stock", "no stock", or "None" go directly to Shipping QC
+      // A missing/non-manufactured stock model is a production configuration
+      // defect, never evidence that manufacturing is complete. Keep the order
+      // in P1 Production Queue until its routing is corrected.
       if (
         stockModel &&
         (stockModel.toLowerCase() === 'no_stock' ||
           stockModel.toLowerCase() === 'no stock' ||
           stockModel.toLowerCase() === 'none')
       ) {
-        ordersToMoveToShipping.push(order);
+        ordersNeedingAttention.push(order);
       }
       // Orders with missing stock model or missing action_length need attention
       // Flattop orders are excluded - they never need attention
@@ -65,28 +65,8 @@ async function autoMoveInvalidStockModelOrders(storage: any) {
     }
 
     console.log(
-      `🧹 Found ${ordersToMoveToShipping.length} orders to move to Shipping QC and ${ordersNeedingAttention.length} orders needing attention`
+      `🧹 Found ${ordersNeedingAttention.length} P1 orders needing manufacturing configuration attention`
     );
-
-    // Move orders with "no_stock"/"None" to Shipping QC
-    for (const order of ordersToMoveToShipping) {
-      const stockModel = order.stockModelId || order.modelId || 'empty';
-      console.log(
-        `🚀 AUTO-MOVING: Order ${order.orderId} (stock model: "${stockModel}") from P1 Production Queue → Shipping QC`
-      );
-
-      try {
-        await storage.updateFinalizedOrder(order.orderId, {
-          currentDepartment: 'Shipping QC',
-          updatedAt: new Date(),
-        });
-        console.log(
-          `✅ Successfully moved order ${order.orderId} to Shipping QC`
-        );
-      } catch (error) {
-        console.error(`❌ Failed to move order ${order.orderId}:`, error);
-      }
-    }
 
     // Log orders needing attention (these will be returned by a separate endpoint)
     for (const order of ordersNeedingAttention) {
@@ -107,11 +87,10 @@ async function autoMoveInvalidStockModelOrders(storage: any) {
     }
 
     if (
-      ordersToMoveToShipping.length > 0 ||
       ordersNeedingAttention.length > 0
     ) {
       console.log(
-        `🧹 AUTO-CLEANUP COMPLETE: Moved ${ordersToMoveToShipping.length} orders to Shipping QC, identified ${ordersNeedingAttention.length} orders needing attention`
+        `🧹 PRODUCTION CONFIGURATION CHECK: identified ${ordersNeedingAttention.length} orders needing attention; no departments were changed`
       );
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- replace the incorrect shipment-based reconciliation with a fail-closed repair for the eight production orders proven by migration 0257 audit events
- return FD007, FD690, FE108, and FE241 from Shipping QC to P1 Production Queue while preserving IN_PROGRESS and all 0171/0257 evidence
- repair FD787's stale open transition ledger without changing its canonical CNC state
- remove both missing/no-stock paths that bypass manufacturing and add a server-side Shipping QC manufacturing gate
- make finalized-order canonical and department-transition writes atomic
- retire one-time row repairs from recurring safe boot

## Safety
- migration 0301 requires exactly the reviewed eight order IDs when 0257 evidence exists and aborts on any unexpected population
- clean/synthetic databases with no 0257 evidence no-op
- the migration is excluded from recurring safe boot and from the registry generator; the dynamic pre-deploy ledger applies it at most once
- no deletes and no rewriting of original audit events

## Validation
- static incident assertions passed
- TypeScript syntax transforms passed for orders.ts and productionQueue.ts
- git diff checks passed
- non-destructive merge-tree check against current origin/main passed
- compare range is one scoped commit

## Unverified boundaries
- focused Vitest could not run locally because this worktree has no installed dependencies and offline package resolution failed
- PostgreSQL clean-schema, populated eight-order, replay/idempotency, row-count/checksum, and rollback certification have not run
- production migration execution and post-deploy verification have not occurred
- repository-wide safe-migration sync check currently also reports pre-existing main drift for 0288_p2_order_draft_progress.sql; this PR does not modify that unrelated migration