### PR TITLE
Add project-scoped manufactured cycle counts

### DIFF
--- a/client/src/pages/CycleCountPage.tsx
+++ b/client/src/pages/CycleCountPage.tsx
@@ -114,6 +114,11 @@ interface VarianceHistoryRow extends CycleCountLine {
   postedAt: string | null;
 }
 
+interface ScopeOptions {
+  projects: Array<{ id: string; projectCode: string; projectName: string; partCount: number }>;
+  manufacturedParts: Array<{ id: number; agPartNumber: string; name: string }>;
+}
+
 const API_BASE = '/api/inventory/cycle-counts';
 
 // ── Utilities ──────────────────────────────────────────────────────────────
@@ -169,7 +174,9 @@ function VarianceBadge({ variance }: { variance: number }) {
 
 function CreateSessionDialog({ onCreated }: { onCreated: (id: number) => void }) {
   const [open, setOpen] = useState(false);
-  const [location, setLocation] = useState('ALL');
+  const [location, setLocation] = useState('WAREHOUSE-MAIN');
+  const [scopeMode, setScopeMode] = useState<'PROJECT' | 'PART'>('PROJECT');
+  const [projectId, setProjectId] = useState('');
   const [partFilter, setPartFilter] = useState('');
   const [countType, setCountType] = useState<'CYCLE' | 'FULL' | 'SPOT' | 'ABC'>('CYCLE');
   const [scheduledFor, setScheduledFor] = useState('');
@@ -183,11 +190,18 @@ function CreateSessionDialog({ onCreated }: { onCreated: (id: number) => void })
     enabled: open,
   });
 
