### PR TITLE
Add Non-Inventory and Customer-Supplied utilization

### DIFF
--- a/client/src/components/inventory/InventoryItemsCard.tsx
+++ b/client/src/components/inventory/InventoryItemsCard.tsx
@@ -393,6 +393,8 @@ interface InventoryFormData {
   utilizedInFacilities: boolean;
   utilizedInAdmin: boolean;
   utilizedInServices: boolean;
+  utilizedInNonInventory: boolean;
+  utilizedInCustomerSupplied: boolean;
   isPacket: boolean;
   isFabric: boolean;
   hasSds: boolean;
@@ -620,14 +622,16 @@ const InventoryForm = ({
     }
   }, [formData.agPartNumber, editingItem, checkDuplicate]);
 
-  type UtilizedKey = 'utilizedInPL1' | 'utilizedInPL2' | 'utilizedInPL3' | 'utilizedInFacilities' | 'utilizedInAdmin' | 'utilizedInServices';
-  const utilizedOptions: { key: UtilizedKey; label: string }[] = [
+  type UtilizedKey = 'utilizedInPL1' | 'utilizedInPL2' | 'utilizedInPL3' | 'utilizedInFacilities' | 'utilizedInAdmin' | 'utilizedInServices' | 'utilizedInNonInventory' | 'utilizedInCustomerSupplied';
+  const utilizedOptions: { key: UtilizedKey; label: string; help?: string }[] = [
     { key: 'utilizedInPL1', label: 'PL1' },
     { key: 'utilizedInPL2', label: 'PL2' },
     { key: 'utilizedInPL3', label: 'PL3' },
     { key: 'utilizedInFacilities', label: 'Facilities' },
     { key: 'utilizedInAdmin', label: 'Admin' },
     { key: 'utilizedInServices', label: 'Services' },
+    { key: 'utilizedInNonInventory', label: 'Non-Inventory', help: 'Physical or purchasable item that does not require an inventory balance.' },
+    { key: 'utilizedInCustomerSupplied', label: 'Customer-Supplied', help: 'Material or item supplied by a customer and controlled separately from company-owned inventory.' },
   ];
   const selectedUtilizedLabels = utilizedOptions.filter(o => formData[o.key]).map(o => o.label);
 
@@ -887,16 +891,19 @@ const InventoryForm = ({
                 <ChevronDown className="h-4 w-4 opacity-50 shrink-0 ml-2" />
               </button>
             </PopoverTrigger>
-            <PopoverContent className="w-48 p-2" align="start">
-              {utilizedOptions.map(({ key, label }) => (
-                <div key={key} className="flex items-center space-x-2 py-1.5 px-1 rounded hover:bg-accent cursor-pointer" onClick={() => onCheckboxChange(key, !formData[key])}>
+            <PopoverContent className="w-80 p-2" align="start">
+              {utilizedOptions.map(({ key, label, help }) => (
+                <div key={key} className="flex items-start space-x-2 py-1.5 px-1 rounded hover:bg-accent cursor-pointer" onClick={() => onCheckboxChange(key, !formData[key])}>
                   <Checkbox
                     id={key}
                     checked={formData[key]}
                     onCheckedChange={(checked) => onCheckboxChange(key, checked as boolean)}
                     data-testid={`checkbox-${key}`}
                   />
-                  <Label htmlFor={key} className="cursor-pointer text-sm font-normal">{label}</Label>
+                  <div>
+                    <Label htmlFor={key} className="cursor-pointer text-sm font-normal">{label}</Label>
+                    {help && <p className="text-xs text-muted-foreground mt-0.5">{help}</p>}
+                  </div>
                 </div>
               ))}
             </PopoverContent>
@@ -1822,6 +1829,10 @@ function inventoryItemMatchesUtilizedFilter(item: InventoryItem, utilizedFilter:
       return item.utilizedInAdmin;
     case 'services':
       return item.utilizedInServices;
+    case 'non-inventory':
+      return item.utilizedInNonInventory;
+    case 'customer-supplied':
+      return item.utilizedInCustomerSupplied;
     default:
       return true;
   }
@@ -1867,6 +1878,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
     utilizedInFacilities: false,
     utilizedInAdmin: false,
     utilizedInServices: false,
+    utilizedInNonInventory: false,
+    utilizedInCustomerSupplied: false,
   });
 
   const [formData, setFormData] = useState<InventoryFormData>({
@@ -1913,6 +1926,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
     utilizedInFacilities: false,
     utilizedInAdmin: false,
     utilizedInServices: false,
+    utilizedInNonInventory: false,
+    utilizedInCustomerSupplied: false,
     isPacket: false,
     isFabric: false,
     hasSds: false,
@@ -2605,6 +2620,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
       utilizedInFacilities: false,
       utilizedInAdmin: false,
       utilizedInServices: false,
+      utilizedInNonInventory: false,
+      utilizedInCustomerSupplied: false,
       isPacket: false,
       isFabric: false,
       hasSds: false,
@@ -2759,6 +2776,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
       utilizedInFacilities: item.utilizedInFacilities || false,
       utilizedInAdmin: item.utilizedInAdmin || false,
       utilizedInServices: item.utilizedInServices || false,
+      utilizedInNonInventory: (item as any).utilizedInNonInventory || false,
+      utilizedInCustomerSupplied: (item as any).utilizedInCustomerSupplied || false,
       isPacket: (item as any).isPacket || false,
       isFabric: item.isFabric || false,
       hasSds: item.hasSds || false,
@@ -2849,6 +2868,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
         utilizedInFacilities: formData.utilizedInFacilities,
         utilizedInAdmin: formData.utilizedInAdmin,
         utilizedInServices: formData.utilizedInServices,
+        utilizedInNonInventory: formData.utilizedInNonInventory,
+        utilizedInCustomerSupplied: formData.utilizedInCustomerSupplied,
         isFabric: formData.isFabric,
         hasSds: formData.hasSds,
         hasTds: formData.hasTds,
@@ -3046,6 +3067,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
         utilizedInFacilities: false,
         utilizedInAdmin: false,
         utilizedInServices: false,
+        utilizedInNonInventory: false,
+        utilizedInCustomerSupplied: false,
       });
       setSelectedItems(new Set());
       queryClient.invalidateQueries({
@@ -3073,6 +3096,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
       utilizedInFacilities: bulkUtilizedFields.utilizedInFacilities,
       utilizedInAdmin: bulkUtilizedFields.utilizedInAdmin,
       utilizedInServices: bulkUtilizedFields.utilizedInServices,
+      utilizedInNonInventory: bulkUtilizedFields.utilizedInNonInventory,
+      utilizedInCustomerSupplied: bulkUtilizedFields.utilizedInCustomerSupplied,
     };
 
     bulkUpdateUtilizedMutation.mutate({
@@ -3329,6 +3354,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
                 <SelectItem value="facilities">Facilities Only</SelectItem>
                 <SelectItem value="admin">Admin Only</SelectItem>
                 <SelectItem value="services">Services Only</SelectItem>
+                <SelectItem value="non-inventory">Non-Inventory Only</SelectItem>
+                <SelectItem value="customer-supplied">Customer-Supplied Only</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -3723,12 +3750,20 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
                             Services
                           </span>
                         )}
+                        {item.utilizedInNonInventory && (
+                          <span className="px-2 py-1 text-xs bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-100 rounded">Non-Inventory</span>
+                        )}
+                        {item.utilizedInCustomerSupplied && (
+                          <span className="px-2 py-1 text-xs bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-100 rounded">Customer-Supplied</span>
+                        )}
                         {!item.utilizedInPL1 &&
                           !item.utilizedInPL2 &&
                           !item.utilizedInPL3 &&
                           !item.utilizedInFacilities &&
                           !item.utilizedInAdmin &&
                           !item.utilizedInServices &&
+                          !item.utilizedInNonInventory &&
+                          !item.utilizedInCustomerSupplied &&
                           '-'}
                       </div>
                     </td>
@@ -3842,6 +3877,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
                     <SelectItem value="facilities">Facilities Only</SelectItem>
                     <SelectItem value="admin">Admin Only</SelectItem>
                     <SelectItem value="services">Services Only</SelectItem>
+                    <SelectItem value="non-inventory">Non-Inventory Only</SelectItem>
+                    <SelectItem value="customer-supplied">Customer-Supplied Only</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -3942,7 +3979,9 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
                                       {item.utilizedInFacilities && <span className="px-2 py-0.5 text-xs bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-100 rounded">Facilities</span>}
                                       {item.utilizedInAdmin && <span className="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 rounded">Admin</span>}
                                       {item.utilizedInServices && <span className="px-2 py-0.5 text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-100 rounded">Services</span>}
-                                      {!item.utilizedInPL1 && !item.utilizedInPL2 && !item.utilizedInPL3 && !item.utilizedInFacilities && !item.utilizedInAdmin && !item.utilizedInServices && '—'}
+                                      {item.utilizedInNonInventory && <span className="px-2 py-0.5 text-xs bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-100 rounded">Non-Inventory</span>}
+                                      {item.utilizedInCustomerSupplied && <span className="px-2 py-0.5 text-xs bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-100 rounded">Customer-Supplied</span>}
+                                      {!item.utilizedInPL1 && !item.utilizedInPL2 && !item.utilizedInPL3 && !item.utilizedInFacilities && !item.utilizedInAdmin && !item.utilizedInServices && !item.utilizedInNonInventory && !item.utilizedInCustomerSupplied && '—'}
                                     </div>
                                   </td>
                                   <td className="px-4 py-2">
@@ -4615,6 +4654,30 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
                     Services
                   </Label>
                 </div>
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="bulk-utilizedInNonInventory"
+                    checked={bulkUtilizedFields.utilizedInNonInventory}
+                    onCheckedChange={(checked) => setBulkUtilizedFields({ ...bulkUtilizedFields, utilizedInNonInventory: checked as boolean })}
+                    data-testid="checkbox-bulk-utilizedInNonInventory"
+                  />
+                  <div>
+                    <Label htmlFor="bulk-utilizedInNonInventory" className="cursor-pointer">Non-Inventory</Label>
+                    <p className="text-xs text-muted-foreground">Physical or purchasable item that does not require an inventory balance.</p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="bulk-utilizedInCustomerSupplied"
+                    checked={bulkUtilizedFields.utilizedInCustomerSupplied}
+                    onCheckedChange={(checked) => setBulkUtilizedFields({ ...bulkUtilizedFields, utilizedInCustomerSupplied: checked as boolean })}
+                    data-testid="checkbox-bulk-utilizedInCustomerSupplied"
+                  />
+                  <div>
+                    <Label htmlFor="bulk-utilizedInCustomerSupplied" className="cursor-pointer">Customer-Supplied</Label>
+                    <p className="text-xs text-muted-foreground">Material or item supplied by a customer and controlled separately from company-owned inventory.</p>
+                  </div>
+                </div>
               </div>
             </div>
             <div className="text-sm text-muted-foreground">
@@ -4634,6 +4697,8 @@ export default function InventoryItemsCard({ initialSearchTerm }: InventoryItems
                   utilizedInFacilities: false,
                   utilizedInAdmin: false,
                   utilizedInServices: false,
+                  utilizedInNonInventory: false,
+                  utilizedInCustomerSupplied: false,
                 });
               }}
               data-testid="button-cancel-bulk-utilized"

--- a/migrations/0307_inventory_utilized_in_balance_eligibility.sql
+++ b/migrations/0307_inventory_utilized_in_balance_eligibility.sql
@@ -1,0 +1,42 @@
+ALTER TABLE inventory_items
+  ADD COLUMN IF NOT EXISTS utilized_in_non_inventory boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS utilized_in_customer_supplied boolean NOT NULL DEFAULT false;
+
+CREATE OR REPLACE FUNCTION enforce_inventory_balance_eligibility()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  item_non_inventory boolean;
+  item_service boolean;
+BEGIN
+  SELECT
+    COALESCE(utilized_in_non_inventory, false),
+    COALESCE(utilized_in_services, false) OR lower(trim(COALESCE(type, ''))) IN ('service', 'services')
+  INTO item_non_inventory, item_service
+  FROM inventory_items
+  WHERE ag_part_number = NEW.ag_part_number;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Inventory item % does not exist', NEW.ag_part_number
+      USING ERRCODE = '23503';
+  END IF;
+  IF item_non_inventory THEN
+    RAISE EXCEPTION 'Non-Inventory item % is not eligible for an inventory balance', NEW.ag_part_number
+      USING ERRCODE = '23514';
+  END IF;
+  IF item_service THEN
+    RAISE EXCEPTION 'Service item % is not eligible for an inventory balance', NEW.ag_part_number
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS inventory_balances_eligibility_guard ON inventory_balances;
+CREATE TRIGGER inventory_balances_eligibility_guard
+BEFORE INSERT OR UPDATE OF ag_part_number ON inventory_balances
+FOR EACH ROW EXECUTE FUNCTION enforce_inventory_balance_eligibility();
+
+-- Existing balances and history are intentionally preserved. The trigger only
+-- prevents prospective creation/re-keying of ineligible balance rows.

--- a/server/__tests__/inventoryBalanceEligibility.test.ts
+++ b/server/__tests__/inventoryBalanceEligibility.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  inventoryBalanceIneligibilityReason,
+  isInventoryBalanceEligible,
+} from '../../shared/inventoryBalanceEligibility';
+
+describe('inventory balance eligibility', () => {
+  it('keeps ordinary purchased and manufactured inventory eligible', () => {
+    expect(isInventoryBalanceEligible({ type: 'Purchased' })).toBe(true);
+    expect(isInventoryBalanceEligible({ type: 'Manufactured' })).toBe(true);
+  });
+
+  it('keeps Customer-Supplied custody eligible and distinct from Non-Inventory', () => {
+    expect(isInventoryBalanceEligible({ utilizedInCustomerSupplied: true })).toBe(true);
+    expect(inventoryBalanceIneligibilityReason({ utilizedInCustomerSupplied: true })).toBeNull();
+  });
+
+  it('makes Non-Inventory ineligible for balances, reservations, and allocations', () => {
+    const item = { utilizedInNonInventory: true };
+    expect(isInventoryBalanceEligible(item)).toBe(false);
+    expect(inventoryBalanceIneligibilityReason(item)).toBe('NON_INVENTORY');
+  });
+
+  it('preserves the existing Service no-balance rule', () => {
+    expect(isInventoryBalanceEligible({ utilizedInServices: true })).toBe(false);
+    expect(isInventoryBalanceEligible({ type: 'Service' })).toBe(false);
+    expect(inventoryBalanceIneligibilityReason({ type: 'services' })).toBe('SERVICE');
+  });
+
+  it('fails closed when the inventory item does not exist', () => {
+    expect(isInventoryBalanceEligible(undefined)).toBe(false);
+    expect(inventoryBalanceIneligibilityReason(undefined)).toBe('ITEM_NOT_FOUND');
+  });
+});

--- a/server/__tests__/inventoryUtilizedInArchitecture.test.ts
+++ b/server/__tests__/inventoryUtilizedInArchitecture.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), 'utf8');
+
+describe('Inventory Item Utilized In architecture', () => {
+  it('persists both additive selections without changing existing defaults', () => {
+    const schema = read('server/schema.ts');
+    const migration = read('migrations/0307_inventory_utilized_in_balance_eligibility.sql');
+    expect(schema).toContain("utilizedInNonInventory: boolean('utilized_in_non_inventory').notNull().default(false)");
+    expect(schema).toContain("utilizedInCustomerSupplied: boolean('utilized_in_customer_supplied').notNull().default(false)");
+    expect(migration).toContain('ADD COLUMN IF NOT EXISTS utilized_in_non_inventory boolean NOT NULL DEFAULT false');
+    expect(migration).toContain('ADD COLUMN IF NOT EXISTS utilized_in_customer_supplied boolean NOT NULL DEFAULT false');
+    expect(migration).not.toMatch(/UPDATE\s+inventory_items/i);
+  });
+
+  it('keeps purchasing selection unchanged and suppresses receipt inventory creation centrally', () => {
+    const poSelector = read('client/src/components/inventory/VendorPOItemSelector.tsx');
+    const storage = read('server/storage.ts');
+    expect(poSelector).not.toContain('utilizedInNonInventory');
+    expect(storage).toContain('if (inventoryItem && isInventoryBalanceEligible(inventoryItem))');
+  });
+
+  it('enforces eligibility in balances, inventory events, allocations, and the database', () => {
+    const inventoryRoute = read('server/src/routes/inventory.ts');
+    const eventService = read('server/src/services/inventoryEventService.ts');
+    const allocationService = read('server/src/services/inventoryAllocationService.ts');
+    const migration = read('migrations/0307_inventory_utilized_in_balance_eligibility.sql');
+    expect(inventoryRoute).toContain('isInventoryBalanceEligible');
+    expect(eventService).toContain("eventType !== 'receipt_pending' && !isInventoryBalanceEligible(item)");
+    expect(allocationService).toContain('part ${agPartNumber} is not eligible for inventory allocation');
+    expect(migration).toContain('inventory_balances_eligibility_guard');
+  });
+
+  it('does not equate Customer-Supplied with Non-Inventory', () => {
+    const helper = read('shared/inventoryBalanceEligibility.ts');
+    expect(helper).toContain('item?.utilizedInNonInventory !== true');
+    expect(helper).not.toMatch(/utilizedInCustomerSupplied\s*!==?\s*true/);
+  });
+});

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -828,6 +828,8 @@ export const inventoryItems = pgTable('inventory_items', {
   utilizedInFacilities: boolean('utilized_in_facilities').default(false), // Used in Facilities
   utilizedInAdmin: boolean('utilized_in_admin').default(false), // Used in Admin
   utilizedInServices: boolean('utilized_in_services').default(false), // Used in Services
+  utilizedInNonInventory: boolean('utilized_in_non_inventory').notNull().default(false), // Purchased/physical item not tracked in ordinary balances
+  utilizedInCustomerSupplied: boolean('utilized_in_customer_supplied').notNull().default(false), // Customer-owned material; custody tracking remains enabled
   isPacket: boolean('is_packet').default(false), // Packet item for cutting table BOM
   isPacketPart: boolean('is_packet_part').default(false), // Part of cutting table packet
   isFabric: boolean('is_fabric').default(false), // Fabric for cutting table

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -361,6 +361,7 @@ export const safeMigrationFiles = [
   '0304_p2_controlled_material_scan_consumption.sql',
   '0305_p2_manufactured_output_genealogy_foundation.sql',
   '0306_p2_manufactured_output_custody_foundation.sql',
+  '0307_inventory_utilized_in_balance_eligibility.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -468,6 +469,7 @@ export const criticalMigrationFiles = new Set([
   '0304_p2_controlled_material_scan_consumption.sql',
   '0305_p2_manufactured_output_genealogy_foundation.sql',
   '0306_p2_manufactured_output_custody_foundation.sql',
+  '0307_inventory_utilized_in_balance_eligibility.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -39,6 +39,7 @@ import {
 } from '../lib/p2ControlCenterReconciliation';
 import { softAuth, authenticateToken, sessionAwareAuth, requireAdminOrOwner } from '../../middleware/auth';
 import { computeEffectivePriority, getEffectivePriorityScore } from '../../../shared/utils/computeEffectivePriority';
+import { isInventoryBalanceEligible } from '@shared/inventoryBalanceEligibility';
 import employeesRoutes from './employees';
 import operatorAuthRoutes from './operatorAuth';
 import employeeQualificationsRoutes from './employeeQualifications';
@@ -719,6 +720,13 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
                 })
                 .returning()
                 .then(([r]) => r);
