### PR TITLE
CI: skip empty pull-request ESLint comparison scope

### DIFF
--- a/.github/workflows/p2-v2-postgres-certification.yml
+++ b/.github/workflows/p2-v2-postgres-certification.yml
@@ -219,6 +219,11 @@ jobs:
           )
           start=$(date +%s)
           npx eslint --max-warnings 0 "${manifest_files[@]}"
+          if [ "${#corrective_files[@]}" -eq 0 ]; then
+            echo "No changed ESLint files; changed-file comparison skipped."
+            echo "focused_eslint: manifest_files=${#manifest_files[@]} corrective_files=0 unique_files=${#files[@]} duration_seconds=$(($(date +%s) - start)) exit_code=0 new_errors=0 new_warnings=0"
+            exit 0
+          fi
           set +e
           npx eslint --format json "${corrective_files[@]}" \
             > /tmp/phase10a-head-eslint.json 2>/tmp/phase10a-head-eslint.stderr

--- a/scripts/resolve-p2-v2-certification-scope.mjs
+++ b/scripts/resolve-p2-v2-certification-scope.mjs
@@ -32,6 +32,9 @@ export function resolveCertificationPaths({
   }
   const resolved = filterCertificationPaths(sourcePaths, kind);
   if (resolved.length === 0) {
+    if (eventName === 'pull_request') {
+      return [];
+    }
     throw new Error(
       `${eventName} resolved an empty ${kind} certification scope; refusing a repository-wide fallback`
     );

--- a/scripts/resolve-p2-v2-certification-scope.test.mjs
+++ b/scripts/resolve-p2-v2-certification-scope.test.mjs
@@ -114,13 +114,25 @@ test('an unrelated file is included only when a pull request changes it', () => 
   assert.deepEqual(scope, [unrelated]);
 });
 
-test('an empty scope fails instead of scanning the repository', () => {
+test('a pull request without lintable changes returns an empty scope', () => {
+  assert.deepEqual(
+    resolveCertificationPaths({
+      eventName: 'pull_request',
+      kind: 'eslint',
+      dispatchPaths,
+      changedPaths: ['migrations/0299_phase4_wad_not_valid_status.sql'],
+    }),
+    []
+  );
+});
+
+test('an empty dispatch scope fails instead of scanning the repository', () => {
   assert.throws(
     () =>
       resolveCertificationPaths({
-        eventName: 'pull_request',
+        eventName: 'workflow_dispatch',
         kind: 'eslint',
-        dispatchPaths,
+        dispatchPaths: ['migrations/0299_phase4_wad_not_valid_status.sql'],
         changedPaths: [],
       }),
     /refusing a repository-wide fallback/
@@ -161,4 +173,16 @@ test('bounded TypeScript comparison isolates compiler state and rejects abnormal
   assert.match(workflow, /head_exit" -ne 1.*head_exit" -ne 2/);
   assert.match(workflow, /base_exit" -ne 1.*base_exit" -ne 2/);
   assert.match(workflow, /head_tree" = "\$base_tree/);
+});
+
+test('ESLint skips changed-file comparison when a pull request has no lintable files', () => {
+  const workflow = fs.readFileSync(
+    path.resolve('.github/workflows/p2-v2-postgres-certification.yml'),
+    'utf8'
+  );
+  assert.match(workflow, /if \[ "\$\{#corrective_files\[@\]\}" -eq 0 \]/);
+  assert.match(
+    workflow,
+    /No changed ESLint files; changed-file comparison skipped\./
+  );
 });


### PR DESCRIPTION
## Problem

Migration-only PR #1822 has no changed ESLint-eligible files. The scope resolver rejected that valid empty pull-request scope inside Bash process substitution; mapfile continued with an empty array, and npx eslint received no paths and scanned the entire repository. The resulting repository-wide legacy diagnostics are not changes introduced by Phase 4.

## Correction

- Return an explicit empty scope for pull requests with no lintable changed files.
- Continue to reject an empty workflow-dispatch manifest fail-closed.
- Run the static Phase 9-10A manifest ESLint gate as before.
- Skip only the changed-file ESLint comparison when its array is empty, before ESLint can receive zero arguments.
- Add migration-only and workflow-guard regression coverage.

## Validation

- Scope resolver tests: 12/12 passed, 0 failed, 0 skipped.
- Prettier check on all three changed files: passed.
- git diff --check: passed.

## Scope

Certification infrastructure only. No migration, schema, runtime route, permission, feature flag, Phase 4 authority, Phase 5, Phase 6, or Phase 7 behavior changes. This PR must be reviewed and merged before rerunning PR #1822's complete P2 V2 certification.