### PR TITLE
Add controlled stock-build release readiness

### DIFF
--- a/client/src/pages/ManufacturingQueue.tsx
+++ b/client/src/pages/ManufacturingQueue.tsx
@@ -497,8 +497,12 @@ function AddQueueItemDialog({
   const [targetStockLocation, setTargetStockLocation] = useState('');
   const [notes, setNotes] = useState('');
   const [draftIdempotencyKey] = useState(() => crypto.randomUUID());
+  const [savedDraft, setSavedDraft] = useState<any>(null);
   const stockBuildWritesEnabled =
     import.meta.env.VITE_STOCK_BUILD_REQUEST_WRITES_ENABLED === 'true';
+  const releaseReadinessWritesEnabled =
+    import.meta.env.VITE_STOCK_BUILD_RELEASE_READINESS_WRITES_ENABLED ===
+    'true';
   const { data, isLoading, isError } = useQuery<{ parts: StockBuildPart[] }>({
     queryKey: ['/api/stock-build-readiness/parts'],
     queryFn: () => apiRequest('/api/stock-build-readiness/parts'),
@@ -520,17 +524,57 @@ function AddQueueItemDialog({
           idempotencyKey: draftIdempotencyKey,
         }),
       }),
-    onSuccess: () => {
+    onSuccess: (result: any) => {
+      setSavedDraft(result.request);
       toast({
         title: 'Stock-build draft saved',
         description:
           'The controlled request was saved. It has not released work or changed inventory.',
       });
-      onOpenChange(false);
     },
     onError: (error: Error) =>
       toast({
         title: 'Unable to save stock-build draft',
+        description: error.message,
+        variant: 'destructive',
+      }),
+  });
+  const { data: releaseReadiness, isFetching: isCheckingReleaseReadiness } =
+    useQuery<any>({
+      queryKey: [
+        '/api/stock-build-readiness/requests',
+        savedDraft?.id,
+        'release-readiness',
+      ],
+      queryFn: () =>
+        apiRequest(
+          `/api/stock-build-readiness/requests/${savedDraft.id}/release-readiness`
+        ),
+      enabled: Boolean(savedDraft?.id),
+    });
+  const authorizeReleaseReadiness = useMutation({
+    mutationFn: () =>
+      apiRequest(
+        `/api/stock-build-readiness/requests/${savedDraft.id}/release-readiness/authorize`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            expectedConcurrencyVersion: Number(savedDraft.concurrency_version),
+            idempotencyKey: crypto.randomUUID(),
+            signatureMeaning:
+              'I authorize this controlled stock-build request as ready for work-order release.',
+          }),
+        }
+      ),
+    onSuccess: () =>
+      toast({
+        title: 'Release readiness authorized',
+        description:
+          'The signed decision is recorded. No work order or inventory transaction was created.',
+      }),
+    onError: (error: Error) =>
+      toast({
+        title: 'Unable to authorize release readiness',
         description: error.message,
         variant: 'destructive',
       }),
