### PR TITLE
P2 Phase 13: Genealogy viewer, search, and evidence reporting

### DIFF
--- a/.github/workflows/p2-genealogy-viewer-postgres.yml
+++ b/.github/workflows/p2-genealogy-viewer-postgres.yml
@@ -1,0 +1,70 @@
+name: P2 Genealogy Viewer PostgreSQL Certification
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'server/src/services/p2GenealogyViewerService.ts'
+      - 'server/src/routes/p2ManufacturingWorkOrders.ts'
+      - 'server/src/lib/featureFlags.ts'
+      - 'client/src/components/p2/P2GenealogyViewer.tsx'
+      - 'client/src/pages/P2ControlCenter.tsx'
+      - 'server/__tests__/p2GenealogyViewerReporting.test.ts'
+      - '.github/workflows/p2-genealogy-viewer-postgres.yml'
+  push:
+    branches: [codex/p2-genealogy-viewer-search-reporting]
+
+jobs:
+  certify:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16.4
+        env:
+          POSTGRES_USER: phase13_cert
+          POSTGRES_PASSWORD: disposable_phase13_password
+          POSTGRES_DB: epoch_phase13_certification
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd "pg_isready -U phase13_cert -d epoch_phase13_certification"
+          --health-interval 10s --health-timeout 5s --health-retries 5
+    env:
+      DATABASE_URL: postgresql://phase13_cert:disposable_phase13_password@127.0.0.1:5432/epoch_phase13_certification
+      NODE_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm }
+      - run: npm ci
+      - name: Prove isolation and disabled gates
+        run: |
+          test "$(node -e "console.log(new URL(process.env.DATABASE_URL).hostname)")" = 127.0.0.1
+          test -z "${P2_GENEALOGY_VIEWER_ENABLED:-}"
+          test -z "${VITE_P2_GENEALOGY_VIEWER_ENABLED:-}"
+      - name: Focused Phase 10-13 contracts
+        run: |
+          npx vitest run --config vitest.config.server.ts server/__tests__/p2ManufacturedOutputGenealogyFoundation.test.ts server/__tests__/p2ManufacturedOutputCustodyFoundation.test.ts server/__tests__/p2ManufacturedComponentIssueGenealogy.test.ts server/__tests__/p2QualityShipmentReleaseFoundation.test.ts server/__tests__/p2GenealogyViewerReporting.test.ts
+      - name: Syntax and hygiene
+        run: |
+          npx esbuild server/src/services/p2GenealogyViewerService.ts server/src/routes/p2ManufacturingWorkOrders.ts client/src/components/p2/P2GenealogyViewer.tsx client/src/pages/P2ControlCenter.tsx --platform=node --format=esm --outdir=/tmp/p2-phase13-ts
+          npx eslint server/src/services/p2GenealogyViewerService.ts server/__tests__/p2GenealogyViewerReporting.test.ts client/src/components/p2/P2GenealogyViewer.tsx --max-warnings 0
+          npx prettier --check server/src/services/p2GenealogyViewerService.ts server/src/routes/p2ManufacturingWorkOrders.ts server/src/lib/featureFlags.ts client/src/components/p2/P2GenealogyViewer.tsx server/__tests__/p2GenealogyViewerReporting.test.ts
+          git diff --check
+      - name: Prove read-only PostgreSQL genealogy relationships
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE TABLE p2_manufacturing_work_order_authorities(id uuid PRIMARY KEY);
+          CREATE TABLE p2_manufactured_output_authorities(id uuid PRIMARY KEY,work_order_authority_id uuid REFERENCES p2_manufacturing_work_order_authorities(id),output_identity text,authority_checksum text);
+          CREATE TABLE p2_manufactured_component_genealogy_edges(id uuid PRIMARY KEY,child_output_authority_id uuid REFERENCES p2_manufactured_output_authorities(id),parent_work_order_authority_id uuid REFERENCES p2_manufacturing_work_order_authorities(id),edge_checksum text);
+          CREATE TABLE p2_material_genealogy_edges(id uuid PRIMARY KEY,output_authority_id uuid REFERENCES p2_manufactured_output_authorities(id),edge_checksum text);
+          INSERT INTO p2_manufacturing_work_order_authorities VALUES ('00000000-0000-0000-0000-000000000001'),('00000000-0000-0000-0000-000000000002');
+          INSERT INTO p2_manufactured_output_authorities VALUES ('00000000-0000-0000-0000-000000000011','00000000-0000-0000-0000-000000000001','SERIAL-A','output-checksum');
+          INSERT INTO p2_manufactured_component_genealogy_edges VALUES ('00000000-0000-0000-0000-000000000021','00000000-0000-0000-0000-000000000011','00000000-0000-0000-0000-000000000002','component-checksum');
+          INSERT INTO p2_material_genealogy_edges VALUES ('00000000-0000-0000-0000-000000000031','00000000-0000-0000-0000-000000000011','material-checksum');
+          CREATE TABLE preservation_marker(id integer PRIMARY KEY,payload text);
+          INSERT INTO preservation_marker VALUES (1,'unchanged');
+          SQL
+          before="$(psql "$DATABASE_URL" -Atc "SELECT count(*)||':'||md5(string_agg(id||payload,',' ORDER BY id)) FROM preservation_marker")"
+          test "$(psql "$DATABASE_URL" -Atc "SELECT count(*) FROM p2_manufactured_output_authorities o JOIN p2_manufactured_component_genealogy_edges c ON c.child_output_authority_id=o.id JOIN p2_material_genealogy_edges m ON m.output_authority_id=o.id WHERE o.output_identity='SERIAL-A'")" = 1
+          after="$(psql "$DATABASE_URL" -Atc "SELECT count(*)||':'||md5(string_agg(id||payload,',' ORDER BY id)) FROM preservation_marker")"
+          test "$before" = "$after"

