### PR TITLE
fix: keep Daily Tag Up on current authority

### DIFF
--- a/.github/workflows/daily-tag-up-postgres.yml
+++ b/.github/workflows/daily-tag-up-postgres.yml
@@ -1,0 +1,51 @@
+name: Daily Tag Up PostgreSQL Certification
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [codex/daily-tag-up-postmerge-hardening]
+  pull_request:
+    paths:
+      - 'server/src/services/dailyTagUpService.ts'
+      - 'server/src/routes/dailyTagUp.ts'
+      - 'server/__tests__/dailyTagUp*.test.ts'
+      - 'client/src/pages/DailyTagUpPage.tsx'
+      - '.github/workflows/daily-tag-up-postgres.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  certify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16.4
+        env:
+          POSTGRES_USER: daily_tag_up_cert
+          POSTGRES_PASSWORD: disposable_daily_tag_up_password
+          POSTGRES_DB: daily_tag_up_certification
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd "pg_isready -U daily_tag_up_cert -d daily_tag_up_certification"
+          --health-interval 5s --health-timeout 5s --health-retries 12
+    env:
+      DATABASE_URL: postgresql://daily_tag_up_cert:disposable_daily_tag_up_password@127.0.0.1:5432/daily_tag_up_certification
+      NODE_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 2 }
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: npm }
+      - run: npm ci --ignore-scripts
+      - name: Prove disposable database boundary
+        run: |
+          test "$(node -e "console.log(new URL(process.env.DATABASE_URL).hostname)")" = 127.0.0.1
+          test "$(node -e "console.log(new URL(process.env.DATABASE_URL).pathname)")" = /daily_tag_up_certification
+      - name: Certify Daily Tag Up SQL and focused contracts
+        run: |
+          npx vitest run --config vitest.config.server.ts server/__tests__/dailyTagUpPostgres.test.ts server/__tests__/dailyTagUpAuthorityContract.test.ts server/__tests__/dailyTagUpService.test.ts --reporter=verbose
+          npx vitest run --config vitest.config.client.ts client/src/__tests__/dailyTagUp.client.test.ts --reporter=verbose
+      - name: Diff hygiene
+        run: git diff --check HEAD^ HEAD

--- a/docs/DailyTagUpAuthorityAudit.md
+++ b/docs/DailyTagUpAuthorityAudit.md
@@ -1,6 +1,6 @@
 # Daily Tag Up authority audit
 
-Audited against `origin/main` `e094936fe5692f32c7d4dfceaf7d19a9766b123e` on 2026-08-28.
+Originally audited before PR #1843 and rechecked after merge against `origin/main` `3cff61b8c8d023e23986d6b159843d9a9f8b6613` on 2026-08-28.
 
 Daily Tag Up is an additive, read-only projection. It does not create or update project, demand, work-order, BOM, queue, traveler, inventory, purchasing, or readiness records.
 
@@ -11,13 +11,13 @@ Daily Tag Up is an additive, read-only projection. It does not create or update 
 | Project | `projects` | Include active, on-hold, or won projects. |
 | Customer PO | `projects.po_id -> p2_purchase_orders.id` | Do not infer a PO from text or older links. |
 | Released project demand and assembly hierarchy | The single `p2_frozen_production_demand_baselines` row with `status='RELEASED'`, plus its `p2_frozen_production_demand_nodes` | Nodes, classifications, make/buy disposition, BOM revision identity, routing identity, and quantities come from the immutable released snapshot. Draft, validated, cancelled, and superseded baselines are not manufacturing truth. |
-| Actual manufacturing work orders | `p2_manufacturing_work_order_authorities -> production_work_orders` | Every displayed work-order row is an existing authority row. Department rollups sum only those child rows. |
+| Actual manufacturing work orders | `p2_manufacturing_work_order_authorities -> production_work_orders` | Every displayed work-order row is an existing authority row tied to the project's current `RELEASED` frozen-demand baseline. Authorities retained for a `SUPERSEDED` baseline are historical evidence and do not contribute to current totals. Department rollups sum only the current child rows. |
 | Department | `p2_manufacturing_work_order_authorities.current_department_id/current_department_name_snapshot` | Use the routed snapshot retained by work-order authority; do not hard-code department names. |
 | Required and complete quantities | `p2_manufacturing_work_order_authorities.required_quantity/completed_quantity` | Remaining is `max(required-complete,0)`. In-progress quantity is the outstanding quantity only when lifecycle status is `IN_PROGRESS`; EPOCH has no separate partial in-progress quantity column. |
 | Readiness and blockers | Work-order lifecycle status, open `p2_manufacturing_work_order_dependencies`, unsatisfied `p2_manufacturing_work_order_material_requirements`, and required traveler presence | Compose existing execution signals. Do not write a new readiness value. |
 | Traveler | `p2_manufacturing_work_order_authorities.traveler_id -> travelers` | Missing required traveler is shown as blocked; no traveler is synthesized. |
 | Inventory | Location rollup of `inventory_balances` | Display on hand, allocated, and available independently. Missing balance rows equal zero availability, consistent with current MRP services. |