@@ -547,11 +591,11 @@ function AddQueueItemDialog({
       <DialogContent className="dark:bg-gray-900 dark:border-gray-800">
         <DialogHeader>
           <DialogTitle className="dark:text-white">
-            Create Stock Work Order
+            Create Stock-Build Request
           </DialogTitle>
           <DialogDescription className="dark:text-gray-400">
-            Select any active manufactured P1 or P2 part. This first increment
-            previews release readiness and does not create production or
+            Select any active manufactured P1 or P2 part. The controlled draft
+            and signed release-readiness decision do not create production or
             inventory records.
           </DialogDescription>
         </DialogHeader>
@@ -710,9 +754,9 @@ function AddQueueItemDialog({
                 </div>
                 {selectedPart.blockers.length === 0 ? (
                   <div className="text-green-700">
-                    Authority prerequisites are present. Release remains
-                    disabled until stock-work mutation and inventory-posting
-                    gates are implemented.
+                    Authority prerequisites are present. Work-order release
+                    remains disabled until the stock-work materialization gate
+                    is implemented.
                   </div>
                 ) : (
                   <ul className="list-disc space-y-1 pl-5 text-amber-800">
@@ -720,6 +764,56 @@ function AddQueueItemDialog({
                       <li key={blocker}>{blocker}</li>
                     ))}
                   </ul>
+                )}
+              </CardContent>
+            </Card>
+          )}
+          {savedDraft && (
+            <Card className="border-blue-300">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">
+                  Controlled release decision
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                {isCheckingReleaseReadiness ? (
+                  <div>Re-evaluating current authority and stock…</div>
+                ) : releaseReadiness?.evaluation ? (
+                  <>
+                    <div>
+                      Requested {releaseReadiness.evaluation.requestedQuantity}{' '}
+                      · Available{' '}
+                      {releaseReadiness.evaluation.availableInventoryQuantity} ·
+                      Net build {releaseReadiness.evaluation.netBuildQuantity}
+                    </div>
+                    <div className="text-muted-foreground">
+                      Open WIP is excluded until controlled work-order linkage
+                      is authoritative.
+                    </div>
+                    {releaseReadiness.evaluation.blockers?.length > 0 && (
+                      <ul className="list-disc pl-5 text-amber-800">
+                        {releaseReadiness.evaluation.blockers.map(
+                          (blocker: string) => (
+                            <li key={blocker}>{blocker}</li>
+                          )
+                        )}
+                      </ul>
+                    )}
+                    <Button
+                      type="button"
+                      disabled={
+                        !releaseReadinessWritesEnabled ||
+                        !releaseReadiness.evaluation.readyForRelease ||
+                        authorizeReleaseReadiness.isPending
+                      }
+                      onClick={() => authorizeReleaseReadiness.mutate()}
+                      data-testid="button-authorize-stock-build-release-readiness"
+                    >
+                      Authorize Ready for Release
+                    </Button>
+                  </>
+                ) : (
+                  <div>Release readiness could not be evaluated.</div>
                 )}
               </CardContent>
             </Card>
@@ -737,6 +831,7 @@ function AddQueueItemDialog({
               type="button"
               disabled={
                 !stockBuildWritesEnabled ||
+                Boolean(savedDraft) ||
                 !selectedPart?.readyForStockBuildPreview ||
                 createDraft.isPending
               }

--- a/migrations/0312_stock_build_release_readiness.sql
+++ b/migrations/0312_stock_build_release_readiness.sql
@@ -1,0 +1,31 @@
+-- Signed stock-build release-readiness authority.
+-- This phase records a release decision only. It creates no work orders, queue rows, travelers, or inventory movements.
+
+CREATE TABLE IF NOT EXISTS stock_build_release_decisions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  stock_build_request_id UUID NOT NULL REFERENCES stock_build_requests(id) ON DELETE RESTRICT,
+  request_concurrency_version INTEGER NOT NULL CHECK (request_concurrency_version > 0),
+  requested_quantity NUMERIC(18,6) NOT NULL CHECK (requested_quantity > 0),
+  available_inventory_quantity NUMERIC(18,6) NOT NULL,
+  authoritative_open_supply_quantity NUMERIC(18,6) NOT NULL DEFAULT 0,
+  net_build_quantity NUMERIC(18,6) NOT NULL CHECK (net_build_quantity >= 0),
+  evaluation_snapshot JSONB NOT NULL,
+  evaluation_checksum TEXT NOT NULL,
+  signature_meaning TEXT NOT NULL,
+  actor_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  actor_employee_id INTEGER REFERENCES employees(id) ON DELETE RESTRICT,
+  actor_display_name TEXT NOT NULL,
+  actor_role TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(stock_build_request_id,idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS stock_build_release_decisions_request_idx
+  ON stock_build_release_decisions(stock_build_request_id,created_at);
+
+CREATE OR REPLACE FUNCTION stock_build_release_decision_immutable() RETURNS trigger AS $$
+BEGIN RAISE EXCEPTION 'Stock-build release decisions are append-only'; END $$ LANGUAGE plpgsql;
+DROP TRIGGER IF EXISTS stock_build_release_decision_immutable ON stock_build_release_decisions;
+CREATE TRIGGER stock_build_release_decision_immutable
+  BEFORE UPDATE OR DELETE ON stock_build_release_decisions FOR EACH ROW
+  EXECUTE FUNCTION stock_build_release_decision_immutable();

--- a/server/__tests__/stockBuildReadinessFoundation.test.ts
+++ b/server/__tests__/stockBuildReadinessFoundation.test.ts
@@ -80,4 +80,38 @@ describe('stock-build readiness foundation', () => {
       /UPDATE\s+(inventory_balances|production_work_orders|manufacturing_queue)/i
     );
   });
+
+  it('records only a gated signed release-readiness decision', () => {
+    const service = read('server/src/services/stockBuildReadinessService.ts');
+    const route = read('server/src/routes/stockBuildReadiness.ts');
+    const migration = read('migrations/0312_stock_build_release_readiness.sql');
+    const registry = read('server/scripts/migrations/runSafeBootMigrations.ts');
+    expect(service).toContain('evaluateReleaseReadiness');
+    expect(service).toContain('STOCK_BUILD_STALE_VERSION');
+    expect(service).toContain('releasedBomRevisionId');
+    expect(service).toContain('activeRoutingId');
+    expect(service).toContain('releasedTraceabilityPolicyId');
+    expect(service).toContain('recreate it before release');
+    expect(service).toContain("status='READY_FOR_RELEASE'");
+    expect(service).toContain('authoritativeOpenSupplyQuantity = 0');
+    expect(route).toContain('areStockBuildReleaseReadinessWritesEnabled()');
+    expect(route).toContain('manufacturing.stock_build.release');
+    expect(migration).toContain(
+      'CREATE TABLE IF NOT EXISTS stock_build_release_decisions'
+    );
+    expect(migration).toContain('release decisions are append-only');
+    expect(
+      registry.match(/0312_stock_build_release_readiness\.sql/g)
+    ).toHaveLength(2);
+    expect(service).not.toMatch(
+      /INSERT INTO (production_work_orders|manufacturing_queue|inventory_balances)/i
+    );
+  });
+
+  it('keeps the raw stock-build classification column out of the global inventory type', () => {
+    const schema = read('server/schema.ts');
+    expect(schema).not.toContain(
+      "stockBuildProductionSystem: text('stock_build_production_system')"
+    );
+  });
 });

--- a/server/schema.ts
+++ b/server/schema.ts
@@ -821,7 +821,6 @@ export const inventoryItems = pgTable('inventory_items', {
   utilizedInPL1: boolean('utilized_in_pl1').default(false), // Used in Production Line 1
   utilizedInPL2: boolean('utilized_in_pl2').default(false), // Used in Production Line 2
   utilizedInPL3: boolean('utilized_in_pl3').default(false), // Used in Production Line 3
-  stockBuildProductionSystem: text('stock_build_production_system'), // Explicit P1 | P2 authority for prospective stock builds
   traceabilityRequired: boolean('traceability_required').default(false), // Traceability required for P2 items
   traceabilityFields: jsonb('traceability_fields')
     .$type<string[]>()

--- a/server/scripts/migrations/runSafeBootMigrations.ts
+++ b/server/scripts/migrations/runSafeBootMigrations.ts
@@ -362,6 +362,7 @@ export const safeMigrationFiles = [
   '0309_p2_quality_shipment_release_foundation.sql',
   '0310_rebuild_p2_ledger_metadata_indexes.sql',
   '0311_stock_build_request_authority.sql',
+  '0312_stock_build_release_readiness.sql',
   'investigation_308_order_duplication.sql',
 ];
 
@@ -474,6 +475,7 @@ export const criticalMigrationFiles = new Set([
   '0309_p2_quality_shipment_release_foundation.sql',
   '0310_rebuild_p2_ledger_metadata_indexes.sql',
   '0311_stock_build_request_authority.sql',
+  '0312_stock_build_release_readiness.sql',
 ]);
 
 export async function runSafeBootMigrations() {

--- a/server/src/lib/featureFlags.ts
+++ b/server/src/lib/featureFlags.ts
@@ -240,6 +240,10 @@ export function areStockBuildRequestWritesEnabled(): boolean {
   return envBool('STOCK_BUILD_REQUEST_WRITES_ENABLED', false);
 }
 
+export function areStockBuildReleaseReadinessWritesEnabled(): boolean {
+  return envBool('STOCK_BUILD_RELEASE_READINESS_WRITES_ENABLED', false);
+}
+
 /** Phase 14 read-only activation readiness controller; never enables other flags. */
 export function isP2ControlledActivationReadinessEnabled(): boolean {
   return envBool('P2_CONTROLLED_ACTIVATION_READINESS_ENABLED', false);

--- a/server/src/routes/stockBuildReadiness.ts
+++ b/server/src/routes/stockBuildReadiness.ts
@@ -7,11 +7,14 @@ import { resolveUserSnapshot } from '../../utils/userSnapshot';
 import {
   areStockBuildRequestReadsEnabled,
   areStockBuildRequestWritesEnabled,
+  areStockBuildReleaseReadinessWritesEnabled,
 } from '../lib/featureFlags';
 import {
   createStockBuildDraft,
+  authorizeStockBuildReleaseReadiness,
   getStockBuildRequest,
   listActiveManufacturedStockBuildParts,
+  previewStockBuildReleaseReadiness,
   StockBuildRequestError,
 } from '../services/stockBuildReadinessService';
 
@@ -24,6 +27,13 @@ const draftBody = z.object({
   targetStockLocation: z.string().trim().max(255).optional(),
   notes: z.string().trim().max(2000).optional(),
   idempotencyKey: z.string().trim().min(1).max(200),
+});
+const releaseBody = z.object({
+  expectedConcurrencyVersion: z.number().int().positive(),
+  idempotencyKey: z.string().trim().min(1).max(200),
+  signatureMeaning: z.literal(
+    'I authorize this controlled stock-build request as ready for work-order release.'
+  ),
 });
 
 const fail = (res: Response, error: unknown) => {
@@ -105,6 +115,49 @@ router.get(
           404
         );
       res.json({ request: await getStockBuildRequest(req.params.id) });
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
+
+router.get(
+  '/requests/:id/release-readiness',
+  authenticateToken,
+  requirePermission('manufacturing.stock_build.release'),
+  async (req, res) => {
+    try {
+      if (!areStockBuildRequestReadsEnabled())
+        throw new StockBuildRequestError(
+          'FEATURE_DISABLED',
+          'Stock-build request reads are disabled.',
+          404
+        );
+      res.json(await previewStockBuildReleaseReadiness(req.params.id));
+    } catch (error) {
+      fail(res, error);
+    }
+  }
+);
+
+router.post(
+  '/requests/:id/release-readiness/authorize',
+  authenticateToken,
+  requirePermission('manufacturing.stock_build.release'),
+  async (req, res) => {
+    try {
+      if (!areStockBuildReleaseReadinessWritesEnabled())
+        throw new StockBuildRequestError(
+          'FEATURE_DISABLED',
+          'Stock-build release-readiness authorization is disabled.',
+          404
+        );
+      const body = releaseBody.parse(req.body);
+      const result = await authorizeStockBuildReleaseReadiness(
+        { requestId: req.params.id, ...body },
+        await actor(req)
+      );
+      res.status(result.replayed ? 200 : 201).json(result);
     } catch (error) {
       fail(res, error);
     }

--- a/server/src/services/stockBuildReadinessService.ts
+++ b/server/src/services/stockBuildReadinessService.ts
@@ -39,13 +39,26 @@ async function loadActiveManufacturedStockBuildParts(tx: Queryable) {
                         AND COALESCE(br.lifecycle_status,'RELEASED')='RELEASED'
                         AND (br.effective_from IS NULL OR br.effective_from<=now())
                         AND (br.effective_to IS NULL OR br.effective_to>now())),0)::int AS released_bom_count,
+            (SELECT max(br.id) FROM boms b JOIN bom_revisions br ON br.bom_id=b.id
+              WHERE (b.parent_inventory_item_id=i.id OR b.parent_part_ag_number=i.ag_part_number)
+                AND b.is_active=true AND br.is_released=true
+                AND COALESCE(br.lifecycle_status,'RELEASED')='RELEASED'
+                AND (br.effective_from IS NULL OR br.effective_from<=now())
+                AND (br.effective_to IS NULL OR br.effective_to>now())) AS released_bom_revision_id,
             COALESCE((SELECT count(*) FROM part_routings pr WHERE pr.is_active=true AND pr.project_id IS NULL
                         AND (pr.inventory_item_fk=i.id OR pr.inventory_item_id=i.id::text
                              OR lower(pr.part_number)=lower(i.ag_part_number))),0)::int AS active_routing_count,
+            (SELECT max(pr.id) FROM part_routings pr WHERE pr.is_active=true AND pr.project_id IS NULL
+              AND (pr.inventory_item_fk=i.id OR pr.inventory_item_id=i.id::text
+                   OR lower(pr.part_number)=lower(i.ag_part_number))) AS active_routing_id,
             COALESCE((SELECT count(*) FROM inventory_item_traceability_policies tp
                       WHERE tp.inventory_item_id=i.id AND tp.status='RELEASED'
                         AND (tp.effective_from IS NULL OR tp.effective_from<=now())
                         AND (tp.effective_to IS NULL OR tp.effective_to>now())),0)::int AS released_traceability_policy_count
+            ,(SELECT max(tp.id) FROM inventory_item_traceability_policies tp
+               WHERE tp.inventory_item_id=i.id AND tp.status='RELEASED'
+                 AND (tp.effective_from IS NULL OR tp.effective_from<=now())
+                 AND (tp.effective_to IS NULL OR tp.effective_to>now())) AS released_traceability_policy_id
        FROM inventory_items i LEFT JOIN inventory_departments d ON d.id=i.default_department_id
       WHERE i.is_active=true AND i.item_type='MANUFACTURED' ORDER BY i.ag_part_number,i.name`
   );
@@ -85,10 +98,13 @@ async function loadActiveManufacturedStockBuildParts(tx: Queryable) {
       defaultDepartmentName: row.default_department_name,
       availableQuantity: Number(row.available_quantity),
       releasedBomCount: Number(row.released_bom_count),
+      releasedBomRevisionId: row.released_bom_revision_id,
       activeRoutingCount: Number(row.active_routing_count),
+      activeRoutingId: row.active_routing_id,
       releasedTraceabilityPolicyCount: Number(
         row.released_traceability_policy_count
       ),
+      releasedTraceabilityPolicyId: row.released_traceability_policy_id,
       readyForStockBuildPreview: blockers.length === 0,
       blockers,
     };
@@ -173,8 +189,11 @@ export async function createStockBuildDraft(
       defaultDepartmentId: part.defaultDepartmentId,
       defaultDepartmentName: part.defaultDepartmentName,
       releasedBomCount: part.releasedBomCount,
+      releasedBomRevisionId: part.releasedBomRevisionId,
       activeRoutingCount: part.activeRoutingCount,
+      activeRoutingId: part.activeRoutingId,
       releasedTraceabilityPolicyCount: part.releasedTraceabilityPolicyCount,
+      releasedTraceabilityPolicyId: part.releasedTraceabilityPolicyId,
       availableQuantity: part.availableQuantity,
       blockers: part.blockers,
       evaluatedAt: new Date().toISOString(),
@@ -247,4 +266,205 @@ export async function getStockBuildRequest(id: string) {
       404
     );
   return result.rows[0];
+}
+
+async function evaluateReleaseReadiness(tx: Queryable, requestId: string) {
+  const requestResult = await tx.query(
+    `SELECT * FROM stock_build_requests WHERE id=$1`,
+    [requestId]
+  );
+  if (!requestResult.rows.length)
+    throw new StockBuildRequestError(
+      'STOCK_BUILD_REQUEST_NOT_FOUND',
+      'The stock-build request was not found.',
+      404
+    );
+  const request = requestResult.rows[0];
+  const part = (await loadActiveManufacturedStockBuildParts(tx)).find(
+    (candidate) => candidate.id === Number(request.inventory_item_id)
+  );
+  const blockers: string[] = [];
+  if (!['DRAFT', 'BLOCKED'].includes(String(request.status)))
+    blockers.push(
+      `Request status ${request.status} cannot be evaluated for release.`
+    );
+  if (!part) {
+    blockers.push('The manufactured part is no longer active.');
+  } else {
+    blockers.push(...part.blockers);
+    const draftAuthority = request.readiness_snapshot as Record<
+      string,
+      unknown
+    > | null;
+    if (part.productionSystem !== request.production_system)
+      blockers.push(
+        'The P1/P2 production-system authority changed after the draft was created.'
+      );
+    if (
+      Number(part.defaultDepartmentId) !==
+      Number(request.department_id_snapshot)
+    )
+      blockers.push(
+        'The assigned manufacturing department changed after the draft was created.'
+      );
+    const exactAuthorities: Array<[string, unknown, unknown]> = [
+      [
+        'released BOM revision',
+        draftAuthority?.releasedBomRevisionId,
+        part.releasedBomRevisionId,
+      ],
+      ['active routing', draftAuthority?.activeRoutingId, part.activeRoutingId],
+      [
+        'released traceability policy',
+        draftAuthority?.releasedTraceabilityPolicyId,
+        part.releasedTraceabilityPolicyId,
+      ],
+    ];
+    for (const [label, draftedId, currentId] of exactAuthorities) {
+      if (draftedId == null)
+        blockers.push(
+          `The draft does not contain an exact ${label} snapshot; recreate it before release.`
+        );
+      else if (String(draftedId) !== String(currentId))
+        blockers.push(
+          `The authoritative ${label} changed after the draft was created.`
+        );
+    }
+  }
+  const availableInventoryQuantity = part?.availableQuantity ?? 0;
+  const authoritativeOpenSupplyQuantity = 0;
+  const netBuildQuantity = Math.max(
+    Number(request.requested_quantity) - availableInventoryQuantity,
+    0
+  );
+  const evaluation = {
+    requestId,
+    requestConcurrencyVersion: Number(request.concurrency_version),
+    requestedQuantity: Number(request.requested_quantity),
+    productionSystem: part?.productionSystem ?? null,
+    departmentId: part?.defaultDepartmentId ?? null,
+    availableInventoryQuantity,
+    authoritativeOpenSupplyQuantity,
+    openSupplyPolicy:
+      'Excluded until a controlled stock-build request has authoritative work-order linkage.',
+    netBuildQuantity,
+    blockers,
+    readyForRelease: blockers.length === 0 && netBuildQuantity > 0,
+    noBuildRequired: blockers.length === 0 && netBuildQuantity === 0,
+    evaluatedAt: new Date().toISOString(),
+  };
+  return { request, evaluation, evaluationChecksum: checksum(evaluation) };
+}
+
+export async function previewStockBuildReleaseReadiness(requestId: string) {
+  return evaluateReleaseReadiness(pool as unknown as Queryable, requestId);
+}
+
+export async function authorizeStockBuildReleaseReadiness(
+  input: {
+    requestId: string;
+    expectedConcurrencyVersion: number;
+    idempotencyKey: string;
+    signatureMeaning: string;
+  },
+  actor: StockBuildActor
+) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+      `stock-build-release:${input.requestId}`,
+    ]);
+    const replay = await client.query(
+      `SELECT * FROM stock_build_release_decisions
+        WHERE stock_build_request_id=$1 AND idempotency_key=$2`,
+      [input.requestId, input.idempotencyKey]
+    );
+    if (replay.rows.length) {
+      await client.query('COMMIT');
+      return { replayed: true, decision: replay.rows[0] };
+    }
+    const { request, evaluation, evaluationChecksum } =
+      await evaluateReleaseReadiness(client, input.requestId);
+    if (
+      Number(request.concurrency_version) !== input.expectedConcurrencyVersion
+    )
+      throw new StockBuildRequestError(
+        'STOCK_BUILD_STALE_VERSION',
+        'The stock-build draft changed. Refresh release readiness before authorizing.'
+      );
+    if (!evaluation.readyForRelease)
+      throw new StockBuildRequestError(
+        evaluation.noBuildRequired
+          ? 'STOCK_BUILD_NO_BUILD_REQUIRED'
+          : 'STOCK_BUILD_RELEASE_BLOCKED',
+        evaluation.noBuildRequired
+          ? 'Available inventory already satisfies the requested quantity.'
+          : 'Current controlled authority is not ready for release.'
+      );
+    const decision = await client.query(
+      `INSERT INTO stock_build_release_decisions
+        (stock_build_request_id,request_concurrency_version,requested_quantity,
+         available_inventory_quantity,authoritative_open_supply_quantity,net_build_quantity,
+         evaluation_snapshot,evaluation_checksum,signature_meaning,actor_user_id,
+         actor_employee_id,actor_display_name,actor_role,idempotency_key)
+       VALUES ($1,$2,$3,$4,0,$5,$6::jsonb,$7,$8,$9,$10,$11,$12,$13) RETURNING *`,
+      [
+        input.requestId,
+        input.expectedConcurrencyVersion,
+        evaluation.requestedQuantity,
+        evaluation.availableInventoryQuantity,
+        evaluation.netBuildQuantity,
+        JSON.stringify(evaluation),
+        evaluationChecksum,
+        input.signatureMeaning,
+        actor.userId,
+        actor.employeeId,
+        actor.displayName,
+        actor.role,
+        input.idempotencyKey,
+      ]
+    );
+    const updated = await client.query(
+      `UPDATE stock_build_requests
+          SET status='READY_FOR_RELEASE',concurrency_version=concurrency_version+1,updated_at=now()
+        WHERE id=$1 AND concurrency_version=$2 AND status IN ('DRAFT','BLOCKED') RETURNING *`,
+      [input.requestId, input.expectedConcurrencyVersion]
+    );
+    if (!updated.rows.length)
+      throw new StockBuildRequestError(
+        'STOCK_BUILD_STALE_VERSION',
+        'The stock-build draft changed before authorization completed.'
+      );
+    await client.query(
+      `INSERT INTO stock_build_request_events
+        (stock_build_request_id,event_type,actor_user_id,actor_employee_id,actor_display_name,
+         actor_role,signature_meaning,evidence)
+       VALUES ($1,'RELEASE_READINESS_AUTHORIZED',$2,$3,$4,$5,$6,$7::jsonb)`,
+      [
+        input.requestId,
+        actor.userId,
+        actor.employeeId,
+        actor.displayName,
+        actor.role,
+        input.signatureMeaning,
+        JSON.stringify({
+          decisionId: decision.rows[0].id,
+          evaluationChecksum,
+          netBuildQuantity: evaluation.netBuildQuantity,
+        }),
+      ]
+    );
+    await client.query('COMMIT');
+    return {
+      replayed: false,
+      decision: decision.rows[0],
+      request: updated.rows[0],
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -6801,8 +6801,8 @@ export class DatabaseStorage implements IStorage {
             sku: sql`EXCLUDED.sku`,
             type: sql`EXCLUDED.type`,
             purchaseUnit: sql`EXCLUDED.purchase_unit`,
-            utilizedPL1: sql`EXCLUDED.utilized_pl1`,
-            utilizedPL2: sql`EXCLUDED.utilized_pl2`,
+            utilizedInPL1: sql`EXCLUDED.utilized_in_pl1`,
+            utilizedInPL2: sql`EXCLUDED.utilized_in_pl2`,
             secondarySupplierPartNumber: sql`EXCLUDED.secondary_supplier_part_number`,
             updatedAt: sql`NOW()`,
           },
@@ -6905,41 +6905,11 @@ export class DatabaseStorage implements IStorage {
   // Inventory Item Groups (assigning items to groups)
   async getItemsByGroupId(groupId: number): Promise<InventoryItem[]> {
     const result = await db
-      .select({
-        id: inventoryItems.id,
-        agPartNumber: inventoryItems.agPartNumber,
-        sku: inventoryItems.sku,
-        name: inventoryItems.name,
-        type: inventoryItems.type,
-        source: inventoryItems.source,
-        vendorId: inventoryItems.vendorId,
-        supplierPartNumber: inventoryItems.supplierPartNumber,
-        secondarySupplierPartNumber: inventoryItems.secondarySupplierPartNumber,
-        costPer: inventoryItems.costPer,
-        vendorUnit: inventoryItems.vendorUnit,
-        purchaseUnit: inventoryItems.purchaseUnit,
-        purchaseQuantity: inventoryItems.purchaseQuantity,
-        consumptionRate: inventoryItems.consumptionRate,
-        usageUnit: inventoryItems.usageUnit,
-        cogsPerUnit: inventoryItems.cogsPerUnit,
-        orderDate: inventoryItems.orderDate,
-        department: inventoryItems.department,
-        secondarySource: inventoryItems.secondarySource,
-        notes: inventoryItems.notes,
-        isStockItem: inventoryItems.isStockItem,
-        utilizedInPL1: inventoryItems.utilizedInPL1,
-        utilizedInPL2: inventoryItems.utilizedInPL2,
-        utilizedInFacilities: inventoryItems.utilizedInFacilities,
-        utilizedInAdmin: inventoryItems.utilizedInAdmin,
-        utilizedInServices: inventoryItems.utilizedInServices,
-        isActive: inventoryItems.isActive,
-        createdAt: inventoryItems.createdAt,
-        updatedAt: inventoryItems.updatedAt,
-      })
+      .select({ item: inventoryItems })
       .from(inventoryItems)
       .innerJoin(inventoryItemGroups, eq(inventoryItems.id, inventoryItemGroups.itemId))
       .where(eq(inventoryItemGroups.groupId, groupId));
-    return result;
+    return result.map(({ item }) => item);
   }
 
   async getGroupsByItemId(itemId: number): Promise<ItemGroup[]> {
@@ -7043,41 +7013,11 @@ export class DatabaseStorage implements IStorage {
   // Vendor Scope - Items and Groups
   async getVendorScopeItems(vendorId: number): Promise<InventoryItem[]> {
     const result = await db
-      .select({
-        id: inventoryItems.id,
-        agPartNumber: inventoryItems.agPartNumber,
-        sku: inventoryItems.sku,
-        name: inventoryItems.name,
-        type: inventoryItems.type,
-        source: inventoryItems.source,
-        vendorId: inventoryItems.vendorId,
-        supplierPartNumber: inventoryItems.supplierPartNumber,
-        secondarySupplierPartNumber: inventoryItems.secondarySupplierPartNumber,
-        costPer: inventoryItems.costPer,
-        vendorUnit: inventoryItems.vendorUnit,
-        purchaseUnit: inventoryItems.purchaseUnit,
-        purchaseQuantity: inventoryItems.purchaseQuantity,
-        consumptionRate: inventoryItems.consumptionRate,
-        usageUnit: inventoryItems.usageUnit,
-        cogsPerUnit: inventoryItems.cogsPerUnit,
-        orderDate: inventoryItems.orderDate,
-        department: inventoryItems.department,
-        secondarySource: inventoryItems.secondarySource,
-        notes: inventoryItems.notes,
-        isStockItem: inventoryItems.isStockItem,
-        utilizedInPL1: inventoryItems.utilizedInPL1,
-        utilizedInPL2: inventoryItems.utilizedInPL2,
-        utilizedInFacilities: inventoryItems.utilizedInFacilities,
-        utilizedInAdmin: inventoryItems.utilizedInAdmin,
-        utilizedInServices: inventoryItems.utilizedInServices,
-        isActive: inventoryItems.isActive,
-        createdAt: inventoryItems.createdAt,
-        updatedAt: inventoryItems.updatedAt,
-      })
+      .select({ item: inventoryItems })
       .from(inventoryItems)
       .innerJoin(vendorScopeItems, eq(inventoryItems.id, vendorScopeItems.itemId))
       .where(eq(vendorScopeItems.vendorId, vendorId));
-    return result;
+    return result.map(({ item }) => item);
   }
 
   async getVendorScopeGroups(vendorId: number): Promise<ItemGroup[]> {


### PR DESCRIPTION
## Summary
- re-evaluate exact BOM revision, routing, traceability policy, department, and P1/P2 authority before release readiness
- net requested stock quantity against current available inventory while explicitly excluding unauthoritative open WIP
- record an immutable signed release-readiness decision and idempotent READY_FOR_RELEASE transition behind a default-off feature gate
- add Manufacturing Queue preview and authorization controls without creating work orders, queue rows, travelers, or inventory movements
- remove the raw stock-build classification column from the global Drizzle inventory type to repair the comparative TypeScript regression introduced by the merged foundation

## Validation
- esbuild syntax transforms passed for the service, route, and Manufacturing Queue UI
- git diff --check passed
- focused source assertions passed for migration registration, exact authority snapshots, feature gating, stale-version handling, and absence of production mutations
- focused Vitest could not start in this clean worktree because linked Vite/Tailwind dependencies are unavailable
- PostgreSQL migration certification was not run locally; CI must certify migration 0312

## Safety boundary
This phase records release readiness only. It does not materialize P1/P2 work orders, manufacturing queue entries, travelers, CNC work, barcode records, allocations, or inventory transactions.