### PR TITLE
Split P2 Production and Material BOM items

### DIFF
--- a/client/src/components/inventory/PartsRequestsCard.tsx
+++ b/client/src/components/inventory/PartsRequestsCard.tsx
@@ -155,6 +155,10 @@ export default function PartsRequestsCard({ scope = 'mine' }: PartsRequestsCardP
     if (typeof window === 'undefined') return false;
     return new URLSearchParams(window.location.search).get('create') === '1';
   }, []);
+  const initialPartNumber = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    return new URLSearchParams(window.location.search).get('partNumber') || '';
+  }, []);
 
   const { data: sessionUser } = useQuery<SessionUser | null>({
     queryKey: ['/api/auth/session'],
@@ -383,6 +387,14 @@ export default function PartsRequestsCard({ scope = 'mine' }: PartsRequestsCardP
       setIsCreateOpen(true);
     }
   }, [initialProjectId, openCreateFromQuery]);
+
+  useEffect(() => {
+    if (!openCreateFromQuery || !initialPartNumber || inventoryItems.length === 0) return;
+    const item = inventoryItems.find(
+      (candidate) => candidate.agPartNumber.trim().toLowerCase() === initialPartNumber.trim().toLowerCase()
+    );
+    if (item) handleInventoryItemSelect(item);
+  }, [initialPartNumber, inventoryItems, openCreateFromQuery]);
 
   const handleSelectChange = (name: string, value: string) => {
     setFormData((prev) => ({ ...prev, [name]: value }));

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -110,6 +110,7 @@ function ProductionHierarchyNode({ node, isRoot = false }: { node: any; isRoot?:
   const demand = node.productionDemand ?? {};
   const departments = Array.isArray(demand.departments) ? demand.departments : [];
   const isPurchased = node.sourceType === 'PURCHASED_MATERIAL';
+  if (isPurchased) return null;
   const typeLabel = node.sourceType === 'ASSEMBLY_WORK_ORDER'
     ? 'Assembly work order'
     : isPurchased
@@ -149,9 +150,11 @@ function ProductionHierarchyNode({ node, isRoot = false }: { node: any; isRoot?:
           </p>
         )}
       </div>
-      {Array.isArray(node.children) && node.children.length > 0 && (
+      {Array.isArray(node.children) && node.children.some((child: any) => child.sourceType !== 'PURCHASED_MATERIAL') && (
         <div className="mt-2 space-y-2">
-          {node.children.map((child: any) => <ProductionHierarchyNode key={child.key} node={child} />)}
+          {node.children
+            .filter((child: any) => child.sourceType !== 'PURCHASED_MATERIAL')
+            .map((child: any) => <ProductionHierarchyNode key={child.key} node={child} />)}
         </div>
       )}
     </div>
@@ -983,6 +986,12 @@ export default function ProjectDetailPage() {
   const productionSummary = hubProduction.summary ?? {};
   const projectSerializedItems = Array.isArray(hubProduction.serializedItems) ? hubProduction.serializedItems : traceabilitySerials;
   const productionLinePlacements = Array.isArray(hubProduction.poLinePlacements) ? hubProduction.poLinePlacements : [];
+  const manufacturedProductionItems = Array.isArray(hubProduction.manufacturedItems) ? hubProduction.manufacturedItems : [];
+  const manufacturedItemsByDepartment = manufacturedProductionItems.reduce((groups: Record<string, any[]>, item: any) => {
+    const department = item.department || 'Unassigned';
+    (groups[department] ??= []).push(item);
+    return groups;
+  }, {});
   const productionAssemblyTree = hubProduction.assemblyTree ?? {};
   const assemblyPoItems = Array.isArray(productionAssemblyTree.poItems) ? productionAssemblyTree.poItems : [];
   const productionPlacementCounts = productionLinePlacements.reduce((counts: Record<string, number>, line: any) => {
@@ -3914,6 +3923,56 @@ export default function ProjectDetailPage() {
                   ))}
                 </div>
               )}
+              <div className="space-y-3" data-testid="manufactured-production-items">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h3 className="text-base font-semibold">Manufactured BOM Items by Department</h3>
+                    <p className="text-sm text-muted-foreground">Only manufactured inventory items are shown here, grouped by the department responsible for their work orders.</p>
+                  </div>
+                  <Badge variant="secondary">{formatQuantityLabel(manufacturedProductionItems.length)} manufactured items</Badge>
+                </div>
+                {manufacturedProductionItems.length === 0 ? (
+                  <p className="rounded-md border p-3 text-sm text-muted-foreground">No manufactured BOM inventory items are available for this project.</p>
+                ) : (
+                  <Accordion type="multiple" className="space-y-2">
+                    {Object.entries(manufacturedItemsByDepartment).map(([department, items]) => (
+                      <AccordionItem key={department} value={department} className="rounded-md border px-3">
+                        <AccordionTrigger className="hover:no-underline">
+                          <span className="flex flex-wrap items-center gap-2 text-left">
+                            <span>{department}</span>
+                            <Badge variant="outline">{(items as any[]).length} items</Badge>
+                          </span>
+                        </AccordionTrigger>
+                        <AccordionContent className="space-y-2 pb-3">
+                          {(items as any[]).map((item: any) => (
+                            <div key={item.id} className="rounded-md border bg-background p-3">
+                              <div className="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                  <p className="font-mono font-semibold">{item.part_number}</p>
+                                  <p className="text-sm text-muted-foreground">{item.part_name || 'No description'}</p>
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                  <Badge variant="outline">Required {formatQuantityLabel(item.quantity)}</Badge>
+                                  <Badge variant={item.progress === 'Completed' ? 'default' : 'secondary'}>{item.progress}</Badge>
+                                  <Badge variant="outline">On hand {formatQuantityLabel(item.quantity_on_hand)}</Badge>
+                                </div>
+                              </div>
+                              <div className="mt-2 flex flex-wrap gap-2">
+                                {(item.work_orders ?? []).map((workOrder: any) => (
+                                  <Badge key={workOrder.id ?? workOrder.workOrderNumber} variant="outline">
+                                    {workOrder.workOrderNumber ?? workOrder.work_order_number} · {workOrder.status ?? 'Unknown'}
+                                  </Badge>
+                                ))}
+                                {(item.work_orders ?? []).length === 0 && <span className="text-xs text-amber-700">Work order has not been provisioned.</span>}
+                              </div>
+                            </div>
+                          ))}
+                        </AccordionContent>
+                      </AccordionItem>
+                    ))}
+                  </Accordion>
+                )}
+              </div>
               <div className="space-y-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div>
@@ -4247,15 +4306,50 @@ export default function ProjectDetailPage() {
                     <p className="text-sm text-muted-foreground">All purchased components required by the active assembly BOM, extended by the ordered assembly quantity.</p>
                   </div>
                   <div className="space-y-2">
-                  {hubMaterial.parts.map((part: any) => (
-                    <div key={part.id} className="flex items-center justify-between rounded-md border p-3">
-                      <div>
-                        <p className="font-medium">{part.part_number}</p>
-                        <p className="text-sm text-muted-foreground">{part.part_name}</p>
-                      </div>
-                      <Badge variant="outline">Qty {part.quantity}</Badge>
-                    </div>
-                  ))}
+                  <Accordion type="multiple" className="space-y-2">
+                    {hubMaterial.parts.map((part: any) => (
+                      <AccordionItem key={part.id} value={String(part.id)} className="rounded-md border px-3">
+                        <AccordionTrigger className="hover:no-underline">
+                          <span className="flex w-full flex-wrap items-center justify-between gap-3 pr-3 text-left">
+                            <span>
+                              <span className="block font-mono font-medium">{part.part_number}</span>
+                              <span className="block text-sm font-normal text-muted-foreground">{part.part_name}</span>
+                            </span>
+                            <span className="flex flex-wrap gap-2">
+                              <Badge variant="outline">Required {formatQuantityLabel(part.quantity)}</Badge>
+                              <Badge variant={Number(part.quantity_available ?? 0) > 0 ? 'default' : 'secondary'}>
+                                Available {formatQuantityLabel(part.quantity_available)}
+                              </Badge>
+                            </span>
+                          </span>
+                        </AccordionTrigger>
+                        <AccordionContent className="space-y-3 pb-3">
+                          {(part.inventory_balances ?? []).length === 0 ? (
+                            <p className="text-sm text-muted-foreground">No inventory balance exists for this purchased item.</p>
+                          ) : (
+                            <div className="grid gap-2 md:grid-cols-2">
+                              {part.inventory_balances.map((balance: any) => (
+                                <div key={balance.id ?? balance.location_id} className="rounded-md border bg-muted/20 p-3 text-sm">
+                                  <p className="font-medium">{balance.location_id}</p>
+                                  <p className="text-muted-foreground">
+                                    On hand {formatQuantityLabel(balance.quantity_on_hand)} · Allocated {formatQuantityLabel(balance.quantity_allocated)} · Available {formatQuantityLabel(balance.quantity_available)}
+                                  </p>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                          <Button
+                            size="sm"
+                            onClick={() => setLocation(`/inventory/parts-request?projectId=${encodeURIComponent(project.id)}&create=1&partNumber=${encodeURIComponent(part.part_number)}`)}
+                            data-testid={`create-parts-request-${part.part_number}`}
+                          >
+                            <Plus className="mr-2 h-4 w-4" />
+                            Create Part Request
+                          </Button>
+                        </AccordionContent>
+                      </AccordionItem>
+                    ))}
+                  </Accordion>
                   </div>
                 </div>
               )}

--- a/server/__tests__/projectBomAssembly.test.ts
+++ b/server/__tests__/projectBomAssembly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildProjectBomAssemblyTree, collectPurchasedBomParts, type ProjectBomAssemblyRow } from '../src/services/projectBomAssembly';
+import { buildProjectBomAssemblyTree, collectManufacturedBomParts, collectPurchasedBomParts, type ProjectBomAssemblyRow } from '../src/services/projectBomAssembly';
 
 const row = (overrides: Partial<ProjectBomAssemblyRow>): ProjectBomAssemblyRow => ({
   node_key: ['root:1000'],
@@ -7,6 +7,7 @@ const row = (overrides: Partial<ProjectBomAssemblyRow>): ProjectBomAssemblyRow =
   root_part_number: '1000',
   part_number: '1000',
   part_name: 'Final assembly',
+  inventory_item_id: 1000,
   item_type: 'MANUFACTURED',
   qty_per: 1,
   operation_seq: null,
@@ -24,6 +25,7 @@ describe('buildProjectBomAssemblyTree', () => {
         parent_key: ['root:1000'],
         part_number: '3000',
         part_name: 'Purchased fastener',
+        inventory_item_id: 3000,
         item_type: 'PURCHASED',
         qty_per: '4',
         operation_seq: 20,
@@ -37,6 +39,7 @@ describe('buildProjectBomAssemblyTree', () => {
         parent_key: ['root:1000'],
         part_number: '2000',
         part_name: 'Manufactured child',
+        inventory_item_id: 2000,
         item_type: 'MANUFACTURED',
         qty_per: '2',
         operation_seq: 10,
@@ -49,6 +52,7 @@ describe('buildProjectBomAssemblyTree', () => {
         parent_key: ['root:1000', 'line:1'],
         part_number: '4000',
         part_name: 'Child material',
+        inventory_item_id: 4000,
         item_type: 'PURCHASED',
         qty_per: '3',
         operation_seq: 10,
@@ -65,9 +69,9 @@ describe('buildProjectBomAssemblyTree', () => {
     expect(tree[0].children[0].children[0]).toMatchObject({ partNumber: '4000', isManufactured: false });
   });
 
-  it('treats a part with a BOM as manufactured when inventory classification is absent', () => {
-    const tree = buildProjectBomAssemblyTree([row({ item_type: null })]);
-    expect(tree[0]).toMatchObject({ isManufactured: true, hasBom: true });
+  it('does not treat a non-inventory BOM node as manufactured', () => {
+    const tree = buildProjectBomAssemblyTree([row({ inventory_item_id: null, item_type: null })]);
+    expect(tree[0]).toMatchObject({ isInventoryItem: false, isManufactured: false, hasBom: true });
   });
 
   it('collects every purchased BOM component and extends quantities through the assembly tree', () => {
@@ -75,15 +79,15 @@ describe('buildProjectBomAssemblyTree', () => {
       row({}),
       row({
         node_key: ['root:1000', 'line:1'], parent_key: ['root:1000'], part_number: '2000',
-        part_name: 'Manufactured child', item_type: 'MANUFACTURED', qty_per: 2, depth: 1, bom_id: 'bom-child',
+        part_name: 'Manufactured child', inventory_item_id: 2000, item_type: 'MANUFACTURED', qty_per: 2, depth: 1, bom_id: 'bom-child',
       }),
       row({
         node_key: ['root:1000', 'line:1', 'line:2'], parent_key: ['root:1000', 'line:1'], part_number: 'BUY-1',
-        part_name: 'Fastener', item_type: 'PURCHASED', qty_per: 3, depth: 2, bom_id: null,
+        part_name: 'Fastener', inventory_item_id: 3000, item_type: 'PURCHASED', qty_per: 3, depth: 2, bom_id: null,
       }),
       row({
         node_key: ['root:1000', 'line:3'], parent_key: ['root:1000'], part_number: 'BUY-1',
-        part_name: 'Fastener', item_type: 'PURCHASED', qty_per: 1, depth: 1, bom_id: null,
+        part_name: 'Fastener', inventory_item_id: 3000, item_type: 'PURCHASED', qty_per: 1, depth: 1, bom_id: null,
       }),
     ]);
 
@@ -91,5 +95,10 @@ describe('buildProjectBomAssemblyTree', () => {
       id: 'bom-purchased:buy-1', part_number: 'BUY-1', part_name: 'Fastener',
       quantity: 70, bom_occurrence_count: 2,
     }]);
+
+    expect(collectManufacturedBomParts(tree, new Map([['1000', 10]]))).toEqual([
+      { id: 'bom-manufactured:1000', part_number: '1000', part_name: 'Final assembly', quantity: 10, bom_occurrence_count: 1 },
+      { id: 'bom-manufactured:2000', part_number: '2000', part_name: 'Manufactured child', quantity: 20, bom_occurrence_count: 1 },
+    ]);
   });
 });

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -40,6 +40,7 @@ import { getQuoteContractReviewGate } from '../services/quoteContractService';
 import { getFileStorageProviderForObjectPath } from '../services/fileStorageProvider';
 import {
   buildProjectBomAssemblyTree,
+  collectManufacturedBomParts,
   collectPurchasedBomParts,
   type ProjectBomAssemblyRow,
 } from '../services/projectBomAssembly';
@@ -3938,7 +3939,7 @@ router.get('/:id/p2-hub', async (req, res) => {
                     NULL::text[] AS parent_key,
                     root.part_number AS root_part_number,
                     root.part_number AS part_number,
-                    inventory.name AS part_name,
+                    inventory.name AS part_name, inventory.id AS inventory_item_id,
                     COALESCE(inventory.item_type::text, inventory.type) AS item_type,
                     1::numeric AS qty_per, NULL::int AS operation_seq, 0 AS depth,
                     ARRAY[root.part_number]::text[] AS part_path,
@@ -3950,7 +3951,7 @@ router.get('/:id/p2-hub', async (req, res) => {
              UNION ALL
              SELECT tree.node_key || ('line:' || line.id::text), tree.node_key,
                     tree.root_part_number, line.child_part_ag_number,
-                    inventory.name,
+                    inventory.name, inventory.id,
                     COALESCE(inventory.item_type::text, inventory.type),
                     line.qty_per, line.operation_seq, tree.depth + 1,
                     tree.part_path || line.child_part_ag_number,
@@ -3963,7 +3964,7 @@ router.get('/:id/p2-hub', async (req, res) => {
              LEFT JOIN selected_boms child_bom ON child_bom.parent_part_ag_number = line.child_part_ag_number
              WHERE NOT line.child_part_ag_number = ANY(tree.part_path)
            )
-           SELECT node_key, parent_key, root_part_number, part_number, part_name, item_type,
+           SELECT node_key, parent_key, root_part_number, part_number, part_name, inventory_item_id, item_type,
                   qty_per, operation_seq, depth, bom_id, bom_code, bom_description,
                   bom_is_active, latest_revision_id, latest_rev_code,
                   latest_rev_created_at, line_count
@@ -3994,6 +3995,42 @@ router.get('/:id/p2-hub', async (req, res) => {
       assemblyTree,
       orderedQuantityByRootPart
     );
+    const manufacturedBomParts = collectManufacturedBomParts(
+      assemblyTree,
+      orderedQuantityByRootPart
+    );
+    const bomInventoryPartNumbers = Array.from(new Set([
+      ...purchasedBomParts.map((part) => part.part_number),
+      ...manufacturedBomParts.map((part) => part.part_number),
+    ]));
+    const inventoryBalanceRows = bomInventoryPartNumbers.length > 0
+      ? await optionalHubQuery<LegacyProjectValue>(
+          'project BOM inventory balances',
+          `SELECT ag_part_number, location_id, quantity_on_hand, quantity_allocated,
+                  quantity_available, last_counted_at
+           FROM inventory_balances
+           WHERE ag_part_number = ANY($1::text[])
+           ORDER BY ag_part_number, location_id`,
+          [bomInventoryPartNumbers]
+        )
+      : [];
+    const inventoryBalancesByPart = new Map<string, LegacyProjectValue[]>();
+    inventoryBalanceRows.forEach((balance) => {
+      const key = String(balance.ag_part_number ?? '').trim().toLowerCase();
+      if (!key) return;
+      const rows = inventoryBalancesByPart.get(key) ?? [];
+      rows.push(balance);
+      inventoryBalancesByPart.set(key, rows);
+    });
+    const addInventoryBalances = <T extends { part_number: string }>(part: T) => {
+      const inventoryBalances = inventoryBalancesByPart.get(part.part_number.trim().toLowerCase()) ?? [];
+      return {
+        ...part,
+        quantity_on_hand: inventoryBalances.reduce((sum, row) => sum + Number(row.quantity_on_hand ?? 0), 0),
+        quantity_available: inventoryBalances.reduce((sum, row) => sum + Number(row.quantity_available ?? 0), 0),
+        inventory_balances: inventoryBalances,
+      };
+    };
     const recursiveBomRecords = Array.from(
       new Map(
         assemblyRows
@@ -4185,6 +4222,27 @@ router.get('/:id/p2-hub', async (req, res) => {
       rows.push(workOrder);
       workOrdersByPart.set(partKey, rows);
     });
+    const manufacturedItems = manufacturedBomParts.map((part) => {
+      const relatedWorkOrders = workOrdersByPart.get(normalizeProductionKey(part.part_number)) ?? [];
+      const departments = Array.from(new Set(relatedWorkOrders
+        .map((workOrder) => workOrder.assignedDepartment ?? workOrder.assigned_department ?? workOrder.departmentName ?? workOrder.department_name ?? workOrder.department)
+        .filter(Boolean)));
+      const statuses = relatedWorkOrders.map((workOrder) => String(workOrder.status ?? '').trim()).filter(Boolean);
+      const progress = statuses.some((status) => ['COMPLETED', 'COMPLETE', 'CLOSED'].includes(status.toUpperCase()))
+        ? 'Completed'
+        : statuses.some((status) => ['IN_PROGRESS', 'ACTIVE', 'STARTED'].includes(status.toUpperCase()))
+          ? 'In Production'
+          : statuses.some((status) => ['RELEASED', 'SCHEDULED'].includes(status.toUpperCase()))
+            ? 'Scheduled'
+            : relatedWorkOrders.length > 0 ? 'Pending' : 'Work Order Required';
+      return addInventoryBalances({
+        ...part,
+        department: departments.join(' / ') || 'Unassigned',
+        progress,
+        work_orders: relatedWorkOrders,
+      });
+    });
+    const purchasedItems = purchasedBomParts.map(addInventoryBalances);
     const poLinePlacements = activePoItems.map((item: LegacyProjectValue) => {
       const lineId = Number(item.id);
       const lineSerializedItems = serializedByLineId.get(lineId) ?? [];
@@ -4807,6 +4865,7 @@ router.get('/:id/p2-hub', async (req, res) => {
             ...productionTotals,
           },
           poLinePlacements,
+          manufacturedItems,
           manufacturingWorkOrderAction,
           productionOrders,
           serializedItems,
@@ -4824,7 +4883,7 @@ router.get('/:id/p2-hub', async (req, res) => {
             materialBudget,
             receivedMaterialCost,
           },
-          parts: purchasedBomParts,
+          parts: purchasedItems,
           partsRequests,
           receivedMaterials,
         },

--- a/server/src/services/projectBomAssembly.ts
+++ b/server/src/services/projectBomAssembly.ts
@@ -4,6 +4,7 @@ export type ProjectBomAssemblyRow = {
   root_part_number: string;
   part_number: string;
   part_name?: string | null;
+  inventory_item_id?: number | null;
   item_type?: string | null;
   qty_per?: string | number | null;
   operation_seq?: number | null;
@@ -25,6 +26,7 @@ export type ProjectBomAssemblyNode = {
   quantityPerParent: number;
   operationSequence: number | null;
   depth: number;
+  isInventoryItem: boolean;
   isManufactured: boolean;
   hasBom: boolean;
   bomId: string | null;
@@ -35,6 +37,14 @@ export type ProjectBomAssemblyNode = {
 };
 
 export type ProjectPurchasedBomPart = {
+  id: string;
+  part_number: string;
+  part_name: string | null;
+  quantity: number;
+  bom_occurrence_count: number;
+};
+
+export type ProjectManufacturedBomPart = {
   id: string;
   part_number: string;
   part_name: string | null;
@@ -67,7 +77,8 @@ export function buildProjectBomAssemblyTree(rows: ProjectBomAssemblyRow[]): Proj
         quantityPerParent: Number(row.qty_per ?? 1),
         operationSequence: row.operation_seq ?? null,
         depth: Number(row.depth),
-        isManufactured: normalizedType === 'MANUFACTURED' || Boolean(row.bom_id),
+        isInventoryItem: Boolean(row.inventory_item_id),
+        isManufactured: Boolean(row.inventory_item_id) && normalizedType === 'MANUFACTURED',
         hasBom: Boolean(row.bom_id),
         bomId: row.bom_id ?? null,
         bomCode: row.bom_code ?? null,
@@ -97,7 +108,7 @@ export function collectPurchasedBomParts(
 
   const visit = (node: ProjectBomAssemblyNode, extendedParentQuantity: number) => {
     const requiredQuantity = extendedParentQuantity * node.quantityPerParent;
-    if (!node.isManufactured) {
+    if (node.isInventoryItem && !node.isManufactured) {
       const normalizedPartNumber = node.partNumber.trim().toLowerCase();
       const existing = purchasedByPart.get(normalizedPartNumber);
       if (existing) {
@@ -124,6 +135,43 @@ export function collectPurchasedBomParts(
   });
 
   return Array.from(purchasedByPart.values()).sort((left, right) =>
+    left.part_number.localeCompare(right.part_number)
+  );
+}
+
+export function collectManufacturedBomParts(
+  roots: ProjectBomAssemblyNode[],
+  orderedQuantityByRootPart: ReadonlyMap<string, number>
+): ProjectManufacturedBomPart[] {
+  const manufacturedByPart = new Map<string, ProjectManufacturedBomPart>();
+
+  const visit = (node: ProjectBomAssemblyNode, extendedParentQuantity: number) => {
+    const requiredQuantity = extendedParentQuantity * node.quantityPerParent;
+    if (node.isManufactured) {
+      const normalizedPartNumber = node.partNumber.trim().toLowerCase();
+      const existing = manufacturedByPart.get(normalizedPartNumber);
+      if (existing) {
+        existing.quantity += requiredQuantity;
+        existing.bom_occurrence_count += 1;
+      } else {
+        manufacturedByPart.set(normalizedPartNumber, {
+          id: `bom-manufactured:${normalizedPartNumber}`,
+          part_number: node.partNumber,
+          part_name: node.partName,
+          quantity: requiredQuantity,
+          bom_occurrence_count: 1,
+        });
+      }
+    }
+    node.children.forEach((child) => visit(child, requiredQuantity));
+  };
+
+  roots.forEach((root) => {
+    const orderedQuantity = orderedQuantityByRootPart.get(root.partNumber.trim().toLowerCase()) ?? 0;
+    visit(root, orderedQuantity);
+  });
+
+  return Array.from(manufacturedByPart.values()).sort((left, right) =>
     left.part_number.localeCompare(right.part_number)
   );
 }


### PR DESCRIPTION
## Summary
- show only explicitly manufactured inventory BOM items in the P2 Project Production tab
- group manufactured work by department and show production progress, work orders, and on-hand inventory
- show purchased inventory BOM items in Material accordions with location balances and a prefilled Part Request action
- exclude non-inventory BOM nodes from manufactured work while preserving classified inventory descendants

## Validation
- focused project BOM assembly tests: 3 passed
- git diff --cached --check passed
- full TypeScript and browser validation not run