### PR TITLE
feat: add Daily Tag Up management view

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -102,6 +102,7 @@ const ProductionStationDashboard = React.lazy(
   () => import('./pages/ProductionStationDashboard')
 );
 const TVDisplayPage = React.lazy(() => import('./pages/TVDisplayPage'));
+const DailyTagUpPage = React.lazy(() => import('./pages/DailyTagUpPage'));
 const TVTimerBoard = React.lazy(() => import('./pages/TVTimerBoard'));
 const ProductionTimerHistory = React.lazy(
   () => import('./pages/ProductionTimerHistory')
@@ -1371,6 +1372,7 @@ function App() {
                           component={ProductionStationDashboard}
                         />
                         <Route path="/tv-display" component={TVDisplayPage} />
+                        <Route path="/daily-tag-up" component={DailyTagUpPage} />
                         <Route
                           path="/tv-timer-board"
                           component={TVTimerBoard}

--- a/client/src/__tests__/dailyTagUp.client.test.ts
+++ b/client/src/__tests__/dailyTagUp.client.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const page = fs.readFileSync(path.join(root, 'client/src/pages/DailyTagUpPage.tsx'), 'utf8');
+const app = fs.readFileSync(path.join(root, 'client/src/App.tsx'), 'utf8');
+const navigation = fs.readFileSync(path.join(root, 'client/src/components/Navigation.tsx'), 'utf8');
+const permissions = fs.readFileSync(path.join(root, 'client/src/config/userPermissions.ts'), 'utf8');
+
+describe('Daily Tag Up client contract', () => {
+  it('registers the top-level route and server capability gate', () => {
+    expect(app).toContain('path="/daily-tag-up"');
+    expect(navigation).toContain("path: '/daily-tag-up'");
+    expect(permissions).toContain("'/daily-tag-up': 'p2.work_orders.view'");
+  });
+
+  it('renders required filters, project drill-down, department accordions, and real record links', () => {
+    for (const label of ['Project', 'Customer', 'Customer PO', 'Department', 'Source', 'Needs attention', 'Status']) expect(page).toContain(`label="${label}"`);
+    expect(page).toContain('>Search</span>');
+    expect(page).toContain('data-testid={`department-${department.label}`}');
+    expect(page).toContain('/p2-work-orders/queues/${wo.departmentId}');
+    expect(page).toContain('wo.readiness.state');
+    expect(page).toContain('<TreeNode');
+    expect(page).toContain('Show Only Problems');
+  });
+
+  it('moves TV Display to the first Verified Modules card and removes the old top-level placement', () => {
+    const verifiedStart = navigation.indexOf('const verifiedModulesItems = [');
+    const tv = navigation.indexOf("path: '/tv-display'", verifiedStart);
+    const firstExisting = navigation.indexOf("path: '/'", verifiedStart);
+    expect(tv).toBeGreaterThan(verifiedStart);
+    expect(tv).toBeLessThan(firstExisting);
+    expect(navigation.match(/path: '\/tv-display'/g)).toHaveLength(1);
+    expect(app).toContain('<Route path="/tv-display" component={TVDisplayPage} />');
+  });
+});

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -317,10 +317,10 @@ export default function Navigation() {
 
   const navItems = [
     {
-      path: '/tv-display',
-      label: 'TV Display',
-      icon: Tv,
-      description: 'Multi-panel shop floor display for monitors and meeting room screens',
+      path: '/daily-tag-up',
+      label: 'Daily Tag Up',
+      icon: LayoutDashboard,
+      description: 'Management visibility across active P2 demand, departments, work orders, materials, and issues',
     },
     {
       path: '/time-clock-admin',
@@ -1502,6 +1502,12 @@ export default function Navigation() {
   ];
 
   const verifiedModulesItems = [
+    {
+      path: '/tv-display',
+      label: 'TV Display',
+      icon: Tv,
+      description: 'Multi-panel shop floor display for monitors and meeting room screens',
+    },
     {
       path: '/',
       label: 'Order Management',

--- a/client/src/config/userPermissions.ts
+++ b/client/src/config/userPermissions.ts
@@ -12,6 +12,7 @@ export interface UserPermissions {
 }
 
 export const CAPABILITY_GATED_ROUTES: Record<string, string | string[]> = {
+  '/daily-tag-up': 'p2.work_orders.view',
   '/p2-work-orders/queues': 'p2.work_orders.view',
   '/pto-command-center': [
     'timekeeping.pto.view_all',
@@ -194,6 +195,7 @@ export const VALID_NAVBAR_ROUTES = [
   '/orders-list',
   '/orders-management',
   '/p2-control-center',
+  '/daily-tag-up',
   '/pm-control-center',
   '/payment-management',
   '/pdf-templates',
@@ -707,6 +709,7 @@ export function hasRouteAccess(
  * Maps route patterns to the roles that can access them
  */
 export const ROLE_ROUTE_ACCESS: Record<string, string[]> = {
+  '/daily-tag-up': ['ADMIN', 'OWNER', 'PROJECT_MANAGER', 'PROGRAM_MANAGER', 'MANAGER', 'SUPERVISOR'],
   '/admin/orders': ['ADMIN', 'OWNER'],
   '/admin/policies': ['ADMIN', 'OWNER'],
   '/system-audits': ['ADMIN', 'OWNER'],

--- a/client/src/pages/DailyTagUpPage.tsx
+++ b/client/src/pages/DailyTagUpPage.tsx
@@ -1,0 +1,125 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'wouter';
+import { AlertTriangle, Boxes, CheckCircle2, ChevronRight, Clock3, Factory, Layers3, RefreshCw, Search, ShoppingCart } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { apiRequest } from '@/lib/queryClient';
+
+type WorkOrder = {
+  authorityId: string; workOrderId: string; workOrderNumber: string; inventoryItemId: number;
+  partNumber: string; partName: string; required: number; complete: number; inProgress: number;
+  needed: number; status: string; departmentId: number; department: string; readiness: { state: string; reason: string | null };
+  dueDate: string | null; travelerId: string | null; travelerNumber: string | null;
+};
+type Node = {
+  id: string; partNumber: string; partName: string; classification: string; source: string;
+  required: number; onHand: number; allocated: number; available: number; short: number;
+  leadTimeDays: number | null; supplyStatus: string; risk: string | null; children: Node[];
+};
+type Department = { label: string; required: number; complete: number; inProgress: number; needed: number; blocked: number; nextDue: string | null; workOrders: WorkOrder[] };
+type Project = Department & {
+  id: string; projectCode: string; projectName: string; customer: string; customerPoId: number | null;
+  customerPo: string; dueDate: string | null; percentComplete: number | null; configurationStatus: string;
+  purchasingShortages: number; departments: Department[]; assemblyTree: Node[]; materials: Node[];
+  issues: { type: string; message: string; href: string; record: string }[];
+};
+type Model = {
+  generatedAt: string;
+  summary: { activeProjects: number; required: number; complete: number; inProgress: number; needed: number; blocked: number; dueWithinWindow: number; purchasingShortages: number };
+  filters: { projects: { id: string; label: string }[]; customers: string[]; customerPos: string[]; departments: string[] };
+  projects: Project[];
+};
+
+const fmt = (value: number) => new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(value);
+const date = (value: string | null) => value ? new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(`${value}T12:00:00`)) : 'Not set';
+const tone = (state: string) => state.includes('BLOCKED') || state.includes('NOT READY') ? 'destructive' : state === 'READY' || state === 'COMPLETE' ? 'default' : 'secondary';
+
+export default function DailyTagUpPage() {
+  const [filters, setFilters] = useState({ projectId: 'all', customer: 'all', customerPo: 'all', department: 'all', source: 'both', attentionDays: '14', status: 'all', search: '', problemsOnly: false });
+  const [searchDraft, setSearchDraft] = useState('');
+  const query = useMemo(() => {
+    const params = new URLSearchParams();
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value !== 'all' && value !== '' && value !== false) params.set(key, String(value));
+    });
+    return params.toString();
+  }, [filters]);
+  const { data, isLoading, isError, refetch, isFetching } = useQuery<Model>({
+    queryKey: ['/api/daily-tag-up', query],
+    queryFn: () => apiRequest(`/api/daily-tag-up?${query}`),
+    refetchInterval: 60_000,
+  });
+  const update = (key: string, value: string | boolean) => setFilters((current) => ({ ...current, [key]: value }));
+
+  if (isLoading) return <div className="p-8 text-muted-foreground">Loading current production authority…</div>;
+  if (isError || !data) return <div className="p-8"><Card><CardContent className="p-6 text-destructive">Daily Tag Up could not load. Your access or the current production schema may need attention.</CardContent></Card></div>;
+
+  const cards = [
+    ['Active Projects', data.summary.activeProjects, Layers3], ['Total Demand', data.summary.required, Boxes],
+    ['Complete', data.summary.complete, CheckCircle2], ['In Progress', data.summary.inProgress, Factory],
+    ['Remaining / Needed', data.summary.needed, Clock3], ['Blocked', data.summary.blocked, AlertTriangle],
+    ['Due in Window', data.summary.dueWithinWindow, Clock3], ['Purchasing Shortages', data.summary.purchasingShortages, ShoppingCart],
+  ] as const;
+
+  return <div className="min-h-screen bg-muted/20 p-4 lg:p-6" data-testid="daily-tag-up-page">
+    <div className="mx-auto max-w-[1800px] space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div><h1 className="text-3xl font-bold tracking-tight">Daily Tag Up</h1><p className="text-muted-foreground">Live management visibility over released P2 demand and actual work orders</p></div>
+        <Button variant="outline" onClick={() => refetch()} disabled={isFetching} data-testid="daily-tag-up-refresh"><RefreshCw className={`mr-2 h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />Refresh</Button>
+      </div>
+
+      <Card className="sticky top-0 z-20 shadow-sm"><CardContent className="p-4">
+        <div className="grid gap-2 md:grid-cols-4 xl:grid-cols-8">
+          <Filter label="Project" value={filters.projectId} onChange={(v) => update('projectId', v)} values={data.filters.projects.map((x) => [x.id, x.label])} />
+          <Filter label="Customer" value={filters.customer} onChange={(v) => update('customer', v)} values={data.filters.customers.map((x) => [x, x])} />
+          <Filter label="Customer PO" value={filters.customerPo} onChange={(v) => update('customerPo', v)} values={data.filters.customerPos.map((x) => [x, x])} />
+          <Filter label="Department" value={filters.department} onChange={(v) => update('department', v)} values={data.filters.departments.map((x) => [x, x])} />
+          <Filter label="Source" value={filters.source} onChange={(v) => update('source', v)} includeAll={false} values={[["manufacturing","Manufacturing"],["purchasing","Purchasing"],["both","Both"]]} />
+          <Filter label="Needs attention" value={filters.attentionDays} onChange={(v) => update('attentionDays', v)} includeAll={false} values={[["0","Today"],["3","3 Days"],["7","7 Days"],["14","14 Days"],["30","30 Days"],["all","All"]]} />
+          <Filter label="Status" value={filters.status} onChange={(v) => update('status', v)} values={[["needed","Needed"],["ready","Ready"],["in_progress","In Progress"],["blocked","Blocked"],["complete","Complete"]]} />
+          <div className="space-y-1"><span className="text-xs font-medium">Search</span><div className="flex"><Input value={searchDraft} onChange={(e) => setSearchDraft(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && update('search', searchDraft)} placeholder="Project, PO, WO, part…" className="rounded-r-none" /><Button size="icon" className="rounded-l-none" onClick={() => update('search', searchDraft)}><Search className="h-4 w-4" /></Button></div></div>
+        </div>
+        <div className="mt-3 flex items-center gap-3"><Button variant={filters.problemsOnly ? 'default' : 'outline'} size="sm" onClick={() => update('problemsOnly', !filters.problemsOnly)}>Show Only Problems</Button><span className="text-xs text-muted-foreground">Updated {new Date(data.generatedAt).toLocaleTimeString()}</span></div>
+      </CardContent></Card>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-8">{cards.map(([label, value, Icon]) => <Card key={label}><CardContent className="p-4"><div className="flex items-center justify-between"><span className="text-xs font-medium text-muted-foreground">{label}</span><Icon className="h-4 w-4 text-muted-foreground" /></div><div className="mt-2 text-2xl font-bold">{fmt(value)}</div></CardContent></Card>)}</div>
+
+      {data.projects.length === 0 ? <Card><CardContent className="p-10 text-center text-muted-foreground">No authoritative project demand matches these filters.</CardContent></Card> : data.projects.map((project) => <ProjectCard key={project.id} project={project} />)}
+    </div>
+  </div>;
+}
+
+function Filter({ label, value, onChange, values, includeAll = true }: { label: string; value: string; onChange: (value: string) => void; values: string[][]; includeAll?: boolean }) {
+  return <div className="space-y-1"><span className="text-xs font-medium">{label}</span><Select value={value} onValueChange={onChange}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{includeAll && <SelectItem value="all">All</SelectItem>}{values.map(([key, text]) => <SelectItem key={key} value={key}>{text}</SelectItem>)}</SelectContent></Select></div>;
+}
+
+function ProjectCard({ project }: { project: Project }) {
+  return <details className="group rounded-lg border bg-card" open data-testid={`project-${project.id}`}>
+    <summary className="cursor-pointer list-none p-4"><div className="flex flex-wrap items-center gap-4"><ChevronRight className="h-5 w-5 transition-transform group-open:rotate-90" /><div className="min-w-[240px] flex-1"><div className="flex flex-wrap items-center gap-2"><span className="text-lg font-semibold">{project.projectCode} — {project.projectName}</span><Badge variant={project.configurationStatus.startsWith('RELEASED') ? 'default' : 'destructive'}>{project.configurationStatus}</Badge></div><div className="text-sm text-muted-foreground">{project.customer} · PO {project.customerPo} · Due {date(project.dueDate)}</div></div><Metric label="Required" value={project.required} /><Metric label="Complete" value={project.complete} /><Metric label="In Progress" value={project.inProgress} /><Metric label="Needed" value={project.needed} /><Metric label="Blocked" value={project.blocked} /><Metric label="Complete" value={project.percentComplete == null ? 'Unavailable' : `${project.percentComplete}%`} /></div></summary>
+    <div className="border-t p-4"><Tabs defaultValue="department"><TabsList className="flex h-auto flex-wrap justify-start"><TabsTrigger value="overview">Overview</TabsTrigger><TabsTrigger value="department">Department Demand</TabsTrigger><TabsTrigger value="assembly">Assembly Tree</TabsTrigger><TabsTrigger value="materials">BOM / Materials</TabsTrigger><TabsTrigger value="purchasing">Purchasing</TabsTrigger><TabsTrigger value="issues">Issues ({project.issues.length})</TabsTrigger></TabsList>
+      <TabsContent value="overview"><div className="grid gap-3 md:grid-cols-4"><MetricCard label="Customer / PO" value={`${project.customer} / ${project.customerPo}`} /><MetricCard label="Project due" value={date(project.dueDate)} /><MetricCard label="Released demand" value={fmt(project.required)} /><MetricCard label="Purchasing shortages" value={project.purchasingShortages} /></div></TabsContent>
+      <TabsContent value="department"><DepartmentTable departments={project.departments} project={project} /></TabsContent>
+      <TabsContent value="assembly"><Card><CardContent className="p-4">{project.assemblyTree.length ? project.assemblyTree.map((node) => <TreeNode key={node.id} node={node} />) : <Empty text="No released Frozen Production Demand hierarchy is available." />}</CardContent></Card></TabsContent>
+      <TabsContent value="materials"><Materials nodes={project.materials} /></TabsContent>
+      <TabsContent value="purchasing"><Materials nodes={project.materials} purchasing /></TabsContent>
+      <TabsContent value="issues"><Card><CardContent className="divide-y p-0">{project.issues.length ? project.issues.map((issue, index) => <div key={`${issue.record}-${index}`} className="flex items-start gap-3 p-4"><AlertTriangle className="mt-0.5 h-4 w-4 text-amber-600" /><div className="flex-1"><Badge variant="outline">{issue.type}</Badge><div className="mt-1 text-sm">{issue.message}</div></div><Link href={issue.href} className="text-sm text-primary hover:underline">{issue.record}</Link></div>) : <Empty text="No current authoritative exceptions." />}</CardContent></Card></TabsContent>
+    </Tabs></div>
+  </details>;
+}
+
+function DepartmentTable({ departments, project }: { departments: Department[]; project: Project }) {
+  if (!departments.length) return <Empty text="No actual work orders match this view." />;
+  return <div className="space-y-2">{departments.map((department) => <details key={department.label} className="group rounded-md border" data-testid={`department-${department.label}`}><summary className="cursor-pointer list-none p-3"><div className="grid items-center gap-2 md:grid-cols-[2fr_repeat(6,1fr)]"><span className="font-semibold"><ChevronRight className="mr-2 inline h-4 w-4 transition-transform group-open:rotate-90" />{department.label}</span><Metric label="Required" value={department.required} /><Metric label="Complete" value={department.complete} /><Metric label="In Progress" value={department.inProgress} /><Metric label="Needed" value={department.needed} /><Metric label="Blocked" value={department.blocked} /><Metric label="Next Due" value={date(department.nextDue)} /></div></summary><div className="overflow-x-auto border-t"><table className="w-full min-w-[1050px] text-sm"><thead className="bg-muted/50 text-left"><tr>{['Work Order','Part','Project / PO','Required','Complete','In Progress','Needed','Readiness','Due','Traveler'].map((x) => <th key={x} className="p-2 font-medium">{x}</th>)}</tr></thead><tbody>{department.workOrders.map((wo) => <tr key={wo.authorityId} className="border-t"><td className="p-2"><Link href={`/p2-work-orders/queues/${wo.departmentId}`} className="font-medium text-primary hover:underline">{wo.workOrderNumber}</Link></td><td className="p-2"><Link href={`/inventory/enhanced-mrp?search=${encodeURIComponent(wo.partNumber)}`} className="text-primary hover:underline">{wo.partNumber}</Link><div className="text-xs text-muted-foreground">{wo.partName}</div></td><td className="p-2"><Link href={`/projects/${project.id}`} className="text-primary hover:underline">{project.projectCode} / {project.customerPo}</Link></td><td className="p-2">{fmt(wo.required)}</td><td className="p-2">{fmt(wo.complete)}</td><td className="p-2">{fmt(wo.inProgress)}</td><td className="p-2">{fmt(wo.needed)}</td><td className="p-2"><Badge variant={tone(wo.readiness.state) as any}>{wo.readiness.state}</Badge>{wo.readiness.reason && <div className="mt-1 max-w-[260px] text-xs text-muted-foreground">{wo.readiness.reason}</div>}</td><td className="p-2">{date(wo.dueDate)}</td><td className="p-2">{wo.travelerId ? <Link href={`/travelers/${wo.travelerId}`} className="text-primary hover:underline">{wo.travelerNumber || 'Traveler'}</Link> : wo.travelerNumber || 'None'}</td></tr>)}</tbody></table></div></details>)}</div>;
+}
+
+function TreeNode({ node }: { node: Node }) { return <details className="ml-3 border-l pl-3" open={node.children.length < 4}><summary className="cursor-pointer py-2"><span className="font-medium">{node.partNumber} — {node.partName}</span> <Badge variant="outline" className="ml-2">{node.classification}</Badge> <Badge variant="secondary" className="ml-1">{node.source === 'manufacturing' ? 'MAKE' : 'BUY'}</Badge><span className="ml-3 text-sm text-muted-foreground">Required {fmt(node.required)} · Available {fmt(node.available)}{node.short > 0 ? ` · Short ${fmt(node.short)}` : ''}</span></summary>{node.children.map((child) => <TreeNode key={child.id} node={child} />)}</details>; }
+function Materials({ nodes, purchasing = false }: { nodes: Node[]; purchasing?: boolean }) { return <Card><CardContent className="overflow-x-auto p-0">{nodes.length ? <table className="w-full min-w-[1000px] text-sm"><thead className="bg-muted/50 text-left"><tr>{['Part','Classification','Required','On Hand','Allocated','Available','Open Supply','Short','Lead Time','Risk'].map((x) => <th key={x} className="p-3">{x}</th>)}</tr></thead><tbody>{nodes.map((node) => <tr key={node.id} className="border-t"><td className="p-3 font-medium">{node.partNumber}<div className="text-xs font-normal text-muted-foreground">{node.partName}</div></td><td className="p-3">{node.classification}</td><td className="p-3">{fmt(node.required)}</td><td className="p-3">{fmt(node.onHand)}</td><td className="p-3">{fmt(node.allocated)}</td><td className="p-3">{fmt(node.available)}</td><td className="p-3"><Badge variant={node.supplyStatus === 'NO OPEN SUPPLY' ? 'outline' : 'secondary'}>{node.supplyStatus}</Badge></td><td className="p-3 font-medium text-destructive">{node.short > 0 ? fmt(node.short) : '—'}</td><td className="p-3">{node.leadTimeDays == null ? 'Lead time not set' : `${node.leadTimeDays} days`}</td><td className="p-3"><Badge variant={node.risk === 'LATE' || node.risk === 'BUY NOW' ? 'destructive' : 'outline'}>{node.risk || '—'}</Badge></td></tr>)}</tbody></table> : <Empty text={purchasing ? 'No purchasing demand in the released configuration.' : 'No released material demand.'} />}</CardContent></Card>; }
+function Metric({ label, value }: { label: string; value: string | number }) { return <div className="text-right"><div className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</div><div className="font-semibold">{typeof value === 'number' ? fmt(value) : value}</div></div>; }
+function MetricCard({ label, value }: { label: string; value: string | number }) { return <Card><CardContent className="p-4"><div className="text-xs text-muted-foreground">{label}</div><div className="mt-1 font-semibold">{typeof value === 'number' ? fmt(value) : value}</div></CardContent></Card>; }
+function Empty({ text }: { text: string }) { return <div className="p-8 text-center text-muted-foreground">{text}</div>; }

--- a/docs/DailyTagUpAuthorityAudit.md
+++ b/docs/DailyTagUpAuthorityAudit.md
@@ -1,0 +1,34 @@
+# Daily Tag Up authority audit
+
+Audited against `origin/main` `e094936fe5692f32c7d4dfceaf7d19a9766b123e` on 2026-08-28.
+
+Daily Tag Up is an additive, read-only projection. It does not create or update project, demand, work-order, BOM, queue, traveler, inventory, purchasing, or readiness records.
+
+## Source-of-truth decisions
+
+| Display concern | Authoritative source | Read-model rule |
+| --- | --- | --- |
+| Project | `projects` | Include active, on-hold, or won projects. |
+| Customer PO | `projects.po_id -> p2_purchase_orders.id` | Do not infer a PO from text or older links. |
+| Released project demand and assembly hierarchy | The single `p2_frozen_production_demand_baselines` row with `status='RELEASED'`, plus its `p2_frozen_production_demand_nodes` | Nodes, classifications, make/buy disposition, BOM revision identity, routing identity, and quantities come from the immutable released snapshot. Draft, validated, cancelled, and superseded baselines are not manufacturing truth. |
+| Actual manufacturing work orders | `p2_manufacturing_work_order_authorities -> production_work_orders` | Every displayed work-order row is an existing authority row. Department rollups sum only those child rows. |
+| Department | `p2_manufacturing_work_order_authorities.current_department_id/current_department_name_snapshot` | Use the routed snapshot retained by work-order authority; do not hard-code department names. |
+| Required and complete quantities | `p2_manufacturing_work_order_authorities.required_quantity/completed_quantity` | Remaining is `max(required-complete,0)`. In-progress quantity is the outstanding quantity only when lifecycle status is `IN_PROGRESS`; EPOCH has no separate partial in-progress quantity column. |
+| Readiness and blockers | Work-order lifecycle status, open `p2_manufacturing_work_order_dependencies`, unsatisfied `p2_manufacturing_work_order_material_requirements`, and required traveler presence | Compose existing execution signals. Do not write a new readiness value. |
+| Traveler | `p2_manufacturing_work_order_authorities.traveler_id -> travelers` | Missing required traveler is shown as blocked; no traveler is synthesized. |
+| Inventory | Location rollup of `inventory_balances` | Display on hand, allocated, and available independently. Missing balance rows equal zero availability, consistent with current MRP services. |
+| Purchasing supply | `vendor_po_items` with exact `project_id` and `ag_part_number`, joined to a current, open `vendor_pos` revision | Unlinked supply is not credited. Show `NO OPEN SUPPLY` instead of matching by description. |
+| Lead time | `inventory_items.lead_time_days`; expected receipt from `vendor_pos.expected_delivery_date` | Missing lead time is displayed explicitly. Risk does not invent a duration. |
+| Permission | Existing `p2.work_orders.view` capability | Server endpoint and client route both require the read capability; no mutation capability is granted. |
+
+## Intentional boundaries
+
+- Legacy projects without a released Frozen Production Demand baseline remain visible but display `NOT RELEASED`; no legacy BOM is substituted.
+- Vendor PO lines without exact project and part traceability are excluded from project supply.
+- NCR aggregation is not included because the current project/work-order linkage was not sufficiently direct for a fail-closed join in this scope.
+- Manufacturing lead time is not calculated because the current work-order authority does not store a separate trusted manufacturing lead-time duration.
+- No migration or index is required. The read model uses existing project, baseline, work-order, inventory, and vendor-PO indexes.
+
+## Post-development capture check
+
+The API response exposes its authority map and returns one server-composed model for summary, projects, departments, actual work orders, released assembly nodes, materials, supply, and issues. React does not fetch queues or BOM lines separately and does not recompute authoritative totals from unrelated endpoints.

--- a/server/__tests__/dailyTagUpAuthorityContract.test.ts
+++ b/server/__tests__/dailyTagUpAuthorityContract.test.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const service = fs.readFileSync(path.join(process.cwd(), 'server/src/services/dailyTagUpService.ts'), 'utf8');
+const route = fs.readFileSync(path.join(process.cwd(), 'server/src/routes/dailyTagUp.ts'), 'utf8');
+
+describe('Daily Tag Up authority contract', () => {
+  it('uses released frozen demand and actual P2 work-order authorities', () => {
+    expect(service).toContain("p2_frozen_production_demand_baselines b ON b.project_id=p.id AND b.status='RELEASED'");
+    expect(service).toContain('FROM p2_manufacturing_work_order_authorities a');
+    expect(service).toContain('JOIN production_work_orders pwo ON pwo.id=a.production_work_order_id');
+    expect(service).toContain("base.status='RELEASED'");
+    expect(service).not.toContain('bom_revisions br');
+  });
+
+  it('uses authoritative inventory and only project-linked current purchasing supply', () => {
+    expect(service).toContain('FROM inventory_balances');
+    expect(service).toContain('WHERE vpi.project_id=ANY($1::uuid[])');
+    expect(service).toContain('vp.is_current_revision=true');
+    expect(service).toContain("supplyStatus: supply ? 'OPEN SUPPLY' : 'NO OPEN SUPPLY'");
+  });
+
+  it('enforces server authorization and provides overview plus focused project endpoints', () => {
+    expect(route).toContain("requirePermission('p2.work_orders.view')");
+    expect(route).toContain("router.get('/',");
+    expect(route).toContain("router.get('/projects/:projectId'");
+  });
+});

--- a/server/__tests__/dailyTagUpService.test.ts
+++ b/server/__tests__/dailyTagUpService.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({ pool: { query: vi.fn() } }));
+import { buildTree, matchesStatus, rollup, workOrderReadiness } from '../src/services/dailyTagUpService';
+
+describe('Daily Tag Up read model calculations', () => {
+  it('rolls department totals only from its actual work-order children', () => {
+    const workOrders = [
+      { required: 10, complete: 4, inProgress: 6, needed: 6, dueDate: '2026-08-29', readiness: { state: 'IN PROGRESS' } },
+      { required: 5, complete: 5, inProgress: 0, needed: 0, dueDate: '2026-08-30', readiness: { state: 'COMPLETE' } },
+    ];
+    const result = rollup('CNC', workOrders);
+    expect(result).toMatchObject({ required: 15, complete: 9, inProgress: 6, needed: 6, blocked: 0, nextDue: '2026-08-29' });
+    expect(result.workOrders).toBe(workOrders);
+  });
+
+  it('uses existing dependency, material, traveler, and lifecycle signals for readiness', () => {
+    expect(workOrderReadiness({ status: 'PLANNED', child_blocker_count: 1 })).toMatchObject({ state: 'NOT READY — WAITING ON UPSTREAM' });
+    expect(workOrderReadiness({ status: 'READY', material_blocker_count: 1 })).toMatchObject({ state: 'BLOCKED' });
+    expect(workOrderReadiness({ status: 'READY', traveler_requirement: 'REQUIRED', traveler_id: null })).toMatchObject({ state: 'BLOCKED', reason: 'Required traveler has not been provisioned' });
+    expect(workOrderReadiness({ status: 'READY', traveler_requirement: 'NOT_REQUIRED_APPROVED' })).toEqual({ state: 'READY', reason: null });
+  });
+
+  it('builds the assembly hierarchy from frozen node identities without synthesizing nodes', () => {
+    const nodes = [
+      { id: 'root', nodeIdentity: 'A', parentNodeIdentity: null },
+      { id: 'child', nodeIdentity: 'B', parentNodeIdentity: 'A' },
+    ];
+    const tree = buildTree(nodes);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].children.map((node: any) => node.id)).toEqual(['child']);
+  });
+
+  it('filters needed, ready, blocked, and complete from authoritative status/readiness', () => {
+    expect(matchesStatus({ status: 'PLANNED', readiness: { state: 'NEEDED / NOT STARTED' } }, 'needed')).toBe(true);
+    expect(matchesStatus({ status: 'READY', readiness: { state: 'READY' } }, 'ready')).toBe(true);
+    expect(matchesStatus({ status: 'HOLD', readiness: { state: 'BLOCKED' } }, 'blocked')).toBe(true);
+    expect(matchesStatus({ status: 'COMPLETE', readiness: { state: 'COMPLETE' } }, 'complete')).toBe(true);
+  });
+});

--- a/server/src/routes/dailyTagUp.ts
+++ b/server/src/routes/dailyTagUp.ts
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+import { authenticateToken } from '../../middleware/auth';
+import { requirePermission } from '../../middleware/requirePermission';
+import { getDailyTagUp } from '../services/dailyTagUpService';
+
+const router = Router();
+router.use(authenticateToken, requirePermission('p2.work_orders.view'));
+
+router.get('/', async (req, res) => {
+  try {
+    const rawDays = req.query.attentionDays;
+    const attentionDays = rawDays === 'all' || rawDays == null ? null : Number(rawDays);
+    res.json(await getDailyTagUp({
+      projectId: typeof req.query.projectId === 'string' ? req.query.projectId : undefined,
+      customer: typeof req.query.customer === 'string' ? req.query.customer : undefined,
+      customerPo: typeof req.query.customerPo === 'string' ? req.query.customerPo : undefined,
+      department: typeof req.query.department === 'string' ? req.query.department : undefined,
+      source: ['manufacturing', 'purchasing', 'both'].includes(String(req.query.source)) ? req.query.source as any : 'both',
+      status: typeof req.query.status === 'string' ? req.query.status : 'all',
+      search: typeof req.query.search === 'string' ? req.query.search : undefined,
+      attentionDays: Number.isFinite(attentionDays) ? attentionDays : null,
+      problemsOnly: req.query.problemsOnly === 'true',
+    }));
+  } catch (error: any) {
+    console.error('[daily-tag-up]', error);
+    res.status(500).json({ error: 'DAILY_TAG_UP_FAILED', message: error?.message ?? 'Failed to load Daily Tag Up' });
+  }
+});
+
+router.get('/projects/:projectId', async (req, res) => {
+  try {
+    const model = await getDailyTagUp({ projectId: req.params.projectId, source: 'both' });
+    if (!model.projects.length) return res.status(404).json({ error: 'PROJECT_NOT_FOUND' });
+    res.json({ generatedAt: model.generatedAt, authority: model.authority, project: model.projects[0] });
+  } catch (error: any) {
+    console.error('[daily-tag-up-project]', error);
+    res.status(500).json({ error: 'DAILY_TAG_UP_FAILED', message: error?.message ?? 'Failed to load Daily Tag Up project' });
+  }
+});
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -77,6 +77,7 @@ import inventoryTraceabilityBomsRoutes from './inventoryTraceabilityBoms';
 import p2ProjectControlledConfigurationsRoutes from './p2ProjectControlledConfigurations';
 import p2FrozenProductionDemandRoutes from './p2FrozenProductionDemand';
 import p2ManufacturingWorkOrderRoutes from './p2ManufacturingWorkOrders';
+import dailyTagUpRoutes from './dailyTagUp';
 import communicationsRoutes from './communications';
 import marketingRoutes from './marketing';
 import internalMessagesRoutes from './internalMessages';
@@ -1464,6 +1465,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
   app.use('/api/configuration-control', p2ProjectControlledConfigurationsRoutes);
   app.use('/api/configuration-control', p2FrozenProductionDemandRoutes);
   app.use('/api', p2ManufacturingWorkOrderRoutes);
+  app.use('/api/daily-tag-up', dailyTagUpRoutes);
 
   // Communications management routes
   app.use('/api/communications', communicationsRoutes);

--- a/server/src/services/dailyTagUpService.ts
+++ b/server/src/services/dailyTagUpService.ts
@@ -1,0 +1,311 @@
+import { pool } from '../../db';
+
+type Row = Record<string, any>;
+
+export type DailyTagUpFilters = {
+  projectId?: string;
+  customer?: string;
+  customerPo?: string;
+  department?: string;
+  source?: 'manufacturing' | 'purchasing' | 'both';
+  status?: string;
+  search?: string;
+  attentionDays?: number | null;
+  problemsOnly?: boolean;
+};
+
+const number = (value: unknown) => Number(value ?? 0);
+const text = (value: unknown) => String(value ?? '').trim();
+const upper = (value: unknown) => text(value).toUpperCase();
+const completeStatuses = new Set(['COMPLETE', 'COMPLETED', 'CLOSED']);
+
+export function workOrderReadiness(row: Row) {
+  const status = upper(row.status);
+  if (completeStatuses.has(status)) return { state: 'COMPLETE', reason: null };
+  if (status === 'IN_PROGRESS') return { state: 'IN PROGRESS', reason: null };
+  if (status === 'BLOCKED' || status === 'HOLD') {
+    return { state: 'BLOCKED', reason: text(row.hold_reason) || 'Work order is on hold' };
+  }
+  if (number(row.child_blocker_count) > 0) {
+    return { state: 'NOT READY — WAITING ON UPSTREAM', reason: `${row.child_blocker_count} upstream requirement(s) incomplete` };
+  }
+  if (number(row.material_blocker_count) > 0) {
+    return { state: 'BLOCKED', reason: `${row.material_blocker_count} material requirement(s) unsatisfied` };
+  }
+  if (row.traveler_requirement === 'REQUIRED' && !row.traveler_id) {
+    return { state: 'BLOCKED', reason: 'Required traveler has not been provisioned' };
+  }
+  if (status === 'READY') return { state: 'READY', reason: null };
+  return { state: 'NEEDED / NOT STARTED', reason: null };
+}
+
+export function matchesStatus(row: Row, requested?: string) {
+  if (!requested || requested === 'all') return true;
+  const readiness = upper(row.readiness?.state);
+  const status = upper(row.status);
+  if (requested === 'needed') return !completeStatuses.has(status);
+  if (requested === 'ready') return readiness === 'READY';
+  if (requested === 'in_progress') return status === 'IN_PROGRESS';
+  if (requested === 'blocked') return readiness.includes('BLOCKED') || readiness.includes('NOT READY');
+  if (requested === 'complete') return completeStatuses.has(status);
+  return true;
+}
+
+function inAttentionWindow(dueDate: string | null, days?: number | null) {
+  if (days == null || !dueDate) return true;
+  const due = new Date(`${dueDate}T23:59:59`);
+  const limit = new Date();
+  limit.setDate(limit.getDate() + days);
+  return due <= limit;
+}
+
+export function buildTree(nodes: Row[]) {
+  const byIdentity = new Map<string, Row>();
+  const roots: Row[] = [];
+  for (const node of nodes) byIdentity.set(node.nodeIdentity, { ...node, children: [] });
+  for (const node of Array.from(byIdentity.values())) {
+    const parent = node.parentNodeIdentity ? byIdentity.get(node.parentNodeIdentity) : null;
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+  }
+  return roots;
+}
+
+export async function getDailyTagUp(filters: DailyTagUpFilters = {}) {
+  const projectResult = await pool.query(
+    `SELECT p.id,p.project_code,p.project_name,p.status,p.target_ship_date,p.customer_name_snapshot,
+       po.id po_id,po.po_number,po.customer_name,po.expected_delivery,
+       b.id baseline_id,b.revision_number baseline_revision,b.project_quantity,b.baseline_checksum
+     FROM projects p
+     LEFT JOIN p2_purchase_orders po ON po.id=p.po_id
+     LEFT JOIN p2_frozen_production_demand_baselines b ON b.project_id=p.id AND b.status='RELEASED'
+     WHERE p.status IN ('active','on_hold','won')
+     ORDER BY COALESCE(p.target_ship_date,po.expected_delivery) NULLS LAST,p.project_code`
+  );
+  const allProjects = projectResult.rows as Row[];
+  const projectIds = allProjects.map((row) => row.id);
+  if (!projectIds.length) return emptyResponse(filters);
+
+  const [workOrderResult, nodeResult, supplyResult] = await Promise.all([
+    pool.query(
+      `SELECT a.id authority_id,a.project_id,a.parent_authority_id,a.assembly_path_identity,
+         a.inventory_item_id,a.part_number_snapshot,a.description_snapshot,a.required_quantity,
+         a.completed_quantity,a.accepted_quantity,a.status,a.current_department_id,
+         a.current_department_name_snapshot,a.traveler_requirement,a.traveler_id,
+         pwo.id work_order_id,pwo.work_order_number,pwo.due_date,
+         t.traveler_number,
+         (SELECT count(*) FROM p2_manufacturing_work_order_dependencies d
+           JOIN p2_manufacturing_work_order_authorities child ON child.id=d.predecessor_authority_id
+           WHERE d.successor_authority_id=a.id AND d.status='OPEN'
+             AND (CASE WHEN d.dependency_type='ACCEPT' THEN child.accepted_quantity ELSE child.completed_quantity END)<d.required_quantity) child_blocker_count,
+         (SELECT count(*) FROM p2_manufacturing_work_order_material_requirements m
+           WHERE m.successor_authority_id=a.id AND m.status='OPEN'
+             AND LEAST(m.accepted_quantity,m.issued_quantity)<m.required_quantity) material_blocker_count
+       FROM p2_manufacturing_work_order_authorities a
+       JOIN production_work_orders pwo ON pwo.id=a.production_work_order_id
+       LEFT JOIN travelers t ON t.id=a.traveler_id
+       WHERE a.project_id=ANY($1::uuid[])`,
+      [projectIds]
+    ),
+    pool.query(
+      `SELECT n.id,n.baseline_id,n.node_identity,n.parent_node_identity,n.assembly_path_identity,n.depth,
+         n.inventory_item_id,n.inventory_item_snapshot,n.item_classification,n.make_buy_disposition,
+         n.required_gross_quantity,n.unit_of_measure,n.quantity_per_parent,n.bom_id,n.bom_revision_id,
+         n.routing_id,i.ag_part_number,i.name,i.lead_time_days,
+         COALESCE(bal.on_hand,0) on_hand,COALESCE(bal.allocated,0) allocated,COALESCE(bal.available,0) available
+       FROM p2_frozen_production_demand_nodes n
+       JOIN p2_frozen_production_demand_baselines base ON base.id=n.baseline_id AND base.status='RELEASED'
+       JOIN inventory_items i ON i.id=n.inventory_item_id
+       LEFT JOIN LATERAL (SELECT SUM(quantity_on_hand) on_hand,SUM(quantity_allocated) allocated,SUM(quantity_available) available
+         FROM inventory_balances WHERE ag_part_number=i.ag_part_number) bal ON true
+       WHERE base.project_id=ANY($1::uuid[])
+       ORDER BY n.depth,n.assembly_path_identity`,
+      [projectIds]
+    ),
+    pool.query(
+      `SELECT vpi.project_id,vpi.ag_part_number,SUM(GREATEST(vpi.quantity-COALESCE(vpi.received_quantity,0),0)) open_quantity,
+         jsonb_agg(jsonb_build_object('vendorPoId',vp.id,'poNumber',vp.po_number,'status',vp.status,
+           'supplier',v.name,'expectedReceipt',vp.expected_delivery_date,
+           'openQuantity',GREATEST(vpi.quantity-COALESCE(vpi.received_quantity,0),0)) ORDER BY vp.expected_delivery_date NULLS LAST) supply
+       FROM vendor_po_items vpi JOIN vendor_pos vp ON vp.id=vpi.vendor_po_id JOIN vendors v ON v.id=vp.vendor_id
+       WHERE vpi.project_id=ANY($1::uuid[]) AND vpi.ag_part_number IS NOT NULL
+         AND vp.status NOT IN ('Cancelled','Voided','Fully Received') AND vp.is_current_revision=true
+       GROUP BY vpi.project_id,vpi.ag_part_number`,
+      [projectIds]
+    ),
+  ]);
+
+  const workOrdersByProject = new Map<string, Row[]>();
+  for (const raw of workOrderResult.rows as Row[]) {
+    const required = number(raw.required_quantity);
+    const complete = number(raw.completed_quantity);
+    const remaining = Math.max(required - complete, 0);
+    const row = {
+      authorityId: raw.authority_id,
+      workOrderId: raw.work_order_id,
+      workOrderNumber: raw.work_order_number,
+      inventoryItemId: raw.inventory_item_id,
+      partNumber: raw.part_number_snapshot,
+      partName: raw.description_snapshot,
+      required,
+      complete,
+      inProgress: upper(raw.status) === 'IN_PROGRESS' ? remaining : 0,
+      needed: remaining,
+      status: raw.status,
+      departmentId: raw.current_department_id,
+      department: raw.current_department_name_snapshot || 'Missing setup',
+      readiness: workOrderReadiness(raw),
+      dueDate: raw.due_date,
+      travelerId: raw.traveler_id,
+      travelerNumber: raw.traveler_number,
+      travelerRequirement: raw.traveler_requirement,
+      assemblyPathIdentity: raw.assembly_path_identity,
+    };
+    (workOrdersByProject.get(raw.project_id) ?? workOrdersByProject.set(raw.project_id, []).get(raw.project_id)!).push(row);
+  }
+  const supplies = new Map((supplyResult.rows as Row[]).map((row) => [`${row.project_id}:${row.ag_part_number}`, row]));
+  const nodesByBaseline = new Map<string, Row[]>();
+  for (const raw of nodeResult.rows as Row[]) {
+    const supply = supplies.get(`${allProjects.find((p) => p.baseline_id === raw.baseline_id)?.id}:${raw.ag_part_number}`);
+    const required = number(raw.required_gross_quantity);
+    const available = number(raw.available);
+    const node = {
+      id: raw.id,
+      nodeIdentity: raw.node_identity,
+      parentNodeIdentity: raw.parent_node_identity,
+      assemblyPathIdentity: raw.assembly_path_identity,
+      depth: number(raw.depth),
+      inventoryItemId: raw.inventory_item_id,
+      partNumber: raw.ag_part_number,
+      partName: raw.name,
+      classification: raw.item_classification || 'Missing setup',
+      source: raw.make_buy_disposition === 'MAKE' ? 'manufacturing' : 'purchasing',
+      required,
+      unitOfMeasure: raw.unit_of_measure,
+      bomId: raw.bom_id,
+      bomRevisionId: raw.bom_revision_id,
+      routingId: raw.routing_id,
+      onHand: number(raw.on_hand),
+      allocated: number(raw.allocated),
+      available,
+      short: raw.make_buy_disposition === 'BUY' ? Math.max(required - available - number(supply?.open_quantity), 0) : 0,
+      leadTimeDays: raw.lead_time_days == null ? null : number(raw.lead_time_days),
+      supply: supply?.supply ?? [],
+      supplyStatus: supply ? 'OPEN SUPPLY' : 'NO OPEN SUPPLY',
+    };
+    (nodesByBaseline.get(raw.baseline_id) ?? nodesByBaseline.set(raw.baseline_id, []).get(raw.baseline_id)!).push(node);
+  }
+
+  const search = upper(filters.search);
+  const projects = allProjects.filter((project) => {
+    if (filters.projectId && project.id !== filters.projectId) return false;
+    if (filters.customer && upper(project.customer_name || project.customer_name_snapshot) !== upper(filters.customer)) return false;
+    if (filters.customerPo && upper(project.po_number) !== upper(filters.customerPo)) return false;
+    return true;
+  }).map((project) => {
+    let workOrders = filters.source === 'purchasing' ? [] : (workOrdersByProject.get(project.id) ?? []);
+    workOrders = workOrders.filter((row) => {
+      if (filters.department && row.department !== filters.department) return false;
+      if (!matchesStatus(row, filters.status)) return false;
+      if (!inAttentionWindow(row.dueDate || project.target_ship_date || project.expected_delivery, filters.attentionDays)) return false;
+      if (filters.problemsOnly && !['BLOCKED', 'NOT READY'].some((value) => upper(row.readiness.state).includes(value))) return false;
+      if (search && ![project.project_code, project.project_name, project.po_number, row.workOrderNumber, row.partNumber, row.partName, row.travelerNumber].some((value) => upper(value).includes(search))) return false;
+      return true;
+    });
+    const departments = Array.from(new Set(workOrders.map((row) => row.department))).sort().map((department) => {
+      const children = workOrders.filter((row) => row.department === department);
+      return rollup(department, children);
+    });
+    let nodes: Row[] = (nodesByBaseline.get(project.baseline_id) ?? []).map((node): Row => ({
+      ...node,
+      risk: supplyRisk(node, project.target_ship_date || project.expected_delivery),
+    }));
+    if (filters.source && filters.source !== 'both') nodes = nodes.filter((node) => node.source === filters.source);
+    const totals = rollup('project', workOrders);
+    const purchasingShortages = nodes.filter((node) => node.source === 'purchasing' && node.short > 0).length;
+    return {
+      id: project.id,
+      projectCode: project.project_code,
+      projectName: project.project_name,
+      customer: project.customer_name || project.customer_name_snapshot || 'Not linked',
+      customerPoId: project.po_id,
+      customerPo: project.po_number || 'Not linked',
+      dueDate: project.target_ship_date || project.expected_delivery,
+      baseline: project.baseline_id ? { id: project.baseline_id, revision: project.baseline_revision, checksum: project.baseline_checksum } : null,
+      configurationStatus: project.baseline_id ? 'RELEASED FROZEN DEMAND' : 'NOT RELEASED',
+      ...totals,
+      purchasingShortages,
+      departments,
+      assemblyTree: buildTree(nodes),
+      materials: nodes.filter((node) => node.source === 'purchasing'),
+      issues: [
+        ...workOrders.filter((row) => upper(row.readiness.state).includes('BLOCKED') || upper(row.readiness.state).includes('NOT READY')).map((row) => ({ type: 'WORK ORDER', message: row.readiness.reason, href: `/p2-work-orders/${row.authorityId}`, record: row.workOrderNumber })),
+        ...nodes.filter((node) => node.source === 'purchasing' && node.short > 0).map((node) => ({ type: 'MATERIAL SHORTAGE', message: `${node.short} ${node.unitOfMeasure} short`, href: `/inventory/items/${node.inventoryItemId}`, record: node.partNumber })),
+        ...(!project.baseline_id ? [{ type: 'CONFIGURATION', message: 'No released Frozen Production Demand baseline', href: `/projects/${project.id}`, record: project.project_code }] : []),
+      ],
+    };
+  }).filter((project) => !search || project.workOrders.length > 0 || [project.projectCode, project.projectName, project.customerPo].some((value) => upper(value).includes(search)));
+
+  const workOrders = projects.flatMap((project) => project.workOrders);
+  return {
+    generatedAt: new Date().toISOString(),
+    authority: {
+      project: 'projects.po_id → p2_purchase_orders',
+      demandAndAssembly: 'released p2_frozen_production_demand_baselines/nodes',
+      workOrders: 'p2_manufacturing_work_order_authorities → production_work_orders',
+      readiness: 'authoritative work-order status, dependency/material satisfaction, and traveler coverage',
+      inventory: 'inventory_balances',
+      purchasing: 'project-linked vendor_po_items → current vendor_pos revisions',
+    },
+    filters: filterOptions(allProjects, workOrderResult.rows),
+    summary: {
+      activeProjects: projects.length,
+      ...rollup('all', workOrders),
+      dueWithinWindow: projects.filter((project) => inAttentionWindow(project.dueDate, filters.attentionDays)).length,
+      purchasingShortages: projects.reduce((sum, project) => sum + project.purchasingShortages, 0),
+    },
+    projects,
+  };
+}
+
+export function rollup(label: string, workOrders: Row[]) {
+  return {
+    label,
+    required: workOrders.reduce((sum, row) => sum + number(row.required), 0),
+    complete: workOrders.reduce((sum, row) => sum + number(row.complete), 0),
+    inProgress: workOrders.reduce((sum, row) => sum + number(row.inProgress), 0),
+    needed: workOrders.reduce((sum, row) => sum + number(row.needed), 0),
+    blocked: workOrders.filter((row) => upper(row.readiness?.state).includes('BLOCKED') || upper(row.readiness?.state).includes('NOT READY')).length,
+    nextDue: workOrders.map((row) => row.dueDate).filter(Boolean).sort()[0] ?? null,
+    percentComplete: workOrders.reduce((sum, row) => sum + number(row.required), 0) > 0
+      ? Math.round(workOrders.reduce((sum, row) => sum + number(row.complete), 0) / workOrders.reduce((sum, row) => sum + number(row.required), 0) * 100)
+      : null,
+    workOrders,
+  };
+}
+
+function filterOptions(projects: Row[], workOrders: Row[]) {
+  const unique = (values: unknown[]) => Array.from(new Set(values.map(text).filter(Boolean))).sort();
+  return {
+    projects: projects.map((row) => ({ id: row.id, label: `${row.project_code} — ${row.project_name}` })),
+    customers: unique(projects.map((row) => row.customer_name || row.customer_name_snapshot)),
+    customerPos: unique(projects.map((row) => row.po_number)),
+    departments: unique(workOrders.map((row) => row.current_department_name_snapshot)),
+  };
+}
+
+function supplyRisk(node: Row, requiredDate: string | null) {
+  if (node.source !== 'purchasing') return null;
+  if (node.short <= 0) return 'ON TRACK';
+  if (node.leadTimeDays == null) return 'LEAD TIME NOT SET';
+  const receipts = (Array.isArray(node.supply) ? node.supply : []).map((entry: Row) => entry.expectedReceipt).filter(Boolean).sort();
+  if (!receipts.length) return 'BUY NOW';
+  if (requiredDate && receipts[0] > requiredDate) return 'LATE';
+  const requiredStart = requiredDate ? new Date(`${requiredDate}T12:00:00`) : null;
+  if (requiredStart) requiredStart.setDate(requiredStart.getDate() - node.leadTimeDays);
+  return requiredStart && requiredStart < new Date() ? 'AT RISK' : 'DUE SOON';
+}
+
+function emptyResponse(filters: DailyTagUpFilters) {
+  return { generatedAt: new Date().toISOString(), authority: {}, filters: { projects: [], customers: [], customerPos: [], departments: [] }, summary: { activeProjects: 0, required: 0, complete: 0, inProgress: 0, needed: 0, blocked: 0, dueWithinWindow: 0, purchasingShortages: 0 }, projects: [], appliedFilters: filters };
+}


### PR DESCRIPTION
## Summary
- add a permission-gated Daily Tag Up management view with project, department, and work-order rollups
- source released frozen demand, actual P2 work orders, inventory balances, and exact project/part vendor PO supply without creating parallel execution authority
- move TV Display to the first Verified Modules card and document the authority audit

## Verification
- server focused tests: 7 passed
- client focused tests: 3 passed
- git diff --check: passed
- rebased onto latest origin/main (8de7b215)

## Boundaries
- no schema migration or backfill
- no deployment or live database/browser certification performed
- repo-wide TypeScript currently reports unrelated pre-existing failures; the Daily Tag Up paths had no filtered TypeScript diagnostics during development