### PR TITLE
Preserve fractional P2 material demand

### DIFF
--- a/client/src/pages/PMControlCenterPage.tsx
+++ b/client/src/pages/PMControlCenterPage.tsx
@@ -1989,6 +1989,7 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
         const openRequestQuantity = getOpenPartsRequestQuantity(data?.rows ?? [], row.itemCode);
         const shortage = Math.max(row.qtyRequired - row.qtyOnHand - openRequestQuantity, 0);
         if (shortage <= 0) throw new Error(`${row.itemCode} has no uncovered demand.`);
+        const requestQuantity = Math.ceil(shortage);
         return apiRequest('/api/inventory/parts-requests', {
           method: 'POST',
           body: {
@@ -1998,7 +1999,7 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
             requestedBy,
             productionLine: 'P2',
             projectId,
-            quantity: shortage,
+            quantity: requestQuantity,
             urgency: 'MEDIUM',
             estimatedCost: row.unitCost > 0 ? row.unitCost : null,
             reason: `Uncovered P2 project demand: ${row.qtyRequired} required, ${row.qtyOnHand} on hand, ${openRequestQuantity} already requested.`,
@@ -2297,7 +2298,9 @@ function MaterialBudgetTab({ projectId }: { projectId: string }) {
                                   onCheckedChange={(checked) => setRequestSelected(row.inventoryItemId, checked === true)}
                                 />
                                 <Label htmlFor={`request-${rowKey}`} className="leading-tight">
-                                  {shortage > 0 ? `Create parts request for ${shortage}` : 'Demand covered by on-hand inventory or open requests'}
+                                  {shortage > 0
+                                    ? `Create parts request for ${Math.ceil(shortage)}${Math.ceil(shortage) !== shortage ? ` (covers ${shortage} shortage)` : ''}`
+                                    : 'Demand covered by on-hand inventory or open requests'}
                                 </Label>
                               </div>
                             ) : (

--- a/server/__tests__/pmDashboardMaterialRequirements.test.ts
+++ b/server/__tests__/pmDashboardMaterialRequirements.test.ts
@@ -14,13 +14,21 @@ const pageSource = readFileSync(
 
 describe('PM dashboard material requirements', () => {
   it('extends BOM quantity-per by the project work-order quantity', () => {
-    expect(routeSource).toContain('SUM(wo.quantity::numeric * bl.qty_per)');
+    expect(routeSource).toContain('SUM(wo.quantity::numeric * bl.qty_per::numeric)');
     expect(routeSource).toContain('SUM(wo.quantity::numeric * bi.quantity::numeric)');
   });
 
   it('uses released Robust BOM revisions before the legacy P2 BOM fallback', () => {
     expect(routeSource).toContain('br.is_released = true');
     expect(routeSource).toContain('NOT EXISTS (');
+  });
+
+  it('uses recursive launched demand, including fractional child usage, when available', () => {
+    expect(routeSource).toContain('SUM(d.gross_required_quantity::numeric)');
+    expect(routeSource).toContain("d.disposition = 'BUY'");
+    expect(routeSource).toContain("pl.status = 'COMPLETE'");
+    expect(routeSource).toContain('SUM(wo.quantity::numeric * bl.qty_per::numeric)');
+    expect(pageSource).toContain('const requestQuantity = Math.ceil(shortage)');
   });
 
   it('returns and displays inventory on-hand quantity', () => {

--- a/server/src/routes/pmDashboard.ts
+++ b/server/src/routes/pmDashboard.ts
@@ -2526,6 +2526,8 @@ ${materialBudgetExpression}
   `, [projectId]);
 
   const hasProjectReceivedMaterials = await canReadProjectReceivedMaterials();
+  const hasProductionDemandLedger = await publicTableExists('project_production_demands')
+    && await publicTableExists('project_production_launches');
   const projectReceivedSummaryRes = hasProjectReceivedMaterials
     ? await pool.query<ProjectReceivedMaterialSummaryRow>(`
         WITH received_costs AS (
@@ -2558,9 +2560,24 @@ ${materialBudgetExpression}
     : [{ pendingReceivedCost: '0', acceptedReceivedCost: '0' }];
 
   const rowsRes = await pool.query<MaterialItemRow>(`
-    WITH robust_requirements AS (
+    WITH launched_requirements AS (
+      ${hasProductionDemandLedger ? `
+      SELECT d.part_number AS ag_part_number,
+             SUM(d.gross_required_quantity::numeric) AS qty_required
+      FROM project_production_demands d
+      JOIN project_production_launches pl ON pl.id = d.production_launch_id
+      WHERE d.project_id = $1
+        AND pl.project_id = d.project_id
+        AND pl.status = 'COMPLETE'
+        AND d.disposition = 'BUY'
+      GROUP BY d.part_number
+      ` : `
+      SELECT NULL::text AS ag_part_number, 0::numeric AS qty_required
+      WHERE false
+      `}
+    ), robust_requirements AS (
       SELECT bl.child_part_ag_number AS ag_part_number,
-             SUM(wo.quantity::numeric * bl.qty_per) AS qty_required
+             SUM(wo.quantity::numeric * bl.qty_per::numeric) AS qty_required
       FROM production_work_orders wo
       JOIN boms b ON b.parent_part_ag_number = wo.part_number AND b.is_active = true
       JOIN LATERAL (
@@ -2574,6 +2591,7 @@ ${materialBudgetExpression}
       ) active_revision ON true
       JOIN bom_lines bl ON bl.revision_id = active_revision.id
       WHERE wo.project_id = $1 AND wo.status <> 'CLOSED'
+        AND NOT EXISTS (SELECT 1 FROM launched_requirements)
       GROUP BY bl.child_part_ag_number
     ), legacy_requirements AS (
       SELECT bi.part_name AS ag_part_number,
@@ -2583,6 +2601,7 @@ ${materialBudgetExpression}
         AND (bd.sku = wo.part_number OR bd.model_name = wo.part_number)
       JOIN bom_items bi ON bi.bom_id = bd.id AND bi.is_active = true AND bi.item_type <> 'labor'
       WHERE wo.project_id = $1 AND wo.status <> 'CLOSED'
+        AND NOT EXISTS (SELECT 1 FROM launched_requirements)
         AND NOT EXISTS (
           SELECT 1 FROM boms b
           JOIN bom_revisions br ON br.bom_id = b.id AND br.is_released = true
@@ -2594,6 +2613,8 @@ ${materialBudgetExpression}
     ), requirements AS (
       SELECT ag_part_number, SUM(qty_required) AS qty_required
       FROM (
+        SELECT * FROM launched_requirements
+        UNION ALL
         SELECT * FROM robust_requirements
         UNION ALL
         SELECT * FROM legacy_requirements


### PR DESCRIPTION
## Summary
- use completed recursive Production Launch demand for current P2 projects so fractional BOM child usage is preserved
- calculate purchased-material demand from frozen gross required quantity; for example, 110 parts times 0.02 sheet displays 2.2 sheets instead of 110
- retain released Robust BOM and legacy BOM calculation as the fallback for projects without a completed launch
- round a fractional shortage up only when creating a Parts Request because that ledger stores whole-unit quantities; the Material tab still displays exact decimal demand

## Verification
- git diff --check passed
- focused material requirement source assertions passed
- branch is one commit ahead of current origin/main
- full Vitest and TypeScript were not run because the clean worktree has no installed dependencies and the shared runtime could not load the worktree Vite configuration

## Scope
- follow-up to merged PR #1835
- no migration or backfill
- on-hand inventory, allocations, and consumption authorities are unchanged