### PR TITLE
Fix manufacturing work order launch action

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -4094,8 +4094,21 @@ export default function ProjectDetailPage() {
                                   Boolean(line.manufacturingHierarchy)) && (
                                 <Button
                                   size="sm"
-                                  disabled={createManufacturingWorkOrders.isPending}
+                                  disabled={
+                                    createManufacturingWorkOrders.isPending ||
+                                    !hubProduction.manufacturingWorkOrderAction?.launchId ||
+                                    !hubProduction.manufacturingWorkOrderAction?.expectedLaunchDigest ||
+                                    !hubProduction.manufacturingWorkOrderAction?.enabled
+                                  }
                                   onClick={() => createManufacturingWorkOrders.mutate()}
+                                  title={
+                                    !hubProduction.manufacturingWorkOrderAction?.launchId ||
+                                    !hubProduction.manufacturingWorkOrderAction?.expectedLaunchDigest
+                                      ? 'Complete Production Launch before creating manufacturing work orders.'
+                                      : !hubProduction.manufacturingWorkOrderAction?.enabled
+                                        ? 'Manufacturing work-order creation is not enabled for this deployment yet.'
+                                        : undefined
+                                  }
                                   data-testid="create-manufacturing-work-orders"
                                 >
                                   {createManufacturingWorkOrders.isPending ? 'Creating...' : 'Create Manufacturing Work Orders'}
@@ -4104,7 +4117,16 @@ export default function ProjectDetailPage() {
                             </div>
                           </div>
                           {line.manufacturingHierarchy ? (
-                            <ProductionHierarchyNode node={line.manufacturingHierarchy} isRoot />
+                            <>
+                              {!hubProduction.manufacturingWorkOrderAction?.completed &&
+                                (!hubProduction.manufacturingWorkOrderAction?.launchId ||
+                                  !hubProduction.manufacturingWorkOrderAction?.expectedLaunchDigest) && (
+                                <p className="mb-2 text-xs text-muted-foreground" data-testid="manufacturing-work-orders-launch-required">
+                                  Complete Production Launch before creating manufacturing work orders.
+                                </p>
+                              )}
+                              <ProductionHierarchyNode node={line.manufacturingHierarchy} isRoot />
+                            </>
                           ) : (
                             <p className="text-sm text-muted-foreground">No released BOM hierarchy is linked to this PO line.</p>
                           )}

--- a/server/__tests__/simpleManufacturingWorkOrderAction.test.ts
+++ b/server/__tests__/simpleManufacturingWorkOrderAction.test.ts
@@ -43,12 +43,16 @@ describe('simple manufacturing work-order action', () => {
     expect(hub).toContain("event_type = 'P2_COMPONENT_TRAVELERS_PROVISIONED'");
   });
 
-  it('shows one plain-language button only while work orders are missing', () => {
+  it('shows one plain-language button only while work orders are missing and disables it until launch is eligible', () => {
     expect(ui).toContain('Create Manufacturing Work Orders');
     expect(ui).toContain('hasMissingManufacturingWorkOrder');
     expect(ui).toContain(
       'Complete Production Launch before creating manufacturing work orders.'
     );
+    expect(ui).toContain('!hubProduction.manufacturingWorkOrderAction?.launchId');
+    expect(ui).toContain('!hubProduction.manufacturingWorkOrderAction?.expectedLaunchDigest');
+    expect(ui).toContain('!hubProduction.manufacturingWorkOrderAction?.enabled');
+    expect(ui).toContain('manufacturing-work-orders-launch-required');
     expect(ui).not.toContain('Authorize Execution</Button>');
     expect(ui).not.toContain('Provision P2 Orders</Button>');
   });


### PR DESCRIPTION
## Summary
- disable Create Manufacturing Work Orders until a completed Production Launch supplies eligible launch evidence
- show the Production Launch prerequisite inline instead of allowing a guaranteed-failure toast
- add regression coverage for launch identity, digest, and deployment enablement

## Validation
- git diff --cached --check passed
- targeted Vitest was not executed because Node was unavailable on PATH and sandboxed dependency retrieval failed