-| Purchasing supply | `vendor_po_items` with exact `project_id` and `ag_part_number`, joined to a current, open `vendor_pos` revision | Unlinked supply is not credited. Show `NO OPEN SUPPLY` instead of matching by description. |
+| Purchasing supply | `vendor_po_items` with exact `project_id` and `ag_part_number`, joined to the current `vendor_pos` revision in `Sent` or `Partially Received` status | Only issued, still-inbound quantities are credited. Draft, RFQ, quote, declined, expired, fully received, cancelled, and voided records do not reduce a shortage. Unlinked supply is not credited. Show `NO OPEN SUPPLY` instead of matching by description. |
 | Lead time | `inventory_items.lead_time_days`; expected receipt from `vendor_pos.expected_delivery_date` | Missing lead time is displayed explicitly. Risk does not invent a duration. |
 | Permission | Existing `p2.work_orders.view` capability | Server endpoint and client route both require the read capability; no mutation capability is granted. |
 
@@ -27,6 +27,7 @@ Daily Tag Up is an additive, read-only projection. It does not create or update 
 - Vendor PO lines without exact project and part traceability are excluded from project supply.
 - NCR aggregation is not included because the current project/work-order linkage was not sufficiently direct for a fail-closed join in this scope.
 - Manufacturing lead time is not calculated because the current work-order authority does not store a separate trusted manufacturing lead-time duration.
+- A cancelled authority on current released demand is shown as blocked because the authoritative demand remains unfulfilled.
 - No migration or index is required. The read model uses existing project, baseline, work-order, inventory, and vendor-PO indexes.
 
 ## Post-development capture check

