### PR TITLE
Add P1/P2 stock work-order readiness preview

### DIFF
--- a/client/src/pages/ManufacturingQueue.tsx
+++ b/client/src/pages/ManufacturingQueue.tsx
@@ -26,8 +26,20 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import {
   Dialog,
   DialogContent,
@@ -51,10 +63,29 @@ import {
   XCircle,
   MoreHorizontal,
   Plus,
-  ArrowUpDown,
+  Check,
+  ChevronsUpDown,
+  ShieldAlert,
 } from 'lucide-react';
 import { ReturnsRepairsSection } from '@/components/ReturnsRepairsSection';
-import type { ManufacturingQueue, InsertManufacturingQueue } from '@shared/schema';
+import type { ManufacturingQueue } from '@shared/schema';
+
+type StockBuildPart = {
+  id: number;
+  agPartNumber: string;
+  name: string;
+  description?: string | null;
+  manufacturedCategory?: string | null;
+  manufacturingLevel?: string | null;
+  productionSystem: 'P1' | 'P2' | null;
+  defaultDepartmentName?: string | null;
+  availableQuantity: number;
+  releasedBomCount: number;
+  activeRoutingCount: number;
+  releasedTraceabilityPolicyCount: number;
+  readyForStockBuildPreview: boolean;
+  blockers: string[];
+};
 
 type QueueItemWithInventory = ManufacturingQueue & {
   inventoryItem: {
@@ -70,18 +101,21 @@ type QueueItemWithInventory = ManufacturingQueue & {
 
 export default function ManufacturingQueue() {
   const { toast } = useToast();
-  const [selectedDepartment, setSelectedDepartment] = useState<string>('Cutting Table');
+  const [selectedDepartment, setSelectedDepartment] =
+    useState<string>('Cutting Table');
   const [selectedStatus, setSelectedStatus] = useState<string>('ALL');
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
 
-
   // Fetch queue items
-  const { data: queueItems = [], isLoading } = useQuery<QueueItemWithInventory[]>({
+  const { data: queueItems = [], isLoading } = useQuery<
+    QueueItemWithInventory[]
+  >({
     queryKey: ['/api/manufacturing-queue', selectedDepartment, selectedStatus],
     queryFn: () => {
       const params = new URLSearchParams();
       if (selectedDepartment) params.append('department', selectedDepartment);
-      if (selectedStatus && selectedStatus !== 'ALL') params.append('status', selectedStatus);
+      if (selectedStatus && selectedStatus !== 'ALL')
+        params.append('status', selectedStatus);
       return apiRequest(`/api/manufacturing-queue?${params.toString()}`);
     },
     enabled: true,
@@ -105,7 +139,8 @@ export default function ManufacturingQueue() {
     onError: (error: Error) => {
       toast({
         title: 'Error',
-        description: error.message || 'Failed to update status. Please try again.',
+        description:
+          error.message || 'Failed to update status. Please try again.',
         variant: 'destructive',
       });
     },
@@ -128,7 +163,8 @@ export default function ManufacturingQueue() {
     onError: (error: Error) => {
       toast({
         title: 'Error',
-        description: error.message || 'Failed to delete item. Please try again.',
+        description:
+          error.message || 'Failed to delete item. Please try again.',
         variant: 'destructive',
       });
     },
@@ -147,13 +183,45 @@ export default function ManufacturingQueue() {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'PENDING':
-        return <Badge variant="outline" className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"><Clock className="w-3 h-3 mr-1" />Pending</Badge>;
+        return (
+          <Badge
+            variant="outline"
+            className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+          >
+            <Clock className="w-3 h-3 mr-1" />
+            Pending
+          </Badge>
+        );
       case 'IN_PROGRESS':
-        return <Badge variant="outline" className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"><PlayCircle className="w-3 h-3 mr-1" />In Progress</Badge>;
+        return (
+          <Badge
+            variant="outline"
+            className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+          >
+            <PlayCircle className="w-3 h-3 mr-1" />
+            In Progress
+          </Badge>
+        );
       case 'COMPLETED':
-        return <Badge variant="outline" className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"><CheckCircle2 className="w-3 h-3 mr-1" />Completed</Badge>;
+        return (
+          <Badge
+            variant="outline"
+            className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+          >
+            <CheckCircle2 className="w-3 h-3 mr-1" />
+            Completed
+          </Badge>
+        );
       case 'CANCELLED':
-        return <Badge variant="outline" className="bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200"><XCircle className="w-3 h-3 mr-1" />Cancelled</Badge>;
+        return (
+          <Badge
+            variant="outline"
+            className="bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200"
+          >
+            <XCircle className="w-3 h-3 mr-1" />
+            Cancelled
+          </Badge>
+        );
       default:
         return <Badge variant="outline">{status}</Badge>;
     }
@@ -161,7 +229,8 @@ export default function ManufacturingQueue() {
 
   const getPriorityColor = (priority: number) => {
     if (priority <= 25) return 'text-red-600 dark:text-red-400 font-bold';
-    if (priority <= 50) return 'text-orange-600 dark:text-orange-400 font-semibold';
+    if (priority <= 50)
+      return 'text-orange-600 dark:text-orange-400 font-semibold';
     if (priority <= 75) return 'text-blue-600 dark:text-blue-400';
     return 'text-gray-600 dark:text-gray-400';
   };
@@ -170,13 +239,15 @@ export default function ManufacturingQueue() {
     <div className="container mx-auto py-6 px-4 dark:bg-gray-950 dark:text-white">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <h1 className="text-3xl font-bold mb-2 dark:text-white">Manufacturing Queue</h1>
+          <h1 className="text-3xl font-bold mb-2 dark:text-white">
+            Manufacturing Queue
+          </h1>
           <p className="text-muted-foreground dark:text-gray-400">
             Track and manage items that need to be manufactured
           </p>
         </div>
-        <AddQueueItemDialog 
-          isOpen={isAddDialogOpen} 
+        <AddQueueItemDialog
+          isOpen={isAddDialogOpen}
           onOpenChange={setIsAddDialogOpen}
         />
       </div>
@@ -193,8 +264,14 @@ export default function ManufacturingQueue() {
               </CardDescription>
             </div>
             <div className="flex gap-2">
-              <Select value={selectedDepartment} onValueChange={setSelectedDepartment}>
-                <SelectTrigger className="w-[200px] dark:bg-gray-800 dark:border-gray-700 dark:text-white" data-testid="select-department">
+              <Select
+                value={selectedDepartment}
+                onValueChange={setSelectedDepartment}
+              >
+                <SelectTrigger
+                  className="w-[200px] dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                  data-testid="select-department"
+                >
                   <SelectValue placeholder="Select department" />
                 </SelectTrigger>
                 <SelectContent className="dark:bg-gray-800 dark:border-gray-700">
@@ -204,7 +281,10 @@ export default function ManufacturingQueue() {
                 </SelectContent>
               </Select>
               <Select value={selectedStatus} onValueChange={setSelectedStatus}>
-                <SelectTrigger className="w-[150px] dark:bg-gray-800 dark:border-gray-700 dark:text-white" data-testid="select-status">
+                <SelectTrigger
+                  className="w-[150px] dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                  data-testid="select-status"
+                >
                   <SelectValue placeholder="Select status" />
                 </SelectTrigger>
                 <SelectContent className="dark:bg-gray-800 dark:border-gray-700">
@@ -220,7 +300,9 @@ export default function ManufacturingQueue() {
         </CardHeader>
         <CardContent>
           {isLoading ? (
-            <div className="text-center py-8 text-muted-foreground dark:text-gray-400">Loading queue items...</div>
+            <div className="text-center py-8 text-muted-foreground dark:text-gray-400">
+              Loading queue items...
+            </div>
           ) : queueItems.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground dark:text-gray-400">
               No items found in the queue for the selected filters.
@@ -230,60 +312,106 @@ export default function ManufacturingQueue() {
               <Table>
                 <TableHeader>
                   <TableRow className="dark:border-gray-800">
-                    <TableHead className="dark:text-gray-300">Priority</TableHead>
-                    <TableHead className="dark:text-gray-300">Part Number</TableHead>
-                    <TableHead className="dark:text-gray-300">Item Name</TableHead>
-                    <TableHead className="dark:text-gray-300">Department</TableHead>
-                    <TableHead className="dark:text-gray-300">Quantity</TableHead>
+                    <TableHead className="dark:text-gray-300">
+                      Priority
+                    </TableHead>
+                    <TableHead className="dark:text-gray-300">
+                      Part Number
+                    </TableHead>
+                    <TableHead className="dark:text-gray-300">
+                      Item Name
+                    </TableHead>
+                    <TableHead className="dark:text-gray-300">
+                      Department
+                    </TableHead>
+                    <TableHead className="dark:text-gray-300">
+                      Quantity
+                    </TableHead>
                     <TableHead className="dark:text-gray-300">Status</TableHead>
-                    <TableHead className="dark:text-gray-300">Due Date</TableHead>
-                    <TableHead className="dark:text-gray-300">Assigned To</TableHead>
-                    <TableHead className="dark:text-gray-300">Actions</TableHead>
+                    <TableHead className="dark:text-gray-300">
+                      Due Date
+                    </TableHead>
+                    <TableHead className="dark:text-gray-300">
+                      Assigned To
+                    </TableHead>
+                    <TableHead className="dark:text-gray-300">
+                      Actions
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {queueItems.map((item) => (
-                    <TableRow key={item.id} className="dark:border-gray-800" data-testid={`row-queue-${item.id}`}>
-                      <TableCell className={getPriorityColor(item.priority || 50)}>
+                    <TableRow
+                      key={item.id}
+                      className="dark:border-gray-800"
+                      data-testid={`row-queue-${item.id}`}
+                    >
+                      <TableCell
+                        className={getPriorityColor(item.priority || 50)}
+                      >
                         {item.priority || 50}
                       </TableCell>
                       <TableCell className="font-mono text-sm dark:text-gray-300">
                         {item.inventoryItem?.agPartNumber || '-'}
                       </TableCell>
-                      <TableCell className="dark:text-gray-300">{item.inventoryItem?.name || 'Unknown'}</TableCell>
-                      <TableCell className="dark:text-gray-300">{item.department}</TableCell>
                       <TableCell className="dark:text-gray-300">
-                        <span className="font-semibold">{item.quantityCompleted || 0}</span> / {item.quantityRequested}
+                        {item.inventoryItem?.name || 'Unknown'}
+                      </TableCell>
+                      <TableCell className="dark:text-gray-300">
+                        {item.department}
+                      </TableCell>
+                      <TableCell className="dark:text-gray-300">
+                        <span className="font-semibold">
+                          {item.quantityCompleted || 0}
+                        </span>{' '}
+                        / {item.quantityRequested}
                       </TableCell>
                       <TableCell>{getStatusBadge(item.status)}</TableCell>
                       <TableCell className="dark:text-gray-300">
-                        {item.dueDate ? new Date(item.dueDate).toLocaleDateString() : '-'}
+                        {item.dueDate
+                          ? new Date(item.dueDate).toLocaleDateString()
+                          : '-'}
                       </TableCell>
-                      <TableCell className="dark:text-gray-300">{item.assignedTo || '-'}</TableCell>
+                      <TableCell className="dark:text-gray-300">
+                        {item.assignedTo || '-'}
+                      </TableCell>
                       <TableCell>
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
-                            <Button variant="ghost" size="sm" data-testid={`button-actions-${item.id}`}>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              data-testid={`button-actions-${item.id}`}
+                            >
                               <MoreHorizontal className="h-4 w-4" />
                             </Button>
                           </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" className="dark:bg-gray-800 dark:border-gray-700">
+                          <DropdownMenuContent
+                            align="end"
+                            className="dark:bg-gray-800 dark:border-gray-700"
+                          >
                             <DropdownMenuItem
-                              onClick={() => handleStatusChange(item.id, 'IN_PROGRESS')}
+                              onClick={() =>
+                                handleStatusChange(item.id, 'IN_PROGRESS')
+                              }
                               disabled={item.status === 'IN_PROGRESS'}
                               className="dark:text-gray-200 dark:focus:bg-gray-700"
                             >
                               Mark In Progress
                             </DropdownMenuItem>
                             <DropdownMenuItem
-                              onClick={() => handleStatusChange(item.id, 'COMPLETED')}
+                              onClick={() =>
+                                handleStatusChange(item.id, 'COMPLETED')
+                              }
                               disabled={item.status === 'COMPLETED'}
                               className="dark:text-gray-200 dark:focus:bg-gray-700"
                             >
                               Mark Completed
                             </DropdownMenuItem>
                             <DropdownMenuItem
-                              onClick={() => handleStatusChange(item.id, 'CANCELLED')}
+                              onClick={() =>
+                                handleStatusChange(item.id, 'CANCELLED')
+                              }
                               disabled={item.status === 'CANCELLED'}
                               className="dark:text-gray-200 dark:focus:bg-gray-700"
                             >
@@ -310,57 +438,25 @@ export default function ManufacturingQueue() {
   );
 }
 
-function AddQueueItemDialog({ isOpen, onOpenChange }: { isOpen: boolean; onOpenChange: (open: boolean) => void }) {
-  const { toast } = useToast();
-  const [formData, setFormData] = useState<Partial<InsertManufacturingQueue>>({
-    department: 'Cutting Table',
-    quantityRequested: 1,
-    priority: 50,
-    status: 'PENDING',
+function AddQueueItemDialog({
+  isOpen,
+  onOpenChange,
+}: {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [partPickerOpen, setPartPickerOpen] = useState(false);
+  const [selectedPartId, setSelectedPartId] = useState<number | null>(null);
+  const [quantity, setQuantity] = useState(1);
+  const [priority, setPriority] = useState(50);
+  const [dueDate, setDueDate] = useState('');
+  const { data, isLoading, isError } = useQuery<{ parts: StockBuildPart[] }>({
+    queryKey: ['/api/stock-build-readiness/parts'],
+    queryFn: () => apiRequest('/api/stock-build-readiness/parts'),
+    enabled: isOpen,
   });
-
-  const createMutation = useMutation({
-    mutationFn: async (data: InsertManufacturingQueue) => {
-      await apiRequest('/api/manufacturing-queue', {
-        method: 'POST',
-        body: JSON.stringify(data),
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/manufacturing-queue'] });
-      toast({
-        title: 'Queue item added',
-        description: 'The item has been added to the manufacturing queue.',
-      });
-      onOpenChange(false);
-      setFormData({
-        department: 'Cutting Table',
-        quantityRequested: 1,
-        priority: 50,
-        status: 'PENDING',
-      });
-    },
-    onError: (error: Error) => {
-      toast({
-        title: 'Error',
-        description: error.message || 'Failed to add item to queue. Please try again.',
-        variant: 'destructive',
-      });
-    },
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!formData.inventoryItemId) {
-      toast({
-        title: 'Error',
-        description: 'Please enter an inventory item ID.',
-        variant: 'destructive',
-      });
-      return;
-    }
-    createMutation.mutate(formData as InsertManufacturingQueue);
-  };
+  const parts = data?.parts ?? [];
+  const selectedPart = parts.find((part) => part.id === selectedPartId);
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -372,106 +468,181 @@ function AddQueueItemDialog({ isOpen, onOpenChange }: { isOpen: boolean; onOpenC
       </DialogTrigger>
       <DialogContent className="dark:bg-gray-900 dark:border-gray-800">
         <DialogHeader>
-          <DialogTitle className="dark:text-white">Add Item to Manufacturing Queue</DialogTitle>
+          <DialogTitle className="dark:text-white">
+            Create Stock Work Order
+          </DialogTitle>
           <DialogDescription className="dark:text-gray-400">
-            Add a new item to the manufacturing queue
+            Select any active manufactured P1 or P2 part. This first increment
+            previews release readiness and does not create production or
+            inventory records.
           </DialogDescription>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-4">
           <div>
-            <Label htmlFor="inventoryItemId" className="dark:text-gray-300">Inventory Item ID</Label>
-            <Input
-              id="inventoryItemId"
-              type="number"
-              value={formData.inventoryItemId || ''}
-              onChange={(e) => setFormData({ ...formData, inventoryItemId: parseInt(e.target.value) })}
-              required
-              className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
-              data-testid="input-inventory-item-id"
-            />
+            <Label className="dark:text-gray-300">
+              Active manufactured part
+            </Label>
+            <Popover open={partPickerOpen} onOpenChange={setPartPickerOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  className="mt-1 w-full justify-between"
+                  data-testid="stock-build-part-picker"
+                >
+                  {selectedPart
+                    ? `${selectedPart.agPartNumber} — ${selectedPart.name}`
+                    : isLoading
+                      ? 'Loading manufactured parts…'
+                      : 'Search part number or name…'}
+                  <ChevronsUpDown className="ml-2 h-4 w-4 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[520px] p-0" align="start">
+                <Command>
+                  <CommandInput placeholder="Search active manufactured parts…" />
+                  <CommandList>
+                    <CommandEmpty>
+                      {isError
+                        ? 'Unable to load manufactured parts.'
+                        : 'No active manufactured part found.'}
+                    </CommandEmpty>
+                    <CommandGroup>
+                      {parts.map((part) => (
+                        <CommandItem
+                          key={part.id}
+                          value={`${part.agPartNumber} ${part.name} ${part.productionSystem ?? 'unclassified'}`}
+                          onSelect={() => {
+                            setSelectedPartId(part.id);
+                            setPartPickerOpen(false);
+                          }}
+                        >
+                          <Check
+                            className={`mr-2 h-4 w-4 ${selectedPartId === part.id ? 'opacity-100' : 'opacity-0'}`}
+                          />
+                          <div className="flex-1">
+                            <div className="font-medium">
+                              {part.agPartNumber} — {part.name}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {part.productionSystem ?? 'P1/P2 not assigned'} ·{' '}
+                              {part.defaultDepartmentName ??
+                                'Department missing'}{' '}
+                              · Available {part.availableQuantity}
+                            </div>
+                          </div>
+                          {!part.readyForStockBuildPreview && (
+                            <ShieldAlert className="h-4 w-4 text-amber-600" />
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
           </div>
-          <div>
-            <Label htmlFor="department" className="dark:text-gray-300">Department</Label>
-            <Select 
-              value={formData.department} 
-              onValueChange={(value) => setFormData({ ...formData, department: value })}
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <Label htmlFor="quantityRequested" className="dark:text-gray-300">
+                Quantity Requested
+              </Label>
+              <Input
+                id="quantityRequested"
+                type="number"
+                min="1"
+                value={quantity}
+                onChange={(e) =>
+                  setQuantity(Math.max(1, Number(e.target.value)))
+                }
+                className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                data-testid="input-quantity-requested"
+              />
+            </div>
+            <div>
+              <Label htmlFor="priority" className="dark:text-gray-300">
+                Priority (1-100, lower = higher priority)
+              </Label>
+              <Input
+                id="priority"
+                type="number"
+                min="1"
+                max="100"
+                value={priority}
+                onChange={(e) => setPriority(Number(e.target.value))}
+                className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                data-testid="input-priority"
+              />
+            </div>
+            <div>
+              <Label htmlFor="dueDate" className="dark:text-gray-300">
+                Due Date (optional)
+              </Label>
+              <Input
+                id="dueDate"
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+                className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                data-testid="input-due-date"
+              />
+            </div>
+          </div>
+          {selectedPart && (
+            <Card
+              className={
+                selectedPart.readyForStockBuildPreview
+                  ? 'border-green-300'
+                  : 'border-amber-300'
+              }
             >
-              <SelectTrigger className="dark:bg-gray-800 dark:border-gray-700 dark:text-white" data-testid="select-add-department">
-                <SelectValue placeholder="Select department" />
-              </SelectTrigger>
-              <SelectContent className="dark:bg-gray-800 dark:border-gray-700">
-                <SelectItem value="Cutting Table">Cutting Table</SelectItem>
-                <SelectItem value="CNC">CNC</SelectItem>
-                <SelectItem value="Cores">Cores</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <Label htmlFor="quantityRequested" className="dark:text-gray-300">Quantity Requested</Label>
-            <Input
-              id="quantityRequested"
-              type="number"
-              min="1"
-              value={formData.quantityRequested || 1}
-              onChange={(e) => setFormData({ ...formData, quantityRequested: parseInt(e.target.value) })}
-              required
-              className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
-              data-testid="input-quantity-requested"
-            />
-          </div>
-          <div>
-            <Label htmlFor="priority" className="dark:text-gray-300">Priority (1-100, lower = higher priority)</Label>
-            <Input
-              id="priority"
-              type="number"
-              min="1"
-              max="100"
-              value={formData.priority || 50}
-              onChange={(e) => setFormData({ ...formData, priority: parseInt(e.target.value) })}
-              className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
-              data-testid="input-priority"
-            />
-          </div>
-          <div>
-            <Label htmlFor="dueDate" className="dark:text-gray-300">Due Date (optional)</Label>
-            <Input
-              id="dueDate"
-              type="date"
-              value={formData.dueDate ? new Date(formData.dueDate).toISOString().split('T')[0] : ''}
-              onChange={(e) => setFormData({ ...formData, dueDate: e.target.value ? new Date(e.target.value) : undefined })}
-              className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
-              data-testid="input-due-date"
-            />
-          </div>
-          <div>
-            <Label htmlFor="assignedTo" className="dark:text-gray-300">Assigned To (optional)</Label>
-            <Input
-              id="assignedTo"
-              value={formData.assignedTo || ''}
-              onChange={(e) => setFormData({ ...formData, assignedTo: e.target.value })}
-              className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
-              data-testid="input-assigned-to"
-            />
-          </div>
-          <div>
-            <Label htmlFor="notes" className="dark:text-gray-300">Notes (optional)</Label>
-            <Textarea
-              id="notes"
-              value={formData.notes || ''}
-              onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-              className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
-              data-testid="input-notes"
-            />
-          </div>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">
+                  {selectedPart.productionSystem ?? 'Unclassified'} stock-build
+                  readiness
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div>
+                  {selectedPart.defaultDepartmentName ?? 'No department'} · BOM{' '}
+                  {selectedPart.releasedBomCount} · Routing{' '}
+                  {selectedPart.activeRoutingCount} · Traceability policy{' '}
+                  {selectedPart.releasedTraceabilityPolicyCount}
+                </div>
+                {selectedPart.blockers.length === 0 ? (
+                  <div className="text-green-700">
+                    Authority prerequisites are present. Release remains
+                    disabled until stock-work mutation and inventory-posting
+                    gates are implemented.
+                  </div>
+                ) : (
+                  <ul className="list-disc space-y-1 pl-5 text-amber-800">
+                    {selectedPart.blockers.map((blocker) => (
+                      <li key={blocker}>{blocker}</li>
+                    ))}
+                  </ul>
+                )}
+              </CardContent>
+            </Card>
+          )}
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} className="dark:bg-gray-800 dark:border-gray-700 dark:text-white">
-              Cancel
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+            >
+              Close
             </Button>
-            <Button type="submit" disabled={createMutation.isPending} data-testid="button-submit-queue-item">
-              {createMutation.isPending ? 'Adding...' : 'Add to Queue'}
+            <Button
+              type="button"
+              disabled
+              data-testid="button-preview-stock-work-order"
+            >
+              Release Stock Work Order (coming next)
             </Button>
           </DialogFooter>
-        </form>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/server/__tests__/stockBuildReadinessFoundation.test.ts
+++ b/server/__tests__/stockBuildReadinessFoundation.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) =>
+  readFileSync(resolve(process.cwd(), path), 'utf8');
+
+describe('stock-build readiness foundation', () => {
+  it('lists every active manufactured inventory part without creating work', () => {
+    const service = read('server/src/services/stockBuildReadinessService.ts');
+    expect(service).toContain(
+      "i.is_active=true AND i.item_type='MANUFACTURED'"
+    );
+    expect(service).toContain('released_bom_count');
+    expect(service).toContain('active_routing_count');
+    expect(service).toContain('released_traceability_policy_count');
+    expect(service).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b/);
+  });
+
+  it('fails closed when P1 or P2 classification authority is ambiguous', () => {
+    const service = read('server/src/services/stockBuildReadinessService.ts');
+    expect(service).toContain(
+      'utilized_in_pl1 === true && row.utilized_in_pl2 !== true'
+    );
+    expect(service).toContain(
+      'utilized_in_pl2 === true && row.utilized_in_pl1 !== true'
+    );
+    expect(service).toContain('assigned to both P1 and P2');
+  });
+
+  it('keeps release disabled in the first UI increment', () => {
+    const page = read('client/src/pages/ManufacturingQueue.tsx');
+    expect(page).toContain('Search active manufactured parts');
+    expect(page).toContain('readyForStockBuildPreview');
+    expect(page).toContain('Release Stock Work Order (coming next)');
+    expect(page).toContain('<Button type="button" disabled');
+  });
+});

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -140,6 +140,7 @@ import costAccountingRoutes from './costAccounting';
 import payrollControlRoutes from './payrollControl';
 import employeeBadgesRoutes from './employeeBadges';
 import manufacturingQueueRoutes from './manufacturingQueue';
+import stockBuildReadinessRoutes from './stockBuildReadiness';
 import cuttingTableManufacturingQueueRoutes from './cuttingTableManufacturingQueue';
 import cuttingDocumentsRoutes from './cuttingDocuments';
 import allocationRequirementsRoutes from './allocationRequirements';
@@ -1614,6 +1615,7 @@ export function registerRoutes(app: Express, existingServer?: Server): Server {
 
   // Manufacturing Queue routes
   app.use('/api/manufacturing-queue', manufacturingQueueRoutes);
+  app.use('/api/stock-build-readiness', stockBuildReadinessRoutes);
 
   // Allocation Requirements routes
   app.use('/api/allocation-requirements', allocationRequirementsRoutes);

--- a/server/src/routes/stockBuildReadiness.ts
+++ b/server/src/routes/stockBuildReadiness.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+
+import { authenticateToken } from '../../middleware/auth';
+import { listActiveManufacturedStockBuildParts } from '../services/stockBuildReadinessService';
+
+const router = Router();
+
+router.get('/parts', authenticateToken, async (_req, res) => {
+  try {
+    res.json({ parts: await listActiveManufacturedStockBuildParts() });
+  } catch (error) {
+    console.error('[stock-build-readiness]', error);
+    res.status(500).json({ error: 'STOCK_BUILD_READINESS_FAILED' });
+  }
+});
+
+export default router;

--- a/server/src/services/stockBuildReadinessService.ts
+++ b/server/src/services/stockBuildReadinessService.ts
@@ -1,0 +1,92 @@
+import { pool } from '../../db';
+
+type ProductionSystem = 'P1' | 'P2' | null;
+
+const resolveProductionSystem = (
+  row: Record<string, unknown>
+): ProductionSystem => {
+  if (row.utilized_in_pl1 === true && row.utilized_in_pl2 !== true) return 'P1';
+  if (row.utilized_in_pl2 === true && row.utilized_in_pl1 !== true) return 'P2';
+  return null;
+};
+
+const classificationBlocker = (row: Record<string, unknown>) => {
+  if (row.utilized_in_pl1 === true && row.utilized_in_pl2 === true)
+    return 'Production system is ambiguous: this part is assigned to both P1 and P2.';
+  return 'Production system is missing: assign this manufactured part to P1 or P2.';
+};
+
+export async function listActiveManufacturedStockBuildParts() {
+  const result = await pool.query(
+    `SELECT i.id,i.ag_part_number,i.name,i.description,i.manufactured_category,
+            i.manufacturing_level,i.default_department_id,i.utilized_in_pl1,
+            i.utilized_in_pl2,d.name AS default_department_name,
+            COALESCE((SELECT sum(COALESCE(ib.quantity_available,0))
+                      FROM inventory_balances ib
+                      WHERE ib.ag_part_number=i.ag_part_number),0) AS available_quantity,
+            COALESCE((SELECT count(*) FROM boms b
+                      JOIN bom_revisions br ON br.bom_id=b.id
+                      WHERE (b.parent_inventory_item_id=i.id OR b.parent_part_ag_number=i.ag_part_number)
+                        AND b.is_active=true AND br.is_released=true
+                        AND COALESCE(br.lifecycle_status,'RELEASED')='RELEASED'
+                        AND (br.effective_from IS NULL OR br.effective_from<=now())
+                        AND (br.effective_to IS NULL OR br.effective_to>now())),0)::int AS released_bom_count,
+            COALESCE((SELECT count(*) FROM part_routings pr
+                      WHERE pr.is_active=true AND pr.project_id IS NULL
+                        AND (pr.inventory_item_fk=i.id OR pr.inventory_item_id=i.id::text
+                             OR lower(pr.part_number)=lower(i.ag_part_number))),0)::int AS active_routing_count,
+            COALESCE((SELECT count(*) FROM inventory_item_traceability_policies tp
+                      WHERE tp.inventory_item_id=i.id AND tp.status='RELEASED'
+                        AND (tp.effective_from IS NULL OR tp.effective_from<=now())
+                        AND (tp.effective_to IS NULL OR tp.effective_to>now())),0)::int AS released_traceability_policy_count
+       FROM inventory_items i
+       LEFT JOIN inventory_departments d ON d.id=i.default_department_id
+      WHERE i.is_active=true AND i.item_type='MANUFACTURED'
+      ORDER BY i.ag_part_number,i.name`
+  );
+
+  return result.rows.map((row) => {
+    const productionSystem = resolveProductionSystem(row);
+    const blockers: string[] = [];
+    if (!productionSystem) blockers.push(classificationBlocker(row));
+    if (!row.default_department_id)
+      blockers.push('A default manufacturing department is required.');
+    if (Number(row.released_bom_count) !== 1)
+      blockers.push(
+        Number(row.released_bom_count) === 0
+          ? 'A released effective BOM is required.'
+          : 'More than one released effective BOM is available; revision authority is ambiguous.'
+      );
+    if (Number(row.active_routing_count) !== 1)
+      blockers.push(
+        Number(row.active_routing_count) === 0
+          ? 'An active stock routing is required.'
+          : 'More than one active stock routing is available; routing authority is ambiguous.'
+      );
+    if (Number(row.released_traceability_policy_count) !== 1)
+      blockers.push(
+        Number(row.released_traceability_policy_count) === 0
+          ? 'A released traceability or approved no-traceability policy is required.'
+          : 'More than one released traceability policy is effective.'
+      );
+    return {
+      id: Number(row.id),
+      agPartNumber: row.ag_part_number,
+      name: row.name,
+      description: row.description,
+      manufacturedCategory: row.manufactured_category,
+      manufacturingLevel: row.manufacturing_level,
+      productionSystem,
+      defaultDepartmentId: row.default_department_id,
+      defaultDepartmentName: row.default_department_name,
+      availableQuantity: Number(row.available_quantity),
+      releasedBomCount: Number(row.released_bom_count),
+      activeRoutingCount: Number(row.active_routing_count),
+      releasedTraceabilityPolicyCount: Number(
+        row.released_traceability_policy_count
+      ),
+      readyForStockBuildPreview: blockers.length === 0,
+      blockers,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- replace manual inventory-ID queue entry with a searchable active manufactured-part selector
- classify unambiguous existing P1/P2 assignments and fail closed when both or neither are assigned
- preview department, released BOM, routing, traceability-policy, and available-inventory readiness
- keep stock-work release disabled; this increment creates no work orders or inventory transactions

## Verification
- focused source assertions passed
- client and server esbuild syntax transforms passed
- git diff --check passed
- Vitest could not start in the clean worktree because local dependency linkage was unavailable
- PostgreSQL certification was not run

## Safety boundary
This is an authenticated read-only preview. The release button remains disabled pending additive request/event authority, permissions, transactional work-order materialization, and idempotent inventory posting.