+  const { data: scopeOptions, isLoading: scopeLoading } = useQuery<ScopeOptions>({
+    queryKey: [API_BASE, 'scope-options'],
+    queryFn: async () => apiRequest(`${API_BASE}/scope-options`),
+    enabled: open,
+  });
+
   const createMutation = useMutation({
     mutationFn: async () => {
       const body = {
         location,
-        partFilter: partFilter.trim() || null,
+        projectId: scopeMode === 'PROJECT' ? projectId || null : null,
+        partFilter: scopeMode === 'PART' ? partFilter.trim() || null : null,
         countType,
         scheduledFor: scheduledFor ? new Date(scheduledFor).toISOString() : null,
         blindCount,
@@ -200,7 +214,7 @@ function CreateSessionDialog({ onCreated }: { onCreated: (id: number) => void })
       toast.success(`Session ${sess.sessionNumber ?? `#${sess.id}`} created`);
       queryClient.invalidateQueries({ queryKey: [API_BASE] });
       setOpen(false);
-      setPartFilter(''); setNotes(''); setScheduledFor('');
+      setProjectId(''); setPartFilter(''); setNotes(''); setScheduledFor('');
       onCreated(sess.id);
     },
     onError: (e: any) => toast.error(e?.responseData?.error ?? e?.message ?? 'Create failed'),
@@ -213,11 +227,12 @@ function CreateSessionDialog({ onCreated }: { onCreated: (id: number) => void })
           <Plus className="h-4 w-4 mr-2" /> New Cycle Count
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle>New Cycle Count Session</DialogTitle>
           <DialogDescription>
-            Pre-populate the count list from active material lots at the chosen location.
+            Choose a project or manufactured part, count the physical quantity at one location,
+            then route variances for approval and balance-sheet posting.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3 py-2">
@@ -239,19 +254,54 @@ function CreateSessionDialog({ onCreated }: { onCreated: (id: number) => void })
               <Input
                 value={location}
                 onChange={(e) => setLocation(e.target.value)}
-                placeholder="ALL or specific location"
+                placeholder="Specific inventory location"
                 data-testid="input-location"
               />
             </div>
           </div>
-          <div>
-            <Label>Part Filter (optional)</Label>
-            <Input
-              value={partFilter}
-              onChange={(e) => setPartFilter(e.target.value)}
-              placeholder="Specific AG Part#"
-              data-testid="input-part-filter"
-            />
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label>Count Scope</Label>
+              <Select value={scopeMode} onValueChange={(value: 'PROJECT' | 'PART') => {
+                setScopeMode(value); setProjectId(''); setPartFilter('');
+              }}>
+                <SelectTrigger data-testid="select-count-scope"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="PROJECT">Project manufactured parts</SelectItem>
+                  <SelectItem value="PART">One manufactured part</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>{scopeMode === 'PROJECT' ? 'Project' : 'Manufactured Part'}</Label>
+              {scopeMode === 'PROJECT' ? (
+                <Select value={projectId} onValueChange={setProjectId} disabled={scopeLoading}>
+                  <SelectTrigger data-testid="select-count-project">
+                    <SelectValue placeholder={scopeLoading ? 'Loading…' : 'Select project'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(scopeOptions?.projects ?? []).map(project => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.projectCode} — {project.projectName} ({project.partCount})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Select value={partFilter} onValueChange={setPartFilter} disabled={scopeLoading}>
+                  <SelectTrigger data-testid="select-count-manufactured-part">
+                    <SelectValue placeholder={scopeLoading ? 'Loading…' : 'Select manufactured part'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(scopeOptions?.manufacturedParts ?? []).map(part => (
+                      <SelectItem key={part.id} value={part.agPartNumber}>
+                        {part.agPartNumber} — {part.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div>
@@ -298,7 +348,11 @@ function CreateSessionDialog({ onCreated }: { onCreated: (id: number) => void })
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
-          <Button onClick={() => createMutation.mutate()} disabled={createMutation.isPending} data-testid="button-confirm-create">
+          <Button
+            onClick={() => createMutation.mutate()}
+            disabled={createMutation.isPending || !location.trim() || (scopeMode === 'PROJECT' ? !projectId : !partFilter)}
+            data-testid="button-confirm-create"
+          >
             {createMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
             Create Session
           </Button>

--- a/server/__tests__/cycleCountProjectBalanceContract.test.ts
+++ b/server/__tests__/cycleCountProjectBalanceContract.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const service = readFileSync(
+  new URL('../src/services/cycleCountService.ts', import.meta.url),
+  'utf8',
+);
+const routes = readFileSync(
+  new URL('../src/routes/cycleCounts.ts', import.meta.url),
+  'utf8',
+);
+const page = readFileSync(
+  new URL('../../client/src/pages/CycleCountPage.tsx', import.meta.url),
+  'utf8',
+);
+
+test('cycle count exposes project and manufactured-part scopes', () => {
+  assert.match(routes, /router\.get\('\/scope-options'/);
+  assert.match(routes, /projectId: z\.string\(\)\.uuid\(\)/);
+  assert.match(service, /p2_project_controlled_configurations/);
+  assert.match(service, /item_type = 'MANUFACTURED'/);
+  assert.match(page, /Project manufactured parts/);
+  assert.match(page, /One manufactured part/);
+});
+
+test('posting locks and updates the location balance in the ledger transaction', () => {
+  assert.match(service, /eq\(inventoryBalances\.locationId, sess\.location\)/);
+  assert.match(service, /\.for\('update'\)/);
+  assert.match(service, /Balance changed after counting/);
+  assert.match(service, /tx\.update\(inventoryBalances\)/);
+  assert.match(service, /quantityOnHand: qtyAfter/);
+  assert.match(service, /lastCountedAt: new Date\(\)/);
+  assert.match(service, /Cannot post an adjustment for ALL locations/);
+});

--- a/server/src/routes/cycleCounts.ts
+++ b/server/src/routes/cycleCounts.ts
@@ -30,6 +30,7 @@ import {
   listVariancePolicies,
   createVariancePolicy,
   listVarianceHistory,
+  listScopeOptions,
   type Actor,
 } from '../services/cycleCountService';
 
@@ -60,6 +61,10 @@ function sendErr(res: Response, err: unknown) {
 
 router.get('/variance-policies', requirePermission('inventory.cycleCount.view'), async (_req, res) => {
   try { res.json(await listVariancePolicies()); } catch (e) { sendErr(res, e); }
+});
+
+router.get('/scope-options', requirePermission('inventory.cycleCount.view'), async (_req, res) => {
+  try { res.json(await listScopeOptions()); } catch (e) { sendErr(res, e); }
 });
 
 router.post('/variance-policies', requirePermission('inventory.cycleCount.create'), async (req, res) => {
@@ -99,6 +104,7 @@ router.post('/', requirePermission('inventory.cycleCount.create'), async (req, r
     const schema = z.object({
       location: z.string().min(1),
       partFilter: z.string().optional().nullable(),
+      projectId: z.string().uuid().optional().nullable(),
       countType: z.enum(['CYCLE', 'FULL', 'SPOT', 'ABC']).optional(),
       scheduledFor: z.string().datetime().optional().nullable(),
       blindCount: z.boolean().optional(),

--- a/server/src/services/cycleCountService.ts
+++ b/server/src/services/cycleCountService.ts
@@ -16,7 +16,7 @@
 
 import crypto from 'crypto';
 import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
-import { db } from '../../db';
+import { db, pool } from '../../db';
 import {
   cycleCountSessions,
   cycleCountLines,
@@ -120,6 +120,7 @@ export async function createVariancePolicy(
 export type CreateSessionInput = {
   location: string;
   partFilter?: string | null;
+  projectId?: string | null;
   countType?: 'CYCLE' | 'FULL' | 'SPOT' | 'ABC';
   scheduledFor?: Date | null;
   blindCount?: boolean;
@@ -127,8 +128,48 @@ export type CreateSessionInput = {
   notes?: string | null;
 };
 
+export type CycleCountScopeOptions = {
+  projects: Array<{ id: string; projectCode: string; projectName: string; partCount: number }>;
+  manufacturedParts: Array<{ id: number; agPartNumber: string; name: string }>;
+};
+
+export async function listScopeOptions(): Promise<CycleCountScopeOptions> {
+  const manufacturedParts = await db
+    .select({ id: inventoryItems.id, agPartNumber: inventoryItems.agPartNumber, name: inventoryItems.name })
+    .from(inventoryItems)
+    .where(and(sql`${inventoryItems.isActive} IS NOT FALSE`, eq(inventoryItems.itemType, 'MANUFACTURED')))
+    .orderBy(asc(inventoryItems.agPartNumber));
+
+  const projectRows = await pool.query<{
+    id: string; project_code: string; project_name: string; part_count: number;
+  }>(`SELECT p.id, p.project_code, p.project_name, COUNT(DISTINCT c.inventory_item_id)::int AS part_count
+      FROM projects p
+      JOIN p2_project_controlled_configurations c
+        ON c.project_id = p.id AND c.status = 'RELEASED'
+      JOIN inventory_items i
+        ON i.id = c.inventory_item_id
+       AND i.is_active IS NOT FALSE
+       AND i.item_type = 'MANUFACTURED'
+      WHERE p.status = 'active'
+      GROUP BY p.id, p.project_code, p.project_name
+      ORDER BY p.project_code`);
+
+  return {
+    projects: projectRows.rows.map(row => ({
+      id: row.id,
+      projectCode: row.project_code,
+      projectName: row.project_name,
+      partCount: row.part_count,
+    })),
+    manufacturedParts,
+  };
+}
+
 export async function createSession(input: CreateSessionInput, actor: Actor): Promise<SessionWithLines> {
   if (!input.location?.trim()) throw httpErr(400, 'location is required');
+  if (input.location === 'ALL') {
+    throw httpErr(400, 'Select a specific inventory location so approved counts can update the correct balance');
+  }
   const countType = input.countType ?? 'CYCLE';
 
   const policy = input.variancePolicyId
@@ -145,7 +186,59 @@ export async function createSession(input: CreateSessionInput, actor: Actor): Pr
 
   const byPart = new Map<string, SeedLine>();
 
-  if (countType === 'FULL') {
+  if (input.projectId) {
+    if (input.partFilter?.trim()) throw httpErr(400, 'Choose either a project or one manufactured part, not both');
+    const configured = await pool.query<{
+      id: number; ag_part_number: string; name: string; quantity_on_hand: string | number;
+    }>(`SELECT i.id, i.ag_part_number, i.name,
+              COALESCE(SUM(b.quantity_on_hand), 0) AS quantity_on_hand
+        FROM p2_project_controlled_configurations c
+        JOIN inventory_items i
+          ON i.id = c.inventory_item_id
+         AND i.is_active IS NOT FALSE
+         AND i.item_type = 'MANUFACTURED'
+        LEFT JOIN inventory_balances b
+          ON b.ag_part_number = i.ag_part_number AND b.location_id = $2
+        WHERE c.project_id = $1 AND c.status = 'RELEASED'
+        GROUP BY i.id, i.ag_part_number, i.name
+        ORDER BY i.ag_part_number`, [input.projectId, input.location]);
+    if (!configured.rows.length) {
+      throw httpErr(409, 'This project has no released manufactured-part configuration to count');
+    }
+    for (const item of configured.rows) {
+      byPart.set(item.ag_part_number, {
+        lotId: null,
+        agPartNumber: item.ag_part_number,
+        materialName: item.name,
+        expectedQty: toNum(item.quantity_on_hand),
+        inventoryItemId: item.id,
+      });
+    }
+  } else if (input.partFilter?.trim()) {
+    const [item] = await db
+      .select({ id: inventoryItems.id, agPartNumber: inventoryItems.agPartNumber, name: inventoryItems.name })
+      .from(inventoryItems)
+      .where(and(
+        sql`${inventoryItems.isActive} IS NOT FALSE`,
+        eq(inventoryItems.itemType, 'MANUFACTURED'),
+        eq(inventoryItems.agPartNumber, input.partFilter.trim()),
+      ));
+    if (!item) throw httpErr(404, 'Active manufactured inventory part not found');
+    const [balance] = await db
+      .select({ quantityOnHand: inventoryBalances.quantityOnHand })
+      .from(inventoryBalances)
+      .where(and(
+        eq(inventoryBalances.agPartNumber, item.agPartNumber),
+        eq(inventoryBalances.locationId, input.location),
+      ));
+    byPart.set(item.agPartNumber, {
+      lotId: null,
+      agPartNumber: item.agPartNumber,
+      materialName: item.name,
+      expectedQty: balance?.quantityOnHand ?? 0,
+      inventoryItemId: item.id,
+    });
+  } else if (countType === 'FULL') {
     const trimmedPartFilter = input.partFilter?.trim();
     const itemWhere = trimmedPartFilter
       ? and(sql`${inventoryItems.isActive} IS NOT FALSE`, eq(inventoryItems.agPartNumber, trimmedPartFilter))
@@ -238,7 +331,7 @@ export async function createSession(input: CreateSessionInput, actor: Actor): Pr
       status: input.scheduledFor ? 'SCHEDULED' : 'IN_PROGRESS',
       countType,
       location: input.location,
-      partFilter: input.partFilter ?? null,
+      partFilter: input.projectId ? `PROJECT:${input.projectId}` : input.partFilter ?? null,
       scheduledFor: input.scheduledFor ?? null,
       blindCount: input.blindCount ?? true,
       variancePolicyId: policy?.id ?? null,
@@ -377,6 +470,9 @@ export async function submitForReview(sessionId: number, actor: Actor): Promise<
     if (sess.status !== 'IN_PROGRESS') throw httpErr(409, 'Only IN_PROGRESS sessions can be submitted');
 
     const lines = await tx.select().from(cycleCountLines).where(eq(cycleCountLines.sessionId, sessionId));
+    const projectId = sess.partFilter?.startsWith('PROJECT:')
+      ? sess.partFilter.slice('PROJECT:'.length)
+      : null;
     const counted = lines.filter(l => l.countedQty != null);
     if (counted.length === 0) throw httpErr(400, 'No counts have been recorded');
 
@@ -454,10 +550,13 @@ export async function postSession(sessionId: number, actor: Actor): Promise<Sess
 
     const lines = await tx.select().from(cycleCountLines).where(eq(cycleCountLines.sessionId, sessionId));
 
+    if (sess.location === 'ALL' && lines.some(line => toNum(line.varianceQty) !== 0)) {
+      throw httpErr(409, 'Cannot post an adjustment for ALL locations; the session must identify one inventory location');
+    }
+
     for (const line of lines) {
       if (line.countedQty == null) continue;
       const variance = toNum(line.varianceQty);
-      if (variance === 0) continue;
       if (line.approvalStatus === 'REJECTED') continue;
 
       // Resolve canonical inventoryItemId (denormalized on line, fallback to lookup by ag_part_number)
@@ -468,25 +567,43 @@ export async function postSession(sessionId: number, actor: Actor): Promise<Sess
         itemId = item.id;
       }
 
-      // Determine quantityBefore — prefer the lot remaining qty; else fall back to inventory_balances rollup.
-      let qtyBefore = 0;
+      const [balance] = await tx
+        .select()
+        .from(inventoryBalances)
+        .where(and(
+          eq(inventoryBalances.agPartNumber, line.agPartNumber),
+          eq(inventoryBalances.locationId, sess.location),
+        ))
+        .for('update');
+      const currentBalanceQty = balance?.quantityOnHand ?? 0;
+      const expectedQty = toNum(line.expectedQty);
+      if (currentBalanceQty !== expectedQty) {
+        throw httpErr(409, `Balance changed after counting ${line.agPartNumber}; expected ${expectedQty}, current ${currentBalanceQty}. Start a new count.`);
+      }
+
+      if (variance === 0) {
+        if (balance) {
+          await tx.update(inventoryBalances).set({ lastCountedAt: new Date(), updatedAt: new Date() }).where(eq(inventoryBalances.id, balance.id));
+        }
+        continue;
+      }
+
+      // The location balance is the posting authority.
+      let qtyBefore = currentBalanceQty;
       let lotForLedger: string | null = line.lotId ?? null;
       if (lotForLedger) {
         const [lot] = await tx.select({ id: materialLots.id, remainingQty: materialLots.remainingQty }).from(materialLots).where(eq(materialLots.id, lotForLedger)).for('update');
-        if (lot) {
-          qtyBefore = toNum(lot.remainingQty);
-        } else {
+        if (!lot) {
           lotForLedger = null;
         }
-      }
-      if (!lotForLedger) {
-        const [bal] = await tx.select({ q: sql<number>`SUM(${inventoryBalances.quantityOnHand})` }).from(inventoryBalances).where(eq(inventoryBalances.agPartNumber, line.agPartNumber));
-        qtyBefore = toNum(bal?.q as any);
       }
 
       const qtyAfter = qtyBefore + variance;
       if (qtyAfter < 0) {
         throw httpErr(409, `Cannot post: posting variance ${variance} for ${line.agPartNumber} would yield negative quantity (${qtyAfter})`);
+      }
+      if (!Number.isInteger(qtyAfter)) {
+        throw httpErr(409, `Manufactured-part balance ${line.agPartNumber} must be a whole-unit quantity`);
       }
 
       const ledgerRow = await recordInventoryLedgerEntry({
@@ -502,6 +619,7 @@ export async function postSession(sessionId: number, actor: Actor): Promise<Sess
         performedByDisplayName: actor.username,
         approvedByUserId: sess.approvedByUserId ?? null,
         approvedByDisplayName: sess.approvedByDisplayName ?? null,
+        projectId,
         reasonCode: 'CYCLE_COUNT',
         notes: `Cycle count session ${sess.sessionNumber ?? '#' + sess.id} line ${line.id}${line.notes ? ': ' + line.notes : ''}`,
         sourceModule: 'cycle_count',
@@ -512,12 +630,32 @@ export async function postSession(sessionId: number, actor: Actor): Promise<Sess
           countedBy: line.countedByDisplayName,
           expectedQty: toNum(line.expectedQty),
           countedQty: toNum(line.countedQty),
+          projectId,
         },
       }, tx as any);
 
       // Update material lot remaining_qty if we have a lot
       if (lotForLedger) {
         await tx.update(materialLots).set({ remainingQty: qtyAfter.toFixed(4), updatedAt: new Date() }).where(eq(materialLots.id, lotForLedger));
+      }
+
+      const allocated = balance?.quantityAllocated ?? 0;
+      if (balance) {
+        await tx.update(inventoryBalances).set({
+          quantityOnHand: qtyAfter,
+          quantityAvailable: Math.max(0, qtyAfter - allocated),
+          lastCountedAt: new Date(),
+          updatedAt: new Date(),
+        }).where(eq(inventoryBalances.id, balance.id));
+      } else {
+        await tx.insert(inventoryBalances).values({
+          agPartNumber: line.agPartNumber,
+          locationId: sess.location,
+          quantityOnHand: qtyAfter,
+          quantityAllocated: 0,
+          quantityAvailable: qtyAfter,
+          lastCountedAt: new Date(),
+        });
       }
 
       // Persist ledger linkage on the line


### PR DESCRIPTION
## Summary
- let counters create sessions for a project's released manufactured configuration or one manufactured inventory part
- seed expected quantities from the selected inventory location and preserve the existing blind count / approval workflow
- atomically update inventory balances and the immutable ledger when approved variances post
- fail closed for aggregate ALL-location adjustments and stale balances

## Validation
- focused cycle-count contract tests: 2 passed
- server TypeScript syntax checks passed with the bundled Node runtime
- git diff check passed

## Verification boundary
- no live database or browser workflow was run in this local environment