+
+              if (effectiveInvItem && !isInventoryBalanceEligible(effectiveInvItem)) {
+                return res.status(422).json({
+                  error: `Item ${item.partNumber} is not eligible for ordinary inventory balance custody.`,
+                  code: 'INVENTORY_BALANCE_INELIGIBLE',
+                });
+              }
 
               if (effectiveInvItem) {
                 // Upsert inventory balance in WAREHOUSE-MAIN location

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -34,18 +34,16 @@ import {
   travelers,
   inventoryDepartments,
 } from '@shared/schema';
+import {
+  isInventoryBalanceEligible,
+  inventoryBalanceIneligibilityReason,
+} from '@shared/inventoryBalanceEligibility';
 
 function withSupplySourceDashboard(item: InventoryItem) {
   return {
     ...item,
     supplySourceDashboard: getSupplySourceDashboard(item.manufacturedCategory as ManufacturedCategory),
   };
-}
-
-function isServiceInventoryItem(item: InventoryItem | undefined): boolean {
-  if (!item) return false;
-  const looseType = (item.type || '').trim().toLowerCase();
-  return item.utilizedInServices === true || looseType === 'service' || looseType === 'services';
 }
 
 import { storage } from '../../storage';
@@ -63,6 +61,35 @@ import {
 } from '../services/sharedDepartmentService';
 
 const router = Router();
+
+async function assertSafeNonInventoryTransition(
+  existingItem: InventoryItem | undefined,
+  updates: Partial<InventoryItem>
+) {
+  if (!existingItem || existingItem.utilizedInNonInventory === true || updates.utilizedInNonInventory !== true) return;
+
+  const evidence = await db.execute(sql`
+    SELECT
+      EXISTS (SELECT 1 FROM inventory_balances WHERE ag_part_number = ${existingItem.agPartNumber}) AS has_balances,
+      EXISTS (SELECT 1 FROM inventory_transactions WHERE ag_part_number = ${existingItem.agPartNumber}) AS has_transactions,
+      EXISTS (SELECT 1 FROM inventory_transaction_ledger WHERE ag_part_number = ${existingItem.agPartNumber}) AS has_ledger,
+      EXISTS (SELECT 1 FROM material_lots WHERE material_part_number = ${existingItem.agPartNumber}) AS has_lots,
+      EXISTS (
+        SELECT 1 FROM material_lot_reservations mlr
+        JOIN material_lots ml ON ml.id = mlr.material_lot_id
+        WHERE ml.material_part_number = ${existingItem.agPartNumber}
+      ) AS has_reservations,
+      EXISTS (SELECT 1 FROM allocation_requirements WHERE required_part_number = ${existingItem.agPartNumber}) AS has_demand,
+      EXISTS (SELECT 1 FROM p2_frozen_production_demand_nodes WHERE inventory_item_id = ${existingItem.id}) AS has_p2_frozen_demand
+  `);
+  const row = evidence.rows?.[0] as Record<string, boolean> | undefined;
+  const blockers = Object.entries(row || {}).filter(([, present]) => present).map(([name]) => name.replace(/^has_/, ''));
+  if (blockers.length > 0) {
+    throw new Error(
+      `Cannot mark ${existingItem.agPartNumber} as Non-Inventory while custody or demand evidence exists (${blockers.join(', ')}). Resolve it through a controlled transition; no records were changed.`
+    );
+  }
+}
 
 async function prepareProspectiveDefaultDepartment(data: any, effectiveType?: string | null) {
   if (!areSharedInventoryDepartmentWritesEnabled()) {
@@ -625,6 +652,7 @@ router.put('/inventory/items/:id', requirePermission('inventory.adjust'), handle
 
     // Strip assignedDepartments from JSONB write — junction table is authoritative
     const { assignedDepartments: deptNames, ...storageUpdates } = updates as any;
+    await assertSafeNonInventoryTransition(existingItem, storageUpdates);
     const updatedItem = await storage.updateInventoryItem(itemId, storageUpdates);
     
     if (deptNames && Array.isArray(deptNames)) {
@@ -778,6 +806,7 @@ router.put('/:id', requirePermission('inventory.adjust'), handleInventoryPdfUplo
       updates,
       updates.itemType ?? existingForDefault?.itemType
     );
+    await assertSafeNonInventoryTransition(existingForDefault, updates);
     const updatedItem = await storage.updateInventoryItem(itemId, updates);
     res.json(withSupplySourceDashboard(updatedItem));
   } catch (error) {
@@ -1004,6 +1033,7 @@ router.put('/items/:id', requirePermission('inventory.adjust'), handleInventoryP
     );
     // Strip assignedDepartments from JSONB write — junction table is authoritative
     const { assignedDepartments: deptNames, ...storageUpdates } = updates as any;
+    await assertSafeNonInventoryTransition(existingItem, storageUpdates);
     const updatedItem = await storage.updateInventoryItem(itemId, storageUpdates);
     
     if (deptNames && Array.isArray(deptNames)) {
@@ -1291,8 +1321,18 @@ router.post('/items/bulk-update-utilized', async (req: Request, res: Response) =
     if ('utilizedInServices' in utilizedFields) {
       updates.utilizedInServices = Boolean(utilizedFields.utilizedInServices);
     }
+    if ('utilizedInNonInventory' in utilizedFields) {
+      updates.utilizedInNonInventory = Boolean(utilizedFields.utilizedInNonInventory);
+    }
+    if ('utilizedInCustomerSupplied' in utilizedFields) {
+      updates.utilizedInCustomerSupplied = Boolean(utilizedFields.utilizedInCustomerSupplied);
+    }
 
-    // Update each item with the new utilized fields
+    // Preflight every selected item before changing any of them.
+    for (const itemId of itemIds) {
+      const existingItem = await storage.getInventoryItem(Number(itemId));
+      await assertSafeNonInventoryTransition(existingItem, updates);
+    }
     for (const itemId of itemIds) {
       await storage.updateInventoryItem(itemId, updates);
     }
@@ -3986,6 +4026,8 @@ function parseUtilizedColumn(value: string): {
   utilizedInFacilities: boolean;
   utilizedInAdmin: boolean;
   utilizedInServices: boolean;
+  utilizedInNonInventory: boolean;
+  utilizedInCustomerSupplied: boolean;
 } {
   const valueLower = value.toLowerCase();
   return {
@@ -3995,6 +4037,8 @@ function parseUtilizedColumn(value: string): {
     utilizedInFacilities: valueLower.includes('facilities'),
     utilizedInAdmin: valueLower.includes('admin'),
     utilizedInServices: valueLower.includes('services'),
+    utilizedInNonInventory: valueLower.includes('non-inventory'),
+    utilizedInCustomerSupplied: valueLower.includes('customer-supplied'),
   };
 }
 
@@ -4053,6 +4097,8 @@ router.post('/inventory/import/csv', async (req: Request, res: Response) => {
           utilizedInFacilities: false,
           utilizedInAdmin: false,
           utilizedInServices: false,
+          utilizedInNonInventory: false,
+          utilizedInCustomerSupplied: false,
           isStockItem: false,
         };
 
@@ -4350,6 +4396,8 @@ router.get('/inventory/export/csv', async (req: Request, res: Response) => {
       if (item.utilizedInFacilities) utilized.push('Facilities');
       if (item.utilizedInAdmin) utilized.push('Admin');
       if (item.utilizedInServices) utilized.push('Services');
+      if (item.utilizedInNonInventory) utilized.push('Non-Inventory');
+      if (item.utilizedInCustomerSupplied) utilized.push('Customer-Supplied');
       return utilized.join(', ');
     };
 
@@ -4488,7 +4536,7 @@ router.get('/inventory/balances', async (req: Request, res: Response) => {
     const balances = await storage.getAllInventoryBalances();
     const items = await storage.getAllInventoryItems();
     const itemMap = new Map(items.map((item) => [item.agPartNumber, item]));
-    const nonServiceBalances = balances.filter((balance) => !isServiceInventoryItem(itemMap.get(balance.agPartNumber)));
+    const eligibleBalances = balances.filter((balance) => isInventoryBalanceEligible(itemMap.get(balance.agPartNumber)));
 
     const ncrInventorySerialRows = await db
       .select({
@@ -4537,7 +4585,7 @@ router.get('/inventory/balances', async (req: Request, res: Response) => {
     }
     
     // Enrich balances with department metadata
-    const enrichedBalances: EnrichedInventoryBalance[] = nonServiceBalances.map((balance) => {
+    const enrichedBalances: EnrichedInventoryBalance[] = eligibleBalances.map((balance) => {
       const deptInfo = DEPARTMENT_LOCATION_MAP[balance.locationId];
       const item = itemMap.get(balance.agPartNumber);
       return {
@@ -4633,6 +4681,18 @@ router.get('/inventory/balances/:id', async (req: Request, res: Response) => {
 router.post('/inventory/balances', requirePermission('inventory.adjust'), async (req: Request, res: Response) => {
   try {
     const data = insertInventoryBalanceSchema.parse(req.body);
+    const item = (await storage.getAllInventoryItems()).find(candidate => candidate.agPartNumber === data.agPartNumber);
+    const reason = inventoryBalanceIneligibilityReason(item);
+    if (reason) {
+      return res.status(422).json({
+        error: reason === 'NON_INVENTORY'
+          ? 'Non-Inventory items do not use inventory balances.'
+          : reason === 'SERVICE'
+            ? 'Service items do not use inventory balances.'
+            : 'Inventory item not found.',
+        code: `INVENTORY_BALANCE_${reason}`,
+      });
+    }
     const balance = await storage.createInventoryBalance(data);
     res.status(201).json(balance);
   } catch (error) {

--- a/server/src/services/inventoryAllocationService.ts
+++ b/server/src/services/inventoryAllocationService.ts
@@ -1,6 +1,7 @@
 import { db } from '../../db';
-import { inventoryBalances, inventoryTransactions, allocationRequirements } from '../../schema';
+import { inventoryBalances, inventoryTransactions, allocationRequirements, inventoryItems } from '../../schema';
 import { eq, and, sql } from 'drizzle-orm';
+import { isInventoryBalanceEligible } from '@shared/inventoryBalanceEligibility';
 import { evaluateQueueReadiness } from './queueReadinessService';
 import { recordInventoryBalanceLedgerChange } from './inventoryTransactionLedgerService';
 
@@ -70,6 +71,18 @@ export async function allocateInventory(
   }
 
   const run = async (runner: DbTransaction): Promise<AllocationResult> => {
+    const [item] = await runner
+      .select({
+        utilizedInNonInventory: inventoryItems.utilizedInNonInventory,
+        utilizedInServices: inventoryItems.utilizedInServices,
+        type: inventoryItems.type,
+      })
+      .from(inventoryItems)
+      .where(eq(inventoryItems.agPartNumber, agPartNumber))
+      .limit(1);
+    if (!isInventoryBalanceEligible(item)) {
+      throw new Error(`allocateInventory: part ${agPartNumber} is not eligible for inventory allocation`);
+    }
     // Lock the row for update to prevent concurrent over-allocation
     const [row] = await runner
       .select()

--- a/server/src/services/inventoryEventService.ts
+++ b/server/src/services/inventoryEventService.ts
@@ -1,6 +1,7 @@
 import { db } from '../../db';
 import { inventoryItems, inventoryTransactions, inventoryBalances } from '../../schema';
 import { eq, and, sql } from 'drizzle-orm';
+import { isInventoryBalanceEligible, inventoryBalanceIneligibilityReason } from '@shared/inventoryBalanceEligibility';
 import {
   recordInventoryBalanceLedgerChange,
   type InventoryLedgerTransactionType,
@@ -91,12 +92,23 @@ export async function createInventoryEvent(params: InventoryEventParams): Promis
 
   await db.transaction(async (tx) => {
   const [item] = await tx
-    .select({ agPartNumber: inventoryItems.agPartNumber })
+    .select({
+      agPartNumber: inventoryItems.agPartNumber,
+      utilizedInNonInventory: inventoryItems.utilizedInNonInventory,
+      utilizedInServices: inventoryItems.utilizedInServices,
+      type: inventoryItems.type,
+    })
     .from(inventoryItems)
     .where(eq(inventoryItems.agPartNumber, agPartNumber));
 
   if (!item) {
     throw new Error(`Part number ${agPartNumber} not found in inventory_items`);
+  }
+  if (eventType !== 'receipt_pending' && !isInventoryBalanceEligible(item)) {
+    const reason = inventoryBalanceIneligibilityReason(item);
+    throw new Error(
+      `${reason === 'NON_INVENTORY' ? 'Non-Inventory' : 'Service'} item ${agPartNumber} cannot create or change an inventory balance`
+    );
   }
 
   const totalCost =

--- a/server/src/services/mrpMaterialPlanning.ts
+++ b/server/src/services/mrpMaterialPlanning.ts
@@ -107,6 +107,11 @@ export async function calculateMaterialDemand(
       AND bi.is_active = true
       AND bi.item_type = 'material'
       AND bi.quantity  > 0
+    JOIN inventory_items ii
+      ON ii.ag_part_number = bi.part_name
+      AND COALESCE(ii.utilized_in_non_inventory, false) = false
+      AND COALESCE(ii.utilized_in_services, false) = false
+      AND lower(trim(COALESCE(ii.type, ''))) NOT IN ('service', 'services')
     WHERE 1=1 ${skuWhere}
     GROUP BY bi.part_name
     ORDER BY total_required DESC, bi.part_name
@@ -225,6 +230,11 @@ export async function calculateBuildCapacity(sku: string): Promise<{
       AND bi.is_active = true
       AND bi.item_type = 'material'
       AND bi.quantity  > 0
+    JOIN inventory_items ii
+      ON ii.ag_part_number = bi.part_name
+      AND COALESCE(ii.utilized_in_non_inventory, false) = false
+      AND COALESCE(ii.utilized_in_services, false) = false
+      AND lower(trim(COALESCE(ii.type, ''))) NOT IN ('service', 'services')
     LEFT JOIN inventory_balances ib
       ON ib.ag_part_number = bi.part_name
     WHERE bd.sku       = $1

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -708,6 +708,7 @@ import {
   type LocalCalendarEvent,
   type InsertLocalCalendarEvent,
 } from './schema';
+import { isInventoryBalanceEligible, inventoryBalanceIneligibilityReason } from '@shared/inventoryBalanceEligibility';
 import { db, pool, rawSql } from './db';
 import { recordAuditEvent } from './src/services/auditLedgerService';
 import { recordInventoryLedgerEntry } from './src/services/inventoryTransactionLedgerService';
@@ -11033,7 +11034,7 @@ export class DatabaseStorage implements IStorage {
           `[vendor-po/receive] Auto-created inventory_items placeholder for ag_part_number="${poLineItem.agPartNumber}" (poLineItemId=${poLineItemId}) so ledger row could be written. Edit Parts Management to fill metadata.`,
         );
       }
-      if (inventoryItem) {
+      if (inventoryItem && isInventoryBalanceEligible(inventoryItem)) {
         const ledgerSourceModule = 'receiving:vendor-po';
 
         // Resolve receiver display name from users table (fall back to
@@ -12181,6 +12182,19 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createInventoryBalance(data: InsertInventoryBalance): Promise<InventoryBalance> {
+    const [item] = await db
+      .select({
+        utilizedInNonInventory: inventoryItems.utilizedInNonInventory,
+        utilizedInServices: inventoryItems.utilizedInServices,
+        type: inventoryItems.type,
+      })
+      .from(inventoryItems)
+      .where(eq(inventoryItems.agPartNumber, data.agPartNumber))
+      .limit(1);
+    if (!isInventoryBalanceEligible(item)) {
+      const reason = inventoryBalanceIneligibilityReason(item);
+      throw new Error(`Inventory balance is not allowed for ${reason === 'NON_INVENTORY' ? 'Non-Inventory' : reason === 'SERVICE' ? 'Service' : 'missing'} item ${data.agPartNumber}`);
+    }
     const [balance] = await db.insert(inventoryBalances).values(data).returning();
     return balance;
   }

--- a/shared/inventoryBalanceEligibility.ts
+++ b/shared/inventoryBalanceEligibility.ts
@@ -1,0 +1,31 @@
+export type InventoryBalanceEligibilityItem = {
+  utilizedInNonInventory?: boolean | null;
+  utilizedInCustomerSupplied?: boolean | null;
+  utilizedInServices?: boolean | null;
+  type?: string | null;
+};
+
+export function isServiceInventoryItem(item: InventoryBalanceEligibilityItem | null | undefined): boolean {
+  if (!item) return false;
+  const looseType = (item.type || '').trim().toLowerCase();
+  return item.utilizedInServices === true || looseType === 'service' || looseType === 'services';
+}
+
+/**
+ * Authoritative application rule for ordinary inventory-balance eligibility.
+ * Customer-supplied items intentionally remain eligible for custody tracking.
+ */
+export function isInventoryBalanceEligible(
+  item: InventoryBalanceEligibilityItem | null | undefined
+): boolean {
+  return Boolean(item) && item?.utilizedInNonInventory !== true && !isServiceInventoryItem(item);
+}
+
+export function inventoryBalanceIneligibilityReason(
+  item: InventoryBalanceEligibilityItem | null | undefined
+): 'NON_INVENTORY' | 'SERVICE' | 'ITEM_NOT_FOUND' | null {
+  if (!item) return 'ITEM_NOT_FOUND';
+  if (item.utilizedInNonInventory === true) return 'NON_INVENTORY';
+  if (isServiceInventoryItem(item)) return 'SERVICE';
+  return null;
+}


### PR DESCRIPTION
## Summary
- add Non-Inventory and Customer-Supplied to the existing Inventory Item Utilized In selector
- centralize ordinary inventory-balance eligibility while preserving Customer-Supplied custody tracking
- prevent Non-Inventory and Service items from creating balances or allocations and preserve existing evidence during transitions
- keep Non-Inventory available for purchasing and PO receipt confirmation without creating false on-hand inventory
- add prospective migration 0307 and regression coverage

## Validation
- eligibility matrix: 7 assertions passed
- syntax checks passed for touched non-TSX TypeScript files
- git diff check and local merge-tree check passed
- full typecheck, Vitest execution, browser testing, and PostgreSQL certification were unavailable because the clean worktree has no installed dependencies, PostgreSQL client, or Docker

## Migration safety
- both new flags default false; no existing item is reclassified
- no balances or history are deleted
- migration is registered in safe and critical boot migration lists
- PostgreSQL clean/populated/replay/row-count/checksum/rollback certification remains required