### PR TITLE
Reconcile P2 cutting demand across PO revisions

### DIFF
--- a/server/__tests__/cuttingCompletedP2PoDemand.test.ts
+++ b/server/__tests__/cuttingCompletedP2PoDemand.test.ts
@@ -13,4 +13,13 @@ describe('weekly cutting queue P2 demand lifecycle', () => {
       /COALESCE\(UPPER\(p2\.status\), ''\) NOT IN \(\s*'CLOSED', 'COMPLETE', 'COMPLETED', 'SHIPPED', 'CANCELLED', 'CANCELED'\s*\)/
     );
   });
+
+  it('reconciles shipment evidence across the complete PO revision family', () => {
+    expect(routeSource).toMatch(
+      /COALESCE\(family\.parent_po_id, family\.id\)\s*= COALESCE\(requested\.parent_po_id, requested\.id\)/
+    );
+    expect(routeSource).toMatch(
+      /P2_SHIPPED_SERIALIZED_ITEM_MEMBERSHIP_SQL[\s\S]*\[shipmentEvidencePoIds\]/
+    );
+  });
 });

--- a/server/src/routes/cuttingTable.ts
+++ b/server/src/routes/cuttingTable.ts
@@ -2705,6 +2705,25 @@ router.get('/weekly-cutting-queue', async (req, res) => {
       ));
       const shippedByPoItem = new Map<number, number>();
       if (p2PoIds.length > 0) {
+        // Shipment documents are immutable evidence and may remain attached to an
+        // older PO revision even after serialized units move to the current revision.
+        // Search the complete PO family so a revision cannot recreate demand that
+        // the original PO already fulfilled.
+        const poFamilyResult = await pool.query(`
+          SELECT DISTINCT family.id
+          FROM p2_purchase_orders requested
+          JOIN p2_purchase_orders family
+            ON COALESCE(family.parent_po_id, family.id)
+             = COALESCE(requested.parent_po_id, requested.id)
+          WHERE requested.id = ANY($1::int[])
+        `, [p2PoIds]);
+        const poFamilyRows = Array.isArray(poFamilyResult)
+          ? poFamilyResult
+          : (poFamilyResult as any).rows || [];
+        const shipmentEvidencePoIds = Array.from(new Set(
+          poFamilyRows.map((row: any) => Number(row.id)).filter(Number.isFinite)
+        ));
+
         const shipmentMembershipResult = await pool.query(`
           SELECT
             si.po_item_id AS "poItemId",
@@ -2714,7 +2733,7 @@ router.get('/weekly-cutting-queue', async (req, res) => {
             ON LOWER(si.id::text) = LOWER(membership."serializedItemId")
           WHERE si.po_item_id IS NOT NULL
           GROUP BY si.po_item_id
-        `, [p2PoIds]);
+        `, [shipmentEvidencePoIds]);
         const shipmentMembershipRows = Array.isArray(shipmentMembershipResult)
           ? shipmentMembershipResult
           : (shipmentMembershipResult as any).rows || [];


### PR DESCRIPTION
## Summary
- expand P2 cutting shipment-evidence lookup to the complete purchase-order revision family
- allow immutable shipment evidence on an older PO revision to satisfy the current revised line
- preserve PO, shipment, production, and serialized-unit history while continuing to count shipped serialized units distinctly
- add regression coverage preventing completed old-revision demand from reappearing on the current PO

## Root cause
The revision workflow moves serialized units to the current PO line, but the weekly cutting queue previously queried shipment evidence using only the current PO ID. Evidence retained on an older revision was excluded before reconciliation, causing FC064 to show a false 87-packet demand.

## Validation
- focused Vitest: 2 test files passed, 4 tests passed
- `git diff --check` passed

## Safety boundary
This changes only the actionable cutting-demand read model. It does not rewrite FC064, merge quantities, delete history, schedule packets, or mutate shipment records.