### PR TITLE
Consolidate P2 production views into Production Map

### DIFF
--- a/client/src/__tests__/p2ProductionMapConsolidation.client.test.ts
+++ b/client/src/__tests__/p2ProductionMapConsolidation.client.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'client/src/pages/P2ControlCenter.tsx'), 'utf8');
+
+describe('P2 Control Center Production Map consolidation', () => {
+  it('replaces the three top-level program views with one Production Map tab', () => {
+    expect(source).toContain('value="production-map"');
+    expect(source).toContain('data-testid="tab-production-map"');
+    expect(source).not.toContain('data-testid="tab-program-overview"');
+    expect(source).not.toContain('data-testid="tab-assembly-tree"');
+    expect(source).not.toContain('data-testid="tab-swimlane"');
+  });
+
+  it('switches one selected-PO orchestration surface between all three views', () => {
+    expect(source).toContain('production-map-view-program');
+    expect(source).toContain('production-map-view-assembly');
+    expect(source).toContain('production-map-view-swimlane');
+    expect(source).toContain('ProgramManufacturingOrchestration mode={productionMapView} projectId={programProjectId}');
+    expect(source).toContain('Select one PO to view its Production Map');
+  });
+
+  it('keeps legacy tab links routed to the matching Production Map view', () => {
+    expect(source).toContain("if (tab === 'assembly-tree') return 'tree'");
+    expect(source).toContain("if (tab === 'swimlane') return 'swimlane'");
+    expect(source).toContain("return 'production-map'");
+  });
+});

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -124,15 +124,29 @@ export default function P2ControlCenter() {
   const wadProjectId = urlParams.get('projectId') || '';
   const wadProjectName = urlParams.get('projectName') || '';
   const wadPoId = urlParams.get('poId') || '';
+  type ProductionMapView = 'overview' | 'tree' | 'swimlane';
+  const resolveProductionMapView = (tab: string | null): ProductionMapView => {
+    if (tab === 'assembly-tree') return 'tree';
+    if (tab === 'swimlane') return 'swimlane';
+    return 'overview';
+  };
   const resolveControlCenterTab = (tab: string | null) => {
-    return tab === 'pos' || tab === 'customers' ? 'status' : tab || 'status';
+    if (tab === 'pos' || tab === 'customers') return 'status';
+    if (tab === 'program' || tab === 'assembly-tree' || tab === 'swimlane') return 'production-map';
+    return tab || 'status';
   };
   const [activeTab, setActiveTab] = useState(resolveControlCenterTab(tabFromUrl));
+  const [productionMapView, setProductionMapView] = useState<ProductionMapView>(resolveProductionMapView(tabFromUrl));
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const tab = params.get('tab');
-    if (tab) setActiveTab(resolveControlCenterTab(tab));
+    if (tab) {
+      setActiveTab(resolveControlCenterTab(tab));
+      if (tab === 'program' || tab === 'assembly-tree' || tab === 'swimlane') {
+        setProductionMapView(resolveProductionMapView(tab));
+      }
+    }
   }, [location]);
 
   const [showPOWizard, setShowPOWizard] = useState(false);
@@ -822,21 +836,13 @@ export default function P2ControlCenter() {
             <Factory className="h-4 w-4" />
             Production
           </TabsTrigger>
-          <TabsTrigger value="program" className="flex items-center gap-2" data-testid="tab-program-overview">
+          <TabsTrigger value="production-map" className="flex items-center gap-2" data-testid="tab-production-map">
             <Layers className="h-4 w-4" />
-            Program
-          </TabsTrigger>
-          <TabsTrigger value="assembly-tree" className="flex items-center gap-2" data-testid="tab-assembly-tree">
-            <Route className="h-4 w-4" />
-            Assembly Tree
+            Production Map
           </TabsTrigger>
           <TabsTrigger value="frozen-demand" className="flex items-center gap-2" data-testid="tab-frozen-demand">
             <Lock className="h-4 w-4" />
             Frozen Demand
-          </TabsTrigger>
-          <TabsTrigger value="swimlane" className="flex items-center gap-2" data-testid="tab-swimlane">
-            <BarChart3 className="h-4 w-4" />
-            Swimlane
           </TabsTrigger>
           <TabsTrigger value="shipping" className="flex items-center gap-2" data-testid="tab-shipping">
             <Truck className="h-4 w-4" />
@@ -941,20 +947,56 @@ export default function P2ControlCenter() {
           <P2ProductionQueue selectedPONumbers={selectedPONumbers} />
         </TabsContent>
 
-        <TabsContent value="program">
-          <ProgramManufacturingOrchestration mode="overview" projectId={programProjectId} />
-        </TabsContent>
+        <TabsContent value="production-map" className="space-y-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <CardTitle>Production Map</CardTitle>
+                  <CardDescription>
+                    One PO shown as a program summary, assembly hierarchy, or production swimlane.
+                  </CardDescription>
+                </div>
+                <Tabs
+                  value={productionMapView}
+                  onValueChange={(value) => setProductionMapView(value as ProductionMapView)}
+                >
+                  <TabsList aria-label="Production Map view">
+                    <TabsTrigger value="overview" className="gap-2" data-testid="production-map-view-program">
+                      <Layers className="h-4 w-4" />
+                      Program
+                    </TabsTrigger>
+                    <TabsTrigger value="tree" className="gap-2" data-testid="production-map-view-assembly">
+                      <Route className="h-4 w-4" />
+                      Assembly
+                    </TabsTrigger>
+                    <TabsTrigger value="swimlane" className="gap-2" data-testid="production-map-view-swimlane">
+                      <BarChart3 className="h-4 w-4" />
+                      Swimlane
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+              </div>
+            </CardHeader>
+          </Card>
 
-        <TabsContent value="assembly-tree">
-          <ProgramManufacturingOrchestration mode="tree" projectId={programProjectId} />
+          {programProjectId ? (
+            <ProgramManufacturingOrchestration mode={productionMapView} projectId={programProjectId} />
+          ) : (
+            <Card>
+              <CardContent className="p-8 text-center">
+                <Layers className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+                <p className="font-medium">Select one PO to view its Production Map</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Program, Assembly, and Swimlane are interchangeable views of the same selected PO.
+                </p>
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
         <TabsContent value="frozen-demand">
           <P2FrozenProductionDemand projectId={programProjectId} />
-        </TabsContent>
-
-        <TabsContent value="swimlane">
-          <ProgramManufacturingOrchestration mode="swimlane" projectId={programProjectId} />
         </TabsContent>
 
         <TabsContent value="shipping" className="space-y-4">


### PR DESCRIPTION
## Summary
- consolidate Program, Assembly Tree, and Swimlane into one Production Map tab
- keep all three as interchangeable views of the selected PO project
- prevent unfiltered global program records from appearing when no single PO is selected
- preserve legacy tab links by routing them to the matching Production Map view

## Validation
- focused source assertions passed
- git diff --check passed
- full Vitest/TypeScript execution not run because dependencies were unavailable in the isolated worktree and registry access was blocked