--- a/client/src/components/p2/P2GenealogyViewer.tsx
+++ b/client/src/components/p2/P2GenealogyViewer.tsx
@@ -56,9 +56,9 @@ export default function P2GenealogyViewer() {
   const [result, setResult] = useState<GenealogyResult | null>(null);
   const search = useMutation({
     mutationFn: () =>
-      apiRequest<GenealogyResult>(
+      apiRequest(
         `/api/p2-genealogy/search?q=${encodeURIComponent(query.trim())}`
-      ),
+      ) as Promise<GenealogyResult>,
     onSuccess: setResult,
   });
 

--- a/client/src/components/p2/P2GenealogyViewer.tsx
+++ b/client/src/components/p2/P2GenealogyViewer.tsx
@@ -1,0 +1,256 @@
+import { useMemo, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Download, GitBranch, Search, ShieldCheck } from 'lucide-react';
+
+import { apiRequest } from '@/lib/queryClient';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+
+interface GenealogyOutput {
+  id: string;
+  work_order_authority_id: string;
+  output_identity: string;
+  part_number_snapshot: string;
+  assembly_path_identity: string;
+  output_quantity: string;
+  status: string;
+  authority_checksum: string;
+  custody_status: string | null;
+  available_quantity: string | null;
+  quality_disposition: string | null;
+  release_scope: string | null;
+}
+
+interface ComponentEdge {
+  id: string;
+  child_output_authority_id: string;
+  parent_work_order_authority_id: string;
+  quantity: string;
+  unit_of_measure: string;
+  issue_status: string;
+  edge_checksum: string;
+}
+
+interface GenealogyResult {
+  query: string;
+  generatedAt: string;
+  outputs: GenealogyOutput[];
+  componentEdges: ComponentEdge[];
+  materialEdges: Array<Record<string, unknown>>;
+  summary: { outputs: number; componentEdges: number; materialEdges: number };
+}
+
+const download = (name: string, type: string, body: string) => {
+  const url = URL.createObjectURL(new Blob([body], { type }));
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = name;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};
+
+export default function P2GenealogyViewer() {
+  const [query, setQuery] = useState('');
+  const [result, setResult] = useState<GenealogyResult | null>(null);
+  const search = useMutation({
+    mutationFn: () =>
+      apiRequest<GenealogyResult>(
+        `/api/p2-genealogy/search?q=${encodeURIComponent(query.trim())}`
+      ),
+    onSuccess: setResult,
+  });
+
+  const parentOutputByAuthority = useMemo(
+    () =>
+      new Map(
+        (result?.outputs ?? []).map((output) => [
+          output.work_order_authority_id,
+          output.id,
+        ])
+      ),
+    [result]
+  );
+
+  const exportCsv = () => {
+    if (!result) return;
+    const rows = [
+      [
+        'output_identity',
+        'part_number',
+        'assembly_path',
+        'quantity',
+        'status',
+        'custody',
+        'quality',
+        'shipment_scope',
+        'checksum',
+      ],
+      ...result.outputs.map((output) => [
+        output.output_identity,
+        output.part_number_snapshot,
+        output.assembly_path_identity,
+        output.output_quantity,
+        output.status,
+        output.custody_status ?? '',
+        output.quality_disposition ?? '',
+        output.release_scope ?? '',
+        output.authority_checksum,
+      ]),
+    ];
+    download(
+      `p2-genealogy-${result.query}.csv`,
+      'text/csv',
+      rows
+        .map((row) => row.map((value) => JSON.stringify(value ?? '')).join(','))
+        .join('\n')
+    );
+  };
+
+  return (
+    <div className="space-y-4" data-testid="p2-genealogy-viewer">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <GitBranch className="h-5 w-5" /> P2 Genealogy
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Read-only search across manufactured output identity, part, project,
+            work-order authority, traveler, and assembly path.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="flex gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (query.trim().length >= 2) search.mutate();
+            }}
+          >
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Serial/batch, part, project, work order, traveler, or assembly path"
+              data-testid="p2-genealogy-search"
+            />
+            <Button disabled={query.trim().length < 2 || search.isPending}>
+              <Search className="mr-2 h-4 w-4" />
+              {search.isPending ? 'Searching…' : 'Search'}
+            </Button>
+          </form>
+          {search.error && (
+            <p className="mt-3 text-sm text-destructive">
+              {search.error instanceof Error
+                ? search.error.message
+                : 'Genealogy search failed.'}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {result && (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{result.summary.outputs} outputs</Badge>
+            <Badge variant="secondary">
+              {result.summary.componentEdges} assembly links
+            </Badge>
+            <Badge variant="secondary">
+              {result.summary.materialEdges} material links
+            </Badge>
+            <Badge variant="outline" className="gap-1">
+              <ShieldCheck className="h-3 w-3" /> immutable evidence
+            </Badge>
+            <Button
+              className="ml-auto"
+              variant="outline"
+              size="sm"
+              onClick={exportCsv}
+              disabled={!result.outputs.length}
+            >
+              <Download className="mr-2 h-4 w-4" /> Export CSV
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                download(
+                  `p2-genealogy-${result.query}.json`,
+                  'application/json',
+                  JSON.stringify(result, null, 2)
+                )
+              }
+              disabled={!result.outputs.length}
+            >
+              <Download className="mr-2 h-4 w-4" /> Evidence JSON
+            </Button>
+          </div>
+
+          {!result.outputs.length ? (
+            <Card>
+              <CardContent className="p-8 text-center text-muted-foreground">
+                No authoritative P2 genealogy matched “{result.query}”.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {result.outputs.map((output) => {
+                const parents = result.componentEdges.filter(
+                  (edge) => edge.child_output_authority_id === output.id
+                );
+                const children = result.componentEdges.filter(
+                  (edge) =>
+                    parentOutputByAuthority.get(
+                      edge.parent_work_order_authority_id
+                    ) === output.id
+                );
+                return (
+                  <Card
+                    key={output.id}
+                    data-testid={`genealogy-output-${output.id}`}
+                  >
+                    <CardContent className="p-4 space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-semibold">
+                          {output.output_identity}
+                        </span>
+                        <Badge>{output.status}</Badge>
+                        {output.custody_status && (
+                          <Badge variant="outline">
+                            Custody: {output.custody_status}
+                          </Badge>
+                        )}
+                        {output.quality_disposition && (
+                          <Badge variant="outline">
+                            Quality: {output.quality_disposition}
+                          </Badge>
+                        )}
+                        {output.release_scope && (
+                          <Badge variant="outline">Shipment eligible</Badge>
+                        )}
+                      </div>
+                      <p className="text-sm">
+                        {output.part_number_snapshot} ·{' '}
+                        {output.assembly_path_identity} ·{' '}
+                        {output.output_quantity}
+                      </p>
+                      <p className="text-xs text-muted-foreground font-mono break-all">
+                        Authority checksum: {output.authority_checksum}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Parents: {parents.length} · Manufactured children:{' '}
+                        {children.length} · Available:{' '}
+                        {output.available_quantity ?? 'not received'}
+                      </p>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/P2ControlCenter.tsx
+++ b/client/src/pages/P2ControlCenter.tsx
@@ -33,7 +33,8 @@ import {
   ChevronRight,
   Filter,
   X,
-  Lock
+  Lock,
+  GitBranch
 } from 'lucide-react';
 import { Link, useLocation } from 'wouter';
 import P2POCreationWizard from '@/components/p2/P2POCreationWizard';
@@ -51,6 +52,7 @@ import { P2POItemsManager } from '@/components/P2POItemsManager';
 import { TravelerCapturedDataById } from '@/components/p2/TravelerCapturedData';
 import ProgramManufacturingOrchestration from '@/components/p2/ProgramManufacturingOrchestration';
 import P2FrozenProductionDemand from '@/components/p2/P2FrozenProductionDemand';
+import P2GenealogyViewer from '@/components/p2/P2GenealogyViewer';
 import { queryClient, apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -112,6 +114,7 @@ interface PartRouting {
 }
 
 export default function P2ControlCenter() {
+  const genealogyEnabled = import.meta.env.VITE_P2_GENEALOGY_VIEWER_ENABLED === 'true';
   const [location, navigate] = useLocation();
   const { toast } = useToast();
   const urlParams = new URLSearchParams(window.location.search);
@@ -844,6 +847,12 @@ export default function P2ControlCenter() {
             <Lock className="h-4 w-4" />
             Frozen Demand
           </TabsTrigger>
+          {genealogyEnabled && (
+            <TabsTrigger value="genealogy" className="flex items-center gap-2" data-testid="tab-genealogy">
+              <GitBranch className="h-4 w-4" />
+              Genealogy
+            </TabsTrigger>
+          )}
           <TabsTrigger value="shipping" className="flex items-center gap-2" data-testid="tab-shipping">
             <Truck className="h-4 w-4" />
             Shipping
@@ -998,6 +1007,12 @@ export default function P2ControlCenter() {
         <TabsContent value="frozen-demand">
           <P2FrozenProductionDemand projectId={programProjectId} />
         </TabsContent>
+
+        {genealogyEnabled && (
+          <TabsContent value="genealogy">
+            <P2GenealogyViewer />
+          </TabsContent>
+        )}
 
         <TabsContent value="shipping" className="space-y-4">
           <div className="flex flex-wrap justify-end gap-2">

--- a/server/__tests__/p2GenealogyViewerReporting.test.ts
+++ b/server/__tests__/p2GenealogyViewerReporting.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) =>
+  readFileSync(resolve(process.cwd(), path), 'utf8');
+const service = read('server/src/services/p2GenealogyViewerService.ts');
+const routes = read('server/src/routes/p2ManufacturingWorkOrders.ts');
+const flags = read('server/src/lib/featureFlags.ts');
+const page = read('client/src/pages/P2ControlCenter.tsx');
+const viewer = read('client/src/components/p2/P2GenealogyViewer.tsx');
+
+describe('Phase 13 P2 genealogy viewer, search, and reporting', () => {
+  it('is read-only and uses existing Phase 10-12 authorities', () => {
+    expect(service).toContain('p2_manufactured_output_authorities');
+    expect(service).toContain('p2_manufactured_component_genealogy_edges');
+    expect(service).toContain('p2_material_genealogy_edges');
+    expect(service).toContain('p2_manufactured_output_quality_acceptances');
+    expect(service).toContain('p2_manufactured_output_shipment_releases');
+    expect(service).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b/i);
+  });
+
+  it('searches authoritative identities and returns checksummed evidence', () => {
+    expect(service).toContain('output_identity');
+    expect(service).toContain('part_number_snapshot');
+    expect(service).toContain('assembly_path_identity');
+    expect(service).toContain('production_work_order_id');
+    expect(service).toContain('traveler_id');
+    expect(service).toContain('authority_checksum');
+    expect(service).toContain('GENEALOGY_SEARCH_TOO_BROAD');
+    expect(service).toContain('GENEALOGY_PROJECT_TOO_LARGE');
+  });
+
+  it('keeps both client and server disabled unless exactly true', () => {
+    expect(flags).toContain("envBool('P2_GENEALOGY_VIEWER_ENABLED', false)");
+    expect(page).toContain(
+      "import.meta.env.VITE_P2_GENEALOGY_VIEWER_ENABLED === 'true'"
+    );
+    expect(routes).toContain('enabled(isP2GenealogyViewerEnabled())');
+  });
+
+  it('requires authenticated P2 view authority on the server', () => {
+    expect(routes).toContain("'/p2-genealogy/search'");
+    expect(routes).toContain("requirePermission('p2.work_orders.view')");
+    expect(routes).toContain('authenticateToken');
+  });
+
+  it('reuses P2 Control Center and supports CSV and evidence JSON reporting', () => {
+    expect(page).toContain('data-testid="tab-genealogy"');
+    expect(page).toContain('<P2GenealogyViewer />');
+    expect(viewer).toContain('Export CSV');
+    expect(viewer).toContain('Evidence JSON');
+    expect(viewer).toContain('Authority checksum:');
+  });
+
+  it('adds no Phase 14 mutation, shipment execution, balance, or genealogy writes', () => {
+    expect(service).not.toMatch(
+      /inventory_transaction_ledger|packing_slip|CREATE TABLE|shipment execution/i
+    );
+    expect(routes).not.toContain('VITE_P2_GENEALOGY_VIEWER');
+  });
+});

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -226,6 +226,11 @@ export function areP2QualityShipmentReleaseWritesEnabled(): boolean {
   return envBool('P2_QUALITY_SHIPMENT_RELEASE_WRITES_ENABLED', false);
 }
 
+/** Phase 13 read-only P2 genealogy search, viewer, and reporting. */
+export function isP2GenealogyViewerEnabled(): boolean {
+  return envBool('P2_GENEALOGY_VIEWER_ENABLED', false);
+}
+
 /**
  * Cutover date for the punch_ledger migration.
  * For pay periods starting ON or AFTER this date, hour computations read

--- a/server/src/routes/p2ManufacturingWorkOrders.ts
+++ b/server/src/routes/p2ManufacturingWorkOrders.ts
@@ -18,6 +18,7 @@ import {
   areP2ManufacturedComponentIssueWritesEnabled,
   areP2QualityShipmentReleaseReadsEnabled,
   areP2QualityShipmentReleaseWritesEnabled,
+  isP2GenealogyViewerEnabled,
   areP2TravelerProvisioningWritesEnabled,
 } from '../lib/featureFlags';
 import {
@@ -59,6 +60,10 @@ import {
   recordP2OutputQualityDisposition,
   releaseP2OutputForShipment,
 } from '../services/p2QualityShipmentReleaseService';
+import {
+  P2GenealogyViewerError,
+  searchP2Genealogy,
+} from '../services/p2GenealogyViewerService';
 
 const router = Router();
 const materializeBody = z.object({
@@ -186,6 +191,11 @@ const fail = (res: Response, error: unknown) => {
       error: error.code,
       message: error.message,
     });
+  if (error instanceof P2GenealogyViewerError)
+    return res.status(error.status).json({
+      error: error.code,
+      message: error.message,
+    });
   if (error instanceof P2ManufacturedOutputError)
     return res
       .status(error.status)
@@ -193,6 +203,20 @@ const fail = (res: Response, error: unknown) => {
   console.error('[p2-manufacturing-work-orders]', error);
   return res.status(500).json({ error: 'P2_WORK_ORDER_FAILED' });
 };
+
+router.get(
+  '/p2-genealogy/search',
+  authenticateToken,
+  requirePermission('p2.work_orders.view'),
+  async (req, res) => {
+    try {
+      enabled(isP2GenealogyViewerEnabled());
+      res.json(await searchP2Genealogy(String(req.query.q ?? '')));
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
 
 router.get(
   '/p2-work-orders/queues/:departmentId',

--- a/server/src/services/p2GenealogyViewerService.ts
+++ b/server/src/services/p2GenealogyViewerService.ts
@@ -50,7 +50,9 @@ export async function searchP2Genealogy(rawQuery: string) {
       'Search matched more than 100 authoritative outputs. Use a more specific identity.'
     );
 
-  const projectIds = [...new Set(seeds.rows.map((row) => row.project_id))];
+  const projectIds = Array.from(
+    new Set(seeds.rows.map((row) => row.project_id))
+  );
   const outputs = await pool.query(
     `SELECT o.id,o.work_order_authority_id,o.project_id,o.inventory_item_id,o.output_identity,
             o.output_quantity,o.assembly_path_identity,o.part_number_snapshot,o.traceability_snapshot,

--- a/server/src/services/p2GenealogyViewerService.ts
+++ b/server/src/services/p2GenealogyViewerService.ts
@@ -1,0 +1,107 @@
+import { pool } from '../../db';
+
+export class P2GenealogyViewerError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 400
+  ) {
+    super(message);
+  }
+}
+
+const normalize = (value: string) => value.trim();
+
+export async function searchP2Genealogy(rawQuery: string) {
+  const query = normalize(rawQuery);
+  if (query.length < 2 || query.length > 200)
+    throw new P2GenealogyViewerError(
+      'INVALID_GENEALOGY_SEARCH',
+      'Search text must contain between 2 and 200 characters.'
+    );
+
+  const seeds = await pool.query(
+    `SELECT o.id,o.work_order_authority_id,o.project_id,o.inventory_item_id,o.output_identity,
+            o.output_quantity,o.assembly_path_identity,o.part_number_snapshot,o.traceability_snapshot,
+            o.status,o.authority_checksum,o.created_at,o.released_at,w.production_work_order_id,w.traveler_id
+       FROM p2_manufactured_output_authorities o
+       JOIN p2_manufacturing_work_order_authorities w ON w.id=o.work_order_authority_id
+      WHERE o.id::text=$1 OR o.project_id::text=$1 OR o.work_order_authority_id::text=$1
+         OR COALESCE(w.production_work_order_id::text,'')=$1 OR COALESCE(w.traveler_id::text,'')=$1
+         OR lower(o.output_identity)=lower($1)
+         OR lower(o.part_number_snapshot) LIKE lower('%'||$1||'%')
+         OR lower(o.assembly_path_identity) LIKE lower('%'||$1||'%')
+      ORDER BY o.created_at DESC LIMIT 101`,
+    [query]
+  );
+
+  if (!seeds.rows.length)
+    return {
+      query,
+      generatedAt: new Date().toISOString(),
+      outputs: [],
+      componentEdges: [],
+      materialEdges: [],
+      summary: { outputs: 0, componentEdges: 0, materialEdges: 0 },
+    };
+  if (seeds.rows.length > 100)
+    throw new P2GenealogyViewerError(
+      'GENEALOGY_SEARCH_TOO_BROAD',
+      'Search matched more than 100 authoritative outputs. Use a more specific identity.'
+    );
+
+  const projectIds = [...new Set(seeds.rows.map((row) => row.project_id))];
+  const outputs = await pool.query(
+    `SELECT o.id,o.work_order_authority_id,o.project_id,o.inventory_item_id,o.output_identity,
+            o.output_quantity,o.assembly_path_identity,o.part_number_snapshot,o.traceability_snapshot,
+            o.status,o.authority_checksum,o.created_at,o.released_at,w.production_work_order_id,w.traveler_id,
+            c.id custody_id,c.custody_status,c.received_quantity,c.issued_quantity,c.reversed_quantity,c.available_quantity,
+            q.id quality_acceptance_id,q.disposition quality_disposition,q.inspection_reference,q.authority_checksum quality_checksum,
+            s.id shipment_release_id,s.release_scope,s.release_reference,s.authority_checksum shipment_release_checksum
+       FROM p2_manufactured_output_authorities o
+       JOIN p2_manufacturing_work_order_authorities w ON w.id=o.work_order_authority_id
+       LEFT JOIN p2_manufactured_output_custodies c ON c.output_authority_id=o.id
+       LEFT JOIN p2_manufactured_output_quality_acceptances q ON q.output_authority_id=o.id
+       LEFT JOIN p2_manufactured_output_shipment_releases s ON s.output_authority_id=o.id
+      WHERE o.project_id=ANY($1::uuid[])
+      ORDER BY o.assembly_path_identity,o.created_at LIMIT 501`,
+    [projectIds]
+  );
+  if (outputs.rows.length > 500)
+    throw new P2GenealogyViewerError(
+      'GENEALOGY_PROJECT_TOO_LARGE',
+      'The genealogy exceeds the 500-output review boundary and cannot be reported partially.'
+    );
+  const outputIds = outputs.rows.map((row) => row.id);
+  const authorityIds = outputs.rows.map((row) => row.work_order_authority_id);
+
+  const [componentEdges, materialEdges] = await Promise.all([
+    pool.query(
+      `SELECT g.*,i.status issue_status,i.output_identity
+         FROM p2_manufactured_component_genealogy_edges g
+         JOIN p2_manufactured_component_issues i ON i.id=g.issue_id
+        WHERE g.child_output_authority_id=ANY($1::uuid[])
+           OR g.parent_work_order_authority_id=ANY($2::uuid[])
+        ORDER BY g.created_at`,
+      [outputIds, authorityIds]
+    ),
+    pool.query(
+      `SELECT g.* FROM p2_material_genealogy_edges g
+        WHERE g.output_authority_id=ANY($1::uuid[]) ORDER BY g.created_at`,
+      [outputIds]
+    ),
+  ]);
+
+  return {
+    query,
+    generatedAt: new Date().toISOString(),
+    outputs: outputs.rows,
+    componentEdges: componentEdges.rows,
+    materialEdges: materialEdges.rows,
+    summary: {
+      outputs: outputs.rows.length,
+      componentEdges: componentEdges.rows.length,
+      materialEdges: materialEdges.rows.length,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Phase 13 adds a foundation-only, read-only Genealogy viewer, search, and evidence reporting surface to the existing P2 Control Center. It presents the authoritative relationships already created by Phases 10-12 without creating or changing manufacturing, custody, quality, shipment, inventory, or genealogy records.

## Business problem and authority model

Manufacturing evidence is currently distributed across released output authority, custody, Quality acceptance, shipment release, manufactured-component genealogy, and material-genealogy records. Authorized users need one bounded search and reporting surface that preserves those authoritative identities and checksums.

The server remains authoritative. Search requires authentication, `p2.work_orders.view`, and the exact-true server flag. Results are read from existing Phase 10-12 authorities and include Inventory Item/part snapshots, assembly paths, custody, Quality disposition, shipment eligibility, parent/child component edges, material edges, and immutable checksums. The viewer introduces no write authority.

## Changes

- Adds bounded read-only genealogy search by output, project, work-order authority, production work order, traveler, output identity, part snapshot, or assembly path.
- Fails closed for ambiguous/broad reports beyond 100 seed outputs or 500 project outputs.
- Adds a Genealogy tab to the existing P2 Control Center.
- Adds CSV and JSON evidence exports generated from the returned authoritative snapshots.
- Adds focused regression contracts and a disposable PostgreSQL 16.4 certification workflow.
- Adds no migration and performs no historical backfill or reinterpretation.

## Feature flags

- Server: `P2_GENEALOGY_VIEWER_ENABLED=false`
- Client: `VITE_P2_GENEALOGY_VIEWER_ENABLED=false`

Both are disabled by default and require exact string value `true`. The client gate controls visibility; the independent server gate remains authoritative and prevents client/server drift from exposing data when the server feature is disabled.

## Certification

Final head: `f01533e7d46e78eaa724509cd1d636ae4c85de6b`

Base/current main integrated: `257cf0101677c733c72366013b85c01b3a0bbb0b`

- [Phase 13 Genealogy Viewer PostgreSQL certification #33118413526](https://github.com/agcomphr25/EPOCH-v83/actions/runs/33118413526): passed on the exact final head.
  - 32/32 focused Phase 10-13 tests passed.
  - Disabled gates, authentication/permission contracts, syntax, formatting, and read-only PostgreSQL relationships passed.
  - Preservation marker count and checksum were unchanged before and after the read-only report query.
- [Complete P2 V2 PostgreSQL certification #33118423563](https://github.com/agcomphr25/EPOCH-v83/actions/runs/33118423563): passed on the exact final head.
  - Both `synthetic-pilot-certification` and `certify` jobs passed.
  - Full TypeScript comparison, ESLint, formatting, schema creation, safe-boot replay/idempotency, migration and legacy preservation, Design Control, Phase 1-9, P2 V2 components, and validation components all passed.
  - No required job or stage was skipped, cancelled, neutral, or allowed to fail.

## Explicit exclusions

This PR does not create or modify work orders, production orders, queues, schedules, travelers, reservations, custody receipts, Quality acceptances, shipment releases, barcodes, Receiving records, inventory transactions, inventory balances, material consumption, manufactured output, or Genealogy edges. It does not deploy or enable any feature flag. It does not begin the next phase.

## Known limitations

- Search is intentionally bounded and returns an error instead of a partial report when the evidence set exceeds its limits.
- Reports reflect existing authoritative records only; absent historical evidence is not inferred or backfilled.
- CSV/JSON downloads are review artifacts, not new controlled records or execution authority.

## Rollback

Revert the Phase 13 commits and redeploy with both flags remaining false. No database rollback, data conversion, or historical repair is required because this PR adds no migration and writes no records.

## Review boundary

This PR is foundation-only and must remain disabled until separately authorized. Do not merge, deploy, or enable flags without authorized review and successful final-tree certification.
