### PR TITLE
P2 certification: restore prospective Phase 4 batch constraint

### DIFF
--- a/migrations/0299_p2_wad_authority_correction.sql
+++ b/migrations/0299_p2_wad_authority_correction.sql
@@ -12,6 +12,7 @@ ALTER TABLE p2_wad_traveler_decision_events
 
 DO $$ BEGIN
   ALTER TABLE p2_wad_traveler_decisions
+    -- Enforce the rule prospectively without rejecting preserved legacy rows.
     ADD CONSTRAINT p2_wad_traveler_batch_coverage_check CHECK (
       traveler_type <> 'BATCH' OR (
         batch_approved_quantity IS NOT NULL AND
@@ -20,7 +21,7 @@ DO $$ BEGIN
         batch_coverage_scope IS NOT NULL AND
         btrim(batch_coverage_scope) <> ''
       )
-    );
+    ) NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 CREATE OR REPLACE FUNCTION p2_released_wad_authorization_immutable()


### PR DESCRIPTION
## Reproduced failure  The dedicated Phase 6 certification stopped in p2WadTravelerAuthorityCorrection.test.ts because migration 0299 no longer contained the intended NOT VALID clause.  ## Root cause  Commit 29270a4f2 removed NOT VALID from the Phase 4 batch-coverage CHECK while leaving the prospective compatibility contract unchanged. A validated constraint can reject preserved historical BATCH decisions that predate explicit coverage fields.  ## Correction  Restore NOT VALID on p2_wad_traveler_batch_coverage_check. PostgreSQL continues enforcing the constraint for new or changed rows while existing historical rows are not scanned, backfilled, or reinterpreted.  ## Preservation and scope  - One migration file changed; no application behavior, permissions, flags, Phase 5, Phase 6, or Phase 7 code changed. - No destructive migration and no production-data access. - No historical updates, backfill, lifecycle weakening, or authority changes. - Rollback: revert this commit before merge. No data rollback is required.  ## Validation  - Phase 4 correction test: 8/8 passed. - Focused Phase 3-6 server tests: 43/43 passed. - Combined with the bounded-TypeScript correction: scope tests 10/10 and Phase 3-6 tests 43/43 passed. - git diff --check passed.  This draft must not be merged until dedicated Phase 4, dedicated Phase 6, and complete P2 V2 disposable PostgreSQL certification pass on the combined exact tree. Phase 7 is not included and must not begin. 

## Final certification evidence

- Head: e9bd89985dbf03850a1247583ecedfda2fdb556e
- Base: 45ecbe4a4eaab8f1f153e24d76492b1c7422f616
- Dedicated Phase 4 PostgreSQL certification: run 32994055179 passed every step.
- Dedicated Phase 6 PostgreSQL certification: run 32994057026 passed every step.
- PostgreSQL 16.4 populated legacy probe preserved 1 BATCH row and quantity 10; catalog convalidated=false; replay passed; rollback probe count=0; a new invalid BATCH row was rejected.
- Required merge order: merge PR #1823 first, then refresh/review this PR against resulting main, merge this PR second, then run complete P2 V2 plus dedicated Phase 4 and Phase 6 certification on exact final main.
- The P2 V2 PR run 32990753188 passed TypeScript and synthetic pilot but failed the preexisting broad ESLint baseline boundary before downstream steps. Those downstream steps passed on PR #1823 run 32992625215 and the dedicated Phase 4/6 runs above. This PR remains draft.

No merge, deployment, flag activation, or Phase 7 work is authorized.