--- a/server/__tests__/dailyTagUpAuthorityContract.test.ts
+++ b/server/__tests__/dailyTagUpAuthorityContract.test.ts
@@ -9,6 +9,8 @@ describe('Daily Tag Up authority contract', () => {
   it('uses released frozen demand and actual P2 work-order authorities', () => {
     expect(service).toContain("p2_frozen_production_demand_baselines b ON b.project_id=p.id AND b.status='RELEASED'");
     expect(service).toContain('FROM p2_manufacturing_work_order_authorities a');
+    expect(service).toContain('current_baseline.id=a.frozen_demand_baseline_id');
+    expect(service).toContain("current_baseline.status='RELEASED'");
     expect(service).toContain('JOIN production_work_orders pwo ON pwo.id=a.production_work_order_id');
     expect(service).toContain("base.status='RELEASED'");
     expect(service).not.toContain('bom_revisions br');
@@ -18,6 +20,8 @@ describe('Daily Tag Up authority contract', () => {
     expect(service).toContain('FROM inventory_balances');
     expect(service).toContain('WHERE vpi.project_id=ANY($1::uuid[])');
     expect(service).toContain('vp.is_current_revision=true');
+    expect(service).toContain("vp.status IN ('Sent','Partially Received')");
+    expect(service).not.toContain("vp.status NOT IN ('Cancelled','Voided','Fully Received')");
     expect(service).toContain("supplyStatus: supply ? 'OPEN SUPPLY' : 'NO OPEN SUPPLY'");
   });
 

--- a/server/__tests__/dailyTagUpPostgres.test.ts
+++ b/server/__tests__/dailyTagUpPostgres.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { pgPool } from '../db';
+import { getDailyTagUp } from '../src/services/dailyTagUpService';
+
+const projectId = '10000000-0000-0000-0000-000000000001';
+const oldBaselineId = '20000000-0000-0000-0000-000000000001';
+const currentBaselineId = '20000000-0000-0000-0000-000000000002';
+
+describe('Daily Tag Up PostgreSQL read-model certification', () => {
+  beforeAll(async () => {
+    await pgPool.query(`
+      CREATE TABLE projects(id uuid PRIMARY KEY,project_code text,project_name text,status text,target_ship_date date,customer_name_snapshot text,po_id integer);
+      CREATE TABLE p2_purchase_orders(id integer PRIMARY KEY,po_number text,customer_name text,expected_delivery date);
+      CREATE TABLE p2_frozen_production_demand_baselines(id uuid PRIMARY KEY,project_id uuid,status text,revision_number integer,project_quantity numeric,baseline_checksum text);
+      CREATE TABLE production_work_orders(id uuid PRIMARY KEY,work_order_number text,due_date date);
+      CREATE TABLE travelers(id varchar PRIMARY KEY,traveler_number text);
+      CREATE TABLE p2_manufacturing_work_order_authorities(id uuid PRIMARY KEY,project_id uuid,frozen_demand_baseline_id uuid,parent_authority_id uuid,assembly_path_identity text,inventory_item_id integer,part_number_snapshot text,description_snapshot text,required_quantity numeric,completed_quantity numeric,accepted_quantity numeric,status text,current_department_id integer,current_department_name_snapshot text,traveler_requirement text,traveler_id varchar,production_work_order_id uuid);
+      CREATE TABLE p2_manufacturing_work_order_dependencies(predecessor_authority_id uuid,successor_authority_id uuid,status text,dependency_type text,required_quantity numeric);
+      CREATE TABLE p2_manufacturing_work_order_material_requirements(successor_authority_id uuid,status text,accepted_quantity numeric,issued_quantity numeric,required_quantity numeric);
+      CREATE TABLE inventory_items(id integer PRIMARY KEY,ag_part_number text,name text,lead_time_days integer);
+      CREATE TABLE inventory_balances(ag_part_number text,quantity_on_hand numeric,quantity_allocated numeric,quantity_available numeric);
+      CREATE TABLE p2_frozen_production_demand_nodes(id uuid PRIMARY KEY,baseline_id uuid,node_identity text,parent_node_identity text,assembly_path_identity text,depth integer,inventory_item_id integer,inventory_item_snapshot jsonb,item_classification text,make_buy_disposition text,required_gross_quantity numeric,unit_of_measure text,quantity_per_parent numeric,bom_id integer,bom_revision_id integer,routing_id integer);
+      CREATE TABLE vendors(id integer PRIMARY KEY,name text);
+      CREATE TABLE vendor_pos(id integer PRIMARY KEY,vendor_id integer,po_number text,status text,expected_delivery_date date,is_current_revision boolean);
+      CREATE TABLE vendor_po_items(vendor_po_id integer,project_id uuid,ag_part_number text,quantity numeric,received_quantity numeric);
+    `);
+    await pgPool.query(`
+      INSERT INTO p2_purchase_orders VALUES (1,'PO-100','Certification Customer','2026-09-15');
+      INSERT INTO projects VALUES ('${projectId}','CERT-100','Certification Project','active','2026-09-15','Certification Customer',1);
+      INSERT INTO p2_frozen_production_demand_baselines VALUES
+        ('${oldBaselineId}','${projectId}','SUPERSEDED',1,99,'old'),('${currentBaselineId}','${projectId}','RELEASED',2,10,'current');
+      INSERT INTO production_work_orders VALUES
+        ('30000000-0000-0000-0000-000000000001','WO-OLD','2026-09-01'),
+        ('30000000-0000-0000-0000-000000000002','WO-CURRENT','2026-09-10');
+      INSERT INTO p2_manufacturing_work_order_authorities VALUES
+        ('40000000-0000-0000-0000-000000000001','${projectId}','${oldBaselineId}',NULL,'old',10,'OLD','Old authority',99,0,0,'PLANNED',1,'CNC','NOT_REQUIRED_APPROVED',NULL,'30000000-0000-0000-0000-000000000001'),
+        ('40000000-0000-0000-0000-000000000002','${projectId}','${currentBaselineId}',NULL,'current',10,'BUY-10','Current authority',10,4,4,'IN_PROGRESS',1,'CNC','NOT_REQUIRED_APPROVED',NULL,'30000000-0000-0000-0000-000000000002');
+      INSERT INTO inventory_items VALUES (10,'BUY-10','Purchased Item',7);
+      INSERT INTO inventory_balances VALUES ('BUY-10',2,0,2);
+      INSERT INTO p2_frozen_production_demand_nodes VALUES ('50000000-0000-0000-0000-000000000001','${currentBaselineId}','root',NULL,'root',0,10,'{}','PURCHASED_COMPONENT','BUY',10,'EA',1,NULL,NULL,NULL);
+      INSERT INTO vendors VALUES (1,'Supplier');
+      INSERT INTO vendor_pos VALUES (1,1,'DRAFT-PO','Draft','2026-09-05',true),(2,1,'SENT-PO','Sent','2026-09-08',true);
+      INSERT INTO vendor_po_items VALUES (1,'${projectId}','BUY-10',50,0),(2,'${projectId}','BUY-10',3,0);
+    `);
+  });
+
+  afterAll(async () => pgPool.end());
+
+  it('uses only current released work and committed inbound supply', async () => {
+    const model = await getDailyTagUp({
+      projectId,
+      source: 'both',
+      attentionDays: null,
+    });
+    expect(model.projects).toHaveLength(1);
+    expect(model.projects[0]).toMatchObject({
+      required: 10,
+      complete: 4,
+      needed: 6,
+      purchasingShortages: 1,
+    });
+    expect(
+      model.projects[0].workOrders.map((row: any) => row.workOrderNumber)
+    ).toEqual(['WO-CURRENT']);
+    expect(model.projects[0].materials[0]).toMatchObject({
+      available: 2,
+      short: 5,
+      supplyStatus: 'OPEN SUPPLY',
+    });
+    expect(
+      model.projects[0].materials[0].supply.map((row: any) => row.poNumber)
+    ).toEqual(['SENT-PO']);
+  });
+});

--- a/server/__tests__/dailyTagUpService.test.ts
+++ b/server/__tests__/dailyTagUpService.test.ts
@@ -19,6 +19,10 @@ describe('Daily Tag Up read model calculations', () => {
     expect(workOrderReadiness({ status: 'READY', material_blocker_count: 1 })).toMatchObject({ state: 'BLOCKED' });
     expect(workOrderReadiness({ status: 'READY', traveler_requirement: 'REQUIRED', traveler_id: null })).toMatchObject({ state: 'BLOCKED', reason: 'Required traveler has not been provisioned' });
     expect(workOrderReadiness({ status: 'READY', traveler_requirement: 'NOT_REQUIRED_APPROVED' })).toEqual({ state: 'READY', reason: null });
+    expect(workOrderReadiness({ status: 'CANCELLED' })).toEqual({
+      state: 'BLOCKED',
+      reason: 'Current released demand has a cancelled work order',
+    });
   });
 
   it('builds the assembly hierarchy from frozen node identities without synthesizing nodes', () => {

--- a/server/src/services/dailyTagUpService.ts
+++ b/server/src/services/dailyTagUpService.ts
@@ -23,6 +23,9 @@ export function workOrderReadiness(row: Row) {
   const status = upper(row.status);
   if (completeStatuses.has(status)) return { state: 'COMPLETE', reason: null };
   if (status === 'IN_PROGRESS') return { state: 'IN PROGRESS', reason: null };
+  if (status === 'CANCELLED' || status === 'CANCELED') {
+    return { state: 'BLOCKED', reason: 'Current released demand has a cancelled work order' };
+  }
   if (status === 'BLOCKED' || status === 'HOLD') {
     return { state: 'BLOCKED', reason: text(row.hold_reason) || 'Work order is on hold' };
   }
@@ -102,6 +105,10 @@ export async function getDailyTagUp(filters: DailyTagUpFilters = {}) {
            WHERE m.successor_authority_id=a.id AND m.status='OPEN'
              AND LEAST(m.accepted_quantity,m.issued_quantity)<m.required_quantity) material_blocker_count
        FROM p2_manufacturing_work_order_authorities a
+       JOIN p2_frozen_production_demand_baselines current_baseline
+         ON current_baseline.id=a.frozen_demand_baseline_id
+        AND current_baseline.project_id=a.project_id
+        AND current_baseline.status='RELEASED'
        JOIN production_work_orders pwo ON pwo.id=a.production_work_order_id
        LEFT JOIN travelers t ON t.id=a.traveler_id
        WHERE a.project_id=ANY($1::uuid[])`,
@@ -129,7 +136,7 @@ export async function getDailyTagUp(filters: DailyTagUpFilters = {}) {
            'openQuantity',GREATEST(vpi.quantity-COALESCE(vpi.received_quantity,0),0)) ORDER BY vp.expected_delivery_date NULLS LAST) supply
        FROM vendor_po_items vpi JOIN vendor_pos vp ON vp.id=vpi.vendor_po_id JOIN vendors v ON v.id=vp.vendor_id
        WHERE vpi.project_id=ANY($1::uuid[]) AND vpi.ag_part_number IS NOT NULL
-         AND vp.status NOT IN ('Cancelled','Voided','Fully Received') AND vp.is_current_revision=true
+         AND vp.status IN ('Sent','Partially Received') AND vp.is_current_revision=true
        GROUP BY vpi.project_id,vpi.ag_part_number`,
       [projectIds]
     ),


### PR DESCRIPTION
## Summary
- restrict Daily Tag Up work-order totals to authorities tied to the current released frozen-demand baseline
- treat cancelled current-demand work orders as blocked instead of needed/not-started
- credit purchasing coverage only from issued inbound vendor POs in Sent or Partially Received status
- add a branch-scoped disposable PostgreSQL 16.4 certification for current-versus-superseded work and committed supply

## Verification
- focused server tests: 7 passed
- focused client tests: 3 passed
- disposable PostgreSQL certification: passed (run 33190133131)
- git diff --check: passed
- changed Daily Tag Up paths produced no filtered TypeScript diagnostics; repository-wide TypeScript retains unrelated existing failures

## Evidence boundaries
- browser verification not performed because no authenticated/open EPOCH tab or authoritative application URL was available
- production-data readiness was not claimed because no identified read-only production database connection was available
- no migration, backfill, production write, deployment, or merge